### PR TITLE
fix(mcp): surface response body on HTTP errors and increase timeout

### DIFF
--- a/mcp/dagster_plus.py
+++ b/mcp/dagster_plus.py
@@ -36,7 +36,7 @@ server = Server("dagster-plus")
 
 def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
     """Execute a GraphQL query against the Dagster+ API."""
-    with httpx.Client(timeout=30) as client:
+    with httpx.Client(timeout=60) as client:
         response = client.post(
             GRAPHQL_URL,
             json={"query": query, "variables": variables or {}},
@@ -45,7 +45,10 @@ def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
                 "Content-Type": "application/json",
             },
         )
-        response.raise_for_status()
+        if not response.is_success:
+            raise RuntimeError(
+                f"Dagster API {response.status_code}: {response.text[:500]}"
+            )
         data = response.json()
         if "errors" in data:
             raise RuntimeError(f"GraphQL errors: {data['errors']}")


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Fix the Dagster MCP server's `gql()` function to include the API response body when HTTP errors occur (e.g., 400 Bad Request), instead of only showing the status code. Also increases the HTTP timeout from 30s to 60s for large `logsForRun` queries.

Previously, `response.raise_for_status()` discarded the response body, making errors like `400 Bad Request` undiagnosable. This was encountered during the illuminate contract debugging session (TEAMSchools/teamster#3533).

## AI Assistance

Claude Code identified the issue during a production debugging session where `get_run_logs` returned opaque 400 errors, and proposed/implemented the fix.

## Self-review

### Dagster _(skip if no Dagster changes)_

- [x] Run `uv run dagster definitions validate` — N/A (MCP server, not a code location)

## CI checks

- [ ] **Trunk** — passes