### PR TITLE
chore(dbt): set job_retries: 3 on remaining district prod profiles

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -217,8 +217,8 @@ deployments. Developers use `.dbt/profiles.yml` for full target support.
 
 - **`job_retries`**: dbt-bigquery defaults to `1`, which doesn't absorb
   sustained transient 503s on `client.list_datasets()` at adapter init. Set
-  `job_retries: 3` on the `prod` output. Set on kipptaf; not on kippnewark,
-  kippcamden, kippmiami, kipppaterson.
+  `job_retries: 3` on the `prod` output. Set on all district profiles and
+  kipptaf.
 
 ## Model Conventions
 

--- a/src/dbt/kippcamden/profiles.yml
+++ b/src/dbt/kippcamden/profiles.yml
@@ -15,3 +15,4 @@ kippcamden:
       method: oauth
       project: teamster-332318
       threads: 40
+      job_retries: 3

--- a/src/dbt/kippmiami/profiles.yml
+++ b/src/dbt/kippmiami/profiles.yml
@@ -15,3 +15,4 @@ kippmiami:
       method: oauth
       project: teamster-332318
       threads: 40
+      job_retries: 3

--- a/src/dbt/kippnewark/profiles.yml
+++ b/src/dbt/kippnewark/profiles.yml
@@ -15,3 +15,4 @@ kippnewark:
       method: oauth
       project: teamster-332318
       threads: 40
+      job_retries: 3

--- a/src/dbt/kipppaterson/profiles.yml
+++ b/src/dbt/kipppaterson/profiles.yml
@@ -15,3 +15,4 @@ kipppaterson:
       method: oauth
       project: teamster-332318
       threads: 40
+      job_retries: 3


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will mirror the kipptaf `job_retries: 3` change from #3860 across the remaining district dbt profiles (kippmiami, kippnewark, kippcamden, kipppaterson) so dbt-bigquery's adapter-level retry absorbs transient BigQuery 503s on `client.list_datasets()` at adapter init, instead of falling through to Dagster's run-level auto-retry.

Today's day-2 window caught the same 503 signature in two new locations:

- kippmiami run `03d39d1f-1070-4163-bae8-43e8efb46eed` (`kippmiami_dbt_assets`)
- kippnewark run `fbec1d82-0373-4800-bc86-37c4ee7870f4` (`kippnewark_dbt_assets`)

Both recovered via Dagster auto-retry, but adapter-level retry keeps recovery inside the same pod (seconds of exponential backoff) instead of a fresh pod spin-up.

Refs #3892, #3860

## AI Assistance

Claude Code identified the matching 503 signatures across the two failing runs, opened #3892, and applied the four profile edits. Human-directed: decision to apply to all four districts on `main`.

## Self-review

### dbt

- [x] Change is a profile-only tweak — no model, source, or contract changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
