### PR TITLE
fix: retry view assets when last execution failed

### DIFF
--- a/src/teamster/core/CLAUDE.md
+++ b/src/teamster/core/CLAUDE.md
@@ -72,8 +72,8 @@ All asset factories that yield Avro output call both of these.
 Two dbt-specific `AutomationCondition` builders (currently **commented out** in
 `CustomDagsterDbtTranslator` but available for future use):
 
-- `dbt_view_automation_condition()` — for VIEW models: only re-runs on
-  `newly_missing` or `code_version_changed`
+- `dbt_view_automation_condition()` — for VIEW models: re-runs on
+  `newly_missing`, `code_version_changed`, or `execution_failed`
 - `dbt_table_automation_condition()` — for TABLE models: also triggers on
   upstream data changes, including through intermediate views via
   `_build_any_ancestor_updated()` (recursive `any_deps_match` up to 5 levels)

--- a/src/teamster/core/automation_conditions.py
+++ b/src/teamster/core/automation_conditions.py
@@ -80,14 +80,19 @@ def dbt_view_automation_condition(
     need re-materialization when:
     - Initially missing (newly_missing)
     - SQL code changes (code_version_changed)
+    - Last execution failed (execution_failed)
     """
     return (
         AutomationCondition.in_latest_time_window()
         & (
-            AutomationCondition.newly_missing()
-            | AutomationCondition.code_version_changed()
-        ).since(
-            AutomationCondition.newly_requested() | AutomationCondition.newly_updated()
+            (
+                AutomationCondition.newly_missing()
+                | AutomationCondition.code_version_changed()
+            ).since(
+                AutomationCondition.newly_requested()
+                | AutomationCondition.newly_updated()
+            )
+            | AutomationCondition.execution_failed()
         )
         & ~AutomationCondition.any_deps_missing().ignore(
             ignore_selection | _EXTERNAL_SOURCE_SELECTION

--- a/tests/test_automation_conditions.py
+++ b/tests/test_automation_conditions.py
@@ -238,6 +238,55 @@ def test_update_propagates_through_view_between_tables():
     assert result.get_num_requested(AssetKey("downstream_table")) == 1
 
 
+def test_view_requested_on_execution_failure():
+    """Views SHOULD be requested when their last execution failed."""
+
+    @asset(tags=_TABLE_TAG)
+    def upstream_table():
+        return 1
+
+    @asset(
+        key="my_view",
+        deps=[upstream_table],
+        automation_condition=_get_view_condition(),
+        tags=_VIEW_TAG,
+    )
+    def my_view_ok():
+        return 2
+
+    instance = DagsterInstance.ephemeral()
+    all_assets = [upstream_table, my_view_ok]
+    defs = Definitions(assets=all_assets)
+
+    # Initial materialization succeeds
+    materialize(assets=all_assets, instance=instance)
+    result = evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.get_num_requested(AssetKey("my_view")) == 0
+
+    # Redefine the view to raise an error
+    @asset(
+        key="my_view",
+        deps=[upstream_table],
+        automation_condition=_get_view_condition(),
+        tags=_VIEW_TAG,
+    )
+    def my_view_fails():
+        raise Exception("intentional failure")
+
+    defs_fail = Definitions(assets=[upstream_table, my_view_fails])
+    materialize(
+        assets=[my_view_fails],
+        instance=instance,
+        selection=[my_view_fails],
+        raise_on_error=False,
+    )
+
+    result = evaluate_automation_conditions(
+        defs=defs_fail, instance=instance, cursor=result.cursor
+    )
+    assert result.get_num_requested(AssetKey("my_view")) == 1
+
+
 def test_view_requested_on_code_version_change():
     """Views SHOULD be requested when their code version changes."""
 


### PR DESCRIPTION
## Summary

- Adds `execution_failed()` to `dbt_view_automation_condition` so a failed view materialization triggers a retry on the next automation evaluation
- `execution_failed()` is a status operand placed outside the `.since()` block (alongside the event-based `newly_missing` / `code_version_changed` triggers), since status conditions don't interact correctly with `.since()`
- Adds `test_view_requested_on_execution_failure` test covering this behavior

## Test plan

- [ ] `uv run pytest tests/test_automation_conditions.py` — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)