### PR TITLE
fix: tier calculation for tier 4 started at 3.5 instead of 3.495

### DIFF
--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__overall_scores.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__overall_scores.sql
@@ -25,7 +25,7 @@ with
             so_score,
             overall_score,
             case
-                when etr_score >= 3.5
+                when etr_score >= 3.495
                 then 4
                 when etr_score >= 2.745
                 then 3
@@ -35,7 +35,7 @@ with
                 then 1
             end as etr_tier,
             case
-                when so_score >= 3.5
+                when so_score >= 3.495
                 then 4
                 when so_score >= 2.945
                 then 3
@@ -45,7 +45,7 @@ with
                 then 1
             end as so_tier,
             case
-                when overall_score >= 3.5
+                when overall_score >= 3.495
                 then 4
                 when overall_score >= 2.745
                 then 3
@@ -76,7 +76,7 @@ with
             avg(so_score) as so_score,
             avg(overall_score) as overall_score,
             case
-                when avg(etr_score) >= 3.5
+                when avg(etr_score) >= 3.495
                 then 4
                 when avg(etr_score) >= 2.745
                 then 3
@@ -86,7 +86,7 @@ with
                 then 1
             end as etr_tier,
             case
-                when avg(so_score) >= 3.5
+                when avg(so_score) >= 3.495
                 then 4
                 when avg(so_score) >= 2.945
                 then 3
@@ -96,7 +96,7 @@ with
                 then 1
             end as so_tier,
             case
-                when avg(overall_score) >= 3.5
+                when avg(overall_score) >= 3.495
                 then 4
                 when avg(overall_score) >= 2.745
                 then 3


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207152478034278