### PR TITLE
refactor(dbt): add PK/FK constraints to every marts model

### DIFF
--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -7,22 +7,44 @@ models:
       effective dates change. FKs to dim_course_sections via course_section_key
       and to dim_staff via staff_key.
 
+    constraints:
+      - type: primary_key
+        columns: [course_section_key, staff_key, role, effective_start_date]
+        warn_unsupported: false
     columns:
       - name: course_section_key
         data_type: string
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_relation. FK
           to dim_course_sections.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_course_sections')
+            to_columns: [course_section_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_course_sections')
+                field: course_section_key
       - name: staff_key
         data_type: string
         description: >-
           Surrogate key derived from employee_number. FK to dim_staff.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: role
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -46,6 +46,7 @@ models:
                 to: ref('dim_staff')
                 field: staff_key
       - name: role
+        quote: true
         data_type: string
         description: >-
           User configurable name uniquely identifying the role to the user

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
@@ -6,23 +6,45 @@ models:
       where the term's date range overlaps with the section's term dates. FK to
       dim_course_sections via course_section_key and to dim_terms via term_key.
 
+    constraints:
+      - type: primary_key
+        columns: [course_section_key, term_key]
+        warn_unsupported: false
     columns:
       - name: course_section_key
         data_type: string
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_relation. FK
           to dim_course_sections.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_course_sections')
+            to_columns: [course_section_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_course_sections')
+                field: course_section_key
       - name: term_key
         data_type: string
         description: >-
           Surrogate key derived from type, code, name, start_date, region, and
           school_id of the matching reporting term. FK to dim_terms.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -8,24 +8,46 @@ models:
       keys to dim_students via student_key and to dim_student_contact_persons
       via student_contact_person_key.
 
+    constraints:
+      - type: primary_key
+        columns: [student_key, student_contact_person_key]
+        warn_unsupported: false
     columns:
       - name: student_key
         data_type: string
         description: >-
           Surrogate key for the student. Foreign key to dim_students. Derived
           from student_number via generate_surrogate_key.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_students')
+                field: student_key
       - name: student_contact_person_key
         data_type: string
         description: >-
           Surrogate key for the contact person. Foreign key to
           dim_student_contact_persons. Derived from _dbt_source_relation and
           powerschool_person_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_contact_persons')
+            to_columns: [student_contact_person_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_contact_persons')
+                field: student_contact_person_key
       - name: relationship_type
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from survey_id and question_shortname. Primary
           key for this bridge.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -20,17 +23,35 @@ models:
         data_type: string
         description: >-
           FK to dim_surveys. Surrogate key derived from survey_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_surveys')
+            to_columns: [survey_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_surveys')
+                field: survey_key
       - name: survey_question_key
         data_type: string
         description: >-
           FK to dim_survey_questions. Surrogate key derived from
           question_shortname.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_survey_questions')
+            to_columns: [survey_question_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_survey_questions')
+                field: survey_question_key
       - name: shortname
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_rubric_measurements.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_rubric_measurements.sql
@@ -11,10 +11,8 @@ select
     m.scale_max,
 
     mgm.measurement_group_name as strand_name,
-    mgm.measurement_group_key as strand_key,
     mgm.measurement_group_weight as strand_weight,
     mgm.measurement_group_description as strand_description,
-    mgm.measurement_key,
     mgm.measurement_weight as weight,
     mgm.is_private_measurement,
     mgm.require_measurement as is_required,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staffing_positions.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staffing_positions.sql
@@ -1,11 +1,23 @@
 select
     {{ dbt_utils.generate_surrogate_key(["dbt_scd_id"]) }} as staffing_position_key,
 
-    {{ dbt_utils.generate_surrogate_key(["adp_location"]) }} as location_key,
+    if(
+        adp_location is not null,
+        {{ dbt_utils.generate_surrogate_key(["adp_location"]) }},
+        cast(null as string)
+    ) as location_key,
 
-    {{ dbt_utils.generate_surrogate_key(["teammate"]) }} as incumbent_staff_key,
+    if(
+        teammate is not null,
+        {{ dbt_utils.generate_surrogate_key(["teammate"]) }},
+        cast(null as string)
+    ) as incumbent_staff_key,
 
-    {{ dbt_utils.generate_surrogate_key(["recruiter"]) }} as recruiter_staff_key,
+    if(
+        recruiter is not null,
+        {{ dbt_utils.generate_surrogate_key(["recruiter"]) }},
+        cast(null as string)
+    ) as recruiter_staff_key,
 
     academic_year,
     recruitment_group,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staffing_positions.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staffing_positions.sql
@@ -7,8 +7,6 @@ select
 
     {{ dbt_utils.generate_surrogate_key(["recruiter"]) }} as recruiter_staff_key,
 
-    dbt_scd_id as staffing_position_natural_key,
-
     academic_year,
     recruitment_group,
     adp_dept as home_department_name,

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from academic_year, test_name, test_code, and
           region. Primary key.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,16 @@ models:
           FK to dim_regions. Derived from region using
           generate_surrogate_key(["region"]).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_regions')
+            to_columns: [region_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_regions')
+                field: region_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
@@ -15,6 +15,9 @@ models:
           Surrogate key derived from academic_year, school_id,
           state_assessment_code, grade_level, and illuminate_subject_area.
           Primary key.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -25,6 +28,16 @@ models:
           FK to dim_locations. Derived from location_clean_name. Null when the
           school does not appear in the location crosswalk.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
@@ -24,6 +24,9 @@ models:
         description: >-
           Surrogate key derived from type, title, subject_area, category,
           module_code, and grade_level_tested. Primary key.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
@@ -13,6 +13,9 @@ models:
           Surrogate primary key derived from student_number and
           college_code_branch. Generated with
           generate_surrogate_key(["student_number", "college_code_branch"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,16 +24,34 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from student_number. FK to dim_students.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_students')
+                field: student_key
       - name: college_key
         data_type: string
         description: >-
           Surrogate key derived from college_code_branch. FK to dim_colleges.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_colleges')
+            to_columns: [college_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_colleges')
+                field: college_key
       - name: start_date_key
         data_type: date
         description: >-
@@ -38,6 +59,16 @@ models:
           x college combination. FK to dim_dates (role-playing as enrollment
           start date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: end_date_key
         data_type: date
         description: >-
@@ -45,6 +76,16 @@ models:
           college combination. FK to dim_dates (role-playing as enrollment end
           date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: status
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_colleges.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_colleges.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate primary key derived from college_code_branch. Generated with
           generate_surrogate_key(["college_code_branch"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_relation.
           Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -20,9 +23,18 @@ models:
         description: >-
           Surrogate key derived from courses_course_number and
           _dbt_source_relation. FK to dim_courses.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_courses')
+            to_columns: [course_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_courses')
+                field: course_key
       - name: location_key
         data_type: string
         description: >-
@@ -30,6 +42,16 @@ models:
           Null when the section's school ID does not match any location in the
           crosswalk.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: identifier
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate key derived from courses_course_number and
           _dbt_source_relation. Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_dates.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_dates.yml
@@ -11,6 +11,9 @@ models:
         data_type: date
         description: >-
           Calendar date. Primary key and join target for all mart models.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_candidates.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_candidates.yml
@@ -10,6 +10,9 @@ models:
         description: >-
           Surrogate primary key derived from candidate_id. Generated with
           generate_surrogate_key(["candidate_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_postings.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_postings.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from job_title, department_internal, and
           job_city. Generated with generate_surrogate_key(["job_title",
           "department_internal", "job_city"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -18,6 +18,9 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from location name.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -28,6 +31,11 @@ models:
           Foreign key to dim_regions. Surrogate key derived from the canonical
           region. Nullable when the location has no region mapping (e.g.,
           network-level locations).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_regions')
+            to_columns: [region_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -43,6 +43,7 @@ models:
                 field: region_key
 
       - name: name
+        quote: true
         data_type: string
         description: >-
           Canonical location name.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
@@ -16,6 +16,7 @@ models:
           - not_null
 
       - name: name
+        quote: true
         data_type: string
         description: >-
           Region name (Newark, Camden, Miami, Paterson).

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
@@ -8,6 +8,9 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from region name.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_school_calendars.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_school_calendars.yml
@@ -5,6 +5,10 @@ models:
       each date is an in-session day and a membership day. Conformed dimension
       used by attendance (session validity) and assessments (school-day counts
       for progress monitoring goals). FK to dim_dates and dim_locations.
+    constraints:
+      - type: primary_key
+        columns: [date_key, location_key]
+        warn_unsupported: false
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -18,9 +22,18 @@ models:
         description: >-
           Each day of the school year including holidays and weekends, such as
           the school day. Indexed.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
         config:
           meta:
             source_system: PowerSchool
@@ -30,9 +43,18 @@ models:
         data_type: string
         description: >-
           Surrogate key for the school. FK to dim_locations.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: is_in_session
         data_type: boolean
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff.yml
@@ -14,6 +14,9 @@ models:
         description: >-
           Surrogate key derived from employee_number. Primary key for the staff
           dimension. Generated with generate_surrogate_key(["employee_number"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -14,6 +14,9 @@ models:
           fields. Generated with generate_surrogate_key(["srh.employee_number",
           "t.type", "t.code", "t.name", "t.start_date", "t.region",
           "t.school_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         data_type: string
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -34,9 +42,18 @@ models:
         description: >-
           Foreign key to dim_terms. Surrogate key derived from term type, code,
           name, start_date, region, and school_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_goal_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_goal_types.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate primary key derived from the goal tag ID. Generated with
           generate_surrogate_key(["tag_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from rubric_id and measurement_id.
           Generated with generate_surrogate_key(["mgm.rubric_id",
           "mgm.measurement_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_observation_rubrics. Surrogate key derived
           from rubric_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_rubrics')
+            to_columns: [staff_observation_rubric_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -55,11 +63,6 @@ models:
         description: >-
           Name of the measurement group (strand) this measurement belongs to.
 
-      - name: strand_key
-        data_type: string
-        description: >-
-          Short key code for the strand within the rubric.
-
       - name: strand_weight
         data_type: int64
         description: >-
@@ -69,11 +72,6 @@ models:
         data_type: string
         description: >-
           Description of the measurement group (strand).
-
-      - name: measurement_key
-        data_type: string
-        description: >-
-          Short key code for the measurement within its strand.
 
       - name: weight
         data_type: float64

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubrics.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubrics.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate primary key derived from rubric_id. Generated with
           generate_surrogate_key(["rubric_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_types.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate primary key derived from the generic tag ID. Generated with
           generate_surrogate_key(["tag_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from employee_number and
           effective_date_start. Generated with
           generate_surrogate_key(["employee_number", "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
@@ -17,6 +17,9 @@ models:
         description: >-
           Surrogate key derived from item_id. Primary key for this dimension.
           Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -28,6 +31,11 @@ models:
           with generate_surrogate_key(["employee_number"]). Null when the
           associate_oid has no active number mapping in
           stg_people__employee_numbers.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -42,6 +50,11 @@ models:
           approves this assignment's time records (distinct from the org-chart
           manager on dim_work_assignment_reporting_relationships). Null when the
           approver's associate_oid has no active number mapping.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
@@ -14,6 +14,9 @@ models:
         description: >-
           Surrogate primary key derived from dbt_scd_id (snapshot row
           identifier). Generated with generate_surrogate_key(["dbt_scd_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,6 +26,11 @@ models:
         description: >-
           Foreign key to dim_locations. Surrogate key derived from the home work
           location name.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3686 — adp_location vs dim_locations.location_name coverage
           # gap (same class as #3672). Promote to error once crosswalk is clean.
@@ -30,15 +38,17 @@ models:
               arguments:
                 to: ref('dim_locations')
                 field: location_key
-              config:
-                severity: warn
-
       - name: incumbent_staff_key
         data_type: string
         description: >-
           Foreign key to dim_staff for the incumbent (staff member filling the
           position). Surrogate key derived from the teammate employee number.
           Nullable — open positions have no incumbent.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3710 — Seat Tracker retains historical incumbents outside
           # dim_staff's active-primary scope. Promote to error once resolved.
@@ -53,6 +63,11 @@ models:
           Foreign key to dim_staff for the assigned recruiter. Surrogate key
           derived from the recruiter employee number. Nullable — positions may
           have no assigned recruiter.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3710 — Seat Tracker recruiter values include staff outside
           # dim_staff's active-primary scope. Promote to error once resolved.
@@ -60,12 +75,6 @@ models:
               arguments:
                 to: ref('dim_staff')
                 field: staff_key
-
-      - name: staffing_position_natural_key
-        data_type: string
-        description: >-
-          The dbt snapshot SCD identifier (dbt_scd_id). Uniquely identifies this
-          specific version of a staffing position.
 
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_assessment_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_assessment_expectations.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from student_number, assessment_id, and
           administered_at. Primary key.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,16 @@ models:
           FK to dim_assessments. Derived from assessment_type, title,
           subject_area, scope, module_code, and grade_level_id.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_assessments')
+            to_columns: [assessment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_assessments')
+                field: assessment_key
       - name: term_key
         data_type: string
         description: >-
@@ -29,10 +42,25 @@ models:
           start_date, region, and school_id. Null when the administration date
           does not fall within any reporting term.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: student_key
         data_type: string
         description: >-
           FK to dim_students. Surrogate key derived from student_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3711 — assessment scaffold includes students absent from
           # PowerSchool enrollments. Promote to error once resolved.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from region_name and
           family_communication_reason. Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -20,6 +23,11 @@ models:
         data_type: string
         description: >-
           FK to dim_regions. Surrogate key derived from region_name.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_regions')
+            to_columns: [region_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate key derived from _dbt_source_relation and the PowerSchool
           personid. Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -13,6 +13,9 @@ models:
           Surrogate key derived from student_number, _dbt_source_relation,
           academic_year, and entrydate. Primary key for this dimension — matches
           the uniqueness grain on int_extracts__student_enrollments.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,9 +24,18 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from student_number. FK to dim_students.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_students')
+                field: student_key
       - name: location_key
         data_type: string
         description: >-
@@ -31,6 +43,16 @@ models:
           Null when schoolid does not match any location in the crosswalk (e.g.,
           grade_level 99 placeholder schools).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: entry_date_key
         data_type: date
         description: >-
@@ -42,6 +64,16 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: entrydate
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: exit_date_key
         data_type: date
         description: >-
@@ -55,6 +87,16 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: exitdate
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -14,6 +14,9 @@ models:
         description: >-
           Surrogate key derived from cc_dcid and _dbt_source_relation. Primary
           key for this dimension — unique per CC record per region.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -25,14 +28,33 @@ models:
           academic_year, and entrydate. FK to dim_student_enrollments. Null when
           no matching student enrollment record covers the CC dateenrolled.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: course_section_key
         data_type: string
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_relation. FK
           to dim_course_sections.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_course_sections')
+            to_columns: [course_section_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_course_sections')
+                field: course_section_key
       - name: term_key
         data_type: string
         description: >-
@@ -41,6 +63,16 @@ models:
           the course-enrollment's term ID does not match any reporting term for
           the section's school and region.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -10,6 +10,9 @@ models:
         description: >-
           Surrogate key derived from student_number. Primary key for the student
           dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from survey_id and term composite fields.
           Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -20,17 +23,35 @@ models:
         data_type: string
         description: >-
           FK to dim_surveys. Surrogate key derived from survey_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_surveys')
+            to_columns: [survey_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_surveys')
+                field: survey_key
       - name: term_key
         data_type: string
         description: >-
           FK to dim_terms. Surrogate key derived from term composite fields
           (type, code, name, start_date, region, school_id).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_expectations.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate key derived from survey_administration_key, respondent_type,
           and the three respondent FK columns. Primary key for this dimension.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,9 +25,18 @@ models:
         description: >-
           FK to dim_survey_administrations. Identifies which survey
           administration this expectation belongs to.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_survey_administrations')
+            to_columns: [survey_administration_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_survey_administrations')
+                field: survey_administration_key
       - name: respondent_type
         data_type: string
         description: >-
@@ -45,14 +57,44 @@ models:
           FK to dim_staff. Populated when respondent_type is staff. Null for
           student and family respondents.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: student_enrollment_key
         data_type: string
         description: >-
           FK to dim_student_enrollments. Populated when respondent_type is
           student. Null for staff and family respondents.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: student_contact_person_key
         data_type: string
         description: >-
           FK to dim_student_contact_persons. Populated when respondent_type is
           family. Null for staff and student respondents.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_contact_persons')
+            to_columns: [student_contact_person_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_contact_persons')
+                field: student_contact_person_key

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_questions.yml
@@ -14,6 +14,9 @@ models:
           Surrogate key derived from question_shortname. Primary key for this
           dimension. Generated with
           generate_surrogate_key(["question_shortname"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_surveys.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_surveys.yml
@@ -11,6 +11,9 @@ models:
         description: >-
           Surrogate key derived from survey_id. Primary key for the survey
           dimension. Generated with generate_surrogate_key(["survey_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
@@ -14,6 +14,9 @@ models:
           code, name, start date, region, and school ID as internal inputs;
           region and school ID are not exposed as mart columns (reachable via
           region_key and location_key FK traversal).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,11 @@ models:
           Foreign key to dim_regions. Surrogate key derived from the canonical
           region. Nullable for org-wide periods and for terms whose school is
           not mapped to a region.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_regions')
+            to_columns: [region_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -36,6 +44,11 @@ models:
           Foreign key to dim_locations. Surrogate key derived from the location
           name. Nullable when the period is region-wide or when the school is
           not present in dim_locations.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
@@ -15,6 +15,9 @@ models:
           effective_date_start. Generated with
           generate_surrogate_key(["item_id", "assignment_type",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
@@ -13,6 +13,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -36,6 +44,11 @@ models:
           to dim_staff identifying the manager this work assignment reports to.
           Null when the manager's associate_oid has no active number mapping in
           stg_people__employee_numbers.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
@@ -13,6 +13,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
@@ -92,7 +92,7 @@ select
     overall_tier as overall_rating,
     observation_notes as notes,
 
-    observed_at_date as observed_date,
+    observed_at_date as observed_date_key,
     observed_at_timestamp as observed_timestamp,
     glows as positive_feedback,
     grows as growth_areas,

--- a/src/dbt/kipptaf/models/marts/facts/fct_support_tickets.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_support_tickets.sql
@@ -14,13 +14,23 @@ select
     {{ dbt_utils.generate_surrogate_key(["submitter.employee_number"]) }}
     as submitter_staff_key,
 
-    {{ dbt_utils.generate_surrogate_key(["assignee.employee_number"]) }}
-    as assignee_staff_key,
+    if(
+        assignee.employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["assignee.employee_number"]) }},
+        cast(null as string)
+    ) as assignee_staff_key,
 
-    {{ dbt_utils.generate_surrogate_key(["orig_assignee.employee_number"]) }}
-    as original_assignee_staff_key,
+    if(
+        orig_assignee.employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["orig_assignee.employee_number"]) }},
+        cast(null as string)
+    ) as original_assignee_staff_key,
 
-    {{ dbt_utils.generate_surrogate_key(["cf.location"]) }} as location_key,
+    if(
+        cf.location is not null,
+        {{ dbt_utils.generate_surrogate_key(["cf.location"]) }},
+        cast(null as string)
+    ) as location_key,
 
     cast(t.created_at as date) as created_date_key,
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -10,6 +10,9 @@ models:
         data_type: string
         description: >-
           Surrogate key. Primary key for this fact table.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -19,6 +22,16 @@ models:
         description: >-
           FK to dim_assessments.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_assessments')
+            to_columns: [assessment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_assessments')
+                field: assessment_key
       - name: student_key
         data_type: string
         description: >-
@@ -26,11 +39,31 @@ models:
           state_student_id for FL state assessments where student_number is
           null. FL fallback keys do not resolve in dim_students (#3626).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_students')
+                field: student_key
       - name: test_date_key
         data_type: date
         description: >-
           FK to dim_dates. The date the assessment was taken.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -11,6 +11,9 @@ models:
         data_type: string
         description: >-
           Surrogate key. Primary key for this fact table.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -20,17 +23,47 @@ models:
         description: >-
           FK to dim_students. Derived from student_number.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_students')
+            to_columns: [student_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_students')
+                field: student_key
       - name: assessment_key
         data_type: string
         description: >-
           FK to dim_assessments.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_assessments')
+            to_columns: [assessment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_assessments')
+                field: assessment_key
       - name: test_date_key
         data_type: date
         description: >-
           FK to dim_dates. The date the assessment was taken. Null for AP exams
           where only the academic year is recorded.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from incident_id, incident_penalty_id, and
           _dbt_source_relation. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,9 +24,18 @@ models:
         description: >-
           FK to fct_behavioral_incidents. Surrogate key derived from incident_id
           and _dbt_source_relation.
+        constraints:
+          - type: foreign_key
+            to: ref('fct_behavioral_incidents')
+            to_columns: [behavioral_incident_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('fct_behavioral_incidents')
+                field: behavioral_incident_key
       - name: start_date_key
         data_type: date
         description: >-
@@ -34,6 +46,16 @@ models:
             source_system: DeansList
             source_model: int_deanslist__incidents__penalties
             source_column: start_date
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: end_date_key
         data_type: date
         description: >-
@@ -44,6 +66,16 @@ models:
             source_system: DeansList
             source_model: int_deanslist__incidents__penalties
             source_column: end_date
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: type
         quote: true
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate key derived from incident_id and _dbt_source_relation.
           Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,9 +25,18 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: referring_staff_key
         data_type: string
         description: >-
@@ -32,6 +44,11 @@ models:
           from the DeansList user's email resolved to an employee_number via
           int_people__staff_roster, then hashed with generate_surrogate_key.
           Nullable when the DeansList user cannot be matched to a staff record.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -44,6 +61,16 @@ models:
           FK to dim_dates for the date the incident was created. Matches
           dim_dates.date_key.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-
@@ -111,9 +138,29 @@ models:
           FK to dim_dates for the date the incident was closed. Matches
           dim_dates.date_key. Nullable — open incidents have no close date.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: return_date_key
         data_type: date
         description: >-
           FK to dim_dates for the date the student is expected to return.
           Matches dim_dates.date_key. Nullable — not all incidents have a return
           date.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from record_id and _dbt_source_relation. Primary
           key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,9 +24,18 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: communicator_staff_key
         data_type: string
         description: >-
@@ -31,6 +43,11 @@ models:
           Derived from the DeansList user's email resolved to an employee_number
           via int_people__staff_roster, then hashed with generate_surrogate_key.
           Nullable when the DeansList user cannot be matched to a staff record.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -42,6 +59,16 @@ models:
         description: >-
           Date the communication occurred. FK to dim_dates.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -14,6 +14,9 @@ models:
         description: >-
           Surrogate key derived from assignmentsectionid, _dbt_source_relation,
           and students_dcid. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,17 +26,35 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_relation.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_section_enrollments')
+            to_columns: [student_section_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_section_enrollments')
+                field: student_section_enrollment_key
       - name: student_enrollment_key
         data_type: string
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: term_key
         data_type: string
         description: >-
@@ -41,6 +62,16 @@ models:
           start_date, region, and school_id. Null when due_date does not fall
           within any reporting term for the school and region.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: due_date_key
         data_type: date
         description: >-
@@ -52,6 +83,16 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__assignmentsection
             source_column: duedate
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate key derived from cc_dcid, _dbt_source_relation, storecode,
           and storecode_type. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,9 +25,18 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_relation.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_section_enrollments')
+            to_columns: [student_section_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_section_enrollments')
+                field: student_section_enrollment_key
       - name: term_key
         data_type: string
         description: >-
@@ -32,6 +44,16 @@ models:
           start_date, region, and school_id. Null when storecode does not map to
           a reporting term for the school and region.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
@@ -14,6 +14,9 @@ models:
           Surrogate key derived from student_number, _dbt_source_relation,
           academic_year, entrydate, and term_name. Grain: one row per
           student_enrollment x term, per spec.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,9 +26,18 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: term_key
         data_type: string
         description: >-
@@ -33,6 +45,11 @@ models:
           start_date, region, and school_id of the matching reporting term. Null
           when the PowerSchool term / year / school does not map to a
           reporting-term record.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate key derived from cc_dcid, _dbt_source_relation, and
           storecode. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,17 +25,35 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_relation.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_section_enrollments')
+            to_columns: [student_section_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_section_enrollments')
+                field: student_section_enrollment_key
       - name: student_enrollment_key
         data_type: string
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: term_key
         data_type: string
         description: >-
@@ -40,18 +61,48 @@ models:
           start_date, region, and school_id. Null when storecode does not map to
           a reporting term for the school and region.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: term_start_date_key
         data_type: date
         description: >-
           Start date of the term bin. FK to dim_dates (role-playing as term
           start date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: term_end_date_key
         data_type: date
         description: >-
           End date of the term bin. FK to dim_dates (role-playing as term end
           date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate primary key derived from application_id. Generated with
           generate_surrogate_key(["application_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,15 +24,29 @@ models:
         description: >-
           Foreign key to dim_job_candidates. Surrogate key derived from
           candidate_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_job_candidates')
+            to_columns: [job_candidate_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_job_candidates')
+                field: job_candidate_key
       - name: shared_with_location_key
         data_type: string
         description: >-
           Foreign key to dim_locations for the location this application is
           shared with. Surrogate key derived from school_shared_with. Nullable
           when the application has no shared location.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3672 — ~20% rows fail FK; promote to error
           # once upstream crosswalk covers `KIPP High School` and siblings.
@@ -37,21 +54,38 @@ models:
               arguments:
                 to: ref('dim_locations')
                 field: location_key
-              config:
-                severity: warn
-
       - name: job_posting_key
         data_type: string
         description: >-
           Foreign key to dim_job_postings. Surrogate key derived from job_title,
           department_internal, and job_city.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_job_postings')
+            to_columns: [job_posting_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_job_postings')
+                field: job_posting_key
       - name: created_date_key
         data_type: date
         description: >-
           Foreign key to dim_dates for the date the application entered the New
           stage. Matches dim_dates.date_key.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: state
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
@@ -17,6 +17,9 @@ models:
           attrition_type. Generated with
           generate_surrogate_key(["employee_number", "academic_year",
           "attrition_type"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -29,6 +32,11 @@ models:
           retained staff (9/1 for foundation/recruitment, 7/1 for
           nj_compliance), termination effective date for attritors. Null when no
           matching status version exists.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_status')
+            to_columns: [staff_status_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
@@ -13,6 +13,9 @@ models:
           plan_name, and enrollment_start_date. Generated with
           generate_surrogate_key(["employee_number", "plan_type", "plan_name",
           "enrollment_start_date"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
@@ -13,6 +13,9 @@ models:
           and effective_date. Generated with
           generate_surrogate_key(["employee_number", "membership_code",
           "effective_date"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
@@ -14,6 +14,9 @@ models:
           assignment_id, and goal tag_id. Generated with
           generate_surrogate_key(["gu.internal_id_int", "a.assignment_id",
           "m.tag_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,14 +26,28 @@ models:
         description: >-
           Foreign key to dim_staff for the teacher receiving the goal. Surrogate
           key derived from employee_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: staff_observation_goal_type_key
         data_type: string
         description: >-
           Foreign key to dim_staff_observation_goal_types. Surrogate key derived
           from the goal tag_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_goal_types')
+            to_columns: [staff_observation_goal_type_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -45,6 +62,16 @@ models:
           Surrogate key derived from creator employee_number. May be null if the
           creator cannot be matched to the staff roster.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: assignment_date
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
@@ -12,6 +12,9 @@ models:
           Surrogate primary key derived from observation_id and measurement_id.
           Generated with generate_surrogate_key(["sd.observation_id",
           "sd.measurement_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,6 +24,11 @@ models:
         description: >-
           Foreign key to fct_staff_observations. Surrogate key derived from
           observation_id.
+        constraints:
+          - type: foreign_key
+            to: ref('fct_staff_observations')
+            to_columns: [staff_observation_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -34,6 +42,16 @@ models:
           Foreign key to dim_staff_observation_rubric_measurements. Surrogate
           key derived from rubric_id and measurement_id.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_rubric_measurements')
+            to_columns: [staff_observation_rubric_measurement_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff_observation_rubric_measurements')
+                field: staff_observation_rubric_measurement_key
       - name: text_box_content
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -13,6 +13,9 @@ models:
         description: >-
           Surrogate primary key derived from observation_id. Generated with
           generate_surrogate_key(["o.observation_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,9 +25,18 @@ models:
         description: >-
           Foreign key to dim_staff for the observed teacher. Surrogate key
           derived from employee_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: staff_observation_type_key
         data_type: string
         description: >-
@@ -32,6 +44,11 @@ models:
           the SchoolMint Grow generic tag_id for the observation type. Null when
           the observation type abbreviation does not resolve to an active
           observationtypes tag.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_types')
+            to_columns: [staff_observation_type_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -43,6 +60,11 @@ models:
         description: >-
           Foreign key to dim_staff_observation_rubrics. Surrogate key derived
           from rubric_id. Null when the observation has no rubric attached.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_rubrics')
+            to_columns: [staff_observation_rubric_key]
+            warn_unsupported: false
         data_tests:
           # TODO: #3712 — dim source is measurement-grain, excludes rubrics
           # without nested measurements. Promote to error once resolved.
@@ -57,18 +79,48 @@ models:
           Foreign key to dim_staff for the observer. Surrogate key derived from
           observer_employee_number.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: location_key
         data_type: string
         description: >-
           Foreign key to dim_locations. Surrogate key derived from the school's
           location_clean_name.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: term_key
         data_type: string
         description: >-
           Foreign key to dim_terms. Surrogate key derived from term composite
           fields.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -121,6 +121,22 @@ models:
               arguments:
                 to: ref('dim_terms')
                 field: term_key
+
+      - name: observed_date_key
+        data_type: date
+        description: >-
+          Local date the observation was conducted. Foreign key to dim_dates.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
+
       - name: academic_year
         data_type: int64
         description: >-
@@ -144,11 +160,6 @@ models:
         data_type: string
         description: >-
           Free-text observation notes (magic notes or shared notes).
-
-      - name: observed_date
-        data_type: date
-        description: >-
-          Local date the observation was conducted.
 
       - name: observed_timestamp
         data_type: timestamp

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -30,6 +30,9 @@ models:
         description: >-
           Surrogate key derived from student_number, _dbt_source_relation, and
           calendardate. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -39,21 +42,50 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: date_key
         data_type: date
         description: >-
           Calendar date of the attendance record. FK to dim_dates. Also used
           with location_key to join dim_school_calendars.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: location_key
         data_type: string
         description: >-
           FK to dim_locations. Surrogate key derived from location_clean_name.
           Used with date_key to join dim_school_calendars.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_locations')
+                field: location_key
       - name: term_key
         data_type: string
         description: >-
@@ -62,10 +94,13 @@ models:
           stg_google_sheets__reporting__terms on (schoolid, term,
           academic_year). Null when the attendance row's term does not appear in
           the terms sheet for that school-year.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
-              config:
-                severity: warn
               arguments:
                 to: ref('dim_terms')
                 field: term_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
@@ -14,6 +14,9 @@ models:
           Surrogate key derived from student_number, academic_year, and the comm
           log reason that identifies the intervention type. Primary key for this
           fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,14 +26,28 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: intervention_type_key
         data_type: string
         description: >-
           FK to dim_student_attendance_intervention_types. Surrogate key derived
           from region_name and family_communication_reason.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_attendance_intervention_types')
+            to_columns: [intervention_type_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -43,6 +60,11 @@ models:
           FK to fct_family_communications. Surrogate key derived from the
           DeansList comm log record_id and _dbt_source_relation. Nullable when
           no matching communication was logged (intervention is not complete).
+        constraints:
+          - type: foreign_key
+            to: ref('fct_family_communications')
+            to_columns: [family_communication_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
@@ -55,6 +77,16 @@ models:
           Date the communication was logged. FK to dim_dates. Null when the
           intervention is missing (not yet completed).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
@@ -12,6 +12,9 @@ models:
         description: >-
           Surrogate key derived from streak_id and _dbt_source_relation. Primary
           key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -21,21 +24,50 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_relation, academic_year, and entrydate.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: streak_start_date_key
         data_type: date
         description: >-
           First date of the streak. FK to dim_dates (role-playing as streak
           start date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: streak_end_date_key
         data_type: date
         description: >-
           Last date of the streak. FK to dim_dates (role-playing as streak end
           date).
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
@@ -15,6 +15,9 @@ models:
         description: >-
           Surrogate primary key derived from ticket id. Generated with
           generate_surrogate_key(["t.id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -24,9 +27,18 @@ models:
         description: >-
           Foreign key to dim_staff for the ticket submitter. Surrogate key
           derived from submitter employee_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: assignee_staff_key
         data_type: string
         description: >-
@@ -34,6 +46,16 @@ models:
           key derived from assignee employee_number. Nullable — unassigned
           tickets have no assignee.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: original_assignee_staff_key
         data_type: string
         description: >-
@@ -41,6 +63,16 @@ models:
           Surrogate key derived from original assignee employee_number. Nullable
           — not all tickets have a creation-time assignee.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: location_key
         data_type: string
         description: >-
@@ -48,22 +80,33 @@ models:
           custom field value on the ticket. Currently fails 100% relationships
           against dim_locations pending Zendesk-slug → canonical-location
           crosswalk (#3709).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_locations')
+            to_columns: [location_key]
+            warn_unsupported: false
         data_tests:
           - relationships:
               arguments:
                 to: ref('dim_locations')
                 field: location_key
-              config:
-                severity: warn
-
       - name: created_date_key
         data_type: date
         description: >-
           Foreign key to dim_dates for the date the ticket was created. Matches
           dim_dates.date_key.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: solved_date_key
         data_type: date
         description: >-
@@ -71,6 +114,16 @@ models:
           dim_dates.date_key. Nullable — open or pending tickets have no solved
           date.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: status
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -13,6 +13,9 @@ models:
           Surrogate key derived from survey_id, survey_response_id,
           respondent_identifier, and question_shortname. Primary key for this
           fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,17 +25,35 @@ models:
         description: >-
           FK to fct_survey_submissions. Links this response to its parent
           submission record.
+        constraints:
+          - type: foreign_key
+            to: ref('fct_survey_submissions')
+            to_columns: [survey_submission_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('fct_survey_submissions')
+                field: survey_submission_key
       - name: survey_question_key
         data_type: string
         description: >-
           FK to dim_survey_questions. Identifies which question this response
           answers.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_survey_questions')
+            to_columns: [survey_question_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_survey_questions')
+                field: survey_question_key
       - name: response_value
         data_type: numeric
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -14,6 +14,9 @@ models:
         description: >-
           Surrogate key derived from survey_id, survey_response_id, and
           respondent identifier. Primary key for this fact.
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -23,15 +26,34 @@ models:
         description: >-
           FK to dim_survey_administrations. Identifies which survey
           administration this submission belongs to.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_survey_administrations')
+            to_columns: [survey_administration_key]
+            warn_unsupported: false
         data_tests:
           - not_null
 
+          - relationships:
+              arguments:
+                to: ref('dim_survey_administrations')
+                field: survey_administration_key
       - name: date_submitted_key
         data_type: date
         description: >-
           FK to dim_dates (role-playing as submission date). The local date the
           survey was submitted.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: respondent_type
         data_type: string
         description: >-
@@ -52,18 +74,48 @@ models:
           FK to dim_staff for the respondent. Populated when respondent_type is
           staff. Null for student and family.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: student_enrollment_key
         data_type: string
         description: >-
           FK to dim_student_enrollments for the respondent. Populated when
           respondent_type is student. Null for staff and family.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_enrollments')
+            to_columns: [student_enrollment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_enrollments')
+                field: student_enrollment_key
       - name: student_contact_person_key
         data_type: string
         description: >-
           FK to dim_student_contact_persons for the respondent. Populated when
           respondent_type is family. Null for staff and student.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_contact_persons')
+            to_columns: [student_contact_person_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_contact_persons')
+                field: student_contact_person_key
       - name: subject_staff_key
         data_type: string
         description: >-
@@ -72,6 +124,16 @@ models:
           (direct report) evaluates their manager (subject). Null for all other
           survey types.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
@@ -15,6 +15,9 @@ models:
           effective_date_start. Generated with
           generate_surrogate_key(["item_id", "earning_item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -24,6 +27,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -37,6 +45,16 @@ models:
           Role-playing FK to dim_dates. The date this earnings version became
           effective, from additionalRemunerations.effectiveDate.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: effective_end_date_key
         data_type: date
         description: >-
@@ -45,6 +63,16 @@ models:
           effective_start_date_key (within the same assignment and earning
           type), or 9999-12-31 for the current version.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: earning_code
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
@@ -13,6 +13,9 @@ models:
           Surrogate primary key derived from item_id and effective_date_start.
           Generated with generate_surrogate_key(["item_id",
           "effective_date_start"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
         data_tests:
           - unique
           - not_null
@@ -22,6 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_work_assignments')
+            to_columns: [work_assignment_key]
+            warn_unsupported: false
         data_tests:
           - not_null
           - relationships:
@@ -35,6 +43,16 @@ models:
           Role-playing FK to dim_dates. The date this compensation version
           became effective, from ADP baseRemuneration.effectiveDate.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: effective_end_date_key
         data_type: date
         description: >-
@@ -42,6 +60,16 @@ models:
           effective. Computed as one day before the next version's
           effective_start_date_key, or 9999-12-31 for the current version.
 
+        constraints:
+          - type: foreign_key
+            to: ref('dim_dates')
+            to_columns: [date_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_dates')
+                field: date_key
       - name: annual_wage
         data_type: numeric
         description: >-


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will expose machine-readable PK/FK relationships on every `kipptaf` marts model, unblocking Cube.js semantic layer setup. Closes #3713.

- Adds `primary_key` constraint on every mart's surrogate key (column-level for
  single-column PKs; model-level composite for the 3 bridges + `dim_school_calendars`).
- Adds `foreign_key` constraint + `relationships` test on every FK column
  (~70 new relationships tests; inherits project-default severity `warn`).
- Strips redundant explicit `severity: warn` from 4 existing tests.
- Drops three R9-violating plumbing columns (raw natural key sitting next to its
  own surrogate):
  - `dim_staff_observation_rubric_measurements.strand_key`
  - `dim_staff_observation_rubric_measurements.measurement_key`
  - `dim_staffing_positions.staffing_position_natural_key`

All constraints carry `warn_unsupported: false` because marts materialize as
views — constraints are informational-only metadata in `manifest.json` for
downstream tooling (Cube). No change to compiled SQL for the 66 models that
didn't have plumbing drops; no surrogate-key hashes change.

Structural FK integrity issues tracked under #3631 are out of scope — the new
relationships tests will surface them at `warn` until those are resolved.

## AI Assistance

AI-assisted (Claude Code):

- Bulk YAML transform via `ruamel.yaml` round-trip script.
- Audit inventory + FK target map.

Human-directed:

- FK target disambiguation (student→dim_students, course_section→dim_course_sections,
  all `*_date_key`→dim_dates).
- Scope decision to drop the three plumbing columns in this refactor.
- Severity policy (project default inherited; no per-test override).

## Self-review

### dbt

- [x] `dbt parse --target dev` clean, no warnings
- [x] `manifest.json` spot-checked: PK/FK constraints carry `to` + `to_columns`
      for Cube consumption
- [x] `trunk check --ci` clean
- [ ] No column removals from contracted marts that aren't dropped plumbing
      (three drops are documented above; no downstream consumer references them)

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes (relationships tests may emit warnings; that's
      expected per #3631)
