### PR TITLE
add: choose participation override from app

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_assignments.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__leadership_development_assignments.sql
@@ -18,7 +18,7 @@ with
     leader_pm_participants as (
         select
             roster.employee_number,
-            coalesce(active_users.app_selection_active, roster.active) as active,
+            coalesce(active_users.active_override, roster.active) as active,
         from roster
         left join active_users on roster.employee_number = active_users.employee_number
     ),


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

use a new column in the app that will only be selected when the person's assignment to leader pm is overridden manually in the app. blank for all others. allows for promotions/new people to be automatically marked active according to title while others can change in app.

## Self-review

**If this is a same-day request, please flag that in our Slack channel!**

- [ ] Update **due date**, **assignee**, and **priority** on our
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] <kbd>Format</kbd> has been run on all modified files

### SQL

- [ ] Ensure you are using the `union_dataset_join_clause()` macro for queries
      that employ any models using these datasets: `deanslist` `edplan` `iready`
      `overgrad` `pearson` `powerschool` `renlearn` `titan`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] If you are adding a new external source, run:

      dbt run-operation stage_external_sources --vars
      "ext_full_refresh: true"

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
