### PR TITLE
changing to inner join on reporting terms to limit

### DIFF
--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
@@ -104,7 +104,7 @@ select
 
     if(safe_cast(sr.response_value as integer) is null, 1, 0) as is_open_ended,
 from {{ ref("base_alchemer__survey_results") }} as sr
-left join
+inner join
     {{ ref("stg_reporting__terms") }} as rt
     on rt.name = sr.survey_title
     and sr.response_date_submitted_date between rt.start_date and rt.end_date


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Switch to left join pulled in 7MM rows, switching it back.

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207360263719934