### PR TITLE
feat(vscode): add task to open YAML properties file for active SQL model

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,18 @@
       "problemMatcher": []
     },
     {
+      "label": "dbt: Open YAML",
+      "type": "shell",
+      "command": "[ -f \"${fileDirname}/properties/${fileBasenameNoExtension}.yml\" ] && code \"${fileDirname}/properties/${fileBasenameNoExtension}.yml\" || code \"${fileDirname}/properties/${fileBasenameNoExtension}.yaml\"",
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared",
+        "focus": false,
+        "close": true
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "dbt: Build Init",
       "type": "shell",
       "command": "bash .vscode/scripts/dbt-build-init.sh ${input:dbtProject}",


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a VS Code task — **"dbt: Open YAML"** — that opens the corresponding `properties/<model>.yml` file for whichever SQL model is currently active in the editor. Handles both `.yml` and `.yaml` extensions.

**To activate it**, add the following to your User Keybindings (`Ctrl+K Ctrl+S`, then click the `{}` icon in the top right):

\`\`\`json
{
  "key": "ctrl+shift+y",
  "command": "workbench.action.tasks.runTask",
  "args": "dbt: Open YAML"
}
\`\`\`

VS Code doesn't support workspace-level keybindings, so each user sets this once in their own profile.

## AI Assistance

Task implementation and branch/PR creation were AI-assisted (Claude Code); change was human-directed.

## Self-review

### General

- [x] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

## CI checks

- [ ] **Trunk** — passes.