### PR TITLE
fix(dbt): default shipped profiles to prod target

### DIFF
--- a/.vscode/scripts/post-merge.sh
+++ b/.vscode/scripts/post-merge.sh
@@ -15,8 +15,7 @@ cd "${toplevel}" || {
 source "${HOME}/.local/bin/env"
 
 for project in kipptaf kippnewark kippcamden kippmiami kipppaterson; do
-  DAGSTER_CLOUD_DEPLOYMENT_NAME=prod \
-    uv run dbt parse --target prod \
+  uv run dbt parse --target prod \
     --project-dir "src/dbt/${project}" \
     --profiles-dir .dbt \
     --target-path target/prod &

--- a/src/dbt/kippcamden/profiles.yml
+++ b/src/dbt/kippcamden/profiles.yml
@@ -1,7 +1,7 @@
 # Dagster-only profile (defer + prod). Developers use .dbt/profiles.yml for
 # full target support (defer/dev/staging/prod).
 kippcamden:
-  target: defer
+  target: prod
   outputs:
     defer:
       type: bigquery

--- a/src/dbt/kippmiami/profiles.yml
+++ b/src/dbt/kippmiami/profiles.yml
@@ -1,7 +1,7 @@
 # Dagster-only profile (defer + prod). Developers use .dbt/profiles.yml for
 # full target support (defer/dev/staging/prod).
 kippmiami:
-  target: defer
+  target: prod
   outputs:
     defer:
       type: bigquery

--- a/src/dbt/kippnewark/profiles.yml
+++ b/src/dbt/kippnewark/profiles.yml
@@ -1,7 +1,7 @@
 # Dagster-only profile (defer + prod). Developers use .dbt/profiles.yml for
 # full target support (defer/dev/staging/prod).
 kippnewark:
-  target: defer
+  target: prod
   outputs:
     defer:
       type: bigquery

--- a/src/dbt/kipppaterson/profiles.yml
+++ b/src/dbt/kipppaterson/profiles.yml
@@ -1,7 +1,7 @@
 # Dagster-only profile (defer + prod). Developers use .dbt/profiles.yml for
 # full target support (defer/dev/staging/prod).
 kipppaterson:
-  target: defer
+  target: prod
   outputs:
     defer:
       type: bigquery

--- a/src/dbt/kipptaf/profiles.yml
+++ b/src/dbt/kipptaf/profiles.yml
@@ -1,7 +1,7 @@
 # Dagster-only profile (defer + prod). Developers use .dbt/profiles.yml for
 # full target support (defer/dev/staging/prod).
 kipptaf:
-  target: defer
+  target: prod
   outputs:
     defer:
       type: bigquery

--- a/src/teamster/core/resources.py
+++ b/src/teamster/core/resources.py
@@ -57,8 +57,8 @@ def get_io_manager_gcs_file(code_location: str, test: bool = False) -> GCSIOMana
 
 def get_dbt_cli_resource(dbt_project: DbtProject) -> DbtCliResource:
     if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT"):
-        return DbtCliResource(project_dir=dbt_project)
-    return DbtCliResource(project_dir=dbt_project, target="prod")
+        return DbtCliResource(project_dir=dbt_project, target="defer")
+    return DbtCliResource(project_dir=dbt_project)
 
 
 def get_powerschool_ssh_resource() -> SSHResource:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Make shipped dbt profiles default to `prod` target instead of `defer`, so
Dagster prod runs use the correct BigQuery schemas without relying on
`DAGSTER_CLOUD_DEPLOYMENT_NAME` being available at Python definition load time.

The previous approach checked `DAGSTER_CLOUD_DEPLOYMENT_NAME` at resource
construction time to decide whether to pass `--target prod`. This env var was
not reliably available, causing prod runs to fall through to the `defer` target
and write to `zz_dagster_*` schemas instead of production schemas.

Now:
- **Shipped profiles** default to `prod` — no Python override needed for prod
- **Branch deployments** explicitly pass `target="defer"` (only case needing
  override)
- **`check_prod_guard`** macro still blocks accidental `--target prod` from
  local dev (fires at dbt runtime where env vars are available)
- **`post-merge.sh`** no longer needs `DAGSTER_CLOUD_DEPLOYMENT_NAME` workaround

## AI Assistance

Claude Code diagnosed the prod schema resolution failure from Dagster run logs
(run `a90d4e0f`) and authored this fix.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

### dbt _(skip if no dbt changes)_

- N/A — profiles only, no model changes

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.
