### PR TITLE
-Removing unnecessary historic data that was causing dupes.

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -133,6 +133,14 @@ with
             is_published
             /* 2023 is first year with new rubric */
             and observed_at >= timestamp(date(2023, 7, 1))
+            /* remove self coaching observations*/
+            and case
+                when
+                    rubric_name = 'Coaching Tool: Coach ETR and Reflection'
+                    and teacher_id = observer_id
+                then false
+                else true
+            end
     ),
 
     observation_measurements as (
@@ -371,25 +379,6 @@ with
     ),
 
     historical_overall_scores as (
-        select
-            s.employee_number,
-            s.academic_year,
-            s.form_term,
-            os.etr_score,
-            os.so_score,
-            os.overall_score,
-        from scaffold as s
-        left join
-            observations as o
-            on o.observed_at between s.start_date and s.end_date
-            /* Matches on name for PM Rounds to distinguish Self and Coach */
-            and s.form_short_name = o.form_short_name
-            and s.user_id = o.teacher_id
-        left join pm_overall_scores as os on o.observation_id = os.observation_id
-        where s.form_type = 'PM'
-
-        union all
-
         select
             employee_number,
             academic_year,


### PR DESCRIPTION
-Removing self-observations

# Pull Request

## Summary & Motivation
Removing historic data that was causing dupes
Not allowing self-observations on coaching tool

[//]: # (When merged, this pull request will...)

## Self-review

- [x] Update **due date**, **assignee**, and **priority** on our [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

    _If this is a same-day request, please flag that in Slack_

- [x] <kbd>Format</kbd> has been run on all modified files

## Troubleshooting
- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206131520723685