### PR TITLE
fix(cube): use correct scope for Admin Directory API groups lookup

### DIFF
--- a/docs/guides/cube.md
+++ b/docs/guides/cube.md
@@ -54,7 +54,7 @@ and data control → API controls → Domain-wide delegation → Add new**:
 - **Client ID**: the numeric client ID from the service account details page in
   GCP
 - **OAuth scopes**:
-  `https://www.googleapis.com/auth/admin.directory.group.member.readonly`
+  `https://www.googleapis.com/auth/admin.directory.group.readonly`
 
 ### 5. Encode the key and set environment variables
 
@@ -119,7 +119,7 @@ Performed in the Cube Cloud UI by an admin:
 6. The service account for BigQuery needs `roles/bigquery.dataViewer` and
    `roles/bigquery.jobUser` on the `teamster-332318` project
 7. The Admin Directory API service account needs domain-wide delegation scoped
-   to `https://www.googleapis.com/auth/admin.directory.group.member.readonly`
+   to `https://www.googleapis.com/auth/admin.directory.group.readonly`
 
 ## Local Dev
 

--- a/docs/superpowers/plans/2026-04-23-cube-infrastructure-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-cube-infrastructure-implementation.md
@@ -145,7 +145,7 @@ contextToGroups: async ({ securityContext }) => {
       credentials: JSON.parse(
         Buffer.from(process.env.GOOGLE_DIRECTORY_SA_KEY, "base64").toString(),
       ),
-      scopes: ["https://www.googleapis.com/auth/admin.directory.group.member.readonly"],
+      scopes: ["https://www.googleapis.com/auth/admin.directory.group.readonly"],
       clientOptions: { subject: process.env.GOOGLE_DIRECTORY_SA_SUBJECT },
     });
     const admin = google.admin({ version: "directory_v1", auth });

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -92,7 +92,7 @@ module.exports = {
           Buffer.from(process.env.GOOGLE_DIRECTORY_SA_KEY, "base64").toString(),
         ),
         scopes: [
-          "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
+          "https://www.googleapis.com/auth/admin.directory.group.readonly",
         ],
         clientOptions: {
           subject: process.env.GOOGLE_DIRECTORY_SA_SUBJECT,


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR will fix the OAuth scope used by Cube's Admin Directory API integration to correctly look up the Google Workspace groups a user belongs to.

The wrong scope (`admin.directory.group.member.readonly`) was specified — that scope grants access to the Members resource (listing members *of* a group), not the Groups resource (listing groups *a user belongs to*). The correct scope is `admin.directory.group.readonly`. This was confirmed by testing against the live Directory API.

Fixed in both `cube.js` and `docs/guides/cube.md`.

Closes #3768

## AI Assistance

Debugging and scope fix were AI-assisted (Claude identified the scope mismatch after the API returned "insufficient authentication scopes"). Human-directed: initial SA setup, DWD configuration in Workspace Admin, and live API testing to confirm.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

## CI checks

- [ ] **Trunk** — passes.