### PR TITLE
feat(google/appsheet): add stg_google_appsheet__kfwd_career_conversations__output

### DIFF
--- a/src/dbt/kipptaf/models/google/appsheet/sources-bigquery.yml
+++ b/src/dbt/kipptaf/models/google/appsheet/sources-bigquery.yml
@@ -92,3 +92,13 @@ sources:
                 - google
                 - appsheet
                 - src_seat_tracker__people
+      - name: src_google_appsheet__kfwd_career_conversations__output
+        identifier: src_kfwd_career_conversations__output
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kipptaf
+                - google
+                - appsheet
+                - src_kfwd_career_conversations__output

--- a/src/dbt/kipptaf/models/google/appsheet/staging/properties/stg_google_appsheet__kfwd_career_conversations__output.yml
+++ b/src/dbt/kipptaf/models/google/appsheet/staging/properties/stg_google_appsheet__kfwd_career_conversations__output.yml
@@ -9,13 +9,14 @@ models:
         data_type: string
         data_tests:
           - unique
+          - not_null
       - name: notes
         description: Free-text notes from the career conversation.
         data_type: string
       - name: is_resume_score
         description: Whether resume was scored.
         data_type: boolean
-      - name: is_linked_in
+      - name: is_linkedin
         description: Whether the alumni's LinkedIn profile was discussed.
         data_type: boolean
       - name: is_mock_interview_or_prep

--- a/src/dbt/kipptaf/models/google/appsheet/staging/properties/stg_google_appsheet__kfwd_career_conversations__output.yml
+++ b/src/dbt/kipptaf/models/google/appsheet/staging/properties/stg_google_appsheet__kfwd_career_conversations__output.yml
@@ -1,0 +1,36 @@
+models:
+  - name: stg_google_appsheet__kfwd_career_conversations__output
+    description: >-
+      Career conversation records from the KFWD AppSheet app, one row per alumni
+      contact.
+    columns:
+      - name: contact_id
+        description: Unique identifier for the alumni contact.
+        data_type: string
+        data_tests:
+          - unique
+      - name: notes
+        description: Free-text notes from the career conversation.
+        data_type: string
+      - name: is_resume_score
+        description: Whether resume was scored.
+        data_type: boolean
+      - name: is_linked_in
+        description: Whether the alumni's LinkedIn profile was discussed.
+        data_type: boolean
+      - name: is_mock_interview_or_prep
+        description:
+          Whether mock interview or interview preparation was discussed.
+        data_type: boolean
+      - name: is_professional_references_list
+        description: Whether the professional references list was discussed.
+        data_type: boolean
+      - name: is_job_search_template
+        description: Whether the job search template was discussed.
+        data_type: boolean
+      - name: is_cover_letter_template
+        description: Whether the cover letter template was discussed.
+        data_type: boolean
+      - name: is_work_samples
+        description: Whether work samples were discussed in the conversation.
+        data_type: boolean

--- a/src/dbt/kipptaf/models/google/appsheet/staging/stg_google_appsheet__kfwd_career_conversations__output.sql
+++ b/src/dbt/kipptaf/models/google/appsheet/staging/stg_google_appsheet__kfwd_career_conversations__output.sql
@@ -2,7 +2,7 @@ select
     contact_id,
     notes,
     resume_score as is_resume_score,
-    linkedin as is_linked_in,
+    linkedin as is_linkedin,
     mock_interview_or_prep as is_mock_interview_or_prep,
     professional_references_list as is_professional_references_list,
     job_search_template as is_job_search_template,

--- a/src/dbt/kipptaf/models/google/appsheet/staging/stg_google_appsheet__kfwd_career_conversations__output.sql
+++ b/src/dbt/kipptaf/models/google/appsheet/staging/stg_google_appsheet__kfwd_career_conversations__output.sql
@@ -1,0 +1,17 @@
+select
+    contact_id,
+    notes,
+    resume_score as is_resume_score,
+    linkedin as is_linked_in,
+    mock_interview_or_prep as is_mock_interview_or_prep,
+    professional_references_list as is_professional_references_list,
+    job_search_template as is_job_search_template,
+    cover_letter_template as is_cover_letter_template,
+    work_samples as is_work_samples,
+from
+    {{
+        source(
+            "google_appsheet",
+            "src_google_appsheet__kfwd_career_conversations__output",
+        )
+    }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a dbt source entry and staging model for the KFWD career conversations AppSheet table, making it available in `kipptaf_google_appsheet` alongside the other AppSheet staging models.

The raw table (`kipptaf_appsheet.src_kfwd_career_conversations__output`) existed in BigQuery without a corresponding dbt source definition or staging model. This PR wires it into the standard AppSheet pipeline.

**AI Assistance**: Claude Code authored all three files (source YAML entry, SQL model, properties YAML). Human-directed scope and column semantics.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with affected teams before merging and document your rollback plan in the summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** so the dbt Cloud CI job can find the table.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered