### PR TITLE
feat(dbt): add rpt_tableau__college_assessment_dashboard_benchmark_calcs

### DIFF
--- a/src/dbt/kipptaf/models/exposures/tableau.yml
+++ b/src/dbt/kipptaf/models/exposures/tableau.yml
@@ -35,6 +35,7 @@ exposures:
       name: Data Team
     depends_on:
       - ref("rpt_tableau__ap_assessment_dashboard")
+      - ref("rpt_tableau__college_assessment_dashboard_benchmark_calcs")
       - ref("rpt_tableau__college_assessment_dashboard_current")
       - ref("rpt_tableau__college_assessment_dashboard_de")
       - ref("rpt_tableau__college_assessment_dashboard_over_time")

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -1,0 +1,53 @@
+version: 2
+
+models:
+  - name: rpt_tableau__college_assessment_dashboard_benchmark_calcs
+    columns:
+      - name: academic_year
+        data_type: int64
+      - name: region
+        data_type: string
+      - name: school
+        data_type: string
+      - name: grade_level
+        data_type: int64
+      - name: student_number
+        data_type: int64
+      - name: enroll_status
+        data_type: int64
+      - name: iep_status
+        data_type: string
+      - name: is_504
+        data_type: boolean
+      - name: grad_iep_exempt_status_overall
+        data_type: string
+      - name: lep_status
+        data_type: boolean
+      - name: ktc_cohort
+        data_type: int64
+      - name: graduation_year
+        data_type: int64
+      - name: year_in_network
+        data_type: int64
+      - name: college_match_gpa
+        data_type: numeric
+      - name: college_match_gpa_bands
+        data_type: string
+      - name: test_type
+        data_type: string
+      - name: scope
+        data_type: string
+      - name: score_type
+        data_type: string
+      - name: subject_area
+        data_type: string
+      - name: aligned_subject_area
+        data_type: string
+      - name: aligned_subject
+        data_type: string
+      - name: max_scale_score
+        data_type: numeric
+      - name: scale_score
+        data_type: numeric
+      - name: alt_max_scale_score
+        data_type: numeric

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -50,10 +50,6 @@ models:
         data_type: string
       - name: subject_area
         data_type: string
-      - name: aligned_subject_area
-        data_type: string
-      - name: aligned_subject
-        data_type: string
       - name: test_date
         data_type: date
       - name: max_scale_score

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -1,7 +1,16 @@
-version: 2
-
 models:
   - name: rpt_tableau__college_assessment_dashboard_benchmark_calcs
+    description: >
+      Student-level college assessment scores used to calculate the percentage
+      of students meeting readiness benchmark for KIPP Forward use.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - academic_year
+              - score_type
+              - test_date
     columns:
       - name: academic_year
         data_type: int64
@@ -45,9 +54,9 @@ models:
         data_type: string
       - name: aligned_subject
         data_type: string
+      - name: test_date
+        data_type: date
       - name: max_scale_score
         data_type: numeric
       - name: scale_score
-        data_type: numeric
-      - name: alt_max_scale_score
         data_type: numeric

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -60,3 +60,7 @@ models:
         data_type: numeric
       - name: scale_score
         data_type: numeric
+      - name: ccr_period
+        data_type: string
+      - name: ccr_teacher
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -1,0 +1,57 @@
+with
+    alt_max_scale_score as (
+        select student_number, score_type, max(scale_score) as alt_max_scale_score,
+        from {{ ref("int_assessments__college_assessment") }}
+        group by student_number, score_type
+    )
+
+select
+    e.academic_year,
+    e.region,
+    e.school,
+    e.student_number,
+    e.grade_level,
+    e.enroll_status,
+    e.iep_status,
+    e.is_504,
+    e.grad_iep_exempt_status_overall,
+    e.lep_status,
+    e.ktc_cohort,
+    e.graduation_year,
+    e.year_in_network,
+    e.college_match_gpa,
+    e.college_match_gpa_bands,
+
+    s.test_type,
+    s.scope,
+    s.score_type,
+    s.subject_area,
+    s.aligned_subject_area,
+    s.aligned_subject,
+    s.max_scale_score,
+    s.scale_score,
+
+    c.alt_max_scale_score,
+
+from {{ ref("int_extracts__student_enrollments") }} as e
+left join
+    {{ ref("int_assessments__college_assessment") }} as s
+    on e.student_number = s.student_number
+    and e.academic_year = s.academic_year
+    and s.rn_highest = 1
+    and s.scope != 'ACT'
+left join
+    alt_max_scale_score as c
+    on s.student_number = c.student_number
+    and s.score_type = c.score_type
+where
+    e.school_level = 'HS'
+    and e.rn_undergrad = 1
+    and e.rn_year = 1
+    and not e.is_out_of_district
+    and s.score_type not in (
+        'psat10_math_test',
+        'psat10_reading',
+        'sat_math_test_score',
+        'sat_reading_test_score'
+    )

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -1,10 +1,3 @@
-with
-    alt_max_scale_score as (
-        select student_number, score_type, max(scale_score) as alt_max_scale_score,
-        from {{ ref("int_assessments__college_assessment") }}
-        group by student_number, score_type
-    )
-
 select
     e.academic_year,
     e.region,
@@ -28,30 +21,24 @@ select
     s.subject_area,
     s.aligned_subject_area,
     s.aligned_subject,
+    s.test_date,
     s.max_scale_score,
     s.scale_score,
 
-    c.alt_max_scale_score,
-
 from {{ ref("int_extracts__student_enrollments") }} as e
-left join
+inner join
     {{ ref("int_assessments__college_assessment") }} as s
     on e.student_number = s.student_number
     and e.academic_year = s.academic_year
-    and s.rn_highest = 1
     and s.scope != 'ACT'
-left join
-    alt_max_scale_score as c
-    on s.student_number = c.student_number
-    and s.score_type = c.score_type
-where
-    e.school_level = 'HS'
-    and e.rn_undergrad = 1
-    and e.rn_year = 1
-    and not e.is_out_of_district
     and s.score_type not in (
         'psat10_math_test',
         'psat10_reading',
         'sat_math_test_score',
         'sat_reading_test_score'
     )
+where
+    e.school_level = 'HS'
+    and e.rn_undergrad = 1
+    and e.rn_year = 1
+    and not e.is_out_of_district

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -19,8 +19,6 @@ select
     s.scope,
     s.score_type,
     s.subject_area,
-    s.aligned_subject_area,
-    s.aligned_subject,
     s.test_date,
     s.max_scale_score,
     s.scale_score,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -25,6 +25,9 @@ select
     s.max_scale_score,
     s.scale_score,
 
+    ce.teacher_lastfirst as ccr_teacher,
+    ce.sections_external_expression as ccr_period,
+
 from {{ ref("int_extracts__student_enrollments") }} as e
 inner join
     {{ ref("int_assessments__college_assessment") }} as s
@@ -37,6 +40,13 @@ inner join
         'sat_math_test_score',
         'sat_reading_test_score'
     )
+left join
+    {{ ref("base_powerschool__course_enrollments") }} as ce
+    on e.student_number = ce.students_student_number
+    and e.academic_year = ce.cc_academic_year
+    and ce.courses_course_name like 'College and Career%'
+    and ce.rn_course_number_year = 1
+    and not ce.is_dropped_section
 where
     e.school_level = 'HS'
     and e.rn_undergrad = 1


### PR DESCRIPTION
## Summary

- Adds new Tableau extract model `rpt_tableau__college_assessment_dashboard_benchmark_calcs` for college assessment dashboard benchmark calculations
- Joins student enrollments with college assessment scores (PSAT, SAT), excluding ACT scope and select sub-scores
- Adds corresponding properties YAML with 25 columns and data types

## Test plan

- [ ] Verify dbt Cloud CI job passes
- [ ] Confirm model compiles and runs against staging
- [ ] Validate distinct `score_type` values match expected 12 values (PSAT 8/9, PSAT 10, PSAT/NMSQT, SAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214060089215302