### PR TITLE
refactor(dbt): hoist FLEID resolution from kipptaf to kippmiami (phase 1)

### DIFF
--- a/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -41,7 +41,7 @@ with
     fleid_lookup_raw as (
         -- TODO: #3887 — 14 FLEIDs map to multiple student_numbers in PS;
         -- dedupe is a workaround until source is cleaned.
-        select s.student_number, s.dcid, suf.fleid,
+        select s.student_number, suf.fleid,
         from {{ ref("stg_powerschool__students") }} as s
         inner join
             {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
@@ -54,7 +54,7 @@ with
             dbt_utils.deduplicate(
                 relation="fleid_lookup_raw",
                 partition_by="fleid",
-                order_by="dcid desc",
+                order_by="student_number desc",
             )
         }}
     )

--- a/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -46,7 +46,7 @@ with
         inner join
             {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
             on s.dcid = suf.studentsdcid
-        where suf.fleid is not null
+            and suf.fleid is not null
     ),
 
     fleid_lookup as (

--- a/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kippmiami/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -35,12 +35,37 @@ with
                 _dbt_source_relation, r'stg_fldoe__(\w+)'
             ) as assessment_name,
         from union_relations
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    fleid_lookup_raw as (
+        -- TODO: #3887 — 14 FLEIDs map to multiple student_numbers in PS;
+        -- dedupe is a workaround until source is cleaned.
+        select s.student_number, s.dcid, suf.fleid,
+        from {{ ref("stg_powerschool__students") }} as s
+        inner join
+            {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
+            on s.dcid = suf.studentsdcid
+        where suf.fleid is not null
+    ),
+
+    fleid_lookup as (
+        {{
+            dbt_utils.deduplicate(
+                relation="fleid_lookup_raw",
+                partition_by="fleid",
+                order_by="dcid desc",
+            )
+        }}
     )
 
 select
-    * except (assessment_name),
+    t.* except (assessment_name),
+
+    fl.student_number,
 
     if(
-        assessment_name = 'science', 'Science', upper(assessment_name)
+        t.assessment_name = 'science', 'Science', upper(t.assessment_name)
     ) as assessment_name,
-from transformed
+from transformed as t
+left join fleid_lookup as fl on t.student_id = fl.fleid

--- a/src/dbt/kippmiami/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
+++ b/src/dbt/kippmiami/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
@@ -1,5 +1,19 @@
 models:
   - name: int_fldoe__all_assessments
+    description: >-
+      Union of FLDOE state assessment results (EOC, FAST, Science, FSA) with
+      assessment-grade and performance-level coalesced to single canonical
+      fields and assessment_name derived from the source relation. Resolves
+      student_number by joining stg_powerschool__u_studentsuserfields on fleid
+      so downstream models can identify students by PowerSchool identifier.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_id
+              - academic_year
+              - administration_window
+              - assessment_subject
     columns:
       - name: test_code
         data_type: string
@@ -25,5 +39,14 @@ models:
         data_type: int64
       - name: student_id
         data_type: string
+        description: >-
+          FLDOE student identifier (FLEID). Coalesced from student_id and fleid
+          source columns across FLDOE staging tables.
       - name: assessment_name
         data_type: string
+      - name: student_number
+        data_type: int64
+        description: >-
+          PowerSchool student_number resolved by joining student_id (FLEID) to
+          stg_powerschool__u_studentsuserfields.fleid. Null for the small number
+          of FLDOE students with no matching PowerSchool record.

--- a/src/dbt/kippmiami/models/powerschool/sis/staging/properties/stg_powerschool__u_studentsuserfields.yml
+++ b/src/dbt/kippmiami/models/powerschool/sis/staging/properties/stg_powerschool__u_studentsuserfields.yml
@@ -19,5 +19,10 @@ models:
         data_type: boolean
       - name: fleid
         data_type: string
+        data_tests:
+          - unique:
+              config:
+                severity: warn
+                # TODO: #3887 — 14 FLEIDs map to multiple student_numbers in PS.
       - name: gifted_and_talented
         data_type: string


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will project `student_number` from `kippmiami/int_fldoe__all_assessments` by joining `stg_powerschool__u_studentsuserfields` on FLEID. This is phase 1 of [#3886](https://github.com/TEAMSchools/teamster/issues/3886) — the kipptaf cleanup (removing its redundant `fleid_lookup` CTE) ships in a follow-up PR after this change is materialized in prod, since kipptaf reads the new column via a cross-region `source()` that resolves to prod under `target=staging`.

## Workaround flagged inline

The join includes a `dbt_utils.deduplicate(partition_by="fleid", order_by="dcid desc")` to keep the model's uniqueness test green. Probing surfaced **14 FLEIDs each tied to 2+ distinct `student_number`s** in `kippmiami_powerschool.stg_powerschool__u_studentsuserfields`. Without dedupe, the join produces 175 fan-out rows that fail the model's uniqueness test. The dedupe picks the most recent enrollment (highest `dcid`).

This is a data-quality issue at the PowerSchool source. Tracked under [#3887](https://github.com/TEAMSchools/teamster/issues/3887) — when the source is clean, the dedupe workaround can be removed.

### AI Assistance

AI-authored via interactive collaboration. Human-directed: scope (phase 1 only), drop+restore-dedupe iteration, PS-source data-quality investigation, decision to ship dedupe as a workaround with a tracked source-side fix.

Refs [#3886](https://github.com/TEAMSchools/teamster/issues/3886) (phase 1 of two).
Refs [#3887](https://github.com/TEAMSchools/teamster/issues/3887) (PS-source duplicates, surfaced by this work).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file updated with model description, model-level uniqueness test, and new `student_number` column.
- [x] No mart-layer changes.
- [x] No external source changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not triggered (no Dagster code changes).