### PR TITLE
fix(tableau): cast max_score to int64 in college assessment benchmark calcs

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -78,7 +78,7 @@ models:
           area across all assessment administrations. Null for students with no
           qualifying score. Used as the score value for benchmark percent-met
           calculations in Tableau.
-        data_type: numeric
+        data_type: int64
       - name: benchmark_name
         description: >
           Readiness benchmark label. One of College-Ready, HS-Ready, EA/ED-Ready

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -103,8 +103,10 @@ with
             s.score_type,
             s.scale_score,
 
-            max(s.scale_score) over (
-                partition by e.student_number, e.aligned_scope, e.subject_area
+            cast(
+                max(s.scale_score) over (
+                    partition by e.student_number, e.aligned_scope, e.subject_area
+                ) as int64
             ) as max_score,
 
         from scaffold as e


### PR DESCRIPTION
## Summary

- Casts `max_score` from `NUMERIC` to `INT64` in `rpt_tableau__college_assessment_dashboard_benchmark_calcs`
- Updates the dbt contract YAML to reflect the new `int64` type
- Fixes Tableau error 9773A965 ("Cannot expand domain of data type string with a value of data type real") caused by a type mismatch between the `NUMERIC` `max_score` field (which Tableau maps to Real) and the Integer benchmark goal parameters

## Test plan

- [ ] Confirm dbt model compiles and runs cleanly against staging
- [ ] Verify Tableau workbook no longer throws error 9773A965 on the `Met Benchmark Goal Status` field after refreshing the data source

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214244015850864