### PR TITLE
ci: switch claude review to API key auth and superpowers plugins

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -31,17 +31,25 @@ jobs:
         with:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           plugin_marketplaces: |
-            https://github.com/anthropics/claude-code.git
+            https://github.com/anthropics/claude-plugins-official.git
             https://github.com/dbt-labs/dbt-agent-skills.git
             https://github.com/dagster-io/skills.git
-          plugins: code-review@claude-code-plugins
+          plugins: |
+            superpowers@claude-plugins-official
+            security-guidance@claude-plugins-official
+            dagster-expert@dagster
+            dignified-python@dagster
+            dbt@dbt-agent-marketplace
           track_progress: true
-          prompt:
-            "/code-review:code-review ${{ github.repository }}/pull/${{
-            github.event.pull_request.number }}"
+          prompt: >-
+            Use the superpowers:requesting-code-review skill to review ${{
+            github.repository }}/pull/${{ github.event.pull_request.number }}.
+            Apply dignified-python for Python standards, security-guidance for
+            security issues, dagster-expert for Dagster assets and pipelines,
+            and dbt for dbt models and transformations.
           allowed_bots: dbt-cloud
           include_fix_links: false
           use_sticky_comment: true


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will replace the personal OAuth token used by the Claude Code Review workflow with a stable `ANTHROPIC_API_KEY` secret, and upgrade the plugin configuration to use `superpowers:requesting-code-review` with domain-specific context.

**Changes:**
- Auth: `CLAUDE_CODE_OAUTH_TOKEN` (OAuth, session-tied) → `ANTHROPIC_API_KEY` (API key, stable)
- Marketplace: `anthropics/claude-code.git` → `anthropics/claude-plugins-official.git` (where superpowers lives)
- Plugins: `code-review@claude-code-plugins` → `superpowers`, `security-guidance`, `dagster-expert`, `dignified-python`, `dbt`
- Prompt: invokes `superpowers:requesting-code-review` with explicit Python, security, Dagster, and dbt context

**Required:** Add `ANTHROPIC_API_KEY` to repo secrets before merging.

## AI Assistance

Fully AI-assisted. Human-directed: switched to API key auth after OAuth session was invalidated, and requested superpowers-based review with domain plugin context.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

## CI checks

- [ ] **Trunk** — passes.