### PR TITLE
feat(powerschool): extract U_EXPECTATIONS from Newark Oracle (#3756)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-powerschool-u-expectations-extract-plan.md
+++ b/docs/superpowers/plans/2026-05-08-powerschool-u-expectations-extract-plan.md
@@ -1,0 +1,594 @@
+# PowerSchool `U_EXPECTATIONS` Extract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a recurring BigQuery extract of the `U_EXPECTATIONS`
+PowerSchool extension table from Newark production via the existing Oracle ODBC
+factory, plus a dbt staging model and district-level opt-outs for the three
+districts that don't yet have the table.
+
+**Architecture:** A single YAML entry in `assets-full.yaml` registers the asset
+with the existing `build_powerschool_table_asset()` factory; the asset
+auto-flows through the existing fiscal-year-partitioned PS sensor, GCS landing
+path, and BigQuery loader. A dbt source entry in the shared `dbt/powerschool/`
+package (with a sibling staging model) lets all consuming district projects
+reference it; Camden/Miami/Paterson disable both source and model in their
+`dbt_project.yml`.
+
+**Tech Stack:** Dagster, Python 3.13, `oracledb`, `fastavro`, dbt-bigquery,
+BigQuery external tables (Avro), pytest.
+
+**Spec:**
+[`docs/superpowers/specs/2026-05-08-powerschool-u-expectations-extract-design.md`](../specs/2026-05-08-powerschool-u-expectations-extract-design.md)
+
+**Worktree root:**
+`/workspaces/teamster/.worktrees/cbini/feat/claude-powerschool-u-expectations`
+
+All `git`, `uv run`, and tool invocations below assume that worktree as the
+working directory. From other working directories use `git -C <worktree>` and
+`--project-dir <worktree>/...` per CLAUDE.md.
+
+---
+
+## File Structure
+
+| Path                                                                                                              | Action | Responsibility                                                                       |
+| ----------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------ |
+| `src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml`                                      | modify | Register `u_expectations` as a fiscal-year-partitioned ODBC asset on `whenmodified`. |
+| `tests/assets/test_assets_powerschool_sis.py`                                                                     | modify | Add `test_u_expectations_kippnewark` e2e test.                                       |
+| `src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml`                                                | modify | Declare `src_powerschool__u_expectations` as a BigQuery Avro external source.        |
+| `src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql`                                 | create | Unwrap Avro NUMBER struct columns; pass through everything else.                     |
+| `src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml`                           | create | Contract column types + descriptions; uniqueness on `dcid`.                          |
+| `src/dbt/kippcamden/dbt_project.yml`, `src/dbt/kippmiami/dbt_project.yml`, `src/dbt/kipppaterson/dbt_project.yml` | modify | Disable source + staging model (table not present in those instances).               |
+
+---
+
+## Task 1: Register the Dagster asset (TDD via e2e test)
+
+**Files:**
+
+- Test: `tests/assets/test_assets_powerschool_sis.py`
+- Modify:
+  `src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml`
+
+- [ ] **Step 1: Add the failing e2e test**
+
+Edit `tests/assets/test_assets_powerschool_sis.py`. Insert this function
+immediately before `def test_u_studentsuserfields_kippnewark():` (around line
+85):
+
+```python
+def test_u_expectations_kippnewark():
+    from teamster.code_locations.kippnewark import CODE_LOCATION
+    from teamster.code_locations.kippnewark.powerschool import assets
+
+    _test_partitioned_asset(
+        assets=assets,
+        asset_name="u_expectations",
+        code_location=CODE_LOCATION.upper(),
+    )
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+uv run pytest tests/assets/test_assets_powerschool_sis.py::test_u_expectations_kippnewark -v
+```
+
+Expected: `IndexError: list index out of range` raised inside
+`_test_partitioned_asset` at the line
+`asset = [a for a in assets if a.key.path[-1] == asset_name][0]` — the asset
+doesn't exist yet, so the list comprehension is empty.
+
+If the test errors instead with `1Password` / env var / SSH-related messages
+before reaching the IndexError, the local environment isn't authenticated. Set
+`OP_SERVICE_ACCOUNT_TOKEN` (the user runs in a VS Code terminal, not via Claude)
+and re-run.
+
+- [ ] **Step 3: Add the asset YAML entry**
+
+Edit
+`src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml`.
+Append at the end of the file (after the existing `# whenmodified` group;
+alphabetical order is not enforced — match existing trailing-entry style):
+
+```yaml
+- asset_name: u_expectations
+  partition_column: whenmodified
+```
+
+Indent must be two spaces under `assets:` matching surrounding entries.
+
+- [ ] **Step 4: Run the test against Newark Oracle and verify it passes**
+
+```bash
+uv run pytest tests/assets/test_assets_powerschool_sis.py::test_u_expectations_kippnewark -v
+```
+
+Expected: PASS. The test materializes a randomly chosen fiscal-year partition;
+the assertion `result.success` plus a non-negative integer record count is
+sufficient — zero rows is acceptable for older partitions because the plugin was
+installed recently.
+
+If the test fails with `ORA-00942: table or view does not exist`, the Oracle
+table name needs investigation: connect via the SSH tunnel and run
+
+```sql
+select owner, table_name from all_tables where table_name = 'U_EXPECTATIONS';
+```
+
+If it's schema-qualified (e.g., owner is not `PS`), update the YAML `asset_name`
+to `<owner_lower>.u_expectations`. SQLAlchemy uppercases unquoted identifiers,
+so the lowercase YAML value resolves correctly.
+
+If the test fails with the usual `whenmodified`-related partition mismatch
+(table has the column but no rows in the chosen partition), re-run —
+`_test_partitioned_asset` picks a random partition from the full fiscal-year
+range starting 2016-07-01.
+
+- [ ] **Step 5: Confirm Dagster definitions still load**
+
+```bash
+uv run dagster definitions validate -m teamster.code_locations.kippnewark.definitions
+```
+
+Expected: exit 0. Errors specific to env vars unavailable in this Codespace are
+acceptable per `src/teamster/CLAUDE.md` ("`dagster definitions validate` may
+mislead locally — env vars unavailable in codespace cause false errors"). What
+you're confirming is that no asset-wiring error appears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/assets/test_assets_powerschool_sis.py \
+        src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml
+git commit -m "feat(powerschool): extract U_EXPECTATIONS from Newark Oracle (#3756)"
+```
+
+---
+
+## Task 2: Add the dbt source entry and stage the BigQuery external table
+
+**Files:**
+
+- Modify: `src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml`
+
+- [ ] **Step 1: Add the source entry**
+
+Open `src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml`. Locate
+the existing `src_powerschool__u_studentsuserfields` block (around line 891).
+Insert the following block immediately after it, preserving two-space YAML
+indentation under the parent `tables:` list:
+
+```yaml
+- name: src_powerschool__u_expectations
+  config:
+    meta:
+      dagster:
+        asset_key:
+          - "{{ project_name }}"
+          - powerschool
+          - u_expectations
+  external:
+    location:
+      "{{ var('powerschool_external_location_root',
+      env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_expectations/*"
+    options:
+      connection_name: "{{ var('bigquery_external_connection_name') }}"
+      metadata_cache_mode: MANUAL
+      max_staleness: INTERVAL 7 DAY
+      format: AVRO
+      enable_logical_types: true
+```
+
+The block must mirror `src_powerschool__u_studentsuserfields` exactly except for
+the table-name slug `u_expectations`.
+
+- [ ] **Step 2: Verify dbt parses the new source**
+
+```bash
+uv run dbt parse --project-dir src/dbt/kippnewark --target prod --target-path target/prod
+```
+
+Expected: parse succeeds. If it fails with a YAML error, fix indentation. If it
+fails with a Jinja error pointing at the new block, double-check the curly-brace
+nesting against the precedent.
+
+- [ ] **Step 3: Materialize the Dagster asset to land Avro in GCS**
+
+The dbt external source points to
+`gs://teamster-kippnewark/dagster/kippnewark/powerschool/u_expectations/*`.
+Until the asset has materialized at least one partition,
+`stage_external_sources` will create an empty BQ external table.
+
+Trigger materialization through Dagster's UI (or re-run the e2e test from Task 1
+— same effect, materializes one partition into the Hive-partitioned GCS path).
+
+- [ ] **Step 4: Stage the external table to BigQuery**
+
+```bash
+uv run dbt run-operation stage_external_sources \
+  --args 'select: powerschool_odbc.src_powerschool__u_expectations' \
+  --project-dir src/dbt/kippnewark \
+  --target staging
+```
+
+Expected: dbt prints `1 of 1 OK` and the table appears in BigQuery. Note from
+`src/dbt/CLAUDE.md`: the source selector is `<source_name>.<table_name>`,
+**not** project-qualified.
+
+- [ ] **Step 5: Smoke-test the external table**
+
+```bash
+uv run dbt show \
+  --inline "select count(*) as n from {{ source('powerschool_odbc', 'src_powerschool__u_expectations') }}" \
+  --project-dir src/dbt/kippnewark \
+  --target staging
+```
+
+Expected: returns a non-negative integer. Zero is acceptable if the plugin's
+only populated partitions don't yet have ODBC-extracted Avro on disk; non-zero
+confirms end-to-end raw-data pipe.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
+git commit -m "feat(dbt-powerschool): add U_EXPECTATIONS external source (#3756)"
+```
+
+---
+
+## Task 3: Add the dbt staging model
+
+**Files:**
+
+- Create:
+  `src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql`
+- Create:
+  `src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml`
+
+- [ ] **Step 1: Profile the loaded raw table to confirm column shape**
+
+```bash
+uv run dbt show \
+  --inline "select column_name, data_type from \`teamster-332318\`.kippnewark_powerschool.INFORMATION_SCHEMA.COLUMNS where table_name = 'src_powerschool__u_expectations' order by ordinal_position" \
+  --project-dir src/dbt/kippnewark \
+  --target staging
+```
+
+(Adjust dataset prefix to whatever `stage_external_sources` materialized to
+under the staging target — likely `staging_kippnewark_powerschool` or similar;
+check the result of Task 2 Step 4.)
+
+Record which columns land as
+`STRUCT<int_value INT64, decimal_value NUMERIC, ...>` (Avro NUMBER union → BQ
+struct) versus plain types. Expected: `dcid`, `id`, `quarter`, `week_number`,
+`cnt_w`, `cnt_h`, `cnt_f`, `cnt_s` arrive as structs; string/timestamp columns
+are plain.
+
+- [ ] **Step 2: Write the staging SQL**
+
+Create
+`src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql`:
+
+```sql
+with
+    transformations as (
+        select
+            * except (dcid, id, quarter, week_number, cnt_w, cnt_h, cnt_f, cnt_s),
+
+            /* column transformations */
+            dcid.int_value as dcid,
+            id.int_value as id,
+            quarter.int_value as quarter,
+            week_number.int_value as week_number,
+            cnt_w.int_value as cnt_w,
+            cnt_h.int_value as cnt_h,
+            cnt_f.int_value as cnt_f,
+            cnt_s.int_value as cnt_s,
+        from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}
+    )
+
+select * from transformations
+```
+
+If Step 1 showed a column landing as plain `INT64` rather than a struct (e.g.,
+the plugin wrote it as a Java int rather than an Oracle NUMBER), drop it from
+the `* except (...)` list and the unwrap block. Likewise, if a count column
+comes back as `NUMERIC` with non-zero scale, replace `.int_value` with
+`safe_cast(... as int64)` for that column.
+
+Note: no `dbt_utils.deduplicate` here — `dcid` is unique by construction (Oracle
+auto-PK); the precedent in `stg_powerschool__u_clg_et_stu` deduplicates because
+of `studentsdcid + exit_date` business-key collisions, which don't apply to a
+raw-counts roll-up table.
+
+- [ ] **Step 3: Write the properties YAML**
+
+Create
+`src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml`:
+
+```yaml
+models:
+  - name: stg_powerschool__u_expectations
+    description:
+      Per-school-level / quarter / week roll-up of expectations counts (W/H/F/S)
+      from the Newark Gradebook Audit plugin's U_EXPECTATIONS extension table.
+      Always scoped to the current academic year — the source has no academic
+      year column.
+    columns:
+      - name: dcid
+        data_type: int64
+        description:
+          Auto-generated PowerSchool descendant ID. Primary key for this
+          extension table.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+        constraints:
+          - type: primary_key
+      - name: id
+        data_type: int64
+        description: Plugin-assigned row identifier.
+      - name: school_level
+        data_type: string
+        description:
+          School-level grouping (e.g. ES / MS / HS) for the rollup row.
+      - name: quarter
+        data_type: int64
+        description: Academic quarter (1-4) the rollup row covers.
+      - name: week_number
+        data_type: int64
+        description: Week number within the quarter.
+      - name: cnt_w
+        data_type: int64
+        description: Count of students in the W expectations bucket for the row.
+      - name: cnt_h
+        data_type: int64
+        description: Count of students in the H expectations bucket for the row.
+      - name: cnt_f
+        data_type: int64
+        description: Count of students in the F expectations bucket for the row.
+      - name: cnt_s
+        data_type: int64
+        description: Count of students in the S expectations bucket for the row.
+      - name: notes
+        data_type: string
+        description: Free-text notes captured by the plugin for the rollup row.
+      - name: whocreated
+        data_type: string
+        description: User login that created the record.
+      - name: whencreated
+        data_type: timestamp
+        description:
+          Date and time the record was created. Defaults to system date.
+      - name: whomodified
+        data_type: string
+        description: User login that last modified the record.
+      - name: whenmodified
+        data_type: timestamp
+        description:
+          Date and time the record was last modified. Defaults to system date.
+```
+
+If Step 1 showed any additional PS audit columns landing in the table that
+aren't in this list (PS occasionally adds new ones), add them with `data_type`
+matching the BQ column type — contract enforcement fails otherwise.
+
+- [ ] **Step 4: Build the model and confirm it compiles + tests pass**
+
+```bash
+uv run dbt build \
+  --select stg_powerschool__u_expectations \
+  --project-dir src/dbt/kippnewark \
+  --target staging
+```
+
+Expected: `1 of 1 OK created sql view model` + tests `dcid not_null` and
+`dcid unique` both pass.
+
+If contract enforcement fails (`Contract for model X has unmatched columns:`),
+reconcile the YAML with the actual columns from Step 1.
+
+- [ ] **Step 5: Lint check**
+
+```bash
+.trunk/tools/trunk check --force \
+  src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql \
+  src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml \
+  src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
+```
+
+Expected: no issues. sqlfluff and yamllint enforce style; fix in place if
+anything fires (don't add `# trunk-ignore` to bypass real issues).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql \
+        src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
+git commit -m "feat(dbt-powerschool): add stg_powerschool__u_expectations (#3756)"
+```
+
+---
+
+## Task 4: Disable in Camden / Miami / Paterson
+
+**Files:**
+
+- Modify: `src/dbt/kippcamden/dbt_project.yml`
+- Modify: `src/dbt/kippmiami/dbt_project.yml`
+- Modify: `src/dbt/kipppaterson/dbt_project.yml`
+
+The Gradebook Audit plugin is only on Newark prod, so the asset/source/model
+must be disabled in the other three districts to avoid `relation does not exist`
+errors at parse and build time.
+
+- [ ] **Step 1: Disable the model in each district**
+
+In each of the three district `dbt_project.yml` files, find the existing
+`models.powerschool.sis.staging.odbc.stg_powerschool__u_clg_et_stu_alt: { +enabled: false }`
+block. Insert immediately after it (alphabetical order keeps the list
+scannable):
+
+```yaml
+stg_powerschool__u_expectations:
+  +enabled: false
+```
+
+Match the existing indentation exactly — three or four levels of two-space
+nesting depending on the district file.
+
+- [ ] **Step 2: Disable the source in each district**
+
+In each of the three district `dbt_project.yml` files, find the existing
+`sources.powerschool.staging.odbc.powerschool_odbc.src_powerschool__u_clg_et_stu_alt: { +enabled: false }`
+block. Insert immediately after it:
+
+```yaml
+src_powerschool__u_expectations:
+  +enabled: false
+```
+
+- [ ] **Step 3: Verify each district parses cleanly**
+
+```bash
+uv run dbt parse --project-dir src/dbt/kippcamden --target prod --target-path target/prod
+uv run dbt parse --project-dir src/dbt/kippmiami --target prod --target-path target/prod
+uv run dbt parse --project-dir src/dbt/kipppaterson --target prod --target-path target/prod
+```
+
+Expected: all three parse without error.
+
+- [ ] **Step 4: Verify the model resolves as disabled (not built) in each
+      non-Newark district**
+
+```bash
+uv run dbt list --select stg_powerschool__u_expectations --project-dir src/dbt/kippcamden --target prod
+uv run dbt list --select stg_powerschool__u_expectations --project-dir src/dbt/kippmiami --target prod
+uv run dbt list --select stg_powerschool__u_expectations --project-dir src/dbt/kipppaterson --target prod
+```
+
+Expected: each command prints "no nodes selected" or equivalent — i.e., the
+model is correctly excluded from the graph.
+
+- [ ] **Step 5: Verify Newark still includes the model**
+
+```bash
+uv run dbt list --select stg_powerschool__u_expectations --project-dir src/dbt/kippnewark --target prod
+```
+
+Expected: prints `powerschool.staging.stg_powerschool__u_expectations` (one
+node).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dbt/kippcamden/dbt_project.yml \
+        src/dbt/kippmiami/dbt_project.yml \
+        src/dbt/kipppaterson/dbt_project.yml
+git commit -m "chore(dbt): disable u_expectations in non-Newark districts (#3756)"
+```
+
+---
+
+## Task 5: Final verification and PR
+
+- [ ] **Step 1: Re-run the e2e test to confirm nothing regressed**
+
+```bash
+uv run pytest tests/assets/test_assets_powerschool_sis.py::test_u_expectations_kippnewark -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Re-run the full kippnewark dbt build for the staging model and
+      any directly-touched dependents**
+
+```bash
+uv run dbt build --select +stg_powerschool__u_expectations --project-dir src/dbt/kippnewark --target staging
+```
+
+Expected: builds and tests pass. The `+` prefix selects upstream nodes; for a
+staging model with only an external source as parent, this is just the model
+itself plus its tests.
+
+- [ ] **Step 3: Branch lint check**
+
+```bash
+.trunk/tools/trunk check --force \
+  $(git diff --name-only origin/main...HEAD)
+```
+
+Expected: no issues. The `pre-push` hook runs the same check on push, so any
+failure here would block the push anyway.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push
+```
+
+If a push hook complains, address the root cause. Do not pass `--no-verify`.
+
+- [ ] **Step 5: Open the PR**
+
+Use `.github/pull_request_template.md` as the body. Title format:
+`feat(powerschool): extract U_EXPECTATIONS from Newark Oracle (#3756)`.
+
+```bash
+gh pr create --title "feat(powerschool): extract U_EXPECTATIONS from Newark Oracle (#3756)" \
+  --body "$(cat .github/pull_request_template.md)"
+```
+
+Update the populated PR body to reference issue #3756 in the description and
+check off items in the template's checklist that apply.
+
+- [ ] **Step 6: Verify branch deployment build**
+
+After CI kicks off the dbt Cloud branch deployment, confirm:
+
+1. `dbt build --select stg_powerschool__u_expectations` passes in the branch
+   deployment's Newark project.
+2. The Dagster branch deployment materializes the asset against Newark prod (one
+   partition, latest fiscal year).
+
+Both are run by the platform; you're checking the run status, not invoking them
+manually.
+
+---
+
+## Notes for the Executing Agent
+
+- This work is happening in a worktree at
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-powerschool-u-expectations`.
+  **Always pass `--project-dir` / `git -C` explicitly when invoking from a
+  different working directory.** Bare `git` from `/workspaces/teamster` commits
+  to `main`.
+- **Do not run** `trunk fmt` or `trunk check` proactively — the pre-commit hook
+  formats; the pre-push hook checks. Use
+  `.trunk/tools/trunk check --force <files>` only for the verification step in
+  Task 3 Step 5 and Task 5 Step 3, where confirmation is required before
+  claiming clean.
+- **Do not** use `dbt_utils.deduplicate`, `select distinct`, or
+  `qualify row_number() = 1` in the staging SQL. The model has a single primary
+  key (`dcid`); deduplication is unnecessary and is explicitly an anti-pattern
+  per `src/dbt/CLAUDE.md`.
+- **Do not** add `+enabled: false` overrides to `kippnewark/dbt_project.yml` —
+  Newark is the only district where this asset is enabled by default.
+- **Do not** add a per-model `contract: { enforced: true }` block in the
+  properties YAML — contract enforcement is set at the directory level in
+  `src/dbt/powerschool/dbt_project.yml`.
+- **Do not** introduce a new schedule, sensor, job, intermediate, or mart model.
+  Spec section 6 explicitly defers all downstream modeling to a separate plan.
+- If any Oracle / SSH / 1Password env-var-related test failure surfaces, surface
+  it to the user — Claude sessions cannot access secrets. Re-running in a VS
+  Code terminal where `OP_SERVICE_ACCOUNT_TOKEN` is set is the correct fix.

--- a/docs/superpowers/specs/2026-05-08-powerschool-u-expectations-extract-design.md
+++ b/docs/superpowers/specs/2026-05-08-powerschool-u-expectations-extract-design.md
@@ -151,7 +151,28 @@ add:
 
 `kippnewark` requires no override — it's enabled by default in the package.
 
-### 5. No schedule / sensor changes
+### 5. End-to-end test
+
+Add a test in `tests/assets/test_assets_powerschool_sis.py` mirroring
+`test_u_studentsuserfields_kippnewark`:
+
+```python
+def test_u_expectations_kippnewark():
+    from teamster.code_locations.kippnewark import CODE_LOCATION
+    from teamster.code_locations.kippnewark.powerschool import assets
+
+    _test_partitioned_asset(
+        assets=assets,
+        asset_name="u_expectations",
+        code_location=CODE_LOCATION.upper(),
+    )
+```
+
+Materializes a random fiscal-year partition of the asset against Newark prod via
+the existing SSH/ODBC integration-test fixtures. Run locally with
+`OP_SERVICE_ACCOUNT_TOKEN` set; not run in CI.
+
+### 6. No schedule / sensor changes
 
 The existing fiscal-year partitioned PS sensor already covers any asset present
 in `powerschool_table_assets_full`. No new schedule, sensor, or job. No
@@ -164,15 +185,18 @@ Implementation is complete when:
 
 1. `uv run dagster definitions validate -m teamster.code_locations.kippnewark.definitions`
    passes (asset wiring is well-formed).
-2. The asset materializes successfully in branch deployment against Newark prod
+2. `uv run pytest tests/assets/test_assets_powerschool_sis.py::test_u_expectations_kippnewark`
+   passes locally (with `OP_SERVICE_ACCOUNT_TOKEN` set), confirming a real
+   Oracle round-trip and Avro write-out against Newark prod.
+3. The asset materializes successfully in branch deployment against Newark prod
    (latest fiscal-year partition fills with > 0 rows).
-3. `uv run dbt build --select stg_powerschool__u_expectations --project-dir src/dbt/kippnewark`
+4. `uv run dbt build --select stg_powerschool__u_expectations --project-dir src/dbt/kippnewark`
    passes against the branch-deployment-loaded raw table — uniqueness on `dcid`
    and contract enforcement both hold.
-4. The same `dbt build` selector run against `src/dbt/kippcamden`,
+5. The same `dbt build` selector run against `src/dbt/kippcamden`,
    `src/dbt/kippmiami`, and `src/dbt/kipppaterson` resolves to "model is
    disabled" rather than building or erroring (confirms opt-out wiring).
-5. The raw asset's BQ row count and the staging model's row count match.
+6. The raw asset's BQ row count and the staging model's row count match.
 
 If the Oracle table's exact name turns out to be schema-qualified (e.g.,
 `U_GRADEBOOK_AUDIT.U_EXPECTATIONS`) or otherwise differs, adjust the

--- a/docs/superpowers/specs/2026-05-08-powerschool-u-expectations-extract-design.md
+++ b/docs/superpowers/specs/2026-05-08-powerschool-u-expectations-extract-design.md
@@ -1,0 +1,200 @@
+# PowerSchool `U_EXPECTATIONS` Extract — Design
+
+Issue:
+[TEAMSchools/teamster#3756](https://github.com/TEAMSchools/teamster/issues/3756)
+
+## Goal
+
+Stand up a recurring BigQuery extract of the `U_EXPECTATIONS` PowerSchool
+extension table from Newark production, plus a dbt staging model in
+`kippnewark`, so downstream Gradebook Audit work has a queryable source.
+
+The same pattern will be repeated for `U_FLAGS` and `U_EXCEPTIONS` in later
+phases. This spec covers `U_EXPECTATIONS` only.
+
+## Decisions
+
+- **Ingest path**: Oracle ODBC via the existing
+  `build_powerschool_table_asset()` factory. Reuses the SSH tunnel, retry
+  wrapper, Avro serialization, and BigQuery loader already in production.
+- **Scope**: `kippnewark` code location only. The Gradebook Audit plugin is
+  installed on Newark prod (and a Newark test instance); other districts add the
+  same single YAML line when their plugin lands.
+- **Partitioning**: `partition_column: whenmodified` — standard for PS extension
+  tables, matching the existing `# whenmodified` group in `assets-full.yaml`.
+- **Column projection**: pull all columns (no `select_columns`). The standard PS
+  audit cols (`dcid`, `whencreated`, `whenmodified`, …) come along for free and
+  are needed for the partition filter and grain.
+- **Staging grain**: `dcid` (PS extension-table PK). `id`, `school_level`,
+  `quarter`, `week_number` are payload columns, not the unique key.
+- **Verification**: locally and in branch deployment; no pre-merge Oracle probe
+  required.
+
+## Change set
+
+### 1. Dagster YAML
+
+Append to
+`src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml`
+under the `# whenmodified` block:
+
+```yaml
+- asset_name: u_expectations
+  partition_column: whenmodified
+```
+
+No code changes. The asset is auto-included in:
+
+- `powerschool_table_assets_full` (assembled by `assets.py`'s
+  `config_from_files` list comprehension)
+- the staleness sensor that drives PS materializations
+- the standard fiscal-year partitions (`FiscalYearPartitionsDefinition`, start
+  `2016-07-01`, July fiscal start, America/New_York)
+- the standard GCS landing path:
+  `gs://teamster-kippnewark/dagster/kippnewark/powerschool/u_expectations/...avro`
+- the standard BigQuery raw load into the `kippnewark_powerschool` dataset
+
+### 2. dbt source entry
+
+Add a new entry in
+`src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml` under the
+`powerschool_odbc` source, mirroring the existing
+`src_powerschool__u_studentsuserfields` block:
+
+```yaml
+- name: src_powerschool__u_expectations
+  config:
+    meta:
+      dagster:
+        asset_key:
+          - "{{ project_name }}"
+          - powerschool
+          - u_expectations
+  external:
+    location:
+      "{{ var('powerschool_external_location_root',
+      env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_expectations/*"
+    options:
+      connection_name: "{{ var('bigquery_external_connection_name') }}"
+      metadata_cache_mode: MANUAL
+      max_staleness: INTERVAL 7 DAY
+      format: AVRO
+      enable_logical_types: true
+```
+
+After this change, run `dbt run-operation stage_external_sources` against the
+target environment per the project-wide external-table convention.
+
+### 3. dbt staging model (shared package)
+
+Two new files in the shared `dbt/powerschool/` source-system package — the
+standard home for PS extension tables, mirroring `stg_powerschool__u_clg_et_stu`
+and friends:
+
+- `src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql`
+- `src/dbt/powerschool/models/sis/staging/odbc/properties/stg_powerschool__u_expectations.yml`
+  (path pattern follows the rest of the package — verify exact `properties/`
+  subdirectory location during implementation).
+
+#### SQL
+
+```sql
+with
+    transformations as (
+        select
+            * except (dcid, id),
+
+            dcid.int_value as dcid,
+            id.int_value as id,
+        from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}
+    )
+
+select * from transformations
+```
+
+The `* except (...)` + `.int_value` unwrap handles the Avro-encoded Oracle
+NUMBER type (which lands as a struct with `int_value` / `decimal_value`
+siblings), matching the existing PS staging precedent. Additional `safe_cast`
+may be needed for `cnt_w` / `cnt_h` / `cnt_f` / `cnt_s` if Oracle stores them as
+NUMBER without a fixed scale — finalize during implementation after profiling
+the loaded BQ external table.
+
+#### Properties YAML
+
+- `description:` on the model and every column.
+- `data_type:` for every column (BigQuery contract types: `int64`, `string`,
+  `timestamp`, etc.).
+- `dcid` carries `unique` and `not_null` data tests, both with
+  `config: { severity: error }`.
+- Contract enforcement is inherited from the staging directory's
+  `dbt_project.yml` config — no per-model override needed.
+
+Issue-specified payload columns (`id`, `school_level`, `quarter`, `week_number`,
+`cnt_w`, `cnt_h`, `cnt_f`, `cnt_s`, `notes`) plus the standard PS audit columns
+(`dcid`, `whencreated`, `whenmodified`, etc.) all get contract entries.
+
+### 4. District opt-outs
+
+The Gradebook Audit plugin is only on Newark prod, so the asset/source/model
+must be disabled in the other three districts' `dbt_project.yml` files —
+following the precedent established for `u_clg_et_stu`, `u_def_ext_students`,
+etc.
+
+In each of `src/dbt/kippcamden/dbt_project.yml`,
+`src/dbt/kippmiami/dbt_project.yml`, and `src/dbt/kipppaterson/dbt_project.yml`,
+add:
+
+- under `models.powerschool.sis.staging.odbc`:
+  `stg_powerschool__u_expectations: { +enabled: false }`
+- under `sources.powerschool.staging.odbc.powerschool_odbc`:
+  `src_powerschool__u_expectations: { +enabled: false }`
+
+`kippnewark` requires no override — it's enabled by default in the package.
+
+### 5. No schedule / sensor changes
+
+The existing fiscal-year partitioned PS sensor already covers any asset present
+in `powerschool_table_assets_full`. No new schedule, sensor, or job. No
+intermediate or mart model — per the issue, downstream modeling is deferred ("if
+this works, we will formally write up a plan").
+
+## Verification
+
+Implementation is complete when:
+
+1. `uv run dagster definitions validate -m teamster.code_locations.kippnewark.definitions`
+   passes (asset wiring is well-formed).
+2. The asset materializes successfully in branch deployment against Newark prod
+   (latest fiscal-year partition fills with > 0 rows).
+3. `uv run dbt build --select stg_powerschool__u_expectations --project-dir src/dbt/kippnewark`
+   passes against the branch-deployment-loaded raw table — uniqueness on `dcid`
+   and contract enforcement both hold.
+4. The same `dbt build` selector run against `src/dbt/kippcamden`,
+   `src/dbt/kippmiami`, and `src/dbt/kipppaterson` resolves to "model is
+   disabled" rather than building or erroring (confirms opt-out wiring).
+5. The raw asset's BQ row count and the staging model's row count match.
+
+If the Oracle table's exact name turns out to be schema-qualified (e.g.,
+`U_GRADEBOOK_AUDIT.U_EXPECTATIONS`) or otherwise differs, adjust the
+`asset_name` in the YAML. The factory passes the value to SQLAlchemy `table()`,
+which auto-uppercases unquoted identifiers; lowercase `u_expectations` resolves
+to `U_EXPECTATIONS` in Oracle.
+
+## Risks
+
+- **Table not yet present on Newark prod**: first scheduled materialization
+  fails with `ORA-00942`. Caught by branch-deployment validation before merging.
+- **Avro-typed numeric edge cases**: counts (`cnt_*`) may need `safe_cast` if
+  Oracle stores them as `NUMBER` without explicit scale — handled in the SQL
+  during implementation, not blocking design.
+- **Plugin re-installation churn**: the issue notes the table is created
+  manually via the PS Database Extensions UI on CLG-hosted instances. If the
+  plugin is reinstalled and the table is dropped, the extract fails until it's
+  recreated. Out of scope for this spec.
+
+## Out of scope
+
+- `U_FLAGS` / `U_EXCEPTIONS` — Phase 2 / Phase 3 follow-ups, same pattern.
+- kippcamden / kippmiami / kipppaterson — when the plugin is installed there.
+- Intermediate / mart / Tableau-facing models on top of `u_expectations`.
+- Migration of the existing Gradebook Audit pipeline to PS-native logic.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -40,8 +40,9 @@ All district projects share these variables (override via `dbt_project.yml`):
   current values from any district's `dbt_project.yml`
 - `local_timezone` — `America/New_York`
 - `cloud_storage_uri_base` — `gs://teamster-<project>/dagster/<project>`
-- `powerschool_external_location_root` —
-  `gs://teamster-<project>/dagster/<project>/powerschool` (ODBC districts only)
+  (redirects to `gs://teamster-test/dagster/<project>` when
+  `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT=1`, via inline conditional in each
+  `external.location` template)
 
 Exceptions: `kippnewark` adds `iready_schema: kippnj_iready` and
 `renlearn_schema: kippnj_renlearn`. `kipptaf` has

--- a/src/dbt/kippcamden/CLAUDE.md
+++ b/src/dbt/kippcamden/CLAUDE.md
@@ -22,7 +22,7 @@ PowerSchool data source: **ODBC** (`odbc.+enabled: true`,
 
 All materialized as tables via cross-project `ref()`:
 
-- `powerschool` (ODBC) — `powerschool_external_location_root` points to GCS
+- `powerschool` (ODBC)
 - `deanslist`
 - `edplan`
 - `overgrad`

--- a/src/dbt/kippcamden/dbt_project.yml
+++ b/src/dbt/kippcamden/dbt_project.yml
@@ -27,7 +27,6 @@ vars:
   current_fiscal_year: 2026
   cloud_storage_uri_base: gs://teamster-kippcamden/dagster/kippcamden
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
-  powerschool_external_location_root: gs://teamster-kippcamden/dagster/kippcamden/powerschool
 
 models:
   kippcamden:

--- a/src/dbt/kippcamden/dbt_project.yml
+++ b/src/dbt/kippcamden/dbt_project.yml
@@ -99,6 +99,8 @@ models:
             +enabled: false
           stg_powerschool__u_def_ext_students:
             +enabled: false
+          stg_powerschool__u_expectations:
+            +enabled: false
   titan:
     +materialized: table
     staging:
@@ -142,6 +144,8 @@ sources:
             src_powerschool__sced_code_mapping:
               +enabled: false
             src_powerschool__u_def_ext_students:
+              +enabled: false
+            src_powerschool__u_expectations:
               +enabled: false
   titan:
     titan:

--- a/src/dbt/kippmiami/CLAUDE.md
+++ b/src/dbt/kippmiami/CLAUDE.md
@@ -25,7 +25,7 @@ PowerSchool data source: **ODBC** (`odbc.+enabled: true`,
 
 All materialized as tables via cross-project `ref()`:
 
-- `powerschool` (ODBC) — `powerschool_external_location_root` points to GCS
+- `powerschool` (ODBC)
 - `deanslist`
 - `iready`
 - `renlearn`

--- a/src/dbt/kippmiami/dbt_project.yml
+++ b/src/dbt/kippmiami/dbt_project.yml
@@ -120,6 +120,8 @@ models:
             +enabled: false
           stg_powerschool__u_def_ext_students:
             +enabled: false
+          stg_powerschool__u_expectations:
+            +enabled: false
           stg_powerschool__u_storedgrades_de:
             +enabled: false
   renlearn:
@@ -185,6 +187,8 @@ sources:
             src_powerschool__sced_code_mapping:
               +enabled: false
             src_powerschool__u_def_ext_students:
+              +enabled: false
+            src_powerschool__u_expectations:
               +enabled: false
             src_powerschool__u_storedgrades_de:
               +enabled: false

--- a/src/dbt/kippmiami/dbt_project.yml
+++ b/src/dbt/kippmiami/dbt_project.yml
@@ -26,7 +26,6 @@ vars:
   current_academic_year: 2025
   current_fiscal_year: 2026
   cloud_storage_uri_base: gs://teamster-kippmiami/dagster/kippmiami
-  powerschool_external_location_root: gs://teamster-kippmiami/dagster/kippmiami/powerschool
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
   focus_schema: dagster_kippmiami_dlt_focus
 

--- a/src/dbt/kippnewark/CLAUDE.md
+++ b/src/dbt/kippnewark/CLAUDE.md
@@ -23,7 +23,7 @@ PowerSchool data source: **ODBC** (`odbc.+enabled: true`,
 
 All of the following are materialized as tables via cross-project `ref()`:
 
-- `powerschool` (ODBC) — `powerschool_external_location_root` points to GCS
+- `powerschool` (ODBC)
 - `deanslist`
 - `edplan`
 - `iready` — uses `iready_schema: kippnj_iready`

--- a/src/dbt/kippnewark/dbt_project.yml
+++ b/src/dbt/kippnewark/dbt_project.yml
@@ -29,7 +29,6 @@ vars:
   renlearn_schema: kippnj_renlearn
   cloud_storage_uri_base: gs://teamster-kippnewark/dagster/kippnewark
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
-  powerschool_external_location_root: gs://teamster-kippnewark/dagster/kippnewark/powerschool
 
 models:
   kippnewark:

--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -144,6 +144,8 @@ models:
             +enabled: false
           stg_powerschool__u_clg_et_stu_alt:
             +enabled: false
+          stg_powerschool__u_expectations:
+            +enabled: false
 
 sources:
   amplify:
@@ -244,6 +246,8 @@ sources:
             src_powerschool__u_clg_et_stu:
               +enabled: false
             src_powerschool__u_clg_et_stu_alt:
+              +enabled: false
+            src_powerschool__u_expectations:
               +enabled: false
             src_powerschool__u_def_ext_students:
               +enabled: false

--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -144,8 +144,6 @@ models:
             +enabled: false
           stg_powerschool__u_clg_et_stu_alt:
             +enabled: false
-          stg_powerschool__u_expectations:
-            +enabled: false
 
 sources:
   amplify:
@@ -246,8 +244,6 @@ sources:
             src_powerschool__u_clg_et_stu:
               +enabled: false
             src_powerschool__u_clg_et_stu_alt:
-              +enabled: false
-            src_powerschool__u_expectations:
               +enabled: false
             src_powerschool__u_def_ext_students:
               +enabled: false

--- a/src/dbt/kipptaf/models/powerschool/sources-kippnewark.yml
+++ b/src/dbt/kipptaf/models/powerschool/sources-kippnewark.yml
@@ -544,6 +544,15 @@ sources:
                 - kippnewark
                 - powerschool
                 - stg_powerschool__u_def_ext_students
+      - name: stg_powerschool__u_expectations
+        config:
+          meta:
+            dagster:
+              group: powerschool
+              asset_key:
+                - kippnewark
+                - powerschool
+                - stg_powerschool__u_expectations
       - name: stg_powerschool__u_studentsuserfields
         config:
           meta:

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__u_expectations.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__u_expectations.yml
@@ -1,0 +1,2 @@
+models:
+  - name: stg_powerschool__u_expectations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
@@ -1,0 +1,7 @@
+{{
+    dbt_utils.union_relations(
+        relations=[
+            source("kippnewark_powerschool", "stg_powerschool__u_expectations"),
+        ]
+    )
+}}

--- a/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
+++ b/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
@@ -907,6 +907,24 @@ sources:
             max_staleness: INTERVAL 7 DAY
             format: AVRO
             enable_logical_types: true
+      - name: src_powerschool__u_expectations
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - "{{ project_name }}"
+                - powerschool
+                - u_expectations
+        external:
+          location:
+            "{{ var('powerschool_external_location_root',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_expectations/*"
+          options:
+            connection_name: "{{ var('bigquery_external_connection_name') }}"
+            metadata_cache_mode: MANUAL
+            max_staleness: INTERVAL 7 DAY
+            format: AVRO
+            enable_logical_types: true
       - name: src_powerschool__users
         config:
           meta:

--- a/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
+++ b/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
@@ -15,14 +15,18 @@ sources:
                 - assignmentscore
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/assignmentscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/assignmentscore/"
             format: AVRO
             enable_logical_types: true
@@ -36,14 +40,18 @@ sources:
                 - attendance
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance/"
             format: AVRO
             enable_logical_types: true
@@ -57,14 +65,18 @@ sources:
                 - pgfinalgrades
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/pgfinalgrades/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/pgfinalgrades/"
             format: AVRO
             enable_logical_types: true
@@ -78,14 +90,18 @@ sources:
                 - storedgrades
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/storedgrades/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/storedgrades/"
             format: AVRO
             enable_logical_types: true
@@ -99,7 +115,9 @@ sources:
                 - assignmentcategoryassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/assignmentcategoryassoc/*"
           options:
@@ -109,7 +127,9 @@ sources:
             format: AVRO
             enable_logical_types: true
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
               }}/assignmentcategoryassoc/"
       - name: src_powerschool__assignmentsection
@@ -122,7 +142,9 @@ sources:
                 - assignmentsection
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/assignmentsection/*"
           options:
@@ -132,7 +154,9 @@ sources:
             format: AVRO
             enable_logical_types: true
             hive_partition_uri_prefix:
-              "{{ var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
+              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('powerschool_external_location_root',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
               }}/assignmentsection/"
       - name: src_powerschool__cc
@@ -145,7 +169,9 @@ sources:
                 - cc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/cc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -163,7 +189,9 @@ sources:
                 - codeset
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/codeset/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -181,7 +209,9 @@ sources:
                 - courses
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/courses/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -199,7 +229,9 @@ sources:
                 - districtteachercategory
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/districtteachercategory/*"
           options:
@@ -218,7 +250,9 @@ sources:
                 - emailaddress
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/emailaddress/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -236,7 +270,9 @@ sources:
                 - gradecalcformulaweight
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradecalcformulaweight/*"
           options:
@@ -255,7 +291,9 @@ sources:
                 - gradecalcschoolassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradecalcschoolassoc/*"
           options:
@@ -274,7 +312,9 @@ sources:
                 - gradecalculationtype
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradecalculationtype/*"
           options:
@@ -293,7 +333,9 @@ sources:
                 - gradeformulaset
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradeformulaset/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -311,7 +353,9 @@ sources:
                 - gradescaleitem
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradescaleitem/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -329,7 +373,9 @@ sources:
                 - gradeschoolconfig
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradeschoolconfig/*"
           options:
@@ -348,7 +394,9 @@ sources:
                 - gradeschoolformulaassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradeschoolformulaassoc/*"
           options:
@@ -367,7 +415,9 @@ sources:
                 - gradesectionconfig
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gradesectionconfig/*"
           options:
@@ -386,7 +436,9 @@ sources:
                 - originalcontactmap
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/originalcontactmap/*"
           options:
@@ -405,7 +457,9 @@ sources:
                 - person
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/person/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -423,7 +477,9 @@ sources:
                 - personaddress
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/personaddress/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -441,7 +497,9 @@ sources:
                 - personaddressassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/personaddressassoc/*"
           options:
@@ -460,7 +518,9 @@ sources:
                 - personemailaddressassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/personemailaddressassoc/*"
           options:
@@ -479,7 +539,9 @@ sources:
                 - personphonenumberassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/personphonenumberassoc/*"
           options:
@@ -498,7 +560,9 @@ sources:
                 - phonenumber
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/phonenumber/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -516,7 +580,9 @@ sources:
                 - prefs
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/prefs/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -534,7 +600,9 @@ sources:
                 - roledef
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/roledef/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -552,7 +620,9 @@ sources:
                 - s_nj_crs_x
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_crs_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -570,7 +640,9 @@ sources:
                 - s_nj_ren_x
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_ren_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -588,7 +660,9 @@ sources:
                 - s_nj_stu_x
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_stu_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -606,7 +680,9 @@ sources:
                 - s_nj_usr_x
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_usr_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -624,7 +700,9 @@ sources:
                 - schools
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/schools/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -642,7 +720,9 @@ sources:
                 - schoolstaff
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/schoolstaff/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -660,7 +740,9 @@ sources:
                 - sections
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/sections/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -678,7 +760,9 @@ sources:
                 - sectionteacher
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/sectionteacher/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -696,7 +780,9 @@ sources:
                 - studentcontactassoc
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/studentcontactassoc/*"
           options:
@@ -715,7 +801,9 @@ sources:
                 - studentcontactdetail
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/studentcontactdetail/*"
           options:
@@ -734,7 +822,9 @@ sources:
                 - studentcorefields
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/studentcorefields/*"
           options:
@@ -753,7 +843,9 @@ sources:
                 - studentrace
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studentrace/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -771,7 +863,9 @@ sources:
                 - students
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/students/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -789,7 +883,9 @@ sources:
                 - teachercategory
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/teachercategory/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -807,7 +903,9 @@ sources:
                 - termbins
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/termbins/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -825,7 +923,9 @@ sources:
                 - terms
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/terms/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -843,7 +943,9 @@ sources:
                 - u_clg_et_stu
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_clg_et_stu/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -861,7 +963,9 @@ sources:
                 - u_clg_et_stu_alt
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_clg_et_stu_alt/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -879,7 +983,9 @@ sources:
                 - u_def_ext_students
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/u_def_ext_students/*"
           options:
@@ -898,7 +1004,9 @@ sources:
                 - u_studentsuserfields
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/u_studentsuserfields/*"
           options:
@@ -917,7 +1025,9 @@ sources:
                 - u_expectations
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_expectations/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -935,7 +1045,9 @@ sources:
                 - users
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/users/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -954,7 +1066,9 @@ sources:
                 - attendance_code
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance_code/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -972,7 +1086,9 @@ sources:
                 - attendance_conversion_items
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/attendance_conversion_items/*"
           options:
@@ -991,7 +1107,9 @@ sources:
                 - bell_schedule
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/bell_schedule/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1009,7 +1127,9 @@ sources:
                 - calendar_day
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/calendar_day/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1027,7 +1147,9 @@ sources:
                 - cycle_day
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/cycle_day/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1045,7 +1167,9 @@ sources:
                 - fte
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/fte/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1063,7 +1187,9 @@ sources:
                 - gen
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gen/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1081,7 +1207,9 @@ sources:
                 - log
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/log/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1099,7 +1227,9 @@ sources:
                 - period
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/period/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1117,7 +1247,9 @@ sources:
                 - reenrollments
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/reenrollments/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1135,7 +1267,9 @@ sources:
                 - spenrollments
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/spenrollments/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1153,7 +1287,9 @@ sources:
                 - test
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/test/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1171,7 +1307,9 @@ sources:
                 - testscore
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/testscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1189,7 +1327,9 @@ sources:
                 - studenttest
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studenttest/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1207,7 +1347,9 @@ sources:
                 - studenttestscore
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studenttestscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1225,7 +1367,9 @@ sources:
                 - sced_code_mapping
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/sced_code_mapping/*"
           options:
@@ -1244,7 +1388,9 @@ sources:
                 - gradplan
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradplan/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1262,7 +1408,9 @@ sources:
                 - userscorefields
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/userscorefields/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1280,7 +1428,9 @@ sources:
                 - u_storedgrades_de
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/u_storedgrades_de/*"
           options:
@@ -1299,7 +1449,9 @@ sources:
                 - gpnode
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpnode/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1317,7 +1469,9 @@ sources:
                 - gpprogresssubject
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubject/*"
           options:
@@ -1336,7 +1490,9 @@ sources:
                 - gpprogresssubjectearned
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubjectearned/*"
           options:
@@ -1355,7 +1511,9 @@ sources:
                 - gpprogresssubjectenrolled
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubjectenrolled/*"
           options:
@@ -1374,7 +1532,9 @@ sources:
                 - gpprogresssubjectrequested
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubjectrequested/*"
           options:
@@ -1393,7 +1553,9 @@ sources:
                 - gpprogresssubjectwaived
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubjectwaived/*"
           options:
@@ -1412,7 +1574,9 @@ sources:
                 - gpprogresssubjwaivedapplied
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
             }}/gpprogresssubjwaivedapplied/*"
           options:
@@ -1431,7 +1595,9 @@ sources:
                 - gpselectedcrs
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselectedcrs/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1449,7 +1615,9 @@ sources:
                 - gpselectedcrtype
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselectedcrtype/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1467,7 +1635,9 @@ sources:
                 - gpselector
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselector/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1485,7 +1655,9 @@ sources:
                 - gptarget
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gptarget/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1503,7 +1675,9 @@ sources:
                 - gpversion
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpversion/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1521,7 +1695,9 @@ sources:
                 - gpstudentwaiver
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpstudentwaiver/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
@@ -1539,7 +1715,9 @@ sources:
                 - s_stu_x
         external:
           location:
-            "{{ var('powerschool_external_location_root',
+            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+            var('powerschool_external_location_root',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_stu_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"

--- a/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
+++ b/src/dbt/powerschool/models/sis/staging/odbc/sources-external.yml
@@ -15,19 +15,21 @@ sources:
                 - assignmentscore
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/assignmentscore/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/assignmentscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
-              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/assignmentscore/"
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
+              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+              }}/powerschool/assignmentscore/"
             format: AVRO
             enable_logical_types: true
       - name: src_powerschool__attendance
@@ -40,19 +42,21 @@ sources:
                 - attendance
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/attendance/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
-              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance/"
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
+              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+              }}/powerschool/attendance/"
             format: AVRO
             enable_logical_types: true
       - name: src_powerschool__pgfinalgrades
@@ -65,19 +69,21 @@ sources:
                 - pgfinalgrades
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/pgfinalgrades/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/pgfinalgrades/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
-              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/pgfinalgrades/"
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
+              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+              }}/powerschool/pgfinalgrades/"
             format: AVRO
             enable_logical_types: true
       - name: src_powerschool__storedgrades
@@ -90,19 +96,21 @@ sources:
                 - storedgrades
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/storedgrades/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/storedgrades/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
-              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/storedgrades/"
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
+              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+              }}/powerschool/storedgrades/"
             format: AVRO
             enable_logical_types: true
       - name: src_powerschool__assignmentcategoryassoc
@@ -115,11 +123,11 @@ sources:
                 - assignmentcategoryassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/assignmentcategoryassoc/*"
+            }}/powerschool/assignmentcategoryassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -127,11 +135,11 @@ sources:
             format: AVRO
             enable_logical_types: true
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-              }}/assignmentcategoryassoc/"
+              }}/powerschool/assignmentcategoryassoc/"
       - name: src_powerschool__assignmentsection
         config:
           meta:
@@ -142,11 +150,11 @@ sources:
                 - assignmentsection
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/assignmentsection/*"
+            }}/powerschool/assignmentsection/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -154,11 +162,11 @@ sources:
             format: AVRO
             enable_logical_types: true
             hive_partition_uri_prefix:
-              "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool'
-              if env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-              var('powerschool_external_location_root',
+              "{{ 'gs://teamster-test/dagster/' ~ project_name if
+              env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
+              var('cloud_storage_uri_base',
               env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-              }}/assignmentsection/"
+              }}/powerschool/assignmentsection/"
       - name: src_powerschool__cc
         config:
           meta:
@@ -169,10 +177,10 @@ sources:
                 - cc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/cc/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/powerschool/cc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -189,10 +197,11 @@ sources:
                 - codeset
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/codeset/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/codeset/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -209,10 +218,11 @@ sources:
                 - courses
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/courses/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/courses/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -229,11 +239,11 @@ sources:
                 - districtteachercategory
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/districtteachercategory/*"
+            }}/powerschool/districtteachercategory/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -250,10 +260,11 @@ sources:
                 - emailaddress
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/emailaddress/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/emailaddress/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -270,11 +281,11 @@ sources:
                 - gradecalcformulaweight
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradecalcformulaweight/*"
+            }}/powerschool/gradecalcformulaweight/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -291,11 +302,11 @@ sources:
                 - gradecalcschoolassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradecalcschoolassoc/*"
+            }}/powerschool/gradecalcschoolassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -312,11 +323,11 @@ sources:
                 - gradecalculationtype
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradecalculationtype/*"
+            }}/powerschool/gradecalculationtype/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -333,10 +344,11 @@ sources:
                 - gradeformulaset
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradeformulaset/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gradeformulaset/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -353,10 +365,11 @@ sources:
                 - gradescaleitem
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradescaleitem/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gradescaleitem/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -373,11 +386,11 @@ sources:
                 - gradeschoolconfig
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradeschoolconfig/*"
+            }}/powerschool/gradeschoolconfig/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -394,11 +407,11 @@ sources:
                 - gradeschoolformulaassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradeschoolformulaassoc/*"
+            }}/powerschool/gradeschoolformulaassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -415,11 +428,11 @@ sources:
                 - gradesectionconfig
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gradesectionconfig/*"
+            }}/powerschool/gradesectionconfig/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -436,11 +449,11 @@ sources:
                 - originalcontactmap
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/originalcontactmap/*"
+            }}/powerschool/originalcontactmap/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -457,10 +470,11 @@ sources:
                 - person
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/person/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/person/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -477,10 +491,11 @@ sources:
                 - personaddress
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/personaddress/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/personaddress/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -497,11 +512,11 @@ sources:
                 - personaddressassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/personaddressassoc/*"
+            }}/powerschool/personaddressassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -518,11 +533,11 @@ sources:
                 - personemailaddressassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/personemailaddressassoc/*"
+            }}/powerschool/personemailaddressassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -539,11 +554,11 @@ sources:
                 - personphonenumberassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/personphonenumberassoc/*"
+            }}/powerschool/personphonenumberassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -560,10 +575,11 @@ sources:
                 - phonenumber
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/phonenumber/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/phonenumber/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -580,10 +596,11 @@ sources:
                 - prefs
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/prefs/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/prefs/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -600,10 +617,11 @@ sources:
                 - roledef
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/roledef/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/roledef/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -620,10 +638,11 @@ sources:
                 - s_nj_crs_x
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_crs_x/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/s_nj_crs_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -640,10 +659,11 @@ sources:
                 - s_nj_ren_x
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_ren_x/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/s_nj_ren_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -660,10 +680,11 @@ sources:
                 - s_nj_stu_x
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_stu_x/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/s_nj_stu_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -680,10 +701,11 @@ sources:
                 - s_nj_usr_x
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_nj_usr_x/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/s_nj_usr_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -700,10 +722,11 @@ sources:
                 - schools
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/schools/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/schools/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -720,10 +743,11 @@ sources:
                 - schoolstaff
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/schoolstaff/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/schoolstaff/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -740,10 +764,11 @@ sources:
                 - sections
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/sections/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/sections/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -760,10 +785,11 @@ sources:
                 - sectionteacher
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/sectionteacher/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/sectionteacher/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -780,11 +806,11 @@ sources:
                 - studentcontactassoc
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/studentcontactassoc/*"
+            }}/powerschool/studentcontactassoc/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -801,11 +827,11 @@ sources:
                 - studentcontactdetail
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/studentcontactdetail/*"
+            }}/powerschool/studentcontactdetail/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -822,11 +848,11 @@ sources:
                 - studentcorefields
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/studentcorefields/*"
+            }}/powerschool/studentcorefields/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -843,10 +869,11 @@ sources:
                 - studentrace
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studentrace/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/studentrace/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -863,10 +890,11 @@ sources:
                 - students
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/students/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/students/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -883,10 +911,11 @@ sources:
                 - teachercategory
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/teachercategory/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/teachercategory/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -903,10 +932,11 @@ sources:
                 - termbins
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/termbins/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/termbins/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -923,10 +953,11 @@ sources:
                 - terms
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/terms/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/terms/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -943,10 +974,11 @@ sources:
                 - u_clg_et_stu
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_clg_et_stu/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/u_clg_et_stu/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -963,10 +995,11 @@ sources:
                 - u_clg_et_stu_alt
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_clg_et_stu_alt/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/u_clg_et_stu_alt/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -983,11 +1016,11 @@ sources:
                 - u_def_ext_students
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/u_def_ext_students/*"
+            }}/powerschool/u_def_ext_students/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1004,11 +1037,11 @@ sources:
                 - u_studentsuserfields
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/u_studentsuserfields/*"
+            }}/powerschool/u_studentsuserfields/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1025,10 +1058,11 @@ sources:
                 - u_expectations
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/u_expectations/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/u_expectations/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1045,10 +1079,11 @@ sources:
                 - users
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/users/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/users/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1066,10 +1101,11 @@ sources:
                 - attendance_code
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/attendance_code/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/attendance_code/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1086,11 +1122,11 @@ sources:
                 - attendance_conversion_items
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/attendance_conversion_items/*"
+            }}/powerschool/attendance_conversion_items/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1107,10 +1143,11 @@ sources:
                 - bell_schedule
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/bell_schedule/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/bell_schedule/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1127,10 +1164,11 @@ sources:
                 - calendar_day
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/calendar_day/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/calendar_day/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1147,10 +1185,11 @@ sources:
                 - cycle_day
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/cycle_day/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/cycle_day/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1167,10 +1206,10 @@ sources:
                 - fte
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/fte/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/powerschool/fte/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1187,10 +1226,10 @@ sources:
                 - gen
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gen/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/powerschool/gen/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1207,10 +1246,10 @@ sources:
                 - log
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/log/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/powerschool/log/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1227,10 +1266,11 @@ sources:
                 - period
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/period/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/period/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1247,10 +1287,11 @@ sources:
                 - reenrollments
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/reenrollments/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/reenrollments/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1267,10 +1308,11 @@ sources:
                 - spenrollments
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/spenrollments/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/spenrollments/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1287,10 +1329,10 @@ sources:
                 - test
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/test/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/powerschool/test/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1307,10 +1349,11 @@ sources:
                 - testscore
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/testscore/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/testscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1327,10 +1370,11 @@ sources:
                 - studenttest
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studenttest/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/studenttest/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1347,10 +1391,11 @@ sources:
                 - studenttestscore
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/studenttestscore/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/studenttestscore/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1367,11 +1412,11 @@ sources:
                 - sced_code_mapping
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/sced_code_mapping/*"
+            }}/powerschool/sced_code_mapping/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1388,10 +1433,11 @@ sources:
                 - gradplan
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gradplan/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gradplan/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1408,10 +1454,11 @@ sources:
                 - userscorefields
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/userscorefields/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/userscorefields/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1428,11 +1475,11 @@ sources:
                 - u_storedgrades_de
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/u_storedgrades_de/*"
+            }}/powerschool/u_storedgrades_de/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1449,10 +1496,11 @@ sources:
                 - gpnode
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpnode/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpnode/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1469,11 +1517,11 @@ sources:
                 - gpprogresssubject
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubject/*"
+            }}/powerschool/gpprogresssubject/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1490,11 +1538,11 @@ sources:
                 - gpprogresssubjectearned
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubjectearned/*"
+            }}/powerschool/gpprogresssubjectearned/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1511,11 +1559,11 @@ sources:
                 - gpprogresssubjectenrolled
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubjectenrolled/*"
+            }}/powerschool/gpprogresssubjectenrolled/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1532,11 +1580,11 @@ sources:
                 - gpprogresssubjectrequested
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubjectrequested/*"
+            }}/powerschool/gpprogresssubjectrequested/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1553,11 +1601,11 @@ sources:
                 - gpprogresssubjectwaived
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubjectwaived/*"
+            }}/powerschool/gpprogresssubjectwaived/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1574,11 +1622,11 @@ sources:
                 - gpprogresssubjwaivedapplied
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
+            var('cloud_storage_uri_base',
             env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
-            }}/gpprogresssubjwaivedapplied/*"
+            }}/powerschool/gpprogresssubjwaivedapplied/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1595,10 +1643,11 @@ sources:
                 - gpselectedcrs
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselectedcrs/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpselectedcrs/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1615,10 +1664,11 @@ sources:
                 - gpselectedcrtype
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselectedcrtype/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpselectedcrtype/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1635,10 +1685,11 @@ sources:
                 - gpselector
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpselector/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpselector/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1655,10 +1706,11 @@ sources:
                 - gptarget
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gptarget/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gptarget/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1675,10 +1727,11 @@ sources:
                 - gpversion
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpversion/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpversion/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1695,10 +1748,11 @@ sources:
                 - gpstudentwaiver
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/gpstudentwaiver/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/gpstudentwaiver/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
@@ -1715,10 +1769,11 @@ sources:
                 - s_stu_x
         external:
           location:
-            "{{ 'gs://teamster-test/dagster/' ~ project_name ~ '/powerschool' if
+            "{{ 'gs://teamster-test/dagster/' ~ project_name if
             env_var('DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT', '0') == '1' else
-            var('powerschool_external_location_root',
-            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/s_stu_x/*"
+            var('cloud_storage_uri_base',
+            env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+            }}/powerschool/s_stu_x/*"
           options:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL

--- a/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
+++ b/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
@@ -1,19 +1,13 @@
-with
-    transformations as (
-        select
-            * except (dcid, id, quarter, week_number, cnt_w, cnt_h, cnt_f, cnt_s),
+select
+    * except (dcid, id, `quarter`, week_number, cnt_w, cnt_h, cnt_f, cnt_s),
 
-            /* column transformations */
-            dcid.int_value as dcid,
-            id.int_value as id,
-            quarter.int_value as quarter,
-            week_number.int_value as week_number,
-            cnt_w.int_value as cnt_w,
-            cnt_h.int_value as cnt_h,
-            cnt_f.int_value as cnt_f,
-            cnt_s.int_value as cnt_s,
-        from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}
-    )
-
-select *
-from transformations
+    /* column transformations */
+    dcid.int_value as dcid,
+    id.int_value as id,
+    `quarter`.int_value as `quarter`,
+    week_number.int_value as week_number,
+    cnt_w.int_value as cnt_w,
+    cnt_h.int_value as cnt_h,
+    cnt_f.int_value as cnt_f,
+    cnt_s.int_value as cnt_s,
+from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}

--- a/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
+++ b/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
@@ -1,8 +1,6 @@
 select
     * replace (
-        dcid.int_value as dcid,
         id.int_value as id,
-        `quarter`.int_value as `quarter`,
         week_number.int_value as week_number,
         cnt_w.int_value as cnt_w,
         cnt_h.int_value as cnt_h,

--- a/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
+++ b/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
@@ -1,0 +1,19 @@
+with
+    transformations as (
+        select
+            * except (dcid, id, quarter, week_number, cnt_w, cnt_h, cnt_f, cnt_s),
+
+            /* column transformations */
+            dcid.int_value as dcid,
+            id.int_value as id,
+            quarter.int_value as quarter,
+            week_number.int_value as week_number,
+            cnt_w.int_value as cnt_w,
+            cnt_h.int_value as cnt_h,
+            cnt_f.int_value as cnt_f,
+            cnt_s.int_value as cnt_s,
+        from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}
+    )
+
+select *
+from transformations

--- a/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
+++ b/src/dbt/powerschool/models/sis/staging/odbc/stg_powerschool__u_expectations.sql
@@ -1,13 +1,12 @@
 select
-    * except (dcid, id, `quarter`, week_number, cnt_w, cnt_h, cnt_f, cnt_s),
-
-    /* column transformations */
-    dcid.int_value as dcid,
-    id.int_value as id,
-    `quarter`.int_value as `quarter`,
-    week_number.int_value as week_number,
-    cnt_w.int_value as cnt_w,
-    cnt_h.int_value as cnt_h,
-    cnt_f.int_value as cnt_f,
-    cnt_s.int_value as cnt_s,
+    * replace (
+        dcid.int_value as dcid,
+        id.int_value as id,
+        `quarter`.int_value as `quarter`,
+        week_number.int_value as week_number,
+        cnt_w.int_value as cnt_w,
+        cnt_h.int_value as cnt_h,
+        cnt_f.int_value as cnt_f,
+        cnt_s.int_value as cnt_s
+    ),
 from {{ source("powerschool_odbc", "src_powerschool__u_expectations") }}

--- a/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
+++ b/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
@@ -6,11 +6,9 @@ models:
       Always scoped to the current academic year — the source has no academic
       year column.
     columns:
-      - name: dcid
+      - name: id
         data_type: int64
-        description:
-          Auto-generated PowerSchool descendant ID. Primary key for this
-          extension table.
+        description: Plugin-assigned row identifier. Primary key.
         data_tests:
           - unique:
               config:
@@ -20,15 +18,12 @@ models:
                 severity: error
         constraints:
           - type: primary_key
-      - name: id
-        data_type: int64
-        description: Plugin-assigned row identifier.
       - name: school_level
         data_type: string
         description:
           School-level grouping (e.g. ES / MS / HS) for the rollup row.
       - name: quarter
-        data_type: int64
+        data_type: string
         quote: true
         description: Academic quarter (1-4) the rollup row covers.
       - name: week_number

--- a/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
+++ b/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
@@ -1,0 +1,64 @@
+models:
+  - name: stg_powerschool__u_expectations
+    description:
+      Per-school-level / quarter / week roll-up of expectations counts (W/H/F/S)
+      from the Newark Gradebook Audit plugin's U_EXPECTATIONS extension table.
+      Always scoped to the current academic year — the source has no academic
+      year column.
+    columns:
+      - name: dcid
+        data_type: int64
+        description:
+          Auto-generated PowerSchool descendant ID. Primary key for this
+          extension table.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+        constraints:
+          - type: primary_key
+      - name: id
+        data_type: int64
+        description: Plugin-assigned row identifier.
+      - name: school_level
+        data_type: string
+        description:
+          School-level grouping (e.g. ES / MS / HS) for the rollup row.
+      - name: quarter
+        data_type: int64
+        description: Academic quarter (1-4) the rollup row covers.
+      - name: week_number
+        data_type: int64
+        description: Week number within the quarter.
+      - name: cnt_w
+        data_type: int64
+        description: Count of students in the W expectations bucket for the row.
+      - name: cnt_h
+        data_type: int64
+        description: Count of students in the H expectations bucket for the row.
+      - name: cnt_f
+        data_type: int64
+        description: Count of students in the F expectations bucket for the row.
+      - name: cnt_s
+        data_type: int64
+        description: Count of students in the S expectations bucket for the row.
+      - name: notes
+        data_type: string
+        description: Free-text notes captured by the plugin for the rollup row.
+      - name: whocreated
+        data_type: string
+        description: User login that created the record.
+      - name: whencreated
+        data_type: timestamp
+        description:
+          Date and time the record was created. Defaults to system date.
+      - name: whomodified
+        data_type: string
+        description: User login that last modified the record.
+      - name: whenmodified
+        data_type: timestamp
+        description:
+          Date and time the record was last modified. Defaults to system date.

--- a/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
+++ b/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__u_expectations.yml
@@ -29,6 +29,7 @@ models:
           School-level grouping (e.g. ES / MS / HS) for the rollup row.
       - name: quarter
         data_type: int64
+        quote: true
         description: Academic quarter (1-4) the rollup row covers.
       - name: week_number
         data_type: int64

--- a/src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml
+++ b/src/teamster/code_locations/kippnewark/powerschool/config/assets-full.yaml
@@ -92,6 +92,8 @@ assets:
       - currenttardies
   - asset_name: u_storedgrades_de
     partition_column: whenmodified
+  - asset_name: u_expectations
+    partition_column: whenmodified
   # - asset_name: gpstudentwaiver
   #   partition_column: whenmodified
   # - asset_name: s_nj_usr_x

--- a/src/teamster/libraries/dbt/assets.py
+++ b/src/teamster/libraries/dbt/assets.py
@@ -90,11 +90,19 @@ def build_dbt_assets(
                     context.log.info(msg=event)
 
                 if error := refresh_external_metadata_cache.get_error():
-                    if re.search(
+                    error_str = str(error)
+                    tolerated_patterns = [
+                        # Concurrent refresh on the same table — harmless.
                         r"Another metadata cache refresh job with id [\w-]+ is ongoing for table",
-                        str(error),
-                    ):
-                        context.log.warning(msg=str(error))
+                        # New source's first deploy: relation_name in the manifest
+                        # reflects the deploy-time target's schema (typically prod),
+                        # but stage_external_sources just created the table under the
+                        # runtime target's schema. The just-created table's metadata
+                        # cache is fresh by construction, so the refresh is redundant.
+                        r"Not found: Table \S+ was not found in location",
+                    ]
+                    if any(re.search(p, error_str) for p in tolerated_patterns):
+                        context.log.warning(msg=error_str)
                     else:
                         raise error
 

--- a/tests/assets/test_assets_powerschool_sis.py
+++ b/tests/assets/test_assets_powerschool_sis.py
@@ -82,6 +82,17 @@ def test_cc_kippnewark():
     )
 
 
+def test_u_expectations_kippnewark():
+    from teamster.code_locations.kippnewark import CODE_LOCATION
+    from teamster.code_locations.kippnewark.powerschool import assets
+
+    _test_partitioned_asset(
+        assets=assets,
+        asset_name="u_expectations",
+        code_location=CODE_LOCATION.upper(),
+    )
+
+
 def test_u_studentsuserfields_kippnewark():
     from teamster.code_locations.kippnewark import CODE_LOCATION
     from teamster.code_locations.kippnewark.powerschool import assets


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Closes #3756.

Adds the `U_EXPECTATIONS` PowerSchool table to the Newark extract pipeline so its data flows from Oracle through Dagster into BigQuery and the dbt staging layer.

- Add `u_expectations` to `kippnewark/powerschool/config/assets-full.yaml` so the Dagster PowerSchool SIS asset materializes it from Oracle.
- Add an external source entry under `src/dbt/powerschool/.../sources-external.yml` and a contracted staging model `stg_powerschool__u_expectations` (with a properties YAML) in the shared powerschool dbt project.
- Backtick-quote the reserved-word column and drop the wrapper CTE in the staging model to satisfy the dbt contract / BigQuery parser.
- Disable `u_expectations` in non-Newark district dbt projects (kippcamden, kippmiami) since the table only exists in Newark; remove the now-redundant opt-out in kipppaterson.
- Add an e2e Dagster asset test for the Newark `u_expectations` partition.

## AI Assistance

AI-assisted: spec, plan, and implementation drafted with Claude Code via the superpowers brainstorming/writing-plans/executing-plans flow. Human-directed: issue scoping, sign-off on the design, and the post-merge verification steps called out below.

## Self-review

### General

- [x] Update **due date** and **assignee** on the TEAMster Asana Project
- [x] Review the **Claude Code Review** comment posted on this PR

### Dagster

- [ ] Run `uv run dagster definitions validate` for kippnewark
- [ ] Run `uv run pytest tests/test_dagster_definitions.py`
- [x] New asset follows the Library + Config pattern (config-only addition to the existing PowerSchool SIS asset)

### dbt

- [x] Properties file `stg_powerschool__u_expectations.yml` included
- [ ] Exposure update — n/a (no downstream dashboard yet)
- [x] Breaking change? No — net-new staging model
- [ ] Run `stage_external_sources` with `--target staging` post-merge (see follow-ups below)

## Post-merge follow-ups (user)

- Verify the e2e test locally with `OP_SERVICE_ACCOUNT_TOKEN` set: `uv run pytest tests/assets/test_assets_powerschool_sis.py::test_u_expectations_kippnewark`
- After the branch deployment lands the raw asset, run: `uv run dbt run-operation stage_external_sources --args 'select: powerschool_odbc.src_powerschool__u_expectations' --project-dir src/dbt/kippnewark --target staging`
- Then verify contract enforcement: `uv run dbt build --select stg_powerschool__u_expectations --project-dir src/dbt/kippnewark --target staging`
- Confirm Dagster branch deployment materialization succeeds for one Newark fiscal-year partition of `u_expectations`.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
