### PR TITLE
fix(dbt): unify fct_survey_responses/submissions submission_key hash

### DIFF
--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_responses.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_responses.sql
@@ -8,7 +8,6 @@ with
             sr.survey_response_id,
             sr.survey_question_id,
             sr.question_shortname,
-            sr.respondent_identifier,
             sr.answer as response_text,
 
             safe_cast(sr.answer as numeric) as response_value,
@@ -34,8 +33,6 @@ with
             ms.answer as response_text,
             ms.answer_value as response_value,
 
-            cast(ms.respondent_df_employee_number as string) as respondent_identifier,
-
             coalesce(
                 ms.survey_response_id,
                 concat(
@@ -56,7 +53,6 @@ with
             survey_response_id,
             survey_question_id,
             question_shortname,
-            respondent_identifier,
             response_text,
             response_value,
         from general_responses
@@ -66,7 +62,6 @@ with
             survey_response_id,
             survey_question_id,
             question_shortname,
-            respondent_identifier,
             response_text,
             response_value,
         from manager_responses
@@ -75,24 +70,12 @@ with
 select
     {{
         dbt_utils.generate_surrogate_key(
-            [
-                "survey_id",
-                "survey_response_id",
-                "respondent_identifier",
-                "survey_question_id",
-            ]
+            ["survey_id", "survey_response_id", "survey_question_id"]
         )
     }} as survey_response_key,
 
-    {{
-        dbt_utils.generate_surrogate_key(
-            [
-                "survey_id",
-                "survey_response_id",
-                "respondent_identifier",
-            ]
-        )
-    }} as survey_submission_key,
+    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
+    as survey_submission_key,
 
     {{ dbt_utils.generate_surrogate_key(["question_shortname"]) }}
     as survey_question_key,

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -277,15 +277,8 @@ with
 
 /* Staff submissions */
 select
-    {{
-        dbt_utils.generate_surrogate_key(
-            [
-                "survey_id",
-                "survey_response_id",
-                "respondent_employee_number",
-            ]
-        )
-    }} as survey_submission_key,
+    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
+    as survey_submission_key,
 
     survey_administration_key,
 
@@ -313,11 +306,8 @@ union all
 
 /* Student submissions */
 select
-    {{
-        dbt_utils.generate_surrogate_key(
-            ["survey_id", "survey_response_id", "student_number"]
-        )
-    }} as survey_submission_key,
+    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
+    as survey_submission_key,
 
     survey_administration_key,
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -10,11 +10,10 @@ models:
       - name: survey_response_key
         data_type: string
         description: >-
-          Surrogate key derived from survey_id, survey_response_id,
-          respondent_identifier, and survey_question_id. Primary key for this
-          fact. Uses survey_question_id rather than question_shortname because
-          Alchemer surveys can reuse a shortname across multiple internal
-          question_ids.
+          Surrogate key derived from survey_id, survey_response_id, and
+          survey_question_id. Primary key for this fact. Uses survey_question_id
+          rather than question_shortname because Alchemer surveys can reuse a
+          shortname across multiple internal question_ids.
         constraints:
           - type: primary_key
             warn_unsupported: false

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: survey_submission_key
         data_type: string
@@ -32,8 +31,6 @@ models:
             to_columns: [survey_submission_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('fct_survey_submissions')
@@ -49,8 +46,6 @@ models:
             to_columns: [survey_question_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_survey_questions')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [survey_administration_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_survey_administrations')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -12,8 +12,8 @@ models:
       - name: survey_submission_key
         data_type: string
         description: >-
-          Surrogate key derived from survey_id, survey_response_id, and
-          respondent identifier. Primary key for this fact.
+          Surrogate key derived from survey_id and survey_response_id. Primary
+          key for this fact.
         constraints:
           - type: primary_key
             warn_unsupported: false

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: survey_administration_key
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will close the 415K (~418K post-#3790) WARN-level relationships test on `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key` by unifying the hash composition on both sides to `[survey_id, survey_response_id]`.

The orphans were caused by hash-input drift, not coverage. `fct_survey_submissions` built three different hashes per leg (staff: `+respondent_employee_number`; student: `+student_number`; family: just the two fields). `fct_survey_responses` built one universal hash with `respondent_identifier = coalesce(employee_number, email)`. Only the staff leg matched.

Verified against `int_surveys__survey_responses` (n=120,865 distinct `(survey_id, survey_response_id)` pairs) that those two fields uniquely identify a respondent and place each pair in exactly one leg, so the respondent identifier in the prior hashes contributed zero discrimination.

Closes #3766, closes #3773 (PR batch H — survey-fact integrity). Residual ~95K student-leg coverage orphans tracked in #3794.

## AI Assistance

AI-assisted: code edits, BigQuery verification queries, draft PR body. Human-directed: scope decision (collapse to 2-input hash vs. per-leg respondent_type routing originally proposed in #3773), residual-coverage trade-off.

## Self-review

### dbt

- [x] Properties YAML descriptions updated to reflect new hash composition (`fct_survey_responses.survey_response_key`, `fct_survey_responses.survey_submission_key`, `fct_survey_submissions.survey_submission_key`).
- [x] Removed pre-existing `not_null` tests from surrogate-key columns on touched files per `src/dbt/CLAUDE.md` (`generate_surrogate_key` never returns null).
- [x] **Breaking change** — surrogate-key *values* change for `fct_survey_submissions.survey_submission_key`, `fct_survey_responses.survey_submission_key`, and `fct_survey_responses.survey_response_key`. Column types/names are unchanged so contracts pass.

#### Coordinated deploy required

Surrogate-key *values* on three columns will change at deploy. Both facts must be rebuilt together (Dagster will handle this via the dbt asset group) so that joins between `fct_survey_responses.survey_submission_key` and `fct_survey_submissions.survey_submission_key` realign. Downstream impact:

- **Cube** (#3591, in development) — no production exposure yet; will pick up new keys on first build against the rebuilt facts.
- **Tableau** — workbooks that join through `survey_submission_key` rebuild from the views and inherit the new keys; no cached-key state is held downstream.
- **Any external snapshot** of submission-key values from the old hash will not match the new hash. None currently identified.

#### Hash-change discipline log

| Model | Key | Reason | Before | After |
|---|---|---|---|---|
| `fct_survey_submissions` | `survey_submission_key` (staff) | Composition | `[survey_id, survey_response_id, respondent_employee_number]` | `[survey_id, survey_response_id]` |
| `fct_survey_submissions` | `survey_submission_key` (student) | Composition | `[survey_id, survey_response_id, student_number]` | `[survey_id, survey_response_id]` |
| `fct_survey_submissions` | `survey_submission_key` (family) | — (already 2-field) | `[survey_id, survey_response_id]` | `[survey_id, survey_response_id]` |
| `fct_survey_responses` | `survey_submission_key` | Composition | `[survey_id, survey_response_id, respondent_identifier]` | `[survey_id, survey_response_id]` |
| `fct_survey_responses` | `survey_response_key` | Composition | `[survey_id, survey_response_id, respondent_identifier, survey_question_id]` | `[survey_id, survey_response_id, survey_question_id]` |

#### Residual orphans (deferred to #3794)

After this fix, ~95K student response rows remain orphans because `fct_survey_submissions` inner-joins `int_extracts__student_enrollments` on `(email, academic_year, enroll_status=0)`. ~9.5K student `(email, year)` pairs don't resolve — almost all because the email exists in enrollments but was inactive in that year. ~230 staff response rows also remain orphans because submissions filters out rows with null `respondent_employee_number`. Tracked in #3794.

## Test plan

- [ ] dbt Cloud CI passes
- [ ] `relationships` test on `fct_survey_responses.survey_submission_key` reports ~95K WARN rows (down from ~418K) — residual is the student-enrollment-coverage gap tracked in #3794
- [ ] PK uniqueness on `fct_survey_responses.survey_response_key` and `fct_survey_submissions.survey_submission_key` still passes