### PR TITLE
Add cumulative Y1 GPA fields to GPA roster extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
@@ -43,6 +43,10 @@ models:
         description: Unweighted projected cumulative Y1 GPA, incorporating current
           in-progress grades not yet stored.
         data_type: float64
+      - name: cumulative_y1_gpa_projected_s1_unweighted
+        description: Unweighted projected cumulative Y1 GPA based on S1 final grades
+          for the current year.
+        data_type: float64
       - name: cumulative_y1_gpa
         description: Weighted cumulative Y1 GPA across all stored grades at the
           current school.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
@@ -35,3 +35,19 @@ models:
         data_type: float64
       - name: gpa_y1
         data_type: float64
+      - name: cumulative_y1_gpa_unweighted
+        description: Unweighted cumulative Y1 GPA across all stored grades at the
+          current school.
+        data_type: float64
+      - name: cumulative_y1_gpa_projected_unweighted
+        description: Unweighted projected cumulative Y1 GPA, incorporating current
+          in-progress grades not yet stored.
+        data_type: float64
+      - name: cumulative_y1_gpa
+        description: Weighted cumulative Y1 GPA across all stored grades at the
+          current school.
+        data_type: float64
+      - name: cumulative_y1_gpa_projected
+        description: Weighted projected cumulative Y1 GPA, incorporating current
+          in-progress grades not yet stored.
+        data_type: float64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
@@ -36,22 +36,27 @@ models:
       - name: gpa_y1
         data_type: float64
       - name: cumulative_y1_gpa_unweighted
-        description: Unweighted cumulative Y1 GPA across all stored grades at the
-          current school.
+        description:
+          Unweighted cumulative Y1 GPA across all stored grades at the current
+          school.
         data_type: float64
       - name: cumulative_y1_gpa_projected_unweighted
-        description: Unweighted projected cumulative Y1 GPA, incorporating current
+        description:
+          Unweighted projected cumulative Y1 GPA, incorporating current
           in-progress grades not yet stored.
         data_type: float64
       - name: cumulative_y1_gpa_projected_s1_unweighted
-        description: Unweighted projected cumulative Y1 GPA based on S1 final grades
-          for the current year.
+        description:
+          Unweighted projected cumulative Y1 GPA based on S1 final grades for
+          the current year.
         data_type: float64
       - name: cumulative_y1_gpa
-        description: Weighted cumulative Y1 GPA across all stored grades at the
-          current school.
+        description:
+          Weighted cumulative Y1 GPA across all stored grades at the current
+          school.
         data_type: float64
       - name: cumulative_y1_gpa_projected
-        description: Weighted projected cumulative Y1 GPA, incorporating current
+        description:
+          Weighted projected cumulative Y1 GPA, incorporating current
           in-progress grades not yet stored.
         data_type: float64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
@@ -20,6 +20,7 @@ with
 
             gc.cumulative_y1_gpa_unweighted,
             gc.cumulative_y1_gpa_projected_unweighted,
+            gc.cumulative_y1_gpa_projected_s1_unweighted,
             gc.cumulative_y1_gpa,
             gc.cumulative_y1_gpa_projected,
 
@@ -75,6 +76,7 @@ select
 
     cumulative_y1_gpa_unweighted,
     cumulative_y1_gpa_projected_unweighted,
+    cumulative_y1_gpa_projected_s1_unweighted,
     cumulative_y1_gpa,
     cumulative_y1_gpa_projected,
 from roster pivot (max(gpa_term) as gpa for term in ('Q1', 'Q2', 'Q3', 'Q4'))

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
@@ -18,6 +18,11 @@ with
 
             y.gpa_y1,
 
+            gc.cumulative_y1_gpa_unweighted,
+            gc.cumulative_y1_gpa_projected_unweighted,
+            gc.cumulative_y1_gpa,
+            gc.cumulative_y1_gpa_projected,
+
             gpa.gpa_term,
         from {{ ref("int_extracts__student_enrollments") }} as co
         cross join unnest(['Q1', 'Q2', 'Q3', 'Q4']) as term
@@ -35,6 +40,11 @@ with
             and term = gpa.term_name
             and co.schoolid = gpa.schoolid
             and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+        left join
+            {{ ref("int_powerschool__gpa_cumulative") }} as gc
+            on co.studentid = gc.studentid
+            and co.schoolid = gc.schoolid
+            and {{ union_dataset_join_clause(left_alias="co", right_alias="gc") }}
         where
             co.academic_year = {{ var("current_academic_year") }}
             and co.rn_year = 1
@@ -62,4 +72,9 @@ select
     gpa_q4,
 
     gpa_y1,
+
+    cumulative_y1_gpa_unweighted,
+    cumulative_y1_gpa_projected_unweighted,
+    cumulative_y1_gpa,
+    cumulative_y1_gpa_projected,
 from roster pivot (max(gpa_term) as gpa for term in ('Q1', 'Q2', 'Q3', 'Q4'))

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
@@ -41,5 +41,7 @@ models:
         data_type: float64
       - name: cumulative_y1_gpa_projected_s1_unweighted
         data_type: float64
+      - name: cumulative_y1_gpa_projected_unweighted
+        data_type: float64
       - name: core_cumulative_y1_gpa
         data_type: float64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add five new cumulative Y1 GPA fields to the `rpt_gsheets__gpa_roster` model by joining with the `int_powerschool__gpa_cumulative` intermediate model. These fields include both weighted and unweighted cumulative GPA metrics (stored, projected, and projected S1 variants), enabling more comprehensive GPA reporting in the Google Sheets extract.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — all new columns are documented in existing `.yml` files
- [x] No breaking changes — only adding new columns to existing models
- [x] Updated properties files:
  - `rpt_gsheets__gpa_roster.yml` — added 5 new column definitions with descriptions
  - `int_powerschool__gpa_cumulative.yml` — added missing `cumulative_y1_gpa_projected_unweighted` column definition

## CI checks

- [ ] **Trunk** — pending
- [ ] **dbt Cloud** — pending
- [ ] **Dagster Cloud** — not triggered (no Dagster changes)

https://claude.ai/code/session_01LwQ4XrKb9Ww67SLkQym74F