### PR TITLE
added tracking for data entry timestamps

### DIFF
--- a/src/dbt/powerschool/models/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/powerschool/models/intermediate/int_powerschool__gradebook_assignments.sql
@@ -11,6 +11,8 @@ with
             asec.extracreditpoints,
             asec.weight,
             asec.iscountedinfinalgrade,
+            asec.whocreated,
+            asec.whencreated,
 
             coalesce(tc.districtteachercategoryid, tc.teachercategoryid) as category_id,
 

--- a/src/dbt/powerschool/models/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/powerschool/models/intermediate/int_powerschool__gradebook_assignments.sql
@@ -13,6 +13,10 @@ with
             asec.iscountedinfinalgrade,
             asec.whocreated,
             asec.whencreated,
+            asec.whomodified,
+            asec.whenmodified,
+            asec.transaction_date,
+            asec.publisheddate,
 
             coalesce(tc.districtteachercategoryid, tc.teachercategoryid) as category_id,
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209646931487608