### PR TITLE
refactor: use default k8s service account for google API opps

### DIFF
--- a/.devcontainer/scripts/postCreate.sh
+++ b/.devcontainer/scripts/postCreate.sh
@@ -38,10 +38,10 @@ op inject -f --in-file=.devcontainer/tpl/deanslist_api_key_map_yaml.tpl \
   sudo mv -f env/deanslist_api_key_map_yaml \
     /etc/secret-volume/deanslist_api_key_map_yaml
 
-op inject -f --in-file=.devcontainer/tpl/gcloud_service_account_json.tpl \
-  --out-file=env/gcloud_service_account_json &&
-  sudo mv -f env/gcloud_service_account_json \
-    /etc/secret-volume/gcloud_service_account_json
+op inject -f --in-file=.devcontainer/tpl/gcloud_dagster_service_account.json.tpl \
+  --out-file=env/gcloud_dagster_service_account.json &&
+  sudo mv -f env/gcloud_dagster_service_account.json \
+    /etc/secret-volume/gcloud_dagster_service_account.json
 
 op inject -f --in-file=.devcontainer/tpl/id_rsa_egencia.tpl \
   --out-file=env/id_rsa_egencia &&
@@ -61,7 +61,7 @@ op inject -f --in-file=.devcontainer/tpl/powerschool_ssh_password.txt.tpl \
 
 # auth gcloud
 gcloud auth activate-service-account \
-  --key-file=/etc/secret-volume/gcloud_service_account_json
+  --key-file=/etc/secret-volume/gcloud_dagster_service_account.json
 
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh || true

--- a/.devcontainer/tpl/gcloud_dagster_service_account.json.tpl
+++ b/.devcontainer/tpl/gcloud_dagster_service_account.json.tpl
@@ -1,0 +1,1 @@
+op://Data Team/TEAMster Service Account - user-cloud-dagster-cloud-agent/teamster-332318-2e17ca003e7d.json

--- a/.devcontainer/tpl/gcloud_service_account_json.tpl
+++ b/.devcontainer/tpl/gcloud_service_account_json.tpl
@@ -1,1 +1,0 @@
-op://Data Team/Teamster Service Account - Default/service_account_gserviceaccount.json

--- a/.k8s/1password/items.yaml
+++ b/.k8s/1password/items.yaml
@@ -290,14 +290,6 @@ spec:
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: op-gcp-service-account-teamster
-  namespace: dagster-cloud
-spec:
-  itemPath: vaults/Data Team/items/Teamster Service Account - Default
----
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
   name: op-tableau-server-api
   namespace: dagster-cloud
 spec:

--- a/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
@@ -37,11 +37,6 @@ locations:
                       - key: dbt_user_credentials.json
                         path: dbt_user_creds_json
                 - secret:
-                    name: op-gcp-service-account-teamster
-                    items:
-                      - key: service_account_gserviceaccount.json
-                        path: gcloud_service_account_json
-                - secret:
                     name: op-gcp-service-account-dlt
                     items:
                       - key: keyfile.json

--- a/src/teamster/code_locations/kipptaf/resources.py
+++ b/src/teamster/code_locations/kipptaf/resources.py
@@ -22,44 +22,6 @@ from teamster.libraries.smartrecruiters.resources import SmartRecruitersResource
 from teamster.libraries.ssh.resources import SSHResource
 from teamster.libraries.tableau.resources import TableauServerResource
 
-
-def get_google_drive_resource(
-    test: bool = False, service_account_file_path: str | None = None
-):
-    return GoogleDriveResource(
-        service_account_file_path=(service_account_file_path if test else None)
-    )
-
-
-def get_google_forms_resource(
-    test: bool = False, service_account_file_path: str | None = None
-):
-    return GoogleFormsResource(
-        service_account_file_path=(service_account_file_path if test else None)
-    )
-
-
-def get_google_sheets_resource(
-    test: bool = False, service_account_file_path: str | None = None
-):
-    return GoogleSheetsResource(
-        service_account_file_path=(service_account_file_path if test else None)
-    )
-
-
-def get_google_directory_resource(
-    customer_id,
-    test: bool = False,
-    delegated_account: str | None = None,
-    service_account_file_path: str | None = None,
-):
-    return GoogleDirectoryResource(
-        customer_id=customer_id,
-        delegated_account=delegated_account,
-        service_account_file_path=(service_account_file_path if test else None),
-    )
-
-
 ADP_WORKFORCE_MANAGER_RESOURCE = AdpWorkforceManagerResource(
     subdomain=EnvVar("ADP_WFM_SUBDOMAIN"),
     app_key=EnvVar("ADP_WFM_APP_KEY"),

--- a/src/teamster/code_locations/kipptaf/resources.py
+++ b/src/teamster/code_locations/kipptaf/resources.py
@@ -22,9 +22,43 @@ from teamster.libraries.smartrecruiters.resources import SmartRecruitersResource
 from teamster.libraries.ssh.resources import SSHResource
 from teamster.libraries.tableau.resources import TableauServerResource
 
-"""
-Dagster resources
-"""
+
+def get_google_drive_resource(
+    test: bool = False, service_account_file_path: str | None = None
+):
+    return GoogleDriveResource(
+        service_account_file_path=(service_account_file_path if test else None)
+    )
+
+
+def get_google_forms_resource(
+    test: bool = False, service_account_file_path: str | None = None
+):
+    return GoogleFormsResource(
+        service_account_file_path=(service_account_file_path if test else None)
+    )
+
+
+def get_google_sheets_resource(
+    test: bool = False, service_account_file_path: str | None = None
+):
+    return GoogleSheetsResource(
+        service_account_file_path=(service_account_file_path if test else None)
+    )
+
+
+def get_google_directory_resource(
+    customer_id,
+    test: bool = False,
+    delegated_account: str | None = None,
+    service_account_file_path: str | None = None,
+):
+    return GoogleDirectoryResource(
+        customer_id=customer_id,
+        delegated_account=delegated_account,
+        service_account_file_path=(service_account_file_path if test else None),
+    )
+
 
 ADP_WORKFORCE_MANAGER_RESOURCE = AdpWorkforceManagerResource(
     subdomain=EnvVar("ADP_WFM_SUBDOMAIN"),
@@ -62,23 +96,16 @@ DIBELS_DATA_SYSTEM_RESOURCE = DibelsDataSystemResource(
 
 DLT_RESOURCE = DagsterDltResource()
 
-GOOGLE_DRIVE_RESOURCE = GoogleDriveResource(
-    service_account_file_path="/etc/secret-volume/gcloud_service_account_json"
-)
+GOOGLE_DRIVE_RESOURCE = GoogleDriveResource()
 
-GOOGLE_FORMS_RESOURCE = GoogleFormsResource(
-    service_account_file_path="/etc/secret-volume/gcloud_service_account_json"
-)
+GOOGLE_FORMS_RESOURCE = GoogleFormsResource()
 
 GOOGLE_DIRECTORY_RESOURCE = GoogleDirectoryResource(
     customer_id=EnvVar("GOOGLE_WORKSPACE_CUSTOMER_ID"),
     delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
-    service_account_file_path="/etc/secret-volume/gcloud_service_account_json",
 )
 
-GOOGLE_SHEETS_RESOURCE = GoogleSheetsResource(
-    service_account_file_path="/etc/secret-volume/gcloud_service_account_json"
-)
+GOOGLE_SHEETS_RESOURCE = GoogleSheetsResource()
 
 LDAP_RESOURCE = LdapResource(
     host=EnvVar("LDAP_HOST_IP"),

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -2,11 +2,7 @@ import time
 
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext, _check
 from dagster._utils.backoff import backoff
-from google.auth import (  # impersonated_credentials,
-    default,
-    iam,
-    load_credentials_from_file,
-)
+from google.auth import compute_engine, default, iam, load_credentials_from_file
 from google.auth.transport import requests
 from google.oauth2 import service_account
 from googleapiclient import discovery, errors
@@ -48,7 +44,7 @@ class GoogleDirectoryResource(ConfigurableResource):
             source_credentials, project_id = default()
 
             source_credentials = _check.inst(
-                obj=source_credentials, ttype=service_account.Credentials
+                obj=source_credentials, ttype=compute_engine.Credentials
             )
 
             # Refresh the default credentials. This ensures that the information about

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -37,8 +37,11 @@ class GoogleDirectoryResource(ConfigurableResource):
                 credentials, service_account.Credentials
             ).with_subject(self.delegated_account)
         else:
+            # https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#user-credentials
+            source_credentials, project_id = default()
+
             credentials = impersonated_credentials.Credentials(
-                source_credentials=default(),
+                source_credentials=source_credentials,
                 target_principal=self.delegated_account,
                 target_scopes=self.scopes,
             )

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -43,6 +43,7 @@ class GoogleDirectoryResource(ConfigurableResource):
             ).with_subject(self.delegated_account)
         else:
             # https://stackoverflow.com/a/57092533
+            # https://github.com/GoogleCloudPlatform/professional-services/tree/main/examples/gce-to-adminsdk
             request = requests.Request()
 
             # Refresh the default credentials. This ensures that the information about

--- a/src/teamster/libraries/google/drive/resources.py
+++ b/src/teamster/libraries/google/drive/resources.py
@@ -1,23 +1,23 @@
-import google.auth
 from dagster import ConfigurableResource, InitResourceContext
+from google import auth
 from googleapiclient import discovery
 from pydantic import PrivateAttr
 
 
 class GoogleDriveResource(ConfigurableResource):
-    service_account_file_path: str | None = None
     version: str = "v3"
-    scopes: list = ["https://www.googleapis.com/auth/drive.metadata.readonly"]
+    scopes: list[str] = ["https://www.googleapis.com/auth/drive.metadata.readonly"]
+    service_account_file_path: str | None = None
 
     _service: discovery.Resource = PrivateAttr()
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         if self.service_account_file_path is not None:
-            credentials, project_id = google.auth.load_credentials_from_file(
+            credentials, project_id = auth.load_credentials_from_file(
                 filename=self.service_account_file_path, scopes=self.scopes
             )
         else:
-            credentials, project_id = google.auth.default(scopes=self.scopes)
+            credentials, project_id = auth.default(scopes=self.scopes)
 
         self._service = discovery.build(
             serviceName="drive", version=self.version, credentials=credentials

--- a/src/teamster/libraries/google/forms/resources.py
+++ b/src/teamster/libraries/google/forms/resources.py
@@ -1,28 +1,28 @@
-import google.auth
 from dagster import ConfigurableResource, InitResourceContext
+from google import auth
 from googleapiclient import discovery
 from pydantic import PrivateAttr
 from tenacity import retry, stop_after_attempt, wait_exponential_jitter
 
 
 class GoogleFormsResource(ConfigurableResource):
-    service_account_file_path: str | None = None
     version: str = "v1"
-    scopes: list = [
+    scopes: list[str] = [
         "https://www.googleapis.com/auth/forms.body.readonly",
         "https://www.googleapis.com/auth/forms.responses.readonly",
         "https://www.googleapis.com/auth/drive.metadata.readonly",
     ]
+    service_account_file_path: str | None = None
 
     _resource: discovery.Resource = PrivateAttr()
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         if self.service_account_file_path is not None:
-            credentials, project_id = google.auth.load_credentials_from_file(
+            credentials, project_id = auth.load_credentials_from_file(
                 filename=self.service_account_file_path, scopes=self.scopes
             )
         else:
-            credentials, project_id = google.auth.default(scopes=self.scopes)
+            credentials, project_id = auth.default(scopes=self.scopes)
 
         self._resource = discovery.build(
             serviceName="forms", version=self.version, credentials=credentials

--- a/src/teamster/libraries/google/sheets/resources.py
+++ b/src/teamster/libraries/google/sheets/resources.py
@@ -1,16 +1,15 @@
-import pathlib
-
-import google.auth
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext, _check
+from google import auth
 from google.auth.credentials import Credentials
-from gspread.auth import authorize, service_account
-from gspread.client import Client
-from gspread.exceptions import SpreadsheetNotFound
-from gspread.utils import rowcol_to_a1
+from gspread import Client, SpreadsheetNotFound, authorize, service_account, utils
 from pydantic import PrivateAttr
 
 
 class GoogleSheetsResource(ConfigurableResource):
+    scopes: list[str] = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
     service_account_file_path: str | None = None
 
     _client: Client = PrivateAttr()
@@ -21,15 +20,10 @@ class GoogleSheetsResource(ConfigurableResource):
 
         if self.service_account_file_path is not None:
             self._client = service_account(
-                filename=pathlib.Path(self.service_account_file_path)
+                filename=self.service_account_file_path, scopes=self.scopes
             )
         else:
-            credentials, project_id = google.auth.default(
-                scopes=[
-                    "https://www.googleapis.com/auth/spreadsheets",
-                    "https://www.googleapis.com/auth/drive",
-                ]
-            )
+            credentials, project_id = auth.default(scopes=self.scopes)
 
             self._client = authorize(
                 credentials=_check.inst(obj=credentials, ttype=Credentials)
@@ -58,4 +52,4 @@ class GoogleSheetsResource(ConfigurableResource):
 
     @staticmethod
     def rowcol_to_a1(row, col):
-        return rowcol_to_a1(row=row, col=col)
+        return utils.rowcol_to_a1(row=row, col=col)

--- a/tests/assets/test_assets_google_directory.py
+++ b/tests/assets/test_assets_google_directory.py
@@ -11,8 +11,8 @@ from teamster.code_locations.kipptaf._google.directory.assets import (
     roles,
     users,
 )
-from teamster.code_locations.kipptaf.resources import get_google_directory_resource
 from teamster.core.resources import get_io_manager_gcs_avro
+from teamster.libraries.google.directory.resources import GoogleDirectoryResource
 
 
 def _test_asset(asset: AssetsDefinition):
@@ -30,13 +30,12 @@ def _test_asset(asset: AssetsDefinition):
             "io_manager_gcs_avro": get_io_manager_gcs_avro(
                 code_location="test", test=True
             ),
-            "google_directory": get_google_directory_resource(
+            "google_directory": GoogleDirectoryResource(
                 customer_id=EnvVar("GOOGLE_WORKSPACE_CUSTOMER_ID"),
                 delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
-                test=True,
-                service_account_file_path=(
-                    "/etc/secret-volume/gcloud_dagster_service_account.json"
-                ),
+                # service_account_file_path=(
+                #     "/etc/secret-volume/gcloud_dagster_service_account.json"
+                # ),
             ),
         },
     )

--- a/tests/assets/test_assets_google_directory.py
+++ b/tests/assets/test_assets_google_directory.py
@@ -1,6 +1,6 @@
 import random
 
-from dagster import AssetsDefinition, TextMetadataValue, _check, materialize
+from dagster import AssetsDefinition, EnvVar, TextMetadataValue, _check, materialize
 from dagster._core.events import StepMaterializationData
 
 from teamster.code_locations.kipptaf._google.directory.assets import (
@@ -11,7 +11,7 @@ from teamster.code_locations.kipptaf._google.directory.assets import (
     roles,
     users,
 )
-from teamster.code_locations.kipptaf.resources import GOOGLE_DIRECTORY_RESOURCE
+from teamster.code_locations.kipptaf.resources import get_google_directory_resource
 from teamster.core.resources import get_io_manager_gcs_avro
 
 
@@ -30,7 +30,14 @@ def _test_asset(asset: AssetsDefinition):
             "io_manager_gcs_avro": get_io_manager_gcs_avro(
                 code_location="test", test=True
             ),
-            "google_directory": GOOGLE_DIRECTORY_RESOURCE,
+            "google_directory": get_google_directory_resource(
+                customer_id=EnvVar("GOOGLE_WORKSPACE_CUSTOMER_ID"),
+                delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
+                test=True,
+                service_account_file_path=(
+                    "/etc/secret-volume/gcloud_dagster_service_account.json"
+                ),
+            ),
         },
     )
 

--- a/tests/resources/test_google_directory_resource.py
+++ b/tests/resources/test_google_directory_resource.py
@@ -1,19 +1,21 @@
 import json
 
-from dagster import build_resources
+from dagster import EnvVar, build_resources
 
+from teamster.code_locations.kipptaf.resources import get_google_directory_resource
 from teamster.libraries.google.directory.resources import GoogleDirectoryResource
 
 
-def get_google_directory_resource() -> GoogleDirectoryResource:
+def _get_google_directory_resource() -> GoogleDirectoryResource:
     with build_resources(
         resources={
-            "directory": GoogleDirectoryResource(
-                customer_id="C029u7m0n",
+            "directory": get_google_directory_resource(
+                customer_id=EnvVar("GOOGLE_WORKSPACE_CUSTOMER_ID"),
+                # delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
+                test=True,
                 service_account_file_path=(
-                    "/etc/secret-volume/gcloud_service_account_json"
+                    "/etc/secret-volume/gcloud_dagster_service_account.json"
                 ),
-                delegated_account="dagster@apps.teamschools.org",
             )
         }
     ) as resources:
@@ -21,7 +23,7 @@ def get_google_directory_resource() -> GoogleDirectoryResource:
 
 
 def test_list_orgunits():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_orgunits(org_unit_type="all")
 
@@ -30,7 +32,7 @@ def test_list_orgunits():
 
 
 def test_get_orgunit():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.get_orgunit(org_unit_path="")
 
@@ -39,7 +41,7 @@ def test_get_orgunit():
 
 
 def test_list_roles():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_roles()
 
@@ -48,7 +50,7 @@ def test_list_roles():
 
 
 def test_list_role_assignments():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_role_assignments()
 
@@ -57,7 +59,7 @@ def test_list_role_assignments():
 
 
 def test_list_members():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_members(
         group_key="group-students-miami@teamstudents.org"
@@ -68,7 +70,7 @@ def test_list_members():
 
 
 def test_list_groups():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_groups()
 
@@ -79,7 +81,7 @@ def test_list_groups():
 def test_get_user():
     user_key = "113203151440162455385"
 
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.get_user(user_key=user_key)
 
@@ -88,7 +90,7 @@ def test_get_user():
 
 
 def test_list_users():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     data = google_directory.list_users(projection="full")
 
@@ -97,7 +99,7 @@ def test_list_users():
 
 
 def test_batch_insert_users():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     google_directory.batch_insert_users(
         [
@@ -124,7 +126,7 @@ def test_batch_insert_users():
 
 
 def test_batch_update_users():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     google_directory.batch_update_users(
         [
@@ -162,7 +164,7 @@ def test_batch_update_users():
 
 
 def test_batch_insert_members():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     google_directory.batch_insert_members(
         [
@@ -181,7 +183,7 @@ def test_batch_insert_members():
 
 
 def test_batch_insert_role_assignments():
-    google_directory = get_google_directory_resource()
+    google_directory = _get_google_directory_resource()
 
     google_directory.batch_insert_role_assignments(
         [

--- a/tests/resources/test_google_directory_resource.py
+++ b/tests/resources/test_google_directory_resource.py
@@ -2,20 +2,18 @@ import json
 
 from dagster import EnvVar, build_resources
 
-from teamster.code_locations.kipptaf.resources import get_google_directory_resource
 from teamster.libraries.google.directory.resources import GoogleDirectoryResource
 
 
-def _get_google_directory_resource() -> GoogleDirectoryResource:
+def get_google_directory_resource() -> GoogleDirectoryResource:
     with build_resources(
         resources={
-            "directory": get_google_directory_resource(
+            "directory": GoogleDirectoryResource(
                 customer_id=EnvVar("GOOGLE_WORKSPACE_CUSTOMER_ID"),
-                # delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
-                test=True,
-                service_account_file_path=(
-                    "/etc/secret-volume/gcloud_dagster_service_account.json"
-                ),
+                delegated_account=EnvVar("GOOGLE_DIRECTORY_DELEGATED_ACCOUNT"),
+                # service_account_file_path=(
+                #     "/etc/secret-volume/gcloud_dagster_service_account.json"
+                # ),
             )
         }
     ) as resources:
@@ -23,7 +21,7 @@ def _get_google_directory_resource() -> GoogleDirectoryResource:
 
 
 def test_list_orgunits():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_orgunits(org_unit_type="all")
 
@@ -32,7 +30,7 @@ def test_list_orgunits():
 
 
 def test_get_orgunit():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.get_orgunit(org_unit_path="")
 
@@ -41,7 +39,7 @@ def test_get_orgunit():
 
 
 def test_list_roles():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_roles()
 
@@ -50,7 +48,7 @@ def test_list_roles():
 
 
 def test_list_role_assignments():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_role_assignments()
 
@@ -59,7 +57,7 @@ def test_list_role_assignments():
 
 
 def test_list_members():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_members(
         group_key="group-students-miami@teamstudents.org"
@@ -70,7 +68,7 @@ def test_list_members():
 
 
 def test_list_groups():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_groups()
 
@@ -81,7 +79,7 @@ def test_list_groups():
 def test_get_user():
     user_key = "113203151440162455385"
 
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.get_user(user_key=user_key)
 
@@ -90,7 +88,7 @@ def test_get_user():
 
 
 def test_list_users():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     data = google_directory.list_users(projection="full")
 
@@ -99,7 +97,7 @@ def test_list_users():
 
 
 def test_batch_insert_users():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     google_directory.batch_insert_users(
         [
@@ -126,7 +124,7 @@ def test_batch_insert_users():
 
 
 def test_batch_update_users():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     google_directory.batch_update_users(
         [
@@ -164,7 +162,7 @@ def test_batch_update_users():
 
 
 def test_batch_insert_members():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     google_directory.batch_insert_members(
         [
@@ -183,7 +181,7 @@ def test_batch_insert_members():
 
 
 def test_batch_insert_role_assignments():
-    google_directory = _get_google_directory_resource()
+    google_directory = get_google_directory_resource()
 
     google_directory.batch_insert_role_assignments(
         [

--- a/tests/sensors/test_sensors_google_forms.py
+++ b/tests/sensors/test_sensors_google_forms.py
@@ -5,10 +5,8 @@ from dagster import DagsterInstance, SensorResult, build_sensor_context
 from teamster.code_locations.kipptaf._google.forms.sensors import (
     google_forms_responses_sensor,
 )
-from teamster.code_locations.kipptaf.resources import (
-    get_google_drive_resource,
-    get_google_forms_resource,
-)
+from teamster.libraries.google.drive.resources import GoogleDriveResource
+from teamster.libraries.google.forms.resources import GoogleFormsResource
 
 
 def test_google_forms_responses_sensor():
@@ -36,14 +34,12 @@ def test_google_forms_responses_sensor():
             sensor_name=google_forms_responses_sensor.name,
             cursor=json.dumps(obj=cursor),
         ),
-        google_forms=get_google_forms_resource(
-            test=True,
+        google_forms=GoogleFormsResource(
             service_account_file_path=(
                 "/etc/secret-volume/gcloud_dagster_service_account.json"
             ),
         ),
-        google_drive=get_google_drive_resource(
-            test=True,
+        google_drive=GoogleDriveResource(
             service_account_file_path=(
                 "/etc/secret-volume/gcloud_dagster_service_account.json"
             ),

--- a/tests/sensors/test_sensors_google_forms.py
+++ b/tests/sensors/test_sensors_google_forms.py
@@ -6,8 +6,8 @@ from teamster.code_locations.kipptaf._google.forms.sensors import (
     google_forms_responses_sensor,
 )
 from teamster.code_locations.kipptaf.resources import (
-    GOOGLE_DRIVE_RESOURCE,
-    GOOGLE_FORMS_RESOURCE,
+    get_google_drive_resource,
+    get_google_forms_resource,
 )
 
 
@@ -36,8 +36,18 @@ def test_google_forms_responses_sensor():
             sensor_name=google_forms_responses_sensor.name,
             cursor=json.dumps(obj=cursor),
         ),
-        google_forms=GOOGLE_FORMS_RESOURCE,
-        google_drive=GOOGLE_DRIVE_RESOURCE,
+        google_forms=get_google_forms_resource(
+            test=True,
+            service_account_file_path=(
+                "/etc/secret-volume/gcloud_dagster_service_account.json"
+            ),
+        ),
+        google_drive=get_google_drive_resource(
+            test=True,
+            service_account_file_path=(
+                "/etc/secret-volume/gcloud_dagster_service_account.json"
+            ),
+        ),
     )
 
     assert isinstance(sensor_result, SensorResult)

--- a/tests/sensors/test_sensors_google_sheets.py
+++ b/tests/sensors/test_sensors_google_sheets.py
@@ -5,7 +5,7 @@ from dagster import SensorResult, build_sensor_context
 from teamster.code_locations.kipptaf._google.sheets.sensors import (
     google_sheets_asset_sensor,
 )
-from teamster.code_locations.kipptaf.resources import get_google_sheets_resource
+from teamster.libraries.google.sheets.resources import GoogleSheetsResource
 
 
 def test_google_sheets_asset_sensor():
@@ -33,8 +33,7 @@ def test_google_sheets_asset_sensor():
         context=build_sensor_context(
             cursor=json.dumps(obj=cursor), sensor_name=google_sheets_asset_sensor.name
         ),
-        gsheets=get_google_sheets_resource(
-            test=True,
+        gsheets=GoogleSheetsResource(
             service_account_file_path=(
                 "/etc/secret-volume/gcloud_dagster_service_account.json"
             ),

--- a/tests/sensors/test_sensors_google_sheets.py
+++ b/tests/sensors/test_sensors_google_sheets.py
@@ -5,7 +5,7 @@ from dagster import SensorResult, build_sensor_context
 from teamster.code_locations.kipptaf._google.sheets.sensors import (
     google_sheets_asset_sensor,
 )
-from teamster.libraries.google.sheets.resources import GoogleSheetsResource
+from teamster.code_locations.kipptaf.resources import get_google_sheets_resource
 
 
 def test_google_sheets_asset_sensor():
@@ -33,8 +33,11 @@ def test_google_sheets_asset_sensor():
         context=build_sensor_context(
             cursor=json.dumps(obj=cursor), sensor_name=google_sheets_asset_sensor.name
         ),
-        gsheets=GoogleSheetsResource(
-            service_account_file_path="/etc/secret-volume/gcloud_service_account_json"
+        gsheets=get_google_sheets_resource(
+            test=True,
+            service_account_file_path=(
+                "/etc/secret-volume/gcloud_dagster_service_account.json"
+            ),
         ),
     )
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209657752323598