### PR TITLE
feat(gradebook): add HS Q3 audit window to is_quarter_end_date_range

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
@@ -170,6 +170,15 @@ with
                     )
                 then true
                 when
+                    tw.school_level = 'HS'
+                    and tw.`quarter` = 'Q3'
+                    and current_date(
+                        '{{ var("local_timezone") }}'
+                    ) between (tw.quarter_end_date_insession + interval 9 day) and (
+                        tw.quarter_end_date_insession + interval 20 day
+                    )
+                then true
+                when
                     tw.region != 'Miami'
                     and current_date(
                         '{{ var("local_timezone") }}'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Adds a Q3-specific audit window for high school students to the `is_quarter_end_date_range` case expression in `int_tableau__gradebook_audit_teacher_scaffold`. When merged, this PR will extend the gradebook audit window for HS Q3 to cover 9–20 days after `quarter_end_date_insession` (vs. the standard ±5/+14 day window for non-Miami schools).

Extracted from PR #3529 which was never merged.

## AI Assistance

Claude Code extracted the specific file change from PR #3529 and created this PR.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model will break downstream exposures.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213888997955411