### PR TITLE
docs: fix and extend star-schema-advisor spec

### DIFF
--- a/docs/superpowers/specs/2026-03-20-star-schema-advisor-design.md
+++ b/docs/superpowers/specs/2026-03-20-star-schema-advisor-design.md
@@ -377,9 +377,10 @@ started.
 
 ### Step 5 — Classify every field
 
-Apply verdict rules to every field in the datasource JSON. Also check each
-field's `contains_lod` flag — if `true`, treat it as an LOD expression
-regardless of `is_calculated`.
+Apply the mart design principles from `src/dbt/CLAUDE.md` (see Prerequisites) to
+classify every field in the datasource JSON. Also check each field's
+`contains_lod` flag — if `true`, treat it as an LOD expression regardless of
+`is_calculated`.
 
 For fields that appear in multiple viz roles across worksheets (e.g. both SUMmed
 and used as a filter), assign **Ambiguous — analyst decision**.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will improve the `/star-schema-advisor` design
spec with corrections, missing context, and foundational mart design work:

**Factual fixes:**
- Clarify credential source (kipptaf/resources.py EnvVar + inject-secrets.sh)
- Remove references to nonexistent scripts/tableau-extract-calcs.py
- Fix .sqlfluff path to .trunk/config/.sqlfluff
- Fix exposure metadata path (config.meta.dagster.asset.metadata.id)
- Note .claude/commands/ directory must be created

**Completeness:**
- Add MCP fallback guidance for Step 4 lineage check
- Add Testing section for the Python extraction script
- Add inline script header example
- Add mart design prerequisites section (principles, missing dims,
  misclassified facts)
- Add src/dbt/CLAUDE.md to Files Changed table

**Consistency:**
- Timestamp format (THHMM) applied to all report filename references
- Column ordering references src/dbt/CLAUDE.md with source-table grouping rule
- Decisions section aligned with Step 8 sequential-session behavior
- Consistent "workbook ID" terminology (replaced stale "LSID")
- Prerequisites section relocated before Workflow for logical reading order

Replaces #3540 (prematurely merged and reverted).

## AI Assistance

Claude Code co-authored all fixes based on human-directed review. Findings were
validated by reading referenced source files and cross-checking internal
consistency across all spec sections.

## Self-review

### General

- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

## CI checks

- [ ] **Trunk** — passes.
