### PR TITLE
removed probe fields and added a filter for non-tested grades in 2023

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_dashboard.sql
@@ -40,6 +40,13 @@ with
             ) as expected_mclass_measure_standard,
 
             if(e.grade_level = 0, 'K', cast(e.grade_level as string)) as grade_level,
+
+            if(
+                e.academic_year = 2024
+                or (e.academic_year = 2023 and e.grade_level <= 2),
+                true,
+                false
+            ) as year_grade_filter,
         from {{ ref("int_tableau__student_enrollments") }} as e
         inner join
             {{ ref("stg_assessments__assessment_expectations") }} as a
@@ -149,9 +156,6 @@ select
     a.mclass_measure_percentile,
     a.mclass_measure_semester_growth,
     a.mclass_measure_year_growth,
-    a.mclass_score_change,
-    null as mclass_probe_number,
-    null as mclass_total_number_of_probes,
 
     t.start_date,
     t.end_date,
@@ -160,6 +164,7 @@ select
     f.tutoring_nj,
 
     right(s.test_code, 1) as expected_round,
+
     if(
         s.expected_grade_level = 0, 'K', cast(s.expected_grade_level as string)
     ) as expected_grade_level,
@@ -188,6 +193,7 @@ left join
     and s.student_number = f.student_number
     and {{ union_dataset_join_clause(left_alias="s", right_alias="f") }}
     and f.iready_subject = 'Reading'
+where s.year_grade_filter
 
 union all
 
@@ -246,9 +252,6 @@ select
     mclass_measure_percentile,
     mclass_measure_semester_growth,
     mclass_measure_year_growth,
-    mclass_score_change,
-    mclass_probe_number,
-    mclass_total_number_of_probes,
 
     start_date,
     end_date,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_pm_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_pm_dashboard.sql
@@ -192,9 +192,6 @@ select distinct
     a.mclass_measure_percentile,
     a.mclass_measure_semester_growth,
     a.mclass_measure_year_growth,
-    a.mclass_score_change,
-    a.mclass_probe_number,
-    a.mclass_total_number_of_probes,
 
     f.nj_student_tier,
     f.tutoring_nj,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [x] <kbd>Format</kbd> has been run on all modified files

- [x] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
