### PR TITLE
fix(docs): align superpowers guide with brainstorm-to-branch conventions

### DIFF
--- a/docs/guides/superpowers.md
+++ b/docs/guides/superpowers.md
@@ -69,10 +69,20 @@ After the brainstorm conversation, Claude will:
    system labels.
 2. **Ask you: worktree or branch switch?** These are two ways to create a
    development branch. Claude will not choose for you.
-   - **Branch switch** — switches your current workspace to the new branch.
-     Simpler, but you can't work on `main` while the branch is active.
-   - **Worktree** — creates an isolated copy of the repo in a separate
-     directory. Useful when you want to keep `main` untouched.
+   - **Branch switch** — switches your current workspace to the new branch. One
+     directory, no extra setup. Tradeoff: you can't work on `main` or another
+     feature without switching back.
+   - **Worktree** — creates a second checkout in `.worktrees/<branch>`. Your
+     original workspace stays on its current branch, so you can run other code
+     or start a separate feature in parallel. Tradeoff: two directories to
+     manage, and your editor needs to open the worktree path.
+
+   | Consideration                                               | Branch switch                  | Worktree                                    |
+   | ----------------------------------------------------------- | ------------------------------ | ------------------------------------------- |
+   | Single-task focus                                           | Good — one branch, one context | Unnecessary overhead                        |
+   | Parallel work (e.g., reviewing a PR while coding a feature) | Must stash/switch constantly   | Each task has its own directory             |
+   | Editor comfort                                              | Tabs and open files stay put   | Need to open a second window or re-navigate |
+
 3. Create and link the dev branch. Branch names follow
    [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):
    `<gh-username>/<commit-type>/claude-<brief-description>`.


### PR DESCRIPTION
## Summary

- **Reorder Phases 1–2**: brainstorm conversation → GitHub issue → worktree/branch choice → branch creation → spec file (on the branch) — matching CLAUDE.md's brainstorm-to-branch discipline
- **Add worktree vs branch switch**: document both options with brief explanations, matching the required user choice
- **Add branch naming convention**: `<gh-username>/<commit-type>/claude-<brief-description>`
- **Add git resuming tip**: Claude merges `main` before resuming work on an existing branch
- **Update Big Picture diagram and Quick Reference** to reflect corrected ordering
- **Resolve merge conflicts** with main (dbt Development and SFTP Integration added to guides index and mkdocs nav)

## Why

The original draft had the spec file written _before_ the GitHub issue and branch were created. CLAUDE.md requires: (1) issue before design doc, (2) ask user worktree or branch switch, (3) no files written until on the feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)