### PR TITLE
adding union to data from google forms

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -40,8 +40,8 @@ with
 
     survey_data as (
         select
-            ri.survey_id,
-            ri.response_id,
+            safe_cast(ri.survey_id as string) as survey_id,
+            safe_cast(ri.response_id as string) as response_id,
             ri.response_date_submitted,
             ri.respondent_salesforce_id,
             ri.respondent_user_principal_name,
@@ -55,6 +55,21 @@ with
             on ri.survey_id = sr.survey_id
             and ri.response_id = sr.response_id
         where ri.survey_id = 6734664  -- 'KIPP Forward Career Launch Survey'
+
+        union all
+
+        select
+            fr.form_id as survey_id,
+            fr.response_id,
+            fr.last_submitted_time as response_date_submitted,
+            null as respondent_salesforce_id,
+            fr.respondent_email as respondent_user_principal_name,
+
+            fr.info_document_title as survey_title,
+            fr.item_abbreviation as question_short_name,
+            fr.text_value as response_string_value,
+        from {{ ref("base_google_forms__form_responses") }} as fr
+        where form_id = '1qfXBcMxp9712NEnqOZS2S-Zm_SAvXRi_UndXxYZUZho' -- 'KIPP Forward Career Launch Survey'
     ),
 
     survey_pivot as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -61,7 +61,7 @@ with
         select
             fr.form_id as survey_id,
             fr.response_id,
-            fr.last_submitted_time as response_date_submitted,
+            safe_cast(fr.last_submitted_time as timestamp) as response_date_submitted,
             null as respondent_salesforce_id,
             fr.respondent_email as respondent_user_principal_name,
 

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -69,7 +69,8 @@ with
             fr.item_abbreviation as question_short_name,
             fr.text_value as response_string_value,
         from {{ ref("base_google_forms__form_responses") }} as fr
-        where form_id = '1qfXBcMxp9712NEnqOZS2S-Zm_SAvXRi_UndXxYZUZho' -- 'KIPP Forward Career Launch Survey'
+        where form_id = '1qfXBcMxp9712NEnqOZS2S-Zm_SAvXRi_UndXxYZUZho'
+    -- 'KIPP Forward Career Launch Survey'
     ),
 
     survey_pivot as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey_weights.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey_weights.sql
@@ -19,6 +19,27 @@ with
                 'imp_9',
                 'imp_10'
             )
+        union all
+
+        select
+            item_title,
+            item_abbreviation,
+            cast(text_value as numeric) as response_numeric_value,
+        from {{ ref("base_google_forms__form_responses") }}
+        where
+            form_id = '1qfXBcMxp9712NEnqOZS2S-Zm_SAvXRi_UndXxYZUZho'
+            and item_abbreviation in (
+                'imp_1',
+                'imp_2',
+                'imp_3',
+                'imp_4',
+                'imp_5',
+                'imp_6',
+                'imp_7',
+                'imp_8',
+                'imp_9',
+                'imp_10'
+            )
     ),
 
     weight_denominator as (


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Add data from Google Forms for the KIPP Forward Career Launch Survey.

@anthonygwalters, @CGibson17, I also added Google Forms to the item weights table but I think you guys might not use it anymore since you're calculating in the same view, let me know if I can/should delete.

Also, since we're joining on email to alumni data in the main select statement, I don't actually think we need salesforce id in the alchemer part of that CTE either. 

-- | --


<br class="Apple-interchange-newline">

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
