### PR TITLE
docs(claude): add PII redaction trigger for external output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,15 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   `grade_level`, `school`, partial dates, zip alone) reidentify in combination —
   never post two together.
 
+- **Before writing any content outside the local dev environment** — including
+  GitHub PRs, issue comments, commit messages, Slack, Asana, scheduled-agent
+  outputs, or any other external system — perform a PII redaction pass on any
+  values from local validation work. Values sourced from columns tagged
+  `config.meta.contains_pii: true` in model YAML — or that meet the PII criteria
+  listed above — must be replaced with redacted labels (`a sample student`,
+  `Student A`) or column-name references. The transition from local analysis to
+  any external output is the trigger.
+
 - **Before writing any spec or plan**: STOP and explicitly ask the user whether
   to open a GitHub issue first. Required for specs/plans; not required for quick
   fixes. Do not write anything until the user answers. If opening: use


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add an explicit trigger rule to CLAUDE.md requiring a PII redaction pass before writing any content outside the local dev environment.

The existing **PII stays local** rule correctly defines what PII is and where it must not appear, but it lacks a trigger — there is no explicit prompt to scan for PII at the moment of transitioning from local analysis to external output. This gap caused a student identifier to appear in a PR description during a recent session.

The new rule generalizes the checkpoint beyond GitHub to cover all external systems (Slack, Asana, scheduled-agent outputs, etc.) and names the transition point explicitly as the trigger.

## AI Assistance

Rule text drafted collaboratively between Claude Code and the team based on a post-incident review.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214561357381286