### PR TITLE
OKRTS update to put "Documentation" referrals in non-behavioral tier

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -198,7 +198,7 @@ select
             left(dli.category, 2) in ('SW', 'SS')
             or left(dli.category, 3) in ('SSC', 'SSW')
         then 'Social Work'
-        when left(dli.category, 2) = 'TX'
+        when (left(dli.category, 2) = 'TX' or dli.category like 'Documentation%')
         then 'Non-Behavioral'
         when left(dli.category, 2) = 'TB'
         then 'Bus Referral (Miami)'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR will exclude "Documentation Only" category referrals from the tier model. This removes it from analysis on the dashboard via an in/out set.

## Self-review

### General

- [ ] If this is a same-day request, please flag that in the #data-team Slack
- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Run <kbd>trunk fmt</kbd> on all modified files

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] New assets follow the `[code_location, integration, table_name]` key
      pattern and use the appropriate IO manager (`pickle`, `avro`, or `file`)
- [ ] New integrations include both a `libraries/<integration>/assets.py`
      factory function and a `config/assets-*.yaml` in the code location

### dbt

- [ ] Include a corresponding `[model name].yml` properties file for all models.
      These can be generated by running
      `dbt run-operation generate_model_yaml --args '{"model_names": ["MODEL NAME"]}'`
      and saving the console output to a YAML file.

      models:
        - name: [model name]
          config:
            contract:
              enforced: false  # required while creating a contracted model, delete before merging
          columns:  # required for contracted models
            - name: ...
              data_type: ...
              data_tests:  # column tests, optional
                - ...
          data_tests:  # model tests, optional
            - ...
            - dbt_utils.unique_combination_of_columns:  # recommended for intermediate models
                arguments:
                  combination_of_columns:
                    - ...
                config:
                  store_failures: true

- [ ] Include (or update) an
      [exposure](https://docs.getdbt.com/reference/exposure-properties) for all
      models that will be consumed by a dashboard, analysis, or application:

      exposures:
        - name: [exposure name, snake_case]
          label: [exposure name, Title Case]
          type: dashboard | notebook | analysis | ml | application
          owner:
            name: Data Team
          depends_on:
            - ref("[model name]")
            - ...
          url: ...  # optional
          config:
            meta:
              dagster:
                kinds:
                  - tableau | googlesheets | ...
                  - ...
                asset:
                  metadata:
                    id: [lsid]  # required for Tableau Server workbooks
                    cron_schedule:  # required for Dagster automation
                      - * * * * *
                      - ...

[Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)

### SQL

- [ ] Use the `union_dataset_join_clause()` macro for queries that employ models
      that use regional datasets
- [ ] Do not use `group by` without any aggregations when you mean to use
      `distinct`
- [ ] All `distinct` usage must be accompanied by a comment explaining its
      necessity
- [ ] Do not use `order by` for `select` statements. That should be done in the
      reporting layer.
- [ ] If you are adding a new external source, before building, run:

      dbt run-operation stage_external_sources --vars "{'ext_full_refresh': 'true'}" --args select: [model name(s)]

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Trunk](https://teamschools.github.io/teamster/CONTRIBUTING/#trunk)
- [dbt](https://teamschools.github.io/teamster/CONTRIBUTING/#dbt-cloud_1)
