### PR TITLE
Add Docker Compose setup with Superset service to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,7 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/teamster",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:latest": {},
     "ghcr.io/devcontainers/features/github-cli:latest": {},
@@ -7,14 +9,6 @@
     "ghcr.io/jajera/features/gcloud-cli:latest": {},
     "ghcr.io/devcontainers/features/node:1": {}
   },
-  "mounts": [
-    "type=tmpfs,destination=/etc/secret-volume,tmpfs-mode=0777,tmpfs-size=10485760"
-  ],
-  "runArgs": [
-    "--cap-drop=NET_RAW",
-    "--cap-drop=SYS_PTRACE",
-    "--cap-drop=NET_ADMIN"
-  ],
   "postCreateCommand": "bash .devcontainer/scripts/postCreate.sh",
   "postStartCommand": "bash .devcontainer/scripts/postStart.sh",
   "containerEnv": {
@@ -35,6 +29,13 @@
         "ms-python.python",
         "redhat.vscode-yaml"
       ]
+    }
+  },
+  "forwardPorts": [8088],
+  "portsAttributes": {
+    "8088": {
+      "label": "Superset",
+      "onAutoForward": "notify"
     }
   }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/python:3.13
+    cap_drop:
+      - NET_RAW
+      - SYS_PTRACE
+      - NET_ADMIN
+    volumes:
+      - type: tmpfs
+        target: /etc/secret-volume
+        tmpfs:
+          mode: 0777
+          size: 10485760
+      - gcloud-config:/home/vscode/.config/gcloud
+    command: sleep infinity
+
+  superset:
+    build:
+      context: ./superset
+    depends_on:
+      superset-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql+psycopg2://superset:superset@superset-db:5432/superset
+      SUPERSET_SECRET_KEY: teamster-superset-dev-key
+      GOOGLE_APPLICATION_CREDENTIALS: /superset-gcloud/application_default_credentials.json
+    ports:
+      - "8088:8088"
+    volumes:
+      - gcloud-config:/superset-gcloud:ro
+      - superset-home:/app/superset_home
+
+  superset-db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: superset
+      POSTGRES_USER: superset
+      POSTGRES_PASSWORD: superset
+    healthcheck:
+      test: [CMD, pg_isready, -U, superset]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - superset-db-data:/var/lib/postgresql/data
+
+volumes:
+  gcloud-config:
+  superset-home:
+  superset-db-data:

--- a/.devcontainer/superset/Dockerfile
+++ b/.devcontainer/superset/Dockerfile
@@ -1,0 +1,13 @@
+FROM apache/superset:4.1.1
+
+USER root
+
+RUN pip install --no-cache-dir sqlalchemy-bigquery
+
+COPY superset_config.py /app/pythonpath/superset_config.py
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+USER superset
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/.devcontainer/superset/docker-entrypoint.sh
+++ b/.devcontainer/superset/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+superset db upgrade
+
+superset fab create-admin \
+  --username admin \
+  --firstname Admin \
+  --lastname Admin \
+  --email admin@superset.com \
+  --password admin 2>/dev/null || true
+
+superset init
+
+exec gunicorn \
+  --bind "0.0.0.0:8088" \
+  --workers 2 \
+  --timeout 120 \
+  "superset.app:create_app()"

--- a/.devcontainer/superset/superset_config.py
+++ b/.devcontainer/superset/superset_config.py
@@ -1,0 +1,8 @@
+import os
+
+SQLALCHEMY_DATABASE_URI = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+psycopg2://superset:superset@superset-db:5432/superset",
+)
+SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY", "change-me-for-production")
+PREVENT_UNSAFE_DB_CONNECTIONS = False


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a Docker Compose-based development environment that includes a Superset instance alongside the existing Python dev container. This enables local development and testing of Superset dashboards with a pre-configured PostgreSQL database and Google Cloud integration.

The changes migrate the dev container from a single-image setup to a multi-service composition, allowing developers to run Superset locally on port 8088 with automatic database initialization and admin user creation.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

## Changes

### Dev Container Configuration
- Migrated `devcontainer.json` from single image to Docker Compose-based setup
- Moved container configuration (capabilities, mounts, tmpfs) to `docker-compose.yml`
- Added port forwarding for Superset (8088) with auto-notify on forward
- Preserved all existing features and post-create/post-start scripts

### Superset Service
- Created `docker-compose.yml` with three services:
  - **devcontainer**: Python 3.13 dev environment (primary service)
  - **superset**: Apache Superset 4.1.1 with BigQuery support
  - **superset-db**: PostgreSQL 15 database with health checks
- Added custom Dockerfile for Superset with:
  - `sqlalchemy-bigquery` dependency for BigQuery integration
  - Custom configuration and entrypoint script
- Configured environment variables for database connectivity and Google Cloud credentials
- Set up persistent volumes for gcloud config, Superset home, and database data

### Superset Initialization
- Created `docker-entrypoint.sh` that:
  - Runs database migrations on startup
  - Creates default admin user (admin/admin)
  - Initializes Superset
  - Starts gunicorn server with 2 workers
- Created `superset_config.py` for database and secret key configuration

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt` locally, fix any issues, and push again.

https://claude.ai/code/session_019evmp3rMPN1aZcZxS45oGp