### PR TITLE
chore(cube): sync dbt descriptions into cube YAMLs and enrich attendance views

### DIFF
--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -22,6 +22,19 @@ import re
 _COLUMN_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
 
+_EXPECTED_SCHEMA = "kipptaf_marts"
+
+
+def _resolve_table_from_sql_table(sql_table: str | None) -> str | None:
+    """Extract ``<table>`` from ``kipptaf_marts.<table>``; ``None`` otherwise."""
+    if not isinstance(sql_table, str):
+        return None
+    parts = sql_table.split(".", 1)
+    if len(parts) != 2 or parts[0] != _EXPECTED_SCHEMA:
+        return None
+    return parts[1].strip() or None
+
+
 def _resolve_dbt_column(sql: str | None) -> str | None:
     """Return the dbt column name from a Cube dimension's ``sql:`` value.
 

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -17,7 +17,9 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import re
+import sys
 from pathlib import Path
 
 import yaml
@@ -31,6 +33,8 @@ _DBT_MART_DIRS: tuple[Path, ...] = (
 )
 
 _EXPECTED_SCHEMA = "kipptaf_marts"
+
+_CUBE_MODEL_DIR = Path("src/cube/model/cubes")
 
 
 def _load_dbt_descriptions(
@@ -166,3 +170,37 @@ def _patch_cube_file(
         with path.open("w") as f:
             ry.dump(doc, f)
     return counts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any file would change.",
+    )
+    args = parser.parse_args(argv)
+    files = sorted(_CUBE_MODEL_DIR.rglob("*.yml"))
+    total: dict[str, int] = {
+        "updated": 0,
+        "skipped_already": 0,
+        "skipped_expr": 0,
+        "skipped_no_match": 0,
+        "skipped_no_table": 0,
+    }
+    any_changes = False
+    for f in files:
+        counts = _patch_cube_file(f)
+        if counts["updated"]:
+            any_changes = True
+            print(f"{f}: {counts['updated']} updated")
+        for k, v in counts.items():
+            total[k] = total.get(k, 0) + v
+    print(f"\nTotal: {total}")
+    if args.check and any_changes:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -1,0 +1,18 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["pyyaml>=6.0", "ruamel.yaml>=0.18"]
+# ///
+
+"""Sync dbt mart YAML descriptions into Cube cube YAML files.
+
+Reads each cube file under ``src/cube/model/cubes/``, locates the matching
+dbt mart YAML via ``sql_table:``, and inserts dbt column descriptions onto
+cube dimensions that lack them. Patches dimensions only — measures are
+calculations and require hand-authored descriptions. Existing Cube
+descriptions are preserved.
+
+Usage:
+    uv run scripts/sync_cube_descriptions.py [--check]
+"""
+
+from __future__ import annotations

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -83,3 +83,86 @@ def _resolve_dbt_column(sql: str | None) -> str | None:
         s = s[len("{CUBE}.") :]
     s = s.strip("`").strip()
     return s if _COLUMN_RE.match(s) else None
+
+
+def _get_ryaml():
+    """Lazy-load ruamel.yaml for round-trip YAML editing.
+
+    ruamel.yaml is declared in PEP 723 script dependencies and is available
+    when running via ``uv run``. Tests that import this module via importlib
+    only call this lazily, so importing the module never imports ruamel.
+    """
+    # trunk-ignore-begin(pyright/reportMissingImports): PEP 723 dep
+    from ruamel.yaml import YAML
+    from ruamel.yaml.scalarstring import FoldedScalarString
+
+    # trunk-ignore-end(pyright/reportMissingImports)
+
+    ry = YAML()
+    ry.preserve_quotes = True
+    ry.width = 80
+    ry.indent(mapping=2, sequence=4, offset=2)
+    return ry, FoldedScalarString
+
+
+def _make_description_scalar(text: str, FoldedScalarString):
+    """Pick a YAML scalar style for a description string.
+
+    Folded (``>-``) for multi-line or long descriptions to match the style
+    already used in Cube and dbt YAMLs; plain string for short single-line.
+    """
+    if "\n" in text or len(text) > 80:
+        return FoldedScalarString(text)
+    return text
+
+
+def _patch_cube_file(
+    path: Path,
+    *,
+    search_dirs: tuple[Path, ...] | list[Path] = _DBT_MART_DIRS,
+) -> dict[str, int]:
+    """Patch dimensions in a single cube file. Return per-action counts."""
+    counts = {
+        "updated": 0,
+        "skipped_already": 0,
+        "skipped_expr": 0,
+        "skipped_no_match": 0,
+        "skipped_no_table": 0,
+    }
+    ry, FoldedScalarString = _get_ryaml()
+    with path.open() as f:
+        doc = ry.load(f)
+    cubes = doc.get("cubes") or []
+    if not cubes:
+        return counts
+    cube = cubes[0]
+    table = _resolve_table_from_sql_table(cube.get("sql_table"))
+    if table is None:
+        counts["skipped_no_table"] += 1
+        return counts
+    descriptions = _load_dbt_descriptions(table, search_dirs=search_dirs)
+    if descriptions is None:
+        counts["skipped_no_table"] += 1
+        return counts
+    for dim in cube.get("dimensions") or []:
+        if "description" in dim:
+            counts["skipped_already"] += 1
+            continue
+        col = _resolve_dbt_column(dim.get("sql"))
+        if col is None:
+            counts["skipped_expr"] += 1
+            continue
+        desc = descriptions.get(col)
+        if not desc:
+            counts["skipped_no_match"] += 1
+            continue
+        scalar = _make_description_scalar(desc, FoldedScalarString)
+        # Insert ``description:`` immediately after ``name:``.
+        keys = list(dim.keys())
+        name_idx = keys.index("name") if "name" in keys else 0
+        dim.insert(name_idx + 1, "description", scalar)
+        counts["updated"] += 1
+    if counts["updated"]:
+        with path.open("w") as f:
+            ry.dump(doc, f)
+    return counts

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -16,3 +16,23 @@ Usage:
 """
 
 from __future__ import annotations
+
+import re
+
+_COLUMN_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def _resolve_dbt_column(sql: str | None) -> str | None:
+    """Return the dbt column name from a Cube dimension's ``sql:`` value.
+
+    Handles bare column (``col``), ``{CUBE}``-qualified
+    (``{CUBE}.col``), and backticked (`col`, ``{CUBE}.`col``).
+    Returns ``None`` for SQL expressions or non-string input.
+    """
+    if not isinstance(sql, str):
+        return None
+    s = sql.strip()
+    if s.startswith("{CUBE}."):
+        s = s[len("{CUBE}.") :]
+    s = s.strip("`").strip()
+    return s if _COLUMN_RE.match(s) else None

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -18,11 +18,45 @@ Usage:
 from __future__ import annotations
 
 import re
+from pathlib import Path
+
+import yaml
 
 _COLUMN_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 
+_DBT_MART_DIRS: tuple[Path, ...] = (
+    Path("src/dbt/kipptaf/models/marts/facts/properties"),
+    Path("src/dbt/kipptaf/models/marts/dimensions/properties"),
+    Path("src/dbt/kipptaf/models/marts/bridges/properties"),
+)
 
 _EXPECTED_SCHEMA = "kipptaf_marts"
+
+
+def _load_dbt_descriptions(
+    table: str,
+    search_dirs: tuple[Path, ...] | list[Path] = _DBT_MART_DIRS,
+) -> dict[str, str] | None:
+    """Find ``<table>.yml`` in any of ``search_dirs`` and return
+    ``{column_name: description}`` for non-empty descriptions.
+
+    Returns ``None`` if no matching YAML is found.
+    """
+    for d in search_dirs:
+        path = Path(d) / f"{table}.yml"
+        if not path.exists():
+            continue
+        doc = yaml.safe_load(path.read_text()) or {}
+        for model in doc.get("models", []) or []:
+            if model.get("name") != table:
+                continue
+            out: dict[str, str] = {}
+            for col in model.get("columns", []) or []:
+                desc = (col.get("description") or "").strip()
+                if desc:
+                    out[col["name"]] = desc
+            return out
+    return None
 
 
 def _resolve_table_from_sql_table(sql_table: str | None) -> str | None:

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -15,8 +15,6 @@ Usage:
     uv run scripts/sync_cube_descriptions.py [--check]
 """
 
-from __future__ import annotations
-
 import argparse
 import re
 import sys
@@ -50,7 +48,7 @@ def _load_dbt_descriptions(
         path = Path(d) / f"{table}.yml"
         if not path.exists():
             continue
-        doc = yaml.safe_load(path.read_text()) or {}
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         for model in doc.get("models", []) or []:
             if model.get("name") != table:
                 continue
@@ -134,7 +132,7 @@ def _patch_cube_file(
         "skipped_no_table": 0,
     }
     ry, FoldedScalarString = _get_ryaml()
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         doc = ry.load(f)
     cubes = doc.get("cubes") or []
     if not cubes:
@@ -167,7 +165,7 @@ def _patch_cube_file(
         dim.insert(name_idx + 1, "description", scalar)
         counts["updated"] += 1
     if counts["updated"]:
-        with path.open("w") as f:
+        with path.open("w", encoding="utf-8") as f:
             ry.dump(doc, f)
     return counts
 
@@ -195,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
             any_changes = True
             print(f"{f}: {counts['updated']} updated")
         for k, v in counts.items():
-            total[k] = total.get(k, 0) + v
+            total[k] += v
     print(f"\nTotal: {total}")
     if args.check and any_changes:
         return 1

--- a/src/cube/model/cubes/attendance/attendance.yml
+++ b/src/cube/model/cubes/attendance/attendance.yml
@@ -31,6 +31,9 @@ cubes:
 
     dimensions:
       - name: student_attendance_daily_key
+        description: >-
+          Surrogate key derived from student_number, _dbt_source_relation, and
+          calendardate. Primary key for this fact.
         sql: student_attendance_daily_key
         type: string
         primary_key: true
@@ -41,71 +44,114 @@ cubes:
         public: true
 
       - name: academic_year
+        description:
+          KIPP academic year (July start) in which this attendance date falls.
         sql: academic_year
         type: number
         public: true
 
       - name: semester
+        description: Semester code for the attendance date (e.g., S1, S2).
         sql: semester
         type: string
         public: true
 
       - name: attendance_code
+        description:
+          Attendance identifier set by school. Examples Tardy, Absent, etc.
         sql: attendance_code
         type: string
         public: true
 
       - name: attendance_category
+        description: >-
+          Coarse attendance category derived from the is_* flags with priority
+          ordering (suspension > absent > tardy > present). Values:
+          Out-of-School Suspension, In-School Suspension, Absent, Tardy,
+          Present. Use this column for GROUP BY in BI tools; use the raw
+          attendance_code for specific-code drill-down.
         sql: attendance_category
         type: string
         public: true
 
       - name: attendance_value
+        description: >-
+          Daily attendance value — a real number, typically a fraction of 1
+          where 1 is a full attendance day. Used with membership_value to
+          compute ADA. Precision depends on the source SIS's attendance mode
+          (full-day vs period-level vs day-part); see source_model for
+          provenance.
         sql: attendance_value
         type: number
         public: true
 
       - name: membership_value
+        description: >-
+          The amount of a student's membership this school claims. If a student
+          attends more than one school eachone will only be able to claim a
+          certain portion of the membership. The largest number for this will
+          usually be1 and fractions expressed as decimals. Like .5 or .25.
         sql: membership_value
         type: number
         public: true
 
       - name: present_weight
+        description: >-
+          Weighted presence value. 0.67 for tardy (T-prefix codes), otherwise
+          equals attendancevalue. Fractional by design — not a 0/1 flag.
         sql: present_weight
         type: number
         public: true
 
       - name: is_absent
+        description:
+          1 if the student was absent, 0 if present. Sum-friendly flag.
         sql: is_absent
         type: number
         public: true
 
       - name: is_tardy
+        description:
+          1 if the student was tardy (T-prefix attendance code), 0 otherwise.
         sql: is_tardy
         type: number
         public: true
 
       - name: is_ontime
+        description: 1 if the student arrived on time (non-tardy), 0 if tardy.
         sql: is_ontime
         type: number
         public: true
 
       - name: is_oss
+        description: >-
+          1 if the student received out-of-school suspension on this date (OS,
+          OSS, OSSP, SHI codes), 0 otherwise.
         sql: is_oss
         type: number
         public: true
 
       - name: is_iss
+        description: >-
+          1 if the student received in-school suspension on this date (S, ISS
+          codes), 0 otherwise.
         sql: is_iss
         type: number
         public: true
 
       - name: is_suspended
+        description: >-
+          1 if the student was suspended (any type) on this date. Union of
+          is_oss and is_iss codes.
         sql: is_suspended
         type: number
         public: true
 
       - name: is_truant
+        description: >-
+          TRUE if the student meets regional truancy criteria. Miami: 15+
+          absences in 90-day rolling window. NJ regions: projected absences
+          reach 50+ for the year.
         sql: is_truant
         type: boolean
         public: true

--- a/src/cube/model/cubes/attendance/attendance.yml
+++ b/src/cube/model/cubes/attendance/attendance.yml
@@ -88,9 +88,9 @@ cubes:
       - name: membership_value
         description: >-
           The amount of a student's membership this school claims. If a student
-          attends more than one school eachone will only be able to claim a
+          attends more than one school each one will only be able to claim a
           certain portion of the membership. The largest number for this will
-          usually be1 and fractions expressed as decimals. Like .5 or .25.
+          usually be 1 and fractions expressed as decimals. Like .5 or .25.
         sql: membership_value
         type: number
         public: true
@@ -98,7 +98,7 @@ cubes:
       - name: present_weight
         description: >-
           Weighted presence value. 0.67 for tardy (T-prefix codes), otherwise
-          equals attendancevalue. Fractional by design — not a 0/1 flag.
+          equals attendance_value. Fractional by design — not a 0/1 flag.
         sql: present_weight
         type: number
         public: true

--- a/src/cube/model/cubes/conformed/dates.yml
+++ b/src/cube/model/cubes/conformed/dates.yml
@@ -5,56 +5,73 @@ cubes:
 
     dimensions:
       - name: date_key
+        description:
+          Calendar date. Primary key and join target for all mart models.
         sql: date_key
         type: string
         primary_key: true
 
       - name: date_day
+        description:
+          Timestamp cast of date_key. Required by Cube for date dimension joins.
         sql: date_timestamp
         type: time
         public: true
 
       - name: academic_year
+        description: >-
+          KIPP academic year (July start). The calendar year in which the
+          academic year begins (e.g., 2025 for the 2025-26 school year).
         sql: academic_year
         type: number
         public: true
 
       - name: fiscal_year
+        description: >-
+          KIPP fiscal year (July start). The calendar year in which the fiscal
+          year ends (e.g., 2026 for FY2026 which begins July 2025).
         sql: fiscal_year
         type: number
         public: true
 
       - name: year_number
+        description: Calendar year.
         sql: year_number
         type: number
         public: true
 
       - name: quarter_number
+        description: Calendar quarter (1-4).
         sql: quarter_number
         type: number
         public: true
 
       - name: month_number
+        description: Month number (1-12).
         sql: month_number
         type: number
         public: true
 
       - name: month_name
+        description: Full month name (January, February, etc.).
         sql: month_name
         type: string
         public: true
 
       - name: day_of_week
+        description: Day of week (1=Sunday through 7=Saturday).
         sql: day_of_week
         type: number
         public: true
 
       - name: day_of_week_name
+        description: Full day name (Monday, Tuesday, etc.).
         sql: day_of_week_name
         type: string
         public: true
 
       - name: is_weekday
+        description: TRUE for Monday through Friday.
         sql: is_weekday
         type: boolean
         public: true

--- a/src/cube/model/cubes/conformed/locations.yml
+++ b/src/cube/model/cubes/conformed/locations.yml
@@ -10,39 +10,53 @@ cubes:
 
     dimensions:
       - name: location_key
+        description: Surrogate key derived from location name.
         sql: location_key
         type: string
         primary_key: true
 
       - name: region_key
+        description: >-
+          Foreign key to dim_regions. Surrogate key derived from
+          `business_unit_code` so this column hashes exactly the keys produced
+          by `dim_regions.region_key`. Network-level locations (e.g., KIPP NJ)
+          map to KIPP_TAF.
         sql: region_key
         type: string
 
       - name: location_name
+        description: Canonical location name.
         sql: "{CUBE}.`name`"
         type: string
         public: true
 
       - name: abbreviation
+        description: Short display name for the location.
         sql: abbreviation
         type: string
         public: true
 
       - name: grade_band
+        description: Grade band served (ES, MS, HS).
         sql: grade_band
         type: string
         public: true
 
       - name: campus
+        description: Physical campus name. Multiple schools may share a campus.
         sql: campus
         type: string
         public: true
 
       - name: is_campus
+        description:
+          TRUE if this location record represents a campus-level entity.
         sql: is_campus
         type: boolean
 
       - name: city
+        description:
+          City. Nullable for non-physical rows (e.g., campus rollups).
         sql: city
         type: string
         public: true

--- a/src/cube/model/cubes/conformed/regions.yml
+++ b/src/cube/model/cubes/conformed/regions.yml
@@ -5,20 +5,24 @@ cubes:
 
     dimensions:
       - name: region_key
+        description: Surrogate key derived from business_unit_code.
         sql: region_key
         type: string
         primary_key: true
 
       - name: region_name
+        description: Region name (Camden, Miami, Newark, Paterson, TAF).
         sql: "{CUBE}.`name`"
         type: string
         public: true
 
       - name: state
+        description: US state (NJ or FL).
         sql: state
         type: string
         public: true
 
       - name: timezone
+        description: IANA timezone identifier.
         sql: timezone
         type: string

--- a/src/cube/model/cubes/conformed/school_calendars.yml
+++ b/src/cube/model/cubes/conformed/school_calendars.yml
@@ -10,19 +10,29 @@ cubes:
         primary_key: true
 
       - name: date_key
+        description: >-
+          Each day of the school year including holidays and weekends, such as
+          the school day. Indexed. Currently warns on 3 NULL rows (project-
+          default `not_null` severity) — junk pre-2000 source dates sanitized to
+          NULL upstream by PR #3809; the 3 rows themselves should be filtered
+          out of this dim. See follow-up note in #3719 thread.
         sql: date_key
         type: string
 
       - name: location_key
+        description: Surrogate key for the school. FK to dim_locations.
         sql: location_key
         type: string
 
       - name: is_in_session
+        description: TRUE if this date is an instructional day at this school.
         sql: is_in_session
         type: boolean
         public: true
 
       - name: is_membership_day
+        description:
+          TRUE if this date counts toward student membership at this school.
         sql: is_membership_day
         type: boolean
         public: true

--- a/src/cube/model/cubes/conformed/school_calendars.yml
+++ b/src/cube/model/cubes/conformed/school_calendars.yml
@@ -12,10 +12,7 @@ cubes:
       - name: date_key
         description: >-
           Each day of the school year including holidays and weekends, such as
-          the school day. Indexed. Currently warns on 3 NULL rows (project-
-          default `not_null` severity) — junk pre-2000 source dates sanitized to
-          NULL upstream by PR #3809; the 3 rows themselves should be filtered
-          out of this dim. See follow-up note in #3719 thread.
+          the school day. Indexed.
         sql: date_key
         type: string
 

--- a/src/cube/model/cubes/conformed/terms.yml
+++ b/src/cube/model/cubes/conformed/terms.yml
@@ -5,38 +5,55 @@ cubes:
 
     dimensions:
       - name: term_key
+        description: >-
+          Surrogate key for this dimension. Hash composition uses term type,
+          code, name, start date, region, and school ID as internal inputs;
+          region and school ID are not exposed as mart columns. Region
+          attributes are reachable via dim_terms → dim_locations → dim_regions
+          FK traversal.
         sql: term_key
         type: string
         primary_key: true
 
       - name: location_key
+        description: >-
+          Foreign key to dim_locations. Surrogate key derived from the location
+          name. Nullable when the period is region-wide or when the school is
+          not present in dim_locations.
         sql: location_key
         type: string
 
       - name: term_type
+        description:
+          Category of period (e.g., academic, PM, survey, assessment, fiscal).
         sql: "{CUBE}.`type`"
         type: string
         public: true
 
       - name: term_code
+        description: Short code for the period (e.g., Q1, Q2, PM1, Fall).
         sql: term_code
         type: string
         public: true
 
       - name: term_name
+        description: Display name for the period.
         sql: term_name
         type: string
         public: true
 
       - name: academic_year
+        description: Academic year this period falls within.
         sql: academic_year
         type: number
 
       - name: fiscal_year
+        description: Fiscal year this period falls within.
         sql: fiscal_year
         type: number
 
       - name: grade_band
+        description: Grade band (ES, MS, HS). Nullable when not school-specific.
         sql: grade_band
         type: string
 
@@ -49,5 +66,8 @@ cubes:
         type: time
 
       - name: is_current
+        description: >-
+          TRUE if the current date falls within this period, or if the period is
+          the latest for its type in a past academic year.
         sql: is_current
         type: boolean

--- a/src/cube/model/cubes/students/student_enrollments.yml
+++ b/src/cube/model/cubes/students/student_enrollments.yml
@@ -10,31 +10,49 @@ cubes:
 
     dimensions:
       - name: student_enrollment_key
+        description: >-
+          Surrogate key derived from student_number, _dbt_source_relation,
+          academic_year, and entrydate. Primary key for this dimension — matches
+          the uniqueness grain on int_extracts__student_enrollments.
         sql: student_enrollment_key
         type: string
         primary_key: true
         public: true
 
       - name: student_key
+        description:
+          Surrogate key derived from student_number. FK to dim_students.
         sql: student_key
         type: string
 
       # degenerate — no dim_locations join declared here to avoid a diamond
       # path with attendance's direct location_key FK to dim_locations
       - name: location_key
+        description: >-
+          Surrogate key derived from location_clean_name. FK to dim_locations.
+          Null when schoolid does not match any location in the crosswalk (e.g.,
+          grade_level 99 placeholder schools).
         sql: location_key
         type: string
 
       - name: academic_year
+        description: >-
+          KIPP academic year (July start) in which this enrollment falls. The
+          calendar year in which the academic year begins (e.g., 2025 for the
+          2025-26 school year).
         sql: academic_year
         type: number
 
       - name: grade_level
+        description: >-
+          The grade the student is in. Since this is an integer: 0=Kindergarten
+          1, -2=Preschool. Indexed.
         sql: grade_level
         type: number
         public: true
 
       - name: graduation_year
+        description: Student graduation year.
         sql: graduation_year
         type: number
         public: true
@@ -50,6 +68,9 @@ cubes:
         public: true
 
       - name: is_retained_year
+        description: >-
+          TRUE if the student repeated this grade level in the same school
+          compared to the prior academic year.
         sql: is_retained_year
         type: boolean
         public: true

--- a/src/cube/model/cubes/students/students.yml
+++ b/src/cube/model/cubes/students/students.yml
@@ -5,6 +5,9 @@ cubes:
 
     dimensions:
       - name: student_key
+        description: >-
+          Surrogate key derived from student_number. Primary key for the student
+          dimension.
         sql: student_key
         type: string
         primary_key: true
@@ -12,11 +15,21 @@ cubes:
 
       # PII — excluded from detail views without cube-access-student-pii
       - name: lea_student_identifier
+        description: >-
+          KIPP's own SIS identifier for the student. KIPP is a charter Local
+          Education Agency (LEA) operating within a host public school district;
+          this column is the identifier issued by KIPP as the LEA. Sourced from
+          the SIS student number for NJ regions (and Focus local ID for Miami
+          once Focus lands). Maps to Ed-Fi District / CEDS District-assigned
+          number from KIPP-as-LEA's perspective.
         sql: lea_student_identifier
         type: number
         public: true
 
       - name: full_name
+        description: >-
+          Student's full name in "Last, First, Mi." format. Matches
+          dim_staff.full_name naming.
         sql: full_name
         type: string
         public: true
@@ -27,24 +40,45 @@ cubes:
         public: true
 
       - name: state_student_identifier
+        description: >-
+          The state-assigned student number for the student. In most cases, this
+          number should stay the same from school to school.
         sql: state_student_identifier
         type: string
         public: true
 
       - name: district_student_identifier
+        description: >-
+          Host public school district's identifier for the student. Populated
+          for Miami (MDCPS student ID) and null for NJ regions where the host
+          district's ID is not surfaced upstream. Generalizes the previously
+          Miami-only mdcps_student_identifier. Ed-Fi District / CEDS
+          District-assigned number from the host district's perspective.
         sql: district_student_identifier
         type: string
 
       - name: salesforce_contact_id
+        description: >-
+          KIPPADB (Salesforce) contact identifier for the student. Populated
+          where the student has a KIPPADB record; null otherwise. Used across
+          KIPPADB consumer tools (Overgrad, alumni tracking, etc.).
         sql: salesforce_contact_id
         type: string
 
       - name: gender_identity
+        description: >-
+          Self-identified gender for the student (e.g., M=Male F=Female).
+          Matches Ed-Fi's genderIdentity attribute (modern inclusive naming).
         sql: gender_identity
         type: string
         public: true
 
       - name: race
+        description: >-
+          Racial category for the student. Decoded from PowerSchool ethnicity
+          code to a full category label (e.g., Black/African American, Hispanic
+          or Latino, Not Hispanic or Latino, Two or More Races, White).
+          Cross-model consistency with dim_staff.race.
         sql: race
         type: string
         public: true
@@ -55,16 +89,28 @@ cubes:
         public: true
 
       - name: enrollment_status
+        description: >-
+          Current enrollment status of the student. Values: Currently Enrolled,
+          Pre-registered, Inactive, Transferred Out, Graduated, Imported as
+          Historical.
         sql: enrollment_status
         type: string
         public: true
 
       - name: is_gifted
+        description: >-
+          TRUE if the student has a gifted-and-talented identification on either
+          the PowerSchool NJ extension or Miami user-fields extension.
         sql: is_gifted
         type: boolean
         public: true
 
       - name: is_ell
+        description: >-
+          TRUE if the student is currently classified as an English Language
+          Learner per the PowerSchool student core fields. Reflects current
+          status only — does not reflect historical enrollment-date-window LEP
+          status.
         sql: is_ell
         type: boolean
         public: true

--- a/src/cube/model/cubes/students/students.yml
+++ b/src/cube/model/cubes/students/students.yml
@@ -83,11 +83,6 @@ cubes:
         type: string
         public: true
 
-      - name: meal_eligibility_status
-        sql: meal_eligibility_status
-        type: string
-        public: true
-
       - name: enrollment_status
         description: >-
           Current enrollment status of the student. Values: Currently Enrolled,
@@ -112,10 +107,5 @@ cubes:
           status only — does not reflect historical enrollment-date-window LEP
           status.
         sql: is_ell
-        type: boolean
-        public: true
-
-      - name: has_iep
-        sql: has_iep
         type: boolean
         public: true

--- a/src/cube/model/views/attendance/attendance_detail.yml
+++ b/src/cube/model/views/attendance/attendance_detail.yml
@@ -1,5 +1,20 @@
 views:
   - name: attendance_detail
+    description: >-
+      Row-level student attendance. One row per student × school day with
+      attendance recorded. Use for drill-down, individual investigations, or
+      breakdowns that need raw codes; for ADA / truancy roll-ups, use
+      attendance_summary instead. ADA is always SUM(attendance_value) /
+      SUM(membership_value); never average a per-row ratio. attendance_value
+      (0.0–1.0) is the fractional attendance contribution; membership_value
+      (0.0–1.0) is the school's claim on the student that day (split across
+      schools if dual-enrolled); present_weight equals attendance_value but
+      tardies count 0.67. attendance_category is the coarse rollup (Present,
+      Absent, Tardy, In-School Suspension, Out-of-School Suspension);
+      attendance_code is the raw SIS code for specific drill-down. is_in_session
+      and is_membership_day come from dim_school_calendars and are joined on
+      (date_key, location_key) to avoid a diamond path. Contains direct student
+      identifiers — see access_policy for PII gating.
 
     cubes:
       - join_path: attendance
@@ -71,11 +86,9 @@ views:
           - state_student_identifier
           - gender_identity
           - race
-          - meal_eligibility_status
           - enrollment_status
           - is_gifted
           - is_ell
-          - has_iep
 
       - join_path: attendance.dim_terms
         prefix: true
@@ -89,6 +102,91 @@ views:
         includes:
           - is_in_session
           - is_membership_day
+
+    meta:
+      folders:
+        - name: Outcome
+          members:
+            - avg_daily_attendance
+            - pct_tardy
+            - count_truants
+            - pct_truant
+            - count_students
+            - attendance_code
+            - attendance_category
+            - attendance_value
+            - membership_value
+            - present_weight
+            - is_absent
+            - is_tardy
+            - is_ontime
+            - is_oss
+            - is_iss
+            - is_suspended
+            - is_truant
+        - name: Date
+          members:
+            - attendance_date
+            - dim_dates_date_day
+            - dim_dates_month_number
+            - dim_dates_month_name
+            - dim_dates_quarter_number
+            - dim_dates_school_week_start_date
+            - dim_dates_day_of_week_name
+            - dim_dates_is_weekday
+        - name: Term
+          members:
+            - dim_terms_term_name
+            - dim_terms_term_code
+            - dim_terms_term_type
+        - name: Location
+          members:
+            - dim_locations_location_name
+            - dim_locations_abbreviation
+            - dim_locations_grade_band
+            - dim_locations_campus
+            - dim_locations_city
+            - dim_regions_region_name
+            - dim_regions_state
+        - name: Student
+          members:
+            - dim_students_student_key
+            - dim_students_full_name
+            - dim_students_birth_date
+            - dim_students_lea_student_identifier
+            - dim_students_state_student_identifier
+            - dim_students_gender_identity
+            - dim_students_race
+            - dim_students_enrollment_status
+            - dim_students_is_gifted
+            - dim_students_is_ell
+        - name: Enrollment
+          members:
+            - dim_student_enrollments_student_enrollment_key
+            - dim_student_enrollments_grade_level
+            - dim_student_enrollments_graduation_year
+            - dim_student_enrollments_entry_date
+            - dim_student_enrollments_exit_date
+            - dim_student_enrollments_is_retained_year
+        - name: Calendar
+          members:
+            - dim_school_calendars_is_in_session
+            - dim_school_calendars_is_membership_day
+        - name: Filter
+          members:
+            - academic_year
+            - semester
+      usage:
+        ada:
+          SUM(attendance_value) / SUM(membership_value); never average a per-row
+          ratio
+        point_in_time: filter to a single date_day for snapshot questions
+        truancy_regional:
+          Miami uses 15+ absences / 90-day rolling; NJ regions use projected
+          50+/year
+        category_vs_code:
+          use attendance_category for GROUP BY breakdowns; attendance_code for
+          raw drill-down
 
     access_policy:
       - group: cube-access-student-data

--- a/src/cube/model/views/attendance/attendance_summary.yml
+++ b/src/cube/model/views/attendance/attendance_summary.yml
@@ -1,5 +1,17 @@
 views:
   - name: attendance_summary
+    description: >-
+      Aggregated student attendance for ADA, tardy rate, and truancy breakdowns.
+      One row per filter slice — never per student-day. ADA is always
+      SUM(attendance_value) / SUM(membership_value); never average a per-row
+      ratio. For point-in-time truancy or count-of-students snapshots, filter to
+      a single date_day. Truancy criteria are regional: Miami uses 15+ absences
+      in a 90-day rolling window; NJ regions use projected 50+ absences for the
+      year. attendance_category is the coarse rollup (Present, Absent, Tardy,
+      In-School Suspension, Out-of-School Suspension); use it for GROUP BY
+      breakdowns instead of attempting to sum the boolean is_* flags. No direct
+      student identifiers — demographic dimensions are aggregate breakdowns
+      only.
 
     cubes:
       - join_path: attendance
@@ -50,10 +62,8 @@ views:
         includes:
           - gender_identity
           - race
-          - meal_eligibility_status
           - is_gifted
           - is_ell
-          - has_iep
 
       - join_path: attendance.dim_terms
         prefix: true
@@ -61,6 +71,62 @@ views:
           - term_name
           - term_code
           - term_type
+
+    meta:
+      folders:
+        - name: Outcome
+          members:
+            - avg_daily_attendance
+            - pct_tardy
+            - count_truants
+            - pct_truant
+            - count_students
+            - attendance_category
+            - is_truant
+        - name: Date
+          members:
+            - dim_dates_date_day
+            - dim_dates_month_number
+            - dim_dates_month_name
+            - dim_dates_quarter_number
+            - dim_dates_school_week_start_date
+        - name: Term
+          members:
+            - dim_terms_term_name
+            - dim_terms_term_code
+            - dim_terms_term_type
+        - name: Location
+          members:
+            - dim_locations_location_name
+            - dim_locations_abbreviation
+            - dim_locations_grade_band
+            - dim_locations_campus
+            - dim_locations_city
+            - dim_regions_region_name
+            - dim_regions_state
+        - name: Student
+          members:
+            - dim_students_gender_identity
+            - dim_students_race
+            - dim_students_is_gifted
+            - dim_students_is_ell
+        - name: Enrollment
+          members:
+            - dim_student_enrollments_grade_level
+            - dim_student_enrollments_graduation_year
+            - dim_student_enrollments_is_retained_year
+        - name: Filter
+          members:
+            - academic_year
+            - semester
+      usage:
+        ada:
+          SUM(attendance_value) / SUM(membership_value); never average a per-row
+          ratio
+        point_in_time: filter to a single date_day for snapshot questions
+        truancy_regional:
+          Miami uses 15+ absences / 90-day rolling; NJ regions use projected
+          50+/year
 
     access_policy:
       # No PII tier — view contains no direct student identifiers.

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -138,9 +138,9 @@ models:
         data_type: float64
         description: >-
           The amount of a student's membership this school claims. If a student
-          attends more than one school eachone will only be able to claim a
+          attends more than one school each one will only be able to claim a
           certain portion of the membership. The largest number for this will
-          usually be1 and fractions expressed as decimals. Like .5 or .25.
+          usually be 1 and fractions expressed as decimals. Like .5 or .25.
 
         config:
           meta:
@@ -151,7 +151,7 @@ models:
         data_type: float64
         description: >-
           Weighted presence value. 0.67 for tardy (T-prefix codes), otherwise
-          equals attendancevalue. Fractional by design — not a 0/1 flag.
+          equals attendance_value. Fractional by design — not a 0/1 flag.
 
       - name: is_truant
         data_type: boolean

--- a/tests/fixtures/cube_yaml/cube_other_schema.yml
+++ b/tests/fixtures/cube_yaml/cube_other_schema.yml
@@ -1,0 +1,9 @@
+cubes:
+  - name: other
+    public: false
+    sql_table: other_schema.something
+
+    dimensions:
+      - name: x
+        sql: x
+        type: string

--- a/tests/fixtures/cube_yaml/cube_sample.yml
+++ b/tests/fixtures/cube_yaml/cube_sample.yml
@@ -1,0 +1,42 @@
+cubes:
+  - name: sample
+    public: false
+    sql_table: kipptaf_marts.fct_sample
+
+    dimensions:
+      - name: sample_key
+        sql: sample_key
+        type: string
+        primary_key: true
+
+      - name: attendance_value
+        sql: attendance_value
+        type: number
+        public: true
+
+      - name: bare_name
+        sql: "{CUBE}.`name`"
+        type: string
+        public: true
+
+      - name: attendance_date
+        sql: CAST(date_key AS TIMESTAMP)
+        type: time
+        public: true
+
+      - name: existing_desc
+        description: Hand-authored, do not touch.
+        sql: attendance_value
+        type: number
+        public: true
+
+      - name: no_match
+        sql: computed_col
+        type: string
+        public: true
+
+    measures:
+      - name: count_rows
+        sql: sample_key
+        type: count_distinct
+        public: true

--- a/tests/fixtures/cube_yaml/dbt_fct_sample.yml
+++ b/tests/fixtures/cube_yaml/dbt_fct_sample.yml
@@ -1,0 +1,12 @@
+models:
+  - name: fct_sample
+    description: Sample fact for tests.
+    columns:
+      - name: sample_key
+        description: Surrogate key.
+      - name: attendance_value
+        description: Daily attendance value (0.0–1.0).
+      - name: name
+        description: Canonical name.
+      - name: computed_col
+        description: ""

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -45,3 +45,23 @@ def test_resolve_expression_returns_none() -> None:
 def test_resolve_non_string_returns_none() -> None:
     mod = _load_script()
     assert mod._resolve_dbt_column(None) is None
+
+
+def test_resolve_table_kipptaf_marts() -> None:
+    mod = _load_script()
+    assert mod._resolve_table_from_sql_table("kipptaf_marts.fct_sample") == "fct_sample"
+
+
+def test_resolve_table_other_schema_returns_none() -> None:
+    mod = _load_script()
+    assert mod._resolve_table_from_sql_table("other_schema.x") is None
+
+
+def test_resolve_table_no_dot_returns_none() -> None:
+    mod = _load_script()
+    assert mod._resolve_table_from_sql_table("kipptaf_marts") is None
+
+
+def test_resolve_table_none_input_returns_none() -> None:
+    mod = _load_script()
+    assert mod._resolve_table_from_sql_table(None) is None

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -20,3 +20,28 @@ def _load_script():
 
 def test_script_module_loads() -> None:
     assert _load_script() is not None
+
+
+def test_resolve_bare_column() -> None:
+    mod = _load_script()
+    assert mod._resolve_dbt_column("attendance_value") == "attendance_value"
+
+
+def test_resolve_cube_qualified() -> None:
+    mod = _load_script()
+    assert mod._resolve_dbt_column("{CUBE}.`name`") == "name"
+
+
+def test_resolve_cube_unquoted() -> None:
+    mod = _load_script()
+    assert mod._resolve_dbt_column("{CUBE}.location_key") == "location_key"
+
+
+def test_resolve_expression_returns_none() -> None:
+    mod = _load_script()
+    assert mod._resolve_dbt_column("CAST(date_key AS TIMESTAMP)") is None
+
+
+def test_resolve_non_string_returns_none() -> None:
+    mod = _load_script()
+    assert mod._resolve_dbt_column(None) is None

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -1,21 +1,22 @@
 """Tests for scripts/sync_cube_descriptions.py."""
 
-from __future__ import annotations
-
 import importlib.util
 import shutil
+import sys
 from pathlib import Path
 
 import yaml as _yaml  # for reading the patched output
 
 _SCRIPT = Path("scripts/sync_cube_descriptions.py")
 _FIXTURE_DIR = Path("tests/fixtures/cube_yaml")
+_MODULE_NAME = "sync_cube_descriptions"
 
 
 def _load_script():
-    spec = importlib.util.spec_from_file_location("sync_cube_descriptions", _SCRIPT)
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCRIPT)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
     spec.loader.exec_module(mod)
     return mod
 

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -65,3 +65,37 @@ def test_resolve_table_no_dot_returns_none() -> None:
 def test_resolve_table_none_input_returns_none() -> None:
     mod = _load_script()
     assert mod._resolve_table_from_sql_table(None) is None
+
+
+def test_load_dbt_descriptions_from_fixture(tmp_path) -> None:
+    """Reads a fake mart YAML and returns column→description for non-empty descriptions only."""
+    mod = _load_script()
+    facts = tmp_path / "facts" / "properties"
+    facts.mkdir(parents=True)
+    shutil.copy(_FIXTURE_DIR / "dbt_fct_sample.yml", facts / "fct_sample.yml")
+    result = mod._load_dbt_descriptions("fct_sample", [facts])
+    assert result == {
+        "sample_key": "Surrogate key.",
+        "attendance_value": "Daily attendance value (0.0–1.0).",
+        "name": "Canonical name.",
+    }
+    assert "computed_col" not in result
+
+
+def test_load_dbt_descriptions_missing_returns_none(tmp_path) -> None:
+    mod = _load_script()
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert mod._load_dbt_descriptions("not_there", [empty]) is None
+
+
+def test_load_dbt_descriptions_searches_multiple_dirs(tmp_path) -> None:
+    mod = _load_script()
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    shutil.copy(_FIXTURE_DIR / "dbt_fct_sample.yml", b / "fct_sample.yml")
+    result = mod._load_dbt_descriptions("fct_sample", [a, b])
+    assert result is not None
+    assert "sample_key" in result

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -1,0 +1,22 @@
+"""Tests for scripts/sync_cube_descriptions.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+_SCRIPT = Path("scripts/sync_cube_descriptions.py")
+_FIXTURE_DIR = Path("tests/fixtures/cube_yaml")
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("sync_cube_descriptions", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_script_module_loads() -> None:
+    assert _load_script() is not None

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -6,6 +6,8 @@ import importlib.util
 import shutil
 from pathlib import Path
 
+import yaml as _yaml  # for reading the patched output
+
 _SCRIPT = Path("scripts/sync_cube_descriptions.py")
 _FIXTURE_DIR = Path("tests/fixtures/cube_yaml")
 
@@ -99,3 +101,65 @@ def test_load_dbt_descriptions_searches_multiple_dirs(tmp_path) -> None:
     result = mod._load_dbt_descriptions("fct_sample", [a, b])
     assert result is not None
     assert "sample_key" in result
+
+
+def _patch_cube_with_fixture(tmp_path, cube_fixture: str) -> tuple[Path, dict]:
+    """Copy the cube fixture into tmp_path, run the patcher, return path and counts."""
+    mod = _load_script()
+    cube_path = tmp_path / "cube.yml"
+    shutil.copy(_FIXTURE_DIR / cube_fixture, cube_path)
+    facts = tmp_path / "facts" / "properties"
+    facts.mkdir(parents=True)
+    shutil.copy(_FIXTURE_DIR / "dbt_fct_sample.yml", facts / "fct_sample.yml")
+    counts = mod._patch_cube_file(cube_path, search_dirs=[facts])
+    return cube_path, counts
+
+
+def test_patch_inserts_descriptions_on_matched_dimensions(tmp_path) -> None:
+    cube_path, counts = _patch_cube_with_fixture(tmp_path, "cube_sample.yml")
+    doc = _yaml.safe_load(cube_path.read_text())
+    dims = {d["name"]: d for d in doc["cubes"][0]["dimensions"]}
+    assert dims["sample_key"]["description"] == "Surrogate key."
+    assert (
+        dims["attendance_value"]["description"] == "Daily attendance value (0.0–1.0)."
+    )
+    assert dims["bare_name"]["description"] == "Canonical name."
+    assert counts["updated"] == 3
+
+
+def test_patch_skips_expression_dimension(tmp_path) -> None:
+    cube_path, counts = _patch_cube_with_fixture(tmp_path, "cube_sample.yml")
+    doc = _yaml.safe_load(cube_path.read_text())
+    dims = {d["name"]: d for d in doc["cubes"][0]["dimensions"]}
+    assert "description" not in dims["attendance_date"]
+    assert counts["skipped_expr"] == 1
+
+
+def test_patch_preserves_existing_description_and_skips_no_match(tmp_path) -> None:
+    cube_path, counts = _patch_cube_with_fixture(tmp_path, "cube_sample.yml")
+    doc = _yaml.safe_load(cube_path.read_text())
+    dims = {d["name"]: d for d in doc["cubes"][0]["dimensions"]}
+    assert dims["existing_desc"]["description"] == "Hand-authored, do not touch."
+    assert "description" not in dims["no_match"]
+    assert counts["skipped_already"] == 1
+    assert counts["skipped_no_match"] == 1
+
+
+def test_patch_leaves_measures_untouched(tmp_path) -> None:
+    cube_path, _counts = _patch_cube_with_fixture(tmp_path, "cube_sample.yml")
+    doc = _yaml.safe_load(cube_path.read_text())
+    measures = doc["cubes"][0]["measures"]
+    assert all("description" not in m for m in measures)
+
+
+def test_patch_skips_other_schema_table(tmp_path) -> None:
+    mod = _load_script()
+    cube_path = tmp_path / "cube.yml"
+    shutil.copy(_FIXTURE_DIR / "cube_other_schema.yml", cube_path)
+    counts = mod._patch_cube_file(cube_path, search_dirs=[])
+    assert counts["skipped_no_table"] == 1
+    assert counts["updated"] == 0
+    # File contents unchanged.
+    text_after = cube_path.read_text()
+    text_before = (_FIXTURE_DIR / "cube_other_schema.yml").read_text()
+    assert text_after == text_before


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will:

- Add a one-shot utility script (`scripts/sync_cube_descriptions.py`) that reads dbt mart column descriptions and patches matching Cube dimension YAMLs in place. The script is **not wired into CI** — future runs are manual (`uv run --with "ruamel.yaml>=0.18" scripts/sync_cube_descriptions.py`).
- Apply the first-ever sync run: 69 dimensions across 8 cube files now carry descriptions sourced from dbt marts (`fct_student_attendance_daily`, `dim_students`, `dim_school_calendars`, `dim_student_enrollments`, `dim_dates`, `dim_locations`, `dim_regions`, `dim_terms`).
- Remove two `dim_students` dimensions (`has_iep`, `meal_eligibility_status`) whose underlying warehouse columns are absent from the current mart — keeping them would have surfaced broken metadata in Cube Cloud.
- Add view-level `description` and `meta.folders` entries to both attendance views (`attendance_summary.yml`, `attendance_detail.yml`), making them discoverable in Cube Cloud's folder browser.
- Correct three prose typos (`eachone`, `usually be1`, `attendancevalue`) in `fct_student_attendance_daily.yml`'s upstream column descriptions, and propagate the fixes to the cube YAML.

Cube Cloud production redeploys automatically on merge to `main`; metadata changes take effect after that redeploy with no manual deploy step required.

> **AI Assistance:** Script, tests, and fixture files were fully AI-generated (Claude Code). Cube YAML edits were applied by running the generated script against the local model. Human direction: chose sync approach, approved design, reviewed output.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run \`uv run dagster definitions validate\` for any modified code location
- [ ] Run \`uv run pytest tests/test_dagster_definitions.py\` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a \`[model_name].yml\` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (\`stg_\`, \`rpt_\`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run \`stage_external_sources\`
      with **\`--target staging\`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: \`uv run scripts/gen-automations-doc.py\`
- [ ] If adding a new integration to a code location, update that location's
      \`CLAUDE.md\` by running \`/claude-md-management:revise-claude-md\`

## CI checks

- [ ] **Trunk** — passes. If it fails, run \`trunk check\` and \`trunk fmt\`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke \`dbt build ...\`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)