### PR TITLE
feat(tableau): add benchmark_goal and met_benchmark_goal to college assessment benchmark calcs

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -82,7 +82,17 @@ models:
       - name: benchmark_name
         description: >
           Readiness benchmark label. One of College-Ready, HS-Ready, EA/ED-Ready
-          (for Combined rows) or EBRW, Math (for subject-specific rows). Tableau
-          consumers filter to a single benchmark_name and compare max_score
-          against a dynamic threshold parameter to compute percent met.
+          (for Combined rows) or EBRW, Math (for subject-specific rows).
+        data_type: string
+      - name: benchmark_goal
+        description: >
+          Hardcoded score threshold for the benchmark. Derived from
+          benchmark_group — each scope/subject_area/benchmark_name combination
+          maps to a fixed integer cutoff.
+        data_type: int64
+      - name: met_benchmark_goal
+        description: >
+          Whether the student met the benchmark. Met if max_score >=
+          benchmark_goal, Not Met otherwise, No Data if the student has no
+          qualifying score.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_benchmark_calcs.yml
@@ -16,6 +16,27 @@ models:
               - aligned_scope
               - benchmark_name
     columns:
+      - name: benchmark_goal
+        description: >
+          Hardcoded score threshold for the benchmark. Derived from
+          benchmark_group — each scope/subject_area/benchmark_name combination
+          maps to a fixed integer cutoff.
+        data_type: int64
+        data_tests:
+          - not_null
+      - name: met_benchmark_goal
+        description: >
+          Whether the student met the benchmark. Met if max_score >=
+          benchmark_goal, Not Met otherwise, No Data if the student has no
+          qualifying score.
+        data_type: string
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - Met
+                  - Not Met
+                  - No Data
       - name: region
         description: KIPP region the student's school belongs to.
         data_type: string
@@ -83,16 +104,4 @@ models:
         description: >
           Readiness benchmark label. One of College-Ready, HS-Ready, EA/ED-Ready
           (for Combined rows) or EBRW, Math (for subject-specific rows).
-        data_type: string
-      - name: benchmark_goal
-        description: >
-          Hardcoded score threshold for the benchmark. Derived from
-          benchmark_group — each scope/subject_area/benchmark_name combination
-          maps to a fixed integer cutoff.
-        data_type: int64
-      - name: met_benchmark_goal
-        description: >
-          Whether the student met the benchmark. Met if max_score >=
-          benchmark_goal, Not Met otherwise, No Data if the student has no
-          qualifying score.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_benchmark_calcs.sql
@@ -17,6 +17,40 @@ with
             regexp_extract(benchmark_group, r'^.+_([^_]+)_[^_]+$') as subject_area,
             regexp_extract(benchmark_group, r'_([^_]+)$') as benchmark_name,
 
+            case
+                benchmark_group
+                when 'PSAT 8/9_EBRW_EBRW'
+                then 410
+                when 'PSAT10/NMSQT_EBRW_EBRW'
+                then 430
+                when 'SAT_EBRW_EBRW'
+                then 480
+                when 'PSAT 8/9_Math_Math'
+                then 450
+                when 'PSAT10/NMSQT_Math_Math'
+                then 480
+                when 'SAT_Math_Math'
+                then 530
+                when 'PSAT 8/9_Combined_College-Ready'
+                then 860
+                when 'PSAT 8/9_Combined_EA/ED-Ready'
+                then 1100
+                when 'PSAT 8/9_Combined_HS-Ready'
+                then 800
+                when 'PSAT10/NMSQT_Combined_College-Ready'
+                then 910
+                when 'PSAT10/NMSQT_Combined_EA/ED-Ready'
+                then 1100
+                when 'PSAT10/NMSQT_Combined_HS-Ready'
+                then 840
+                when 'SAT_Combined_College-Ready'
+                then 1010
+                when 'SAT_Combined_EA/ED-Ready'
+                then 1200
+                when 'SAT_Combined_HS-Ready'
+                then 890
+            end as benchmark_goal,
+
         from {{ ref("int_extracts__student_enrollments") }}
         cross join
             unnest(
@@ -98,6 +132,7 @@ with
             e.aligned_scope,
             e.subject_area,
             e.benchmark_name,
+            e.benchmark_goal,
 
             s.test_type,
             s.score_type,
@@ -135,5 +170,14 @@ select
     subject_area,
     max_score,
     benchmark_name,
+    benchmark_goal,
+
+    case
+        when max_score is null
+        then 'No Data'
+        when max_score >= benchmark_goal
+        then 'Met'
+        else 'Not Met'
+    end as met_benchmark_goal,
 
 from base


### PR DESCRIPTION
## Summary

- Adds `benchmark_goal` (INT64) to the scaffold CTE via a `CASE` on `benchmark_group`, hardcoding the score threshold for each scope/subject/benchmark combination
- Propagates `benchmark_goal` through the `base` CTE to the final `SELECT`
- Adds `met_benchmark_goal` (STRING) to the final `SELECT` — `'Met'` / `'Not Met'` / `'No Data'` — computed as a simple comparison of `max_score >= benchmark_goal`
- Moves all benchmark threshold logic out of Tableau calculated fields and into the dbt model, eliminating the Tableau type-mismatch error (Error 9773A965) that occurred when filtering on string fields derived from numeric comparisons

## Test plan

- [ ] Confirm dbt model compiles and runs cleanly against staging
- [ ] Verify `benchmark_goal` values are correct for each scope/subject/benchmark combination
- [ ] Verify `met_benchmark_goal` returns `Met`, `Not Met`, and `No Data` as expected
- [ ] Refresh Tableau extract and confirm `met_benchmark_goal` can be added to the filter shelf without error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)