### PR TITLE
fix(skill): update day2 skill to reference .k8s/CLAUDE.md

### DIFF
--- a/.claude/skills/day2/SKILL.md
+++ b/.claude/skills/day2/SKILL.md
@@ -127,6 +127,5 @@ server failures, unhealthy daemons, ScaleUpFailed, evictions, daemon pod storms.
   _Escalate_ (sustained platform problems).
 - **Truncation warning** if any GKE query hit 100 results.
 
-Reference matching sections from the GKE hardening spec (branch
-`cbini/docs/claude-dagster-gke-best-practices`, file
-`docs/superpowers/specs/2026-03-27-dagster-gke-best-practices-design.md`).
+Reference `.k8s/CLAUDE.md` for scheduling strategy, topology spread, security
+contexts, and config restrictions.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Replace the stale branch reference in the day2 skill (`cbini/docs/claude-dagster-gke-best-practices`) with a reference to `.k8s/CLAUDE.md`, which documents the K8s scheduling strategy, topology spread, security contexts, and config restrictions. The branch reference would break after #3561 merges.

## AI Assistance

Claude Code identified the stale reference and made the edit. Human directed the change.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR

## CI checks

- [ ] **Trunk** — passes
