### PR TITLE
docs: replace inline linter table with file pointer in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,33 +94,9 @@ uv run pytest tests/assets/test_assets_dbt.py
 
 ### Linting
 
-Linting is managed via [Trunk](https://trunk.io). Configuration lives in
-`.trunk/trunk.yaml` (enabled linters) and `.trunk/config/` (per-linter config
-files).
-
-Enabled linters:
-
-| Linter           | Config file                        | Scope                        |
-| ---------------- | ---------------------------------- | ---------------------------- |
-| `ruff`           | `.trunk/config/ruff.toml`          | Python (`src/teamster/`)     |
-| `pyright`        | `.trunk/config/pyrightconfig.json` | Python (excl. `dlt_sources`) |
-| `isort`          | `.trunk/config/.isort.cfg`         | Python                       |
-| `bandit`         | `.trunk/config/.bandit`            | Python                       |
-| `sqlfluff`       | `.trunk/config/.sqlfluff`          | SQL (`src/dbt/`)             |
-| `sqlfmt`         | —                                  | SQL (`src/dbt/`)             |
-| `prettier`       | `.trunk/config/.prettierrc.yaml`   | YAML, JSON, Markdown, etc.   |
-| `yamllint`       | `.trunk/config/.yamllint`          | YAML                         |
-| `markdownlint`   | `.trunk/config/.markdownlint.yaml` | Markdown                     |
-| `hadolint`       | `.trunk/config/.hadolint.yaml`     | Dockerfiles                  |
-| `shellcheck`     | `.trunk/config/.shellcheckrc`      | Shell scripts                |
-| `shfmt`          | —                                  | Shell scripts                |
-| `actionlint`     | —                                  | GitHub Actions workflows     |
-| `taplo`          | —                                  | TOML                         |
-| `gitleaks`       | —                                  | Secrets scanning             |
-| `osv-scanner`    | —                                  | Dependency vulnerabilities   |
-| `oxipng`         | —                                  | PNG optimization             |
-| `svgo`           | `.trunk/config/svgo.config.js`     | SVG optimization             |
-| `git-diff-check` | —                                  | Merge conflict markers       |
+Linting is managed via [Trunk](https://trunk.io) and enforced by a pre-commit
+hook. See `.trunk/trunk.yaml` for the full list of enabled linters and
+`.trunk/config/` for per-linter configuration files.
 
 ```bash
 # Check all files


### PR DESCRIPTION
## Summary

- Replace the 18-row inline linter table in root `CLAUDE.md` with a pointer to `.trunk/trunk.yaml` and `.trunk/config/`
- Saves ~300 tokens on the always-loaded root file (1,602 → 1,444 words)
- SQL style rules remain inline — those prevent real mistakes

## Why only this change (partial close of #3433)

The issue proposed a broad Haiku-first optimization of all CLAUDE.md files. After analysis, most of the proposed optimizations are **not desirable** for Sonnet/Opus workflows:

1. **Haiku isn't used for Claude Code in this project.** The model switcher goes between Sonnet and Opus. Optimizing for a model that isn't used here is speculative.

2. **The current CLAUDE.md files are already earning their tokens.** Every section exists because of a real mistake — the directory tree prevents wrong file path guesses, the code blocks prevent bare `python` invocations, the architecture patterns prevent structural mistakes. Replacing these with file pointers forces extra tool call round-trips that cost more than the inline content saves.

3. **The "2,000 token degradation threshold" doesn't apply here.** The root file was ~2,100 tokens — a tiny fraction of the 200k context window. Sub-directory files only load when working in that path (2-3 files per session, not all 58).

4. **Evidence from this project shows Sonnet failures are attention/compliance issues, not context overload.** Bare `python3` usage, proactive commits, and incorrect PR review comments all happened despite clear, explicit instructions already being present. Shorter CLAUDE.md wouldn't fix those.

**The only unambiguously positive change:** The linter table was pure reference data (not an instruction) and Trunk's pre-commit hook catches violations regardless. Replacing it with a pointer has zero behavioral risk for any model.

Closes #3433

## Test plan

- [ ] Verify `trunk check` and `trunk fmt` commands still referenced in CLAUDE.md
- [ ] Verify SQL style rules still inline
- [ ] Confirm no Sonnet/Opus behavioral regression on representative tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)