### PR TITLE
feat(kipptaf): add grade level to award ceremony GPA extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
@@ -1,31 +1,48 @@
 models:
   - name: rpt_gsheets__award_ceremony_gpa
+    description: >
+      Per-student subject GPA extract for award ceremony use, scoped to active
+      HS students (grades 9–12) in the current academic year. Reports both
+      stored (Y1) and live (Q4) GPA points pivoted by credit type.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - school
+              - grade_level
               - student_number
     columns:
       - name: school
         data_type: string
+        description: School abbreviation from PowerSchool.
       - name: grade_level
         data_type: int64
+        description: Student's current grade level (9–12).
       - name: student_number
         data_type: int64
+        description: Student's PowerSchool student number.
       - name: student_name
         data_type: string
+        description: Student's full name in last, first format.
       - name: english
         data_type: float64
+        description: Weighted GPA for English (ENG) credit type.
       - name: math
         data_type: float64
+        description: Weighted GPA for Math (MATH) credit type.
       - name: science
         data_type: float64
+        description: Weighted GPA for Science (SCI) credit type.
       - name: social_studies
         data_type: float64
+        description: Weighted GPA for Social Studies (SOC) credit type.
       - name: world_language
         data_type: float64
+        description: Weighted GPA for World Language (WLANG) credit type.
       - name: vpa
         data_type: float64
+        description:
+          Weighted GPA for Visual & Performing Arts (ART) credit type.
       - name: physed
         data_type: float64
+        description: Weighted GPA for Physical Education (PHYSED) credit type.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__award_ceremony_gpa.yml
@@ -9,6 +9,8 @@ models:
     columns:
       - name: school
         data_type: string
+      - name: grade_level
+        data_type: int64
       - name: student_number
         data_type: int64
       - name: student_name

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
@@ -4,6 +4,7 @@ with
             'Stored' as gpa_type,
 
             co.school_abbreviation,
+            co.grade_level,
             co.student_number,
             co.lastfirst,
 
@@ -20,7 +21,7 @@ with
             on sg.studentid = co.studentid
             and {{ union_dataset_join_clause(left_alias="sg", right_alias="co") }}
             and sg.schoolid = co.schoolid
-            and co.grade_level = 12
+            and co.grade_level >= 9
             and co.rn_year = 1
             and co.enroll_status = 0
             and co.academic_year = {{ var("current_academic_year") }}
@@ -32,6 +33,7 @@ with
             'Live' as gpa_type,
 
             co.school_abbreviation,
+            co.grade_level,
             co.student_number,
             co.lastfirst,
 
@@ -54,7 +56,7 @@ with
             and {{ union_dataset_join_clause(left_alias="fg", right_alias="co") }}
             and fg.schoolid = co.schoolid
             and fg.academic_year = co.academic_year
-            and co.grade_level = 12
+            and co.grade_level >= 9
             and co.rn_year = 1
             and co.enroll_status = 0
         where
@@ -65,6 +67,7 @@ with
     calculations as (
         select
             school_abbreviation,
+            grade_level,
             student_number,
             lastfirst,
             credittype,
@@ -77,11 +80,12 @@ with
         where
             potentialcrhrs != 0
             and credittype in ('ENG', 'MATH', 'SCI', 'SOC', 'WLANG', 'ART', 'PHYSED')
-        group by school_abbreviation, student_number, lastfirst, credittype
+        group by school_abbreviation, grade_level, student_number, lastfirst, credittype
     )
 
 select
     school_abbreviation as school,
+    grade_level,
     student_number,
     lastfirst as student_name,
     eng as english,


### PR DESCRIPTION
## Summary
- Adds `grade_level` column to `rpt_gsheets__award_ceremony_gpa`
- Expands student scope from seniors only (grade 12) to all HS students (grades 9–12)

## Test plan
- [ ] `dbt build --select rpt_gsheets__award_ceremony_gpa` passes locally (view created, uniqueness test passes)
- [ ] Verify Google Sheet consumer handles additional grade levels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214399308568914