### PR TITLE
hotfix: Pm final scores and exceptions

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -1,3 +1,16 @@
+with
+    final_tier as (
+        select
+            employee_number,
+            academic_year,
+            overall_score as final_score,
+            overall_tier as final_tier,
+            pm_term,
+        from {{ ref("int_performance_management__overall_scores") }} as os
+        where pm_term = 'PM4'
+
+    )
+
 select
     sr.employee_number,
     sr.sam_account_name,
@@ -34,6 +47,9 @@ select
     os.etr_tier,
     os.so_tier,
     os.overall_tier,
+
+    ft.final_score,
+    ft.final_tier,
 
     coalesce(srh.preferred_name_lastfirst, sr.preferred_name_lastfirst) as teammate,
     coalesce(srh.business_unit_home_name, sr.business_unit_home_name) as entity,
@@ -73,7 +89,13 @@ left join
 left join
     {{ ref("base_people__staff_roster") }} as sr2
     on od.observer_employee_number = sr2.employee_number
+left join
+    final_tier as ft
+    on sr.employee_number = ft.employee_number
+    and od.academic_year = ft.academic_year
+    and rt.type = 'PM'
 where
     (sr.job_title like '%Teacher%' or sr.job_title = 'Learning Specialist')
     and sr.assignment_status not in ('Terminated', 'Deceased')
     and rt.type in ('PM', 'O3', 'WT')
+

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -98,4 +98,3 @@ where
     (sr.job_title like '%Teacher%' or sr.job_title = 'Learning Specialist')
     and sr.assignment_status not in ('Terminated', 'Deceased')
     and rt.type in ('PM', 'O3', 'WT')
-

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -6,7 +6,7 @@ with
             overall_score as final_score,
             overall_tier as final_tier,
             pm_term,
-        from {{ ref("int_performance_management__overall_scores") }} as os
+        from {{ ref("int_performance_management__overall_scores") }}
         where pm_term = 'PM4'
 
     )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Add final scores and final tiers as columns to the PM rows.

## Self-review

- [x] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [x] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
