### PR TITLE
fix(cube): populate groupCache so queryRewrite resolves groups from CUBE_TESTING_USERS

### DIFF
--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -51,7 +51,9 @@ module.exports = {
         const map = JSON.parse(process.env.CUBE_TESTING_USERS);
         // All users handled here — listed get groups, unlisted get [] (default
         // deny). Prevents fallthrough to Directory API in testing deployments.
-        return (map[email] ?? []).filter((g) => g.startsWith("cube-"));
+        const groups = (map[email] ?? []).filter((g) => g.startsWith("cube-"));
+        groupCache.set(email, { groups, expiresAt: nextMidnightEastern() });
+        return groups;
       } catch (err) {
         console.error("CUBE_TESTING_USERS is not valid JSON:", err.message);
         return [];
@@ -117,7 +119,15 @@ module.exports = {
   },
 
   queryRewrite: (query, { securityContext }) => {
-    const groups = securityContext?.groups ?? [];
+    const email = securityContext?.email;
+    const jwtGroups = securityContext?.groups;
+    const cached = email ? groupCache.get(email) : null;
+    const groups =
+      Array.isArray(jwtGroups) && jwtGroups.length > 0
+        ? jwtGroups
+        : cached?.expiresAt > Date.now()
+          ? cached.groups
+          : [];
 
     // Users without cube-access-student-data see no student cubes.
     // STUDENT_CUBES list is a placeholder — full list added during YAML implementation.

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -65,7 +65,9 @@ module.exports = {
     if (process.env.NODE_ENV !== "production" && process.env.CUBE_GROUP_MAP) {
       try {
         const map = JSON.parse(process.env.CUBE_GROUP_MAP);
-        return (map[email] ?? []).filter((g) => g.startsWith("cube-"));
+        const groups = (map[email] ?? []).filter((g) => g.startsWith("cube-"));
+        groupCache.set(email, { groups, expiresAt: nextMidnightEastern() });
+        return groups;
       } catch (err) {
         console.error("CUBE_GROUP_MAP is not valid JSON:", err.message);
         return [];


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix `queryRewrite` not seeing groups resolved by `contextToGroups` in Cube Cloud.

`contextToGroups` results are not automatically injected into `securityContext` — so `queryRewrite` was reading `securityContext?.groups ?? []`, getting nothing, and hitting default deny for all users. Fix: populate `groupCache` in the `CUBE_TESTING_USERS` block and update `queryRewrite` to check the cache when `securityContext.groups` is empty.

**AI Assistance:** Claude Code co-authored this PR, directed by Cristina Baldor.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
