### PR TITLE
fix: rm dataset joins for iready

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 1.22.7
+  version: 1.22.8
 plugins:
   sources:
     - id: trunk
@@ -8,8 +8,8 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - pyright@1.1.387
-    - actionlint@1.7.3
+    - pyright@1.1.388
+    - actionlint@1.7.4
     - git-diff-check
     - gitleaks@8.21.1
     - hadolint@2.12.0

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
@@ -138,7 +138,6 @@ with
         union all
 
         select
-            _dbt_source_relation,
             student_id as student_number,
             academic_year_int as academic_year,
             `subject`,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
@@ -102,7 +102,6 @@ with
 
     iready as (
         select
-            _dbt_source_relation,
             student_id as student_number,
             academic_year_int as academic_year,
             `subject`,
@@ -254,7 +253,6 @@ with
             iready as ir
             on co.student_number = ir.student_number
             and co.academic_year = ir.academic_year
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="ir") }}
             and s.subject = ir.subject
         where co.rn_year = 1 and co.enroll_status = 0 and co.grade_level between 3 and 8
 
@@ -327,7 +325,6 @@ with
             iready as ir
             on co.student_number = ir.student_number
             and co.academic_year = ir.academic_year
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="ir") }}
             and s.subject = ir.subject
         where co.rn_year = 1 and co.enroll_status = 0 and co.grade_level between 0 and 2
     ),

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__miami_k2_iready.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__miami_k2_iready.sql
@@ -57,7 +57,6 @@ left join
     {{ ref("base_iready__diagnostic_results") }} as ir
     on co.student_number = ir.student_id
     and co.academic_year = ir.academic_year_int
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="ir") }}
     and subj.iready_subject = ir.subject
     and ar = ir.test_round
     and ir.rn_subj_round = 1
@@ -68,7 +67,6 @@ left join
     and ir.subject = up.subject
     and ir.start_date = up.start_date
     and ir.completion_date = up.completion_date
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="up") }}
 where
     co.academic_year = {{ var("current_academic_year") }}
     and co.rn_year = 1

--- a/src/dbt/kipptaf/models/iready/base/base_iready__diagnostic_results.sql
+++ b/src/dbt/kipptaf/models/iready/base/base_iready__diagnostic_results.sql
@@ -1,7 +1,6 @@
 with
     diagnostic_results as (
         select
-            _dbt_source_relation,
             student_id,
             academic_year,
             academic_year_int,
@@ -79,7 +78,6 @@ with
     )
 
 select
-    dr._dbt_source_relation,
     dr.student_id,
     dr.academic_year,
     dr.academic_year_int,

--- a/src/dbt/kipptaf/models/iready/base/base_iready__diagnostic_results.sql
+++ b/src/dbt/kipptaf/models/iready/base/base_iready__diagnostic_results.sql
@@ -1,6 +1,7 @@
 with
     diagnostic_results as (
         select
+            _dbt_source_relation,
             student_id,
             academic_year,
             academic_year_int,

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__domain_unpivot.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__domain_unpivot.sql
@@ -1,6 +1,7 @@
 with
     domain_unpivot as (
         select
+            _dbt_source_relation,
             student_id,
             `subject`,
             academic_year_int,

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__domain_unpivot.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__domain_unpivot.sql
@@ -1,7 +1,6 @@
 with
     domain_unpivot as (
         select
-            _dbt_source_relation,
             student_id,
             `subject`,
             academic_year_int,
@@ -31,7 +30,6 @@ with
     )
 
 select
-    _dbt_source_relation,
     student_id,
     `subject`,
     academic_year_int,

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson_union.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson_union.sql
@@ -1,5 +1,4 @@
 select
-    _dbt_source_relation,
     academic_year_int,
     student_id,
     school,
@@ -20,7 +19,6 @@ from {{ ref("stg_iready__instruction_by_lesson") }}
 union all
 
 select
-    _dbt_source_relation,
     academic_year_int,
     student_id,
     school,

--- a/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__student_filters.sql
+++ b/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__student_filters.sql
@@ -133,7 +133,6 @@ with
         union all
 
         select
-            _dbt_source_relation,
             student_id as student_number,
             academic_year_int as academic_year,
             `subject`,

--- a/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__student_filters.sql
+++ b/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__student_filters.sql
@@ -100,7 +100,6 @@ with
 
     prev_yr_iready as (
         select
-            _dbt_source_relation,
             student_id,
             `subject`,
 
@@ -120,7 +119,6 @@ with
 
     cur_yr_iready as (
         select
-            _dbt_source_relation,
             student_id as student_number,
             academic_year_int as academic_year,
             `subject`,
@@ -318,18 +316,15 @@ left join
     and co.academic_year = py.academic_year_plus
     and {{ union_dataset_join_clause(left_alias="co", right_alias="py") }}
     and sj.illuminate_subject_area = py.subject
-/* removed union join clause due to issues with i-Ready source data */
 left join
     prev_yr_iready as pr
     on co.student_number = pr.student_id
     and co.academic_year = pr.academic_year_plus
-    -- and {{ union_dataset_join_clause(left_alias="co", right_alias="pr") }}
     and sj.iready_subject = pr.subject
 left join
     cur_yr_iready as ci
     on co.student_number = ci.student_number
     and co.academic_year = ci.academic_year
-    -- and {{ union_dataset_join_clause(left_alias="co", right_alias="ci") }}
     and sj.iready_subject = ci.subject
 left join
     iready_exempt as ie


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
