### PR TITLE
hotfix: terminated observers being filtered out

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -98,3 +98,4 @@ where
     (sr.job_title like '%Teacher%' or sr.job_title = 'Learning Specialist')
     and sr.assignment_status not in ('Terminated', 'Deceased')
     and rt.type in ('PM', 'O3', 'WT')
+    and od.rn_submission = 1

--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
@@ -105,8 +105,8 @@ with
             {{ ref("stg_reporting__terms") }} as t
             on regexp_contains(m.form_long_name, t.name)
             and m.observed_at between t.start_date and t.end_date
-            --and t.lockbox_date
-            --between m.last_modified_date and m.last_modified_date_lead
+        -- and t.lockbox_date
+        -- between m.last_modified_date and m.last_modified_date_lead
         left join pm_overall_scores_pivot as sp on m.observation_id = sp.observation_id
 
         union all
@@ -178,5 +178,3 @@ select
         then 1
     end as rn_submission,
 from observation_details
-where employee_number = 300099
-and academic_year = 2023

--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
@@ -27,7 +27,7 @@ with
         from {{ ref("stg_schoolmint_grow__observations") }} as o
         inner join
             {{ ref("stg_schoolmint_grow__users") }} as u on o.teacher_id = u.user_id
-        inner join
+        left join
             {{ ref("stg_schoolmint_grow__users") }} as u2 on o.observer_id = u2.user_id
         left join
             {{ ref("stg_schoolmint_grow__observations_history__observation_scores") }}
@@ -105,8 +105,8 @@ with
             {{ ref("stg_reporting__terms") }} as t
             on regexp_contains(m.form_long_name, t.name)
             and m.observed_at between t.start_date and t.end_date
-            and t.lockbox_date
-            between m.last_modified_date and m.last_modified_date_lead
+            --and t.lockbox_date
+            --between m.last_modified_date and m.last_modified_date_lead
         left join pm_overall_scores_pivot as sp on m.observation_id = sp.observation_id
 
         union all
@@ -178,3 +178,5 @@ select
         then 1
     end as rn_submission,
 from observation_details
+where employee_number = 300099
+and academic_year = 2023

--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
@@ -105,8 +105,8 @@ with
             {{ ref("stg_reporting__terms") }} as t
             on regexp_contains(m.form_long_name, t.name)
             and m.observed_at between t.start_date and t.end_date
-         and t.lockbox_date
-         between m.last_modified_date and m.last_modified_date_lead
+            and t.lockbox_date
+            between m.last_modified_date and m.last_modified_date_lead
         left join pm_overall_scores_pivot as sp on m.observation_id = sp.observation_id
 
         union all

--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observation_details.sql
@@ -105,8 +105,8 @@ with
             {{ ref("stg_reporting__terms") }} as t
             on regexp_contains(m.form_long_name, t.name)
             and m.observed_at between t.start_date and t.end_date
-        -- and t.lockbox_date
-        -- between m.last_modified_date and m.last_modified_date_lead
+         and t.lockbox_date
+         between m.last_modified_date and m.last_modified_date_lead
         left join pm_overall_scores_pivot as sp on m.observation_id = sp.observation_id
 
         union all


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Fix an inner join that's filtering out people whose observers are no longer active in SMG.

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
