### PR TITLE
chore(dbt): set job_retries: 3 on kipptaf prod profile

### DIFF
--- a/src/dbt/kipptaf/profiles.yml
+++ b/src/dbt/kipptaf/profiles.yml
@@ -15,3 +15,4 @@ kipptaf:
       method: oauth
       project: teamster-332318
       threads: 40
+      job_retries: 3


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Set `job_retries: 3` on the `prod` output in `src/dbt/kipptaf/profiles.yml` so dbt-bigquery's adapter-level retry recovers from transient BigQuery 503s without falling through to Dagster's run-level auto-retry.

Context: a recent Dagster run for the kipptaf code location failed during dbt startup with `503 GET https://bigquery.googleapis.com/bigquery/v2/projects/teamster-332318/datasets?...` from `client.list_datasets()`. dbt-bigquery [does pass](https://github.com/dbt-labs/dbt-bigquery/blob/main/dbt/adapters/bigquery/connections.py#L552) `retry=create_reopen_with_deadline(...)` to that call, and `ServiceUnavailable` is in the retryable set ([PR #1408](https://github.com/dbt-labs/dbt-bigquery/pull/1408)) — but `BigQueryCredentials.job_retries` defaults to `1`. Both attempts hit the 503 and the adapter raised, taking the whole Dagster run with it. Bumping to 3 keeps recovery inside the adapter (~seconds of exponential backoff) instead of a fresh pod spin-up.

Resolves #3860.

## AI Assistance

AI-assisted: root-cause trace through dbt-bigquery + google-cloud-bigquery sources, identifying the retry-budget gap. Human-directed: decision to set the value to 3 and scope to the `prod` output only.

## Self-review

### dbt

- [x] No model changes — profile-only edit, no contract/exposure/external-source implications.

## CI checks

- [ ] **Trunk** — pre-push hook ran clean.
- [ ] **dbt Cloud** — n/a for profile changes (dbt Cloud uses its own connection settings, not this shipped profile).
- [ ] **Dagster Cloud** — should pass; profile change is picked up on next deploy.
