### PR TITLE
fix: coalesce scoreentrypoints types

### DIFF
--- a/src/dbt/powerschool/models/staging/stg_powerschool__assignmentsection.sql
+++ b/src/dbt/powerschool/models/staging/stg_powerschool__assignmentsection.sql
@@ -1,32 +1,54 @@
-{{
-    teamster_utils.generate_staging_model(
-        unique_key="assignmentsectionid.int_value",
-        transform_cols=[
-            {"name": "assignmentsectionid", "extract": "int_value"},
-            {"name": "yearid", "extract": "int_value"},
-            {"name": "sectionsdcid", "extract": "int_value"},
-            {"name": "assignmentid", "extract": "int_value"},
-            {"name": "relatedgradescaleitemdcid", "extract": "int_value"},
-            {"name": "scoreentrypoints", "extract": "bytes_decimal_value"},
-            {"name": "extracreditpoints", "extract": "bytes_decimal_value"},
-            {"name": "weight", "extract": "bytes_decimal_value"},
-            {"name": "totalpointvalue", "extract": "bytes_decimal_value"},
-            {"name": "iscountedinfinalgrade", "extract": "int_value"},
-            {"name": "isscoringneeded", "extract": "int_value"},
-            {"name": "publishdaysbeforedue", "extract": "int_value"},
-            {"name": "publishedscoretypeid", "extract": "int_value"},
-            {"name": "isscorespublish", "extract": "int_value"},
-            {"name": "maxretakeallowed", "extract": "int_value"},
-            {"name": "whomodifiedid", "extract": "int_value"},
-        ],
-        except_cols=[
-            "_dagster_partition_fiscal_year",
-            "_dagster_partition_date",
-            "_dagster_partition_hour",
-            "_dagster_partition_minute",
-        ],
+with
+    deduplicate as (
+        {{
+            dbt_utils.deduplicate(
+                relation=source("powerschool", "src_powerschool__assignmentsection"),
+                partition_by="assignmentsectionid.int_value",
+                order_by="_file_name desc",
+            )
+        }}
     )
-}}
 
-select *
-from staging
+-- trunk-ignore(sqlfluff/AM04)
+select
+    * except (
+        assignmentsectionid,
+        yearid,
+        sectionsdcid,
+        assignmentid,
+        relatedgradescaleitemdcid,
+        scoreentrypoints,
+        extracreditpoints,
+        `weight`,
+        totalpointvalue,
+        iscountedinfinalgrade,
+        isscoringneeded,
+        publishdaysbeforedue,
+        publishedscoretypeid,
+        isscorespublish,
+        maxretakeallowed,
+        whomodifiedid
+    ),
+
+    assignmentsectionid.int_value as assignmentsectionid,
+    yearid.int_value as yearid,
+    sectionsdcid.int_value as sectionsdcid,
+    assignmentid.int_value as assignmentid,
+    relatedgradescaleitemdcid.int_value as relatedgradescaleitemdcid,
+    extracreditpoints.bytes_decimal_value as extracreditpoints,
+    weight.bytes_decimal_value as `weight`,
+    totalpointvalue.bytes_decimal_value as totalpointvalue,
+    iscountedinfinalgrade.int_value as iscountedinfinalgrade,
+    isscoringneeded.int_value as isscoringneeded,
+    publishdaysbeforedue.int_value as publishdaysbeforedue,
+    publishedscoretypeid.int_value as publishedscoretypeid,
+    isscorespublish.int_value as isscorespublish,
+    maxretakeallowed.int_value as maxretakeallowed,
+    whomodifiedid.int_value as whomodifiedid,
+
+    coalesce(
+        scoreentrypoints.bytes_decimal_value,
+        scoreentrypoints.double_value,
+        scoreentrypoints.int_value
+    ) as scoreentrypoints,
+from deduplicate


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
