### PR TITLE
coalesce ml fields for Pearson

### DIFF
--- a/src/dbt/pearson/models/staging/stg_pearson__njgpa.sql
+++ b/src/dbt/pearson/models/staging/stg_pearson__njgpa.sql
@@ -12,7 +12,6 @@ select
     testscorecomplete,
 
     studentwithdisabilities,
-    englishlearnerel,
     hispanicorlatinoethnicity,
     americanindianoralaskanative,
     asian,
@@ -26,6 +25,8 @@ select
     cast(left(assessmentyear, 4) as int) as academic_year,
 
     cast(regexp_extract(assessmentgrade, r'Grade\s(\d+)') as int) as test_grade,
+
+    coalesce(multilinguallearnerml, englishlearnerel) as englishlearnerel,
 
     coalesce(
         staffmemberidentifier.long_value,

--- a/src/dbt/pearson/models/staging/stg_pearson__njsla.sql
+++ b/src/dbt/pearson/models/staging/stg_pearson__njsla.sql
@@ -93,6 +93,8 @@ select
                 "filler",
                 "staffmemberidentifier",
                 "testadministrator",
+                "englishlearnerel",
+                "multilinguallearnerml",
             ],
         )
     }},
@@ -105,6 +107,8 @@ select
     cast(left(assessmentyear, 4) as int) as academic_year,
 
     cast(regexp_extract(assessmentgrade, r'Grade\s(\d+)') as int) as test_grade,
+
+    coalesce(multilinguallearnerml, englishlearnerel) as englishlearnerel,
 
     if(
         `subject` in ('English Language Arts', 'English Language Arts/Literacy'),


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
