### PR TITLE
Add quality bar audit report for college list review

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippadb_quality_bar_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippadb_quality_bar_audit.yml
@@ -99,6 +99,27 @@ models:
           int_overgrad__admissions on student contact ID and
           stg_kippadb__account.nces_id =
           int_overgrad__admissions.university__ipeds_id.
+      - name: n_overgrad_1st_choice
+        data_type: int64
+        description: >
+          Count of colleges this student has marked #1 Choice in Overgrad.
+          Values > 1 indicate the student has tagged multiple schools as their
+          top choice.
+      - name: n_overgrad_2nd_choice
+        data_type: int64
+        description: Count of colleges this student has marked #2 Choice in Overgrad.
+      - name: n_overgrad_3rd_choice
+        data_type: int64
+        description: Count of colleges this student has marked #3 Choice in Overgrad.
+      - name: has_duplicate_overgrad_1st_choice
+        data_type: boolean
+        description: True if the student has marked more than one college as #1 Choice in Overgrad.
+      - name: has_duplicate_overgrad_2nd_choice
+        data_type: boolean
+        description: True if the student has marked more than one college as #2 Choice in Overgrad.
+      - name: has_duplicate_overgrad_3rd_choice
+        data_type: boolean
+        description: True if the student has marked more than one college as #3 Choice in Overgrad.
       - name: is_4yr
         data_type: boolean
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippadb_quality_bar_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippadb_quality_bar_audit.sql
@@ -25,6 +25,18 @@ with
         where top_choice_schools is not null
     ),
 
+    overgrad_choice_counts as (
+        select
+            student__external_student_id,
+
+            countif(top_choice_schools = '#1 Choice') as n_overgrad_1st_choice,
+            countif(top_choice_schools = '#2 Choice') as n_overgrad_2nd_choice,
+            countif(top_choice_schools = '#3 Choice') as n_overgrad_3rd_choice,
+        from {{ ref("int_overgrad__admissions") }}
+        where top_choice_schools is not null
+        group by student__external_student_id
+    ),
+
     `rollup` as (
         select
             applicant,
@@ -90,6 +102,12 @@ select
     a.is_strong_oos_option as is_strong_oos,
     a.is_early_action_decision,
     og.top_choice_schools as overgrad_top_choice,
+    ogc.n_overgrad_1st_choice,
+    ogc.n_overgrad_2nd_choice,
+    ogc.n_overgrad_3rd_choice,
+    ogc.n_overgrad_1st_choice > 1 as has_duplicate_overgrad_1st_choice,
+    ogc.n_overgrad_2nd_choice > 1 as has_duplicate_overgrad_2nd_choice,
+    ogc.n_overgrad_3rd_choice > 1 as has_duplicate_overgrad_3rd_choice,
 
     -- per-app quality bar component flags
     a.account_type in ('Public 4 yr', 'Private 4 yr') as is_4yr,
@@ -164,4 +182,6 @@ left join
     overgrad_top_choice as og
     on a.applicant = og.student__external_student_id
     and acc.nces_id = og.university_ipeds_id_str
+left join
+    overgrad_choice_counts as ogc on a.applicant = ogc.student__external_student_id
 where a.application_submission_status in ('Wishlist', 'Submitted')


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a new audit report (`rpt_gsheets__kippadb_quality_bar_audit`) that surfaces application-level details for the college list quality bar. This report enables stakeholders to verify which applications contribute to each quality bar component and understand why a student does or does not meet the bar.

The model joins student roster data, application details, and student-level rollup counts to create a comprehensive audit view with one row per application (wishlist or submitted). It includes per-application flags (ECC thresholds, account type, NJ status, etc.) alongside student-level aggregate counts that drive the quality bar logic, plus the quality bar tier classification for each student.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
  - Added comprehensive `rpt_gsheets__kippadb_quality_bar_audit.yml` with 60+ column definitions
  - Included unique constraint test on `(contact_id, application_id)` with failure storage enabled
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
  - *Note: Exposure should be added if this report is consumed by a Google Sheet or dashboard*
- [ ] Breaking change? Not applicable — new model only

### CI checks

- [ ] **Trunk** — will validate on push
- [ ] **dbt Cloud** — will validate on push
- [ ] **Dagster Cloud** — not triggered (no Dagster code changes)

## Notes

- Model filters to `application_submission_status in ('Wishlist', 'Submitted')` only
- Joins to Overgrad admissions data on student ID and NCES ID to surface top choice rankings
- Quality bar tier logic mirrors the CASE statement from `int_kippadb__app_rollup` for audit transparency
- All column descriptions provided for stakeholder clarity on what drives quality bar decisions

https://claude.ai/code/session_01EE41KQ1U5UNYTdkxFJGYvN