### PR TITLE
< should have been > for date in fix to score weighting.

### DIFF
--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
@@ -98,7 +98,7 @@ with
             t.type as form_type,
             t.academic_year,
             if(
-                m.observed_at <= date(2023, 07, 01), sp.overall_score, m.overall_score
+                m.observed_at >= date(2023, 07, 01), sp.overall_score, m.overall_score
             ) as overall_score,
         from measurements as m
         inner join


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Instead of fix being applied to new observations it was being applied to old ones because of wrong > < sign.

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
