### PR TITLE
fix(deanslist): revert transcript_gpas to pre-#3586 storedgrades-grouped per-year CTE

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_gpas.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_gpas.sql
@@ -1,31 +1,55 @@
-select
-    e.student_number,
-    e.academic_year,
+with
+    storedgrades_points as (
+        select
+            sg.academic_year,
 
-    g.gpa_y1 as `GPA_Y1_weighted`,
-    g.gpa_y1_unweighted as `GPA_Y1_unweighted`,
-from {{ ref("base_powerschool__student_enrollments") }} as e
-inner join
-    {{ ref("int_powerschool__gpa_term") }} as g
-    on e.studentid = g.studentid
-    and e.yearid = g.yearid
-    and e.schoolid = g.schoolid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="g") }}
-    and g.is_current
-where e.rn_year = 1
+            s.student_number,
+
+            cast(sg.potentialcrhrs as numeric) as potentialcrhrs,
+            cast(sg.potentialcrhrs as numeric)
+            * cast(sg.gpa_points as numeric) as weighted_points,
+
+            cast(sg.potentialcrhrs as numeric)
+            * cast(suw.grade_points as numeric) as unweighted_points,
+        from {{ ref("stg_powerschool__storedgrades") }} as sg
+        inner join
+            {{ ref("stg_powerschool__students") }} as s
+            on sg.studentid = s.id
+            and {{ union_dataset_join_clause(left_alias="sg", right_alias="s") }}
+        left outer join
+            {{ ref("int_powerschool__gradescaleitem_lookup") }} as suw
+            on {{ union_dataset_join_clause(left_alias="sg", right_alias="suw") }}
+            and sg.percent between suw.min_cutoffpercentage and suw.max_cutoffpercentage
+            and sg.gradescale_name_unweighted = suw.gradescale_name
+        where sg.storecode = 'Y1' and sg.excludefromgpa = 0
+    ),
+
+    points_rollup as (
+        select
+            student_number,
+            academic_year,
+            sum(weighted_points) as weighted_points,
+            sum(unweighted_points) as unweighted_points,
+            nullif(sum(potentialcrhrs), 0) as credit_hours,
+        from storedgrades_points
+        group by student_number, academic_year
+    )
+
+select
+    student_number,
+    academic_year,
+    round(weighted_points / credit_hours, 2) as `GPA_Y1_weighted`,
+    round(unweighted_points / credit_hours, 2) as `GPA_Y1_unweighted`,
+from points_rollup
 
 union all
 
 select
-    e.student_number,
+    student_number,
+
     null as academic_year,
 
-    c.cumulative_y1_gpa as `GPA_Y1_weighted`,
-    c.cumulative_y1_gpa_unweighted as `GPA_Y1_unweighted`,
-from {{ ref("int_extracts__student_enrollments") }} as e
-inner join
-    {{ ref("int_powerschool__gpa_cumulative") }} as c
-    on e.studentid = c.studentid
-    and e.schoolid = c.schoolid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="c") }}
-where e.rn_undergrad = 1
+    cumulative_y1_gpa as `GPA_Y1_weighted`,
+    cumulative_y1_gpa_unweighted as `GPA_Y1_unweighted`,
+from {{ ref("int_extracts__student_enrollments") }}
+where rn_undergrad = 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
