### PR TITLE
Fix March 15 enrollment date calculation for next academic year

### DIFF
--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
@@ -260,7 +260,7 @@ select
         date(academic_year, 10, 15) between entrydate and exitdate, true, false
     ) as is_enrolled_oct15,
     if(
-        date(academic_year, 3, 15) between entrydate and exitdate, true, false
+        date(academic_year + 1, 3, 15) between entrydate and exitdate, true, false
     ) as is_enrolled_mar15,
 
     case


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix the `is_enrolled_mar15` calculation in the student enrollment union model to correctly reference the next academic year (academic_year + 1) instead of the current academic year. 

The March 15 enrollment check should evaluate against the following academic year since March 15 falls after the October 15 start date but before the end of the academic year cycle. This aligns with the intended logic for mid-year enrollment status tracking.

## Self-review

### dbt

- [ ] Run `dbt build` on the modified model to verify the change produces correct results
- [ ] Verify that the `is_enrolled_mar15` flag now correctly identifies students enrolled in the subsequent academic year

## Test Plan

The change is a straightforward date calculation fix. Existing dbt tests will validate that the model builds successfully. Manual verification of the `is_enrolled_mar15` values against known student enrollment records would confirm the fix produces the intended results.

https://claude.ai/code/session_01KnD6jThNnstn1ZYiRXLGmF