### PR TITLE
added exclusion of non-ela-math for es fl summative grade check

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_section_week_student_category_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_section_week_student_category_scaffold.sql
@@ -13,6 +13,7 @@ with
                 ),
                 2
             ) as category_quarter_average_all_courses,
+
         from {{ ref("int_powerschool__category_grades") }}
         where
             yearid = {{ var("current_academic_year") - 1990 }}
@@ -65,6 +66,7 @@ select
     if(
         s.region = 'Miami'
         and s.school_level = 'ES'
+        and s.credit_type in ('ENG', 'MATH')
         and ge.assignment_category_code = 'S'
         and cg.percent_grade is null
         and s.is_quarter_end_date_range,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries
      that employ any models using these datasets: `deanslist` `edplan` `iready`
      `overgrad` `pearson` `powerschool` `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
