### PR TITLE
feat(dbt): update AP and college assessment dashboard models

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -1,81 +1,142 @@
 models:
   - name: rpt_tableau__ap_assessment_dashboard
+    description: >
+      AP assessment scores joined to student enrollment and course schedules for
+      Tableau reporting. One row per student per AP course subject, including
+      students enrolled in AP courses who did not take the exam.
     columns:
       - name: academic_year
         data_type: int64
+        description: Academic year of enrollment.
       - name: academic_year_display
         data_type: string
+        description: Academic year formatted for display (e.g. 2024-25).
       - name: region
         data_type: string
+        description: KIPP region of the student's enrollment.
       - name: schoolid
         data_type: int64
+        description: The School_Number of the associated Schools record.
       - name: school
         data_type: string
+        description: School abbreviation.
       - name: student_number
         data_type: int64
+        description: Student Number assigned by the school. Indexed.
       - name: student_name
         data_type: string
+        description: Student full name (last, first).
       - name: grade_level
         data_type: int64
+        description: >
+          The grade the student is in. Since this is an integer: 0=Kindergarten
+          1, -2=Preschool. Indexed.
       - name: enroll_status
         data_type: int64
+        description: The enrollment status of the student.
       - name: entrydate
         data_type: date
+        description: >
+          The date the student enrolled in school for the current enrollment.
+          Indexed.
       - name: exitdate
         data_type: date
+        description: >
+          The date the student exited for the current/last enrollment. This is
+          the day after a student-attended class. Indexed.
       - name: cohort
         data_type: int64
+        description: Student cohort (expected graduation year).
       - name: advisory
         data_type: string
+        description: Advisory or homeroom assignment.
       - name: is_enrolled_recent
         data_type: boolean
+        description: Whether the student was recently enrolled.
       - name: is_enrolled_y1
         data_type: boolean
+        description: Whether the student was enrolled for the full year.
       - name: c_504_status
         data_type: boolean
+        description: Whether the student has a 504 plan.
       - name: lep_status
         data_type: boolean
+        description: Student Limited English Proficiency status.
       - name: gifted_and_talented
         data_type: string
+        description: Gifted and talented program designation.
       - name: contact_id
         data_type: string
+        description: Salesforce contact ID.
       - name: ktc_cohort
         data_type: int64
+        description: KIPP Through College cohort year.
       - name: graduation_year
         data_type: int64
+        description: Student graduation year.
       - name: ap_date_enrolled
         data_type: date
+        description: Date the student enrolled in the AP course section.
       - name: ap_date_left
         data_type: date
+        description: Date the student left the AP course section.
       - name: ap_course_section
         data_type: string
+        description: External expression (period/section) of the AP course.
       - name: ap_teacher_name
         data_type: string
+        description: AP course teacher name (last, first).
       - name: ap_course_subject
         data_type: string
+        description: AP subject code from PowerSchool course enrollments.
       - name: test_name
         data_type: string
+        description: AP exam name as reported by College Board.
       - name: test_subject
         data_type: string
+        description: AP exam subject as reported by College Board.
       - name: exam_score
         data_type: numeric
+        description: AP exam score (1–5).
       - name: irregularity_code_1
         data_type: string
+        description: First exam irregularity code, if any.
       - name: irregularity_code_2
         data_type: string
+        description: Second exam irregularity code, if any.
       - name: data_source
         data_type: string
+        description: Source of the AP score record (e.g. CB File).
       - name: ps_ap_course_subject_code
         data_type: string
+        description:
+          AP subject code used to join PowerSchool and College Board data.
       - name: ap_course_name
         data_type: string
+        description: >
+          AP course name from the College Board crosswalk; 'Not an AP course' if
+          no match found.
       - name: course_name
         data_type: string
+        description: >
+          PowerSchool course name; 'Not an AP course' if student has no AP
+          course enrollment.
       - name: test_subject_area
         data_type: string
+        description: >
+          Derived field indicating exam relationship to course: 'Not applicable'
+          if no AP course, 'Took course, but not AP exam.' if enrolled but did
+          not test, otherwise the College Board AP course name.
       - name: sped
         data_type: int64
+        description: Special education indicator (1 = has IEP, 0 = no IEP).
       - name: expected_scope
         data_type: string
+        description: >
+          'AP' if student is enrolled in an AP course, 'Not applicable'
+          otherwise.
       - name: expected_test_type
         data_type: string
+        description: >
+          'Official' if student is enrolled in an AP course, 'Not applicable'
+          otherwise.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -41,6 +41,8 @@ models:
         data_type: string
       - name: ktc_cohort
         data_type: int64
+      - name: graduation_year
+        data_type: int64
       - name: ap_date_enrolled
         data_type: date
       - name: ap_date_left

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -4,6 +4,13 @@ models:
       AP assessment scores joined to student enrollment and course schedules for
       Tableau reporting. One row per student per AP course subject, including
       students enrolled in AP courses who did not take the exam.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - academic_year
+              - student_number
+              - ap_course_subject
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
@@ -13,8 +13,6 @@ models:
         data_type: string
       - name: aligned_subject_area
         data_type: string
-      - name: test_date
-        data_type: date
       - name: scale_score
         data_type: numeric
       - name: max_scale_score
@@ -27,3 +25,5 @@ models:
         data_type: int64
       - name: ktc_cohort
         data_type: int64
+      - name: benchmark_name
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
@@ -1,29 +1,65 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard_scores
+    description: >
+      Max college assessment scores (SAT and PSAT variants) per student and
+      score type, joined to current enrollment for region and school context.
+      Expanded by benchmark_name for Tableau filtering — Total scores fan out to
+      three benchmark rows (College-Ready, HS-Ready, EA/ED-Ready); subject
+      scores produce one row each (EBRW, Math).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - score_type
+              - benchmark_name
     columns:
       - name: student_number
         data_type: int64
+        description: PowerSchool student number.
       - name: test_type
         data_type: string
+        description: Assessment test type (e.g. Official, School-Day).
       - name: scope
         data_type: string
+        description:
+          Assessment program (e.g. SAT, PSAT NMSQT, PSAT10, PSAT 8/9).
       - name: score_type
         data_type: string
+        description: >
+          Score dimension identifier (e.g. sat_total_score, sat_ebrw,
+          psat89_math_section).
       - name: subject_area
         data_type: string
+        description: Raw subject area label from the source system.
       - name: aligned_subject_area
         data_type: string
+        description: >
+          Normalized subject area (Total, EBRW, Math) used to assign
+          benchmark_name.
       - name: scale_score
         data_type: numeric
+        description: Student's highest scale score for this score type.
       - name: max_scale_score
         data_type: numeric
+        description: >
+          Pre-computed max scale score from int_assessments__college_assessment,
+          used for superscore and goal calculations.
       - name: region
         data_type: string
+        description: KIPP region of the student's current enrollment.
       - name: school
         data_type: string
+        description: School abbreviation of the student's current enrollment.
       - name: graduation_year
         data_type: int64
+        description: Expected graduation year.
       - name: ktc_cohort
         data_type: int64
+        description: KIPP Through College cohort year.
       - name: benchmark_name
         data_type: string
+        description: >
+          Benchmark category for Tableau filtering. Total scores expand to
+          College-Ready, HS-Ready, and EA/ED-Ready; EBRW and Math scores use
+          their subject area directly.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
@@ -19,6 +19,7 @@ select
     e.gifted_and_talented,
     e.salesforce_id as contact_id,
     e.ktc_cohort,
+    e.graduation_year,
 
     s.cc_dateenrolled as ap_date_enrolled,
     s.cc_dateleft as ap_date_left,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
@@ -38,14 +38,39 @@ with
             )
     )
 
-select *,
+select
+    student_number,
+    test_type,
+    scope,
+    score_type,
+    subject_area,
+    aligned_subject_area,
+    scale_score,
+    max_scale_score,
+    region,
+    school,
+    graduation_year,
+    ktc_cohort,
+    benchmark_name,
 from base
 cross join unnest(['College-Ready', 'HS-Ready', 'EA/ED-Ready']) as benchmark_name
 where aligned_subject_area = 'Total'
 
 union all
 
--- trunk-ignore(sqlfluff/AM04)
-select *, aligned_subject_area as benchmark_name,
+select
+    student_number,
+    test_type,
+    scope,
+    score_type,
+    subject_area,
+    aligned_subject_area,
+    scale_score,
+    max_scale_score,
+    region,
+    school,
+    graduation_year,
+    ktc_cohort,
+    aligned_subject_area as benchmark_name,
 from base
 where aligned_subject_area in ('EBRW', 'Math')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
@@ -1,42 +1,51 @@
-select
-    s.student_number,
-    s.test_type,
-    s.scope,
-    s.score_type,
-    s.subject_area,
-    s.aligned_subject_area,
-    s.scale_score,
-    s.max_scale_score,
+with
+    base as (
+        select
+            s.student_number,
+            s.test_type,
+            s.scope,
+            s.score_type,
+            s.subject_area,
+            s.aligned_subject_area,
+            s.scale_score,
+            s.max_scale_score,
 
-    e.region,
-    e.school,
-    e.graduation_year,
-    e.ktc_cohort,
+            e.region,
+            e.school,
+            e.graduation_year,
+            e.ktc_cohort,
 
-    benchmark_name,
-
-from {{ ref("int_assessments__college_assessment") }} as s
-cross join
-    unnest(
-        ['College-Ready', 'HS-Ready', 'EBRW', 'Math', 'EA/ED-Ready']
-    ) as benchmark_name
-inner join
-    {{ ref("int_extracts__student_enrollments") }} as e
-    on s.student_number = e.student_number
-    and e.school_level = 'HS'
-    and e.rn_undergrad = 1
-    and e.rn_year = 1
-    and not e.is_out_of_district
-where
-    s.rn_highest = 1
-    and s.score_type not in (
-        'act_composite',
-        'act_english',
-        'act_math',
-        'act_reading',
-        'act_science',
-        'psat10_math_test',
-        'psat10_reading',
-        'sat_math_test_score',
-        'sat_reading_test_score'
+        from {{ ref("int_assessments__college_assessment") }} as s
+        inner join
+            {{ ref("int_extracts__student_enrollments") }} as e
+            on s.student_number = e.student_number
+            and e.school_level = 'HS'
+            and e.rn_undergrad = 1
+            and e.rn_year = 1
+            and not e.is_out_of_district
+        where
+            s.rn_highest = 1
+            and s.score_type not in (
+                'act_composite',
+                'act_english',
+                'act_math',
+                'act_reading',
+                'act_science',
+                'psat10_math_test',
+                'psat10_reading',
+                'sat_math_test_score',
+                'sat_reading_test_score'
+            )
     )
+
+select *,
+from base
+cross join unnest(['College-Ready', 'HS-Ready', 'EA/ED-Ready']) as benchmark_name
+where aligned_subject_area = 'Total'
+
+union all
+
+-- trunk-ignore(sqlfluff/AM04)
+select *, aligned_subject_area as benchmark_name,
+from base
+where aligned_subject_area in ('EBRW', 'Math')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
@@ -5,7 +5,6 @@ select
     s.score_type,
     s.subject_area,
     s.aligned_subject_area,
-    s.test_date,
     s.scale_score,
     s.max_scale_score,
 
@@ -14,7 +13,13 @@ select
     e.graduation_year,
     e.ktc_cohort,
 
+    benchmark_name,
+
 from {{ ref("int_assessments__college_assessment") }} as s
+cross join
+    unnest(
+        ['College-Ready', 'HS-Ready', 'EBRW', 'Math', 'EA/ED-Ready']
+    ) as benchmark_name
 inner join
     {{ ref("int_extracts__student_enrollments") }} as e
     on s.student_number = e.student_number
@@ -23,8 +28,12 @@ inner join
     and e.rn_year = 1
     and not e.is_out_of_district
 where
-    s.score_type not in (
+    s.rn_highest = 1
+    and s.score_type not in (
+        'act_composite',
         'act_english',
+        'act_math',
+        'act_reading',
         'act_science',
         'psat10_math_test',
         'psat10_reading',


### PR DESCRIPTION
## Summary
- Add `graduation_year` to `rpt_tableau__ap_assessment_dashboard`
- Remove `test_date`, filter to max score only (`rn_highest = 1`), exclude all ACT score types (resolves duplicates), and add `benchmark_name` cross join with five benchmark categories to `rpt_tableau__college_assessment_dashboard_scores`

## Test plan
- [ ] `rpt_tableau__ap_assessment_dashboard` builds clean
- [ ] `rpt_tableau__college_assessment_dashboard_scores` builds clean with no duplicates on `student_number, score_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214140008207019