### PR TITLE
refactor: leader pm roster and assignments

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_assignments.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_assignments.sql
@@ -1,31 +1,75 @@
-select
-    ldr.employee_number,
-    ldr.entity,
-    ldm.region,
+with
+    roster as (
+        select *
+        from {{ ref("rpt_appsheet__leadership_development_roster") }}
+    ),
 
-    ldm.academic_year,
-    ldm.metric_id,
+    metrics as (
+        select *
+        from {{ ref("stg_performance_management__leadership_development_metrics") }}
+        where academic_year = 2025 and not disabled
+    ),
 
-    concat(ldr.employee_number, ldm.metric_id) as assignment_id,
-from {{ ref("rpt_appsheet__leadership_development_roster") }} as ldr
-inner join
-    {{ ref("stg_performance_management__leadership_development_metrics") }} as ldm
-    on ldr.route = ldm.role
-    and ldr.entity = ldm.region
+    existing_assignments as (
+        select assignment_id
+        from {{ ref("stg_leadership_development__output") }}
+    ),
 
-union all
+    -- logic to create list of assignments
+    assignments as (
+        select
+            roster.employee_number,
+            metrics.academic_year,
+            metrics.metric_id,
+            concat(roster.employee_number, metrics.metric_id) as assignment_id,
+            null as notes_boy,
+            null as rating_moy,
+            null as rating_eoy,
+            null as notes_moy,
+            null as notes_eoy,
+            null as manager_rating_moy,
+            null as manager_rating_eoy,
+            null as manager_notes_moy,
+            null as manager_notes_eoy,
+            null as edited_at,
+            null as edited_by,
+            true as active_assignment,
+        from roster
+        inner join metrics on metrics.role = 'All'
 
-select
-    ldr.employee_number,
-    ldr.entity,
-    ldm.region,
+        union all
 
-    ldm.academic_year,
-    ldm.metric_id,
+        select
+            roster.employee_number,
+            metrics.academic_year,
+            metrics.metric_id,
+            concat(roster.employee_number, metrics.metric_id) as assignment_id,
+            null as notes_boy,
+            null as rating_moy,
+            null as rating_eoy,
+            null as notes_moy,
+            null as notes_eoy,
+            null as manager_rating_moy,
+            null as manager_rating_eoy,
+            null as manager_notes_moy,
+            null as manager_notes_eoy,
+            null as edited_at,
+            null as edited_by,
+            true as active_assignment,
+        from roster
+        inner join metrics on roster.job_title = metrics.role
+    ),
 
-    concat(ldr.employee_number, ldm.metric_id) as assignment_id,
-from {{ ref("rpt_appsheet__leadership_development_roster") }} as ldr
-inner join
-    {{ ref("stg_performance_management__leadership_development_metrics") }} as ldm
-    on ldr.route = ldm.role
-    and ldm.region = 'All'
+    -- only include assignments not already on output
+    final as (
+        select assignments.*
+        from assignments
+        left join
+            existing_assignments
+            on assignments.assignment_id = existing_assignments.assignment_id
+        where existing_assignments.assignment_id is null
+    )
+
+select *
+from final
+order by assignment_id

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_roster.sql
@@ -1,76 +1,75 @@
-select
-    employee_number,
-    formatted_name,
-    home_work_location_name as location,
-    home_business_unit_name as entity,
-    home_department_name as department,
-    assignment_status as status,
-    job_title,
-    mail,
-    reports_to_mail,
-    google_email,
-    reports_to_google_email,
-    null as active,
-    if(
-        job_title in (
-            'Assistant School Leader',
-            'Assistant School Leader, SPED',
-            'Assistant School Leader, School Culture',
-            'School Leader',
-            'School Leader in Residence',
-            'Head of Schools',
-            'Head of Schools in Residence',
-            'Director School Operations',
-            'Director Campus Operations',
-            'Fellow School Operations Director',
-            'Managing Director of School Operations',
-            'Associate Director of School Operations'
-        ),
-        job_title,
-        'CMO and Other Leaders'
-    ) as route,
-    if(
-        contains_substr(job_title, 'Leader')
-        or contains_substr(job_title, 'Head')
-        or contains_substr(job_title, 'Director')
-        or contains_substr(job_title, 'Chief')
-        or contains_substr(job_title, 'Controller'),
-        true,
-        false
-    ) as default_include,
-    case
-        when
-            home_department_name
-            in ('Data', 'Human Resources', 'Leadership Development')
-        then 6
-        when contains_substr(job_title, 'Chief')
-        then 6
-        when contains_substr(job_title, 'President')
-        then 6
-        when
-            job_title in (
-                'Managing Director Operations',
-                'Managing Director of Operations',
-                'Managing Director School Operations',
-                'Head of Schools',
-                'Head of Schools in Residence'
-            )
-        then 5
-        when
-            job_title in (
-                'School Leader',
-                'School Leader in Residence'
-                'Director School Operations',
-                'Director Campus Operations'
-            )
-        then 4
-        when contains_substr(job_title, 'Assistant School Leader')
-        then 3
-        when
-            contains_substr(job_title, 'Director')
-            and home_department_name = 'Operations'
-        then 3
-        else 1
-    end as permission_level,
-from {{ ref("int_people__staff_roster") }}
-where assignment_status in ('Active', 'Leave')
+with
+
+    roster as (
+        select
+            employee_number,
+            reports_to_employee_number,
+            formatted_name,
+            home_work_location_name as location,
+            home_business_unit_name as entity,
+            home_department_name as department,
+            assignment_status as status,
+            job_title,
+            mail,
+            reports_to_mail,
+            google_email,
+            reports_to_google_email,
+        from {{ ref("int_people__staff_roster") }}
+        where assignment_status in ('Active', 'Leave')
+    ),
+
+    final as (
+        select
+            roster.*,
+            -- logic to determine if title is active in leader performance management by default, editable in app
+            case
+                when
+                    contains_substr(roster.job_title, 'Chief')
+                    or contains_substr(roster.job_title, 'Director')
+                    or contains_substr(roster.job_title, 'Head')
+                    or contains_substr(roster.job_title, 'Leader')
+                    or contains_substr(roster.job_title, 'President')
+                    or job_title = 'Controller'
+                then true
+                else false
+            end as active,
+            -- logic for permissions levels in app
+            case
+                when
+                    department
+                    in ('Data', 'Human Resources', 'Leadership Development')
+                then 6
+                when contains_substr(job_title, 'Chief')
+                then 6
+                when contains_substr(job_title, 'President')
+                then 6
+                when
+                    job_title in (
+                        'Managing Director Operations',
+                        'Managing Director of Operations',
+                        'Managing Director School Operations',
+                        'Head of Schools',
+                        'Head of Schools in Residence'
+                    )
+                then 5
+                when
+                    job_title in (
+                        'School Leader',
+                        'School Leader in Residence'
+                        'Director School Operations',
+                        'Director Campus Operations'
+                    )
+                then 4
+                when contains_substr(job_title, 'Assistant School Leader')
+                then 3
+                when
+                    contains_substr(job_title, 'Director')
+                    and department = 'Operations'
+                then 3
+                else 1
+            end as permission_level,
+        from roster
+    )
+
+select *
+from final


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

This PR will update the logic for default participation in leader performance management in the roster, and refactors the assignments table to produce just the "new" metric assignments by title that are not present on the current output table for insertion later via app/Zapier/upload to output table.

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries
      that employ any models using these datasets: `deanslist` `edplan` `iready`
      `overgrad` `pearson` `powerschool` `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
