### PR TITLE
fix: using current name for all records

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -55,7 +55,6 @@ with
 /* tracking for current year */
 select
     srh.employee_number,
-    srh.formatted_name as teammate,
     srh.home_business_unit_name as entity,
     srh.home_work_location_name as `location`,
     srh.home_work_location_grade_band as grade_band,
@@ -104,7 +103,10 @@ select
     tr.teacher_moves_track,
     tr.student_habits_track,
     tr.number_of_kids,
+
     sr.assignment_status as current_assignment_status,
+    sr.formatted_name as teammate,
+
     sro.formatted_name as observer_name,
 
     tgl.grade_level as grade_taught,
@@ -192,7 +194,6 @@ union all
 /* actual responses from past years*/
 select
     srh.employee_number,
-    srh.formatted_name as teammate,
     srh.home_business_unit_name as entity,
     srh.home_work_location_name as `location`,
     srh.home_work_location_grade_band as grade_band,
@@ -243,6 +244,8 @@ select
     null as number_of_kids,
 
     sr.assignment_status as current_assignment_status,
+    sr.formatted_name as teammate,
+
     sro.formatted_name as observer_name,
 
     tgl.grade_level as grade_taught,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries
      that employ any models using these datasets: `deanslist` `edplan` `iready`
      `overgrad` `pearson` `powerschool` `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
