### PR TITLE
the longer school name matches more cleanly with the staff roster

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippmiami_payout_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippmiami_payout_roster.sql
@@ -104,7 +104,7 @@ with
         select
             co.academic_year,
             'ada' as measure,
-            co.school_abbreviation as grade_level,
+            co.school_name as grade_level,
             round(avg(ada.ada), 2) as criteria,
         from {{ ref("int_powerschool__ada") }} as ada
         inner join
@@ -114,7 +114,7 @@ with
             and co.region = 'Miami'
             and co.grade_level != 99
             and co.rn_year = 1
-        group by co.academic_year, co.school_abbreviation
+        group by co.academic_year, co.school_name
 
         union all
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation
Changing the school from the abbreviation name to the full name. Full name matches more cleanly with the staff roster

[//]: # "When merged, this pull request will..."

## Self-review

- [x] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [x] <kbd>Format</kbd> has been run on all modified files

- [x] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
