### PR TITLE
refactor(kipptaf): simplify college assessment benchmark calcs view

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -3,17 +3,17 @@ models:
     description: >
       Student-level college assessment scores used to calculate the percentage
       of students meeting readiness benchmarks for KIPP Forward use. One row per
-      student per (scope, benchmark_name) combination — including students with
-      no qualifying score (null max_score) so they count in the denominator.
-      Excludes IEP-exempt students and students without a graduation year.
-      Scores reflect each student's all-time best across administrations, not
-      scoped to the current academic year.
+      student per (aligned_scope, benchmark_name) combination — including
+      students with no qualifying score (null max_score) so they count in the
+      denominator. Excludes IEP-exempt students and students without a
+      graduation year. Scores reflect each student's all-time best across
+      administrations, not scoped to the current academic year.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - student_number
-              - scope
+              - aligned_scope
               - benchmark_name
     columns:
       - name: region
@@ -52,17 +52,11 @@ models:
       - name: college_match_gpa_bands
         description: GPA band grouping for college match purposes.
         data_type: string
-      - name: scope
-        description: >
-          Raw assessment scope from the scaffold (e.g., SAT, PSAT 8/9, PSAT10,
-          PSAT NMSQT). PSAT10 and PSAT NMSQT appear as separate scope rows even
-          though they share the same aligned_scope.
-        data_type: string
       - name: aligned_scope
         description: >
-          Assessment scope normalized for benchmark comparison. PSAT10 and PSAT
-          NMSQT are merged into PSAT10/NMSQT; all other scopes are unchanged.
-          Used as the join key between the scaffold and assessment scores.
+          Assessment scope used for benchmark comparison. PSAT10 and PSAT NMSQT
+          are merged into PSAT10/NMSQT; all other scopes (PSAT 8/9, SAT) are
+          unchanged.
         data_type: string
       - name: test_type
         description: Broad classification of the assessment (e.g., SAT Suite).

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -2,7 +2,12 @@ models:
   - name: rpt_tableau__college_assessment_dashboard_benchmark_calcs
     description: >
       Student-level college assessment scores used to calculate the percentage
-      of students meeting readiness benchmark for KIPP Forward use.
+      of students meeting readiness benchmarks for KIPP Forward use. One row per
+      student per (scope, benchmark_name) combination — including students with
+      no qualifying score (null max_score) so they count in the denominator.
+      Excludes IEP-exempt students and students without a graduation year.
+      Scores reflect each student's all-time best across administrations, not
+      scoped to the current academic year.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -12,38 +17,78 @@ models:
               - benchmark_name
     columns:
       - name: region
+        description: KIPP region the student's school belongs to.
         data_type: string
       - name: school
+        description: School name.
         data_type: string
       - name: student_number
+        description: Student Number assigned by the school. Indexed.
         data_type: int64
       - name: student_name
+        description: Student's full name.
         data_type: string
       - name: iep_status
+        description: >
+          Database extension field associated to the Students table. Conditional
+          on spedlep.
         data_type: string
       - name: is_504
+        description: Whether the student has a 504 accommodation plan.
         data_type: boolean
       - name: lep_status
+        description: Student Limited English Proficiency status.
         data_type: boolean
       - name: graduation_year
+        description: Student graduation year.
         data_type: int64
       - name: year_in_network
+        description:
+          Number of years the student has been enrolled in the KIPP network.
         data_type: int64
       - name: college_match_gpa
+        description: Cumulative GPA used for college match categorization.
         data_type: numeric
       - name: college_match_gpa_bands
+        description: GPA band grouping for college match purposes.
         data_type: string
       - name: scope
+        description: >
+          Raw assessment scope from the scaffold (e.g., SAT, PSAT 8/9, PSAT10,
+          PSAT NMSQT). PSAT10 and PSAT NMSQT appear as separate scope rows even
+          though they share the same aligned_scope.
         data_type: string
       - name: aligned_scope
+        description: >
+          Assessment scope normalized for benchmark comparison. PSAT10 and PSAT
+          NMSQT are merged into PSAT10/NMSQT; all other scopes are unchanged.
+          Used as the join key between the scaffold and assessment scores.
         data_type: string
       - name: test_type
+        description: Broad classification of the assessment (e.g., SAT Suite).
         data_type: string
       - name: score_type
+        description: >
+          Specific score dimension within the assessment (e.g., sat_total,
+          sat_ebrw, sat_math).
         data_type: string
       - name: subject_area
+        description: >
+          Subject area of the score — Combined, EBRW, or Math. Combined rows are
+          cross-joined with the three named benchmarks; EBRW and Math rows use
+          subject_area as the benchmark_name directly.
         data_type: string
       - name: max_score
+        description: >
+          Highest scale score for the student on this aligned scope and subject
+          area across all assessment administrations. Null for students with no
+          qualifying score. Used as the score value for benchmark percent-met
+          calculations in Tableau.
         data_type: numeric
       - name: benchmark_name
+        description: >
+          Readiness benchmark label. One of College-Ready, HS-Ready, EA/ED-Ready
+          (for Combined rows) or EBRW, Math (for subject-specific rows). Tableau
+          consumers filter to a single benchmark_name and compare max_score
+          against a dynamic threshold parameter to compute percent met.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -8,32 +8,23 @@ models:
           arguments:
             combination_of_columns:
               - student_number
-              - academic_year
-              - score_type
+              - scope
               - benchmark_name
     columns:
-      - name: academic_year
-        data_type: int64
       - name: region
         data_type: string
       - name: school
         data_type: string
-      - name: grade_level
-        data_type: int64
       - name: student_number
         data_type: int64
-      - name: enroll_status
-        data_type: int64
+      - name: student_name
+        data_type: string
       - name: iep_status
         data_type: string
       - name: is_504
         data_type: boolean
-      - name: grad_iep_exempt_status_overall
-        data_type: string
       - name: lep_status
         data_type: boolean
-      - name: ktc_cohort
-        data_type: int64
       - name: graduation_year
         data_type: int64
       - name: year_in_network
@@ -42,25 +33,17 @@ models:
         data_type: numeric
       - name: college_match_gpa_bands
         data_type: string
-      - name: test_type
-        data_type: string
       - name: scope
+        data_type: string
+      - name: aligned_scope
+        data_type: string
+      - name: test_type
         data_type: string
       - name: score_type
         data_type: string
       - name: subject_area
         data_type: string
-      - name: aligned_subject_area
-        data_type: string
-      - name: test_date
-        data_type: date
-      - name: max_scale_score
+      - name: max_score
         data_type: numeric
-      - name: scale_score
-        data_type: numeric
-      - name: ccr_period
-        data_type: string
-      - name: ccr_teacher
-        data_type: string
       - name: benchmark_name
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -71,6 +71,14 @@ with
                 scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope
             ) as aligned_scope,
 
+            row_number() over (
+                partition by
+                    student_number,
+                    if(scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope),
+                    subject_area
+                order by scale_score desc
+            ) as rn,
+
         from {{ ref("int_assessments__college_assessment") }}
         where
             rn_highest = 1
@@ -81,15 +89,7 @@ with
                 'sat_math_test_score',
                 'sat_reading_test_score'
             )
-        qualify
-            row_number() over (
-                partition by
-                    student_number,
-                    if(scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope),
-                    subject_area
-                order by scale_score desc
-            )
-            = 1
+        qualify rn = 1
     ),
 
     base as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -13,38 +13,26 @@ with
             college_match_gpa,
             college_match_gpa_bands,
 
-            regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$') as scope,
+            regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$') as aligned_scope,
             regexp_extract(benchmark_group, r'^.+_([^_]+)_[^_]+$') as subject_area,
             regexp_extract(benchmark_group, r'_([^_]+)$') as benchmark_name,
-
-            if(
-                regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$')
-                in ('PSAT10', 'PSAT NMSQT'),
-                'PSAT10/NMSQT',
-                regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$')
-            ) as aligned_scope,
 
         from {{ ref("int_extracts__student_enrollments") }}
         cross join
             unnest(
                 [
                     'PSAT 8/9_EBRW_EBRW',
-                    'PSAT NMSQT_EBRW_EBRW',
-                    'PSAT10_EBRW_EBRW',
+                    'PSAT10/NMSQT_EBRW_EBRW',
                     'SAT_EBRW_EBRW',
                     'PSAT 8/9_Math_Math',
-                    'PSAT NMSQT_Math_Math',
-                    'PSAT10_Math_Math',
+                    'PSAT10/NMSQT_Math_Math',
                     'SAT_Math_Math',
                     'PSAT 8/9_Combined_College-Ready',
                     'PSAT 8/9_Combined_EA/ED-Ready',
                     'PSAT 8/9_Combined_HS-Ready',
-                    'PSAT NMSQT_Combined_College-Ready',
-                    'PSAT NMSQT_Combined_EA/ED-Ready',
-                    'PSAT NMSQT_Combined_HS-Ready',
-                    'PSAT10_Combined_College-Ready',
-                    'PSAT10_Combined_EA/ED-Ready',
-                    'PSAT10_Combined_HS-Ready',
+                    'PSAT10/NMSQT_Combined_College-Ready',
+                    'PSAT10/NMSQT_Combined_EA/ED-Ready',
+                    'PSAT10/NMSQT_Combined_HS-Ready',
                     'SAT_Combined_College-Ready',
                     'SAT_Combined_EA/ED-Ready',
                     'SAT_Combined_HS-Ready'
@@ -107,7 +95,6 @@ with
             e.year_in_network,
             e.college_match_gpa,
             e.college_match_gpa_bands,
-            e.scope,
             e.aligned_scope,
             e.subject_area,
             e.benchmark_name,
@@ -140,7 +127,6 @@ select
     year_in_network,
     college_match_gpa,
     college_match_gpa_bands,
-    scope,
     aligned_scope,
     test_type,
     score_type,
@@ -149,4 +135,3 @@ select
     benchmark_name,
 
 from base
-where scale_score = max_score or max_score is null

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -59,6 +59,7 @@ with
             and not is_out_of_district
     ),
 
+    -- trunk-ignore(sqlfluff/ST03)
     aligned_scores_pre as (
         select
             student_number,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -59,7 +59,7 @@ with
             and not is_out_of_district
     ),
 
-    aligned_scores as (
+    aligned_scores_pre as (
         select
             student_number,
             test_type,
@@ -71,14 +71,6 @@ with
                 scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope
             ) as aligned_scope,
 
-            row_number() over (
-                partition by
-                    student_number,
-                    if(scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope),
-                    subject_area
-                order by scale_score desc
-            ) as rn,
-
         from {{ ref("int_assessments__college_assessment") }}
         where
             rn_highest = 1
@@ -89,7 +81,16 @@ with
                 'sat_math_test_score',
                 'sat_reading_test_score'
             )
-        qualify rn = 1
+    ),
+
+    aligned_scores as (
+        {{
+            dbt_utils.deduplicate(
+                relation="aligned_scores_pre",
+                partition_by="student_number, aligned_scope, subject_area",
+                order_by="scale_score desc",
+            )
+        }}
     ),
 
     base as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -1,120 +1,150 @@
 with
-    base as (
+    scaffold as (
         select
-            e.academic_year,
-            e.region,
-            e.school,
-            e.student_number,
-            e.grade_level,
-            e.enroll_status,
-            e.iep_status,
-            e.is_504,
-            e.grad_iep_exempt_status_overall,
-            e.lep_status,
-            e.ktc_cohort,
-            e.graduation_year,
-            e.year_in_network,
-            e.college_match_gpa,
-            e.college_match_gpa_bands,
+            region,
+            school,
+            student_number,
+            student_name,
+            iep_status,
+            is_504,
+            lep_status,
+            graduation_year,
+            year_in_network,
+            college_match_gpa,
+            college_match_gpa_bands,
 
-            s.test_type,
-            s.scope,
-            s.score_type,
-            s.subject_area,
-            s.aligned_subject_area,
-            s.test_date,
-            s.max_scale_score,
-            s.scale_score,
+            regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$') as scope,
+            regexp_extract(benchmark_group, r'^.+_([^_]+)_[^_]+$') as subject_area,
+            regexp_extract(benchmark_group, r'_([^_]+)$') as benchmark_name,
 
-            ce.teacher_lastfirst as ccr_teacher,
-            ce.sections_external_expression as ccr_period,
+            if(
+                regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$')
+                in ('PSAT10', 'PSAT NMSQT'),
+                'PSAT10/NMSQT',
+                regexp_extract(benchmark_group, r'^(.+)_[^_]+_[^_]+$')
+            ) as aligned_scope,
 
-        from {{ ref("int_extracts__student_enrollments") }} as e
-        inner join
-            {{ ref("int_assessments__college_assessment") }} as s
-            on e.student_number = s.student_number
-            and e.academic_year = s.academic_year
-            and s.rn_highest = 1
-            and s.scope != 'ACT'
-            and s.score_type not in (
+        from {{ ref("int_extracts__student_enrollments") }}
+        cross join
+            unnest(
+                [
+                    'PSAT 8/9_EBRW_EBRW',
+                    'PSAT NMSQT_EBRW_EBRW',
+                    'PSAT10_EBRW_EBRW',
+                    'SAT_EBRW_EBRW',
+                    'PSAT 8/9_Math_Math',
+                    'PSAT NMSQT_Math_Math',
+                    'PSAT10_Math_Math',
+                    'SAT_Math_Math',
+                    'PSAT 8/9_Combined_College-Ready',
+                    'PSAT 8/9_Combined_EA/ED-Ready',
+                    'PSAT 8/9_Combined_HS-Ready',
+                    'PSAT NMSQT_Combined_College-Ready',
+                    'PSAT NMSQT_Combined_EA/ED-Ready',
+                    'PSAT NMSQT_Combined_HS-Ready',
+                    'PSAT10_Combined_College-Ready',
+                    'PSAT10_Combined_EA/ED-Ready',
+                    'PSAT10_Combined_HS-Ready',
+                    'SAT_Combined_College-Ready',
+                    'SAT_Combined_EA/ED-Ready',
+                    'SAT_Combined_HS-Ready'
+                ]
+            ) as benchmark_group
+        where
+            school_level = 'HS'
+            and rn_undergrad = 1
+            and rn_year = 1
+            and grad_iep_exempt_status_overall != 'Yes'
+            and graduation_year is not null
+            and not is_out_of_district
+    ),
+
+    aligned_scores as (
+        select
+            student_number,
+            test_type,
+            score_type,
+            subject_area,
+            scale_score,
+
+            if(
+                scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope
+            ) as aligned_scope,
+
+        from {{ ref("int_assessments__college_assessment") }}
+        where
+            rn_highest = 1
+            and scope != 'ACT'
+            and score_type not in (
                 'psat10_math_test',
                 'psat10_reading',
                 'sat_math_test_score',
                 'sat_reading_test_score'
             )
+        qualify
+            row_number() over (
+                partition by
+                    student_number,
+                    if(scope in ('PSAT10', 'PSAT NMSQT'), 'PSAT10/NMSQT', scope),
+                    subject_area
+                order by scale_score desc
+            )
+            = 1
+    ),
+
+    base as (
+        select
+            e.region,
+            e.school,
+            e.student_number,
+            e.student_name,
+            e.iep_status,
+            e.is_504,
+            e.lep_status,
+            e.graduation_year,
+            e.year_in_network,
+            e.college_match_gpa,
+            e.college_match_gpa_bands,
+            e.scope,
+            e.aligned_scope,
+            e.subject_area,
+            e.benchmark_name,
+
+            s.test_type,
+            s.score_type,
+            s.scale_score,
+
+            max(s.scale_score) over (
+                partition by e.student_number, e.aligned_scope, e.subject_area
+            ) as max_score,
+
+        from scaffold as e
         left join
-            {{ ref("base_powerschool__course_enrollments") }} as ce
-            on e.student_number = ce.students_student_number
-            and e.academic_year = ce.cc_academic_year
-            and ce.courses_course_name like 'College and Career%'
-            and ce.rn_course_number_year = 1
-            and not ce.is_dropped_section
-        where
-            e.school_level = 'HS'
-            and e.rn_undergrad = 1
-            and e.rn_year = 1
-            and not e.is_out_of_district
+            aligned_scores as s
+            on e.student_number = s.student_number
+            and e.aligned_scope = s.aligned_scope
+            and e.subject_area = s.subject_area
     )
 
 select
-    academic_year,
     region,
     school,
     student_number,
-    grade_level,
-    enroll_status,
+    student_name,
     iep_status,
     is_504,
-    grad_iep_exempt_status_overall,
     lep_status,
-    ktc_cohort,
     graduation_year,
     year_in_network,
     college_match_gpa,
     college_match_gpa_bands,
-    test_type,
     scope,
+    aligned_scope,
+    test_type,
     score_type,
     subject_area,
-    aligned_subject_area,
-    test_date,
-    max_scale_score,
-    scale_score,
-    ccr_teacher,
-    ccr_period,
+    max_score,
     benchmark_name,
-from base
-cross join unnest(['College-Ready', 'HS-Ready', 'EA/ED-Ready']) as benchmark_name
-where aligned_subject_area = 'Total'
 
-union all
-
-select
-    academic_year,
-    region,
-    school,
-    student_number,
-    grade_level,
-    enroll_status,
-    iep_status,
-    is_504,
-    grad_iep_exempt_status_overall,
-    lep_status,
-    ktc_cohort,
-    graduation_year,
-    year_in_network,
-    college_match_gpa,
-    college_match_gpa_bands,
-    test_type,
-    scope,
-    score_type,
-    subject_area,
-    aligned_subject_area,
-    test_date,
-    max_scale_score,
-    scale_score,
-    ccr_teacher,
-    ccr_period,
-    aligned_subject_area as benchmark_name,
 from base
-where aligned_subject_area in ('EBRW', 'Math')
+where scale_score = max_score or max_score is null


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will simplify \`rpt_tableau__college_assessment_dashboard_benchmark_calcs\` by replacing the UNION ALL + inner join pattern with a scaffold CTE approach. The scaffold cross-joins all enrolled HS students against the 15 valid (aligned_scope × subject_area × benchmark_name) combinations, then left-joins to scores — ensuring students with no scores appear in every benchmark row with a null \`max_score\`, enabling correct % met calculations in Tableau.

Key changes:
- Replaced UNION ALL with a scaffold CTE driven by a single \`cross join unnest([...])\` over 15 aligned_scope/subject/benchmark combos
- Changed inner join to left join so unscored students appear in the output as the denominator
- Dropped CCR course enrollment join (\`ccr_teacher\`, \`ccr_period\`)
- Dropped \`academic_year\` scoping — model now shows each student's all-time best score per aligned_scope/subject
- Added \`student_name\`, \`aligned_scope\` (PSAT10 and PSAT NMSQT merged to PSAT10/NMSQT), \`max_score\` (window function)
- Removed \`academic_year\`, \`grade_level\`, \`enroll_status\`, \`ktc_cohort\`, \`aligned_subject_area\`, \`max_scale_score\`, \`test_date\`, \`ccr_teacher\`, \`ccr_period\`, raw \`scope\`
- Used \`dbt_utils.deduplicate()\` in \`aligned_scores\` to keep only the best score per \`(student_number, aligned_scope, subject_area)\` — prevents dupes when a student has both PSAT10 and PSAT NMSQT records
- Verified zero uniqueness violations across 92,505 output rows

**Population changes (denominator):** Two new filters in the scaffold CTE change which students appear in the output vs. the old model:
- \`grad_iep_exempt_status_overall != 'Yes'\` — IEP-exempt students are now excluded from both numerator and denominator. The old model included them in the output.
- \`graduation_year is not null\` — students without a graduation year on record are now excluded. Coordinate with Tableau consumers before merging.

> AI-assisted: refactoring was co-authored with Claude Code. SQL logic, scaffold design, and quality checks (uniqueness, no-score student coverage) were verified against production source tables before PR.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a \`[model_name].yml\` properties file for all new models
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Yes — column removals and population filter changes in a contracted \`rpt_\` model. Coordinate with Tableau consumers before merging.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered