### PR TITLE
feat(dbt): update AP and college assessment dashboard models

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -10,7 +10,7 @@ models:
               - student_number
               - academic_year
               - score_type
-              - test_date
+              - benchmark_name
     columns:
       - name: academic_year
         data_type: int64
@@ -50,6 +50,8 @@ models:
         data_type: string
       - name: subject_area
         data_type: string
+      - name: aligned_subject_area
+        data_type: string
       - name: test_date
         data_type: date
       - name: max_scale_score
@@ -59,4 +61,6 @@ models:
       - name: ccr_period
         data_type: string
       - name: ccr_teacher
+        data_type: string
+      - name: benchmark_name
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_scores.yml
@@ -1,65 +1,29 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard_scores
-    description: >
-      Max college assessment scores (SAT and PSAT variants) per student and
-      score type, joined to current enrollment for region and school context.
-      Expanded by benchmark_name for Tableau filtering — Total scores fan out to
-      three benchmark rows (College-Ready, HS-Ready, EA/ED-Ready); subject
-      scores produce one row each (EBRW, Math).
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - student_number
-              - score_type
-              - benchmark_name
     columns:
       - name: student_number
         data_type: int64
-        description: PowerSchool student number.
       - name: test_type
         data_type: string
-        description: Assessment test type (e.g. Official, School-Day).
       - name: scope
         data_type: string
-        description:
-          Assessment program (e.g. SAT, PSAT NMSQT, PSAT10, PSAT 8/9).
       - name: score_type
         data_type: string
-        description: >
-          Score dimension identifier (e.g. sat_total_score, sat_ebrw,
-          psat89_math_section).
       - name: subject_area
         data_type: string
-        description: Raw subject area label from the source system.
       - name: aligned_subject_area
         data_type: string
-        description: >
-          Normalized subject area (Total, EBRW, Math) used to assign
-          benchmark_name.
+      - name: test_date
+        data_type: date
       - name: scale_score
         data_type: numeric
-        description: Student's highest scale score for this score type.
       - name: max_scale_score
         data_type: numeric
-        description: >
-          Pre-computed max scale score from int_assessments__college_assessment,
-          used for superscore and goal calculations.
       - name: region
         data_type: string
-        description: KIPP region of the student's current enrollment.
       - name: school
         data_type: string
-        description: School abbreviation of the student's current enrollment.
       - name: graduation_year
         data_type: int64
-        description: Expected graduation year.
       - name: ktc_cohort
         data_type: int64
-        description: KIPP Through College cohort year.
-      - name: benchmark_name
-        data_type: string
-        description: >
-          Benchmark category for Tableau filtering. Total scores expand to
-          College-Ready, HS-Ready, and EA/ED-Ready; EBRW and Math scores use
-          their subject area directly.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -1,52 +1,120 @@
-select
-    e.academic_year,
-    e.region,
-    e.school,
-    e.student_number,
-    e.grade_level,
-    e.enroll_status,
-    e.iep_status,
-    e.is_504,
-    e.grad_iep_exempt_status_overall,
-    e.lep_status,
-    e.ktc_cohort,
-    e.graduation_year,
-    e.year_in_network,
-    e.college_match_gpa,
-    e.college_match_gpa_bands,
+with
+    base as (
+        select
+            e.academic_year,
+            e.region,
+            e.school,
+            e.student_number,
+            e.grade_level,
+            e.enroll_status,
+            e.iep_status,
+            e.is_504,
+            e.grad_iep_exempt_status_overall,
+            e.lep_status,
+            e.ktc_cohort,
+            e.graduation_year,
+            e.year_in_network,
+            e.college_match_gpa,
+            e.college_match_gpa_bands,
 
-    s.test_type,
-    s.scope,
-    s.score_type,
-    s.subject_area,
-    s.test_date,
-    s.max_scale_score,
-    s.scale_score,
+            s.test_type,
+            s.scope,
+            s.score_type,
+            s.subject_area,
+            s.aligned_subject_area,
+            s.test_date,
+            s.max_scale_score,
+            s.scale_score,
 
-    ce.teacher_lastfirst as ccr_teacher,
-    ce.sections_external_expression as ccr_period,
+            ce.teacher_lastfirst as ccr_teacher,
+            ce.sections_external_expression as ccr_period,
 
-from {{ ref("int_extracts__student_enrollments") }} as e
-inner join
-    {{ ref("int_assessments__college_assessment") }} as s
-    on e.student_number = s.student_number
-    and e.academic_year = s.academic_year
-    and s.scope != 'ACT'
-    and s.score_type not in (
-        'psat10_math_test',
-        'psat10_reading',
-        'sat_math_test_score',
-        'sat_reading_test_score'
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        inner join
+            {{ ref("int_assessments__college_assessment") }} as s
+            on e.student_number = s.student_number
+            and e.academic_year = s.academic_year
+            and s.rn_highest = 1
+            and s.scope != 'ACT'
+            and s.score_type not in (
+                'psat10_math_test',
+                'psat10_reading',
+                'sat_math_test_score',
+                'sat_reading_test_score'
+            )
+        left join
+            {{ ref("base_powerschool__course_enrollments") }} as ce
+            on e.student_number = ce.students_student_number
+            and e.academic_year = ce.cc_academic_year
+            and ce.courses_course_name like 'College and Career%'
+            and ce.rn_course_number_year = 1
+            and not ce.is_dropped_section
+        where
+            e.school_level = 'HS'
+            and e.rn_undergrad = 1
+            and e.rn_year = 1
+            and not e.is_out_of_district
     )
-left join
-    {{ ref("base_powerschool__course_enrollments") }} as ce
-    on e.student_number = ce.students_student_number
-    and e.academic_year = ce.cc_academic_year
-    and ce.courses_course_name like 'College and Career%'
-    and ce.rn_course_number_year = 1
-    and not ce.is_dropped_section
-where
-    e.school_level = 'HS'
-    and e.rn_undergrad = 1
-    and e.rn_year = 1
-    and not e.is_out_of_district
+
+select
+    academic_year,
+    region,
+    school,
+    student_number,
+    grade_level,
+    enroll_status,
+    iep_status,
+    is_504,
+    grad_iep_exempt_status_overall,
+    lep_status,
+    ktc_cohort,
+    graduation_year,
+    year_in_network,
+    college_match_gpa,
+    college_match_gpa_bands,
+    test_type,
+    scope,
+    score_type,
+    subject_area,
+    aligned_subject_area,
+    test_date,
+    max_scale_score,
+    scale_score,
+    ccr_teacher,
+    ccr_period,
+    benchmark_name,
+from base
+cross join unnest(['College-Ready', 'HS-Ready', 'EA/ED-Ready']) as benchmark_name
+where aligned_subject_area = 'Total'
+
+union all
+
+select
+    academic_year,
+    region,
+    school,
+    student_number,
+    grade_level,
+    enroll_status,
+    iep_status,
+    is_504,
+    grad_iep_exempt_status_overall,
+    lep_status,
+    ktc_cohort,
+    graduation_year,
+    year_in_network,
+    college_match_gpa,
+    college_match_gpa_bands,
+    test_type,
+    scope,
+    score_type,
+    subject_area,
+    aligned_subject_area,
+    test_date,
+    max_scale_score,
+    scale_score,
+    ccr_teacher,
+    ccr_period,
+    aligned_subject_area as benchmark_name,
+from base
+where aligned_subject_area in ('EBRW', 'Math')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_scores.sql
@@ -1,76 +1,33 @@
-with
-    base as (
-        select
-            s.student_number,
-            s.test_type,
-            s.scope,
-            s.score_type,
-            s.subject_area,
-            s.aligned_subject_area,
-            s.scale_score,
-            s.max_scale_score,
+select
+    s.student_number,
+    s.test_type,
+    s.scope,
+    s.score_type,
+    s.subject_area,
+    s.aligned_subject_area,
+    s.test_date,
+    s.scale_score,
+    s.max_scale_score,
 
-            e.region,
-            e.school,
-            e.graduation_year,
-            e.ktc_cohort,
+    e.region,
+    e.school,
+    e.graduation_year,
+    e.ktc_cohort,
 
-        from {{ ref("int_assessments__college_assessment") }} as s
-        inner join
-            {{ ref("int_extracts__student_enrollments") }} as e
-            on s.student_number = e.student_number
-            and e.school_level = 'HS'
-            and e.rn_undergrad = 1
-            and e.rn_year = 1
-            and not e.is_out_of_district
-        where
-            s.rn_highest = 1
-            and s.score_type not in (
-                'act_composite',
-                'act_english',
-                'act_math',
-                'act_reading',
-                'act_science',
-                'psat10_math_test',
-                'psat10_reading',
-                'sat_math_test_score',
-                'sat_reading_test_score'
-            )
+from {{ ref("int_assessments__college_assessment") }} as s
+inner join
+    {{ ref("int_extracts__student_enrollments") }} as e
+    on s.student_number = e.student_number
+    and e.school_level = 'HS'
+    and e.rn_undergrad = 1
+    and e.rn_year = 1
+    and not e.is_out_of_district
+where
+    s.score_type not in (
+        'act_english',
+        'act_science',
+        'psat10_math_test',
+        'psat10_reading',
+        'sat_math_test_score',
+        'sat_reading_test_score'
     )
-
-select
-    student_number,
-    test_type,
-    scope,
-    score_type,
-    subject_area,
-    aligned_subject_area,
-    scale_score,
-    max_scale_score,
-    region,
-    school,
-    graduation_year,
-    ktc_cohort,
-    benchmark_name,
-from base
-cross join unnest(['College-Ready', 'HS-Ready', 'EA/ED-Ready']) as benchmark_name
-where aligned_subject_area = 'Total'
-
-union all
-
-select
-    student_number,
-    test_type,
-    scope,
-    score_type,
-    subject_area,
-    aligned_subject_area,
-    scale_score,
-    max_scale_score,
-    region,
-    school,
-    graduation_year,
-    ktc_cohort,
-    aligned_subject_area as benchmark_name,
-from base
-where aligned_subject_area in ('EBRW', 'Math')


### PR DESCRIPTION
## Summary
- `rpt_tableau__college_assessment_dashboard_benchmark_calcs`: filter to max scores (`rn_highest=1`), add `aligned_subject_area`, add `benchmark_name` via UNION ALL — Total scores fan out to College-Ready/HS-Ready/EA/ED-Ready, EBRW and Math use subject area directly; update uniqueness test to include `benchmark_name`
- `rpt_tableau__college_assessment_dashboard_scores`: reverted to main state
- `rpt_tableau__ap_assessment_dashboard`: add `graduation_year`

## Test plan
- [ ] `rpt_tableau__college_assessment_dashboard_benchmark_calcs` builds clean with no duplicates on `(student_number, academic_year, score_type, benchmark_name)`
- [ ] `rpt_tableau__college_assessment_dashboard_scores` builds clean (unchanged from main)
- [ ] `rpt_tableau__ap_assessment_dashboard` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214140661981986