### PR TITLE
gradebook-audit-patch

### DIFF
--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -751,6 +751,20 @@ exposures:
           kinds:
             - googlesheets
 
+  - name: rpt_gsheets__award_ceremony_gpa
+    label: Award Ceremony GPA
+    type: analysis
+    owner:
+      name: Data Team
+    url: https://docs.google.com/spreadsheets/d/1270459PDpJu_HYxEYTPPBi7Q4yScJjUIBV7MC_OJqXI
+    depends_on:
+      - ref("rpt_gsheets__award_ceremony_gpa")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - googlesheets
+
   # - name: hro_2425_renewal_workbook_data_team_workspace
   #   label: HRO 24-25 Renewal Workbook - Data Team Workspace
   #   type: application

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
@@ -1,5 +1,29 @@
 models:
   - name: rpt_gsheets__award_ceremony_gpa
-    config:
-      contract:
-        enforced: false
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - school
+              - student_number
+    columns:
+      - name: school
+        data_type: string
+      - name: student_number
+        data_type: int64
+      - name: student_name
+        data_type: string
+      - name: english
+        data_type: float64
+      - name: math
+        data_type: float64
+      - name: science
+        data_type: float64
+      - name: social_studies
+        data_type: float64
+      - name: world_language
+        data_type: float64
+      - name: vpa
+        data_type: float64
+      - name: physed
+        data_type: float64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
@@ -1,0 +1,5 @@
+models:
+  - name: rpt_gsheets__award_ceremony_gpa
+    config:
+      contract:
+        enforced: false

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
@@ -1,0 +1,99 @@
+with
+    grade_source as (
+        select
+            'Stored' as gpa_type,
+
+            co.school_abbreviation,
+            co.student_number,
+            co.lastfirst,
+
+            sg.course_number,
+            sg.agg_credittype as credittype,
+            sg.potentialcrhrs,
+
+            sg.earnedcrhrs,
+            sg.gpa_points,
+
+        from {{ ref("stg_powerschool__storedgrades") }} as sg
+        inner join
+            {{ ref("base_powerschool__student_enrollments") }} as co
+            on sg.studentid = co.studentid
+            and {{ union_dataset_join_clause(left_alias="sg", right_alias="co") }}
+            and sg.schoolid = co.schoolid
+            and co.grade_level = 12
+            and co.rn_year = 1
+            and co.enroll_status = 0
+            and co.academic_year = {{ var("current_academic_year") }}
+        where sg.storecode = 'Y1'
+
+        union all
+
+        select
+            'Live' as gpa_type,
+
+            co.school_abbreviation,
+            co.student_number,
+            co.lastfirst,
+
+            fg.course_number,
+            fg.credittype,
+            fg.courses_credit_hours as potentialcrhrs,
+
+            if(
+                fg.y1_letter_grade_adjusted not like 'F%', fg.courses_credit_hours, 0
+            ) as earnedcrhrs,
+
+            if(
+                fg.y1_letter_grade_adjusted not like 'F%', fg.y1_grade_points, 0
+            ) as gpa_points,
+
+        from {{ ref("base_powerschool__final_grades") }} as fg
+        inner join
+            {{ ref("base_powerschool__student_enrollments") }} as co
+            on fg.studentid = co.studentid
+            and {{ union_dataset_join_clause(left_alias="fg", right_alias="co") }}
+            and fg.schoolid = co.schoolid
+            and fg.academic_year = co.academic_year
+            and co.grade_level = 12
+            and co.rn_year = 1
+            and co.enroll_status = 0
+        where
+            co.academic_year = {{ var("current_academic_year") }}
+            and fg.storecode = 'Q4'
+    ),
+
+    calculations as (
+        select
+            school_abbreviation,
+            student_number,
+            lastfirst,
+            credittype,
+
+            round(
+                sum(gpa_points * earnedcrhrs) / sum(potentialcrhrs), 3
+            ) as gpa_subject,
+
+        from grade_source
+        where
+            potentialcrhrs != 0
+            and credittype in ('ENG', 'MATH', 'SCI', 'SOC', 'WLANG', 'ART', 'PHYSED')
+        group by school_abbreviation, student_number, lastfirst, credittype
+    )
+
+select
+    school_abbreviation as school,
+    student_number,
+    lastfirst as student_name,
+    eng as english,
+    math,
+    sci as science,
+    soc as social_studies,
+    wlang as world_language,
+    art as vpa,
+    physed,
+
+from
+    calculations pivot (
+        max(gpa_subject) for credittype
+        in ('ENG', 'MATH', 'SCI', 'SOC', 'WLANG', 'ART', 'PHYSED')
+    )

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
@@ -111,6 +111,7 @@ with
             t.academic_year = {{ var("current_academic_year") }}
             and t.term_start_date <= current_date('{{ var("local_timezone") }}')
             and t.schoolid not in (0, 999999)
+            and t.term not in ('Q1', 'Q2')
     ),
 
     school_level_mod as (

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
@@ -142,5 +142,7 @@ models:
         data_type: string
       - name: _dbt_source_relation
         data_type: string
+      - name: agg_credittype
+        data_type: string
       - name: is_transfer_grade
         data_type: boolean

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
@@ -14,7 +14,23 @@ with
         }}
     )
 
-select u.*, if(l.name is null, true, false) as is_transfer_grade,
+select
+    u.*,
+
+    case
+        when u.credit_type like 'ENG%'
+        then 'ENG'
+        when u.credit_type like 'MATH%'
+        then 'MATH'
+        when u.credit_type like 'SCI%'
+        then 'SCI'
+        when u.credit_type like 'SOC%'
+        then 'SOC'
+        else u.credit_type
+    end as agg_credittype,
+
+    if(l.name is null, true, false) as is_transfer_grade,
+
 from union_relations as u
 left join
     {{ ref("stg_google_sheets__people__location_crosswalk") }} as l


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

[//]: # "When merged, this pull request will..."

- **`int_tableau__gradebook_audit_teacher_scaffold`** — exclude Q1 and Q2 from the `term_weeks` CTE to reduce data volume processed on Tableau Server (semesters 1 scope only)
- **`rpt_gsheets__award_ceremony_gpa`** — new Google Sheets reporting model for end-of-year award ceremony GPA tracking for grade 12 students; sources from `stg_powerschool__storedgrades` (Y1) and `base_powerschool__final_grades` (Q4), pivoting subject-level GPA across ENG, MATH, SCI, SOC, WLANG, ART, PHYSED
- **`stg_powerschool__storedgrades`** — added `agg_credittype` column to support the new GPA report
- **Exposure** added to `google-sheets.yml` for `rpt_gsheets__award_ceremony_gpa`

## Self-review

### General

- [ ] If this is a same-day request, please flag that in the #data-team Slack
- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Run `trunk fmt` on all modified files

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging.
- [ ] If adding a new external source, run `stage_external_sources` before
      building — see
      [SQL conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#sql-conventions)

### Docs

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md`

### CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details.
- [ ] **Claude Code Review** — review the automated comment. Note: Claude is not
      a blocking check and its feedback may contain errors; use your judgement.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214072907609170