### PR TITLE
Add not_null validation and clarify bulk_add survey logic

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -308,6 +308,7 @@ select
         row_number() over (
             partition by r.contact_id
             order by
+                /* bulk_add wins; intended only for alumni with no survey response */
                 if(sp.survey_id = 'bulk_add', 0, 1), sp.response_date_submitted desc
         ),
         null

--- a/src/dbt/kipptaf/models/google/sheets/sources.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources.yml
@@ -1693,6 +1693,7 @@ sources:
               - https://docs.google.com/spreadsheets/d/1E1XfD05PSplIrnSnByER6GoXvFv3hzACtyO9m8FcSrY/
             sheet_range: career_launch_bulk_add_v1
             skip_leading_rows: 1
+        config:
           meta:
             dagster:
               asset_key:

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__kippfwd__career_launch_bulk_add.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__kippfwd__career_launch_bulk_add.yml
@@ -7,6 +7,9 @@ models:
           - unique:
               config:
                 store_failures: true
+          - not_null:
+              config:
+                store_failures: true
       - name: email
         data_type: string
       - name: cell_phone


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will:
- Add a `not_null` dbt test with failure storage to the `contact_id` column in the Career Launch bulk add staging model
- Add a clarifying comment explaining that bulk_add survey responses take precedence in the Tableau report's row numbering logic
- Fix a YAML indentation issue in the Google Sheets sources configuration

## Changes

1. **stg_google_sheets__kippfwd__career_launch_bulk_add.yml**: Added `not_null` test with `store_failures: true` config to the `contact_id` column to ensure data quality
2. **rpt_tableau__kfwd_career_launch_survey.sql**: Added inline comment explaining that bulk_add survey records are prioritized (ordered first) and are intended only for alumni with no survey response
3. **sources.yml**: Fixed indentation by moving `config:` to proper YAML structure level

## Self-review

### dbt

- [ ] Run `dbt build` to validate the new test and model changes
- [ ] Verify the `not_null` test executes successfully on the staging model
- [ ] Confirm the Tableau report query logic remains unchanged (comment-only addition)

### CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Claude Code Review** — review automated feedback

https://claude.ai/code/session_019wuFAqu94dBvQYNMHxxQYr