### PR TITLE
seat tracker mdo regions

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
@@ -15,8 +15,6 @@ select
     sr.sam_account_name as tableau_username,
     sr.reports_to_sam_account_name as tableau_manager_username,
 
-    lx.mdo_employee_number,
-
     /* future feeds from other data sources*/
     null as itr_response,
     null as certification_renewal_status,
@@ -39,6 +37,10 @@ select
             in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
         then 'New Jersey'
         when sr.home_business_unit_name = 'KIPP Miami'
+        then 'Miami'
+        when
+            sr.home_work_location_name = 'Room 11'
+            and sr.job_title = 'Managing Director of Operations'
         then 'Miami'
         else 'CMO'
     end as region_state,
@@ -104,9 +106,6 @@ inner join
     {{ ref("stg_people__location_crosswalk") }} as lc
     on sr.home_work_location_name = lc.name
 left join
-    {{ ref("int_people__leadership_crosswalk") }} as lx
-    on sr.home_work_location_name = lx.home_work_location_name
-left join
     {{ ref("stg_people__campus_crosswalk") }} as cc
     on sr.home_work_location_name = cc.location_name
 left join
@@ -134,7 +133,6 @@ select
     null as worker_termination_date,
     null as tableau_username,
     null as tableau_manager_username,
-    null as mdo_employee_number,
     null as itr_response,
     null as certification_renewal_status,
     null as last_performance_management_score,
@@ -164,7 +162,6 @@ select
     null as worker_termination_date,
     null as tableau_username,
     null as tableau_manager_username,
-    null as mdo_employee_number,
     null as itr_response,
     null as certification_renewal_status,
     null as last_performance_management_score,
@@ -194,7 +191,6 @@ select
     null as worker_termination_date,
     null as tableau_username,
     null as tableau_manager_username,
-    null as mdo_employee_number,
     null as itr_response,
     null as certification_renewal_status,
     null as last_performance_management_score,
@@ -224,7 +220,6 @@ select
     null as worker_termination_date,
     null as tableau_username,
     null as tableau_manager_username,
-    null as mdo_employee_number,
     null as itr_response,
     null as certification_renewal_status,
     null as last_performance_management_score,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

Change how we're assigning MDOs to region-states to account for Miami MDO being in KTAF.

## Self-review

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files
- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars "ext_full_refresh: true"

  **If this is a same-day request, please flag that in our Slack channel!**

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
