### PR TITLE
perf(dbt): materialize gradebook Tableau views as tables

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
@@ -1,5 +1,7 @@
 models:
   - name: rpt_tableau__gradebook_audit
+    config:
+      materialized: table
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_es_comments.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_es_comments.yml
@@ -1,5 +1,7 @@
 models:
   - name: rpt_tableau__gradebook_es_comments
+    config:
+      materialized: table
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
@@ -1,5 +1,7 @@
 models:
   - name: rpt_tableau__gradebook_gpa
+    config:
+      materialized: table
     columns:
       - name: _dbt_source_relation
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_ms_hs_comments.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_ms_hs_comments.yml
@@ -1,5 +1,7 @@
 models:
   - name: rpt_tableau__gradebook_ms_hs_comments
+    config:
+      materialized: table
     columns:
       - name: academic_year
         data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Materialize 4 Gradebook and GPA Dashboard Tableau extract views as tables to fix workbook refresh timeouts on Tableau Server (>1 hour).

BigQuery `INFORMATION_SCHEMA.JOBS` analysis showed:
- `rpt_tableau__gradebook_audit`: ~170s, 1.97 GB per refresh
- `rpt_tableau__gradebook_es_comments`: ~147s, 1.97 GB per refresh
- `rpt_tableau__gradebook_ms_hs_comments`: ~147s, 1.97 GB per refresh
- `rpt_tableau__gradebook_gpa`: ~26s, 0.87 GB per refresh

These 4 views account for ~8.5 min of BigQuery compute per refresh cycle. Materializing them as tables will let Tableau query pre-built results instead of recomputing the full view DAG each time. This dashboard needs to survive until June 20, 2026 when it will be revamped.

## AI Assistance

Claude Code investigated BigQuery job history and Dagster run logs to identify the bottleneck, then made the config changes. Human-directed decision on which models to materialize and the overall approach.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No — this only changes materialization strategy, not schema or columns.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)