### PR TITLE
fix: add distinct mail to survey reminders

### DIFF
--- a/src/dbt/kipptaf/models/extracts/surveys/rpt_extracts__survey_reminder.sql
+++ b/src/dbt/kipptaf/models/extracts/surveys/rpt_extracts__survey_reminder.sql
@@ -1,4 +1,4 @@
-select mail as email,
+select distinct mail as email,
 from {{ ref("rpt_tableau__survey_completion") }}
 where
     mail is not null


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries that employ any
      models using these datasets: `deanslist` `edplan` `iready` `overgrad` `pearson` `powerschool`
      `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
