### PR TITLE
Refactor admissions model to use explicit table alias and join students

### DIFF
--- a/src/dbt/overgrad/models/staging/stg_overgrad__admissions.sql
+++ b/src/dbt/overgrad/models/staging/stg_overgrad__admissions.sql
@@ -11,46 +11,47 @@ with
 
 -- trunk-ignore(sqlfluff/AM04)
 select
-    * except (custom_field_values, student, university, due_date, award_letter),
+    d.* except (custom_field_values, student, university, due_date, award_letter),
 
     /* records */
-    student.id as student__id,
-    student.external_student_id as student__external_student_id,
+    d.student.id as student__id,
+    s.external_student_id as student__external_student_id,
 
-    university.id as university__id,
-    university.ipeds_id as university__ipeds_id,
+    d.university.id as university__id,
+    d.university.ipeds_id as university__ipeds_id,
 
-    due_date.date as due_date__date,
-    due_date.type as due_date__type,
+    d.due_date.date as due_date__date,
+    d.due_date.type as due_date__type,
 
-    award_letter.status as award_letter__status,
-    award_letter.tuition_and_fees as award_letter__tuition_and_fees,
-    award_letter.housing_and_meals as award_letter__housing_and_meals,
-    award_letter.books_and_supplies as award_letter__books_and_supplies,
-    award_letter.transportation as award_letter__transportation,
-    award_letter.other_education_costs as award_letter__other_education_costs,
-    award_letter.grants_and_scholarships_from_school
+    d.award_letter.status as award_letter__status,
+    d.award_letter.tuition_and_fees as award_letter__tuition_and_fees,
+    d.award_letter.housing_and_meals as award_letter__housing_and_meals,
+    d.award_letter.books_and_supplies as award_letter__books_and_supplies,
+    d.award_letter.transportation as award_letter__transportation,
+    d.award_letter.other_education_costs as award_letter__other_education_costs,
+    d.award_letter.grants_and_scholarships_from_school
     as award_letter__grants_and_scholarships_from_school,
-    award_letter.federal_pell_grant as award_letter__federal_pell_grant,
-    award_letter.grants_from_state as award_letter__grants_from_state,
-    award_letter.other_scholarships as award_letter__other_scholarships,
-    award_letter.work_study as award_letter__work_study,
-    award_letter.federal_perkins_loan as award_letter__federal_perkins_loan,
-    award_letter.federal_direct_subsidized_loan
+    d.award_letter.federal_pell_grant as award_letter__federal_pell_grant,
+    d.award_letter.grants_from_state as award_letter__grants_from_state,
+    d.award_letter.other_scholarships as award_letter__other_scholarships,
+    d.award_letter.work_study as award_letter__work_study,
+    d.award_letter.federal_perkins_loan as award_letter__federal_perkins_loan,
+    d.award_letter.federal_direct_subsidized_loan
     as award_letter__federal_direct_subsidized_loan,
-    award_letter.federal_direct_unsubsidized_loan
+    d.award_letter.federal_direct_unsubsidized_loan
     as award_letter__federal_direct_unsubsidized_loan,
-    award_letter.parent_plus_loan as award_letter__parent_plus_loan,
-    award_letter.military_benefits as award_letter__military_benefits,
-    award_letter.private_loan as award_letter__private_loan,
-    award_letter.cost_of_attendance as award_letter__cost_of_attendance,
-    award_letter.grants_and_scholarships as award_letter__grants_and_scholarships,
-    award_letter.net_cost as award_letter__net_cost,
-    award_letter.loans as award_letter__loans,
-    award_letter.other_options as award_letter__other_options,
-    award_letter.out_of_pocket as award_letter__out_of_pocket,
-    award_letter.unmet_need as award_letter__unmet_need,
-    award_letter.unmet_need_with_max_family_contribution
+    d.award_letter.parent_plus_loan as award_letter__parent_plus_loan,
+    d.award_letter.military_benefits as award_letter__military_benefits,
+    d.award_letter.private_loan as award_letter__private_loan,
+    d.award_letter.cost_of_attendance as award_letter__cost_of_attendance,
+    d.award_letter.grants_and_scholarships as award_letter__grants_and_scholarships,
+    d.award_letter.net_cost as award_letter__net_cost,
+    d.award_letter.loans as award_letter__loans,
+    d.award_letter.other_options as award_letter__other_options,
+    d.award_letter.out_of_pocket as award_letter__out_of_pocket,
+    d.award_letter.unmet_need as award_letter__unmet_need,
+    d.award_letter.unmet_need_with_max_family_contribution
     as award_letter__unmet_need_with_max_family_contribution,
-    award_letter.seog as award_letter__seog,
-from deduplicate
+    d.award_letter.seog as award_letter__seog,
+from deduplicate as d
+left join {{ ref("stg_overgrad__students") }} as s on d.student.id = s.id

--- a/src/dbt/overgrad/models/staging/stg_overgrad__admissions.sql
+++ b/src/dbt/overgrad/models/staging/stg_overgrad__admissions.sql
@@ -53,5 +53,8 @@ select
     d.award_letter.unmet_need_with_max_family_contribution
     as award_letter__unmet_need_with_max_family_contribution,
     d.award_letter.seog as award_letter__seog,
+-- The admissions API returns only student.id in the nested student object;
+-- external_student_id is not populated there. Joining students here keeps the
+-- field in the enforced staging contract without requiring a contract migration.
 from deduplicate as d
 left join {{ ref("stg_overgrad__students") }} as s on d.student.id = s.id

--- a/src/dbt/overgrad/models/staging/stg_overgrad__followings.sql
+++ b/src/dbt/overgrad/models/staging/stg_overgrad__followings.sql
@@ -1,9 +1,12 @@
 select
-    * except (student, university),
+    f.* except (student, university),
 
-    student.id as student__id,
-    student.external_student_id as student__external_student_id,
+    f.student.id as student__id,
+    s.external_student_id as student__external_student_id,
 
-    university.id as university__id,
-    university.ipeds_id as university__ipeds_id,
-from {{ source("overgrad", "src_overgrad__followings") }}
+    f.university.id as university__id,
+    f.university.ipeds_id as university__ipeds_id,
+-- The followings API has the same gap as admissions: student.external_student_id
+-- is not returned in the nested student object; join students to resolve it.
+from {{ source("overgrad", "src_overgrad__followings") }} as f
+left join {{ ref("stg_overgrad__students") }} as s on f.student.id = s.id


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will refactor the `stg_overgrad__admissions` model to:
- Add explicit table aliasing (`d` for deduplicate) for improved clarity and maintainability
- Join the `stg_overgrad__students` staging table to access the `external_student_id` field directly
- Replace the nested struct reference `student.external_student_id` with the joined table reference `s.external_student_id`

This change improves code readability by making table sources explicit and enables access to student attributes through a proper join relationship rather than relying on nested struct fields.

## Self-review

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model will break downstream exposures
- [ ] If adding or modifying an external source, run `stage_external_sources` with `--target staging`

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

https://claude.ai/code/session_01VwxV9kkSA8Vhk9x7wk8FvQ