### PR TITLE
removing duplicate historic termination & deceased records that were …

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -586,7 +586,7 @@ from historical_data as hd
 left join
     {{ ref("base_people__staff_roster_history") }} as sr
     on hd.employee_number = sr.employee_number
-    and sr.assignment_status NOT IN ('Terminated','Deceased')
+    and sr.assignment_status not in ('Terminated', 'Deceased')
     and hd.observed_at
     between safe_cast(sr.work_assignment__fivetran_start as date) and safe_cast(
         sr.work_assignment__fivetran_end as date

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -586,6 +586,7 @@ from historical_data as hd
 left join
     {{ ref("base_people__staff_roster_history") }} as sr
     on hd.employee_number = sr.employee_number
+    and sr.assignment_status NOT IN ('Terminated','Deceased')
     and hd.observed_at
     between safe_cast(sr.work_assignment__fivetran_start as date) and safe_cast(
         sr.work_assignment__fivetran_end as date

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
@@ -87,6 +87,7 @@ inner join
 inner join
     {{ ref("base_people__staff_roster_history") }} as reh
     on ri.respondent_df_employee_number = reh.employee_number
+    and reh.assignment_status NOT IN ('Terminated','Deceased')
     and ri.date_submitted
     between reh.work_assignment__fivetran_start and reh.work_assignment__fivetran_end
 inner join
@@ -140,6 +141,7 @@ inner join
 left join
     {{ ref("base_people__staff_roster_history") }} as reh
     on sda.respondent_df_employee_number = reh.employee_number
+    and reh.assignment_status NOT IN ('Terminated','Deceased')
     and sda.date_submitted
     between reh.work_assignment__fivetran_start and reh.work_assignment__fivetran_end
 inner join

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
@@ -87,7 +87,7 @@ inner join
 inner join
     {{ ref("base_people__staff_roster_history") }} as reh
     on ri.respondent_df_employee_number = reh.employee_number
-    and reh.assignment_status NOT IN ('Terminated','Deceased')
+    and reh.assignment_status not in ('Terminated', 'Deceased')
     and ri.date_submitted
     between reh.work_assignment__fivetran_start and reh.work_assignment__fivetran_end
 inner join
@@ -141,7 +141,7 @@ inner join
 left join
     {{ ref("base_people__staff_roster_history") }} as reh
     on sda.respondent_df_employee_number = reh.employee_number
-    and reh.assignment_status NOT IN ('Terminated','Deceased')
+    and reh.assignment_status not in ('Terminated', 'Deceased')
     and sda.date_submitted
     between reh.work_assignment__fivetran_start and reh.work_assignment__fivetran_end
 inner join

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__support_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__support_survey_details.sql
@@ -73,7 +73,7 @@ inner join
 inner join
     {{ ref("base_people__staff_roster_history") }} as eh
     on ri.respondent_df_employee_number = eh.employee_number
-    and eh.assignment_status NOT IN ('Terminated','Deceased')
+    and eh.assignment_status not in ('Terminated', 'Deceased')
     and ri.date_submitted
     between eh.work_assignment__fivetran_start and eh.work_assignment__fivetran_end
 where fi.abbreviation != 'respondent_name'
@@ -117,6 +117,6 @@ inner join
 left join
     {{ ref("base_people__staff_roster_history") }} as eh
     on sda.respondent_df_employee_number = eh.employee_number
-    and eh.assignment_status NOT IN ('Terminated','Deceased')
+    and eh.assignment_status not in ('Terminated', 'Deceased')
     and timestamp(sda.date_submitted)
     between eh.work_assignment__fivetran_start and eh.work_assignment__fivetran_end

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__support_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__support_survey_details.sql
@@ -73,6 +73,7 @@ inner join
 inner join
     {{ ref("base_people__staff_roster_history") }} as eh
     on ri.respondent_df_employee_number = eh.employee_number
+    and eh.assignment_status NOT IN ('Terminated','Deceased')
     and ri.date_submitted
     between eh.work_assignment__fivetran_start and eh.work_assignment__fivetran_end
 where fi.abbreviation != 'respondent_name'
@@ -116,5 +117,6 @@ inner join
 left join
     {{ ref("base_people__staff_roster_history") }} as eh
     on sda.respondent_df_employee_number = eh.employee_number
+    and eh.assignment_status NOT IN ('Terminated','Deceased')
     and timestamp(sda.date_submitted)
     between eh.work_assignment__fivetran_start and eh.work_assignment__fivetran_end


### PR DESCRIPTION
…matching

# Pull Request

## Summary & Motivation
removing duplicate records because of matching to historic terminated & deceased records. It should match on active or leave records only

[//]: # (When merged, this pull request will...)

## Self-review

- [x] Update due date and assignee on the [Teamster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] <kbd>Format</kbd> has been run on all modified files

## Troubleshooting
- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206071263397950