### PR TITLE
fix(k8s): use Custom ComputeClasses to drive Autopilot NAP provisioning

### DIFF
--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -23,18 +23,36 @@ on GKE Autopilot.
 
 ## Scheduling
 
-- Weighted `nodeAffinity` preferences (no hard `nodeSelector`). Compute-class
-  tiers: Scale-Out arm64 > General-Purpose > Scale-Out x86. Balanced removed —
-  its separation/extended-duration minimums (1 vCPU / 4 GiB) exceed our requests
-  (500m / 2 GiB), which would cause pod admission rejection if anti-affinity is
-  ever applied. Spot adds +50 on code server pods (not agent or run pods).
-  Autopilot bills per-pod, so fallback tiers have no cost penalty.
-- Agent pods use `safe-to-evict: "false"` (extended-duration) to prevent
-  Autopilot scale-down churn, which is mutually exclusive with spot. Agent pods
-  exclude arm64 tiers (image is x86-only).
+- **Hard `nodeSelector` on `cloud.google.com/compute-class`** — Autopilot NAP
+  only provisions matching nodes for `required` / `nodeSelector` constraints.
+  `preferredDuringSchedulingIgnoredDuringExecution` is scheduler scoring applied
+  to existing nodes; it does NOT drive provisioning. With only `preferred`, NAP
+  falls back to default N4 amd64 and every weighted preference scores 0. Same
+  trap for `preferred kubernetes.io/arch: arm64`.
+- **One `cloud.google.com/compute-class` value per pod** — Warden
+  (`autopilot-compute-class-limitation`,
+  `ccc-node-affinity-selector-limitation`) rejects multiple values across ORed
+  `nodeSelectorTerms`. Use a Custom ComputeClass with priority-ordered fallbacks
+  instead of multi-value affinity.
+- **Custom ComputeClasses** in
+  [compute-classes.yaml](/.k8s/dagster/compute-classes.yaml):
+  `dagster-codeserver` (spot t2a → on-demand t2a → t2d) and `dagster-run`
+  (on-demand t2a → t2d — no spot, runs are `safe-to-evict: "false"`). Agent uses
+  the built-in `General-Purpose` class — its image is amd64-only, no arm64
+  fallback.
+- **Do NOT add Balanced to CCC priorities** — its separation / extended-duration
+  minimums (1 vCPU / 4 GiB) exceed our requests (500m / 2 GiB) and would cause
+  pod admission rejection if anti-affinity is applied.
+- **CCC delivery is manual** —
+  `kubectl apply -f .k8s/dagster/compute-classes.yaml`, NOT via Helm
+  `extraManifests`. The agent's Helm ServiceAccount lacks cluster-scoped create
+  perms on `cloud.google.com/v1/ComputeClass`.
+- Agent pods use `safe-to-evict: "false"` (extended-duration), which is mutually
+  exclusive with spot — do not move the agent to a spot tier.
 - **Agent topology spread** uses `ScheduleAnyway` across
-  `topology.kubernetes.io/zone` via `additionalPodSpecConfig`. Prefers
-  cross-zone but allows same-zone during capacity exhaustion.
+  `topology.kubernetes.io/zone` via `additionalPodSpecConfig` — prefers
+  cross-zone but allows same-zone during capacity exhaustion (do not switch to
+  `DoNotSchedule`, which would block agent rollouts when one zone is full).
 
 ## Security
 

--- a/.k8s/dagster/compute-classes.yaml
+++ b/.k8s/dagster/compute-classes.yaml
@@ -1,0 +1,58 @@
+---
+# Cluster-scoped Custom ComputeClasses (CCC) consumed by code server and run
+# pods via `nodeSelector: { cloud.google.com/compute-class: <name> }`.
+#
+# Why CCCs and not weighted nodeAffinity:
+#   On Autopilot, Node Auto-Provisioning (NAP) only honors `required` /
+#   `nodeSelector` constraints when deciding what hardware to provision.
+#   `preferredDuringSchedulingIgnoredDuringExecution` is a scheduler scoring
+#   hint applied AFTER candidate nodes exist; it does not drive provisioning.
+#   With only `preferred` rules, NAP falls back to default N4 amd64 and every
+#   weighted preference scores 0 against those unlabeled nodes.
+#
+#   Hard-requiring `compute-class: Scale-Out, arch: arm64` does drive NAP, but
+#   reintroduces the STOCKOUT hang we hit on 2026-03-30/31. Multi-value
+#   `nodeSelectorTerms` over `cloud.google.com/compute-class` is rejected by
+#   Warden (`autopilot-compute-class-limitation`,
+#   `ccc-node-affinity-selector-limitation` — only one value allowed for that
+#   key per pod).
+#
+#   CCCs solve all three: a single nodeSelector value drives NAP, the
+#   `priorities` list expresses ordered fallback at the GKE layer (not the
+#   pod scheduler layer), and Warden admission passes.
+#
+# Delivery model:
+#   These manifests are applied manually with `kubectl apply -f
+#   .k8s/dagster/compute-classes.yaml`. They are NOT included in the
+#   Dagster Cloud Helm chart's `extraManifests` because:
+#     - CCCs are cluster-scoped CRDs; the agent's Helm ServiceAccount lacks
+#       cluster-scoped create perms on `cloud.google.com/v1/ComputeClass`.
+#     - CCCs change rarely; coupling them to per-release Helm rollouts adds
+#       churn without benefit.
+#
+# Re-apply after editing this file.
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: dagster-codeserver
+spec:
+  priorities:
+    # Code server pods are stateless, PDB-protected (minAvailable: 1), and
+    # tolerate eviction — spot is safe and saves cost.
+    - machineFamily: t2a
+      spot: true
+    - machineFamily: t2a
+    - machineFamily: t2d
+  whenUnsatisfiable: ScaleUpAnyway
+---
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: dagster-run
+spec:
+  priorities:
+    # Run/step pods carry `safe-to-evict: "false"` and cannot use spot —
+    # eviction would consume Dagster retry budget and surface as run failures.
+    - machineFamily: t2a
+    - machineFamily: t2d
+  whenUnsatisfiable: ScaleUpAnyway

--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -65,23 +65,14 @@ dagsterCloudAgent:
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 
+  # Hard nodeSelector (not preferred) — Autopilot NAP only provisions matching
+  # nodes for required/nodeSelector constraints. The agent image is amd64-only
+  # so arm64 fallback is not an option; pin to the built-in General-Purpose
+  # compute class to drive NAP correctly.
+  nodeSelector:
+    cloud.google.com/compute-class: General-Purpose
+
   affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 30
-          preference:
-            matchExpressions:
-              - key: cloud.google.com/compute-class
-                operator: In
-                values:
-                  - General-Purpose
-        - weight: 20
-          preference:
-            matchExpressions:
-              - key: cloud.google.com/compute-class
-                operator: In
-                values:
-                  - Scale-Out
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
@@ -141,38 +132,13 @@ workspace:
       annotations:
         operator.1password.io/auto-restart: "true"
     podSpecConfig:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 40
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - Scale-Out
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - arm64
-            - weight: 30
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - General-Purpose
-            - weight: 20
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - Scale-Out
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
+      # Reference the cluster-scoped Custom ComputeClass `dagster-codeserver`
+      # defined in .k8s/dagster/compute-classes.yaml. Priorities (spot t2a →
+      # on-demand t2a → t2d) are enforced by GKE at provisioning time; a
+      # single nodeSelector value satisfies Warden's one-value-per-pod rule
+      # for `cloud.google.com/compute-class`.
+      nodeSelector:
+        cloud.google.com/compute-class: dagster-codeserver
       terminationGracePeriodSeconds: 60
       topologySpreadConstraints:
         - maxSkew: 1
@@ -242,38 +208,13 @@ workspace:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     podSpecConfig:
       priorityClassName: dagster-run
+      # Reference the cluster-scoped Custom ComputeClass `dagster-run` defined
+      # in .k8s/dagster/compute-classes.yaml. No spot tier — run/step pods
+      # carry `safe-to-evict: "false"` and cannot be evicted without consuming
+      # Dagster retry budget. Priorities: on-demand t2a → t2d.
+      nodeSelector:
+        cloud.google.com/compute-class: dagster-run
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 40
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - Scale-Out
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - arm64
-            - weight: 30
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - General-Purpose
-            - weight: 20
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/compute-class
-                    operator: In
-                    values:
-                      - Scale-Out
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
         # Hard-block run/step pods from sharing a node with code servers
         # (eliminates preemption-driven code server evictions) or with the
         # agent (protects the single-replica agent from kubelet node-pressure


### PR DESCRIPTION
## Summary & Motivation

Closes #3675.

When merged, this pull request will restore Scale-Out arm64 provisioning for code server and run pods on Autopilot, replacing the weighted `nodeAffinity` preferences that silently regressed all workloads onto default N4 amd64 nodes.

**Root cause** (per #3675): Autopilot Node Auto-Provisioning only honors `required` / `nodeSelector` constraints. `preferredDuringSchedulingIgnoredDuringExecution` is scheduler scoring against existing nodes — it does not drive provisioning. With only `preferred` rules, NAP fell back to default N4 amd64 and every weighted preference scored 0. The naive ORed-`nodeSelectorTerms` fix is rejected by Warden (`autopilot-compute-class-limitation`) — only one `cloud.google.com/compute-class` value is allowed per pod.

**Fix**: cluster-scoped Custom ComputeClasses with priority-ordered fallbacks, referenced by a single-value `nodeSelector`. GKE handles inter-priority fallback at provisioning time.

- New `.k8s/dagster/compute-classes.yaml`:
  - `dagster-codeserver`: spot t2a → on-demand t2a → t2d
  - `dagster-run`: on-demand t2a → t2d (no spot — runs are `safe-to-evict: "false"`)
- `values-override.yaml`:
  - Agent pinned to built-in `General-Purpose` (image is amd64-only)
  - Code server / run pods reference the new CCCs via `nodeSelector`
- `.k8s/CLAUDE.md`: documents the "`preferred` alone doesn't drive NAP" trap, the one-value-per-pod Warden rule, the manual CCC delivery model, and the Balanced exclusion so the regression doesn't recur.

**Manual deploy steps** (both Helm and kubectl are manual per `.k8s/CLAUDE.md`):

1. `kubectl apply -f .k8s/dagster/compute-classes.yaml`
2. `helm upgrade` the Dagster Cloud agent to roll out the new `nodeSelector`s.

CCCs are applied via kubectl rather than Helm `extraManifests` because the agent's Helm ServiceAccount lacks cluster-scoped create perms on `cloud.google.com/v1/ComputeClass`.

## AI Assistance

Claude Code drafted the CCC manifests, Helm values changes, and `.k8s/CLAUDE.md` edits under direction; root-cause diagnosis and the proposed CCC design came from the human-authored issue body in #3675.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.
