### PR TITLE
fix: date spine for seat tracker all in one view

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__seat_tracker_snapshot.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__seat_tracker_snapshot.sql
@@ -59,16 +59,15 @@ with
             recruiter_info.formatted_name as recruiter,
             recruiter_info.reports_to_formatted_name as recruiter_manager,
 
-            if(seats_snapshot.is_open, 1, 0) as snapshot_open,
-            if(seats_snapshot.is_new_hire, 1, 0) as snapshot_new_hire,
-            if(seats_snapshot.is_staffed, 1, 0) as snapshot_staffed,
-            if(seats_snapshot.is_active, 1, 0) as snapshot_active,
-            if(seats_snapshot.is_mid_year_hire, 1, 0) as snapshot_mid_year_hire,
+            if(seats_snapshot.is_open, 1, 0) as open_seats,
+            if(seats_snapshot.is_new_hire, 1, 0) as new_hires,
+            if(seats_snapshot.is_staffed, 1, 0) as staffed_seats,
+            if(seats_snapshot.is_active, 1, 0) as active_seats,
+            if(seats_snapshot.is_mid_year_hire, 1, 0) as mid_year_hires,
         from date_spine
         inner join
             seats_snapshot
-            on date_spine.academic_year = seats_snapshot.academic_year
-            and date_spine.date_week
+            on date_spine.date_week
             between seats_snapshot.valid_from and seats_snapshot.valid_to
         inner join
             seats_detail

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__seat_tracker_snapshot.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__seat_tracker_snapshot.sql
@@ -1,12 +1,21 @@
 with
     date_spine as (
-        select date_week,
+        select
+            date_week,
+            {{
+                date_to_fiscal_year(
+                    date_field="date_week",
+                    start_month=7,
+                    year_source="start",
+                )
+            }} as academic_year,
         from
             unnest(
                 generate_date_array(
-                    /* first date of the appsheet snapshot */
+                    {# first date of the appsheet snapshot #}
                     '2023-08-04',
-                    current_date('{{ var("local_timezone") }}'),
+                    {# need current week as it happens #}
+                    current_date('{{ var("local_timezone") }}') + 7,
                     interval 1 week
                 )
             ) as date_week
@@ -16,11 +25,11 @@ with
 
     seats_detail as (select *, from {{ ref("stg_seat_tracker__seats") }}),
 
-    staff_roster as (select *, from {{ ref("int_people__staff_roster") }}),
-
     projections as (
         select *, from {{ ref("stg_google_sheets__recruitment__school_projections") }}
     ),
+
+    staff_roster as (select *, from {{ ref("int_people__staff_roster") }}),
 
     final as (
         select
@@ -43,44 +52,38 @@ with
             seats_detail.short_name,
             seats_detail.recruitment_group,
 
+            projections.anticipated_hires,
+
             teammate_info.formatted_name as teammate,
 
             recruiter_info.formatted_name as recruiter,
             recruiter_info.reports_to_formatted_name as recruiter_manager,
-
-            projections.anticipated_hires,
 
             if(seats_snapshot.is_open, 1, 0) as snapshot_open,
             if(seats_snapshot.is_new_hire, 1, 0) as snapshot_new_hire,
             if(seats_snapshot.is_staffed, 1, 0) as snapshot_staffed,
             if(seats_snapshot.is_active, 1, 0) as snapshot_active,
             if(seats_snapshot.is_mid_year_hire, 1, 0) as snapshot_mid_year_hire,
-            if(
-                current_date()
-                between seats_snapshot.valid_from and seats_snapshot.valid_to,
-                true,
-                false
-            ) as is_current,
-
         from date_spine
-        left join
+        inner join
             seats_snapshot
-            on date_spine.date_week
+            on date_spine.academic_year = seats_snapshot.academic_year
+            and date_spine.date_week
             between seats_snapshot.valid_from and seats_snapshot.valid_to
-        left join
+        inner join
             seats_detail
             on seats_snapshot.staffing_model_id = seats_detail.staffing_model_id
             and seats_snapshot.academic_year = seats_detail.academic_year
+        inner join
+            projections
+            on seats_detail.adp_location = projections.primary_site
+            and seats_detail.academic_year = projections.academic_year
         left join
             staff_roster as teammate_info
             on seats_snapshot.teammate_employee_number = teammate_info.employee_number
         left join
             staff_roster as recruiter_info
             on seats_detail.recruiter = recruiter_info.employee_number
-        left join
-            projections
-            on seats_snapshot.adp_location = projections.primary_site
-            and seats_snapshot.academic_year = projections.academic_year
     )
 
 select *,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

## Self-review

### General

- [ ] If this is a same-day request, please flag that in the #data-team Slack
- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Run <kbd>Format</kbd> on all modified files

### dbt

- [x] Include a corresponding `[model name].yml` properties file for all models:

      models:
        - name: [model name]
          config:
            contract:  # optional
              enforced: true
          columns:  # optional, unless using a contract
            - name: ...
              data_type: ...
              data_tests:  # column tests, optional
                - ...
          data_tests:  # model tests, optional
            - ...

- [x] Include (or update) an
      [exposure](https://docs.getdbt.com/reference/exposure-properties) for all
      models that will be consumed by a dashboard, analysis, or application:

      exposures:
        - name: [exposure name, snake_case]
          label: [exposure name, Title Case]
          type: dashboard | notebook | analysis | ml | application
          owner:
            name: Data Team
          depends_on:
            - ref("[model name]")
            - ...
          url: ...  # optional
          meta:
            dagster:
              kinds:
                - tableau | googlesheets | ...
                - ...
            asset:
              metadata:
                id: [lsid]  # optional, for Tableau Server workbooks
                cron_schedule:  # optional, for Dagster automation
                  - * * * * *
                  - ...

[Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)

### SQL

- [ ] Use the `union_dataset_join_clause()` macro for queries that employ models
      that use regional datasets
- [ ] Do not use `group by` without any aggregations when you mean to use
      `distinct`
- [ ] All `distinct` usage must be accompanied by an comment explaining it's
      necessity
- [ ] Do not use `order by` for `select` statements. That should be done in the
      reporting layer.
- [ ] If you are adding a new external source, before building, run:

      dbt run-operation stage_external_sources --vars "{'ext_full_refresh': 'true'}" --args select: [model name(s)]

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
