### PR TITLE
chore(cube): address review feedback on PR #3843 — folder rename, drop meta.usage, split skipped counter

### DIFF
--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -143,6 +143,8 @@ def _patch_cube_file(
     cube = cubes[0]
     table = _resolve_table_from_sql_table(cube.get("sql_table"))
     if table is None:
+        # Also covers a missing ``sql_table:`` key — _resolve_table_from_sql_table
+        # returns None for non-string input.
         counts["skipped_wrong_schema"] += 1
         return counts
     descriptions = _load_dbt_descriptions(table, search_dirs=search_dirs)
@@ -191,14 +193,22 @@ def main(argv: list[str] | None = None) -> int:
         "skipped_no_dbt_yaml": 0,
     }
     any_changes = False
+    any_errors = False
     for f in files:
-        counts = _patch_cube_file(f)
+        try:
+            counts = _patch_cube_file(f)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            any_errors = True
+            continue
         if counts["updated"]:
             any_changes = True
             print(f"{f}: {counts['updated']} updated")
         for k, v in counts.items():
             total[k] += v
     print(f"\nTotal: {total}")
+    if any_errors:
+        return 1
     if args.check and any_changes:
         return 1
     return 0

--- a/scripts/sync_cube_descriptions.py
+++ b/scripts/sync_cube_descriptions.py
@@ -129,7 +129,8 @@ def _patch_cube_file(
         "skipped_already": 0,
         "skipped_expr": 0,
         "skipped_no_match": 0,
-        "skipped_no_table": 0,
+        "skipped_wrong_schema": 0,
+        "skipped_no_dbt_yaml": 0,
     }
     ry, FoldedScalarString = _get_ryaml()
     with path.open(encoding="utf-8") as f:
@@ -137,14 +138,16 @@ def _patch_cube_file(
     cubes = doc.get("cubes") or []
     if not cubes:
         return counts
+    if len(cubes) != 1:
+        raise ValueError(f"{path}: expected exactly one cube, found {len(cubes)}")
     cube = cubes[0]
     table = _resolve_table_from_sql_table(cube.get("sql_table"))
     if table is None:
-        counts["skipped_no_table"] += 1
+        counts["skipped_wrong_schema"] += 1
         return counts
     descriptions = _load_dbt_descriptions(table, search_dirs=search_dirs)
     if descriptions is None:
-        counts["skipped_no_table"] += 1
+        counts["skipped_no_dbt_yaml"] += 1
         return counts
     for dim in cube.get("dimensions") or []:
         if "description" in dim:
@@ -184,7 +187,8 @@ def main(argv: list[str] | None = None) -> int:
         "skipped_already": 0,
         "skipped_expr": 0,
         "skipped_no_match": 0,
-        "skipped_no_table": 0,
+        "skipped_wrong_schema": 0,
+        "skipped_no_dbt_yaml": 0,
     }
     any_changes = False
     for f in files:

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -42,6 +42,18 @@ school_calendars) go in `cubes/conformed/`.
   facts cast through (`CAST({CUBE}.date_key AS TIMESTAMP)`).
 - **Hidden helper measures** prefix with `_` and set `public: false` (see
   `_sum_attendance_value` building blocks).
+- **`meta.folders` is the only Cube-rendered `meta.*` key.** Put guidance in
+  `description:`, not `meta.usage` / `meta.synonyms` / etc. — those land in
+  `/v1/meta` but Cube Cloud and the chat agent don't read them.
+- **Folders group dimensions only.** Cube Cloud separates measures natively;
+  don't list measures under `members:`.
+- **Folder member naming.** Bare for top-cube members; `<prefix>_<member>` for
+  `prefix: true` joins, where `<prefix>` is the last `join_path` segment — so
+  `dim_regions_region_name` for the two-hop
+  `attendance.dim_locations.dim_regions`.
+- **Branch schema validation is manual.** Cube Cloud Staging Environments don't
+  auto-create from pushes. Open Cube Cloud → Data Model → Dev Mode → add branch
+  by name to spin up a per-branch staging instance.
 
 ## View access policies
 

--- a/src/cube/model/views/attendance/attendance_detail.yml
+++ b/src/cube/model/views/attendance/attendance_detail.yml
@@ -13,8 +13,11 @@ views:
       Absent, Tardy, In-School Suspension, Out-of-School Suspension);
       attendance_code is the raw SIS code for specific drill-down. is_in_session
       and is_membership_day come from dim_school_calendars and are joined on
-      (date_key, location_key) to avoid a diamond path. Contains direct student
-      identifiers — see access_policy for PII gating.
+      (date_key, location_key) to avoid a diamond path. For point-in-time
+      queries (e.g. is_truant on a specific date), filter to a single date_day.
+      Truancy criteria are regional: Miami uses 15+ absences in a 90-day rolling
+      window; NJ regions use projected 50+ absences for the year. Contains
+      direct student identifiers — see access_policy for PII gating.
 
     cubes:
       - join_path: attendance
@@ -105,13 +108,8 @@ views:
 
     meta:
       folders:
-        - name: Outcome
+        - name: Attendance
           members:
-            - avg_daily_attendance
-            - pct_tardy
-            - count_truants
-            - pct_truant
-            - count_students
             - attendance_code
             - attendance_category
             - attendance_value
@@ -176,17 +174,6 @@ views:
           members:
             - academic_year
             - semester
-      usage:
-        ada:
-          SUM(attendance_value) / SUM(membership_value); never average a per-row
-          ratio
-        point_in_time: filter to a single date_day for snapshot questions
-        truancy_regional:
-          Miami uses 15+ absences / 90-day rolling; NJ regions use projected
-          50+/year
-        category_vs_code:
-          use attendance_category for GROUP BY breakdowns; attendance_code for
-          raw drill-down
 
     access_policy:
       - group: cube-access-student-data

--- a/src/cube/model/views/attendance/attendance_summary.yml
+++ b/src/cube/model/views/attendance/attendance_summary.yml
@@ -74,13 +74,8 @@ views:
 
     meta:
       folders:
-        - name: Outcome
+        - name: Attendance
           members:
-            - avg_daily_attendance
-            - pct_tardy
-            - count_truants
-            - pct_truant
-            - count_students
             - attendance_category
             - is_truant
         - name: Date
@@ -119,14 +114,6 @@ views:
           members:
             - academic_year
             - semester
-      usage:
-        ada:
-          SUM(attendance_value) / SUM(membership_value); never average a per-row
-          ratio
-        point_in_time: filter to a single date_day for snapshot questions
-        truancy_regional:
-          Miami uses 15+ absences / 90-day rolling; NJ regions use projected
-          50+/year
 
     access_policy:
       # No PII tier — view contains no direct student identifiers.

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 from pathlib import Path
 
+import pytest
 import yaml as _yaml  # for reading the patched output
 
 _SCRIPT = Path("scripts/sync_cube_descriptions.py")
@@ -171,7 +172,7 @@ def test_patch_skips_no_dbt_yaml(tmp_path) -> None:
     """sql_table is kipptaf_marts.<x> but no matching dbt YAML exists."""
     mod = _load_script()
     cube_path = tmp_path / "cube.yml"
-    cube_path.write_text(
+    cube_text = (
         "cubes:\n"
         "  - name: orphan\n"
         "    public: false\n"
@@ -180,15 +181,17 @@ def test_patch_skips_no_dbt_yaml(tmp_path) -> None:
         "    dimensions:\n"
         "      - name: x\n"
         "        sql: x\n"
-        "        type: string\n",
-        encoding="utf-8",
+        "        type: string\n"
     )
+    cube_path.write_text(cube_text, encoding="utf-8")
     empty = tmp_path / "empty"
     empty.mkdir()
     counts = mod._patch_cube_file(cube_path, search_dirs=[empty])
     assert counts["skipped_no_dbt_yaml"] == 1
     assert counts["skipped_wrong_schema"] == 0
     assert counts["updated"] == 0
+    # File contents unchanged on skip — no write should occur.
+    assert cube_path.read_text(encoding="utf-8") == cube_text
 
 
 def test_patch_raises_on_multiple_cubes_per_file(tmp_path) -> None:
@@ -211,7 +214,5 @@ def test_patch_raises_on_multiple_cubes_per_file(tmp_path) -> None:
         "        type: string\n",
         encoding="utf-8",
     )
-    import pytest
-
     with pytest.raises(ValueError, match="expected exactly one cube"):
         mod._patch_cube_file(cube_path, search_dirs=[])

--- a/tests/test_sync_cube_descriptions.py
+++ b/tests/test_sync_cube_descriptions.py
@@ -153,14 +153,65 @@ def test_patch_leaves_measures_untouched(tmp_path) -> None:
     assert all("description" not in m for m in measures)
 
 
-def test_patch_skips_other_schema_table(tmp_path) -> None:
+def test_patch_skips_wrong_schema(tmp_path) -> None:
     mod = _load_script()
     cube_path = tmp_path / "cube.yml"
     shutil.copy(_FIXTURE_DIR / "cube_other_schema.yml", cube_path)
     counts = mod._patch_cube_file(cube_path, search_dirs=[])
-    assert counts["skipped_no_table"] == 1
+    assert counts["skipped_wrong_schema"] == 1
+    assert counts["skipped_no_dbt_yaml"] == 0
     assert counts["updated"] == 0
     # File contents unchanged.
     text_after = cube_path.read_text()
     text_before = (_FIXTURE_DIR / "cube_other_schema.yml").read_text()
     assert text_after == text_before
+
+
+def test_patch_skips_no_dbt_yaml(tmp_path) -> None:
+    """sql_table is kipptaf_marts.<x> but no matching dbt YAML exists."""
+    mod = _load_script()
+    cube_path = tmp_path / "cube.yml"
+    cube_path.write_text(
+        "cubes:\n"
+        "  - name: orphan\n"
+        "    public: false\n"
+        "    sql_table: kipptaf_marts.fct_does_not_exist\n"
+        "\n"
+        "    dimensions:\n"
+        "      - name: x\n"
+        "        sql: x\n"
+        "        type: string\n",
+        encoding="utf-8",
+    )
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    counts = mod._patch_cube_file(cube_path, search_dirs=[empty])
+    assert counts["skipped_no_dbt_yaml"] == 1
+    assert counts["skipped_wrong_schema"] == 0
+    assert counts["updated"] == 0
+
+
+def test_patch_raises_on_multiple_cubes_per_file(tmp_path) -> None:
+    """Each cube YAML should declare exactly one cube; multi-cube files raise."""
+    mod = _load_script()
+    cube_path = tmp_path / "two_cubes.yml"
+    cube_path.write_text(
+        "cubes:\n"
+        "  - name: a\n"
+        "    sql_table: kipptaf_marts.a\n"
+        "    dimensions:\n"
+        "      - name: x\n"
+        "        sql: x\n"
+        "        type: string\n"
+        "  - name: b\n"
+        "    sql_table: kipptaf_marts.b\n"
+        "    dimensions:\n"
+        "      - name: y\n"
+        "        sql: y\n"
+        "        type: string\n",
+        encoding="utf-8",
+    )
+    import pytest
+
+    with pytest.raises(ValueError, match="expected exactly one cube"):
+        mod._patch_cube_file(cube_path, search_dirs=[])


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Follow-up to PR #3843 addressing [@cristinabaldor's review](https://github.com/TEAMSchools/teamster/pull/3843#pullrequestreview-4247405424).

When merged, this pull request will:

- **Rename `Outcome` folder → `Attendance`** in both attendance views, and remove measures from the folder. Cube Cloud's field picker already separates measures from dimensions natively; the folder's actual purpose is grouping the raw event dimensions (codes, values, suspension/tardy flags), and `Attendance` describes that accurately. `is_oss` etc. are events, not outcomes.
- **Drop `meta.usage`** from both views. `meta.*` keys other than `folders` are free-form passthrough that Cube Cloud doesn't render and the chat agent doesn't read. All `usage:` content was already covered by `attendance_summary`'s view-level description; added the missing point-in-time and regional-truancy sentences to `attendance_detail`'s description so the guidance reaches the agent.
- **Split `skipped_no_table` counter** in the script into `skipped_wrong_schema` (cube references a non-`kipptaf_marts` schema) and `skipped_no_dbt_yaml` (kipptaf_marts table but no matching dbt YAML found). The latter could otherwise mask a broken path. Added tests for both branches.
- **Raise `ValueError` if a cube file declares more than one cube** under `cubes:`. Every cube file in `src/cube/model/cubes/` declares exactly one; the explicit check makes the assumption legible and catches future drift. Added a regression test.

Items deferred from the review (FYI in the original comment):
- No test for `main()` / `--check` — would require refactoring `_CUBE_MODEL_DIR` to be a parameter; low value for a one-shot script.
- `ruamel.yaml` availability for tests — already addressed in the canonical invocation (`uv run --with "ruamel.yaml>=0.18" pytest`); no precedent in this repo for promoting script-only PEP 723 deps to project-level dev deps.

> **AI Assistance:** Edits and tests were AI-generated (Claude Code). Human direction: triaged review items, picked which to implement, reviewed each diff.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

No dbt model changes in this PR. The script reads `src/dbt/kipptaf/models/marts/*/properties/*.yml` but does not modify them.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule/sensor/integration changes.

## CI checks

- [ ] **Trunk** — passes locally (`trunk check --force` on touched files).
- [ ] **dbt Cloud** — N/A (no dbt model changes).
- [ ] **Dagster Cloud** — N/A (no Dagster changes).

## Verification

- 20/20 pytest pass (added 2 new tests for the split counters and the multi-cube assertion)
- `uv run scripts/sync_cube_descriptions.py --check` exits 0 with `updated: 0` (idempotent)
- Both view YAMLs parse with `yaml.safe_load`