### PR TITLE
Update CLAUDE.md docs to use dbt 1.9+ test arguments syntax

### DIFF
--- a/src/dbt/amplify/CLAUDE.md
+++ b/src/dbt/amplify/CLAUDE.md
@@ -70,9 +70,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/deanslist/CLAUDE.md
+++ b/src/dbt/deanslist/CLAUDE.md
@@ -61,9 +61,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/edplan/CLAUDE.md
+++ b/src/dbt/edplan/CLAUDE.md
@@ -59,9 +59,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/finalsite/CLAUDE.md
+++ b/src/dbt/finalsite/CLAUDE.md
@@ -57,9 +57,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/iready/CLAUDE.md
+++ b/src/dbt/iready/CLAUDE.md
@@ -57,9 +57,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/kippcamden/CLAUDE.md
+++ b/src/dbt/kippcamden/CLAUDE.md
@@ -80,9 +80,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/kippmiami/CLAUDE.md
+++ b/src/dbt/kippmiami/CLAUDE.md
@@ -79,9 +79,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/kippnewark/CLAUDE.md
+++ b/src/dbt/kippnewark/CLAUDE.md
@@ -85,9 +85,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/kipppaterson/CLAUDE.md
+++ b/src/dbt/kipppaterson/CLAUDE.md
@@ -73,9 +73,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -227,9 +227,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/overgrad/CLAUDE.md
+++ b/src/dbt/overgrad/CLAUDE.md
@@ -57,9 +57,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/pearson/CLAUDE.md
+++ b/src/dbt/pearson/CLAUDE.md
@@ -54,9 +54,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/powerschool/CLAUDE.md
+++ b/src/dbt/powerschool/CLAUDE.md
@@ -78,9 +78,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/renlearn/CLAUDE.md
+++ b/src/dbt/renlearn/CLAUDE.md
@@ -57,9 +57,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```

--- a/src/dbt/titan/CLAUDE.md
+++ b/src/dbt/titan/CLAUDE.md
@@ -55,9 +55,10 @@ columns:
 # multi-column uniqueness (when no single column is unique)
 data_tests:
   - dbt_utils.unique_combination_of_columns:
-      combination_of_columns:
-        - column_a
-        - column_b
+      arguments:
+        combination_of_columns:
+          - column_a
+          - column_b
       config:
         store_failures: true
 ```


### PR DESCRIPTION
## Summary

- Updates all dbt project `CLAUDE.md` files (15 files) to document the current `dbt_utils.unique_combination_of_columns` syntax
- Adds the `arguments:` wrapper key around `combination_of_columns`, matching what all actual model YAML files in the repo already use

## Test plan

- No functional changes — documentation only
- Verified the new syntax matches existing `.yml` files (e.g. `stg_deanslist__roster_assignments.yml`, `int_students__dibels_participation_roster.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)