### PR TITLE
feat: add manager_job_title column to school metrics extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
@@ -22,6 +22,7 @@ models:
               - grain_type
               - grain
               - manager
+              - manager_job_title
     columns:
       - name: domain
         description: >
@@ -84,6 +85,13 @@ models:
           int_people__staff_roster reports_to_formatted_name). Populated for
           Homeroom and Section grain types where a single lead teacher can be
           identified. Null for Grade Level aggregations.
+        data_type: string
+      - name: manager_job_title
+        description: >
+          Job title of the lead teacher's direct manager (from
+          int_people__staff_roster job_title, looked up via
+          reports_to_employee_number). Populated for Homeroom and Section grain
+          types. Null for Grade Level aggregations.
         data_type: string
       - name: value
         description:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
@@ -21,6 +21,7 @@ models:
               - school
               - grain_type
               - grain
+              - teacher_name
               - manager
               - manager_job_title
     columns:
@@ -78,6 +79,12 @@ models:
           Actual identifier for the grain. Homeroom advisory section number
           (e.g., 3FSU), numeric grade level as string (e.g., 8), or PowerSchool
           section number for academic courses.
+        data_type: string
+      - name: teacher_name
+        description: >
+          Formatted name of the lead teacher (homeroom advisor or section
+          teacher). Populated for Homeroom and Section grain types. Null for
+          Grade Level aggregations.
         data_type: string
       - name: manager
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
@@ -53,6 +53,7 @@ with
             e.school,
             e.team,
 
+            sr.formatted_name as teacher_name,
             sr.reports_to_formatted_name as manager,
             mgr.job_title as manager_job_title,
         from enrollments as e
@@ -108,6 +109,7 @@ with
             asbw.team,
             asbw.week_start_monday,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -120,6 +122,7 @@ with
             asbw.school,
             asbw.team,
             asbw.week_start_monday,
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title
     ),
@@ -144,6 +147,7 @@ with
             asbw.team,
             asbw.week_start_monday,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -157,6 +161,7 @@ with
             asbw.school,
             asbw.team,
             asbw.week_start_monday,
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title
     ),
@@ -211,6 +216,7 @@ with
             a.discipline,
             a.module_code,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -228,6 +234,7 @@ with
             a.week_start_monday,
             a.discipline,
             a.module_code,
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title
     ),
@@ -283,6 +290,7 @@ with
             ew.team,
             ew.week_start_monday,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -305,7 +313,12 @@ with
             and ew.week_start_monday = dl.week_start_monday
         left join team_manager as tm on ew.school = tm.school and ew.team = tm.team
         group by
-            ew.region, ew.school, ew.team, ew.week_start_monday, tm.manager,
+            ew.region,
+            ew.school,
+            ew.team,
+            ew.week_start_monday,
+            tm.teacher_name,
+            tm.manager,
             tm.manager_job_title
     ),
 
@@ -349,6 +362,7 @@ with
             ew.week_start_monday,
             dl.category,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -368,6 +382,7 @@ with
             ew.team,
             ew.week_start_monday,
             dl.category,
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title
     ),
@@ -441,6 +456,7 @@ with
             enr._dbt_source_relation,
             enr.cc_sectionid,
 
+            sr.formatted_name as teacher_name,
             sr.reports_to_formatted_name as manager,
             mgr.job_title as manager_job_title,
         from section_enrollments_dedup as enr
@@ -473,6 +489,7 @@ with
             enr.sections_section_number,
             enr.courses_course_name,
             fg.storecode,
+            stm.teacher_name,
             stm.manager,
             stm.manager_job_title,
 
@@ -505,6 +522,7 @@ with
             enr.sections_section_number,
             enr.courses_course_name,
             fg.storecode,
+            stm.teacher_name,
             stm.manager,
             stm.manager_job_title
     ),
@@ -521,6 +539,7 @@ with
             e.team,
             g.week_start_monday,
 
+            tm.teacher_name,
             tm.manager,
             tm.manager_job_title,
 
@@ -539,7 +558,12 @@ with
                 interval -9 week
             )
         group by
-            e.region, e.school, e.team, g.week_start_monday, tm.manager,
+            e.region,
+            e.school,
+            e.team,
+            g.week_start_monday,
+            tm.teacher_name,
+            tm.manager,
             tm.manager_job_title
     ),
 
@@ -581,6 +605,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     metric_value as value,
@@ -600,6 +625,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     metric_value as value,
@@ -619,6 +645,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     metric_value as value,
@@ -638,6 +665,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     metric_value as value,
@@ -657,6 +685,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     metric_value as value,
@@ -676,6 +705,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     metric_value as value,
@@ -695,6 +725,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     cast(referral_all as float64) as value,
@@ -714,6 +745,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     cast(referral_high as float64) as value,
@@ -733,6 +765,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     cast(referral_middle as float64) as value,
@@ -752,6 +785,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     cast(referral_low as float64) as value,
@@ -771,6 +805,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     cast(referral_all as float64) as value,
@@ -790,6 +825,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     cast(referral_high as float64) as value,
@@ -809,6 +845,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     cast(referral_middle as float64) as value,
@@ -828,6 +865,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     cast(referral_low as float64) as value,
@@ -847,6 +885,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     cast(referral_count as float64) as value,
@@ -866,6 +905,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     cast(referral_count as float64) as value,
@@ -885,6 +925,7 @@ select
     school,
     'Section' as grain_type,
     sections_section_number as grain,
+    teacher_name,
     manager,
     manager_job_title,
     safe_divide(n_failing, n_students) as value,
@@ -904,6 +945,7 @@ select
     school,
     'Homeroom' as grain_type,
     team as grain,
+    teacher_name,
     manager,
     manager_job_title,
     metric_value as value,
@@ -923,6 +965,7 @@ select
     school,
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
+    cast(null as string) as teacher_name,
     cast(null as string) as manager,
     cast(null as string) as manager_job_title,
     metric_value as value,

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
@@ -49,11 +49,19 @@ with
      * TEACHER MANAGER LOOKUP — homeroom advisor's "reports to"
      * ============================================================ */
     team_manager_raw as (
-        select e.school, e.team, sr.reports_to_formatted_name as manager,
+        select
+            e.school,
+            e.team,
+
+            sr.reports_to_formatted_name as manager,
+            mgr.job_title as manager_job_title,
         from enrollments as e
         left join
             {{ ref("int_people__staff_roster") }} as sr
             on e.advisor_teachernumber = sr.powerschool_teacher_number
+        left join
+            {{ ref("int_people__staff_roster") }} as mgr
+            on sr.reports_to_employee_number = mgr.employee_number
     ),
 
     team_manager as (
@@ -101,12 +109,19 @@ with
             asbw.week_start_monday,
 
             tm.manager,
+            tm.manager_job_title,
 
             avg(asbw.ada_running) as metric_value,
         from ada_by_student_week as asbw
         left join team_manager as tm on asbw.school = tm.school and asbw.team = tm.team
         where asbw.ada_running is not null
-        group by asbw.region, asbw.school, asbw.team, asbw.week_start_monday, tm.manager
+        group by
+            asbw.region,
+            asbw.school,
+            asbw.team,
+            asbw.week_start_monday,
+            tm.manager,
+            tm.manager_job_title
     ),
 
     ada_gradelevel_week as (
@@ -130,13 +145,20 @@ with
             asbw.week_start_monday,
 
             tm.manager,
+            tm.manager_job_title,
 
             avg(
                 if(asbw.ada_running is not null, asbw.is_chronic_absent, null)
             ) as metric_value,
         from ada_by_student_week as asbw
         left join team_manager as tm on asbw.school = tm.school and asbw.team = tm.team
-        group by asbw.region, asbw.school, asbw.team, asbw.week_start_monday, tm.manager
+        group by
+            asbw.region,
+            asbw.school,
+            asbw.team,
+            asbw.week_start_monday,
+            tm.manager,
+            tm.manager_job_title
     ),
 
     chronic_gradelevel_week as (
@@ -190,6 +212,7 @@ with
             a.module_code,
 
             tm.manager,
+            tm.manager_job_title,
 
             avg(a.is_mastery_num) as metric_value,
         from assessment_responses as a
@@ -205,7 +228,8 @@ with
             a.week_start_monday,
             a.discipline,
             a.module_code,
-            tm.manager
+            tm.manager,
+            tm.manager_job_title
     ),
 
     proficiency_gradelevel_week as (
@@ -260,6 +284,7 @@ with
             ew.week_start_monday,
 
             tm.manager,
+            tm.manager_job_title,
 
             count(
                 distinct if(dl.referral_tier = 'High', dl.incident_id, null)
@@ -279,7 +304,9 @@ with
             and ew.deanslist_school_id = dl.deanslist_school_id
             and ew.week_start_monday = dl.week_start_monday
         left join team_manager as tm on ew.school = tm.school and ew.team = tm.team
-        group by ew.region, ew.school, ew.team, ew.week_start_monday, tm.manager
+        group by
+            ew.region, ew.school, ew.team, ew.week_start_monday, tm.manager,
+            tm.manager_job_title
     ),
 
     dl_gradelevel_week as (
@@ -323,6 +350,7 @@ with
             dl.category,
 
             tm.manager,
+            tm.manager_job_title,
 
             count(distinct dl.incident_id) as referral_count,
         from enrollments_weeks as ew
@@ -335,7 +363,13 @@ with
         left join team_manager as tm on ew.school = tm.school and ew.team = tm.team
         where dl.category is not null
         group by
-            ew.region, ew.school, ew.team, ew.week_start_monday, dl.category, tm.manager
+            ew.region,
+            ew.school,
+            ew.team,
+            ew.week_start_monday,
+            dl.category,
+            tm.manager,
+            tm.manager_job_title
     ),
 
     -- Same sparse-row design as dl_category_homeroom_week above.
@@ -406,7 +440,9 @@ with
         select
             enr._dbt_source_relation,
             enr.cc_sectionid,
+
             sr.reports_to_formatted_name as manager,
+            mgr.job_title as manager_job_title,
         from section_enrollments_dedup as enr
         left join
             {{ ref("base_powerschool__sections") }} as sec
@@ -415,6 +451,9 @@ with
         left join
             {{ ref("int_people__staff_roster") }} as sr
             on sec.teachernumber = sr.powerschool_teacher_number
+        left join
+            {{ ref("int_people__staff_roster") }} as mgr
+            on sr.reports_to_employee_number = mgr.employee_number
     ),
 
     section_teacher_manager as (
@@ -435,6 +474,7 @@ with
             enr.courses_course_name,
             fg.storecode,
             stm.manager,
+            stm.manager_job_title,
 
             count(enr.cc_studentid) as n_students,
             countif(fg.y1_letter_grade_adjusted in ('F', 'F*')) as n_failing,
@@ -465,7 +505,8 @@ with
             enr.sections_section_number,
             enr.courses_course_name,
             fg.storecode,
-            stm.manager
+            stm.manager,
+            stm.manager_job_title
     ),
 
     /* ============================================================
@@ -481,6 +522,7 @@ with
             g.week_start_monday,
 
             tm.manager,
+            tm.manager_job_title,
 
             avg(g.gpa_y1) as metric_value,
         from enrollments as e
@@ -496,7 +538,9 @@ with
                 date_trunc(current_date('{{ var("local_timezone") }}'), week(monday)),
                 interval -9 week
             )
-        group by e.region, e.school, e.team, g.week_start_monday, tm.manager
+        group by
+            e.region, e.school, e.team, g.week_start_monday, tm.manager,
+            tm.manager_job_title
     ),
 
     gpa_gradelevel_week as (
@@ -538,6 +582,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     metric_value as value,
 from ada_homeroom_week
 
@@ -556,6 +601,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     metric_value as value,
 from ada_gradelevel_week
 
@@ -574,6 +620,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     metric_value as value,
 from chronic_homeroom_week
 
@@ -592,6 +639,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     metric_value as value,
 from chronic_gradelevel_week
 
@@ -610,6 +658,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     metric_value as value,
 from proficiency_homeroom_week
 
@@ -628,6 +677,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     metric_value as value,
 from proficiency_gradelevel_week
 
@@ -646,6 +696,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     cast(referral_all as float64) as value,
 from dl_homeroom_week
 
@@ -664,6 +715,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     cast(referral_high as float64) as value,
 from dl_homeroom_week
 
@@ -682,6 +734,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     cast(referral_middle as float64) as value,
 from dl_homeroom_week
 
@@ -700,6 +753,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     cast(referral_low as float64) as value,
 from dl_homeroom_week
 
@@ -718,6 +772,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     cast(referral_all as float64) as value,
 from dl_gradelevel_week
 
@@ -736,6 +791,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     cast(referral_high as float64) as value,
 from dl_gradelevel_week
 
@@ -754,6 +810,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     cast(referral_middle as float64) as value,
 from dl_gradelevel_week
 
@@ -772,6 +829,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     cast(referral_low as float64) as value,
 from dl_gradelevel_week
 
@@ -790,6 +848,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     cast(referral_count as float64) as value,
 from dl_category_homeroom_week
 
@@ -808,6 +867,7 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     cast(referral_count as float64) as value,
 from dl_category_gradelevel_week
 
@@ -826,6 +886,7 @@ select
     'Section' as grain_type,
     sections_section_number as grain,
     manager,
+    manager_job_title,
     safe_divide(n_failing, n_students) as value,
 from section_grades_raw
 
@@ -844,6 +905,7 @@ select
     'Homeroom' as grain_type,
     team as grain,
     manager,
+    manager_job_title,
     metric_value as value,
 from gpa_homeroom_week
 
@@ -862,5 +924,6 @@ select
     'Grade Level' as grain_type,
     cast(grade_level as string) as grain,
     cast(null as string) as manager,
+    cast(null as string) as manager_job_title,
     metric_value as value,
 from gpa_gradelevel_week


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
