### PR TITLE
refactor(dbt): remove redundant FLEID lookup from kipptaf int_fldoe__all_assessments (phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,9 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Pull requests**: Squash merge. Use `.github/pull_request_template.md` as the
   PR body.
 
+- **PR project linkage**: PRs auto-appear on project boards via issue refs
+  (`Refs #N`, `Closes #N`) in the body. Do NOT `gh project item-add` a PR.
+
 - **Python**: Always `uv run` — never bare `python`, `python3`, or
   venv-installed tools (`dbt`, `dagster`, etc.).
 
@@ -97,6 +100,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Built-in tools over Bash**: Use dedicated tools for file I/O (Read, Grep,
   Glob, Edit, Write). Bash is only for commands with no dedicated tool (`git`,
   `uv run`, `gh`, `docker`, `trunk`, `ls`).
+
+- **Don't pipe `Bash(run_in_background=true)` output through
+  `head`/`tail`/`grep`**. The pipe truncates what reaches the output file —
+  defeats the purpose. Pipe the raw stream; filter with Read/Bash after.
 
 - **Verify tool-call results for resource creation/update**: syntax errors in
   structured tool-call parameters (malformed closing tags, misnested blocks) can
@@ -308,6 +315,10 @@ data. `list_time_series` `alignmentPeriod` must end with `s` (e.g., `"60s"` not
 
 Truncates results at 50 rows. When querying `INFORMATION_SCHEMA.COLUMNS` for
 wide tables, paginate with `WHERE ordinal_position > N`.
+
+`bq` CLI fallback for shell contexts (Monitor poll loops): binary at
+`/usr/local/share/google-cloud-sdk/bin/bq`, `--project_id=teamster-332318`. Same
+SELECT-only constraints apply.
 
 Pre-merge queries against PR-branch schema use
 `dbt_cloud_pr_<ci_id>_<pr_num>_<schema>` — prod `<schema>` lacks unmerged

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -86,6 +86,19 @@ Two inline patterns (see spec for details):
 - **Region source schema** (kipptaf `sources-kipp*` files only): prefixes for
   `dev` only (`defer` resolves to production)
 
+## kipptaf source consumers of district columns
+
+When adding a new column to a district intermediate consumed by kipptaf via
+`source()`, ship in two PRs: district first, wait for Dagster to materialize
+prod, then kipptaf. The kipptaf source resolves to prod for `target=staging`
+(dbt Cloud CI), so coupling fails CI deterministically.
+
+## dbt logs persist locally
+
+Every `dbt` invocation appends to `<project>/logs/dbt.log` (full output, not
+truncated). When a background build's captured output is incomplete, read that
+file before re-running the build.
+
 ## dbt Cloud CI state comparison
 
 `state:modified+` hashes every source node through `{{ target.name }}`
@@ -153,15 +166,17 @@ change.
 
 A single integration may have both files under the same source `name:` — dbt
 merges at parse time. When both exist **in the same project**,
-`sources-bigquery.yml` may omit `schema:` (inherits from the external file).
-However, in **source-system packages** consumed by district projects, the
-cross-file schema merge does not bridge the package/consumer boundary — the
-consuming project's schema override won't reach the package-level BQ file. In
-that case, `sources-bigquery.yml` must include its own `schema:` (plain `var()`
-without target-conditional prefixes, since BQ-native tables are static
-production data). Never mix `external:` and non-external active tables in one
-file. Source-system projects place source files alongside or inside their model
-subdirectories, not at the top-level `models/` directory.
+`sources-bigquery.yml` may omit `schema:` ONLY for tables also declared in
+`sources-external.yml`. Tables declared only in the BQ file do NOT inherit and
+resolve to bare `<source_name>` (likely a non-existent dataset). However, in
+**source-system packages** consumed by district projects, the cross-file schema
+merge does not bridge the package/consumer boundary — the consuming project's
+schema override won't reach the package-level BQ file. In that case,
+`sources-bigquery.yml` must include its own `schema:` (plain `var()` without
+target-conditional prefixes, since BQ-native tables are static production data).
+Never mix `external:` and non-external active tables in one file. Source-system
+projects place source files alongside or inside their model subdirectories, not
+at the top-level `models/` directory.
 
 ### `{{ project_name }}` in source schemas
 

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -7,30 +7,6 @@ with
         }}
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    fleid_lookup_raw as (
-        select s.student_number, s.dcid, suf.fleid,
-        from {{ ref("stg_powerschool__students") }} as s
-        inner join
-            {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
-            on s.dcid = suf.studentsdcid
-            and {{ union_dataset_join_clause(left_alias="s", right_alias="suf") }}
-        where
-            s._dbt_source_relation like '%kippmiami%'
-            and s.dcid >= 1
-            and suf.fleid is not null
-    ),
-
-    fleid_lookup as (
-        {{
-            dbt_utils.deduplicate(
-                relation="fleid_lookup_raw",
-                partition_by="fleid",
-                order_by="dcid desc",
-            )
-        }}
-    ),
-
     scale_crosswalk as (
         select
             administration_window,
@@ -79,7 +55,7 @@ select
     fl.student_id,
     fl.assessment_name,
 
-    pl.student_number,
+    fl.student_number,
 
     cw1.sublevel_number,
     cw1.sublevel_name,
@@ -103,7 +79,6 @@ select
         order by fl.administration_window asc
     ) as scale_score_prev,
 from source as fl
-left join fleid_lookup as pl on fl.student_id = pl.fleid
 left join
     scale_crosswalk as sc
     on fl.academic_year = sc.academic_year

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -54,7 +54,6 @@ select
     fl.performance_level,
     fl.student_id,
     fl.assessment_name,
-
     fl.student_number,
 
     cw1.sublevel_number,

--- a/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
@@ -2,13 +2,10 @@ models:
   - name: int_fldoe__all_assessments
     description: >-
       Union of FLDOE state assessment results (EOC, FAST, Science, FSA) across
-      kippmiami source relations, with assessment-grade and performance-level
-      coalesced to single canonical fields and assessment_name derived from the
-      source relation. Adds a PowerSchool student_number resolved via the
-      stg_powerschool__u_studentsuserfields.fleid lookup so downstream marts can
-      FK into dim_students on the PowerSchool identifier space rather than the
-      FLEID. Joined to the iReady scale-score crosswalk to expose sublevel and
-      points-to-proficiency / points-to-growth derivations.
+      kippmiami source relations, sourced from the kippmiami
+      int_fldoe__all_assessments intermediate which resolves student_number via
+      the FLEID lookup. Joined to the iReady scale-score crosswalk to expose
+      sublevel and points-to-proficiency / points-to-growth derivations.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -50,11 +47,10 @@ models:
       - name: student_number
         data_type: int64
         description: >-
-          PowerSchool student_number resolved by joining FLDOE student_id
-          (FLEID) to stg_powerschool__u_studentsuserfields.fleid for Miami
-          students. Null when no PS Miami student carries the matching FLEID.
-          Used by downstream marts to FK into dim_students consistently with
-          PowerSchool-sourced facts.
+          PowerSchool student_number resolved in the upstream kippmiami
+          int_fldoe__all_assessments model by joining FLDOE student_id (FLEID)
+          to stg_powerschool__u_studentsuserfields.fleid. Null when no PS Miami
+          student carries the matching FLEID.
       - name: sublevel_number
         data_type: int64
       - name: sublevel_name


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will complete [#3886](https://github.com/TEAMSchools/teamster/issues/3886) by removing the redundant `fleid_lookup_raw` and `fleid_lookup` CTEs from `kipptaf/int_fldoe__all_assessments`. The model now consumes `student_number` directly from the upstream `source("kippmiami_fldoe", "int_fldoe__all_assessments")` (added in [#3888](https://github.com/TEAMSchools/teamster/pull/3888), phase 1).

End state: FLEID → `student_number` resolution lives in one place (the kippmiami district intermediate), per the original design intent.

## Draft until prod materializes

Held as a draft until Dagster has materialized the kippmiami change in prod `kippmiami_fldoe`. CI will fail with `Name student_number not found inside fl` until then because dbt Cloud reads the cross-region source from prod under `target=staging`. Once prod has the column, mark ready-for-review.

### AI Assistance

AI-authored mechanical refactor: CTE removal, column-source change (`pl.student_number` → `fl.student_number`), YAML description update. Human-directed: the split-into-two-PRs decision after PR #3883's CI gap.

Refs [#3886](https://github.com/TEAMSchools/teamster/issues/3886) (phase 2 of two).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file description updated to reflect new upstream provenance.
- [x] No new/renamed columns — `student_number` column unchanged in output.
- [x] No mart-layer changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes (after prod materialization of kippmiami).
- [ ] **Dagster Cloud** — not triggered.