### PR TITLE
Add goal_numeric and goal_integer columns to topline models

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__topline_cascade_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__topline_cascade_dashboard.yml
@@ -41,6 +41,16 @@ models:
         data_type: string
       - name: goal
         data_type: numeric
+      - name: goal_numeric
+        data_type: numeric
+        description:
+          NULL values for all goals not numeric in data type - for Tableau
+          formatting
+      - name: goal_integer
+        data_type: int64
+        description:
+          NULL values for all goals not integer in data type - for Tableau
+          formatting
       - name: metric_aggregate_value
         data_type: float64
       - name: metric_aggregate_value_numeric

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__topline_cascade_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__topline_cascade_dashboard.sql
@@ -19,6 +19,8 @@ select
     db.aggregation_hash,
     db.aggregation_display,
     db.goal,
+    db.goal_numeric,
+    db.goal_integer,
     db.metric_aggregate_value,
     db.metric_aggregate_value_numeric,
     db.metric_aggregate_value_integer,

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__dashboard_aggregations.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__dashboard_aggregations.sql
@@ -41,6 +41,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -80,7 +82,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
 
         union all
 
@@ -108,6 +112,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -144,7 +150,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
 
         union all
 
@@ -172,6 +180,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -206,7 +216,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
     ),
 
     enrollment as (
@@ -289,6 +301,8 @@ with
             tg.aggregation_hash,
             tg.aggregation_display,
             tg.goal,
+            tg.goal_numeric,
+            tg.goal_integer,
 
             round(
                 safe_divide(tu.metric_aggregate_value, tu.goal), 3
@@ -324,6 +338,8 @@ with
             aggregation_hash,
             aggregation_display,
             goal,
+            goal_numeric,
+            goal_integer,
             metric_aggregate_value,
         from pre_agg_union_student
 
@@ -350,6 +366,8 @@ with
             aggregation_hash,
             aggregation_display,
             goal,
+            goal_numeric,
+            goal_integer,
             metric_aggregate_value,
         from target_goals
 
@@ -378,6 +396,8 @@ with
             aggregation_hash,
             aggregation_display,
             goal,
+            goal_numeric,
+            goal_integer,
             metric_aggregate_value,
         from {{ ref("int_topline__student_retention_weekly_aggregations") }}
     ),
@@ -407,6 +427,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -444,7 +466,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
 
         union all
 
@@ -474,6 +498,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -508,7 +534,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
 
         union all
 
@@ -538,6 +566,8 @@ with
             g.aggregation_hash,
             g.aggregation_display,
             g.goal,
+            g.goal_numeric,
+            g.goal_integer,
 
             case
                 g.aggregation_type
@@ -571,7 +601,9 @@ with
             g.aggregation_type,
             g.aggregation_hash,
             g.aggregation_display,
-            g.goal
+            g.goal,
+            g.goal_numeric,
+            g.goal_integer
 
         union all
 
@@ -600,6 +632,8 @@ with
             aggregation_hash,
             aggregation_display,
             goal,
+            goal_numeric,
+            goal_integer,
             metric_aggregate_value,
         from {{ ref("int_topline__seats_staffed_weekly_aggregations") }}
     )

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__seats_staffed_weekly_aggregations.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__seats_staffed_weekly_aggregations.sql
@@ -37,6 +37,8 @@ with
             aggregation_hash,
             aggregation_display,
             goal,
+            goal_numeric,
+            goal_integer,
             layer,
             topline_indicator,
         from {{ ref("int_google_sheets__topline_aggregate_goals") }}
@@ -84,6 +86,8 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator as indicator,
 
@@ -112,6 +116,8 @@ group by
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator
 
@@ -138,6 +144,8 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator as indicator,
 
@@ -160,6 +168,8 @@ group by
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator
 
@@ -186,6 +196,8 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator as indicator,
 
@@ -207,5 +219,7 @@ group by
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
     g.layer,
     g.topline_indicator

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__student_retention_weekly_aggregations.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__student_retention_weekly_aggregations.sql
@@ -47,6 +47,10 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
+    g.goal_numeric,
+    g.goal_integer,
 
     'Student and Family Experience' as layer,
     'Student Retention' as indicator,
@@ -77,7 +81,9 @@ group by
     g.aggregation_type,
     g.aggregation_hash,
     g.aggregation_display,
-    g.goal
+    g.goal,
+    g.goal_numeric,
+    g.goal_integer
 
 union all
 
@@ -102,6 +108,10 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
+    g.goal_numeric,
+    g.goal_integer,
 
     'Student and Family Experience' as layer,
     'Student Retention' as indicator,
@@ -129,7 +139,9 @@ group by
     g.aggregation_type,
     g.aggregation_hash,
     g.aggregation_display,
-    g.goal
+    g.goal,
+    g.goal_numeric,
+    g.goal_integer
 
 union all
 
@@ -154,6 +166,10 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
+    g.goal_numeric,
+    g.goal_integer,
+    g.goal_numeric,
+    g.goal_integer,
 
     'Student and Family Experience' as layer,
     'Student Retention' as indicator,
@@ -179,4 +195,6 @@ group by
     g.aggregation_type,
     g.aggregation_hash,
     g.aggregation_display,
-    g.goal
+    g.goal,
+    g.goal_numeric,
+    g.goal_integer

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__student_retention_weekly_aggregations.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__student_retention_weekly_aggregations.sql
@@ -49,8 +49,6 @@ select
     g.goal,
     g.goal_numeric,
     g.goal_integer,
-    g.goal_numeric,
-    g.goal_integer,
 
     'Student and Family Experience' as layer,
     'Student Retention' as indicator,
@@ -110,8 +108,6 @@ select
     g.goal,
     g.goal_numeric,
     g.goal_integer,
-    g.goal_numeric,
-    g.goal_integer,
 
     'Student and Family Experience' as layer,
     'Student Retention' as indicator,
@@ -166,8 +162,6 @@ select
     g.aggregation_hash,
     g.aggregation_display,
     g.goal,
-    g.goal_numeric,
-    g.goal_integer,
     g.goal_numeric,
     g.goal_integer,
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add `goal_numeric` and `goal_integer` columns to the topline dashboard aggregation models and their downstream Tableau extract. These new columns provide type-specific versions of the `goal` field to enable better Tableau formatting and filtering capabilities.

The changes propagate these columns through:
- `int_topline__dashboard_aggregations.sql` (main aggregation logic)
- `int_topline__student_retention_weekly_aggregations.sql` (retention-specific aggregations)
- `int_topline__seats_staffed_weekly_aggregations.sql` (staffing-specific aggregations)
- `rpt_tableau__topline_cascade_dashboard.sql` (Tableau extract)
- `rpt_tableau__topline_cascade_dashboard.yml` (column documentation)

## Self-review

### dbt

- [x] Updated properties file (`rpt_tableau__topline_cascade_dashboard.yml`) with documentation for new columns
- [x] Changes are additive only — no breaking changes to existing columns
- [x] New columns include descriptions explaining their purpose for Tableau formatting

## CI checks

- [ ] **Trunk** — pending
- [ ] **dbt Cloud** — pending
- [ ] **Dagster Cloud** — not triggered (no Dagster changes)

https://claude.ai/code/session_01WBjht33zYAmcr5nzcEQHLF