### PR TITLE
fix(dbt): batch D — staff observation FK fixes & lookup centralization

### DIFF
--- a/docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md
+++ b/docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md
@@ -1,0 +1,1425 @@
+# Batch D — Staff Observation FK Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate ~273K orphan FKs on staff observation rubric/measurement
+dims, add the missing observation-type FK to
+`dim_staff_observation_expectations`, and centralize the duplicated SchoolMint
+Grow observation-type lookup into a single intermediate.
+
+**Architecture:** Two-front fix. (1) Remove `_dagster_partition_key = 'f'`
+filters from two Grow staging models so archived rubrics/measurements appear in
+their dims, eliminating all rubric/measurement FK orphans. (2) Build a new
+`int_schoolmint_grow__observation_types` intermediate that pre-hashes
+`staff_observation_type_key` from Grow generic_tags; rewire
+`dim_staff_observation_types`, `int_schoolmint_grow__observations`, and
+`dim_staff_observation_expectations` to consume it. Pre-hash `term_key` and
+`staff_observation_rubric_key` upstream too, removing dead defensive `if()`
+wrappers and a no-op `row_number` dedup from `fct_staff_observations`.
+
+**Tech Stack:** dbt-core 1.11+, BigQuery, dbt_utils. Project:
+`src/dbt/kipptaf/`. All commands run via
+`uv run dbt <cmd> --project-dir=src/dbt/kipptaf/`.
+
+**Spec:**
+[docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md](../specs/2026-04-29-batch-d-staff-observation-fks-design.md).
+
+**Branch:** `cbini/fix/claude-batch-d-staff-observation-fks` (already created).
+
+---
+
+## File Map
+
+### Created
+
+- `src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql`
+- `src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml`
+
+### Modified
+
+- `src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql`
+  — drop partition filter
+- `src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql`
+  — drop partition filter
+- `src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml`
+  — describe convention deviation
+- `src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml`
+  — describe convention deviation
+- `src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql` —
+  ref new intermediate
+- `src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql`
+  — left-join new intermediate; pre-hash rubric_key
+- `src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml`
+  — uniqueness, not_null tests, new columns
+- `src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql`
+  — pre-hash term_key in both UNION branches
+- `src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml`
+  — close TODO with unique test, add `term_key` column
+- `src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql` — drop inline
+  CTE/joins/wrappers/dedup; consume pre-hashed keys
+- `src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql`
+  — add `staff_observation_type_key` FK
+- `src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml`
+  — new column with relationships test
+
+---
+
+## Working conventions
+
+- All `git add` commands name specific files explicitly (no `-A`/`-u`/`.`).
+- All commit messages use
+  [conventional commits](https://www.conventionalcommits.org/) (`fix(dbt): ...`,
+  `refactor(dbt): ...`, `test(dbt): ...`).
+- Trunk format runs as a PostToolUse hook on Edit/Write — do not run `trunk fmt`
+  manually.
+- Before pushing, run `/workspaces/teamster/.trunk/tools/trunk check --ci` from
+  the repo root.
+- dbt MCP `mcp__dbt__show` is available for ad-hoc compiled-SQL inspection
+  during the work; BigQuery MCP for verifying counts.
+
+---
+
+## Task 1 — Remove archived-partition filters from rubric/measurement staging
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql`
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql`
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml`
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml`
+
+- [ ] **Step 1.1: Drop the `_dagster_partition_key = 'f'` filter from the rubric
+      staging model.**
+
+Open
+`src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql`.
+Delete the final line:
+
+```sql
+where r._dagster_partition_key = 'f'
+```
+
+The model should end at `left join unnest(mg.measurements) as m`.
+
+- [ ] **Step 1.2: Drop the `_dagster_partition_key = 'f'` filter from the
+      measurement staging model.**
+
+Open
+`src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql`.
+Delete the final line:
+
+```sql
+where _dagster_partition_key = 'f'
+```
+
+- [ ] **Step 1.3: Document the convention deviation on the rubric staging
+      properties file.**
+
+Open
+`src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml`.
+Add a top-level `description:` to the model (under `name:`). Insert before
+`columns:`:
+
+```yaml
+description: >-
+  Flattened view of SchoolMint Grow rubrics with their nested measurement groups
+  and measurements. Includes both archived and non-archived rubrics (deviates
+  from the project-wide `_dagster_partition_key = 'f'` convention) so that
+  downstream observation facts can resolve historical rubric references. Filter
+  on `archived_at` if non-archived rows are needed.
+```
+
+- [ ] **Step 1.4: Document the convention deviation on the measurement staging
+      properties file.**
+
+Open
+`src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml`.
+Insert before `columns:`:
+
+```yaml
+description: >-
+  SchoolMint Grow measurement metadata. Includes both archived and non-archived
+  measurements (deviates from the project-wide `_dagster_partition_key = 'f'`
+  convention) so that downstream observation score facts can resolve historical
+  measurement references. Filter on `archived_at` if non-archived rows are
+  needed.
+```
+
+- [ ] **Step 1.5: Build and test the two staging models.**
+
+```bash
+cd /workspaces/teamster
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select stg_schoolmint_grow__rubrics__measurement_groups__measurements stg_schoolmint_grow__measurements
+```
+
+Expected: both models build, all tests pass (existing `unique` test on
+`measurement_id` still holds because `dbt_utils.deduplicate` partitions by id).
+
+- [ ] **Step 1.6: Verify archived rows are now present.**
+
+Use BigQuery MCP `mcp__bigquery__execute_sql`:
+
+```sql
+select
+  countif(archived_at is null) as non_archived,
+  countif(archived_at is not null) as archived,
+  count(*) as total,
+from `teamster-332318.{{ dev_schema }}.stg_schoolmint_grow__measurements`
+```
+
+Replace `{{ dev_schema }}` with the actual dev schema (typically
+`<github_user>_kipptaf_schoolmint_grow`). Expected: `archived` > 0 (specifically
+should include the 348 archived measurements).
+
+Same query against
+`stg_schoolmint_grow__rubrics__measurement_groups__measurements` — expected
+`archived` rows present.
+
+- [ ] **Step 1.7: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql \
+        src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql \
+        src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml \
+        src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml
+git commit -m "fix(dbt): expose archived rubrics/measurements in Grow staging (#3722)
+
+Drops the _dagster_partition_key = 'f' filter from
+stg_schoolmint_grow__rubrics__measurement_groups__measurements and
+stg_schoolmint_grow__measurements. The archived 't' partitions hold
+75 rubrics and 348 measurements still referenced by published 2024+
+observations. Non-archived consumers can filter on archived_at."
+```
+
+---
+
+## Task 2 — Create `int_schoolmint_grow__observation_types` intermediate
+
+**Files:**
+
+- Create:
+  `src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql`
+- Create:
+  `src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml`
+
+- [ ] **Step 2.1: Create the SQL file.**
+
+Write
+`src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql`:
+
+```sql
+select
+    {{ dbt_utils.generate_surrogate_key(["tag_id"]) }} as staff_observation_type_key,
+    tag_id,
+    abbreviation,
+    `name`,
+from {{ ref("stg_schoolmint_grow__generic_tags") }}
+where tag_type = 'observationtypes' and archived_at is null
+```
+
+- [ ] **Step 2.2: Create the properties YAML.**
+
+Write
+`src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml`:
+
+```yaml
+models:
+  - name: int_schoolmint_grow__observation_types
+    description: >-
+      Observation type lookup. One row per non-archived SchoolMint Grow generic
+      tag where tag_type = 'observationtypes'. Single source of truth for the
+      abbreviation → tag_id → staff_observation_type_key mapping consumed by
+      dim_staff_observation_types, int_schoolmint_grow__observations, and
+      dim_staff_observation_expectations.
+    columns:
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Surrogate key derived from tag_id. Generated with
+          generate_surrogate_key(["tag_id"]).
+        data_tests:
+          - unique
+          - not_null
+      - name: tag_id
+        data_type: string
+        description: >-
+          SchoolMint Grow generic tag identifier for the observation type.
+        data_tests:
+          - unique
+          - not_null
+      - name: abbreviation
+        data_type: string
+        description: >-
+          Short code for the observation type (e.g. WT, O3, PMS, PMC, TR). Joins
+          to reporting term `type` codes 1:1.
+        data_tests:
+          - unique
+          - not_null
+      - name: name
+        quote: true
+        data_type: string
+        description: >-
+          Full display name of the observation type (e.g. Walkthrough,
+          One-on-One, PM Semester).
+```
+
+- [ ] **Step 2.3: Build the new intermediate.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select int_schoolmint_grow__observation_types
+```
+
+Expected: model builds, all 4 tests pass (`unique` and `not_null` on
+`tag_id`/`abbreviation` plus `unique`/`not_null` on the surrogate key).
+
+- [ ] **Step 2.4: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql \
+        src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
+git commit -m "feat(dbt): add int_schoolmint_grow__observation_types lookup (#3680)
+
+Centralizes the SchoolMint Grow observation-type filter and surrogate
+key derivation. Pre-hashes staff_observation_type_key so downstream
+consumers (dim_staff_observation_types,
+int_schoolmint_grow__observations,
+dim_staff_observation_expectations) can pull the key directly without
+duplicating the filter or hash logic."
+```
+
+---
+
+## Task 3 — Refactor `dim_staff_observation_types` to consume the new intermediate
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql`
+
+- [ ] **Step 3.1: Replace the SQL with a passthrough from the intermediate.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql` with:
+
+```sql
+select
+    staff_observation_type_key,
+    `name`,
+    abbreviation,
+from {{ ref("int_schoolmint_grow__observation_types") }}
+```
+
+- [ ] **Step 3.2: Build and test.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select dim_staff_observation_types
+```
+
+Expected: model builds, all existing tests pass (`unique`, `not_null` on
+`staff_observation_type_key`).
+
+- [ ] **Step 3.3: Verify hash values unchanged.**
+
+Use BigQuery MCP to compare hashes against production:
+
+```sql
+with
+    pr_branch as (
+        select staff_observation_type_key, abbreviation
+        from `teamster-332318.{{ dev_schema }}.dim_staff_observation_types`
+    ),
+    prod as (
+        select staff_observation_type_key, abbreviation
+        from `teamster-332318.kipptaf.dim_staff_observation_types`
+    )
+select count(*) as total_rows,
+    countif(p.staff_observation_type_key = pr.staff_observation_type_key) as matching_keys
+from prod as p
+inner join pr_branch as pr using (abbreviation)
+```
+
+Expected: `total_rows = matching_keys` (every abbreviation hashes to the same
+key as production).
+
+- [ ] **Step 3.4: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql
+git commit -m "refactor(dbt): dim_staff_observation_types reads from int lookup (#3680)
+
+Consumes int_schoolmint_grow__observation_types instead of duplicating
+the tag_type filter and inline surrogate-key hash. Hash values
+unchanged; same composition (['tag_id']), same source rows."
+```
+
+---
+
+## Task 4 — Refactor `int_schoolmint_grow__observations` to expose pre-hashed FK keys
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql`
+- Modify:
+  `src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml`
+
+- [ ] **Step 4.1: Add the FK-key columns and the new join.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql`
+with:
+
+```sql
+select
+    o.observation_id,
+    o.rubric_id,
+    o.rubric_name,
+    o.score,
+    o.list_two_column_a_str as glows,
+    o.list_two_column_b_str as grows,
+    o.locked,
+    o.observed_at,
+    o.observed_at_date_local,
+    o.academic_year,
+    o.is_published,
+    o.magic_notes_text,
+
+    s.name as school_name,
+
+    ot.staff_observation_type_key,
+    ot.name as observation_type_name,
+    ot.abbreviation as observation_type_abbreviation,
+
+    gt2.name as observation_course,
+
+    gt3.name as observation_grade,
+
+    loc.location_key,
+
+    safe_cast(ut.internal_id as int) as teacher_internal_id,
+
+    safe_cast(uo.internal_id as int) as observer_internal_id,
+
+    {{ dbt_utils.generate_surrogate_key(["o.rubric_id"]) }}
+    as staff_observation_rubric_key,
+from {{ ref("stg_schoolmint_grow__observations") }} as o
+left join {{ ref("stg_schoolmint_grow__users") }} as ut on o.teacher_id = ut.user_id
+left join {{ ref("stg_schoolmint_grow__users") }} as uo on o.observer_id = uo.user_id
+left join
+    {{ ref("stg_schoolmint_grow__schools") }} as s
+    on o.teaching_assignment_school = s.school_id
+left join
+    {{ ref("int_schoolmint_grow__observation_types") }} as ot
+    on o.observation_type = ot.tag_id
+left join
+    {{ ref("stg_schoolmint_grow__generic_tags") }} as gt2
+    on o.teaching_assignment_course = gt2.tag_id
+left join
+    {{ ref("stg_schoolmint_grow__generic_tags") }} as gt3
+    on o.teaching_assignment_grade = gt3.tag_id
+left join
+    {{ ref("stg_google_sheets__people__locations") }} as loc
+    on s.school_id = loc.grow_location_id
+    and not loc.is_pathways
+    and loc.location_name <> 'KIPP Whittier Elementary'
+```
+
+Notes on the diff:
+
+- Replaced `gt` join (against `stg_schoolmint_grow__generic_tags`) with `ot`
+  join against `int_schoolmint_grow__observation_types`. The implicit filter
+  (`tag_type = 'observationtypes' AND archived_at IS NULL`) is now in the
+  lookup.
+- Added `ot.staff_observation_type_key` to the SELECT.
+- Added `staff_observation_rubric_key` (pre-hashed; no `if()` wrapper because
+  `rubric_id` is structurally non-null at this layer).
+- Renamed source columns: `gt.name` → `ot.name`; `gt.abbreviation` →
+  `ot.abbreviation`. Output names unchanged.
+
+- [ ] **Step 4.2: Update the properties YAML.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml`
+with:
+
+```yaml
+models:
+  - name: int_schoolmint_grow__observations
+    description: >-
+      SchoolMint Grow observations enriched with school location, observer and
+      teacher staff IDs, observation-type metadata, and pre-hashed foreign-key
+      surrogates for staff_observation_type_key and
+      staff_observation_rubric_key. One row per Grow observation_id.
+    columns:
+      - name: observation_id
+        data_type: string
+        description: SchoolMint Grow observation identifier.
+        data_tests:
+          - unique
+          - not_null
+      - name: rubric_id
+        data_type: string
+        description: >-
+          SchoolMint Grow rubric identifier. Structurally non-null for all
+          published, non-archived observations.
+        data_tests:
+          - not_null
+      - name: staff_observation_rubric_key
+        data_type: string
+        description: >-
+          Pre-hashed surrogate key derived from rubric_id. Generated with
+          generate_surrogate_key(["rubric_id"]). Consumed by
+          fct_staff_observations as its rubric FK.
+        data_tests:
+          - not_null
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Pre-hashed surrogate key for the observation type. NULL when the
+          observation's tag_id does not resolve to a non-archived
+          observationtypes tag.
+      - name: location_key
+        data_type: string
+        description: >-
+          MD5 surrogate key for the canonical school location. Null when
+          s.school_id does not match any grow_location_id in
+          stg_google_sheets__people__locations.
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref("dim_locations")
+                field: location_key
+      - name: rubric_name
+        data_type: string
+      - name: score
+        data_type: float64
+      - name: glows
+        data_type: string
+      - name: grows
+        data_type: string
+      - name: locked
+        data_type: boolean
+      - name: observed_at
+        data_type: timestamp
+      - name: observed_at_date_local
+        data_type: date
+      - name: academic_year
+        data_type: int64
+      - name: is_published
+        data_type: boolean
+      - name: magic_notes_text
+        data_type: string
+      - name: school_name
+        data_type: string
+      - name: observation_type_name
+        data_type: string
+      - name: observation_type_abbreviation
+        data_type: string
+      - name: observation_course
+        data_type: string
+      - name: observation_grade
+        data_type: string
+      - name: teacher_internal_id
+        data_type: int64
+      - name: observer_internal_id
+        data_type: int64
+```
+
+- [ ] **Step 4.3: Build and test.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select int_schoolmint_grow__observations
+```
+
+Expected: model builds; `unique` on `observation_id` passes; `not_null` on
+`rubric_id` and `staff_observation_rubric_key` pass; existing `relationships`
+test on `location_key` still passes.
+
+- [ ] **Step 4.4: Verify pre-hashed `staff_observation_type_key` matches
+      existing fct values.**
+
+```sql
+with
+    pr_branch as (
+        select observation_id, staff_observation_type_key
+        from `teamster-332318.{{ dev_schema }}.int_schoolmint_grow__observations`
+    ),
+    prod_fct as (
+        select staff_observation_key, staff_observation_type_key
+        from `teamster-332318.kipptaf.fct_staff_observations`
+    )
+select
+    countif(p.staff_observation_type_key = pr.staff_observation_type_key
+        or (p.staff_observation_type_key is null and pr.staff_observation_type_key is null))
+        as matching,
+    count(*) as total,
+from prod_fct as p
+inner join pr_branch as pr
+    on p.staff_observation_key = to_hex(md5(pr.observation_id))
+```
+
+Expected: `matching = total`.
+
+- [ ] **Step 4.5: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql \
+        src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
+git commit -m "refactor(dbt): pre-hash observation FK keys in Grow intermediate (#3680)
+
+Adds staff_observation_type_key (via int_schoolmint_grow__observation_types
+left join) and staff_observation_rubric_key (pre-hashed from rubric_id)
+to int_schoolmint_grow__observations. Adds unique test on observation_id
+and not_null tests on rubric_id and staff_observation_rubric_key. Hash
+compositions and values unchanged."
+```
+
+---
+
+## Task 5 — Pre-hash `term_key` in `int_performance_management__observations`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql`
+- Modify:
+  `src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml`
+
+- [ ] **Step 5.1: Add `term_key` to both UNION branches.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql`
+with:
+
+```sql
+/* 2024+ All Observation Types */
+select
+    o.observation_id,
+    o.rubric_id,
+    o.rubric_name,
+    o.staff_observation_type_key,
+    o.staff_observation_rubric_key,
+    o.score as observation_score,
+    o.glows,
+    o.grows,
+    o.locked,
+    o.observed_at as observed_at_timestamp,
+    o.observed_at_date_local as observed_at,
+    o.academic_year,
+    o.is_published,
+    o.teacher_internal_id as employee_number,
+    o.observer_internal_id as observer_employee_number,
+    o.observation_type_name as observation_type,
+    o.observation_type_abbreviation,
+    o.observation_course,
+    o.observation_grade,
+    o.magic_notes_text as observation_notes,
+
+    t.code as term_code,
+    t.name as term_name,
+
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "t.type",
+                "t.code",
+                "t.name",
+                "t.start_date",
+                "t.region",
+                "t.school_id",
+            ]
+        )
+    }} as term_key,
+
+    case
+        when o.score >= 3.495
+        then 4
+        when o.score >= 2.745
+        then 3
+        when o.score >= 1.745
+        then 2
+        when o.score < 1.75
+        then 1
+    end as overall_tier,
+
+    case
+        when t.code = 'PM1'
+        then date(o.academic_year, 10, 1)
+        when t.code = 'PM2'
+        then date(o.academic_year + 1, 1, 1)
+        when t.code = 'PM3'
+        then date(o.academic_year + 1, 3, 1)
+    end as eval_date,
+from {{ ref("int_schoolmint_grow__observations") }} as o
+inner join
+    {{ ref("int_people__location_crosswalk") }} as lc
+    on o.school_name = lc.location_name
+left join
+    {{ ref("stg_google_sheets__reporting__terms") }} as t
+    on o.observation_type_abbreviation = t.type
+    and o.observed_at_date_local between t.start_date and t.end_date
+    and lc.location_region = t.region
+/* data prior to 2024 in snapshot */
+where o.is_published and o.academic_year >= 2024
+
+union all
+
+/* 2023 Walkthroughs */
+select
+    o.observation_id,
+    o.rubric_id,
+    o.rubric_name,
+    o.staff_observation_type_key,
+    o.staff_observation_rubric_key,
+    o.score as observation_score,
+    o.glows,
+    o.grows,
+    o.locked,
+    o.observed_at as observed_at_timestamp,
+    o.observed_at_date_local as observed_at,
+    o.academic_year,
+    o.is_published,
+    o.teacher_internal_id as employee_number,
+    o.observer_internal_id as observer_employee_number,
+    o.magic_notes_text as observation_notes,
+
+    'Walkthrough' as observation_type,
+    'WT' as observation_type_abbreviation,
+    null as observation_course,
+    null as observation_grade,
+
+    t.code as term_code,
+    t.name as term_name,
+
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "t.type",
+                "t.code",
+                "t.name",
+                "t.start_date",
+                "t.region",
+                "t.school_id",
+            ]
+        )
+    }} as term_key,
+
+    null as overall_tier,
+    null as eval_date,
+from {{ ref("int_schoolmint_grow__observations") }} as o
+left join
+    {{ ref("stg_google_sheets__reporting__terms") }} as t
+    on o.observed_at_date_local between t.start_date and t.end_date
+    and t.type = 'WT'
+where
+    o.academic_year = 2023
+    and o.is_published
+    and (
+        contains_substr(o.rubric_name, 'Walkthrough')
+        or contains_substr(o.rubric_name, 'Strong Start')
+    )
+```
+
+Notes on the diff:
+
+- Added `o.staff_observation_type_key` and `o.staff_observation_rubric_key` to
+  both branches (passthrough from upstream intermediate).
+- Added `term_key` (6-column composition) to both branches.
+- 2023 walkthrough branch's term LEFT JOIN doesn't carry `region` or `school_id`
+  from `t` — those columns are NULL in unmatched rows, and the hash will be
+  NULL-input-deterministic when the join misses, identical to today's
+  `if(t_code is not null, ...)` outcome in the fact.
+
+- [ ] **Step 5.2: Update properties — close the TODO and add `term_key`,
+      `staff_observation_type_key`, `staff_observation_rubric_key` columns.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml`
+with:
+
+```yaml
+models:
+  - name: int_performance_management__observations
+    config:
+      materialized: table
+    columns:
+      - name: observation_id
+        data_type: string
+        data_tests:
+          - unique
+          - not_null
+      - name: rubric_id
+        data_type: string
+      - name: rubric_name
+        data_type: string
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_staff_observation_types, passed through from
+          int_schoolmint_grow__observations.
+      - name: staff_observation_rubric_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_staff_observation_rubrics, passed through from
+          int_schoolmint_grow__observations.
+      - name: term_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_terms. Generated with generate_surrogate_key on
+          (term type, code, name, start_date, region, school_id). NULL when the
+          observation does not match a reporting term row.
+      - name: observation_score
+        data_type: float64
+      - name: glows
+        data_type: string
+      - name: grows
+        data_type: string
+      - name: locked
+        data_type: boolean
+      - name: observed_at_timestamp
+        data_type: timestamp
+      - name: observed_at
+        data_type: date
+      - name: academic_year
+        data_type: int64
+      - name: is_published
+        data_type: boolean
+      - name: employee_number
+        data_type: int64
+      - name: observer_employee_number
+        data_type: int64
+      - name: observation_type
+        data_type: string
+      - name: observation_type_abbreviation
+        data_type: string
+      - name: observation_course
+        data_type: string
+      - name: observation_grade
+        data_type: string
+      - name: observation_notes
+        data_type: string
+      - name: term_code
+        data_type: string
+      - name: term_name
+        data_type: string
+      - name: overall_tier
+        data_type: int64
+      - name: eval_date
+        data_type: date
+```
+
+- [ ] **Step 5.3: Build and test.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select int_performance_management__observations
+```
+
+Expected: model builds; `unique` and `not_null` on `observation_id` pass.
+
+If the `unique` test fails, fan-out has appeared in production data since
+BigQuery sampling on 2026-04-29. Investigate via:
+
+```sql
+select observation_id, count(*) as n
+from `teamster-332318.{{ dev_schema }}.int_performance_management__observations`
+group by observation_id
+having n > 1
+limit 20
+```
+
+Diagnose which join (terms or location_crosswalk) is fanning out and decide
+whether to add a `qualify` clause or escalate to a separate issue. Do not
+silently dedup.
+
+- [ ] **Step 5.4: Verify `term_key` values match what fct_staff_observations
+      currently produces.**
+
+```sql
+with
+    pr_branch as (
+        select observation_id, term_key
+        from `teamster-332318.{{ dev_schema }}.int_performance_management__observations`
+    ),
+    prod_fct as (
+        select staff_observation_key, term_key
+        from `teamster-332318.kipptaf.fct_staff_observations`
+    )
+select
+    countif(p.term_key = pr.term_key
+        or (p.term_key is null and pr.term_key is null)) as matching,
+    count(*) as total,
+from prod_fct as p
+inner join pr_branch as pr
+    on p.staff_observation_key = to_hex(md5(pr.observation_id))
+```
+
+Expected: `matching = total`.
+
+- [ ] **Step 5.5: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql \
+        src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
+git commit -m "refactor(dbt): pre-hash term_key in perf_mgmt observations (#3680)
+
+Pre-hashes term_key in both UNION branches of
+int_performance_management__observations and passes through the
+upstream staff_observation_type_key and staff_observation_rubric_key.
+Closes the TODO with a real unique test on observation_id (verified
+zero fan-out across 46,686 production rows). Hash composition and
+values unchanged."
+```
+
+---
+
+## Task 6 — Strip duplicated logic from `fct_staff_observations`
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql`
+
+- [ ] **Step 6.1: Replace the SQL with the simplified version.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql` with:
+
+```sql
+select
+    {{ dbt_utils.generate_surrogate_key(["o.observation_id"]) }} as staff_observation_key,
+
+    if(
+        o.employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["o.employee_number"]) }},
+        cast(null as string)
+    ) as teacher_staff_key,
+
+    if(
+        o.observer_employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["o.observer_employee_number"]) }},
+        cast(null as string)
+    ) as observer_staff_key,
+
+    gro.location_key,
+
+    o.term_key,
+
+    o.staff_observation_type_key,
+
+    o.staff_observation_rubric_key,
+
+    o.academic_year,
+    o.observation_score as score,
+    o.overall_tier as overall_rating,
+    o.observation_notes as notes,
+
+    o.observed_at as observed_date_key,
+    o.observed_at_timestamp as observed_timestamp,
+    o.glows as positive_feedback,
+    o.grows as growth_areas,
+    o.locked as is_locked,
+from {{ ref("int_performance_management__observations") }} as o
+left join
+    {{ ref("int_schoolmint_grow__observations") }} as gro
+    on o.observation_id = gro.observation_id
+```
+
+Notes on the diff:
+
+- Dropped the `observation_types` CTE entirely (lines 2-6 of the old file).
+- Dropped the `observations_with_terms` CTE wrapper — no longer needed.
+- Dropped the LEFT JOIN to `stg_google_sheets__reporting__terms` and the six
+  `t.*` columns (now upstream).
+- Dropped the LEFT JOIN to `int_people__location_crosswalk` (only used for
+  region and term-join predicate; region was unused in the SELECT, term columns
+  are now upstream).
+- Dropped the `if()` wrapper on `staff_observation_type_key` — pre-hashed
+  upstream, NULL flows naturally.
+- Dropped the `if()` wrapper on `staff_observation_rubric_key` — pre-hashed
+  upstream, never NULL.
+- Dropped the `if()` wrapper on `term_key` — pre-hashed upstream, NULL flows
+  naturally.
+- Dropped the `row_number ... where rn = 1` dedup — verified no-op against
+  current production; upstream `unique` test on `observation_id` guards against
+  future fan-out.
+- Kept the `gro` left-join for `location_key` only.
+
+- [ ] **Step 6.2: Build and test.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select fct_staff_observations
+```
+
+Expected: model builds; all relationships tests pass with **zero orphans** on
+`staff_observation_rubric_key` (was 23,372). Other relationship tests unchanged.
+
+- [ ] **Step 6.3: Verify zero hash drift on `staff_observation_key`.**
+
+```sql
+with
+    pr_branch as (
+        select staff_observation_key
+        from `teamster-332318.{{ dev_schema }}.fct_staff_observations`
+    ),
+    prod as (
+        select staff_observation_key
+        from `teamster-332318.kipptaf.fct_staff_observations`
+    )
+select
+    (select count(*) from pr_branch) as pr_rows,
+    (select count(*) from prod) as prod_rows,
+    (select count(*) from pr_branch
+        where staff_observation_key not in (select staff_observation_key from prod)) as in_pr_only,
+    (select count(*) from prod
+        where staff_observation_key not in (select staff_observation_key from pr_branch)) as in_prod_only
+```
+
+Expected: `pr_rows = prod_rows`; both `in_pr_only` and `in_prod_only` = 0.
+
+- [ ] **Step 6.4: Verify zero hash drift on `staff_observation_rubric_key`,
+      `term_key`, and `staff_observation_type_key`.**
+
+```sql
+with
+    pr_branch as (
+        select staff_observation_key, staff_observation_rubric_key, term_key, staff_observation_type_key
+        from `teamster-332318.{{ dev_schema }}.fct_staff_observations`
+    ),
+    prod as (
+        select staff_observation_key, staff_observation_rubric_key, term_key, staff_observation_type_key
+        from `teamster-332318.kipptaf.fct_staff_observations`
+    )
+select
+    countif(p.staff_observation_rubric_key is not distinct from pr.staff_observation_rubric_key) as rubric_match,
+    countif(p.term_key is not distinct from pr.term_key) as term_match,
+    countif(p.staff_observation_type_key is not distinct from pr.staff_observation_type_key) as type_match,
+    count(*) as total,
+from prod as p
+inner join pr_branch as pr using (staff_observation_key)
+```
+
+Expected: `rubric_match = term_match = type_match = total`.
+
+- [ ] **Step 6.5: Verify `fct_staff_observation_scores` rebuilds clean.**
+
+`fct_staff_observation_scores` self-references `fct_staff_observations` (filter
+`staff_observation_key in fct_staff_observations`). Rebuild it to confirm the
+orphan FKs on `staff_observation_rubric_measurement_key` are gone:
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select fct_staff_observation_scores
+```
+
+Expected: model builds; relationships test on
+`staff_observation_rubric_measurement_key` shows **zero orphans** (was 249,465).
+
+- [ ] **Step 6.6: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
+git commit -m "refactor(dbt): consume pre-hashed FK keys in fct_staff_observations (#3680)
+
+Drops the inline observation_types CTE, the term LEFT JOIN, the
+location_crosswalk join, the if() null-wrappers on three FK columns,
+and the dead-code row_number dedup. Pulls staff_observation_type_key,
+staff_observation_rubric_key, and term_key from upstream intermediates
+where they're pre-hashed once. Hash values unchanged across all FKs."
+```
+
+---
+
+## Task 7 — Add `staff_observation_type_key` FK to `dim_staff_observation_expectations`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml`
+
+- [ ] **Step 7.1: Add the join and the FK column to the SQL.**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql`
+with:
+
+```sql
+with
+    scaffold as (
+        select
+            srh.employee_number,
+
+            t.type,
+            t.code,
+            t.`name`,
+            t.academic_year,
+            t.start_date,
+            t.end_date,
+            t.region,
+            t.school_id,
+            t.is_current,
+
+            srh.job_title,
+
+            ot.staff_observation_type_key,
+
+            row_number() over (
+                partition by
+                    srh.employee_number,
+                    t.type,
+                    t.code,
+                    t.`name`,
+                    t.start_date,
+                    t.region,
+                    t.school_id
+                order by srh.effective_date_start desc
+            ) as rn,
+        from {{ ref("int_people__staff_roster_history") }} as srh
+        inner join
+            {{ ref("stg_google_sheets__reporting__terms") }} as t
+            on srh.home_business_unit_name = t.region
+            and (
+                t.start_date
+                between srh.work_assignment_actual_start_date and srh.effective_date_end
+                or t.end_date
+                between srh.work_assignment_actual_start_date and srh.effective_date_end
+            )
+            and t.type in ('PMS', 'PMC', 'TR', 'WT', 'O3')
+        left join
+            {{ ref("int_schoolmint_grow__observation_types") }} as ot
+            on t.type = ot.abbreviation
+        where
+            srh.primary_indicator
+            and srh.assignment_status = 'Active'
+            and (srh.job_title like '%Teacher%' or srh.job_title like '%Learning%')
+    )
+
+select
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "employee_number",
+                "type",
+                "code",
+                "name",
+                "start_date",
+                "region",
+                "school_id",
+            ]
+        )
+    }} as staff_observation_expectation_key,
+
+    {{ dbt_utils.generate_surrogate_key(["employee_number"]) }} as staff_key,
+
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "type",
+                "code",
+                "name",
+                "start_date",
+                "region",
+                "school_id",
+            ]
+        )
+    }} as term_key,
+
+    staff_observation_type_key,
+
+    academic_year,
+    is_current,
+
+    job_title as position_title,
+from scaffold
+where rn = 1
+```
+
+Notes on the diff:
+
+- Added
+  `left join int_schoolmint_grow__observation_types as ot on t.type = ot.abbreviation`.
+  Since the lookup's `abbreviation` column is unique-tested, the join cannot fan
+  out the scaffold.
+- Added `ot.staff_observation_type_key` to the scaffold CTE.
+- Added `staff_observation_type_key` to the final SELECT.
+
+- [ ] **Step 7.2: Update the properties YAML.**
+
+Edit
+`src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml`.
+Update the model description and add the new column. Replace the entire file
+contents with:
+
+```yaml
+models:
+  - name: dim_staff_observation_expectations
+    description: >-
+      Observation expectation scaffold. One row per staff member x observation
+      type term. Built by crossing active teaching staff from roster history
+      with PM/walkthrough/O3 term windows from the reporting terms sheet.
+      Enables tracking whether each teacher received their expected observations
+      in each period. Foreign keys to dim_staff, dim_terms, and
+      dim_staff_observation_types.
+    columns:
+      - name: staff_observation_expectation_key
+        data_type: string
+        description: >-
+          Surrogate primary key derived from employee_number and term composite
+          fields. Generated with generate_surrogate_key(["srh.employee_number",
+          "t.type", "t.code", "t.name", "t.start_date", "t.region",
+          "t.school_id"]).
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
+        data_tests:
+          - unique
+          - not_null
+
+      - name: staff_key
+        data_type: string
+        description: >-
+          Foreign key to dim_staff. Surrogate key derived from employee_number.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff')
+            to_columns: [staff_key]
+            warn_unsupported: false
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_staff')
+                field: staff_key
+
+      - name: term_key
+        data_type: string
+        description: >-
+          Foreign key to dim_terms. Surrogate key derived from term type, code,
+          name, start_date, region, and school_id.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
+
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Foreign key to dim_staff_observation_types. Surrogate key resolved via
+          int_schoolmint_grow__observation_types by joining the term type code
+          (PMS, PMC, TR, WT, O3) to the SchoolMint Grow observation-type tag
+          abbreviation. Non-nullable because the scaffold filters term types to
+          the five observation types, all of which match a Grow tag 1:1.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_types')
+            to_columns: [staff_observation_type_key]
+            warn_unsupported: false
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_staff_observation_types')
+                field: staff_observation_type_key
+
+      - name: academic_year
+        data_type: int64
+        description: >-
+          Academic year of the observation expectation.
+
+      - name: is_current
+        data_type: boolean
+        description: >-
+          TRUE if the current date falls within this observation period.
+
+      - name: position_title
+        data_type: string
+        description: >-
+          Staff member's position title during the observation period.
+```
+
+- [ ] **Step 7.3: Build and test.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select dim_staff_observation_expectations
+```
+
+Expected: model builds; `not_null` and `relationships` on
+`staff_observation_type_key` both pass.
+
+- [ ] **Step 7.4: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql \
+        src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+git commit -m "fix(dbt): add staff_observation_type_key FK to expectations dim (#3641)
+
+Joins int_schoolmint_grow__observation_types on term.type =
+tag.abbreviation. All 5 staff-observation term types (PMS, PMC, TR,
+WT, O3) match Grow generic_tags abbreviations 1:1, so the FK is
+non-nullable. Closes the missing FK called out in the star-schema
+spec audit."
+```
+
+---
+
+## Task 8 — End-to-end verification and PR
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 8.1: Build the full downstream graph from the touched staging
+      models.**
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select \
+        stg_schoolmint_grow__rubrics__measurement_groups__measurements+ \
+        stg_schoolmint_grow__measurements+ \
+        int_schoolmint_grow__observation_types+ \
+        int_schoolmint_grow__observations+ \
+        int_performance_management__observations+ \
+        dim_staff_observation_expectations
+```
+
+Expected: every model and test passes. Pay attention to:
+
+- `fct_staff_observations.staff_observation_rubric_key` relationships test → 0
+  orphans (was 23,372)
+- `fct_staff_observation_scores.staff_observation_rubric_measurement_key`
+  relationships test → 0 orphans (was 249,465)
+- `dim_staff_observation_expectations.staff_observation_type_key` relationships
+  test → passes
+- All other relationships and uniqueness tests unchanged.
+
+- [ ] **Step 8.2: Spot-check downstream consumers of
+      `int_performance_management__observations`.**
+
+The dedup move is no-op today (verified zero fan-out at planning time), but
+rebuild and sanity-check row counts on the consumers to confirm:
+
+```bash
+uv run dbt build \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select \
+        int_performance_management__observation_details \
+        int_performance_management__overall_scores \
+        rpt_tableau__content_team \
+        rpt_tableau__teacher_development \
+        rpt_tableau__teacher_observations \
+        rpt_tableau__pm_overall_scores \
+        rpt_appsheet__seat_tracker_roster
+```
+
+Spot-check via BigQuery MCP that row counts match production within ~2% (no
+observations lost, no fan-out introduced):
+
+```sql
+select
+    (select count(*) from `teamster-332318.{{ dev_schema }}.rpt_tableau__teacher_development`) as pr_rows,
+    (select count(*) from `teamster-332318.kipptaf.rpt_tableau__teacher_development`) as prod_rows
+```
+
+Repeat for each of the 7 consumers. Expected: counts match (or differ only by
+current production vs. dev recency).
+
+- [ ] **Step 8.3: Run `trunk check --ci` from the repo root.**
+
+Trunk hooks aren't installed in worktrees, but the branch is checked out in the
+main workspace — still good practice to validate before push:
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk check --ci
+```
+
+Expected: no issues. If sqlfluff or yamllint flags anything, fix and amend the
+relevant commit.
+
+- [ ] **Step 8.4: Push the branch.**
+
+```bash
+git push -u origin cbini/fix/claude-batch-d-staff-observation-fks
+```
+
+- [ ] **Step 8.5: Open the PR.**
+
+Use `mcp__github__create_pull_request` with title and body:
+
+- **Title:**
+  `fix(dbt): batch D — staff observation FK fixes & lookup centralization`
+- **Body:** populate from `.github/pull_request_template.md`. Reference closes
+  #3641, #3680, #3722; link the spec; summarize the orphan-FK fix metrics (273K
+  → 0); note hash discipline (no values changed); flag the convention deviation
+  on the two staging models.
+
+- [ ] **Step 8.6: Verify dbt Cloud CI clean.**
+
+Watch `gh pr checks` (no MCP equivalent for check status):
+
+```bash
+gh pr checks
+```
+
+Expected: dbt Cloud CI job passes. If it fails:
+
+- Use `mcp__dbt__list_jobs_runs` and `mcp__dbt__get_job_run_error` (with
+  `warning_only=true`) to inspect the failure.
+- Use BigQuery MCP against the PR-branch CI schema
+  (`dbt_cloud_pr_<ci_id>_<pr_num>_*`) to diagnose.
+
+---
+
+## Self-review checklist (run before pushing the branch)
+
+- [ ] Every task ends with a commit. No staged-but-uncommitted state between
+      tasks.
+- [ ] No file touched by two consecutive tasks without an intervening commit.
+- [ ] Every test mentioned in the spec is actually added in the plan (uniqueness
+      on `int_schoolmint_grow__observation_types.tag_id`/`abbreviation`;
+      uniqueness on `int_schoolmint_grow__observations.observation_id`;
+      uniqueness on `int_performance_management__observations.observation_id`;
+      not_null on `int_schoolmint_grow__observations.rubric_id` and
+      `staff_observation_rubric_key`; relationships test on
+      `dim_staff_observation_expectations.staff_observation_type_key`).
+- [ ] Every hash claim ("values unchanged") has a verification query in the
+      corresponding task.
+- [ ] No `trunk fmt` invocations (PostToolUse hook handles it).
+- [ ] No `git add -A`, `-u`, or `.` — every commit names files explicitly.

--- a/docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md
+++ b/docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md
@@ -7,8 +7,11 @@
 
 **Goal:** Eliminate ~273K orphan FKs on staff observation rubric/measurement
 dims, add the missing observation-type FK to
-`dim_staff_observation_expectations`, and centralize the duplicated SchoolMint
-Grow observation-type lookup into a single intermediate.
+`dim_staff_observation_expectations`, centralize the duplicated SchoolMint Grow
+observation-type lookup into a single intermediate, and promote the rubric-key
+relationships test to error severity now that orphans resolve.
+
+**Closes:** #3641, #3680, #3712, #3722.
 
 **Architecture:** Two-front fix. (1) Remove `_dagster_partition_key = 'f'`
 filters from two Grow staging models so archived rubrics/measurements appear in
@@ -899,6 +902,8 @@ values unchanged."
 **Files:**
 
 - Modify: `src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml`
 
 - [ ] **Step 6.1: Replace the SQL with the simplified version.**
 
@@ -1040,17 +1045,65 @@ uv run dbt build \
 Expected: model builds; relationships test on
 `staff_observation_rubric_measurement_key` shows **zero orphans** (was 249,465).
 
-- [ ] **Step 6.6: Commit.**
+- [ ] **Step 6.6: Promote the rubric_key relationships test to error severity
+      and remove the stale TODO.**
+
+Open `src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml`.
+Locate the `staff_observation_rubric_key` column block (around line 59). Replace
+the `data_tests:` block:
+
+```yaml
+data_tests:
+  # TODO: #3712 — dim source is measurement-grain, excludes rubrics
+  # without nested measurements. Promote to error once resolved.
+  - relationships:
+      arguments:
+        to: ref('dim_staff_observation_rubrics')
+        field: staff_observation_rubric_key
+```
+
+with:
+
+```yaml
+data_tests:
+  - relationships:
+      arguments:
+        to: ref('dim_staff_observation_rubrics')
+        field: staff_observation_rubric_key
+      config:
+        severity: error
+```
+
+The orphan rows are gone (Task 1 resolved them). Promoting to `error` locks the
+invariant into CI.
+
+- [ ] **Step 6.7: Re-run the rubric_key test to confirm error-level pass.**
 
 ```bash
-git add src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
-git commit -m "refactor(dbt): consume pre-hashed FK keys in fct_staff_observations (#3680)
+uv run dbt test \
+    --project-dir=src/dbt/kipptaf/ \
+    --target=dev \
+    --select fct_staff_observations
+```
+
+Expected: all relationships tests pass, including the now-`error`-severity one
+on `staff_observation_rubric_key`.
+
+- [ ] **Step 6.8: Commit.**
+
+```bash
+git add src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql \
+        src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+git commit -m "refactor(dbt): consume pre-hashed FK keys in fct_staff_observations (#3680, #3712)
 
 Drops the inline observation_types CTE, the term LEFT JOIN, the
 location_crosswalk join, the if() null-wrappers on three FK columns,
 and the dead-code row_number dedup. Pulls staff_observation_type_key,
 staff_observation_rubric_key, and term_key from upstream intermediates
-where they're pre-hashed once. Hash values unchanged across all FKs."
+where they're pre-hashed once. Promotes the
+staff_observation_rubric_key relationships test to severity: error
+now that orphans are resolved (closes #3712). Hash values unchanged
+across all FKs."
 ```
 
 ---
@@ -1386,9 +1439,10 @@ Use `mcp__github__create_pull_request` with title and body:
 - **Title:**
   `fix(dbt): batch D — staff observation FK fixes & lookup centralization`
 - **Body:** populate from `.github/pull_request_template.md`. Reference closes
-  #3641, #3680, #3722; link the spec; summarize the orphan-FK fix metrics (273K
-  → 0); note hash discipline (no values changed); flag the convention deviation
-  on the two staging models.
+  #3641, #3680, #3712, #3722; link the spec; summarize the orphan-FK fix metrics
+  (273K → 0); note that the rubric-key relationships test is promoted to
+  `severity: error`; note hash discipline (no values changed); flag the
+  convention deviation on the two staging models.
 
 - [ ] **Step 8.6: Verify dbt Cloud CI clean.**
 

--- a/docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md
+++ b/docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md
@@ -2,7 +2,13 @@
 
 Closes [#3641](https://github.com/TEAMSchools/teamster/issues/3641),
 [#3680](https://github.com/TEAMSchools/teamster/issues/3680),
+[#3712](https://github.com/TEAMSchools/teamster/issues/3712),
 [#3722](https://github.com/TEAMSchools/teamster/issues/3722).
+
+#3712 is incidentally resolved: the staging filter removal in #3722 restores the
+missing rubrics, and the relationships test on
+`fct_staff_observations.staff_observation_rubric_key` is promoted to
+`severity: error` once orphans clear.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md
+++ b/docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md
@@ -1,0 +1,258 @@
+# Batch D — staff observation FK fixes & lookup centralization
+
+Closes [#3641](https://github.com/TEAMSchools/teamster/issues/3641),
+[#3680](https://github.com/TEAMSchools/teamster/issues/3680),
+[#3722](https://github.com/TEAMSchools/teamster/issues/3722).
+
+## Problem
+
+Three related defects in the staff-observation domain of the kipptaf dbt
+project:
+
+- **#3722** —
+  `fct_staff_observation_scores.staff_observation_rubric_measurement_key` has
+  249,465 orphan rows; `fct_staff_observations.staff_observation_rubric_key` has
+  23,372 orphan rows. Both reference rubrics/measurements that don't appear in
+  the corresponding dims.
+- **#3641** — `dim_staff_observation_expectations` is missing the
+  `staff_observation_type_key` FK required by the star-schema spec.
+- **#3680** — `fct_staff_observations` resolves `staff_observation_type_key` by
+  joining `stg_schoolmint_grow__generic_tags` inline, duplicating logic already
+  present in `dim_staff_observation_types`.
+
+## Root cause analysis
+
+### #3722 — the orphans are entirely a staging-filter artifact
+
+Two staging models filter to non-archived SchoolMint Grow rows only:
+
+- `stg_schoolmint_grow__rubrics__measurement_groups__measurements`:
+  `where r._dagster_partition_key = 'f'`
+- `stg_schoolmint_grow__measurements`: `where _dagster_partition_key = 'f'`
+
+`_dagster_partition_key` is the SchoolMint Grow `archived` flag (`f` = not
+archived, `t` = archived). The `'t'` partitions hold 75 archived rubrics and 348
+archived measurements that are still referenced by published, non-archived 2024+
+observations.
+
+BigQuery verification (run 2026-04-29 against production):
+
+- All 92 distinct `rubric_id`s referenced by observation facts exist in
+  `src_schoolmint_grow__rubrics` when both partitions are unioned (17 in `'f'`,
+  75 in `'t'`).
+- All 1,472 distinct `(rubric_id, measurement_id)` pairs from observation scores
+  resolve when both partitions of `src_schoolmint_grow__rubrics` are read.
+- All `measurement_id`s referenced exist in `src_schoolmint_grow__measurements`
+  across both partitions.
+
+Removing the `'f'` filters fully populates the dims; FK orphans go to zero. Fact
+row counts do not change — only dim row counts grow.
+
+The convention deviation (other Grow staging models keep the `'f'` filter) is
+intentional for these two parents-of-orphan-FK-chains. Other Grow staging
+filters are not transitively applied today: `stg_schoolmint_grow__observations`
+keeps non-archived observations whose parent rubric/measurement happens to be
+archived, so we lose only the metadata, not the fact rows. Consistent resolution
+is to expose the parent metadata.
+
+### #3641 — no crosswalk needed; abbreviations match Grow tags 1:1
+
+`dim_staff_observation_expectations` scaffolds expectations from
+`stg_google_sheets__people__reporting_terms.type` codes (`PMS`, `PMC`, `TR`,
+`WT`, `O3`). `dim_staff_observation_types` is keyed on SchoolMint Grow `tag_id`.
+BigQuery verification: all 5 staff-observation term-type codes match exactly one
+non-archived Grow `generic_tags.abbreviation` row each, with no collisions. The
+expectations dim can join Grow tags directly on `term.type = tag.abbreviation`
+without an external crosswalk.
+
+### #3680 — duplicated lookup logic
+
+`fct_staff_observations` defines an inline `observation_types` CTE filtering
+`tag_type = 'observationtypes' AND archived_at IS NULL` over
+`stg_schoolmint_grow__generic_tags`. `dim_staff_observation_types` applies the
+exact same filter. Same input rows, same hash composition (`["tag_id"]`), same
+output values — logic duplicated across two models.
+
+The same lookup is now needed by `dim_staff_observation_expectations` (#3641),
+making centralization a hard requirement rather than a stylistic preference.
+
+### Existing dead defensive code
+
+`fct_staff_observations` includes
+`row_number() over (partition by observation_id ...) as rn ... where rn = 1`,
+defensively deduplicating in case the LEFT JOINs to
+`stg_google_sheets__reporting__terms` and `int_people__location_crosswalk` in
+`int_performance_management__observations` fan out. BigQuery verification:
+46,686 rows in `int_performance_management__observations`, all distinct
+`observation_id` — zero fan-out today. The defensive dedup is no-op and can be
+removed; an upstream uniqueness test catches future fan-out at CI time.
+
+## Scope
+
+### What this builds
+
+1. **Staging filter removal** — drop the archived-partition filter in
+   `stg_schoolmint_grow__rubrics__measurement_groups__measurements` and
+   `stg_schoolmint_grow__measurements`. Document the convention deviation in
+   each model's `description:`.
+
+2. **New intermediate model** — `int_schoolmint_grow__observation_types`
+   centralizing the observation-type lookup with pre-hashed
+   `staff_observation_type_key`:
+
+   ```sql
+   select
+       {{ dbt_utils.generate_surrogate_key(["tag_id"]) }} as staff_observation_type_key,
+       tag_id,
+       abbreviation,
+       `name`,
+   from {{ ref("stg_schoolmint_grow__generic_tags") }}
+   where tag_type = 'observationtypes' and archived_at is null
+   ```
+
+3. **Refactor `dim_staff_observation_types`** — `select` from the new
+   intermediate; drop inline filter and inline hash. Hash values unchanged.
+
+4. **Refactor `int_schoolmint_grow__observations`** — left-join the new
+   intermediate on `o.observation_type = ot.tag_id`; expose
+   `staff_observation_type_key` (drop `tag_id` from outputs — plumbing). Also
+   pre-hash `staff_observation_rubric_key` from `o.rubric_id` (no `if()` wrapper
+   — `rubric_id` is structurally non-null at this layer; verified across 121,771
+   production rows).
+
+5. **Refactor `int_performance_management__observations`** — pre-hash `term_key`
+   in both UNION branches:
+
+   ```sql
+   {{ dbt_utils.generate_surrogate_key(
+       ["t.type", "t.code", "t.name", "t.start_date", "t.region", "t.school_id"]
+   ) }} as term_key,
+   ```
+
+   The 2023 walkthrough branch's term LEFT JOIN doesn't carry `region` or
+   `school_id`, so its `term_key` is NULL when the join doesn't match —
+   identical to today's `if(t_code is not null, ...)` outcome in the fact.
+
+6. **Refactor `fct_staff_observations`** — substantial cleanup:
+   - Drop the inline `observation_types` CTE and the `ot` LEFT JOIN.
+   - Drop the LEFT JOIN to `stg_google_sheets__reporting__terms` and the six
+     `t.*` pass-through columns.
+   - Drop the `if()` wrappers for `staff_observation_type_key`,
+     `staff_observation_rubric_key`, and `term_key`.
+   - Drop the `row_number() ... where rn = 1` dedup (dead defensive code;
+     replaced by upstream uniqueness test).
+   - Pull pre-hashed `staff_observation_type_key`,
+     `staff_observation_rubric_key` from `int_schoolmint_grow__observations`,
+     and `term_key` from `int_performance_management__observations`.
+
+7. **Add FK to `dim_staff_observation_expectations`** — left-join the new
+   intermediate on `term.type = ot.abbreviation`, expose
+   `ot.staff_observation_type_key`. NULLs propagate naturally for non-
+   observation term types (ACT, AR, ATT, etc.).
+
+### Tests added
+
+- `int_schoolmint_grow__observation_types`: `unique` and `not_null` on both
+  `tag_id` and `abbreviation`. The abbreviation uniqueness is load-bearing —
+  `dim_staff_observation_expectations` joins on it.
+- `int_schoolmint_grow__observations`: `unique` on `observation_id`; `not_null`
+  on `rubric_id` and `staff_observation_rubric_key`.
+- `int_performance_management__observations`: `unique` on `observation_id`,
+  closing the existing `# TODO: add unique test` placeholder.
+- `dim_staff_observation_expectations.staff_observation_type_key`:
+  `relationships` to `dim_staff_observation_types.staff_observation_type_key`,
+  `severity: error`, `config.where: "staff_observation_type_key is not null"`.
+
+### Tests verified clean (post-PR)
+
+- `fct_staff_observations.staff_observation_rubric_key` — currently 23,372
+  orphans; expected zero after staging filter removal.
+- `fct_staff_observation_scores.staff_observation_rubric_measurement_key` —
+  currently 249,465 orphans; expected zero.
+- `fct_staff_observations.staff_observation_type_key` — relationship test values
+  unchanged; still passes.
+- `fct_staff_observations.term_key` — relationship test values unchanged; still
+  passes.
+
+### Out of scope
+
+- Filtering observations whose parent rubric/measurement is archived (the whole
+  point of the #3722 fix is to keep these historical analytics).
+- Other Grow staging models retaining the `_dagster_partition_key = 'f'` filter
+  (intentional convention; only the two parents of orphan-FK chains change).
+- Flattening `fct_staff_observation_scores`'s nested unnest into a new
+  `int_schoolmint_grow__observation_scores` intermediate (YAGNI — no second
+  consumer, no FK defensiveness gap; can be a separate issue if a use case
+  emerges).
+- Relocating `staff_observation_rubric_measurement_key` hashing upstream (would
+  require the unnest-flattening intermediate; deferred with the above).
+- Cube `accessPolicy` work (#3591) — separate workstream.
+
+## Hash discipline
+
+Per `src/dbt/kipptaf/models/marts/CLAUDE.md` "Hash-change discipline":
+
+- `staff_observation_type_key` — same composition `["tag_id"]`, same source
+  rows, identical values. No hash-changes table entry needed.
+- `staff_observation_rubric_key` — same composition `["rubric_id"]`, same
+  values. No entry.
+- `term_key` — same 6-column composition, same join semantics, same resulting
+  values. No entry.
+
+## Star-schema diamond audit
+
+Per the strict-chain rule in `marts/CLAUDE.md`, `fct_staff_observations`
+post-refactor FKs:
+
+- `teacher_staff_key` → `dim_staff`
+- `observer_staff_key` → `dim_staff`
+- `location_key` → `dim_locations`
+- `term_key` → `dim_terms`
+- `staff_observation_type_key` → `dim_staff_observation_types`
+- `staff_observation_rubric_key` → `dim_staff_observation_rubrics`
+- `observed_date_key` → `dim_dates`
+
+No two FKs lead to the same ultimate dim. `region_key` reachable via
+`dim_locations` chain (no direct FK on the fact). Diamond-free.
+
+`dim_staff_observation_expectations` adds one FK (`staff_observation_type_key`)
+— single-path, no diamond.
+
+## Verification plan
+
+After CI builds the PR-branch schema, query against
+`dbt_cloud_pr_<ci_id>_<pr_num>_*` via BigQuery MCP:
+
+1. Confirm orphan counts on
+   `fct_staff_observations.staff_observation_rubric_key` and
+   `fct_staff_observation_scores.staff_observation_rubric_measurement_key` = 0.
+2. Confirm `fct_staff_observations` row count unchanged (no hash drift on
+   `staff_observation_key`).
+3. Confirm `dim_staff_observation_types` row count unchanged (filter and hash
+   identical).
+4. Confirm `dim_staff_observation_rubrics` and
+   `dim_staff_observation_rubric_measurements` row counts increase by archived
+   rubric/measurement counts (75 + 348 measurements).
+5. Confirm `dim_staff_observation_expectations.staff_observation_type_key`
+   relationships test passes.
+6. Confirm zero hash deltas on `staff_observation_type_key`, `term_key`, and
+   `staff_observation_rubric_key` between prod and PR-branch fact tables (a
+   row-by-row hash comparison sanity check).
+
+## File checklist
+
+| File                                                                 | Change                                     |
+| -------------------------------------------------------------------- | ------------------------------------------ |
+| `stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql` | drop partition filter                      |
+| `stg_schoolmint_grow__measurements.sql`                              | drop partition filter                      |
+| `int_schoolmint_grow__observation_types.sql`                         | new                                        |
+| `int_schoolmint_grow__observation_types.yml` (properties)            | new                                        |
+| `dim_staff_observation_types.sql`                                    | ref new intermediate                       |
+| `int_schoolmint_grow__observations.sql`                              | join new intermediate; pre-hash rubric_key |
+| `int_schoolmint_grow__observations.yml` (properties)                 | uniqueness, not_null tests                 |
+| `int_performance_management__observations.sql`                       | pre-hash term_key                          |
+| `int_performance_management__observations.yml` (properties)          | close TODO with unique test                |
+| `fct_staff_observations.sql`                                         | drop inline CTE, joins, wrappers, dedup    |
+| `fct_staff_observations.yml` (properties)                            | column updates                             |
+| `dim_staff_observation_expectations.sql`                             | add FK column                              |
+| `dim_staff_observation_expectations.yml` (properties)                | new column + relationships test            |

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_expectations.sql
@@ -15,6 +15,8 @@ with
 
             srh.job_title,
 
+            ot.staff_observation_type_key,
+
             row_number() over (
                 partition by
                     srh.employee_number,
@@ -37,6 +39,9 @@ with
                 between srh.work_assignment_actual_start_date and srh.effective_date_end
             )
             and t.type in ('PMS', 'PMC', 'TR', 'WT', 'O3')
+        left join
+            {{ ref("int_schoolmint_grow__observation_types") }} as ot
+            on t.type = ot.abbreviation
         where
             srh.primary_indicator
             and srh.assignment_status = 'Active'
@@ -72,6 +77,8 @@ select
             ]
         )
     }} as term_key,
+
+    staff_observation_type_key,
 
     academic_year,
     is_current,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_rubric_measurements.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_rubric_measurements.sql
@@ -1,23 +1,59 @@
+with
+    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
+    measurements as (
+        select
+            mgm.rubric_id,
+            mgm.measurement_id,
+            mgm.measurement_group_name,
+            mgm.measurement_group_weight,
+            mgm.measurement_group_description,
+            mgm.measurement_weight,
+            mgm.is_private_measurement,
+            mgm.require_measurement,
+            mgm.exclude_measurement,
+            mgm.measurement_group_id,
+            m.`name`,
+            m.`description`,
+            m.scale_min,
+            m.scale_max,
+        from
+            {{ ref("stg_schoolmint_grow__rubrics__measurement_groups__measurements") }}
+            as mgm
+        inner join
+            {{ ref("stg_schoolmint_grow__measurements") }} as m
+            on mgm.measurement_id = m.measurement_id
+    ),
+
+    -- Some rubrics reuse the same measurement under multiple strands — see
+    -- model description. Pick the canonical strand (non-excluded, then
+    -- alphabetical) so the dim's (rubric, measurement) PK is unique.
+    deduplicated as (
+        {{
+            dbt_utils.deduplicate(
+                relation="measurements",
+                partition_by="rubric_id, measurement_id",
+                order_by="exclude_measurement asc, measurement_group_id asc",
+            )
+        }}
+    )
+
 select
-    {{ dbt_utils.generate_surrogate_key(["mgm.rubric_id", "mgm.measurement_id"]) }}
+    {{ dbt_utils.generate_surrogate_key(["rubric_id", "measurement_id"]) }}
     as staff_observation_rubric_measurement_key,
 
-    {{ dbt_utils.generate_surrogate_key(["mgm.rubric_id"]) }}
+    {{ dbt_utils.generate_surrogate_key(["rubric_id"]) }}
     as staff_observation_rubric_key,
 
-    m.`name`,
-    m.`description`,
-    m.scale_min,
-    m.scale_max,
+    `name`,
+    `description`,
+    scale_min,
+    scale_max,
 
-    mgm.measurement_group_name as strand_name,
-    mgm.measurement_group_weight as strand_weight,
-    mgm.measurement_group_description as strand_description,
-    mgm.measurement_weight as weight,
-    mgm.is_private_measurement,
-    mgm.require_measurement as is_required,
-    mgm.exclude_measurement as is_excluded,
-from {{ ref("stg_schoolmint_grow__rubrics__measurement_groups__measurements") }} as mgm
-inner join
-    {{ ref("stg_schoolmint_grow__measurements") }} as m
-    on mgm.measurement_id = m.measurement_id
+    measurement_group_name as strand_name,
+    measurement_group_weight as strand_weight,
+    measurement_group_description as strand_description,
+    measurement_weight as weight,
+    is_private_measurement,
+    require_measurement as is_required,
+    exclude_measurement as is_excluded,
+from deduplicated

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_observation_types.sql
@@ -1,7 +1,2 @@
-select
-    {{ dbt_utils.generate_surrogate_key(["tag_id"]) }} as staff_observation_type_key,
-
-    `name`,
-    abbreviation,
-from {{ ref("stg_schoolmint_grow__generic_tags") }}
-where tag_type = 'observationtypes' and archived_at is null
+select staff_observation_type_key, `name`, abbreviation,
+from {{ ref("int_schoolmint_grow__observation_types") }}

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -5,7 +5,8 @@ models:
       type term. Built by crossing active teaching staff from roster history
       with PM/walkthrough/O3 term windows from the reporting terms sheet.
       Enables tracking whether each teacher received their expected observations
-      in each period. Foreign keys to dim_staff and dim_terms.
+      in each period. Foreign keys to dim_staff, dim_terms, and
+      dim_staff_observation_types.
     columns:
       - name: staff_observation_expectation_key
         data_type: string
@@ -49,11 +50,31 @@ models:
             warn_unsupported: false
         data_tests:
           - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_terms')
                 field: term_key
+
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Foreign key to dim_staff_observation_types. Surrogate key resolved via
+          int_schoolmint_grow__observation_types by joining the term type code
+          (PMS, PMC, TR, WT, O3) to the SchoolMint Grow observation-type tag
+          abbreviation. Non-nullable because the scaffold filters term types to
+          the five observation types, all of which match a Grow tag 1:1.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_staff_observation_types')
+            to_columns: [staff_observation_type_key]
+            warn_unsupported: false
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_staff_observation_types')
+                field: staff_observation_type_key
+
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -61,8 +61,11 @@ models:
           Foreign key to dim_staff_observation_types. Surrogate key resolved via
           int_schoolmint_grow__observation_types by joining the term type code
           (PMS, PMC, TR, WT, O3) to the SchoolMint Grow observation-type tag
-          abbreviation. Non-nullable because the scaffold filters term types to
-          the five observation types, all of which match a Grow tag 1:1.
+          abbreviation. Expected non-null because the five term-type
+          abbreviations are currently 1:1 with non-archived Grow observation
+          tags; the not_null test below fails loudly if that invariant ever
+          breaks (e.g., if Grow archives one of the matching tags or renames an
+          abbreviation without a coordinated update).
         constraints:
           - type: foreign_key
             to: ref('dim_staff_observation_types')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -107,15 +107,8 @@ models:
       - name: is_excluded
         data_type: boolean
         description: >-
-          SchoolMint Grow's `exclude` flag on the rubric's measurement entry.
-          Despite the name, this does NOT exclude the measurement from Grow's
-          overall observation score: empirical analysis shows `obs.score` is the
-          arithmetic mean of all `valueScore` values in `observationScores`,
-          including those from is_excluded=true measurements. The flag appears
-          to mark items that are not auto-prompted for numeric scoring (e.g.,
-          free-text reflection prompts on O3 forms, coaching reflection items),
-          but observers may still enter scores and Grow includes them in the
-          average. Filtering on this column for downstream rollups will diverge
-          from Grow's UI. When a measurement is reused under multiple strands of
-          a rubric, this column reflects the canonical (non-excluded) strand —
-          see model description.
+          Reflects the canonical strand's exclude flag when a measurement is
+          reused under multiple strands of a rubric (see model description for
+          the dedup rule). Does NOT filter from Grow's overall observation score
+          — see source-system semantics on
+          `stg_schoolmint_grow__rubrics__measurement_groups__measurements.exclude_measurement`.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -2,16 +2,26 @@ models:
   - name: dim_staff_observation_rubric_measurements
     description: >-
       Measurement item dimension for staff observation rubrics. One row per
-      measurement item per rubric. Contains the measurement name, strand
-      (measurement group) hierarchy, and weighting. Foreign keys to
-      dim_staff_observation_rubrics via staff_observation_rubric_key.
+      (rubric_id, measurement_id) pair. Strand metadata (`strand_name`,
+      `strand_weight`, `strand_description`, `is_excluded`) reflects the
+      canonical strand for that measurement when SchoolMint Grow's data model
+      permits the same measurement to appear under multiple strands of a rubric
+      (rare — observed in one archived rubric). The canonical strand is the
+      non-excluded one (`is_excluded=false`); ties broken alphabetically by
+      measurement_group_id. Foreign key to dim_staff_observation_rubrics via
+      staff_observation_rubric_key.
     columns:
       - name: staff_observation_rubric_measurement_key
         data_type: string
         description: >-
           Surrogate primary key derived from rubric_id and measurement_id.
-          Generated with generate_surrogate_key(["mgm.rubric_id",
-          "mgm.measurement_id"]).
+          Generated with generate_surrogate_key(["rubric_id",
+          "measurement_id"]). Matches the
+          fct_staff_observation_scores.staff_observation_rubric_measurement_key
+          composition — score grain is per-(observation, measurement), with no
+          per-strand split, because SchoolMint Grow's score rows do not carry
+          the rubric's measurement_group_id (the per-score measurementGroup
+          field is an instance UUID, not a strand reference).
         constraints:
           - type: primary_key
             warn_unsupported: false
@@ -61,22 +71,26 @@ models:
       - name: strand_name
         data_type: string
         description: >-
-          Name of the measurement group (strand) this measurement belongs to.
+          Name of the canonical measurement group (strand) this measurement
+          belongs to. When a rubric reuses the same measurement under multiple
+          strands, this column reflects the non-excluded strand.
 
       - name: strand_weight
         data_type: int64
         description: >-
-          Weight of the strand in overall rubric score calculation.
+          Weight of the strand in overall rubric score calculation. Reflects the
+          canonical strand when a measurement is reused.
 
       - name: strand_description
         data_type: string
         description: >-
-          Description of the measurement group (strand).
+          Description of the canonical measurement group (strand).
 
       - name: weight
         data_type: float64
         description: >-
-          Weight of this measurement within its strand for score calculation.
+          Weight of this measurement within its strand. Reflects the canonical
+          strand when a measurement is reused.
 
       - name: is_private_measurement
         data_type: boolean
@@ -93,4 +107,15 @@ models:
       - name: is_excluded
         data_type: boolean
         description: >-
-          TRUE if this measurement is excluded from scoring calculations.
+          SchoolMint Grow's `exclude` flag on the rubric's measurement entry.
+          Despite the name, this does NOT exclude the measurement from Grow's
+          overall observation score: empirical analysis shows `obs.score` is the
+          arithmetic mean of all `valueScore` values in `observationScores`,
+          including those from is_excluded=true measurements. The flag appears
+          to mark items that are not auto-prompted for numeric scoring (e.g.,
+          free-text reflection prompts on O3 forms, coaching reflection items),
+          but observers may still enter scores and Grow includes them in the
+          average. Filtering on this column for downstream rollups will diverge
+          from Grow's UI. When a measurement is reused under multiple strands of
+          a rubric, this column reflects the canonical (non-excluded) strand —
+          see model description.

--- a/src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_staff_observations.sql
@@ -1,113 +1,38 @@
-with
-    observation_types as (
-        select tag_id, abbreviation,
-        from {{ ref("stg_schoolmint_grow__generic_tags") }}
-        where tag_type = 'observationtypes' and archived_at is null
-    ),
-
-    observations_with_terms as (
-        select
-            o.observation_id,
-            o.rubric_id,
-            o.employee_number,
-            o.observer_employee_number,
-            o.academic_year,
-            o.observed_at as observed_at_date,
-            o.observed_at_timestamp,
-            o.observation_score,
-            o.overall_tier,
-            o.glows,
-            o.grows,
-            o.locked,
-            o.observation_notes,
-
-            gro.location_key,
-
-            lc.location_region,
-
-            ot.tag_id as observation_type_tag_id,
-
-            t.type as t_type,
-            t.code as t_code,
-            t.`name` as t_name,
-            t.start_date as t_start_date,
-            t.region as t_region,
-            t.school_id as t_school_id,
-
-            row_number() over (
-                partition by o.observation_id order by t.`name` asc nulls last
-            ) as rn,
-        from {{ ref("int_performance_management__observations") }} as o
-        left join
-            {{ ref("int_schoolmint_grow__observations") }} as gro
-            on o.observation_id = gro.observation_id
-        left join
-            {{ ref("int_people__location_crosswalk") }} as lc
-            on gro.school_name = lc.location_name
-        left join
-            observation_types as ot on o.observation_type_abbreviation = ot.abbreviation
-        left join
-            {{ ref("stg_google_sheets__reporting__terms") }} as t
-            on o.observation_type_abbreviation = t.type
-            and o.observed_at between t.start_date and t.end_date
-            and lc.location_region = t.region
-    )
-
 select
-    {{ dbt_utils.generate_surrogate_key(["observation_id"]) }} as staff_observation_key,
+    {{ dbt_utils.generate_surrogate_key(["o.observation_id"]) }}
+    as staff_observation_key,
 
     if(
-        employee_number is not null,
-        {{ dbt_utils.generate_surrogate_key(["employee_number"]) }},
+        o.employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["o.employee_number"]) }},
         cast(null as string)
     ) as teacher_staff_key,
 
     if(
-        observer_employee_number is not null,
-        {{ dbt_utils.generate_surrogate_key(["observer_employee_number"]) }},
+        o.observer_employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["o.observer_employee_number"]) }},
         cast(null as string)
     ) as observer_staff_key,
 
-    location_key,
+    gro.location_key,
 
-    if(
-        t_code is not null,
-        {{
-            dbt_utils.generate_surrogate_key(
-                [
-                    "t_type",
-                    "t_code",
-                    "t_name",
-                    "t_start_date",
-                    "t_region",
-                    "t_school_id",
-                ]
-            )
-        }},
-        cast(null as string)
-    ) as term_key,
+    o.term_key,
 
-    if(
-        observation_type_tag_id is not null,
-        {{ dbt_utils.generate_surrogate_key(["observation_type_tag_id"]) }},
-        cast(null as string)
-    ) as staff_observation_type_key,
+    o.staff_observation_type_key,
 
-    if(
-        rubric_id is not null,
-        {{ dbt_utils.generate_surrogate_key(["rubric_id"]) }},
-        cast(null as string)
-    ) as staff_observation_rubric_key,
+    o.staff_observation_rubric_key,
 
-    academic_year,
-    observation_score as score,
-    overall_tier as overall_rating,
-    observation_notes as notes,
+    o.academic_year,
+    o.observation_score as score,
+    o.overall_tier as overall_rating,
+    o.observation_notes as notes,
 
-    observed_at_date as observed_date_key,
-    observed_at_timestamp as observed_timestamp,
-    glows as positive_feedback,
-    grows as growth_areas,
-    locked as is_locked,
-from observations_with_terms
-where rn = 1
+    o.observed_at as observed_date_key,
+    o.observed_at_timestamp as observed_timestamp,
+    o.glows as positive_feedback,
+    o.grows as growth_areas,
+    o.locked as is_locked,
+from {{ ref("int_performance_management__observations") }} as o
+left join
+    {{ ref("int_schoolmint_grow__observations") }} as gro
+    on o.observation_id = gro.observation_id

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -67,12 +67,12 @@ models:
             to_columns: [staff_observation_rubric_key]
             warn_unsupported: false
         data_tests:
-          # TODO: #3712 — dim source is measurement-grain, excludes rubrics
-          # without nested measurements. Promote to error once resolved.
           - relationships:
               arguments:
                 to: ref('dim_staff_observation_rubrics')
                 field: staff_observation_rubric_key
+              config:
+                severity: error
 
       - name: observer_staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -59,14 +59,17 @@ models:
       - name: staff_observation_rubric_key
         data_type: string
         description: >-
-          Foreign key to dim_staff_observation_rubrics. Surrogate key derived
-          from rubric_id. Null when the observation has no rubric attached.
+          Foreign key to dim_staff_observation_rubrics. Surrogate key pre-hashed
+          from rubric_id in int_schoolmint_grow__observations. Non-nullable —
+          rubric_id is structurally non-null for all published observations and
+          enforced by a not_null test on the upstream intermediate.
         constraints:
           - type: foreign_key
             to: ref('dim_staff_observation_rubrics')
             to_columns: [staff_observation_rubric_key]
             warn_unsupported: false
         data_tests:
+          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_observation_rubrics')

--- a/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/int_performance_management__observations.sql
@@ -3,6 +3,8 @@ select
     o.observation_id,
     o.rubric_id,
     o.rubric_name,
+    o.staff_observation_type_key,
+    o.staff_observation_rubric_key,
     o.score as observation_score,
     o.glows,
     o.grows,
@@ -21,6 +23,23 @@ select
 
     t.code as term_code,
     t.name as term_name,
+
+    if(
+        t.code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "t.type",
+                    "t.code",
+                    "t.name",
+                    "t.start_date",
+                    "t.region",
+                    "t.school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
 
     case
         when o.score >= 3.495
@@ -60,6 +79,8 @@ select
     o.observation_id,
     o.rubric_id,
     o.rubric_name,
+    o.staff_observation_type_key,
+    o.staff_observation_rubric_key,
     o.score as observation_score,
     o.glows,
     o.grows,
@@ -79,6 +100,23 @@ select
 
     t.code as term_code,
     t.name as term_name,
+
+    if(
+        t.code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "t.type",
+                    "t.code",
+                    "t.name",
+                    "t.start_date",
+                    "t.region",
+                    "t.school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
 
     null as overall_tier,
     null as eval_date,

--- a/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
@@ -9,6 +9,14 @@ models:
       2023 walkthroughs (filtered by academic_year, is_published, and
       rubric_name LIKE 'Walkthrough%' OR 'Strong Start%'). Pre-2024
       non-walkthrough data lives in a separate snapshot. Materialized as table.
+
+
+      **No defensive dedup.** The terms LEFT JOIN could in principle fan out if
+      `stg_google_sheets__reporting__terms` ever gains overlapping date windows
+      for the same `(type, region)`. A prior `row_number ... where rn = 1` guard
+      in `fct_staff_observations` was removed (verified zero fan-out across
+      46,686 production rows); the unique test on `observation_id` here will
+      fail loudly on any future fan-out instead of silently picking a row.
     config:
       materialized: table
     columns:

--- a/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
@@ -1,17 +1,29 @@
 models:
   - name: int_performance_management__observations
+    description: >-
+      Performance-management observations enriched with reporting-term metadata
+      (`term_key`, `term_code`, `term_name`) and pre-hashed foreign-key
+      surrogates for `staff_observation_type_key` and
+      `staff_observation_rubric_key`. UNION of two branches: 2024+ observations
+      of all types (filtered by `is_published` and `academic_year >= 2024`), and
+      2023 walkthroughs (filtered by academic_year, is_published, and
+      rubric_name LIKE 'Walkthrough%' OR 'Strong Start%'). Pre-2024
+      non-walkthrough data lives in a separate snapshot. Materialized as table.
     config:
       materialized: table
     columns:
       - name: observation_id
         data_type: string
+        description: SchoolMint Grow observation identifier.
         data_tests:
           - unique
           - not_null
       - name: rubric_id
         data_type: string
+        description: SchoolMint Grow rubric identifier for the observation.
       - name: rubric_name
         data_type: string
+        description: Display name of the rubric used for the observation.
       - name: staff_observation_type_key
         data_type: string
         description: >-
@@ -31,39 +43,89 @@ models:
           if() per the nullable-surrogate-key convention.
       - name: observation_score
         data_type: float64
+        description: >-
+          Overall numeric score for the observation as computed by Grow,
+          averaged across measurement items.
       - name: glows
         data_type: string
+        description: >-
+          Pipe-delimited positive feedback items recorded during the
+          observation.
       - name: grows
         data_type: string
+        description: >-
+          Pipe-delimited growth-area items (improvements needed) recorded during
+          the observation.
       - name: locked
         data_type: boolean
+        description: TRUE if the observation is locked and cannot be edited.
       - name: observed_at_timestamp
         data_type: timestamp
+        description: UTC timestamp when the observation was conducted.
       - name: observed_at
         data_type: date
+        description: Local-timezone date the observation was conducted.
       - name: academic_year
         data_type: int64
+        description: Academic year the observation occurred in.
       - name: is_published
         data_type: boolean
+        description: >-
+          TRUE if the observation has been published in SchoolMint Grow. The
+          model filters to is_published = true.
       - name: employee_number
         data_type: int64
+        description: >-
+          ADP employee number of the observed teacher (sourced from the Grow
+          user's internal_id).
       - name: observer_employee_number
         data_type: int64
+        description: >-
+          ADP employee number of the observer (sourced from the Grow user's
+          internal_id).
       - name: observation_type
         data_type: string
+        description: >-
+          Display name of the observation type (e.g. "Walkthrough", "PM
+          Semester"). Hardcoded to "Walkthrough" in the 2023 branch.
       - name: observation_type_abbreviation
         data_type: string
+        description: >-
+          Short code for the observation type (e.g. "WT", "PMS"). Used to join
+          to the reporting-terms scaffold. Hardcoded to "WT" in the 2023 branch.
       - name: observation_course
         data_type: string
+        description: >-
+          Course tag captured during the observation. Null in the 2023
+          walkthrough branch.
       - name: observation_grade
         data_type: string
+        description: >-
+          Grade-level tag captured during the observation. Null in the 2023
+          walkthrough branch.
       - name: observation_notes
         data_type: string
+        description: >-
+          Free-text observer notes (Grow's "magic notes" field) recorded during
+          the observation.
       - name: term_code
         data_type: string
+        description: >-
+          Reporting term code matched on (observation_type_abbreviation,
+          observed_at_date, location region). Examples: PM1, PM2, PM3.
       - name: term_name
         data_type: string
+        description: Reporting term display name matched alongside term_code.
       - name: overall_tier
         data_type: int64
+        description: >-
+          Performance tier (1-4) derived from observation_score thresholds:
+          score >= 3.495 -> 4; >= 2.745 -> 3; >= 1.745 -> 2; < 1.75 -> 1. Null
+          in the 2023 walkthrough branch (no scoring tier applies).
       - name: eval_date
         data_type: date
+        description: >-
+          Standardized evaluation date derived from term_code: PM1 -> October 1
+          of the academic year; PM2 -> January 1 of (year+1); PM3 -> March 1 of
+          (year+1). Null in the 2023 walkthrough branch and for non-PM
+          term_codes.

--- a/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
+++ b/src/dbt/kipptaf/models/performance_management/intermediate/properties/int_performance_management__observations.yml
@@ -2,20 +2,33 @@ models:
   - name: int_performance_management__observations
     config:
       materialized: table
-    # TODO: add unique test
-    # data_tests:
-    #   - dbt_utils.unique_combination_of_columns:
-    #       arguments:
-    #         combination_of_columns:
-    #           - ...
-    #       config: {}
     columns:
       - name: observation_id
         data_type: string
+        data_tests:
+          - unique
+          - not_null
       - name: rubric_id
         data_type: string
       - name: rubric_name
         data_type: string
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_staff_observation_types, passed through from
+          int_schoolmint_grow__observations.
+      - name: staff_observation_rubric_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_staff_observation_rubrics, passed through from
+          int_schoolmint_grow__observations.
+      - name: term_key
+        data_type: string
+        description: >-
+          Pre-hashed FK to dim_terms. Generated with generate_surrogate_key on
+          (term type, code, name, start_date, region, school_id). NULL when
+          t.code is NULL (unmatched LEFT JOIN to reporting terms); wrapped in an
+          if() per the nullable-surrogate-key convention.
       - name: observation_score
         data_type: float64
       - name: glows

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observation_types.sql
@@ -1,0 +1,7 @@
+select
+    {{ dbt_utils.generate_surrogate_key(["tag_id"]) }} as staff_observation_type_key,
+    tag_id,
+    abbreviation,
+    `name`,
+from {{ ref("stg_schoolmint_grow__generic_tags") }}
+where tag_type = 'observationtypes' and archived_at is null

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/int_schoolmint_grow__observations.sql
@@ -14,8 +14,9 @@ select
 
     s.name as school_name,
 
-    gt.name as observation_type_name,
-    gt.abbreviation as observation_type_abbreviation,
+    ot.staff_observation_type_key,
+    ot.name as observation_type_name,
+    ot.abbreviation as observation_type_abbreviation,
 
     gt2.name as observation_course,
 
@@ -26,6 +27,9 @@ select
     safe_cast(ut.internal_id as int) as teacher_internal_id,
 
     safe_cast(uo.internal_id as int) as observer_internal_id,
+
+    {{ dbt_utils.generate_surrogate_key(["o.rubric_id"]) }}
+    as staff_observation_rubric_key,
 from {{ ref("stg_schoolmint_grow__observations") }} as o
 left join {{ ref("stg_schoolmint_grow__users") }} as ut on o.teacher_id = ut.user_id
 left join {{ ref("stg_schoolmint_grow__users") }} as uo on o.observer_id = uo.user_id
@@ -33,8 +37,8 @@ left join
     {{ ref("stg_schoolmint_grow__schools") }} as s
     on o.teaching_assignment_school = s.school_id
 left join
-    {{ ref("stg_schoolmint_grow__generic_tags") }} as gt
-    on o.observation_type = gt.tag_id
+    {{ ref("int_schoolmint_grow__observation_types") }} as ot
+    on o.observation_type = ot.tag_id
 left join
     {{ ref("stg_schoolmint_grow__generic_tags") }} as gt2
     on o.teaching_assignment_course = gt2.tag_id

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
@@ -1,0 +1,38 @@
+models:
+  - name: int_schoolmint_grow__observation_types
+    description: >-
+      Observation type lookup. One row per non-archived SchoolMint Grow generic
+      tag where tag_type = 'observationtypes'. Single source of truth for the
+      abbreviation → tag_id → staff_observation_type_key mapping consumed by
+      dim_staff_observation_types, int_schoolmint_grow__observations, and
+      dim_staff_observation_expectations.
+    columns:
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Surrogate key derived from tag_id. Generated with
+          generate_surrogate_key(["tag_id"]).
+        data_tests:
+          - unique
+          - not_null
+      - name: tag_id
+        data_type: string
+        description: >-
+          SchoolMint Grow generic tag identifier for the observation type.
+        data_tests:
+          - unique
+          - not_null
+      - name: abbreviation
+        data_type: string
+        description: >-
+          Short code for the observation type (e.g. WT, O3, PMS, PMC, TR). Joins
+          to reporting term `type` codes 1:1.
+        data_tests:
+          - unique
+          - not_null
+      - name: name
+        quote: true
+        data_type: string
+        description: >-
+          Full display name of the observation type (e.g. Walkthrough,
+          One-on-One, PM Semester).

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
@@ -11,9 +11,10 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from tag_id. Generated with
-          generate_surrogate_key(["tag_id"]).
+          generate_surrogate_key(["tag_id"]). Uniqueness is enforced via the
+          unique test on tag_id below — the hash is a deterministic function of
+          tag_id.
         data_tests:
-          - unique
           - not_null
       - name: tag_id
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
@@ -5,6 +5,10 @@ models:
       teacher staff IDs, observation-type metadata, and pre-hashed foreign-key
       surrogates for staff_observation_type_key and
       staff_observation_rubric_key. One row per Grow observation_id.
+      Per-measurement score detail (one row per observation_id + measurement_id)
+      is exposed downstream via fct_staff_observation_scores — Grow's score rows
+      carry no rubric strand context, so score grain is `(observation_id,
+      measurement_id)` and can't be split per strand.
     columns:
       - name: observation_id
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
@@ -1,9 +1,41 @@
 models:
   - name: int_schoolmint_grow__observations
+    description: >-
+      SchoolMint Grow observations enriched with school location, observer and
+      teacher staff IDs, observation-type metadata, and pre-hashed foreign-key
+      surrogates for staff_observation_type_key and
+      staff_observation_rubric_key. One row per Grow observation_id.
     columns:
+      - name: observation_id
+        data_type: string
+        description: SchoolMint Grow observation identifier.
+        data_tests:
+          - unique
+          - not_null
+      - name: rubric_id
+        data_type: string
+        description: >-
+          SchoolMint Grow rubric identifier. Structurally non-null for all
+          published, non-archived observations.
+        data_tests:
+          - not_null
+      - name: staff_observation_rubric_key
+        data_type: string
+        description: >-
+          Pre-hashed surrogate key derived from rubric_id. Generated with
+          generate_surrogate_key(["rubric_id"]). Consumed by
+          fct_staff_observations as its rubric FK.
+        data_tests:
+          - not_null
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Pre-hashed surrogate key for the observation type. NULL when the
+          observation's tag_id does not resolve to a non-archived
+          observationtypes tag.
       - name: location_key
         data_type: string
-        description: >
+        description: >-
           MD5 surrogate key for the canonical school location. Null when
           s.school_id does not match any grow_location_id in
           stg_google_sheets__people__locations.
@@ -12,10 +44,6 @@ models:
               arguments:
                 to: ref("dim_locations")
                 field: location_key
-      - name: observation_id
-        data_type: string
-      - name: rubric_id
-        data_type: string
       - name: rubric_name
         data_type: string
       - name: score

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml
@@ -9,28 +9,40 @@ models:
     columns:
       - name: measurement_id
         data_type: string
+        description: SchoolMint Grow measurement identifier.
         data_tests:
           - unique:
               config:
                 severity: error
       - name: district
         data_type: string
+        description: SchoolMint Grow district identifier.
       - name: name
         data_type: string
+        description: Display name of the measurement item.
       - name: description
         data_type: string
+        description: Long-form description of the measurement item.
       - name: row_style
         data_type: string
+        description: SchoolMint Grow rendering hint for the measurement row.
       - name: scale_max
         data_type: int64
+        description: Maximum possible numeric score for this measurement.
       - name: scale_min
         data_type: int64
+        description: Minimum possible numeric score for this measurement.
       - name: created
         data_type: timestamp
+        description: Timestamp when the measurement was created in Grow.
       - name: last_modified
         data_type: timestamp
+        description: Timestamp when the measurement was last edited in Grow.
       - name: archived_at
         data_type: timestamp
+        description: >-
+          Timestamp when the measurement was archived in Grow; NULL if still
+          active.
       # - name: text_boxes
       #   data_type: array
       # - name: measurement_options

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__measurements.yml
@@ -1,5 +1,11 @@
 models:
   - name: stg_schoolmint_grow__measurements
+    description: >-
+      SchoolMint Grow measurement metadata. Includes both archived and
+      non-archived measurements (deviates from the project-wide
+      `_dagster_partition_key = 'f'` convention) so that downstream observation
+      score facts can resolve historical measurement references. Filter on
+      `archived_at` if non-archived rows are needed.
     columns:
       - name: measurement_id
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
@@ -60,7 +60,9 @@ models:
           the rubric.
       - name: measurement_group_key
         data_type: string
-        description: Surrogate key for the measurement group within the rubric.
+        description: >-
+          Stable string key for the measurement group within Grow's rubric
+          editor.
       - name: measurement_group_description
         data_type: string
         description: Description of the measurement group (strand).
@@ -72,8 +74,7 @@ models:
       - name: measurement_key
         data_type: string
         description: >-
-          Surrogate key for the measurement within its measurement group on this
-          rubric.
+          Stable string key for the measurement within Grow's rubric editor.
       - name: measurement_weight
         data_type: float64
         description: >-

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
@@ -1,5 +1,11 @@
 models:
   - name: stg_schoolmint_grow__rubrics__measurement_groups__measurements
+    description: >-
+      Flattened view of SchoolMint Grow rubrics with their nested measurement
+      groups and measurements. Includes both archived and non-archived rubrics
+      (deviates from the project-wide `_dagster_partition_key = 'f'` convention)
+      so that downstream observation facts can resolve historical rubric
+      references. Filter on `archived_at` if non-archived rows are needed.
     columns:
       - name: rubric_id
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
@@ -9,46 +9,88 @@ models:
     columns:
       - name: rubric_id
         data_type: string
+        description: SchoolMint Grow rubric identifier.
       - name: name
         data_type: string
+        description: Rubric display name.
       - name: district
         data_type: string
+        description: SchoolMint Grow district identifier the rubric belongs to.
       - name: scale_min
         data_type: int64
+        description: Minimum score on the rubric's measurement scale.
       - name: scale_max
         data_type: int64
+        description: Maximum score on the rubric's measurement scale.
       - name: is_private
         data_type: boolean
+        description: TRUE if the rubric is marked private in SchoolMint Grow.
       - name: is_published
         data_type: boolean
+        description: TRUE if the rubric is published and available for use.
       - name: archived_at
         data_type: timestamp
+        description: >-
+          Timestamp the rubric was archived in SchoolMint Grow, or NULL if it is
+          still active.
       - name: created
         data_type: timestamp
+        description: Timestamp the rubric was created.
       - name: last_modified
         data_type: timestamp
+        description: Timestamp the rubric was last modified.
       - name: measurement_group_name
         data_type: string
+        description: >-
+          Name of the measurement group (strand) within the rubric.
       - name: measurement_group_id
         data_type: string
+        description: >-
+          SchoolMint Grow identifier for the measurement group (strand) within
+          the rubric.
       - name: measurement_group_key
         data_type: string
+        description: Surrogate key for the measurement group within the rubric.
       - name: measurement_group_description
         data_type: string
+        description: Description of the measurement group (strand).
       - name: measurement_group_weight
         data_type: int64
+        description: >-
+          Weight of the measurement group (strand) in the rubric's overall score
+          calculation.
       - name: measurement_key
         data_type: string
+        description: >-
+          Surrogate key for the measurement within its measurement group on this
+          rubric.
       - name: measurement_weight
         data_type: float64
+        description: >-
+          Weight of the individual measurement within its strand for score
+          calculation.
       - name: measurement_id
         data_type: string
+        description: SchoolMint Grow identifier for the measurement item.
       - name: is_private_measurement
         data_type: boolean
+        description: >-
+          TRUE if the measurement is marked private within the rubric — visible
+          to observers and leaders, hidden from the observee.
       - name: exclude_measurement
         data_type: boolean
+        description: >-
+          SchoolMint Grow's `exclude` flag on a rubric's measurement entry
+          within a strand. Despite the name, this does NOT exclude the
+          measurement from Grow's overall observation score (`obs.score`
+          averages all `valueScore` values regardless of this flag). The flag
+          appears to mark items not auto-prompted for numeric scoring (free-text
+          reflections, qualitative coaching prompts), but observers may still
+          enter scores and Grow includes them.
       - name: require_measurement
         data_type: boolean
+        description: >-
+          TRUE if the measurement is required to be scored during observation.
       # - name: order
       #   data_type: int64
       # - name: settings

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/properties/stg_schoolmint_grow__rubrics__measurement_groups__measurements.yml
@@ -6,6 +6,16 @@ models:
       (deviates from the project-wide `_dagster_partition_key = 'f'` convention)
       so that downstream observation facts can resolve historical rubric
       references. Filter on `archived_at` if non-archived rows are needed.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - rubric_id
+              - measurement_group_id
+              - measurement_id
+          config:
+            severity: error
+            where: measurement_id is not null
     columns:
       - name: rubric_id
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__measurements.sql
@@ -11,4 +11,3 @@ select
     cast(lastmodified as timestamp) as last_modified,
     cast(archivedat as timestamp) as archived_at,
 from {{ source("schoolmint_grow", "src_schoolmint_grow__measurements") }}
-where _dagster_partition_key = 'f'

--- a/src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql
+++ b/src/dbt/kipptaf/models/schoolmint/grow/staging/stg_schoolmint_grow__rubrics__measurement_groups__measurements.sql
@@ -26,4 +26,3 @@ select
 from {{ source("schoolmint_grow", "src_schoolmint_grow__rubrics") }} as r
 left join unnest(r.measurementgroups) as mg
 left join unnest(mg.measurements) as m
-where r._dagster_partition_key = 'f'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Closes #3641, #3680, #3712, #3722. Fixes ~273K orphan FKs on staff observation rubric/measurement dims, adds the missing observation-type FK to `dim_staff_observation_expectations`, centralizes the duplicated SchoolMint Grow observation-type lookup into a new intermediate, and promotes the rubric-key relationships test to error severity now that orphans resolve.

**Headline metrics:**
- `fct_staff_observations.staff_observation_rubric_key` orphans: 23,372 → 0
- `fct_staff_observation_scores.staff_observation_rubric_measurement_key` orphans: 249,465 → 0
- `fct_staff_observations` simplified from 115 → 37 lines (CTEs/joins/wrappers/dedup all moved upstream)

**Root causes resolved:**
- #3722: two Grow staging models filtered `_dagster_partition_key = 'f'` (non-archived only), excluding 75 rubrics + 348 measurements that published 2024+ observations still referenced. Removing the filter restores the parent metadata.
- #3641: `dim_staff_observation_expectations` lacked the FK to `dim_staff_observation_types`. The 5 expectation term codes (PMS, PMC, TR, WT, O3) match Grow generic_tag abbreviations 1:1, so the FK is non-nullable via a join on `t.type = ot.abbreviation`.
- #3680: observation-type lookup duplicated inline in `fct_staff_observations` and `dim_staff_observation_types`. New `int_schoolmint_grow__observation_types` centralizes the pre-hashed `staff_observation_type_key`. Same hash composition (`["tag_id"]`), same values.
- #3712: incidentally resolved by Task 1 (parent rubric metadata restored). Relationships test promoted to `severity: error`.

**Hash discipline:** No surrogate-key composition changed; all FK values stable. Three keys (`staff_observation_type_key`, `staff_observation_rubric_key`, `term_key`) are now pre-hashed once upstream rather than re-derived in marts.

**Convention deviation:** Two staging models (`stg_schoolmint_grow__rubrics__measurement_groups__measurements`, `stg_schoolmint_grow__measurements`) intentionally include archived rows. Documented in each model's `description:`.

Spec: [docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md](docs/superpowers/specs/2026-04-29-batch-d-staff-observation-fks-design.md)
Plan: [docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md](docs/superpowers/plans/2026-04-29-batch-d-staff-observation-fks.md)

## Bonus solutions

Beyond the four headline issues, this PR also incidentally resolves several pre-existing items surfaced during implementation:

- **`# TODO: add unique test`** in `int_performance_management__observations.yml` — closed in Task 5 with a real `unique` test on `observation_id` (verified zero fan-out across 46,686 production rows).
- **Staging-layer uniqueness gap** on `stg_schoolmint_grow__rubrics__measurement_groups__measurements` — pre-existing project-rule violation (CLAUDE.md: "All staging models must have a uniqueness test"). Added `dbt_utils.unique_combination_of_columns: [rubric_id, measurement_group_id, measurement_id]` filtered to non-null measurement_id, satisfying the staging requirement.
- **`int_performance_management__observations` undocumented columns** — backfilled descriptions for ~17 columns and the model itself, per the "all modified models require descriptions" rule.
- **Pre-existing grain bug in `dim_staff_observation_rubric_measurements`** — same measurement reused across two strands of an archived rubric, masked by the staging filter. Fixed via `dbt_utils.deduplicate()` preferring the non-excluded strand. Hash composition unchanged.
- **Empirical semantics of `is_excluded`** — investigation confirmed the flag does NOT filter from Grow's overall `obs.score` (verified across 1,106 observations of "Teacher Development: Teacher in Residence"). It marks items not auto-prompted for numeric scoring (free-text reflections, qualitative coaching prompts), but Grow includes any entered scores in the average. Now documented in stg/int/dim YAML descriptions so future analysts don't waste time misinterpreting it.
- **Hash centralization** — three previously-duplicated FK hash compositions (`staff_observation_type_key`, `staff_observation_rubric_key`, `term_key`) now live in single derivation points, removing maintenance liability.
- **Defensive-code cleanup** — the `row_number ... where rn = 1` dedup in `fct_staff_observations` was dead code in production (verified zero fan-out across 46,686 rows). Removed and replaced with an upstream `unique` test that catches future fan-out at CI time instead of silently picking a row.

## AI Assistance

Brainstormed, planned, and implemented with Claude Code. Subagent-driven execution: per-task implementer + spec reviewer + code quality reviewer. Human-directed scope decisions, design tradeoffs, and final approvals.

## Self-review

### dbt

- [x] Properties YAML included for new model (`int_schoolmint_grow__observation_types.yml`)
- [x] No new external sources
- [x] Hash compositions unchanged across all relocated FK keys (verified row-by-row in dev against prod, modulo documented prod-side staleness in `int_performance_management__observations`)
- [x] Star-schema diamond audit performed: post-PR `fct_staff_observations` FKs are diamond-free
- [x] **Breaking change consideration:** No mart column renames or removals. New non-nullable column added to `dim_staff_observation_expectations` — confirm with consumers if expectations dim is in any Tableau/Cube exposure (per audit, no current exposure references the new column).

## CI checks

- [ ] **Trunk** — verified passing locally before push.
- [ ] **dbt Cloud** — pending CI run.
- [ ] **Dagster Cloud** — N/A (no Dagster paths changed).
