### PR TITLE
fix: removing ops restriction for directors level 2

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__stipend_app_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__stipend_app_roster.sql
@@ -47,17 +47,11 @@ select
         then 3
         /* in-region/state view */
         when
-            contains_substr(r.job_title, 'Director')
-            and r.home_department_name = 'Operations'
-            and contains_substr(r.home_work_location_name, 'Room')
-        then 2
-
-        when
-            r.job_title in (
-                'Head of Schools',
-                'Managing Director of Operations',
-                'Managing Director of School Operations'
+            (
+                contains_substr(r.job_title, 'Director')
+                or contains_substr(r.job_title, 'Head')
             )
+            and contains_substr(r.home_work_location_name, 'Room')
         then 2
         /* in-region/state view: username temp permissions for RDO coverage */
         when r.sam_account_name = 'tmiddleton'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
