### PR TITLE
fix(gradebook): prevent HS Q3 from falling through to general EOQ window

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
@@ -178,6 +178,8 @@ with
                         tw.quarter_end_date_insession + interval 20 day
                     )
                 then true
+                when tw.school_level = 'HS' and tw.`quarter` = 'Q3'
+                then false
                 when
                     tw.region != 'Miami'
                     and current_date(


### PR DESCRIPTION
## Summary

- The `is_quarter_end_date_range` CASE expression has a dedicated HS Q3 window that returns `TRUE` between `quarter_end_date_insession + 9` and `quarter_end_date_insession + 20` days
- When today falls outside that window, HS Q3 rows were leaking into the general non-Miami branch (`-5 to +14 days`), causing `is_quarter_end_date_range = TRUE` when it should be `FALSE`
- Added an explicit `WHEN school_level = 'HS' AND quarter = 'Q3' THEN false` guard between the two branches to prevent fallthrough

## Test plan

- [ ] Verified via `dbt show` that `is_quarter_end_date_range` returns `FALSE` for HS Q3 today (April 1), with `quarter_end_date_insession = April 4`
- [ ] Window will correctly flip to `TRUE` on April 13 (`quarter_end_date_insession + 9`) through April 24 (`+ 20`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213895435640639