### PR TITLE
adding non-teacher and non-admin coaches

### DIFF
--- a/src/dbt/kipptaf/models/extracts/rpt_schoolmint_grow__users.sql
+++ b/src/dbt/kipptaf/models/extracts/rpt_schoolmint_grow__users.sql
@@ -55,7 +55,10 @@ with
                 when
                     sr.management_position_indicator
                     and (
-                        sr.job_title like '%Teacher%' or sr.job_title like '%Learning%'
+                        sr.job_title like '%Teacher%'
+                        or sr.job_title like '%Learning%'
+                        or sr.department_home_name
+                        in ('School Support', 'Student Support', 'KIPP Forward')
                     )
                 then 'Coach'
                 when (sr.job_title like '%Teacher%' or sr.job_title like '%Learning%')


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Add Coach roles for those without school admin or teacher titles. Student Support and KIPP Forward department members coaching teachers were not being assigned roles and inactivated in SMG.

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
