### PR TITLE
docs: fix factual inaccuracies in star-schema-advisor spec

### DIFF
--- a/docs/superpowers/specs/2026-03-20-star-schema-advisor-design.md
+++ b/docs/superpowers/specs/2026-03-20-star-schema-advisor-design.md
@@ -369,9 +369,10 @@ exactly which files changed:
 
 **Adding to an existing mart:**
 
-- Add the column to the SQL `SELECT` clause following column ordering
-  convention: plain refs → simple functions → nested functions → logicals → CASE
-  → window functions
+- Add the column to the SQL `SELECT` clause following the column ordering in
+  `src/dbt/CLAUDE.md`: plain refs (grouped by source table in join order,
+  separated by blank lines) → constants → simple functions → nested functions →
+  logicals → CASE → window functions
 - Add a corresponding entry to the properties YAML (`name`, `data_type`,
   optional `description`)
 - Follow `.trunk/config/.sqlfluff` style: trailing commas, single quotes, max 88
@@ -615,9 +616,9 @@ BI tool.
 - **Standalone script.** `tableau-analyze-workbook.py` is a new standalone
   script with no Dagster dependencies. It reads credentials directly from
   environment variables.
-- **One datasource per run.** Multi-datasource workbooks are handled by running
-  the command multiple times; each run produces a separate report with a
-  datasource slug in the filename.
+- **One datasource at a time.** Multi-datasource workbooks are processed
+  sequentially within a single session (see Step 8); each datasource produces
+  its own report with a datasource slug in the filename.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will correct factual inaccuracies and fill gaps
in the `/star-schema-advisor` design spec identified during review:

- **Credential source**: Clarified that credentials come from `inject-secrets.sh`
  and are wired via `EnvVar()` in `kipptaf/resources.py`, not defined by the
  Dagster resource class itself
- **Nonexistent script**: Removed all references to `scripts/tableau-extract-calcs.py`
  (does not exist in the repo)
- **Wrong path**: Fixed `.sqlfluff` reference to `.trunk/config/.sqlfluff`
- **Column ordering**: Inlined the convention into the spec (not documented in
  `src/dbt/CLAUDE.md` as claimed)
- **Missing directory**: Noted `.claude/commands/` must be created during
  implementation
- **MCP fallback**: Added fallback guidance for Step 4 when dbt MCP is
  unavailable; clarified it runs locally (not dbt Cloud)
- **Testing**: Added a Testing section for the Python extraction script
- **Filename collisions**: Added timestamp to report filenames to prevent
  same-day overwrites
- **Minor**: Added inline script header example, clarified sequential processing
  assumption

## AI Assistance

Claude Code co-authored these fixes based on a human-directed review of the spec
against the actual codebase. All findings were validated by reading the
referenced source files.

## Self-review

### General

- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

## CI checks

- [ ] **Trunk** — passes.
