### PR TITLE
fix: use client_date in PM branch join for int_amplify__all_assessments

### DIFF
--- a/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
+++ b/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
@@ -143,7 +143,7 @@ with
             and p.assessment_grade_int = e.grade
             and p.measure = e.expected_measure_standard
             and p.pm_period = e.admin_season
-            and p.sync_date between e.start_date and e.end_date
+            and p.client_date between e.start_date and e.end_date
             and e.assessment_include is null
             and e.pm_goal_include is null
         where p.enrollment_grade = p.assessment_grade and p.assessment_grade is not null


### PR DESCRIPTION
## Summary

- `sync_date` has more nulls than `client_date` in `int_amplify__mclass__pm_student_summary`, causing valid PM assessments to be silently dropped from `int_amplify__all_assessments`
- `client_date` is also semantically correct — the window dates (`start_date`/`end_date`) represent when assessments were administered, not when data was synced

## Test plan

- [ ] Compile passes locally (`dbt compile --select int_amplify__all_assessments`)
- [ ] Verify PM row counts increase after materialization
- [ ] Spot-check that newly included rows have `client_date` within the expected window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213646082361778