### PR TITLE
fix: using survey_response_id for unique count

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -13,7 +13,7 @@ select
     sl.is_current,
     sl.mail,
     sr.survey_response_id,
-    if(survey_response_id is not null, 1,0) as completion,
+    if(survey_response_id is not null, 1, 0) as completion,
 from {{ ref("rpt_tableau__survey_links") }} as sl
 left join
     {{ ref("rpt_tableau__survey_responses") }} as sr

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -20,4 +20,4 @@ left join
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
-where sr.round_rn is null or <= 1
+where sr.round_rn is null or sr.round_rn <= 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -11,11 +11,12 @@ select
     sl.academic_year,
     sl.survey_round,
     sl.is_current,
+    sl.mail,
     sr.survey_response_id,
+    if(survey_response_id is not null, 1,0) as completion,
 from {{ ref("rpt_tableau__survey_links") }} as sl
 left join
     {{ ref("rpt_tableau__survey_responses") }} as sr
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
-where sr.round_rn = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -20,4 +20,4 @@ left join
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
-where sr.round_rn <= 1
+where sr.round_rn is null or <= 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -13,7 +13,7 @@ select
     sl.is_current,
     sl.mail,
     sr.survey_response_id,
-    if(survey_response_id is not null, 1, 0) as completion,
+    if(sr.survey_response_id is not null, 1, 0) as completion,
 from {{ ref("rpt_tableau__survey_links") }} as sl
 left join
     {{ ref("rpt_tableau__survey_responses") }} as sr

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -20,3 +20,4 @@ left join
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
+where round_rn <= 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -20,4 +20,4 @@ left join
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
-where round_rn <= 1
+where sr.round_rn <= 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__survey_completion.sql
@@ -7,26 +7,15 @@ select
     sl.department,
     sl.job_title,
     sl.hire_date,
-    sl.mail,
-    sl.google_email,
-    sl.report_to_employee_number,
-    sl.report_to_preferred_name_lastfirst,
-    sl.samaccountname,
-    sl.username,
     sl.survey,
-    sl.link,
-    sl.assignment,
     sl.academic_year,
     sl.survey_round,
     sl.is_current,
-
-    if(sr.date_submitted is not null, 1, 0) as completion,
-
-    datetime(sr.date_submitted, 'America/New_York') as date_submitted,
+    sr.survey_response_id,
 from {{ ref("rpt_tableau__survey_links") }} as sl
 left join
     {{ ref("rpt_tableau__survey_responses") }} as sr
     on sl.employee_number = sr.employee_number
     and sl.academic_year = sr.academic_year
     and sl.survey_round = sr.survey_code
-    and sr.round_rn = 1
+where sr.round_rn = 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries
      that employ any models using these datasets: `deanslist` `edplan` `iready`
      `overgrad` `pearson` `powerschool` `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210035844478410