### PR TITLE
Refactor: Extract Finalsite exclude IDs to intermediate model

### DIFF
--- a/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__status_report.sql
+++ b/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__status_report.sql
@@ -33,5 +33,5 @@ from union_relations
 where
     finalsite_enrollment_id not in (
         select x.finalsite_student_id,
-        from {{ ref("stg_google_sheets__finalsite__exclude_ids") }} as x
+        from {{ ref("int_google_sheets__finalsite__exclude_ids") }} as x
     )

--- a/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__finalsite__exclude_ids.sql
+++ b/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__finalsite__exclude_ids.sql
@@ -1,0 +1,10 @@
+select finalsite_student_id,
+from {{ ref("stg_google_sheets__finalsite__exclude_ids") }}
+
+union distinct
+
+select text_value as finalsite_student_id,
+from {{ ref("int_google_forms__form_responses") }}
+where
+    form_id = '1iH4Cjy_RIc8TWJf6Ts0sxhpVmCnx4paiT5RSNOS2Rn4'
+    and text_value is not null

--- a/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__finalsite__exclude_ids.sql
+++ b/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__finalsite__exclude_ids.sql
@@ -6,5 +6,4 @@ union distinct
 select text_value as finalsite_student_id,
 from {{ ref("int_google_forms__form_responses") }}
 where
-    form_id = '1iH4Cjy_RIc8TWJf6Ts0sxhpVmCnx4paiT5RSNOS2Rn4'
-    and text_value is not null
+    form_id = '1iH4Cjy_RIc8TWJf6Ts0sxhpVmCnx4paiT5RSNOS2Rn4' and text_value is not null

--- a/src/dbt/kipptaf/models/google/sheets/intermediate/properties/int_google_sheets__finalsite__exclude_ids.yml
+++ b/src/dbt/kipptaf/models/google/sheets/intermediate/properties/int_google_sheets__finalsite__exclude_ids.yml
@@ -1,0 +1,9 @@
+models:
+  - name: int_google_sheets__finalsite__exclude_ids
+    columns:
+      - name: finalsite_student_id
+        data_type: string
+        data_tests:
+          - unique:
+              config:
+                store_failures: true


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will refactor the Finalsite exclude IDs logic into a dedicated intermediate dbt model that combines data from both the Google Sheets staging table and Google Forms responses. This consolidates the exclude IDs logic in one place and makes it reusable across multiple models.

**Changes:**
- Created new intermediate model `int_google_sheets__finalsite__exclude_ids` that unions Finalsite student IDs from the staging table with IDs extracted from a specific Google Form
- Updated `stg_finalsite__status_report` to reference the new intermediate model instead of the staging table directly
- Added corresponding YAML properties file with data tests

## Self-review

### dbt

- [x] Include a corresponding `[model name].yml` properties file for all models
- [x] Added unique constraint test on `finalsite_student_id` column with `store_failures: true`

### SQL

- [x] Used `union distinct` with appropriate logic for combining two data sources
- [x] No `group by` without aggregations
- [x] No `order by` in select statements

## Test Plan

Existing dbt tests will validate:
- Uniqueness of `finalsite_student_id` values in the new intermediate model
- Referential integrity in `stg_finalsite__status_report` when filtering by the new model

https://claude.ai/code/session_01E7WESstQxAcGY2ry66oPfN