### PR TITLE
fix: revert schedule CTE filters to courses_credittype

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
@@ -32,7 +32,7 @@ with
             c.cc_academic_year = {{ var("current_academic_year") }}
             and c.rn_credittype_year = 1
             and not c.is_dropped_section
-            and c.discipline in ('ELA', 'MATH', 'SCI', 'SOC')
+            and c.courses_credittype in ('ENG', 'MATH', 'SCI', 'SOC')
     ),
 
     schedules as (
@@ -64,7 +64,7 @@ with
             e.cc_academic_year >= {{ var("current_academic_year") - 7 }}
             and e.rn_credittype_year = 1
             and not e.is_dropped_section
-            and e.discipline in ('ELA', 'MATH', 'SCI', 'SOC')
+            and e.courses_credittype in ('ENG', 'MATH', 'SCI', 'SOC')
     ),
 
     state_comps as (


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will restore correct row counts in the State Assessments Dashboard by reverting the `schedules_current` and `schedules` CTE filters from `discipline` back to `courses_credittype`.

**Root cause:** A recent commit ([`43a648a09`](https://github.com/TEAMSchools/teamster/commit/43a648a09800bee2b857c712f880be91fa72abda)) changed the WHERE clause in both schedule CTEs from `courses_credittype in (...)` to `discipline in ('ELA', 'MATH', 'SCI', 'SOC')`. The `discipline` column comes from the course subject crosswalk and can map multiple courses with different credit types to the same discipline value. Because `rn_credittype_year = 1` only deduplicates per `(student, credittype)` — not per `(student, discipline)` — filtering on `discipline` lets multiple rows through per student. The outer join then uses `a.discipline = m.discipline`, so each extra schedule row multiplies assessment score rows, inflating counts. FL/MIA and NJ/NEW ELA counts roughly doubled after the Tableau refresh.

**Why `'ENG'` is correct:** `base_powerschool__course_enrollments` now normalizes Paterson 2023 credit type variants (`'ELA' → 'ENG'`, `'Math' → 'MATH'`, `'Science' → 'SCI'`) upstream, so the original Paterson fix from PR #3489 remains intact — no variant codes need to appear in this filter.

## AI Assistance

Root cause diagnosis and fix were AI-assisted (Claude Code); change was human-directed after observing inflated Tableau row counts post-refresh.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model will break downstream exposures. Coordinate with affected teams before merging and document your rollback plan in the summary above.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213819941056149