### PR TITLE
activating coaching conversation tool and adding refreshes

### DIFF
--- a/src/teamster/code_locations/kipptaf/tableau/config/assets.yaml
+++ b/src/teamster/code_locations/kipptaf/tableau/config/assets.yaml
@@ -226,11 +226,15 @@ assets:
     metadata:
       id: 9a4decae-3707-468f-8098-d3f625d770eb
       cron_schedule: 0 2 * * *
-  # - name: Coaching Conversation Tool
-  #   deps:
-  #     - [kipptaf, tableau, rpt_tableau__schoolmint_grow_observation_details]
-  #   metadata:
-  #     id: db88d328-0d54-4dac-8003-6197841e1432
+  - name: Coaching Conversation Tool
+    deps:
+      - [kipptaf, tableau, rpt_tableau__schoolmint_grow_observation_details]
+    metadata:
+      id: db88d328-0d54-4dac-8003-6197841e1432
+      cron_schedule:
+        - 0 6 * * *
+        - 30 14 * * *
+        - 15 16 * * *
   # - name: Master Renewal Tracking Tool
   #   deps:
   #     - [kipptaf, tableau, rpt_tableau__staff_performance_compliance_history]


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Add the Coaching Conversation Tool dashboard to the tableau assets and set a cron_schedule the same as the SchoolMint Grow Dashboard

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)

  _If this is a same-day request, please flag that in Slack_

- [ ] <kbd>Format</kbd> has been run on all modified files

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models from these datasets:
  - deanslist
  - edplan
  - iready
  - pearson
  - powerschool
  - renlearn
  - titan

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
