### PR TITLE
refactor: retire use of extract

### DIFF
--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -98,19 +98,8 @@ models:
       +schema: edplan
     extracts:
       +schema: extracts
-      +materialized: table
-      clever:
-        +materialized: view
-      deanslist:
-        +materialized: view
-      google:
-        sheets:
-          +materialized: view
-      powerschool:
-        +materialized: view
       tableau:
         +schema: tableau
-        +materialized: view
     facebook:
       +enabled: false
     finance:

--- a/src/teamster/code_locations/kipptaf/extracts/assets.py
+++ b/src/teamster/code_locations/kipptaf/extracts/assets.py
@@ -6,54 +6,10 @@ from teamster.code_locations.kipptaf import CODE_LOCATION, LOCAL_TIMEZONE
 from teamster.code_locations.kipptaf.adp.payroll.assets import (
     GENERAL_LEDGER_FILE_PARTITIONS_DEF,
 )
-from teamster.libraries.extracts.assets import (
-    build_bigquery_extract_sftp_asset,
-    build_bigquery_query_sftp_asset,
-)
+from teamster.libraries.extracts.assets import build_bigquery_query_sftp_asset
 
 config_dir = pathlib.Path(__file__).parent / "config"
 
-# BQ extract jobs
-
-illuminate_extract_assets = [
-    build_bigquery_extract_sftp_asset(
-        code_location=CODE_LOCATION,
-        timezone=LOCAL_TIMEZONE,
-        extract_job_config={"field_delimiter": "\t"},
-        destination_config={"name": "illuminate"},
-        **a,
-    )
-    for a in config_from_files([f"{config_dir}/illuminate.yaml"])["assets"]
-]
-
-coupa_extract = build_bigquery_extract_sftp_asset(
-    code_location=CODE_LOCATION,
-    timezone=LOCAL_TIMEZONE,
-    dataset_config={"dataset_id": "kipptaf_extracts", "table_id": "rpt_coupa__users"},
-    file_config={"stem": "users_{today}", "suffix": "csv"},
-    destination_config={"name": "coupa", "path": "/Incoming/Users"},
-)
-
-egencia_extract = build_bigquery_extract_sftp_asset(
-    code_location=CODE_LOCATION,
-    timezone=LOCAL_TIMEZONE,
-    dataset_config={"dataset_id": "kipptaf_extracts", "table_id": "rpt_egencia__users"},
-    file_config={"stem": "users_{today}", "suffix": "csv"},
-    destination_config={"name": "egencia", "path": "/global/50323/USERS"},
-)
-
-littlesis_extract = build_bigquery_extract_sftp_asset(
-    code_location=CODE_LOCATION,
-    timezone=LOCAL_TIMEZONE,
-    dataset_config={
-        "dataset_id": "kipptaf_extracts",
-        "table_id": "rpt_littlesis__enrollments",
-    },
-    file_config={"stem": "littlesis_extract", "suffix": "csv"},
-    destination_config={"name": "littlesis"},
-)
-
-# BQ query
 clever_extract_assets = [
     build_bigquery_query_sftp_asset(
         code_location=CODE_LOCATION,
@@ -63,6 +19,22 @@ clever_extract_assets = [
     )
     for a in config_from_files([f"{config_dir}/clever.yaml"])["assets"]
 ]
+
+coupa_extract = build_bigquery_query_sftp_asset(
+    code_location=CODE_LOCATION,
+    timezone=LOCAL_TIMEZONE,
+    query_config={
+        "type": "schema",
+        "value": {
+            "table": {
+                "name": "rpt_coupa__users",
+                "schema": "kipptaf_extracts",
+            }
+        },
+    },
+    file_config={"stem": "users_{today}", "suffix": "csv"},
+    destination_config={"name": "coupa", "path": "/Incoming/Users"},
+)
 
 deanslist_annual_extract_assets = [
     build_bigquery_query_sftp_asset(
@@ -90,6 +62,22 @@ deanslist_continuous_extract = build_bigquery_query_sftp_asset(
     destination_config={"name": "deanslist"},
 )
 
+egencia_extract = build_bigquery_query_sftp_asset(
+    code_location=CODE_LOCATION,
+    timezone=LOCAL_TIMEZONE,
+    query_config={
+        "type": "schema",
+        "value": {
+            "table": {
+                "name": "rpt_egencia__users",
+                "schema": "kipptaf_extracts",
+            }
+        },
+    },
+    file_config={"stem": "users_{today}", "suffix": "csv"},
+    destination_config={"name": "egencia", "path": "/global/50323/USERS"},
+)
+
 idauto_extract = build_bigquery_query_sftp_asset(
     code_location=CODE_LOCATION,
     timezone=LOCAL_TIMEZONE,
@@ -108,6 +96,16 @@ idauto_extract = build_bigquery_query_sftp_asset(
     destination_config={"name": "idauto"},
 )
 
+illuminate_extract_assets = [
+    build_bigquery_query_sftp_asset(
+        code_location=CODE_LOCATION,
+        timezone=LOCAL_TIMEZONE,
+        destination_config={"name": "illuminate"},
+        **a,
+    )
+    for a in config_from_files([f"{config_dir}/illuminate.yaml"])["assets"]
+]
+
 intacct_extract = build_bigquery_query_sftp_asset(
     code_location=CODE_LOCATION,
     timezone=LOCAL_TIMEZONE,
@@ -123,6 +121,22 @@ intacct_extract = build_bigquery_query_sftp_asset(
     file_config={"stem": "adp_payroll_{date}_{group_code}", "suffix": "csv"},
     destination_config={"name": "couchdrop", "path": "/data-team/accounting/intacct"},
     partitions_def=GENERAL_LEDGER_FILE_PARTITIONS_DEF,
+)
+
+littlesis_extract = build_bigquery_query_sftp_asset(
+    code_location=CODE_LOCATION,
+    timezone=LOCAL_TIMEZONE,
+    query_config={
+        "type": "schema",
+        "value": {
+            "table": {
+                "name": "rpt_littlesis__enrollments",
+                "schema": "kipptaf_extracts",
+            }
+        },
+    },
+    file_config={"stem": "littlesis_extract", "suffix": "csv"},
+    destination_config={"name": "littlesis"},
 )
 
 assets = [

--- a/src/teamster/code_locations/kipptaf/extracts/config/illuminate.yaml
+++ b/src/teamster/code_locations/kipptaf/extracts/config/illuminate.yaml
@@ -1,67 +1,122 @@
 assets:
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__courses
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__courses
     file_config:
       stem: courses
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__enrollment
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__enrollment
     file_config:
       stem: enrollment
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__mastschd
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__mastschd
     file_config:
       stem: mastschd
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__roles
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__roles
     file_config:
       stem: roles
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__roster
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__roster
     file_config:
       stem: roster
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__users
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__users
     file_config:
       stem: users
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__terms
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__terms
     file_config:
       stem: terms
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__student_portal_accounts
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__student_portal_accounts
     file_config:
       stem: student_portal_accounts
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__studemo
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__studemo
     file_config:
       stem: studemo
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__sites
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__sites
     file_config:
       stem: sites
       suffix: txt
-  - dataset_config:
-      dataset_id: kipptaf_extracts
-      table_id: rpt_illuminate__programs
+      format:
+        delimiter: "\t"
+  - query_config:
+      type: schema
+      value:
+        table:
+          schema: kipptaf_extracts
+          name: rpt_illuminate__programs
     file_config:
       stem: programs
       suffix: txt
+      format:
+        delimiter: "\t"

--- a/src/teamster/libraries/extracts/assets.py
+++ b/src/teamster/libraries/extracts/assets.py
@@ -213,7 +213,7 @@ def build_bigquery_query_sftp_asset(
         data = [dict(row) for row in query_job.result()]
 
         if len(data) == 0:
-            context.log.warn("Query returned an empty result")
+            context.log.warning("Query returned an empty result")
 
         transformed_data = transform_data(
             data=data,

--- a/src/teamster/libraries/extracts/assets.py
+++ b/src/teamster/libraries/extracts/assets.py
@@ -15,11 +15,8 @@ from dagster import (
     _check,
     asset,
 )
-from dagster_gcp import BigQueryResource, GCSResource
-from google.cloud.bigquery import Client as BigQueryClient
-from google.cloud.bigquery import DatasetReference, ExtractJobConfig
+from google.cloud.bigquery import Client
 from google.cloud.storage import Blob
-from google.cloud.storage import Client as CloudStorageClient
 from sqlalchemy.sql.expression import literal_column, select, table, text
 
 from teamster.core.utils.classes import CustomJSONEncoder
@@ -206,9 +203,10 @@ def build_bigquery_query_sftp_asset(
 
         query = construct_query(query_type=query_type, query_value=query_value)
 
-        db_bigquery: BigQueryClient = next(context.resources.db_bigquery)
+        # required_resource_keys yields generator
+        bq_client: Client = next(context.resources.db_bigquery)
 
-        query_job = db_bigquery.query(query=query)
+        query_job = bq_client.query(query=query)
 
         data = [dict(row) for row in query_job.result()]
 
@@ -232,178 +230,5 @@ def build_bigquery_query_sftp_asset(
             file_name=file_name,
             destination_path=destination_path,
         )
-
-    return _asset
-
-
-def build_bigquery_extract_sftp_asset(
-    code_location,
-    timezone,
-    dataset_config,
-    file_config,
-    destination_config,
-    extract_job_config: dict | None = None,
-    op_tags: dict | None = None,
-    partitions_def=None,
-):
-    if extract_job_config is None:
-        extract_job_config = {}
-
-    dataset_id = dataset_config["dataset_id"]
-    table_id = dataset_config["table_id"]
-
-    destination_name = destination_config["name"]
-    destination_path = destination_config.get("path", "")
-
-    file_suffix = file_config["suffix"]
-    file_stem = file_config["stem"]
-
-    asset_name = (
-        re.sub(pattern="[^A-Za-z0-9_]", repl="", string=file_stem) + f"_{file_suffix}"
-    )
-
-    @asset(
-        key=[code_location, "extracts", destination_name, asset_name],
-        deps=[AssetKey([code_location, "extracts", table_id])],
-        required_resource_keys={"gcs", "db_bigquery", f"ssh_{destination_name}"},
-        partitions_def=partitions_def,
-        op_tags=op_tags,
-        group_name="extracts",
-        kinds={"python"},
-    )
-    def _asset(context: AssetExecutionContext):
-        now = datetime.now(timezone)
-
-        if context.has_partition_key and isinstance(
-            context.assets_def.partitions_def, MultiPartitionsDefinition
-        ):
-            partition_key = _check.inst(
-                obj=context.partition_key, ttype=MultiPartitionKey
-            )
-
-            substitutions = partition_key.keys_by_dimension
-        else:
-            substitutions = {
-                "now": str(now.timestamp()).replace(".", "_"),
-                "today": now.date().isoformat(),
-            }
-
-        file_name = format_file_name(
-            stem=file_stem, suffix=file_suffix, **substitutions
-        )
-
-        # establish gcs blob
-        gcs: CloudStorageClient = context.resources.gcs
-
-        bucket = gcs.get_bucket(f"teamster-{code_location}")
-
-        blob = bucket.blob(
-            blob_name=(
-                f"dagster/{code_location}/extracts/data/{destination_name}/{file_name}"
-            )
-        )
-
-        # execute bq extract job
-        bq_client: BigQueryClient = next(context.resources.db_bigquery)
-
-        dataset_ref = DatasetReference(project=bq_client.project, dataset_id=dataset_id)
-
-        extract_job = bq_client.extract_table(
-            source=dataset_ref.table(table_id=table_id),
-            destination_uris=[f"gs://teamster-{code_location}/{blob.name}"],
-            job_config=ExtractJobConfig(**extract_job_config),
-        )
-
-        extract_job.result()
-
-        # transfer via sftp
-        load_sftp(
-            context=context,
-            ssh=getattr(context.resources, f"ssh_{destination_name}"),
-            data=blob,
-            file_name=file_name,
-            destination_path=destination_path,
-        )
-
-    return _asset
-
-
-def build_bigquery_extract_asset(
-    code_location,
-    timezone,
-    dataset_config,
-    file_config,
-    destination_config,
-    extract_job_config: dict | None = None,
-    op_tags: dict | None = None,
-):
-    if extract_job_config is None:
-        extract_job_config = {}
-
-    dataset_id = dataset_config["dataset_id"]
-    table_id = dataset_config["table_id"]
-
-    destination_name = destination_config["name"]
-    destination_path = destination_config.get("path", "")
-
-    file_suffix = file_config["suffix"]
-    file_stem = file_config["stem"]
-
-    asset_name = (
-        re.sub(pattern="[^A-Za-z0-9_]", repl="", string=file_stem) + f"_{file_suffix}"
-    )
-
-    @asset(
-        key=[code_location, "extracts", destination_name, asset_name],
-        deps=[AssetKey([code_location, "extracts", table_id])],
-        op_tags=op_tags,
-        group_name="extracts",
-        kinds={"python"},
-    )
-    def _asset(
-        context: AssetExecutionContext, gcs: GCSResource, db_bigquery: BigQueryResource
-    ):
-        now = datetime.now(timezone)
-
-        if context.has_partition_key and isinstance(
-            context.assets_def.partitions_def, MultiPartitionsDefinition
-        ):
-            partition_key = _check.inst(
-                obj=context.partition_key, ttype=MultiPartitionKey
-            )
-
-            substitutions = partition_key.keys_by_dimension
-        else:
-            substitutions = {
-                "now": str(now.timestamp()).replace(".", "_"),
-                "today": now.date().isoformat(),
-            }
-
-        file_name = format_file_name(
-            stem=file_stem, suffix=file_suffix, **substitutions
-        )
-
-        # establish gcs blob
-        gcs_client = gcs.get_client()
-
-        bucket = gcs_client.get_bucket(f"teamster-{code_location}")
-
-        blob = bucket.blob(
-            blob_name=f"{destination_path}/{destination_name}/{file_name}"
-        )
-
-        # execute bq extract job
-        with db_bigquery.get_client() as bq_client:
-            dataset_ref = DatasetReference(
-                project=bq_client.project, dataset_id=dataset_id
-            )
-
-            extract_job = bq_client.extract_table(
-                source=dataset_ref.table(table_id=table_id),
-                destination_uris=[f"gs://teamster-{code_location}/{blob.name}"],
-                job_config=ExtractJobConfig(**extract_job_config),
-            )
-
-            extract_job.result()
 
     return _asset

--- a/tests/assets/test_assets_extracts.py
+++ b/tests/assets/test_assets_extracts.py
@@ -68,7 +68,7 @@ def test_construct_query_schema():
     print(sql)
     assert str(sql) == (
         "SELECT * \nFROM "
-        f"{query_value["table"]["schema"]}.{query_value["table"]["name"]} \n"
+        f"{query_value['table']['schema']}.{query_value['table']['name']} \n"
         f"WHERE date = '{date}' AND group_code = '{group_code}'"
     )
 
@@ -167,4 +167,15 @@ def test_clever_extract():
         assets=clever_extract_assets,
         asset_selection="kipptaf/extracts/clever/students_csv",
         ssh_clever=SSH_RESOURCE_CLEVER,
+    )
+
+
+def test_illuminate_extract():
+    from teamster.code_locations.kipptaf.extracts.assets import (
+        illuminate_extract_assets,
+    )
+    from teamster.code_locations.kipptaf.resources import SSH_RESOURCE_ILLUMINATE
+
+    _test_asset(
+        assets=illuminate_extract_assets, ssh_illuminate=SSH_RESOURCE_ILLUMINATE
     )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
