### PR TITLE
fix: shortname label and staff history dates

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
@@ -27,8 +27,10 @@ with
             end as answer_short,
         -- trunk-ignore-end(sqlfluff/LT05)
         from {{ ref("rpt_tableau__survey_responses") }}
-        where survey_code = 'ITR' and question_shortname = 'itr_plans'
-        and academic_year = {{ var("current_academic_year") }}
+        where
+            survey_code = 'ITR'
+            and question_shortname = 'itr_plans'
+            and academic_year = {{ var("current_academic_year") }}
         group by employee_number, answer, academic_year
     ),
 

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
@@ -7,8 +7,6 @@ with
             max(date_submitted) as last_date_submitted,
             -- trunk-ignore-begin(sqlfluff/LT05)
             case
-                when academic_year <> {{ var("current_academic_year") }}
-                then 'No Response'
                 when
                     answer
                     = 'I am committed to my school community/team and, if offered a renewal contract, definitely returning; the Recruitment Team should NOT hire for my position.'
@@ -30,6 +28,7 @@ with
         -- trunk-ignore-end(sqlfluff/LT05)
         from {{ ref("rpt_tableau__survey_responses") }}
         where survey_code = 'ITR' and question_shortname = 'itr_plans'
+        and academic_year = {{ var("current_academic_year") }}
         group by employee_number, answer, academic_year
     ),
 

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_responses.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_responses.sql
@@ -42,8 +42,9 @@ from {{ ref("int_surveys__survey_responses") }} as sr
 left join
     {{ ref("base_people__staff_roster_history") }} as eh
     on sr.respondent_email = eh.google_email
-    and sr.date_submitted
-    between eh.work_assignment_start_timestamp and eh.work_assignment_end_timestamp
+    -- temporary fix until the move to ADP people data table --
+    and safe_cast(sr.date_submitted as date)
+    between eh.work_assignment_actual_start_date and eh.work_assignment_termination_date
 left join
     {{ ref("int_powerschool__teacher_grade_levels") }} as tgl
     on eh.powerschool_teacher_number = tgl.teachernumber


### PR DESCRIPTION
surveys: fix join on dates to staff roster history

# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
