### PR TITLE
fix: handle Paterson credit type variants in schedule CTEs

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
@@ -19,14 +19,13 @@ with
             s.abbreviation as school,
 
             case
-                c.courses_credittype
-                when 'ENG'
+                when c.courses_credittype in ('ENG', 'ELA')
                 then 'ELA'
-                when 'MATH'
+                when c.courses_credittype in ('MATH', 'Math')
                 then 'Math'
-                when 'SCI'
+                when c.courses_credittype in ('SCI', 'Science')
                 then 'Science'
-                when 'SOC'
+                when c.courses_credittype = 'SOC'
                 then 'Civics'
             end as discipline,
 
@@ -38,7 +37,8 @@ with
             c.cc_academic_year = {{ var("current_academic_year") }}
             and c.rn_credittype_year = 1
             and not c.is_dropped_section
-            and c.courses_credittype in ('ENG', 'MATH', 'SCI', 'SOC')
+            and c.courses_credittype
+            in ('ENG', 'MATH', 'SCI', 'SOC', 'ELA', 'Math', 'Science')
     ),
 
     schedules as (
@@ -56,14 +56,13 @@ with
             c.teacher_name as teacher_name_current,
 
             case
-                e.courses_credittype
-                when 'ENG'
+                when e.courses_credittype in ('ENG', 'ELA')
                 then 'ELA'
-                when 'MATH'
+                when e.courses_credittype in ('MATH', 'Math')
                 then 'Math'
-                when 'SCI'
+                when e.courses_credittype in ('SCI', 'Science')
                 then 'Science'
-                when 'SOC'
+                when e.courses_credittype = 'SOC'
                 then 'Civics'
             end as discipline,
 
@@ -76,7 +75,8 @@ with
             e.cc_academic_year >= {{ var("current_academic_year") - 7 }}
             and e.rn_credittype_year = 1
             and not e.is_dropped_section
-            and e.courses_credittype in ('ENG', 'MATH', 'SCI', 'SOC')
+            and e.courses_credittype
+            in ('ENG', 'MATH', 'SCI', 'SOC', 'ELA', 'Math', 'Science')
     ),
 
     state_comps as (


### PR DESCRIPTION
## Motivation

Paterson PowerSchool stores `credittype` as `'ELA'`/`'Math'`/`'Science'` for ~59 course records in 2023, instead of the standard `'ENG'`/`'MATH'`/`'SCI'` used by all other regions and all Paterson data from 2024 onward. Investigation confirmed the mismatch is in the raw `courses` table in PowerSchool (surfaces unchanged through staging). A fix at the PowerSchool level is not feasible, so this handles both variants in dbt.

Without this fix, those ~59 Paterson students' 2023 course records are excluded by the `IN` filter in both `schedules_current` and `schedules` CTEs, resulting in null `teachernumber`/`teacher_name` in the State Assessments Dashboard for that cohort.

## Changes

- Updated `CASE` expressions in `schedules_current` and `schedules` to map both `'ENG'`/`'ELA'` → `'ELA'`, `'MATH'`/`'Math'` → `'Math'`, `'SCI'`/`'Science'` → `'Science'`
- Extended `IN` filters in both CTEs to include the Paterson variants

## Test plan

- [ ] Confirm Paterson 2023 students (e.g. `student_number = 400007`) now have `teachernumber` populated in the dashboard
- [ ] Confirm Newark and Camden schedule data is unchanged
- [ ] Confirm 2024+ data is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213737432919716