### PR TITLE
adding view region permissions for Directors of Regional Ops

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
@@ -89,6 +89,11 @@ select
             contains_substr(sr.job_title, 'Managing Director')
             and sr.home_department_name in ('Operations', 'School Support')
         then 2
+        when
+            contains_substr(sr.job_title, 'Director')
+            and sr.home_department_name in ('Operations', 'School Support')
+            and sr.home_work_location_name like '%Room%'
+        then 2
         when contains_substr(sr.job_title, 'Head of Schools')
         then 2
         /* see nothing */


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Add region-wide permission level (2) for Directors in Operations whose location is a "Room"

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
