### PR TITLE
fix: disable gradebook_audit_teacher_report exposure

### DIFF
--- a/src/dbt/kipptaf/models/exposures/tableau.yml
+++ b/src/dbt/kipptaf/models/exposures/tableau.yml
@@ -365,6 +365,7 @@ exposures:
       - ref("rpt_tableau__gradebook_es_comments")
       - ref("rpt_tableau__gradebook_gpa")
     config:
+      enabled: false
       meta:
         dagster:
           kinds:


### PR DESCRIPTION
## Motivation

Disables the `gradebook_audit_teacher_report` Tableau exposure (Gradebook Audit - Teacher Report) to stop Dagster from managing the automated Tuesday 7:30am email refresh. The exposure is disabled rather than deleted to preserve the configuration for reference.

## Changes

- Added `enabled: false` to the `gradebook_audit_teacher_report` exposure config in `models/exposures/tableau.yml`

## dbt checklist

- [x] No dbt model SQL changes — exposure-only update, no model documentation required
- [ ] dbt project parses without errors (`dagster definitions validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)