### PR TITLE
correcting is_prestart...moving most_recent_hire upstream

### DIFF
--- a/src/dbt/kipptaf/models/adp/workforce_now/api/intermediate/int_adp_workforce_now__workers.sql
+++ b/src/dbt/kipptaf/models/adp/workforce_now/api/intermediate/int_adp_workforce_now__workers.sql
@@ -25,6 +25,7 @@ select
     w.person__legal_name__given_name,
     w.person__race_code_name,
     w.race_ethnicity_reporting,
+    w.worker_hire_date_recent,
 
     wa.item_id,
     wa.position_id,
@@ -73,10 +74,6 @@ select
     rtw.person__family_name_1
     || ', '
     || rtw.person__given_name as reports_to_formatted_name,
-
-    coalesce(
-        w.worker_dates__rehire_date, w.worker_dates__original_hire_date
-    ) as worker_hire_date_recent,
 
     {{
         dbt_utils.generate_surrogate_key(

--- a/src/dbt/kipptaf/models/adp/workforce_now/api/staging/stg_adp_workforce_now__workers.sql
+++ b/src/dbt/kipptaf/models/adp/workforce_now/api/staging/stg_adp_workforce_now__workers.sql
@@ -373,6 +373,9 @@ select
     *,
 
     coalesce(
+        worker_dates__rehire_date, worker_dates__original_hire_date
+    ) as worker_hire_date_recent,
+    coalesce(
         person__preferred_name__given_name, person__legal_name__given_name
     ) as person__given_name,
     coalesce(
@@ -413,7 +416,8 @@ select
 
     if(
         worker_status__status_code__code_value = 'Active'
-        and effective_date_start > current_date('{{ var("local_timezone") }}')
+        and coalesce(worker_dates__rehire_date, worker_dates__original_hire_date)
+        > current_date('{{ var("local_timezone") }}')
         and (
             worker_status__status_code__code_value_lag = 'Terminated'
             or worker_status__status_code__code_value_lag is null


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
