### PR TITLE
fix(dbt): repair dim_student_contact_persons phone/email/address pivot

### DIFF
--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
@@ -127,14 +127,14 @@ select
 from contacts_deduped as c
 left join
     phone as ph
-    on c._dbt_source_relation = ph._dbt_source_relation
-    and c.personid = ph.personid
+    on c.personid = ph.personid
+    and {{ union_dataset_join_clause(left_alias="c", right_alias="ph") }}
 left join
     email as em
-    on c._dbt_source_relation = em._dbt_source_relation
-    and c.personid = em.personid
+    on c.personid = em.personid
+    and {{ union_dataset_join_clause(left_alias="c", right_alias="em") }}
 left join
     address as ad
-    on c._dbt_source_relation = ad._dbt_source_relation
-    and c.personid = ad.personid
+    on c.personid = ad.personid
+    and {{ union_dataset_join_clause(left_alias="c", right_alias="ad") }}
 where c.person_type != 'self'

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -10,15 +10,21 @@ models:
     columns:
       - name: student_contact_person_key
         data_type: string
-        description: >-
-          Surrogate key derived from _dbt_source_relation and the PowerSchool
-          personid. Primary key for this dimension.
+        description:
+          Surrogate key for the contact person. Primary key for this dimension.
         constraints:
           - type: primary_key
             warn_unsupported: false
         data_tests:
           - unique
           - not_null
+
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: int_powerschool__contacts
+            source_column: personid
+            column_role: primary_key
 
       - name: full_name
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR will restore phone, email, and home_address coverage on `dim_student_contact_persons`, which were 100% null in production despite ~50k mobile, ~36k email, and ~27k home address rows per district upstream.

**Root cause**: The three LEFT JOINs in [dim_student_contact_persons.sql](src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql) matched on `c._dbt_source_relation = X._dbt_source_relation` between two `dbt_utils.union_relations` outputs built from different upstream tables (`int_powerschool__contacts` vs `int_powerschool__person_contacts`). Because `union_relations` stamps `_dbt_source_relation` with `schema.table`, the values never matched and every join nulled out.

**Fix**: Replace the equality with `union_dataset_join_clause()`, which extracts the district prefix (`kipp\w+`) from `_dbt_source_relation`. This is the canonical pattern documented in [src/dbt/kipptaf/CLAUDE.md](src/dbt/kipptaf/CLAUDE.md).

**Verification** (against prod data via the corrected join):

| Metric | Before | After |
| --- | --- | --- |
| Rows | 142,441 | 142,441 |
| `phone IS NOT NULL` | 0 | 56,693 |
| `email IS NOT NULL` | 0 | 49,469 |
| `home_address IS NOT NULL` | 0 | 10,235 |

## AI Assistance

AI-assisted: root-cause profiling via BigQuery, fix application, verification query. Human-directed: scope decisions (no regression test — PowerSchool contacts are scheduled to be replaced by Finalsite per #3706), batch reorganization on the project board.

Closes #3682.

## Self-review

### dbt

- [x] No new models — change is to the join logic of an existing mart.
- [x] No exposure changes (no column adds/removes/renames).
- [x] Not a breaking change — column names and types unchanged; only NULL→non-NULL value coverage on existing columns.
- [x] No external sources modified.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not applicable (no `src/teamster/` changes).