### PR TITLE
fixing the deduping error

### DIFF
--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
@@ -31,9 +31,20 @@ with
             fr.form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
             and fr.question_id = '315a6c37'
     ),
+
     deduped_ri as (
         select
-            *,
+            survey_id,
+            survey_title,
+            survey_response_id,
+            respondent_email,
+            campaign_academic_year,
+            campaign_name,
+            campaign_reporting_term,
+            respondent_df_employee_number,
+            subject_df_employee_number,
+            date_started,
+            date_submitted,
             row_number() over (
                 partition by
                     survey_id,
@@ -42,7 +53,7 @@ with
                     campaign_reporting_term,
                     respondent_df_employee_number,
                     subject_df_employee_number
-            ) as rn_cur
+            ) as rn_cur,
         from response_identifiers
     )
 


### PR DESCRIPTION
# Pull Request
Fixing a dedupe error on the manager int view. previously the view was pulling only the most recently submitted manager survey response regardless of year/term. This fix will pull the most recently submitted by year/term.

## Summary & Motivation
We're motivated to fix it because it's broke.

[//]: # "When merged, this pull request will..."

## Self-review

- [x] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [x] <kbd>Format</kbd> has been run on all modified files

- [x] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
