### PR TITLE
fix(dbt): populate gpa_y1_unweighted on Y1 rows in rpt_tableau__gradebook_gpa

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
@@ -92,11 +92,16 @@ with
             term.semester,
 
             gtq.gpa_semester,
-            gtq.gpa_y1_unweighted,
+
             gtq.total_credit_hours_y1 as gpa_total_credit_hours,
             gtq.n_failing_y1 as gpa_n_failing_y1,
 
+            if(
+                term.quarter = 'Y1', gty.gpa_y1_unweighted, gtq.gpa_y1_unweighted
+            ) as gpa_y1_unweighted,
+
             if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_term) as gpa_for_quarter,
+
             if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1) as gpa_y1,
 
         from {{ ref("int_extracts__student_enrollments") }} as enr


### PR DESCRIPTION
## Summary
- `gpa_y1_unweighted` was always `NULL` on `quarter = 'Y1'` rows because it sourced only from the term-specific join (`gtq`), which has no Y1 record in `int_powerschool__gpa_term`
- Applied the same conditional already used for `gpa_y1`: use the `is_current` join (`gty`) on Y1 rows, and the term-specific join (`gtq`) on quarterly rows

## Test plan
- [ ] Verify `gpa_y1_unweighted` is non-null on Y1 rows after model rebuild
- [ ] Confirm Tableau unweighted Y1 GPA chart populates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214498953046347