### PR TITLE
Add Fresh Dashboard intermediate models and snapshots

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__fresh_dashboard_enrollment_metrics.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__fresh_dashboard_enrollment_metrics.sql
@@ -1,0 +1,403 @@
+with
+    source as (
+        select *
+        from {{ ref("rpt_tableau__fresh_dashboard_progress_to_goals") }}
+    )
+
+select
+    academic_year,
+    org,
+    region,
+    schoolid,
+    school,
+    school_level,
+
+    case school_level
+        when 'ES' then 1
+        when 'MS' then 2
+        when 'HS' then 3
+    end as school_level_sort,
+
+    -- school-level enrollment counts (grade_level = -1)
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    ) as all_student_enrollment_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    ) as new_student_enrollment_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    ) as re_enroll_enrollment_s,
+
+    -- school+grade enrollment counts (grade_level != -1)
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) as all_student_enrollment_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) as new_student_enrollment_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) as re_enroll_enrollment_sg,
+
+    -- target fields (school rollup, grade_level = -1)
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then seat_target
+        end
+    ) as seat_target_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then fdos_target
+        end
+    ) as fdos_target_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then new_student_target
+        end
+    ) as new_student_target_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then re_enroll_projection
+        end
+    ) as re_enroll_projection_s,
+
+    -- distance to target (count), school rollup
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    )
+    - sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then seat_target
+        end
+    ) as seat_target_distance_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    )
+    - sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then fdos_target
+        end
+    ) as fdos_target_distance_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    ) - sum(budget_target) as budget_target_distance_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    )
+    - sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then new_student_target
+        end
+    ) as new_student_target_distance_s,
+
+    sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Student'
+                and grade_level = -1
+                then student_count
+        end
+    )
+    - sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Goal'
+                and grade_level = -1
+                then re_enroll_projection
+        end
+    ) as re_enroll_target_distance_s,
+
+    -- distance to target (count), school+grade
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) - sum(seat_target) as seat_target_distance_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) - sum(fdos_target) as fdos_target_distance_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'All'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) - sum(budget_target) as budget_target_distance_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'New'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) - sum(new_student_target) as new_student_target_distance_sg,
+
+    sum(
+        case
+            when
+                enrollment_type = 'Returning'
+                and row_type = 'Student'
+                and grade_level != -1
+                then student_count
+        end
+    ) - sum(re_enroll_projection) as re_enroll_target_distance_sg,
+
+    -- percent distance to target (school rollup)
+    safe_divide(
+        sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Student'
+                    and grade_level = -1
+                    then student_count
+            end
+        )
+        - sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then seat_target
+            end
+        ),
+        sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then seat_target
+            end
+        )
+    ) as seat_target_distance_pct,
+
+    safe_divide(
+        sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Student'
+                    and grade_level = -1
+                    then student_count
+            end
+        )
+        - sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then fdos_target
+            end
+        ),
+        sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then fdos_target
+            end
+        )
+    ) as fdos_target_distance_pct,
+
+    safe_divide(
+        sum(
+            case
+                when
+                    enrollment_type = 'All'
+                    and row_type = 'Student'
+                    and grade_level = -1
+                    then student_count
+            end
+        ) - sum(budget_target),
+        sum(budget_target)
+    ) as budget_target_distance_pct,
+
+    safe_divide(
+        sum(
+            case
+                when
+                    enrollment_type = 'New'
+                    and row_type = 'Student'
+                    and grade_level = -1
+                    then student_count
+            end
+        )
+        - sum(
+            case
+                when
+                    enrollment_type = 'New'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then new_student_target
+            end
+        ),
+        sum(
+            case
+                when
+                    enrollment_type = 'New'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then new_student_target
+            end
+        )
+    ) as new_student_target_distance_pct,
+
+    safe_divide(
+        sum(
+            case
+                when
+                    enrollment_type = 'Returning'
+                    and row_type = 'Student'
+                    and grade_level = -1
+                    then student_count
+            end
+        )
+        - sum(
+            case
+                when
+                    enrollment_type = 'Returning'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then re_enroll_projection
+            end
+        ),
+        sum(
+            case
+                when
+                    enrollment_type = 'Returning'
+                    and row_type = 'Goal'
+                    and grade_level = -1
+                    then re_enroll_projection
+            end
+        )
+    ) as re_enroll_target_distance_pct,
+
+from source
+group by
+    academic_year,
+    org,
+    region,
+    schoolid,
+    school,
+    school_level,

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__fresh_dashboard_goal_metrics.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__fresh_dashboard_goal_metrics.sql
@@ -1,0 +1,112 @@
+with
+    source as (
+        select *
+        from {{ ref("rpt_tableau__fresh_dashboard_aggregated") }}
+    )
+
+select
+    academic_year,
+    org,
+    region,
+    school_level,
+    schoolid,
+    school,
+    grade_level,
+    goal_granularity,
+    goal_type,
+    goal_name,
+    enrollment_type,
+    grouped_status_timeframe,
+
+    concat(
+        cast(academic_year as string),
+        '-',
+        right(cast(academic_year + 1 as string), 2)
+    ) as academic_year_display,
+
+    min(goal_value) as goal_value,
+
+    if(
+        goal_type in ('Applications', 'Offers', 'Pending Offers'),
+        min(goal_value),
+        null
+    ) as goal_value_counts,
+
+    if(
+        goal_type in ('Conversion', 'Assigned School'),
+        min(goal_value) * 100,
+        null
+    ) as goal_value_pct,
+
+    case
+        when goal_type in ('Applications', 'Offers', 'Pending Offers')
+            then cast(min(goal_value) as string)
+        when goal_type in ('Conversion', 'Assigned School')
+            then concat(cast(min(goal_value) * 100 as string), '%')
+    end as display_goal,
+
+    count(distinct goal_name_value) as goal_name_value_counts,
+
+    safe_divide(
+        count(distinct goal_name_value), count(distinct finalsite_id)
+    ) as goal_name_value_pct,
+
+    case
+        when goal_type in ('Conversion', 'Assigned School')
+            then concat(
+                cast(
+                    round(
+                        safe_divide(
+                            count(distinct goal_name_value),
+                            count(distinct finalsite_id)
+                        ) * 100,
+                        1
+                    ) as string
+                ),
+                '%'
+            )
+        else cast(count(distinct goal_name_value) as string)
+    end as display_value,
+
+    case
+        when min(goal_value) is null
+            then 'No Goal'
+        when
+            goal_type in ('Applications', 'Offers', 'Pending Offers')
+            and count(distinct goal_name_value)
+            >= min(
+                case
+                    when goal_type in ('Applications', 'Offers', 'Pending Offers')
+                        then goal_value
+                end
+            )
+            then 'Met Goal'
+        when
+            goal_type in ('Conversion', 'Assigned School')
+            and safe_divide(
+                count(distinct goal_name_value), count(distinct finalsite_id)
+            )
+            >= min(
+                case
+                    when goal_type in ('Conversion', 'Assigned School')
+                        then goal_value
+                end
+            )
+            then 'Met Goal'
+        else 'Did Not Meet Goal'
+    end as met_goal,
+
+from source
+group by
+    academic_year,
+    org,
+    region,
+    school_level,
+    schoolid,
+    school,
+    grade_level,
+    goal_granularity,
+    goal_type,
+    goal_name,
+    enrollment_type,
+    grouped_status_timeframe,

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__fresh_dashboard_enrollment_metrics.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__fresh_dashboard_enrollment_metrics.yml
@@ -1,0 +1,77 @@
+models:
+  - name: int_tableau__fresh_dashboard_enrollment_metrics
+    config:
+      materialized: table
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - academic_year
+              - schoolid
+          config:
+            store_failures: true
+    columns:
+      - name: academic_year
+        data_type: int64
+      - name: org
+        data_type: string
+      - name: region
+        data_type: string
+      - name: schoolid
+        data_type: int64
+      - name: school
+        data_type: string
+      - name: school_level
+        data_type: string
+      - name: school_level_sort
+        data_type: int64
+      - name: all_student_enrollment_s
+        data_type: int64
+      - name: new_student_enrollment_s
+        data_type: int64
+      - name: re_enroll_enrollment_s
+        data_type: int64
+      - name: all_student_enrollment_sg
+        data_type: int64
+      - name: new_student_enrollment_sg
+        data_type: int64
+      - name: re_enroll_enrollment_sg
+        data_type: int64
+      - name: seat_target_s
+        data_type: numeric
+      - name: fdos_target_s
+        data_type: numeric
+      - name: new_student_target_s
+        data_type: numeric
+      - name: re_enroll_projection_s
+        data_type: numeric
+      - name: seat_target_distance_s
+        data_type: numeric
+      - name: fdos_target_distance_s
+        data_type: numeric
+      - name: budget_target_distance_s
+        data_type: numeric
+      - name: new_student_target_distance_s
+        data_type: numeric
+      - name: re_enroll_target_distance_s
+        data_type: numeric
+      - name: seat_target_distance_sg
+        data_type: numeric
+      - name: fdos_target_distance_sg
+        data_type: numeric
+      - name: budget_target_distance_sg
+        data_type: numeric
+      - name: new_student_target_distance_sg
+        data_type: numeric
+      - name: re_enroll_target_distance_sg
+        data_type: numeric
+      - name: seat_target_distance_pct
+        data_type: float64
+      - name: fdos_target_distance_pct
+        data_type: float64
+      - name: budget_target_distance_pct
+        data_type: float64
+      - name: new_student_target_distance_pct
+        data_type: float64
+      - name: re_enroll_target_distance_pct
+        data_type: float64

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__fresh_dashboard_goal_metrics.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__fresh_dashboard_goal_metrics.yml
@@ -1,0 +1,61 @@
+models:
+  - name: int_tableau__fresh_dashboard_goal_metrics
+    config:
+      materialized: table
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - academic_year
+              - schoolid
+              - grade_level
+              - goal_granularity
+              - goal_type
+              - goal_name
+              - enrollment_type
+              - grouped_status_timeframe
+          config:
+            store_failures: true
+    columns:
+      - name: academic_year
+        data_type: int64
+      - name: org
+        data_type: string
+      - name: region
+        data_type: string
+      - name: school_level
+        data_type: string
+      - name: schoolid
+        data_type: int64
+      - name: school
+        data_type: string
+      - name: grade_level
+        data_type: int64
+      - name: goal_granularity
+        data_type: string
+      - name: goal_type
+        data_type: string
+      - name: goal_name
+        data_type: string
+      - name: enrollment_type
+        data_type: string
+      - name: grouped_status_timeframe
+        data_type: string
+      - name: academic_year_display
+        data_type: string
+      - name: goal_value
+        data_type: numeric
+      - name: goal_value_counts
+        data_type: numeric
+      - name: goal_value_pct
+        data_type: numeric
+      - name: display_goal
+        data_type: string
+      - name: goal_name_value_counts
+        data_type: int64
+      - name: goal_name_value_pct
+        data_type: float64
+      - name: display_value
+        data_type: string
+      - name: met_goal
+        data_type: string

--- a/src/dbt/kipptaf/snapshots/tableau.yml
+++ b/src/dbt/kipptaf/snapshots/tableau.yml
@@ -1,0 +1,49 @@
+snapshots:
+  - name: snapshot_tableau__fresh_dashboard_goal_metrics
+    relation: ref("int_tableau__fresh_dashboard_goal_metrics")
+    config:
+      schema: tableau
+      strategy: check
+      unique_key:
+        - academic_year
+        - schoolid
+        - grade_level
+        - goal_granularity
+        - goal_type
+        - goal_name
+        - enrollment_type
+        - grouped_status_timeframe
+      check_cols:
+        - met_goal
+        - display_value
+      dbt_valid_to_current: "'9999-12-31'"
+      meta:
+        dagster:
+          group: tableau
+          asset_key:
+            - kipptaf
+            - tableau
+            - snapshot_tableau__fresh_dashboard_goal_metrics
+
+  - name: snapshot_tableau__fresh_dashboard_enrollment_metrics
+    relation: ref("int_tableau__fresh_dashboard_enrollment_metrics")
+    config:
+      schema: tableau
+      strategy: check
+      unique_key:
+        - academic_year
+        - schoolid
+      check_cols:
+        - all_student_enrollment_s
+        - new_student_enrollment_s
+        - re_enroll_enrollment_s
+        - seat_target_distance_s
+        - fdos_target_distance_s
+      dbt_valid_to_current: "'9999-12-31'"
+      meta:
+        dagster:
+          group: tableau
+          asset_key:
+            - kipptaf
+            - tableau
+            - snapshot_tableau__fresh_dashboard_enrollment_metrics


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add two new intermediate dbt models and their corresponding snapshots to support the Fresh Dashboard Tableau extract:

- `int_tableau__fresh_dashboard_enrollment_metrics`: Aggregates enrollment data by school and academic year, calculating enrollment counts, targets, and distance-to-target metrics (both absolute and percentage)
- `int_tableau__fresh_dashboard_goal_metrics`: Aggregates goal achievement data by school, grade level, and goal type, calculating goal values and tracking whether goals were met

These intermediate models serve as the foundation for Tableau dashboard visualizations and include snapshots to track changes over time.

## Changes

### New Models
- **int_tableau__fresh_dashboard_enrollment_metrics.sql** (403 lines)
  - Sources from `rpt_tableau__fresh_dashboard_progress_to_goals`
  - Groups by academic year, org, region, school, and school level
  - Calculates enrollment metrics at school level (grade_level = -1) and school+grade level (grade_level != -1)
  - Computes distance to targets (seat, FDOS, budget, new student, re-enrollment) in both count and percentage formats
  - Includes school level sort field for proper ordering (ES=1, MS=2, HS=3)

- **int_tableau__fresh_dashboard_goal_metrics.sql** (112 lines)
  - Sources from `rpt_tableau__fresh_dashboard_aggregated`
  - Groups by academic year, school, grade level, goal granularity, goal type, and enrollment type
  - Calculates goal achievement metrics with conditional formatting for counts vs. percentages
  - Determines met goal status based on goal type (Applications/Offers/Pending Offers vs. Conversion/Assigned School)
  - Includes display-friendly fields for dashboard consumption

### Properties & Tests
- Added comprehensive `.yml` property files for both models with:
  - Data type definitions for all columns
  - Unique combination tests to ensure data integrity
  - Materialized as tables for performance

### Snapshots
- Added `snapshot_tableau__fresh_dashboard_goal_metrics` tracking changes to `met_goal` and `display_value`
- Added `snapshot_tableau__fresh_dashboard_enrollment_metrics` tracking changes to enrollment and distance-to-target metrics
- Both use check strategy with dbt_valid_to_current set to '9999-12-31'

## Self-review

- [ ] Run `trunk fmt` on all modified files
- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location
- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard

https://claude.ai/code/session_019dpZt3HX2MFW1u9hVogaej