### PR TITLE
fix(dbt): add missing arguments key to unique_combination_of_columns test

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippadb_quality_bar_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippadb_quality_bar_audit.yml
@@ -10,9 +10,10 @@ models:
       or does not meet the bar.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - contact_id
-            - application_id
+          arguments:
+            combination_of_columns:
+              - contact_id
+              - application_id
           config:
             store_failures: true
     columns:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will resolve a `MissingArgumentsPropertyInGenericTestDeprecation` warning emitted by dbt during parsing. The `dbt_utils.unique_combination_of_columns` test in `rpt_gsheets__kippadb_quality_bar_audit.yml` was passing `combination_of_columns` directly instead of nesting it under the required `arguments:` key.

## AI Assistance

Fully AI-assisted: Claude identified the culprit file by diffing indentation patterns across all YAML test definitions, applied the one-line fix, and opened this PR.

## Self-review

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — N/A (fix to existing)
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — N/A
- [x] **Breaking change?** No — this is a non-breaking YAML fix.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213744935707236