### PR TITLE
added RHET to NJ ES comment check

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_section_week_student_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_section_week_student_scaffold.sql
@@ -155,7 +155,7 @@ select
         s.region != 'Miami'
         and sec.is_quarter_end_date_range
         and s.grade_level < 5
-        and ce.courses_credittype in ('HR', 'MATH', 'ENG')
+        and ce.courses_credittype in ('HR', 'MATH', 'ENG', 'RHET')
         and qg.comment_value is null,
         true,
         false

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__assignment_score_rollup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__assignment_score_rollup.sql
@@ -5,18 +5,23 @@ with
             a.sectionsdcid,
             a.assignmentsectionid,
 
-            s.studentsdcid,
-            s.islate,
-            s.isexempt,
-            s.ismissing,
+            e.students_dcid,
 
-            if(s.isexempt = 0, true, false) as is_expected,
+            coalesce(s.islate, 0) as islate,
+            coalesce(s.isexempt, 0) as isexempt,
+            coalesce(s.ismissing, 0) as ismissing,
+
+            if(coalesce(s.isexempt, 0) = 0, true, false) as is_expected,
 
             if(s.scorepoints is null, 1, 0) as is_null,
 
-            if(s.scorepoints is null and s.ismissing = 1, 1, 0) as is_null_missing,
+            if(
+                s.scorepoints is null and coalesce(s.ismissing, 0) = 1, 1, 0
+            ) as is_null_missing,
 
-            if(s.scorepoints is null and s.ismissing = 0, 1, 0) as is_null_not_missing,
+            if(
+                s.scorepoints is null and coalesce(s.ismissing, 0) = 0, 1, 0
+            ) as is_null_not_missing,
 
             case
                 when s.isexempt = 1
@@ -47,7 +52,6 @@ with
             and {{ union_dataset_join_clause(left_alias="a", right_alias="s") }}
             and e.students_dcid = s.studentsdcid
             and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
-        where s.studentsdcid is not null
     ),
 
     school_course_exceptions as (
@@ -79,7 +83,8 @@ select
     s._dbt_source_relation,
     s.assignmentsectionid,
 
-    count(s.studentsdcid) as n_students,
+    count(s.students_dcid) as n_students,
+
     sum(s.islate) as n_late,
     sum(s.isexempt) as n_exempt,
     sum(s.ismissing) as n_missing,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__assignment_score_rollup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__assignment_score_rollup.sql
@@ -14,6 +14,10 @@ with
 
             if(s.scorepoints is null, 1, 0) as is_null,
 
+            if(s.scorepoints is null and s.ismissing = 1, 1, 0) as is_null_missing,
+
+            if(s.scorepoints is null and s.ismissing = 0, 1, 0) as is_null_not_missing,
+
             case
                 when s.isexempt = 1
                 then false
@@ -43,6 +47,7 @@ with
             and {{ union_dataset_join_clause(left_alias="a", right_alias="s") }}
             and e.students_dcid = s.studentsdcid
             and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
+        where s.studentsdcid is not null
     ),
 
     school_course_exceptions as (
@@ -79,6 +84,8 @@ select
     sum(s.isexempt) as n_exempt,
     sum(s.ismissing) as n_missing,
     sum(s.is_null) as n_null,
+    sum(s.is_null_missing) as n_is_null_missing,
+    sum(s.is_null_not_missing) as n_is_null_not_missing,
 
     countif(s.is_expected) as n_expected,
     countif(s.is_expected_scored) as n_expected_scored,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
