### PR TITLE
fix(dbt): batch L — join-path FK fixes

### DIFF
--- a/docs/superpowers/plans/2026-05-04-batch-l-join-path-fk-fixes.md
+++ b/docs/superpowers/plans/2026-05-04-batch-l-join-path-fk-fixes.md
@@ -1,0 +1,1175 @@
+# Batch L — join-path FK fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve all 8 originally-failing `relationships` tests in batch L by
+rerouting `dim_courses` and `dim_students` to canonical PowerSchool staging and
+sanitizing pre-2000 junk dates at the staging layer.
+
+**Architecture:** `dim_courses` switches source from
+`base_powerschool__course_enrollments` to `stg_powerschool__courses` with a
+`_dbt_source_relation` token replacement to keep `course_key` hash-compatible
+with `dim_course_sections`. `dim_students` switches source from
+`int_extracts__student_enrollments` to `stg_powerschool__students` plus four
+LEFT JOINs (`stg_kippadb__contact`, `stg_powerschool__u_studentsuserfields`,
+`stg_powerschool__s_nj_stu_x`, `stg_powerschool__studentcorefields`) that
+preserve student-grain attributes; `meal_eligibility_status` and `has_iep` are
+dropped (they're enrollment attributes, not student attributes). Date
+sanitization wraps offending date columns with
+`if(<col> < date '2000-01-01', null, <col>)` at five staging models, with
+`dbt_utils.expression_is_true` warn-severity tests guarding regressions.
+
+**Tech Stack:** dbt-bigquery, BigQuery, dbt_utils, trunk
+(sqlfluff/markdownlint).
+
+**Spec:**
+[`docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md`](../specs/2026-05-04-batch-l-join-path-fk-fixes-design.md)
+
+**Worktree:**
+`/workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes`
+
+**Branch:** `cbini/fix/claude-batch-l-fk-fixes` (linked to #3719; PR closes
+#3719, #3721, #3723).
+
+**Conventions to remember:**
+
+- All dbt commands MUST use
+  `uv run dbt ... --project-dir <worktree>/src/dbt/kipptaf` and `--target dev`.
+- All git commands MUST use `git -C <worktree>` from outside the worktree, or
+  `cd` once and stay there.
+- Use Edit / Read / Write tools — not `cat`/`sed`/`echo` via Bash.
+- Trunk formats automatically on PostToolUse; do not run `trunk fmt` manually.
+- Do not commit with `--no-verify`.
+
+---
+
+## File Structure
+
+**Files modified (8 SQL, 4 YAML):**
+
+- `src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql` (rewrite)
+- `src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml` (update
+  source_column metadata)
+- `src/dbt/kipptaf/models/marts/dimensions/dim_students.sql` (rewrite)
+- `src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml` (drop 2
+  columns, update metadata)
+- `src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql`
+  (wrap from pure union to union+sanitize)
+- `src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml`
+  (add expression_is_true test)
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql`
+  (sanitize `date_taken`)
+- `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml`
+  (add expression_is_true test)
+- DeansList incident & consequence staging: located in Task 4c during impl
+- Student-scoped assessment date origin (1900-01-01 source): located in Task 4d
+  during impl
+
+**Files NOT modified (verified during planning):**
+
+- `dim_course_sections.sql` — keeps existing `_dbt_source_relation` value
+  `...base_powerschool__sections`; the reroute fixes hash compatibility on the
+  dim_courses side.
+- `dim_dates.sql` — already spans 2000–9999; bad data will become NULL upstream.
+
+---
+
+## Task 0: Pre-flight verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 0.1: Confirm working directory and branch**
+
+Run:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes status
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes log --oneline -3
+```
+
+Expected: branch is `cbini/fix/claude-batch-l-fk-fixes`, recent commits include
+the spec and severity-update commits, working tree clean.
+
+- [ ] **Step 0.2: Merge latest main**
+
+Run:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes fetch origin main
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes merge origin/main --no-edit
+```
+
+Expected: clean merge or "Already up to date."
+
+- [ ] **Step 0.3: Snapshot pre-change CI warnings baseline**
+
+Use `mcp__dbt__list_jobs_runs` to find the most recent successful run on `main`
+for the kipptaf CI job. Then call `mcp__dbt__get_job_run_error` with
+`run_id=<that run>, warning_only=true`. Save the warning list to
+`.claude/scratch/batch-l-warnings-baseline.txt` (use the Write tool). This is
+the comparison set for Task 6.
+
+If the warnings list is empty, write `EMPTY` to the file. The diff in Task 6
+still runs.
+
+---
+
+## Task 1: Audit `dim_students` consumers for to-be-dropped columns
+
+The spec drops `meal_eligibility_status` and `has_iep` from `dim_students`
+(they're enrollment attributes, not student-grain). Verify no SQL or exposure
+consumer references these by name before changing the schema.
+
+**Files:** none (audit only).
+
+- [ ] **Step 1.1: Audit SQL references**
+
+Run:
+
+```bash
+grep -rnE "meal_eligibility_status|has_iep" /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes/src/dbt/ --include="*.sql"
+```
+
+Expected: zero or only-self-reference (current `dim_students.sql`). If any other
+model references them, STOP and surface to user before continuing.
+
+- [ ] **Step 1.2: Audit YAML / exposure references**
+
+Run:
+
+```bash
+grep -rnE "meal_eligibility_status|has_iep" /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes/src/dbt/ --include="*.yml" --include="*.yaml"
+```
+
+Expected: only references in `dim_students.yml` (the column definitions we're
+removing). If `cube.yml` or any exposure file references either column, STOP and
+surface to user.
+
+- [ ] **Step 1.3: Document audit result**
+
+Append findings to `.claude/scratch/batch-l-audit.md` (Write tool). Format:
+
+```markdown
+# Batch L pre-change audit (Task 1)
+
+## meal_eligibility_status references
+
+<list, or "none outside dim_students.{sql,yml}">
+
+## has_iep references
+
+<list, or "none outside dim_students.{sql,yml}">
+```
+
+---
+
+## Task 2: Reroute `dim_courses` (#3721)
+
+`dim_courses` switches source from `base_powerschool__course_enrollments`
+(enrollment-derived; misses courses with no in-scope enrollments) to
+`stg_powerschool__courses` (canonical catalog). Two design points:
+
+1. `stg_powerschool__courses` is grain-correct on
+   `(course_number, _dbt_source_relation)` — verified via BigQuery uniqueness
+   check during planning. No `dbt_utils.deduplicate` needed.
+2. `dim_course_sections.course_key` hashes
+   `(courses_course_number, base_powerschool__sections_relation)`. To keep the
+   FK chain intact, `dim_courses` must hash a `_dbt_source_relation` ending in
+   `base_powerschool__sections`, not `stg_powerschool__courses`. Use a string
+   `replace()` to normalize.
+3. `discipline` (academic_subject) is not on `stg_powerschool__courses`; it
+   comes from `stg_google_sheets__assessments__course_subject_crosswalk`, joined
+   on `course_number`.
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql`
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml`
+
+- [ ] **Step 2.1: Read current `dim_courses.sql` and YAML to confirm column
+      inventory**
+
+Read both files. Current columns: `course_key`, `course_code`, `course_title`,
+`credit_type`, `academic_subject`, `credits`. All preserved.
+
+- [ ] **Step 2.2: Rewrite `dim_courses.sql`**
+
+Replace the entire file contents with:
+
+```sql
+select
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "c.course_number",
+                (
+                    "replace(c._dbt_source_relation,"
+                    " 'stg_powerschool__courses',"
+                    " 'base_powerschool__sections')"
+                ),
+            ]
+        )
+    }} as course_key,
+
+    c.course_number as course_code,
+    c.course_name as course_title,
+    c.credittype as credit_type,
+    csc.discipline as academic_subject,
+    c.credit_hours as credits,
+
+from {{ ref("stg_powerschool__courses") }} as c
+left join
+    {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
+    on c.course_number = csc.powerschool_course_number
+```
+
+Notes:
+
+- Single source — no union model joining needed beyond the cross-source
+  crosswalk (which is keyed on course_number alone, no `_dbt_source_relation`).
+- The `replace()` token rewrites `..._powerschool.stg_powerschool__courses` to
+  `..._powerschool.base_powerschool__sections`, matching the
+  `_dbt_source_relation` value used by `dim_course_sections`.
+
+- [ ] **Step 2.3: Update `dim_courses.yml` source_column metadata**
+
+The `course_code` column already documents
+`source_model: stg_powerschool__courses`, `source_column: course_number` — keep
+as-is.
+
+The `credit_type` column currently has
+`source_model: stg_powerschool__storedgrades`, `source_column: credit_type` —
+this is wrong (stale). Update to:
+
+```yaml
+config:
+  meta:
+    source_system: PowerSchool
+    source_model: stg_powerschool__courses
+    source_column: credittype
+```
+
+The `academic_subject` column has no source metadata — add:
+
+```yaml
+config:
+  meta:
+    source_system: Google Sheets
+    source_model: stg_google_sheets__assessments__course_subject_crosswalk
+    source_column: discipline
+```
+
+The model description currently says "Attributes represent the most recent
+non-null values from the PowerSchool course table as observed in enrollment
+records." This is no longer accurate — replace with:
+
+```yaml
+description: >-
+  Course catalog dimension. One row per course per source region. Course numbers
+  are not unique across regions, so the surrogate key includes the source
+  relation. Sourced from the canonical PowerSchool course catalog;
+  academic_subject joins the assessment course-subject crosswalk by course
+  number.
+```
+
+- [ ] **Step 2.4: Build the model and run uniqueness test**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select dim_courses --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected: model builds, uniqueness test passes.
+
+If the build fails with "table not found" on a staging dependency, follow
+`src/dbt/CLAUDE.md` → "Dev `--defer` for unstaged externals" — add
+`--defer --state=src/dbt/kipptaf/target/prod/`.
+
+- [ ] **Step 2.5: Run `dim_course_sections.course_key` relationships test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt test --select dim_course_sections --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected:
+`relationships_dim_course_sections_course_key__course_key__ref_dim_courses_`
+passes (was failing with 30,241 rows).
+
+If it fails, query the orphan set:
+
+```sql
+select count(*) from `<dev_schema>.dim_course_sections` cs
+left join `<dev_schema>.dim_courses` c using (course_key)
+where c.course_key is null
+```
+
+Expected: 0.
+
+- [ ] **Step 2.6: Hash spot-check (5 known courses)**
+
+Pick 5 distinct `course_key` values from the prod `dim_courses`:
+
+```sql
+select course_key, course_code from `teamster-332318.kipptaf_marts.dim_courses` limit 5
+```
+
+Then verify each appears in the dev rebuild:
+
+```sql
+select course_key from `<dev_schema>.dim_courses` where course_key in ('<key1>', ..., '<key5>')
+```
+
+Expected: all 5 found. If any are missing, the hash strategy is wrong — STOP and
+re-check the `replace()` token.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes
+git add src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+git commit -m "fix(dbt): reroute dim_courses to stg_powerschool__courses (closes #3721)
+
+Sources from canonical course catalog instead of
+base_powerschool__course_enrollments. Hash-compatible via _dbt_source_relation
+token replacement so dim_course_sections.course_key FK still resolves.
+academic_subject joins course-subject crosswalk by course number."
+```
+
+---
+
+## Task 3: Reroute `dim_students` (#3723)
+
+`dim_students` switches source from `int_extracts__student_enrollments`
+(current-enrollment-scoped) to `stg_powerschool__students` (canonical, includes
+graduated/transferred). Drops `meal_eligibility_status` and `has_iep`
+(enrollment attributes, not student attributes per user direction). Keeps
+`is_gifted` and `is_ell` via simplified joins (deferred enrollment-attribute
+relocation).
+
+**Hash discipline:** `student_key = generate_surrogate_key([student_number])` —
+single column, no `_dbt_source_relation`. Hash unchanged across reroute.
+
+**Source map for retained columns:**
+
+| Mart column                   | Source table                                                                        | Column / logic                                                                                                                                                                                   |
+| ----------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `lea_student_identifier`      | `stg_powerschool__students`                                                         | `student_number`                                                                                                                                                                                 |
+| `district_student_identifier` | derived                                                                             | Miami-only: `state_studentnumber` (the host district MDCPS ID surfaces here for Miami); null for NJ. Region derived from `_dbt_source_relation`.                                                 |
+| `state_student_identifier`    | mixed                                                                               | Miami: `suf.fleid`. NJ: `s.state_studentnumber`.                                                                                                                                                 |
+| `salesforce_contact_id`       | `stg_kippadb__contact` (LEFT JOIN on `s.student_number = adb.school_specific_id`)   | `adb.id`                                                                                                                                                                                         |
+| `full_name`                   | `stg_powerschool__students`                                                         | `concat(s.last_name, ', ', s.first_name)` (simplified — current `lastfirst` is `"Last, First, Mi."`; the simplification drops middle initial, which is consistent with student-grain projection) |
+| `birth_date`                  | `stg_powerschool__students`                                                         | `dob`                                                                                                                                                                                            |
+| `gender_identity`             | `stg_powerschool__students`                                                         | `gender`                                                                                                                                                                                         |
+| `enrollment_status`           | `stg_powerschool__students`                                                         | CASE on `enroll_status` (verbatim from current `dim_students`)                                                                                                                                   |
+| `is_gifted`                   | `stg_powerschool__s_nj_stu_x` (njs) + `stg_powerschool__u_studentsuserfields` (suf) | `coalesce(njs.gifted_and_talented, suf.gifted_and_talented, 'N') != 'N'` (simplified to boolean)                                                                                                 |
+| `is_ell`                      | `stg_powerschool__studentcorefields` (scf)                                          | `scf.lep_status` (boolean). Simplified — drops the NJ enrollment-date-window logic which requires enrollment context.                                                                            |
+| `race`                        | `stg_powerschool__students`                                                         | CASE on `ethnicity` (verbatim from current `dim_students`)                                                                                                                                       |
+
+**Important constraint:** the kipptaf-level `stg_powerschool__students` is a
+pure union view. The downstream join targets (`u_studentsuserfields`,
+`s_nj_stu_x`, `studentcorefields`) all key on `students_dcid` per district — but
+`stg_powerschool__students.dcid` is the same key (DCID is unique per district
+per student). All four staging tables carry `_dbt_source_relation`; use
+`union_dataset_join_clause` for cross-source safety.
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_students.sql`
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml`
+
+- [ ] **Step 3.1: Verify column availability on each join target**
+
+Run BigQuery queries to confirm the columns exist on each kipptaf-level staging:
+
+```sql
+select table_name, column_name
+from `teamster-332318.kipptaf_powerschool.INFORMATION_SCHEMA.COLUMNS`
+where table_name in (
+  'stg_powerschool__u_studentsuserfields',
+  'stg_powerschool__s_nj_stu_x',
+  'stg_powerschool__studentcorefields'
+)
+and column_name in (
+  'studentsdcid', '_dbt_source_relation',
+  'fleid', 'gifted_and_talented',
+  'lep_status', 'spedlep'
+)
+order by table_name, column_name
+```
+
+Required:
+
+- `stg_powerschool__u_studentsuserfields`: `studentsdcid`,
+  `_dbt_source_relation`, `fleid`, `gifted_and_talented`
+- `stg_powerschool__s_nj_stu_x`: `studentsdcid`, `_dbt_source_relation`,
+  `gifted_and_talented`
+- `stg_powerschool__studentcorefields`: `studentsdcid`, `_dbt_source_relation`,
+  `lep_status`
+
+Verify `stg_kippadb__contact` has `id` and `school_specific_id`:
+
+```sql
+select column_name from `teamster-332318.kipptaf_kippadb.INFORMATION_SCHEMA.COLUMNS`
+where table_name = 'stg_kippadb__contact'
+and column_name in ('id', 'school_specific_id')
+```
+
+Required: both present. If any column is missing or differently named, update
+the SQL in Step 3.2 to match. Document any deviation in
+`.claude/scratch/batch-l-audit.md`.
+
+- [ ] **Step 3.2: Rewrite `dim_students.sql`**
+
+Replace the entire file contents with:
+
+```sql
+with
+    students_with_region as (
+        select
+            s.*,
+            initcap(regexp_extract(s._dbt_source_relation, r'kipp(\w+)_')) as region,
+        from {{ ref("stg_powerschool__students") }} as s
+    )
+
+select
+    {{ dbt_utils.generate_surrogate_key(["s.student_number"]) }} as student_key,
+
+    s.student_number as lea_student_identifier,
+
+    if(
+        s.region = 'Miami', s.state_studentnumber, cast(null as string)
+    ) as district_student_identifier,
+
+    if(s.region = 'Miami', suf.fleid, s.state_studentnumber) as state_student_identifier,
+
+    adb.id as salesforce_contact_id,
+
+    concat(s.last_name, ', ', s.first_name) as full_name,
+
+    s.dob as birth_date,
+    s.gender as gender_identity,
+
+    coalesce(njs.gifted_and_talented, suf.gifted_and_talented, 'N')
+    != 'N' as is_gifted,
+
+    scf.lep_status as is_ell,
+
+    case
+        when s.ethnicity = 'B'
+        then 'Black/African American'
+        when s.ethnicity = 'H'
+        then 'Hispanic or Latino'
+        when s.ethnicity = 'T'
+        then 'Two or More Races'
+        when s.ethnicity = 'W'
+        then 'White'
+        when s.ethnicity = 'I'
+        then 'American Indian or Alaska Native'
+        when s.ethnicity = 'A'
+        then 'Asian'
+        when s.ethnicity = 'P'
+        then 'Native Hawaiian or Other Pacific Islander'
+        when s.ethnicity = 'N'
+        then 'Not Hispanic or Latino'
+        else 'Not Listed'
+    end as race,
+
+    case
+        s.enroll_status
+        when -2
+        then 'Inactive'
+        when -1
+        then 'Pre-registered'
+        when 0
+        then 'Currently Enrolled'
+        when 1
+        then 'Inactive'
+        when 2
+        then 'Transferred Out'
+        when 3
+        then 'Graduated'
+        when 4
+        then 'Imported as Historical'
+    end as enrollment_status,
+
+from students_with_region as s
+left join
+    {{ ref("stg_kippadb__contact") }} as adb
+    on s.student_number = adb.school_specific_id
+left join
+    {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
+    on s.dcid = suf.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="suf") }}
+left join
+    {{ ref("stg_powerschool__s_nj_stu_x") }} as njs
+    on s.dcid = njs.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="njs") }}
+left join
+    {{ ref("stg_powerschool__studentcorefields") }} as scf
+    on s.dcid = scf.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="scf") }}
+```
+
+Notes:
+
+- ST06 column ordering: plain refs from `s` first, then constants/functions,
+  then logicals (CASE, IF). Re-order during sqlfluff fix-up if needed.
+- Join order matches dependency direction (kippadb is the only non-PowerSchool
+  source).
+- The model description in YAML already documents the
+  `district_student_identifier` "Miami-only" semantics — no doc update needed
+  for that column.
+
+- [ ] **Step 3.3: Update `dim_students.yml`**
+
+Three changes:
+
+**(a) Drop the `meal_eligibility_status` block** (lines 101-106 in current file,
+both the column entry and any data_tests).
+
+**(b) Drop the `has_iep` block** (lines 130-134 in current file).
+
+**(c) Update source_column metadata for retained columns:**
+
+For `lea_student_identifier`: `source_model` is already
+`stg_powerschool__students` and `source_column: student_number` — keep.
+
+For `state_student_identifier`: change `source_column` to:
+
+```yaml
+config:
+  meta:
+    source_system: PowerSchool
+    source_model:
+      stg_powerschool__students, stg_powerschool__u_studentsuserfields
+    source_column: state_studentnumber (NJ); fleid (Miami)
+    contains_pii: true
+```
+
+For `salesforce_contact_id`: add `config.meta`:
+
+```yaml
+config:
+  meta:
+    source_system: Salesforce (KIPPADB)
+    source_model: stg_kippadb__contact
+    source_column: id
+    contains_pii: true
+```
+
+For `full_name`: change `source_column`:
+
+```yaml
+config:
+  meta:
+    source_system: PowerSchool
+    source_model: stg_powerschool__students
+    source_column: last_name, first_name
+    contains_pii: true
+```
+
+For `is_gifted` description, update to reflect new logic:
+
+```yaml
+- name: is_gifted
+  data_type: boolean
+  description: >-
+    TRUE if the student has a gifted-and-talented identification on either the
+    PowerSchool NJ extension or Miami user-fields extension.
+  config:
+    meta:
+      source_system: PowerSchool
+      source_model:
+        stg_powerschool__s_nj_stu_x, stg_powerschool__u_studentsuserfields
+      source_column: gifted_and_talented
+```
+
+For `is_ell` description, update to reflect simplification:
+
+```yaml
+- name: is_ell
+  data_type: boolean
+  description: >-
+    TRUE if the student is currently classified as an English Language Learner
+    per the PowerSchool student core fields. Reflects current status only — does
+    not reflect historical enrollment-date-window LEP status.
+  config:
+    meta:
+      source_system: PowerSchool
+      source_model: stg_powerschool__studentcorefields
+      source_column: lep_status
+```
+
+For `enrollment_status`, source_model is already correct — keep.
+
+For the model description (lines 3-6), it currently says "Contains stable
+person-level attributes only. Enrollment history is in
+dim_student_enrollments..." That's still accurate — keep.
+
+- [ ] **Step 3.4: Build and test**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select dim_students --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected: model builds, uniqueness/not_null tests pass.
+
+- [ ] **Step 3.5: Run `bridge_student_contacts.student_key` relationships test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt test --select bridge_student_contacts --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected:
+`relationships_bridge_student_contacts_student_key__student_key__ref_dim_students_`
+passes (was failing with 9,835 rows).
+
+If it fails, query the orphan set:
+
+```sql
+select count(*) from `<dev_schema>.bridge_student_contacts` b
+left join `<dev_schema>.dim_students` d using (student_key)
+where d.student_key is null
+```
+
+Expected: 0.
+
+- [ ] **Step 3.6: Hash spot-check (5 known students)**
+
+Pick 5 `student_key` values from prod:
+
+```sql
+select student_key, lea_student_identifier from `teamster-332318.kipptaf_marts.dim_students` limit 5
+```
+
+Verify each appears in dev:
+
+```sql
+select student_key from `<dev_schema>.dim_students` where student_key in ('<key1>', ..., '<key5>')
+```
+
+Expected: all 5 found. If any missing, hash inputs drifted — STOP.
+
+- [ ] **Step 3.7: Spot-check downstream student-FK facts**
+
+For each fact that FKs to `dim_students.student_key`, run its relationships
+test:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt test --select fct_assessment_scores_enrollment_scoped fct_assessment_scores_student_scoped fct_behavioral_incidents fct_behavioral_consequences --target dev --project-dir src/dbt/kipptaf 2>&1 | grep -E "student_key|PASS|FAIL|WARN"
+```
+
+Expected: every `*_student_key__student_key__ref_dim_students_` test PASSes (or
+stays at its prior pass/warn state — no new regressions). If a test that was
+passing now fails, the dim grew/shrank in an unexpected direction — STOP and
+investigate.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes
+git add src/dbt/kipptaf/models/marts/dimensions/dim_students.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+git commit -m "fix(dbt): reroute dim_students to stg_powerschool__students (closes #3723)
+
+Sources from canonical PowerSchool student catalog (includes
+graduated/transferred students) instead of int_extracts__student_enrollments.
+LEFT JOINs kippadb contact for salesforce_contact_id and PS extension tables
+for fleid, gifted_and_talented, lep_status. Drops meal_eligibility_status and
+has_iep (enrollment attributes, not student attributes). is_ell simplified to
+current PS core-fields lep_status flag (drops enrollment-date-window logic)."
+```
+
+---
+
+## Task 4: Sanitize pre-2000 dates at staging (#3719)
+
+Apply `if(<col> < date '2000-01-01', null, <col>)` at the staging model where
+each fact's date originates. Add `dbt_utils.expression_is_true` test at
+`severity: warn` per spec.
+
+Five sites to patch:
+
+1. `stg_powerschool__calendar_day.date_value` → `dim_school_calendars.date_key`
+2. DeansList incident close-date staging →
+   `fct_behavioral_incidents.close_date_key`
+3. DeansList consequence start/end-date staging →
+   `fct_behavioral_consequences.{start,end}_date_key`
+4. `int_assessments__response_rollup.date_taken` →
+   `fct_assessment_scores_enrollment_scoped.test_date_key`
+5. Student-scoped assessment date origin (1900-01-01, 100 rows) →
+   `fct_assessment_scores_student_scoped.test_date_key`
+
+### Task 4a: PowerSchool `calendar_day` (3 rows, `1900-01-01`)
+
+The kipptaf-level `stg_powerschool__calendar_day` is currently a pure
+`union_relations()` macro call. To add sanitization, wrap it.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql`
+- Modify:
+  `src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml`
+
+- [ ] **Step 4a.1: Read current SQL and YAML**
+
+Read both files. Confirm the kipptaf-level SQL is a pure union, and the YAML has
+a `data_tests:` block (or model-level config) we can add an `expression_is_true`
+to.
+
+- [ ] **Step 4a.2: Rewrite `stg_powerschool__calendar_day.sql`**
+
+Replace contents with:
+
+```sql
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__calendar_day"),
+                    source("kippcamden_powerschool", "stg_powerschool__calendar_day"),
+                    source("kippmiami_powerschool", "stg_powerschool__calendar_day"),
+                    source("kipppaterson_powerschool", "stg_powerschool__calendar_day"),
+                ]
+            )
+        }}
+    )
+
+select
+    * except (date_value),
+
+    if(date_value < date '2000-01-01', null, date_value) as date_value,
+from union_relations
+```
+
+- [ ] **Step 4a.3: Add expression_is_true test to
+      `stg_powerschool__calendar_day.yml`**
+
+Locate the `date_value` column entry in the YAML. Add a `data_tests:` block (or
+extend the existing one). The full column spec should look like:
+
+```yaml
+- name: date_value
+  data_tests:
+    - dbt_utils.expression_is_true:
+        arguments:
+          expression: "date_value is null or date_value >= '2000-01-01'"
+        config:
+          severity: warn
+```
+
+If the column already has tests, append the new one. If the YAML doesn't
+currently list `date_value` as a column entry, add the entry.
+
+- [ ] **Step 4a.4: Build and test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select stg_powerschool__calendar_day --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected: build passes, new test passes (warn severity).
+
+- [ ] **Step 4a.5: Build and test `dim_school_calendars`**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select dim_school_calendars --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected:
+`relationships_dim_school_calendars_date_key__date_key__ref_dim_dates_` passes
+(was failing with 3 rows).
+
+### Task 4b: DeansList incident close-date
+
+- [ ] **Step 4b.1: Locate the upstream date column**
+
+`fct_behavioral_incidents.close_date_key` originates in DeansList. Find the
+producing model:
+
+```bash
+grep -rln "close_date_key\|closed_at" /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes/src/dbt/kipptaf/models --include="*.sql"
+```
+
+Then trace from `fct_behavioral_incidents.sql` upward to find the staging
+`stg_deanslist__*` or `int_deanslist__*` model that emits the column ultimately
+mapped to `close_date_key`.
+
+Document the exact producing file path and column name in
+`.claude/scratch/batch-l-audit.md`.
+
+- [ ] **Step 4b.2: Apply sanitization in the producing staging/intermediate
+      model**
+
+In the model identified in 4b.1, wrap the date column with the standard guard.
+If the column is currently `select cast(<source_col> as date) as <col>`, change
+to:
+
+```sql
+if(
+    cast(<source_col> as date) < date '2000-01-01',
+    null,
+    cast(<source_col> as date)
+) as <col>
+```
+
+Or if the column is already a `date` value passed through, change `<col>` to
+`if(<col> < date '2000-01-01', null, <col>) as <col>`.
+
+- [ ] **Step 4b.3: Add expression_is_true test in the producing model's
+      properties YAML**
+
+Same pattern as Task 4a.3, on the producing column.
+
+- [ ] **Step 4b.4: Build and test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select <producing_model>+ fct_behavioral_incidents --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected: builds pass,
+`relationships_fct_behavioral_incidents_close_date_key__date_key__ref_dim_dates_`
+passes (was failing with 3 rows).
+
+### Task 4c: DeansList consequence start/end-date
+
+- [ ] **Step 4c.1: Locate the upstream date columns**
+
+Trace `fct_behavioral_consequences.start_date_key` and `.end_date_key` to their
+staging/intermediate origin. They likely come from a single producing model with
+both columns.
+
+```bash
+grep -rln "start_date_key\|end_date_key\|consequence" /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes/src/dbt/kipptaf/models/deanslist /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes/src/dbt/deanslist --include="*.sql"
+```
+
+Document the path and column names.
+
+- [ ] **Step 4c.2: Apply sanitization to both columns in the producing model**
+
+Same pattern as 4b.2, applied to both date columns.
+
+- [ ] **Step 4c.3: Add expression_is_true tests for both columns**
+
+Two test entries in the YAML, one per column.
+
+- [ ] **Step 4c.4: Build and test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select <producing_model>+ fct_behavioral_consequences --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected: both
+`relationships_fct_behavioral_consequences_*_date_key__date_key__ref_dim_dates_`
+tests pass (were failing with 1 + 3 rows).
+
+### Task 4d: Illuminate response-rollup `date_taken`
+
+`fct_assessment_scores_enrollment_scoped.test_date_key` (Illuminate branch)
+sources from `int_assessments__response_rollup.date_taken`. The 0001-01-01,
+0006-01-01, 0201-01-01, 1901-01-15, 1969-12-31, and borderline 1999-12-16 dates
+all originate here (~347 rows).
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql`
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml`
+
+- [ ] **Step 4d.1: Read the current model SQL**
+
+Read `int_assessments__response_rollup.sql`. Locate every `select` clause that
+emits or passes through `date_taken`. The earlier exploration showed line 21
+(`s.date_taken`), line 76 (`(date_taken is null) asc`), line 77
+(`date_taken asc`), line 89 (`canonical_administered_at as administered_at`),
+line 106 (`min(date_taken) as date_taken`), line 130, line 166.
+
+The cleanest sanitize point is at the staging entry — the first SELECT that
+pulls `date_taken` from the source assessment table. Wrap it there so all
+downstream CTEs see sanitized values.
+
+Open the file to identify the exact source CTE.
+
+- [ ] **Step 4d.2: Apply sanitization at the source CTE**
+
+In the first CTE that pulls `date_taken` from upstream, change:
+
+```sql
+s.date_taken,
+```
+
+to:
+
+```sql
+if(s.date_taken < date '2000-01-01', null, s.date_taken) as date_taken,
+```
+
+Verify subsequent CTEs that reference `date_taken` (line 76, 77, 106, etc.)
+continue to work unchanged — they consume the now-sanitized value.
+
+- [ ] **Step 4d.3: Add expression_is_true test on `date_taken`**
+
+In `properties/int_assessments__response_rollup.yml`, find the `date_taken`
+column entry and add:
+
+```yaml
+data_tests:
+  - dbt_utils.expression_is_true:
+      arguments:
+        expression: "date_taken is null or date_taken >= '2000-01-01'"
+      config:
+        severity: warn
+```
+
+If the column doesn't have an entry, add one.
+
+- [ ] **Step 4d.4: Build and test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select int_assessments__response_rollup+ fct_assessment_scores_enrollment_scoped --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected:
+`relationships_fct_assessment_scores_enrollment_scoped_test_date_key__date_key__ref_dim_dates_`
+passes (was failing with 347 rows).
+
+### Task 4e: Student-scoped assessment date (100 rows, `1900-01-01`)
+
+`fct_assessment_scores_student_scoped.test_date_key = 1900-01-01` (100 rows).
+Need to locate the source.
+
+- [ ] **Step 4e.1: Locate the producing model**
+
+Read `fct_assessment_scores_student_scoped.sql` (find via
+`find ... -name "fct_assessment_scores_student_scoped*"`). Identify the upstream
+model that supplies `test_date_key` (or its pre-aliased equivalent).
+
+Likely candidates: Renaissance, iReady, Amplify, or a state-assessment
+intermediate. The 1900-01-01 sentinel is a classic vendor placeholder. Trace via
+`ref()` calls to the staging/intermediate source.
+
+Run a BigQuery query to identify which vendor:
+
+```sql
+select <vendor_field>, count(*) as n
+from `teamster-332318.kipptaf_marts.fct_assessment_scores_student_scoped`
+where test_date_key = date '1900-01-01'
+group by 1
+```
+
+If the fact has no vendor column, join its `assessment_administration_key` to
+`dim_assessment_administrations` and filter by 1900-01-01 to recover the vendor.
+
+Document the producing file in `.claude/scratch/batch-l-audit.md`.
+
+- [ ] **Step 4e.2: Apply sanitization at the producing model**
+
+Same pattern as 4d.2.
+
+- [ ] **Step 4e.3: Add expression_is_true test**
+
+Same pattern as 4d.3.
+
+- [ ] **Step 4e.4: Build and test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select <producing_model>+ fct_assessment_scores_student_scoped --target dev --project-dir src/dbt/kipptaf
+```
+
+Expected:
+`relationships_fct_assessment_scores_student_scoped_test_date_key__date_key__ref_dim_dates_`
+passes (was failing with 100 rows).
+
+### Task 4f: Commit
+
+- [ ] **Step 4f.1: Stage and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes
+git add -u
+git commit -m "fix(dbt): sanitize pre-2000 dates at staging (closes #3719)
+
+Wraps date columns producing dim_dates FK orphans with
+'if(d < 2000-01-01, null, d)' at five staging/intermediate sites:
+calendar_day, deanslist incidents/consequences, illuminate response-rollup,
+student-scoped assessment vendor. Adds expression_is_true tests at
+severity: warn so future upstream typos surface in the warnings audit
+without blocking CI."
+```
+
+---
+
+## Task 5: Full-graph rebuild and final test sweep
+
+Run the complete affected slice end-to-end to confirm nothing else regressed.
+
+- [ ] **Step 5.1: Build all affected models**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes && uv run dbt build --select dim_courses dim_course_sections dim_students bridge_student_contacts dim_school_calendars fct_assessment_scores_enrollment_scoped fct_assessment_scores_student_scoped fct_behavioral_incidents fct_behavioral_consequences --target dev --project-dir src/dbt/kipptaf 2>&1 | tee .claude/scratch/batch-l-build.log
+```
+
+Expected: all models build, all 8 originally-failing relationships tests pass.
+
+- [ ] **Step 5.2: Verify acceptance criteria**
+
+Grep the build log for the 8 originally-failing tests:
+
+```bash
+grep -E "relationships_(dim_course_sections_course_key|bridge_student_contacts_student_key|dim_school_calendars_date_key|fct_assessment_scores_(enrollment|student)_scoped_test_date_key|fct_behavioral_incidents_close_date_key|fct_behavioral_consequences_(start|end)_date_key)" .claude/scratch/batch-l-build.log
+```
+
+Expected: 8 lines, all PASS.
+
+- [ ] **Step 5.3: Verify the 5 new expression_is_true tests pass at warn**
+
+```bash
+grep "expression_is_true" .claude/scratch/batch-l-build.log
+```
+
+Expected: 5 entries, all PASS or WARN (warn severity is fine — currently they
+should PASS since we sanitized everything).
+
+---
+
+## Task 6: Push, open PR, CI-warnings audit
+
+- [ ] **Step 6.1: Run trunk check on the worktree**
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk check --ci /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes
+```
+
+Expected: clean (no issues). Fix any reported issues before pushing.
+
+- [ ] **Step 6.2: Push the branch**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-batch-l-fk-fixes push origin cbini/fix/claude-batch-l-fk-fixes
+```
+
+- [ ] **Step 6.3: Open the PR**
+
+Use the `.github/pull_request_template.md` body. Title:
+`fix(dbt): batch L — join-path FK fixes`. Body must reference all three issues
+with `Closes` syntax:
+
+```markdown
+## Summary
+
+Resolves the 8 `relationships` test failures in
+[PR batch L](https://github.com/orgs/TEAMSchools/projects/4):
+
+- `dim_courses` and `dim_students` rerouted from enrollment-derived
+  intermediates to canonical PowerSchool staging.
+- 5 staging/intermediate models gained pre-2000 date-sanitization guards plus
+  regression `expression_is_true` tests at `severity: warn`.
+- `meal_eligibility_status` and `has_iep` removed from `dim_students`
+  (enrollment attributes; not student-grain).
+- `is_ell` simplified to `studentcorefields.lep_status` (drops
+  enrollment-date-window logic).
+
+## Closes
+
+- Closes #3719
+- Closes #3721
+- Closes #3723
+
+## Spec / plan
+
+- Spec: `docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md`
+- Plan: `docs/superpowers/plans/2026-05-04-batch-l-join-path-fk-fixes.md`
+
+## Test plan
+
+- [x] All 8 originally-failing relationships tests pass on dev
+- [x] 5 new expression_is_true tests pass at severity: warn
+- [x] Hash spot-check: 5 known student_keys + 5 known course_keys verified
+      stable
+- [ ] dbt Cloud CI passes
+- [ ] CI warnings audit completed (see comment after CI green)
+```
+
+Use `mcp__github__create_pull_request` with `base="main"`,
+`head="cbini/fix/claude-batch-l-fk-fixes"`, `draft=false` (or `true` if you want
+to wait on CI before review).
+
+- [ ] **Step 6.4: Wait for dbt Cloud CI**
+
+Find the PR's CI run via:
+
+```bash
+gh pr checks <PR_NUMBER> --repo TEAMSchools/teamster
+```
+
+When the dbt Cloud check is `success`, proceed.
+
+- [ ] **Step 6.5: Pull post-CI warnings**
+
+Use `mcp__dbt__get_job_run_error` with
+`run_id=<the CI run id>, warning_only=true`. Save to
+`.claude/scratch/batch-l-warnings-post.txt` (Write tool).
+
+- [ ] **Step 6.6: Diff against baseline**
+
+Compare `.claude/scratch/batch-l-warnings-baseline.txt` (from Task 0.3) and
+`.claude/scratch/batch-l-warnings-post.txt`. Categorize each delta into:
+
+- **Bonus closures** — warnings present in baseline but absent post-PR. Look up
+  whether each maps to an open issue. If yes, add `Closes #<num>` to the PR
+  body.
+- **New regressions** — warnings absent in baseline but present post-PR.
+  Investigate and fix before merge. STOP if you can't resolve them.
+- **Newly surfaced** — warnings absent in baseline AND absent post-PR but only
+  because tests that were previously erroring (and skipping warn-level checks
+  downstream) are now passing. Less common; identify by inspecting the baseline
+  failure list.
+
+Write the categorization to a PR comment via `mcp__github__add_issue_comment`:
+
+```markdown
+## CI warnings audit
+
+### Bonus closures
+
+<list, or "none">
+
+### New regressions
+
+<list, or "none">
+
+### Newly surfaced
+
+<list, or "none">
+
+Baseline: `<run_id_baseline>`. Post-PR: `<run_id_post>`.
+```
+
+If "Bonus closures" is non-empty, also update the PR body to add `Closes #<num>`
+for each bonus issue (use `mcp__github__update_pull_request`).
+
+- [ ] **Step 6.7: Mark PR ready for review**
+
+If opened as draft, mark as ready via
+`gh pr ready <PR_NUMBER> --repo TEAMSchools/teamster`.
+
+---
+
+## Self-review checklist (run before declaring complete)
+
+- [ ] All 3 issues closed via PR body
+- [ ] All 8 acceptance-criteria tests pass
+- [ ] All 5 new expression_is_true tests added and passing
+- [ ] Hash spot-checks succeed (no `student_key` or `course_key` drift)
+- [ ] CI warnings diff posted and bonus closures linked
+- [ ] No `meal_eligibility_status` or `has_iep` references remaining outside
+      `dim_students.{sql,yml}` (re-grep)
+- [ ] Trunk check clean
+- [ ] PR description matches `.github/pull_request_template.md` shape

--- a/docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md
@@ -1,0 +1,222 @@
+# Batch L — join-path FK fixes design
+
+Closes [#3719](https://github.com/TEAMSchools/teamster/issues/3719),
+[#3721](https://github.com/TEAMSchools/teamster/issues/3721),
+[#3723](https://github.com/TEAMSchools/teamster/issues/3723).
+
+## Problem
+
+Three open issues in
+[PR batch L](https://github.com/orgs/TEAMSchools/projects/4) report
+`relationships` test failures where mart-layer join paths cannot resolve foreign
+keys:
+
+| Issue | Child column                                                                                                                                                                                                                                                                        | Parent                     | Orphans |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------: |
+| #3719 | `fct_assessment_scores_enrollment_scoped.test_date_key`, `fct_assessment_scores_student_scoped.test_date_key`, `dim_school_calendars.date_key`, `fct_behavioral_incidents.close_date_key`, `fct_behavioral_consequences.start_date_key`, `fct_behavioral_consequences.end_date_key` | `dim_dates.date_key`       |     457 |
+| #3721 | `dim_course_sections.course_key`                                                                                                                                                                                                                                                    | `dim_courses.course_key`   |  30,241 |
+| #3723 | `bridge_student_contacts.student_key`                                                                                                                                                                                                                                               | `dim_students.student_key` |   9,835 |
+
+The three issues share a join-path theme but split into two distinct root
+causes.
+
+### Root cause A: dim sourced from enrollment-derived intermediate (#3721, #3723)
+
+Both `dim_courses` and `dim_students` are built from intermediate models scoped
+to recent enrollment activity, not from the canonical PowerSchool catalog
+tables.
+
+`dim_courses` deduplicates `base_powerschool__course_enrollments` — only courses
+with course-enrollment activity in scope appear. `dim_course_sections` sources
+from `base_powerschool__sections` and includes every section, so sections whose
+course never had an in-scope enrollment have no resolvable `course_key`.
+
+`dim_students` deduplicates `int_extracts__student_enrollments` — only students
+with recent enrollments. `bridge_student_contacts` unions PowerSchool contact
+rows for every historical student, so contacts for graduated/transferred
+students orphan against `dim_students`.
+
+Both dims should be rerouted to source from canonical PowerSchool staging
+(`stg_powerschool__courses`, `stg_powerschool__students`). Hash inputs do not
+change, so existing FKs from facts continue to resolve.
+
+### Root cause B: junk dates outside the `dim_dates` range (#3719)
+
+`dim_dates` already spans 2000–9999 (`models/marts/dimensions/dim_dates.sql`),
+so the orphan `*_date_key` values are not a missing-future-range problem.
+Profiling the 457 orphan rows shows three classes of bad value, all upstream
+data quality:
+
+- **Year-typo dates** (e.g. `0001-01-01`, `0006-01-01`, `0019-11-12`,
+  `0204-01-26`, `1029-12-05`) — user data-entry errors in source systems.
+- **Sentinel defaults** — `1900-01-01` (103 rows), `1901-01-15`, `1969-12-31`.
+- **Borderline pre-2000** — `1999-12-16` (9 rows from Illuminate). Same source
+  as the year-typo dates above; almost certainly also a typo, not legitimate
+  Y2K-era testing.
+
+These should be sanitized to NULL at the staging layer where the date
+originates. NULL FKs satisfy `relationships`; orphan FKs do not.
+
+## Goals
+
+- All eight originally-failing `relationships` tests return 0 rows.
+- Bad dates do not propagate to any consumer (current or future).
+- Hash discipline preserved: `student_key` and `course_key` hash inputs do not
+  change.
+- A regression guard fires if upstream emits new pre-2000 garbage.
+
+## Non-goals
+
+- Active/inactive course filtering on `dim_course_sections`.
+- Resolving the survey-fact enrollment-coverage gap (#3794) — same problem
+  class, different fix shape, blocked on PR #3793.
+- Pushing entity-grain projections from marts into intermediate (#3780).
+
+## Design
+
+### Section 1 — Reroute `dim_courses` to staging (#3721)
+
+Switch `dim_courses` to source from `stg_powerschool__courses` and project the
+canonical course attributes directly. The current model deduplicates by
+`courses_course_number, _dbt_source_relation`; if `stg_powerschool__courses` is
+already grain-correct on the same union key (verify via the staging model's
+uniqueness test during implementation), the explicit `dbt_utils.deduplicate` CTE
+can be dropped. Otherwise, retain it.
+
+`course_key = generate_surrogate_key(["course_number", "_dbt_source_relation"])`
+remains identical, so `dim_course_sections.course_key` and any future course-FK
+fact resolve unchanged.
+
+Column mapping (verify against `INFORMATION_SCHEMA.COLUMNS` on
+`stg_powerschool__courses` during implementation):
+
+| Mart column        | Staging source                                  |
+| ------------------ | ----------------------------------------------- |
+| `course_code`      | `course_number` (or staging-renamed equivalent) |
+| `course_title`     | `course_name`                                   |
+| `credit_type`      | `credittype`                                    |
+| `academic_subject` | `discipline`                                    |
+| `credits`          | `credit_hours`                                  |
+
+If a staging column is missing or named differently, alias inline.
+
+### Section 2 — Reroute `dim_students` to staging (#3723)
+
+Switch `dim_students` to source from `stg_powerschool__students` (canonical
+student catalog including graduated/transferred students PowerSchool retains)
+and project the canonical attributes directly.
+
+`student_key = generate_surrogate_key(["student_number"])` remains identical, so
+`bridge_student_contacts.student_key` and every student-FK fact resolve
+unchanged.
+
+`salesforce_contact_id` is not a PowerSchool attribute. Preserve it via a LEFT
+JOIN to the kippadb contact crosswalk (e.g. `stg_kippadb__contact` keyed on
+`school_specific_id` / `student_number` — confirm exact key during
+implementation).
+
+All other current `dim_students` columns map directly from
+`stg_powerschool__students` (or its column-renamed equivalents):
+`lea_student_identifier`, `district_student_identifier`,
+`state_student_identifier`, `full_name`, `birth_date`, `gender_identity`,
+`meal_eligibility_status`, `enrollment_status`, `is_gifted`, `is_ell`,
+`has_iep`, `race`. The current `ethnicity → race` CASE expression migrates
+verbatim.
+
+The dim grows because graduated/transferred students are now included. That is
+the desired outcome; bridges and historical-scope facts resolve their FKs.
+
+### Section 3 — Sanitize pre-2000 dates at staging (#3719)
+
+Apply `if(<col> < date '2000-01-01', null, <col>)` to the date column at the
+staging model where each affected fact's date originates. NULL satisfies the
+`relationships` test; junk values do not propagate to any other consumer.
+
+Patch sites (final list confirmed during implementation by tracing each fact's
+date column upstream):
+
+1. **PowerSchool `calendar_day` staging** — feeds
+   `dim_school_calendars.date_key` (3 orphan rows, `1900-01-01`).
+2. **DeansList incident staging** — feeds
+   `fct_behavioral_incidents.close_date_key` (3 typo-year rows).
+3. **DeansList consequence staging** — feeds
+   `fct_behavioral_consequences.start_date_key` (1 row) and `end_date_key` (3
+   rows).
+4. **Illuminate `int_assessments__response_rollup`** — feeds
+   `fct_assessment_scores_enrollment_scoped.test_date_key` (~347 rows of typo
+   and sentinel values, including the 9 borderline `1999-12-16` rows).
+5. **Student-scoped assessment branch** — locate the `1900-01-01` source feeding
+   `fct_assessment_scores_student_scoped.test_date_key` (likely Renaissance,
+   iReady, or Amplify staging — 100 rows) and sanitize there.
+
+Add a `dbt_utils.expression_is_true` test on each sanitized column at the
+staging model:
+
+```yaml
+- dbt_utils.expression_is_true:
+    arguments:
+      expression:
+        "{{ column_name }} is null or {{ column_name }} >= '2000-01-01'"
+    config:
+      severity: error
+```
+
+Staging-layer tests must set `severity: error` per project convention. The test
+passes immediately after sanitization. If upstream emits new pre-2000 garbage,
+the test catches it before it reaches a fact's `relationships` test.
+
+No reusable macro until this pattern recurs in a third domain.
+
+## Implementation sequence
+
+Three logical commits, each independently reviewable:
+
+1. **`dim_courses` reroute.** Switch source, verify column mapping, run
+   `relationships` test on `dim_course_sections.course_key` → 0 orphans.
+2. **`dim_students` reroute.** Switch source, add kippadb LEFT JOIN for
+   `salesforce_contact_id`, verify `bridge_student_contacts.student_key`
+   `relationships` → 0 orphans. Spot-check student-FK facts (e.g.
+   `fct_assessment_scores_*.student_key`) for unexpected resolution changes.
+3. **Date sanitization.** Patch the 4–5 staging sites, add `expression_is_true`
+   tests on sanitized columns. Verify all 6 originally-failing date
+   `relationships` tests → 0 orphans.
+
+### Hash discipline check
+
+After each reroute, sample 5 known student / course keys before and after to
+confirm hash equivalence. The hash inputs are unchanged by design, so this is a
+guard against accidental input-list drift during the edit.
+
+### dbt Cloud CI
+
+Standard `dbt build --select state:modified+ --full-refresh` against staging.
+The reroutes touch mart sources, not source schemas — no
+`stage_external_sources` step required.
+
+### CI warnings audit (mandatory before merge)
+
+After each commit's CI run passes, pull warnings via
+`mcp__dbt__get_job_run_error` with `warning_only=true` (success ≠ warning-free,
+per `src/dbt/CLAUDE.md`). Diff against the most recent main-branch CI run and
+categorize each delta:
+
+- **Bonus closures** — warnings incidentally fixed. Note in PR body and close
+  the corresponding issues if any exist.
+- **New regressions** — warnings introduced by this commit. Fix before merge.
+- **Newly surfaced** — warnings previously masked by the failures this PR
+  resolves. File new issues, link to this PR, leave for follow-up batches.
+
+## Acceptance criteria
+
+- [ ] `dim_course_sections.course_key` → `dim_courses.course_key`
+      `relationships` test returns 0 rows.
+- [ ] `bridge_student_contacts.student_key` → `dim_students.student_key`
+      `relationships` test returns 0 rows.
+- [ ] All six date `relationships` tests from #3719 return 0 rows.
+- [ ] Five new `expression_is_true` tests on sanitized date columns added and
+      passing at `severity: error`.
+- [ ] Sampled `student_key` and `course_key` values match pre-merge values (no
+      hash drift).
+- [ ] Post-CI warnings audit completed for each commit; PR body lists bonus
+      closures, regressions, and newly-surfaced issues with links.
+- [ ] Closes #3719, #3721, #3723.

--- a/docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md
@@ -158,12 +158,15 @@ staging model:
       expression:
         "{{ column_name }} is null or {{ column_name }} >= '2000-01-01'"
     config:
-      severity: error
+      severity: warn
 ```
 
-Staging-layer tests must set `severity: error` per project convention. The test
-passes immediately after sanitization. If upstream emits new pre-2000 garbage,
-the test catches it before it reaches a fact's `relationships` test.
+`severity: warn` is intentional here, overriding the staging-default
+`severity: error`. New pre-2000 garbage requires a source-system fix
+(user-entered typos in PowerSchool, DeansList, Illuminate); that work shouldn't
+block CI. The warning surfaces the regression in the post-CI warnings audit so
+we can file a follow-up issue against the source system without halting
+downstream builds.
 
 No reusable macro until this pattern recurs in a third domain.
 
@@ -214,7 +217,8 @@ categorize each delta:
       `relationships` test returns 0 rows.
 - [ ] All six date `relationships` tests from #3719 return 0 rows.
 - [ ] Five new `expression_is_true` tests on sanitized date columns added and
-      passing at `severity: error`.
+      passing at `severity: warn` (intentional override of staging default — new
+      pre-2000 garbage requires a source-system fix, not a CI block).
 - [ ] Sampled `student_key` and `course_key` values match pre-merge values (no
       hash drift).
 - [ ] Post-CI warnings audit completed for each commit; PR body lists bonus

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -18,7 +18,6 @@ with
             s.is_internal_assessment,
             s.is_replacement,
             s.student_assessment_id,
-            s.date_taken,
             s.canonical_assessment_id,
             s.canonical_title,
             s.canonical_administered_at,
@@ -34,6 +33,8 @@ with
             asr.percent_correct,
 
             pb.canonical_performance_band_set_id,
+
+            if(s.date_taken < date '2000-01-01', null, s.date_taken) as date_taken,
         from {{ ref("int_assessments__scaffold") }} as s
         left join
             {{ ref("int_illuminate__agg_student_responses") }} as asr

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -18,6 +18,12 @@ models:
               - response_type
               - response_type_id
               - is_replacement
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              date_taken is null or date_taken >= '2000-01-01'
+          config:
+            severity: warn
     columns:
       - name: illuminate_student_id
         data_type: int64

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
@@ -9,10 +9,21 @@ with
                 ]
             )
         }}
+    ),
+
+    sanitized as (
+        -- trunk-ignore(sqlfluff/AM04): union_relations expands at compile time
+        select
+            * except (close_ts_date),
+
+            if(
+                close_ts_date < datetime '2000-01-01', null, close_ts_date
+            ) as close_ts_date,
+        from union_relations
     )
 
 select u.*, {{ extract_code_location("u") }} as _dbt_source_project, loc.location_key,
-from union_relations as u
+from sanitized as u
 left join
     {{ ref("stg_google_sheets__people__locations") }} as loc
     on u.school_id = loc.deanslist_school_id

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
@@ -15,7 +15,17 @@ with
                 ]
             )
         }}
+    ),
+
+    sanitized as (
+        -- trunk-ignore(sqlfluff/AM04): union_relations expands at compile time
+        select
+            * except (start_date, end_date),
+
+            if(start_date < date '2000-01-01', null, start_date) as start_date,
+            if(end_date < date '2000-01-01', null, end_date) as end_date,
+        from union_relations
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
-from union_relations
+select *, {{ extract_code_location("sanitized") }} as _dbt_source_project,
+from sanitized

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents.yml
@@ -2,6 +2,13 @@ models:
   - name: int_deanslist__incidents
     config:
       materialized: table
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              close_ts_date is null or close_ts_date >= '2000-01-01'
+          config:
+            severity: warn
     columns:
       - name: location_key
         data_type: string

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
@@ -17,6 +17,7 @@ models:
             severity: warn
     columns:
       - name: school_id
+        data_type: int64
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
@@ -2,6 +2,19 @@ models:
   - name: int_deanslist__incidents__penalties
     config:
       materialized: table
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              start_date is null or start_date >= '2000-01-01'
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              end_date is null or end_date >= '2000-01-01'
+          config:
+            severity: warn
     columns:
       - name: school_id
         data_tests:

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__standardized_test_unpivot.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__standardized_test_unpivot.sql
@@ -6,11 +6,11 @@ with
             school_specific_id,
             academic_year,
             administration_round,
-            `date`,
             test_type,
-
             score_type,
             score,
+
+            if(`date` < date '2000-01-01', null, `date`) as `date`,
 
             case
                 when

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
@@ -2,6 +2,13 @@ models:
   - name: int_kippadb__standardized_test_unpivot
     config:
       materialized: table
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              `date` is null or `date` >= '2000-01-01'
+          config:
+            severity: warn
     columns:
       - name: id
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
@@ -3,7 +3,7 @@ select
     -- base_powerschool__sections. Rewrite c's source relation to the parent's.
     -- TODO: replace() is a no-op if a future district uses a different base
     -- model name. Long-term fix: hash region prefix only, consistent across
-    -- producer and consumer (#3678 follow-up).
+    -- producer and consumer (#3820).
     {{
         dbt_utils.generate_surrogate_key(
             [

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
@@ -1,25 +1,24 @@
-with
-    deduplicated as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("base_powerschool__course_enrollments"),
-                partition_by="courses_course_number, _dbt_source_relation",
-                order_by="cc_academic_year desc",
-            )
-        }}
-    )
-
 select
     {{
         dbt_utils.generate_surrogate_key(
-            ["courses_course_number", "_dbt_source_relation"]
+            [
+                "c.course_number",
+                (
+                    "replace(c._dbt_source_relation,"
+                    " 'stg_powerschool__courses',"
+                    " 'base_powerschool__sections')"
+                ),
+            ]
         )
     }} as course_key,
 
-    courses_course_number as course_code,
-    courses_course_name as course_title,
-    courses_credittype as credit_type,
-    discipline as academic_subject,
-    courses_credit_hours as credits,
+    c.course_number as course_code,
+    c.course_name as course_title,
+    c.credittype as credit_type,
+    csc.discipline as academic_subject,
+    c.credit_hours as credits,
 
-from deduplicated
+from {{ ref("stg_powerschool__courses") }} as c
+left join
+    {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
+    on c.course_number = csc.powerschool_course_number

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
@@ -1,4 +1,9 @@
 select
+    -- FK source_relation must match dim_course_sections, which is built from
+    -- base_powerschool__sections. Rewrite c's source relation to the parent's.
+    -- TODO: replace() is a no-op if a future district uses a different base
+    -- model name. Long-term fix: hash region prefix only, consistent across
+    -- producer and consumer (#3678 follow-up).
     {{
         dbt_utils.generate_surrogate_key(
             [

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -31,7 +31,7 @@ select
     -- base_powerschool__sections. Rewrite cc's source relation to the parent's.
     -- TODO: replace() is a no-op if a future district uses a different base
     -- model name. Long-term fix: hash region prefix only, consistent across
-    -- producer and consumer (#3678 follow-up).
+    -- producer and consumer (#3820).
     {{
         dbt_utils.generate_surrogate_key(
             [

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
@@ -4,7 +4,6 @@ with
             s.*,
             initcap(regexp_extract(s._dbt_source_relation, r'kipp(\w+)_')) as region,
         from {{ ref("stg_powerschool__students") }} as s
-        where s.enroll_status != -100
     )
 
 select

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
@@ -1,49 +1,87 @@
 with
-    deduplicated as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_extracts__student_enrollments"),
-                partition_by="student_number",
-                order_by="academic_year desc, entrydate desc",
-            )
-        }}
+    students_with_region as (
+        select
+            s.*,
+            initcap(regexp_extract(s._dbt_source_relation, r'kipp(\w+)_')) as region,
+        from {{ ref("stg_powerschool__students") }} as s
+        where s.enroll_status != -100
     )
 
 select
-    {{ dbt_utils.generate_surrogate_key(["student_number"]) }} as student_key,
+    {{ dbt_utils.generate_surrogate_key(["s.student_number"]) }} as student_key,
 
-    student_number as lea_student_identifier,
-    secondary_state_studentnumber as district_student_identifier,
-    state_studentnumber as state_student_identifier,
-    salesforce_id as salesforce_contact_id,
-    student_name as full_name,
-    dob as birth_date,
-    gender as gender_identity,
-    lunch_status as meal_eligibility_status,
-    enroll_status_string as enrollment_status,
+    s.student_number as lea_student_identifier,
 
-    gifted_and_talented is not null as is_gifted,
+    if(
+        s.region = 'Miami', s.state_studentnumber, cast(null as string)
+    ) as district_student_identifier,
 
-    lep_status is not null as is_ell,
-    iep_status = 'With IEP' as has_iep,
+    if(
+        s.region = 'Miami', suf.fleid, s.state_studentnumber
+    ) as state_student_identifier,
+
+    adb.id as salesforce_contact_id,
+
+    concat(s.last_name, ', ', s.first_name) as full_name,
+
+    s.dob as birth_date,
+    s.gender as gender_identity,
+
+    coalesce(njs.gifted_and_talented, suf.gifted_and_talented, 'N') != 'N' as is_gifted,
+
+    scf.lep_status as is_ell,
 
     case
-        when ethnicity = 'B'
+        when s.ethnicity = 'B'
         then 'Black/African American'
-        when ethnicity = 'H'
+        when s.ethnicity = 'H'
         then 'Hispanic or Latino'
-        when ethnicity = 'T'
+        when s.ethnicity = 'T'
         then 'Two or More Races'
-        when ethnicity = 'W'
+        when s.ethnicity = 'W'
         then 'White'
-        when ethnicity = 'I'
+        when s.ethnicity = 'I'
         then 'American Indian or Alaska Native'
-        when ethnicity = 'A'
+        when s.ethnicity = 'A'
         then 'Asian'
-        when ethnicity = 'P'
+        when s.ethnicity = 'P'
         then 'Native Hawaiian or Other Pacific Islander'
-        when ethnicity = 'N'
+        when s.ethnicity = 'N'
         then 'Not Hispanic or Latino'
         else 'Not Listed'
     end as race,
-from deduplicated
+
+    case
+        s.enroll_status
+        when -2
+        then 'Inactive'
+        when -1
+        then 'Pre-registered'
+        when 0
+        then 'Currently Enrolled'
+        when 1
+        then 'Inactive'
+        when 2
+        then 'Transferred Out'
+        when 3
+        then 'Graduated'
+        when 4
+        then 'Imported as Historical'
+    end as enrollment_status,
+
+from students_with_region as s
+left join
+    {{ ref("stg_kippadb__contact") }} as adb
+    on s.student_number = adb.school_specific_id
+left join
+    {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
+    on s.dcid = suf.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="suf") }}
+left join
+    {{ ref("stg_powerschool__s_nj_stu_x") }} as njs
+    on s.dcid = njs.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="njs") }}
+left join
+    {{ ref("stg_powerschool__studentcorefields") }} as scf
+    on s.dcid = scf.studentsdcid
+    and {{ union_dataset_join_clause(left_alias="s", right_alias="scf") }}

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -3,15 +3,15 @@ models:
     description: >-
       Course catalog dimension. One row per course per source region. Course
       numbers are not unique across regions, so the surrogate key includes the
-      source relation. Sourced from the canonical PowerSchool course catalog;
+      source region. Sourced from the canonical PowerSchool course catalog;
       academic_subject joins the assessment course-subject crosswalk by course
       number.
     columns:
       - name: course_key
         data_type: string
         description: >-
-          Surrogate key derived from courses_course_number and
-          _dbt_source_relation. Primary key for this dimension.
+          Surrogate key for this dimension. Derived from the course number and
+          source region.
         constraints:
           - type: primary_key
             warn_unsupported: false
@@ -22,7 +22,7 @@ models:
       - name: course_code
         data_type: string
         description: >-
-          The number the school assigns to a particular course. Indexed.
+          The number the school assigns to a particular course.
         data_tests:
           - not_null
 
@@ -44,8 +44,8 @@ models:
       - name: credit_type
         data_type: string
         description: >-
-          Copied from the Credit Type field in the Course table. The type of
-          credit this counts as towardgraduation, such as Math or elective.
+          The type of credit this course counts toward graduation, such as Math
+          or elective.
 
         config:
           meta:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -3,8 +3,9 @@ models:
     description: >-
       Course catalog dimension. One row per course per source region. Course
       numbers are not unique across regions, so the surrogate key includes the
-      source relation. Attributes represent the most recent non-null values from
-      the PowerSchool course table as observed in enrollment records.
+      source relation. Sourced from the canonical PowerSchool course catalog;
+      academic_subject joins the assessment course-subject crosswalk by course
+      number.
     columns:
       - name: course_key
         data_type: string
@@ -49,14 +50,20 @@ models:
         config:
           meta:
             source_system: PowerSchool
-            source_model: stg_powerschool__storedgrades
-            source_column: credit_type
+            source_model: stg_powerschool__courses
+            source_column: credittype
       - name: academic_subject
         data_type: string
         description: >-
           Subject area discipline mapped from course number via the course
           subject crosswalk. Null when the course number is not in the
           crosswalk.
+
+        config:
+          meta:
+            source_system: Google Sheets
+            source_model: stg_google_sheets__assessments__course_subject_crosswalk
+            source_column: discipline
 
       - name: credits
         data_type: float64

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -45,6 +45,12 @@ models:
           Miami-only mdcps_student_identifier. Ed-Fi District / CEDS
           District-assigned number from the host district's perspective.
 
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: stg_powerschool__students
+            source_column: state_studentnumber (Miami only)
+            contains_pii: true
       - name: state_student_identifier
         data_type: string
         description: >-
@@ -54,8 +60,9 @@ models:
         config:
           meta:
             source_system: PowerSchool
-            source_model: stg_powerschool__students
-            source_column: state_studentnumber
+            source_model:
+              stg_powerschool__students, stg_powerschool__u_studentsuserfields
+            source_column: state_studentnumber (NJ); fleid (Miami)
             contains_pii: true
       - name: salesforce_contact_id
         data_type: string
@@ -64,6 +71,12 @@ models:
           where the student has a KIPPADB record; null otherwise. Used across
           KIPPADB consumer tools (Overgrad, alumni tracking, etc.).
 
+        config:
+          meta:
+            source_system: Salesforce (KIPPADB)
+            source_model: stg_kippadb__contact
+            source_column: id
+            contains_pii: true
       - name: full_name
         data_type: string
         description: >-
@@ -74,7 +87,7 @@ models:
           meta:
             source_system: PowerSchool
             source_model: stg_powerschool__students
-            source_column: lastfirst
+            source_column: last_name, first_name
             contains_pii: true
       - name: birth_date
         data_type: date
@@ -98,12 +111,6 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: gender
-      - name: meal_eligibility_status
-        data_type: string
-        description: >-
-          National School Lunch Program (NSLP) meal eligibility status (e.g.,
-          Free, Reduced, Paid).
-
       - name: enrollment_status
         data_type: string
         description: >-
@@ -119,18 +126,27 @@ models:
       - name: is_gifted
         data_type: boolean
         description: >-
-          TRUE if the student has a gifted-and-talented identification.
+          TRUE if the student has a gifted-and-talented identification on either
+          the PowerSchool NJ extension or Miami user-fields extension.
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model:
+              stg_powerschool__s_nj_stu_x, stg_powerschool__u_studentsuserfields
+            source_column: gifted_and_talented
 
       - name: is_ell
         data_type: boolean
         description: >-
-          TRUE if the student is classified as an active English Language
-          Learner (ELL).
-
-      - name: has_iep
-        data_type: boolean
-        description: >-
-          TRUE if the student has an Individualized Education Program (IEP).
+          TRUE if the student is currently classified as an English Language
+          Learner per the PowerSchool student core fields. Reflects current
+          status only — does not reflect historical enrollment-date-window LEP
+          status.
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: stg_powerschool__studentcorefields
+            source_column: lep_status
 
       - name: race
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -111,18 +111,6 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: gender
-      - name: enrollment_status
-        data_type: string
-        description: >-
-          Current enrollment status of the student. Values: Currently Enrolled,
-          Pre-registered, Inactive, Transferred Out, Graduated, Imported as
-          Historical.
-
-        config:
-          meta:
-            source_system: PowerSchool
-            source_model: stg_powerschool__students
-            source_column: enroll_status
       - name: is_gifted
         data_type: boolean
         description: >-
@@ -160,3 +148,16 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: ethnicity
+
+      - name: enrollment_status
+        data_type: string
+        description: >-
+          Current enrollment status of the student. Values: Currently Enrolled,
+          Pre-registered, Inactive, Transferred Out, Graduated, Imported as
+          Historical.
+
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: stg_powerschool__students
+            source_column: enroll_status

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml
@@ -1,2 +1,9 @@
 models:
   - name: stg_powerschool__calendar_day
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |-
+              date_value is null or date_value >= '2000-01-01'
+          config:
+            severity: warn

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
@@ -2,3 +2,24 @@ models:
   - name: stg_powerschool__studentcorefields
     config:
       materialized: table
+    description: >-
+      Cross-region union of the PowerSchool student core-fields extension table.
+      One row per student per region. Carries the per-student LEP status flag
+      consumed by dim_students.is_ell.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - studentsdcid
+              - _dbt_source_relation
+          config:
+            severity: error
+    columns:
+      - name: studentsdcid
+        data_type: int64
+        description: >-
+          DCID of the associated Student record. Per-region primary key for this
+          extension table.
+      - name: lep_status
+        data_type: boolean
+        description: Student Limited English Proficiency status.

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
@@ -1,19 +1,10 @@
 models:
   - name: stg_powerschool__studentcorefields
-    config:
-      materialized: table
     description: >-
       Cross-region union of the PowerSchool student core-fields extension table.
       One row per student per region. Carries the per-student LEP status flag
-      consumed by dim_students.is_ell.
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - studentsdcid
-              - _dbt_source_relation
-          config:
-            severity: error
+      consumed by dim_students.is_ell. Functionally an intermediate — uniqueness
+      and contract enforcement live on the per-region staging models.
     columns:
       - name: studentsdcid
         data_type: int64

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
@@ -1,0 +1,4 @@
+models:
+  - name: stg_powerschool__studentcorefields
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
@@ -1,10 +1,22 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__calendar_day"),
-            source("kippcamden_powerschool", "stg_powerschool__calendar_day"),
-            source("kippmiami_powerschool", "stg_powerschool__calendar_day"),
-            source("kipppaterson_powerschool", "stg_powerschool__calendar_day"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__calendar_day"),
+                    source("kippcamden_powerschool", "stg_powerschool__calendar_day"),
+                    source("kippmiami_powerschool", "stg_powerschool__calendar_day"),
+                    source(
+                        "kipppaterson_powerschool", "stg_powerschool__calendar_day"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations expands at compile time
+select
+    * except (date_value),
+
+    if(date_value < date '2000-01-01', null, date_value) as date_value,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studentcorefields.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studentcorefields.sql
@@ -1,0 +1,10 @@
+{{
+    dbt_utils.union_relations(
+        relations=[
+            source("kippnewark_powerschool", "stg_powerschool__studentcorefields"),
+            source("kippcamden_powerschool", "stg_powerschool__studentcorefields"),
+            source("kippmiami_powerschool", "stg_powerschool__studentcorefields"),
+            source("kipppaterson_powerschool", "stg_powerschool__studentcorefields"),
+        ]
+    )
+}}

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
@@ -12,6 +12,7 @@ with
         }}
     )
 
+-- trunk-ignore(sqlfluff/AM04): union_relations produces an unknown column count
 select *,
 from union_relations
 where dcid >= 1

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
@@ -14,4 +14,4 @@ with
 
 select *,
 from union_relations
-where dcid > 0
+where dcid >= 1

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__students"),
-            source("kippcamden_powerschool", "stg_powerschool__students"),
-            source("kippmiami_powerschool", "stg_powerschool__students"),
-            source("kipppaterson_powerschool", "stg_powerschool__students"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__students"),
+                    source("kippcamden_powerschool", "stg_powerschool__students"),
+                    source("kippmiami_powerschool", "stg_powerschool__students"),
+                    source("kipppaterson_powerschool", "stg_powerschool__students"),
+                ]
+            )
+        }}
     )
-}}
+
+select *,
+from union_relations
+where dcid > 0


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will resolve the 8 originally-failing `relationships` tests in [PR batch L](https://github.com/orgs/TEAMSchools/projects/4) (join-path FK fixes).

- **`dim_courses`** rerouted from `base_powerschool__course_enrollments` to `stg_powerschool__courses` (canonical course catalog). Hash-compatible via `_dbt_source_relation` token replacement so `dim_course_sections.course_key` FK resolves.
- **`dim_students`** rerouted from `int_extracts__student_enrollments` to `stg_powerschool__students` (canonical, includes graduated/transferred). LEFT JOINs kippadb contact + PS extension tables to preserve `salesforce_contact_id`, `fleid`, `gifted_and_talented`, `lep_status`. Drops `meal_eligibility_status` and `has_iep` (enrollment attributes, not student-grain). `is_ell` simplified to current `studentcorefields.lep_status` flag (drops enrollment-date-window logic — relocate via follow-up).
- **PowerSchool phantom-row filter** — added `where dcid >= 1` at `stg_powerschool__students` to drop 4 PowerSchool placeholder rows (one per district, `dcid=-100`, `student_number=0`, `enroll_status=-100`) that broke `dim_students` PK uniqueness after the reroute.
- **New staging union model** `stg_powerschool__studentcorefields` (kipptaf-level union of the 4 region sources, mirrors `stg_powerschool__u_studentsuserfields` pattern). Required by `dim_students` for `lep_status`.
- **Pre-2000 date sanitization** at 5 staging/intermediate sites — wraps junk dates (year typos like `0001-01-01`, sentinels like `1900-01-01`) with `if(d < '2000-01-01', null, d)` so they don't propagate as orphan FKs against `dim_dates`. Adds 6 `dbt_utils.expression_is_true` regression-guard tests at `severity: warn`.

## AI Assistance

Claude Code authored this PR end-to-end (spec → plan → implementation → review). Human-directed at multiple inflection points:
- Direction to source dims from canonical staging rather than enrollment-derived intermediates.
- Decision to drop `meal_eligibility_status` / `has_iep` from `dim_students` (they're enrollment attributes).
- Choice of `dcid >= 1` as the phantom-row filter predicate.
- Override to use `severity: warn` for date-sanitization regression tests (per spec rationale: bad dates require source-system fixes, shouldn't block CI).

Spec: [`docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md`](docs/superpowers/specs/2026-05-04-batch-l-join-path-fk-fixes-design.md)
Plan: [`docs/superpowers/plans/2026-05-04-batch-l-join-path-fk-fixes.md`](docs/superpowers/plans/2026-05-04-batch-l-join-path-fk-fixes.md)

Closes #3719
Closes #3721
Closes #3723

## Self-review

### General

- [x] Reviewed Claude Code Review feedback inline through development (will address the formal PR review on this PR after dbt Cloud CI lands).

### dbt

- [x] All new/modified models include properties YAML.
- [x] `dim_students` removes columns from a contracted model — flagged as breaking. No SQL consumers in this repo reference `meal_eligibility_status` or `has_iep`. Cube exposure references `dim_students` but doesn't name those columns; coordinate with Cube admin if any Cube model field referenced them.
- [x] No new external sources — `stg_external_sources` not needed.

### CI checks

- [ ] **Trunk** — passes locally (`trunk check --ci` clean from worktree).
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — n/a (no Dagster code changes).

## Test plan

Verified locally on dev target:

- [x] All 8 originally-failing relationships tests PASS (was: `dim_course_sections.course_key` 30,241 orphans; `bridge_student_contacts.student_key` 9,835 orphans; 6 `*_date_key` columns 457 orphans total).
- [x] 6 new `expression_is_true` tests added at `severity: warn` and passing (one per sanitized date column; site 4c covers 2 columns).
- [x] Hash spot-check: 5 known prod `student_key` values verified in dev rebuild (single-column hash unchanged). 5 `course_key` values intentionally drifted (the new hash matches `dim_course_sections`'s existing convention; old prod hashes were broken — that was the bug).
- [x] No new student-FK fact regressions (pre-existing 19,924 / 162,742 orphan warnings unchanged).
- [x] Side-effect: `not_null_dim_school_calendars_date_key` now WARN 3 (the previously-orphan rows became NULL — same junk surfaced through a different test; project-default warn severity).

## CI warnings audit

To complete after dbt Cloud CI lands:

- [ ] Pull post-CI warnings via `mcp__dbt__get_job_run_error` with `warning_only=true`.
- [ ] Diff against the main-branch baseline (snapshot taken at run `70403206041351`, zero warnings).
- [ ] Categorize bonus closures, regressions, newly-surfaced — comment on this PR.