### PR TITLE
fix(dbt): close survey responses → submissions FK gap

### DIFF
--- a/docs/superpowers/plans/2026-05-12-survey-responses-fk-gap.md
+++ b/docs/superpowers/plans/2026-05-12-survey-responses-fk-gap.md
@@ -1,0 +1,910 @@
+# Survey Responses FK Gap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the
+`fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
+relationships-test gap (143,758 orphan response rows / 12,261 orphan submissions
+on 2026-05-12) by fixing two upstream join defects.
+
+**Architecture:** Two coordinated upstream edits.
+
+1. `int_surveys__survey_responses.sql` — add an additive Google Directory
+   alias-resolution fallback so staff respondents who took the survey from an
+   aliased email pick up their `respondent_employee_number`. Empirically
+   recovers 21 of 23 currently-null staff submissions with 0 silent
+   reassignments and 0 regressions.
+2. `fct_survey_submissions.sql` — replace the student-leg join predicate
+   (`enroll_status = 0 AND academic_year =`) with a date-range membership check
+   on `date_submitted` against the enrollment's `[entrydate, exitdate)` window;
+   drop the now-unnecessary `row_number()` tiebreaker; drop the staff-leg
+   `respondent_employee_number is not null` filter and wrap `staff_key` with the
+   nullable-FK pattern.
+
+**Tech Stack:** dbt 1.11+ (BigQuery), `dbt_utils.generate_surrogate_key`,
+`uv run dbt` invocation, sqlfluff via trunk (auto-applied at commit/push).
+
+**Working directory:** All paths in this plan are relative to the worktree root
+`/workspaces/teamster/.worktrees/cbini/fix/claude-survey-responses-fk-gap`. Use
+absolute paths or `git -C <worktree>` /
+`uv run dbt ... --project-dir <worktree>/src/dbt/kipptaf` from any other
+location (project root or other worktree).
+
+**Pre-flight:** Confirm `target/prod/manifest.json` exists under the dbt project
+(`src/dbt/kipptaf/target/prod/`). If absent or stale (older than the most recent
+`git pull`), regenerate it with:
+
+```bash
+uv run dbt parse --target prod \
+  --project-dir src/dbt/kipptaf \
+  --target-path target/prod
+```
+
+The `post-merge` git hook normally does this; only re-run if a build fails with
+"Could not find manifest".
+
+---
+
+## File Structure
+
+| File                                                                            | Action | Responsibility                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql` | Modify | Add `gdir_alias_map` CTE; add fallback `left join`s in both Google Forms (lines 41-58) and Alchemer (lines 101-120) branches; `coalesce` the resolved `employee_number` / `sam_account_name` / `user_principal_name` / `formatted_name`.                              |
+| `src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql`                 | Modify | Student leg: rewrite join predicate to half-open date-range, drop `row_number()` tiebreaker, collapse two CTEs into one, source `academic_year` from `enr` not `sr`. Staff leg: drop `is not null` filter, wrap `staff_key` with nullable-FK pattern at final SELECT. |
+| `src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml`      | Modify | Update model `description:` to document the date-range attribution rule and nullable `student_enrollment_key` / `staff_key` semantics.                                                                                                                                |
+
+No new files. No schema/contract changes.
+
+---
+
+## Task 1: Add Google Directory alias-fallback to `int_surveys__survey_responses`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql`
+
+This task is purely additive. The existing `left join` on
+`int_people__staff_roster_history` stays. We add (a) a `gdir_alias_map` CTE that
+flattens `stg_google_directory__users` aliases / emails / primary, (b) a second
+`left join` chain that maps `respondent_email` → `primary_email` → fresh `srh`
+row, in **both** the Google Forms branch (lines 41-58) and the Alchemer branch
+(lines 101-120). At the final projection we `coalesce` the resolved values,
+current-path-first.
+
+### Step 1.1: Read the file in full to confirm structure
+
+- [ ] Run:
+
+```bash
+cat src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+```
+
+Expected: file is 128 lines; two `union all` branches inside an `enriched` CTE;
+both use a `left join` to `int_people__staff_roster_history as srh` to populate
+`respondent_employee_number`, `respondent_preferred_name`,
+`respondent_samaccountname`, `respondent_userprincipalname`.
+
+### Step 1.2: Replace the file body with the alias-fallback version
+
+- [ ] Apply this Edit. Old string is the existing `with` keyword opening through
+      the end of the file's terminal `from enriched as e`; new string adds the
+      `gdir_alias_map` CTE before `enriched`, plus the two fallback `left join`
+      blocks and `coalesce` projections inside each union branch.
+
+The four columns to coalesce (in this order) are:
+
+```text
+respondent_employee_number  ← srh.employee_number,  fallback srh_alias.employee_number
+respondent_preferred_name   ← srh.formatted_name,   fallback srh_alias.formatted_name
+respondent_samaccountname   ← srh.sam_account_name, fallback srh_alias.sam_account_name
+respondent_userprincipalname← srh.user_principal_name, fallback srh_alias.user_principal_name
+```
+
+The Google Forms branch passes the response timestamp into the time-bound
+predicate as `timestamp(fr.last_submitted_time)`. The Alchemer branch passes
+`sr.response_date_submitted`. Use the same expressions for the alias-fallback
+join.
+
+Replace the entire file content with the version below. (It's easier and safer
+to overwrite than to patch — the file is small.)
+
+```sql
+with
+    gdir_alias_map as (
+        select gd.primary_email, addr.address as known_address,
+        from {{ ref("stg_google_directory__users") }} as gd,
+            unnest(gd.emails) as addr
+        union distinct
+        select gd.primary_email, alias,
+        from {{ ref("stg_google_directory__users") }} as gd,
+            unnest(gd.aliases) as alias
+        union distinct
+        select gd.primary_email, gd.primary_email,
+        from {{ ref("stg_google_directory__users") }} as gd
+    ),
+
+    enriched as (
+        select
+            fr.form_id as survey_id,
+            fr.info_title as survey_title,
+            fr.response_id as survey_response_id,
+            fr.question_id as survey_question_id,
+            fr.text_value as answer,
+            fr.item_title as question_title,
+            fr.item_abbreviation as question_shortname,
+            fr.respondent_email,
+
+            rt.academic_year,
+            rt.code as term_code,
+            rt.name as term_name,
+
+            coalesce(
+                srh.employee_number, srh_alias.employee_number
+            ) as respondent_employee_number,
+
+            coalesce(
+                srh.formatted_name, srh_alias.formatted_name
+            ) as respondent_preferred_name,
+            coalesce(
+                srh.sam_account_name, srh_alias.sam_account_name
+            ) as respondent_samaccountname,
+            coalesce(
+                srh.user_principal_name, srh_alias.user_principal_name
+            ) as respondent_userprincipalname,
+
+            safe_cast(fr.text_value as numeric) as answer_value,
+
+            timestamp(fr.create_time) as date_started,
+            timestamp(fr.last_submitted_time) as date_submitted,
+
+            concat(
+                'https://docs.google.com/forms/d/',
+                fr.form_id,
+                '/edit#response=',
+                fr.response_id
+            ) as survey_response_link,
+
+            if(safe_cast(fr.text_value as int) is null, 1, 0) as is_open_ended,
+
+            dense_rank() over (
+                partition by fr.respondent_email, rt.academic_year, rt.code, fr.form_id
+                order by fr.last_submitted_time desc
+            ) as round_rn,
+        from {{ ref("int_google_forms__form_responses") }} as fr
+        left join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on fr.info_title = rt.name
+            and date(fr.last_submitted_time) between rt.start_date and rt.end_date
+            and rt.type = 'SURVEY'
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh
+            on (
+                lower(regexp_extract(fr.respondent_email, r'^([^@]+)'))
+                = srh.sam_account_name
+                or fr.respondent_email = srh.google_email
+            )
+            and timestamp(fr.last_submitted_time)
+            between srh.effective_date_start_timestamp
+            and srh.effective_date_end_timestamp
+            and srh.primary_indicator
+        left join gdir_alias_map as gam on fr.respondent_email = gam.known_address
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh_alias
+            on gam.primary_email = srh_alias.google_email
+            and timestamp(fr.last_submitted_time)
+            between srh_alias.effective_date_start_timestamp
+            and srh_alias.effective_date_end_timestamp
+            and srh_alias.primary_indicator
+
+        union all
+
+        select
+            safe_cast(sr.survey_id as string) as survey_id,
+
+            sr.survey_title,
+
+            safe_cast(sr.response_id as string) as survey_response_id,
+
+            safe_cast(sr.question_id as string) as survey_question_id,
+
+            sr.response_value as answer,
+            sr.question_title_english as question_title,
+            sr.question_short_name as question_shortname,
+
+            ri.respondent_mail as respondent_email,
+
+            coalesce(sr.campaign_fiscal_year - 1, rt.academic_year) as academic_year,
+
+            coalesce(regexp_extract(sr.campaign_name, r'\s(.*)'), rt.code) as term_code,
+
+            rt.name as term_name,
+
+            coalesce(
+                srh.employee_number, srh_alias.employee_number
+            ) as respondent_employee_number,
+            coalesce(
+                srh.formatted_name, srh_alias.formatted_name
+            ) as respondent_preferred_name,
+            coalesce(
+                srh.sam_account_name, srh_alias.sam_account_name
+            ) as respondent_samaccountname,
+            coalesce(
+                srh.user_principal_name, srh_alias.user_principal_name
+            ) as respondent_userprincipalname,
+
+            safe_cast(sr.response_value as numeric) as answer_value,
+
+            sr.response_date_started as date_started,
+            sr.response_date_submitted as date_submitted,
+
+            concat(
+                sr.survey_link_default,
+                '?snc=',
+                sr.response_session_id,
+                '&sg_navigate=start'
+            ) as survey_response_link,
+
+            if(safe_cast(sr.response_value as int) is null, 1, 0) as is_open_ended,
+
+            1 as round_rn,
+        from {{ source("alchemer", "base_alchemer__survey_results") }} as sr
+        inner join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on sr.survey_title = rt.name
+            and sr.response_date_submitted_date between rt.start_date and rt.end_date
+        left join
+            {{ source("surveys", "int_surveys__response_identifiers") }} as ri
+            on sr.survey_id = ri.survey_id
+            and sr.response_id = ri.response_id
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh
+            on (
+                lower(regexp_extract(ri.respondent_mail, r'^([^@]+)'))
+                = srh.sam_account_name
+                or ri.respondent_mail = srh.google_email
+            )
+            and sr.response_date_submitted
+            between srh.effective_date_start_timestamp
+            and srh.effective_date_end_timestamp
+            and srh.primary_indicator
+        left join gdir_alias_map as gam on ri.respondent_mail = gam.known_address
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh_alias
+            on gam.primary_email = srh_alias.google_email
+            and sr.response_date_submitted
+            between srh_alias.effective_date_start_timestamp
+            and srh_alias.effective_date_end_timestamp
+            and srh_alias.primary_indicator
+    )
+
+select
+    e.*,
+    coalesce(
+        cast(e.respondent_employee_number as string), e.respondent_email
+    ) as respondent_identifier,
+from enriched as e
+```
+
+### Step 1.3: Build the model with downstream tests
+
+- [ ] Run:
+
+```bash
+uv run dbt build --select int_surveys__survey_responses+1 \
+  --project-dir src/dbt/kipptaf \
+  --target dev \
+  --defer --state target/prod/
+```
+
+Expected: PASS for `int_surveys__survey_responses` and all
+immediately-downstream tests. `+1` limits to direct children so this step stays
+fast; the full `+` selector comes in Task 5.
+
+If the build fails with "Could not find manifest" or "table not found" on a
+`stg_*` source, regenerate the prod manifest (see Pre-flight).
+
+### Step 1.4: Verify zero silent reassignments + alias recovery sizing
+
+- [ ] Run via BigQuery MCP `mcp__bigquery__execute_sql`. Replace `<dev_schema>`
+      with the developer's dev schema (look it up via `~/.dbt/profiles.yml` or
+      the dbt parse output if unsure — it follows the pattern
+      `zz_<github_username>_kipptaf_surveys`).
+
+```sql
+with new_resolution as (
+  select
+    survey_response_id,
+    survey_title,
+    respondent_email,
+    respondent_employee_number as new_emp,
+  from `teamster-332318.<dev_schema>.int_surveys__survey_responses`
+  where survey_title in (
+    'School Community Diagnostic Staff Survey',
+    'Engagement & Support Surveys'
+  )
+),
+prod_resolution as (
+  select
+    survey_response_id,
+    respondent_email,
+    respondent_employee_number as prod_emp,
+  from `teamster-332318.kipptaf_surveys.int_surveys__survey_responses`
+  where survey_title in (
+    'School Community Diagnostic Staff Survey',
+    'Engagement & Support Surveys'
+  )
+),
+joined as (
+  select n.survey_response_id, n.respondent_email, p.prod_emp, n.new_emp
+  from new_resolution as n
+  inner join prod_resolution as p using (survey_response_id)
+)
+select
+  count(distinct survey_response_id) as distinct_submissions,
+  countif(prod_emp is null and new_emp is not null) as recovered,
+  countif(prod_emp is null and new_emp is null) as still_null,
+  countif(prod_emp is not null and new_emp != prod_emp) as reassignments,
+  countif(prod_emp is not null and new_emp is null) as regressions,
+from joined
+```
+
+Expected:
+
+- `recovered` ≥ 21 (multiple response rows per submission collapse here; the
+  distinct-submission target is 21, raw rows will be higher)
+- `still_null` corresponds to the 1 unresolvable email
+  (`jperez@apps.teamschools.org` per the spec residual)
+- `reassignments` = 0
+- `regressions` = 0
+
+**If `reassignments > 0`**: STOP. Investigate which email got reassigned and to
+which `employee_number`. Likely cause: a Google Directory record holds an alias
+that another active employee uses as their `sam_account_name`. Do NOT proceed
+until reassignments are 0 — the wrap design assumes additive-only recovery.
+
+**If `regressions > 0`**: STOP. The `coalesce(srh.x, srh_alias.x)` is
+current-first, so regressions should be impossible. If they occur, a bug exists
+in the new SQL.
+
+### Step 1.5: Commit and push
+
+- [ ] Run:
+
+```bash
+git -C . add src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+git -C . commit -m "$(cat <<'EOF'
+fix(dbt): add Google Directory alias fallback to survey response resolution
+
+Refs #3794. When the current sam_account_name / google_email join against
+int_people__staff_roster_history returns null for a staff survey response,
+fall through to a Google Directory alias-resolution path: respondent_email
+→ stg_google_directory__users (emails/aliases/primary) → primary_email →
+fresh srh lookup. Coalesce current-first.
+
+Recovers 21 of 23 currently-null respondent_employee_number values across
+staff and engagement surveys (prod 2026-05-12) with 0 silent reassignments
+and 0 regressions to currently-resolved submissions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git -C . push
+```
+
+Expected: pre-commit fmt runs cleanly; pre-push trunk-check passes
+sqlfluff/yamllint; remote receives the commit.
+
+---
+
+## Task 2: `fct_survey_submissions` — student-leg rewrite
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql` (lines
+  39-99, the `student_submissions_ranked` and `student_submissions` CTEs)
+
+Three changes in one CTE:
+
+1. Replace the join predicate
+   `enr.enroll_status = 0 AND sr.academic_year = enr.academic_year` with
+   `enr.entrydate <= sr.date_submitted AND enr.exitdate > sr.date_submitted`.
+2. Drop the
+   `row_number() OVER (PARTITION BY sr.survey_response_id ORDER BY enr.entrydate DESC)`
+   tiebreaker and the wrapper `student_submissions` CTE — collapse to a single
+   CTE.
+3. Source `academic_year` from `enr.academic_year` (not `sr.academic_year`) so
+   the `student_enrollment_key` hash composition matches
+   `dim_student_enrollments`.
+
+### Step 2.1: Apply the student-leg edit
+
+- [ ] Edit `src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql`.
+      Replace the block from line 38 `    /* Student SCD submissions */` through
+      line 99 `    ),` (inclusive — through and including the closing
+      parenthesis of `student_submissions`) with:
+
+```sql
+    /* Student SCD submissions */
+    student_submissions as (
+        select
+            sr.survey_id,
+            sr.survey_response_id,
+            sr.respondent_email,
+            sr.date_submitted,
+            sr.term_code,
+
+            rt.type as term_type,
+            rt.code as rt_code,
+            rt.`name` as rt_name,
+            rt.start_date as rt_start_date,
+            rt.region as rt_region,
+            rt.school_id as rt_school_id,
+
+            'student' as respondent_type,
+
+            enr.student_number,
+            enr._dbt_source_relation,
+            enr.academic_year,
+            enr.entrydate,
+        from {{ ref("int_surveys__survey_responses") }} as sr
+        inner join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on sr.survey_title = rt.`name`
+            and sr.academic_year = rt.academic_year
+            and sr.term_code = rt.code
+            and rt.type = 'SURVEY'
+        inner join
+            {{ ref("int_extracts__student_enrollments") }} as enr
+            on sr.respondent_email = enr.student_email
+            and enr.entrydate <= sr.date_submitted
+            and enr.exitdate > sr.date_submitted
+        where sr.survey_title = 'School Community Diagnostic Student Survey'
+    ),
+```
+
+Key points to verify after editing:
+
+- `sr.academic_year` is no longer in the SELECT list of `student_submissions`.
+  `enr.academic_year` replaces it.
+- The two-CTE shape (`student_submissions_ranked` → `student_submissions`)
+  collapses to one CTE named `student_submissions`. The `combined_student` and
+  downstream `select ... from combined_student` references continue to compile
+  because the new CTE preserves the same column set the old
+  `student_submissions` exposed (the `rn_enrollment` column is dropped — confirm
+  via grep below it has no other consumers).
+
+### Step 2.2: Confirm `rn_enrollment` was only referenced in the dropped wrapper
+
+- [ ] Run:
+
+```bash
+grep -rn "rn_enrollment" src/dbt/kipptaf/
+```
+
+Expected: zero matches. If any match exists outside the file you just edited,
+that's a real consumer — STOP and resolve.
+
+### Step 2.3: Build the model and run tests
+
+- [ ] Run:
+
+```bash
+uv run dbt build --select fct_survey_submissions \
+  --project-dir src/dbt/kipptaf \
+  --target dev \
+  --defer --state target/prod/
+```
+
+Expected: model materializes successfully; `unique` test on
+`survey_submission_key` passes; FK relationships tests against
+`dim_student_enrollments`, `dim_staff`, `dim_survey_administrations`,
+`dim_dates`, and `dim_student_contact_persons` all PASS or WARN (some WARN at
+default mart severity, which is acceptable per the spec).
+
+**If `unique` fails**: Investigate fan-out. Cause is either (a) an enrollment
+overlap that does intersect a submission date for some student (a hypothesis the
+spec explicitly tests as "currently zero"), or (b) a duplicate response
+upstream. Re-run the spec's overlap-detection query (see spec § "Implementation"
+→ "fct_survey_submissions.sql — student leg") against the dev schema's
+`student_submissions` materialization to characterize.
+
+### Step 2.4: Commit and push
+
+- [ ] Run:
+
+```bash
+git -C . add src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+git -C . commit -m "$(cat <<'EOF'
+fix(dbt): use date-range membership for student-leg enrollment join
+
+Refs #3794. Replaces the student-leg join in fct_survey_submissions from
+(academic_year =, enroll_status = 0) to a half-open date-range membership
+check on enr.entrydate <= sr.date_submitted < enr.exitdate. The old
+predicates were both wrong: enroll_status is a student-level current-active
+flag (drops historical enrollments for since-departed students), and the
+academic_year equality misses mid-year enrollment year-tag changes.
+
+Collapses student_submissions_ranked and student_submissions into a single
+CTE, dropping the row_number() tiebreaker after verifying zero
+enrollment-overlap fan-out on actual survey submissions. The PK uniqueness
+test on survey_submission_key remains the regression guard.
+
+Sources academic_year from the matched enrollment row so
+student_enrollment_key hash inputs match dim_student_enrollments.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git -C . push
+```
+
+---
+
+## Task 3: `fct_survey_submissions` — staff-leg nullable FK
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql` (lines
+  30-31 in the `staff_submissions` CTE; line 289 in the staff-leg final SELECT)
+
+Two changes:
+
+1. Drop the `sr.respondent_employee_number is not null and` predicate from
+   `staff_submissions`'s WHERE clause.
+2. Wrap `staff_key` with the nullable-FK
+   `if(... is not null, generate_surrogate_key(...), cast(null as string))`
+   pattern, mirroring `subject_staff_key`.
+
+### Step 3.1: Drop the `is not null` filter
+
+- [ ] Edit. Replace:
+
+```sql
+        where
+            sr.respondent_employee_number is not null
+            and sr.survey_title in (
+                'School Community Diagnostic Staff Survey',
+                'Engagement & Support Surveys'
+            )
+```
+
+with:
+
+```sql
+        where
+            sr.survey_title in (
+                'School Community Diagnostic Staff Survey',
+                'Engagement & Support Surveys'
+            )
+```
+
+### Step 3.2: Wrap `staff_key` with the nullable-FK pattern
+
+- [ ] Edit. Replace the line in the staff-leg final SELECT (currently
+      `fct_survey_submissions.sql:289`):
+
+```sql
+    {{ dbt_utils.generate_surrogate_key(["respondent_employee_number"]) }} as staff_key,
+```
+
+with:
+
+```sql
+    if(
+        respondent_employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["respondent_employee_number"]) }},
+        cast(null as string)
+    ) as staff_key,
+```
+
+### Step 3.3: Build and run tests
+
+- [ ] Run:
+
+```bash
+uv run dbt build --select fct_survey_submissions \
+  --project-dir src/dbt/kipptaf \
+  --target dev \
+  --defer --state target/prod/
+```
+
+Expected: PASS. The relationships test `staff_key → dim_staff.staff_key` should
+report zero orphans because every now-included null-employee submission produces
+`staff_key = null` (relationships tests treat null FKs as not-applicable).
+
+**If new `staff_key → dim_staff` orphans appear**: a recovered `employee_number`
+from Task 1's alias resolution doesn't exist in `dim_staff`. Investigate by
+joining the orphan keys back to `int_surveys__survey_responses`; cross-check
+those emails against `dim_staff`. The expected resolution: file a follow-up
+issue for the missing `dim_staff` row(s); for this PR, accept the WARN and call
+it out in the PR description.
+
+### Step 3.4: Commit and push
+
+- [ ] Run:
+
+```bash
+git -C . add src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+git -C . commit -m "$(cat <<'EOF'
+fix(dbt): include null-employee staff survey submissions
+
+Refs #3794. Drops the respondent_employee_number is not null filter from
+fct_survey_submissions.staff_submissions and wraps staff_key with the
+nullable-FK if-not-null pattern. Submissions whose respondent_employee_number
+still cannot be resolved after upstream alias resolution now produce a row
+with staff_key = null, restoring 1:1 coverage with fct_survey_responses.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git -C . push
+```
+
+---
+
+## Task 4: Update `fct_survey_submissions` model description
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml`
+  (lines 3-10 model description; line 70-72 `staff_key`; line 86-88
+  `student_enrollment_key`)
+
+Update the descriptions to document (a) the date-range attribution rule for the
+student leg, (b) the nullable-FK semantics on `staff_key` and
+`student_enrollment_key`.
+
+### Step 4.1: Update model-level description
+
+- [ ] Edit. Replace lines 3-10:
+
+```yaml
+description: >-
+  Survey submission fact table. One row per respondent x survey_administration.
+  Records survey completion events across all populations (staff, student,
+  family). The respondent_type discriminator determines which respondent FK is
+  populated (exactly one per row). Nullable subject_staff_key is populated only
+  for Manager Survey submissions (role-playing FK to dim_staff for the manager
+  being evaluated). FK to dim_survey_administrations and dim_dates.
+```
+
+with:
+
+```yaml
+description: >-
+  Survey submission fact table. One row per respondent x survey_administration.
+  Records survey completion events across all populations (staff, student,
+  family). The respondent_type discriminator determines which respondent FK is
+  populated (exactly one per row). For student submissions,
+  student_enrollment_key resolves to the enrollment row whose [entrydate,
+  exitdate) window contains date_submitted. staff_key and student_enrollment_key
+  are nullable for respondents whose identity cannot be resolved (e.g. staff
+  respondents whose employee_number was never linked, or student respondents
+  whose email is not present in int_extracts__student_enrollments). Nullable
+  subject_staff_key is populated only for Manager Survey submissions
+  (role-playing FK to dim_staff for the manager being evaluated). FK to
+  dim_survey_administrations and dim_dates.
+```
+
+### Step 4.2: Update `staff_key` column description
+
+- [ ] Edit. Replace:
+
+```yaml
+- name: staff_key
+  data_type: string
+  description: >-
+    FK to dim_staff for the respondent. Populated when respondent_type is staff.
+    Null for student and family.
+```
+
+with:
+
+```yaml
+- name: staff_key
+  data_type: string
+  description: >-
+    FK to dim_staff for the respondent. Populated when respondent_type is staff
+    AND the upstream respondent_employee_number resolves. Null for student /
+    family respondents AND for staff respondents whose identity cannot be
+    resolved upstream.
+```
+
+### Step 4.3: Update `student_enrollment_key` column description
+
+- [ ] Edit. Replace:
+
+```yaml
+- name: student_enrollment_key
+  data_type: string
+  description: >-
+    FK to dim_student_enrollments for the respondent. Populated when
+    respondent_type is student. Null for staff and family.
+```
+
+with:
+
+```yaml
+- name: student_enrollment_key
+  data_type: string
+  description: >-
+    FK to dim_student_enrollments for the respondent, resolved by matching
+    respondent_email to an enrollment row whose [entrydate, exitdate) window
+    contains date_submitted. Populated when respondent_type is student AND such
+    an enrollment exists. Null for staff / family respondents AND for student
+    respondents whose email is not present in int_extracts__student_enrollments
+    or has no enrollment row covering date_submitted.
+```
+
+### Step 4.4: Re-parse the project to verify YAML is well-formed
+
+- [ ] Run:
+
+```bash
+uv run dbt parse --target dev \
+  --project-dir src/dbt/kipptaf \
+  --no-partial-parse
+```
+
+Expected: parse completes without errors. `--no-partial-parse` forces a full
+re-parse so any description-merge edge case surfaces.
+
+### Step 4.5: Commit and push
+
+- [ ] Run:
+
+```bash
+git -C . add src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+git -C . commit -m "$(cat <<'EOF'
+docs(dbt): update fct_survey_submissions description for nullable FKs
+
+Refs #3794. Documents the date-range attribution rule for the student leg
+and the nullable-FK semantics on staff_key and student_enrollment_key.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git -C . push
+```
+
+---
+
+## Task 5: Final verification on PR-branch schema
+
+After Task 4 pushes, the dbt Cloud CI job builds the PR's models into a schema
+named `dbt_cloud_pr_<ci_id>_3794_<schema_part>`. Wait for CI to complete
+(visible on the GitHub PR), then verify against the materialized PR-branch
+tables.
+
+### Step 5.1: Find the CI run's PR-schema id
+
+- [ ] Run:
+
+```bash
+gh pr view --json number,statusCheckRollup
+```
+
+Look for the dbt Cloud CI run and its run id. The PR-branch schema follows the
+pattern `dbt_cloud_pr_<env_id>_<pr_number>_<schema_suffix>`. For this repo
+`env_id` is `70403104388001` and `pr_number` is whatever GitHub assigned. The
+suffix matches the model's prod schema suffix (`surveys`, `marts`, `extracts`,
+etc.).
+
+### Step 5.2: Verify orphan count returns to zero on PR-branch marts schema
+
+- [ ] Run via `mcp__bigquery__execute_sql`, substituting the correct PR-branch
+      schema names:
+
+```sql
+select
+  count(*) as orphan_responses,
+  count(distinct r.survey_submission_key) as orphan_distinct_submissions,
+from `teamster-332318.dbt_cloud_pr_70403104388001_<PR>_marts.fct_survey_responses` as r
+left join `teamster-332318.dbt_cloud_pr_70403104388001_<PR>_marts.fct_survey_submissions` as s
+  on r.survey_submission_key = s.survey_submission_key
+where r.survey_submission_key is not null
+  and s.survey_submission_key is null
+```
+
+Expected: `orphan_responses = 0` and `orphan_distinct_submissions = 0`.
+
+If non-zero, run the diagnostic breakdown:
+
+```sql
+select
+  r.respondent_type,
+  r.survey_title,
+  count(*) as orphan_rows,
+  count(distinct r.survey_submission_key) as distinct_submissions,
+from `teamster-332318.dbt_cloud_pr_70403104388001_<PR>_marts.fct_survey_responses` as r
+left join `teamster-332318.dbt_cloud_pr_70403104388001_<PR>_marts.fct_survey_submissions` as s
+  on r.survey_submission_key = s.survey_submission_key
+where r.survey_submission_key is not null
+  and s.survey_submission_key is null
+group by 1, 2
+order by orphan_rows desc
+```
+
+### Step 5.3: Confirm PK uniqueness and FK relationships tests pass
+
+- [ ] Use `mcp__dbt__get_job_run_error` with `warning_only=true` on the CI run's
+      job id and look for any test referencing `fct_survey_submissions`. The
+      relationship test for
+      `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
+      should report zero rows; the `unique` test on `survey_submission_key`
+      should pass.
+
+If the `fct_survey_responses → fct_survey_submissions` relationships test
+reports zero rows, optionally flip its severity from default `warn` to `error`
+(in the properties yml for `fct_survey_responses`); confirm with the user before
+doing so since severity changes affect deploy-time gating.
+
+### Step 5.4: Marts pre-merge checklist
+
+- [ ] Walk the `marts/CLAUDE.md` § "Pre-merge checklist" items inline in the PR
+      description:
+  - Diamond paths introduced? (Expected: no — only join shape changed.)
+  - R1–R10 violations? (Expected: no — no new columns.)
+  - Marts-model warnings from latest CI run via
+    `mcp__dbt__get_job_run_error(warning_only=true)`. List any new warnings; for
+    each, search open issues by model name + FK target. Confirm the survey-FK
+    warning disappears and no new warnings (incl. `staff_key → dim_staff`)
+    appear.
+  - Scan `https://github.com/orgs/TEAMSchools/projects/4/views/1` for bonus
+    issues incidentally resolved; close them in the PR.
+
+### Step 5.5: Open the PR
+
+- [ ] Open the PR using the repository's PR template
+      (`.github/pull_request_template.md` — `gh pr create` loads it by default).
+      Title: `fix(dbt): close survey responses → submissions FK gap`. Body: fill
+      in the template's _Summary & Motivation_ with:
+
+  > When merged, this pull request will close the
+  > `fct_survey_responses → fct_survey_submissions` FK gap (143,758 orphan
+  > response rows / 12,261 orphan submissions on 2026-05-12) by adding a Google
+  > Directory alias-resolution fallback in `int_surveys__survey_responses` and
+  > rewriting the `fct_survey_submissions` student-leg join to use date-range
+  > enrollment membership. Closes #3794.
+
+  Add an _AI Assistance_ note: spec authoring, plan generation, and SQL drafting
+  were Claude-assisted; data verification (BigQuery queries against prod and dev
+  schemas) and final review human-directed.
+
+  Check the dbt section items as applicable (no new exposures, no new external
+  sources, no breaking column renames). Leave the unrelated sections unchecked /
+  let the template's "skip if no X changes" guidance apply.
+
+- [ ] Run:
+
+```bash
+gh pr create --title "fix(dbt): close survey responses → submissions FK gap"
+```
+
+(omitting `--body` so `gh` opens an editor pre-filled with the template; paste
+in the summary above before saving)
+
+---
+
+## Follow-up issues to file (not part of this PR)
+
+- **LDAP `employeeID` provisioning gap** — the `jperez@apps.teamschools.org`
+  residual. Administrative remediation, not a model change.
+- **`int_people__staff_roster_history` identifier historicization** —
+  `sam_account_name` / `google_email` / `user_principal_name` overwritten with
+  current values across all effective-dated rows; a true effective-dated
+  identifier history would obviate the Directory-alias fallback added in this
+  PR.
+- **Paterson `primary_indicator = false` on currently-effective rows** — for
+  both Paterson Prep staff in `int_people__staff_roster_history`, the most
+  recent effective row has `primary_indicator = false`, meaning the existing
+  survey-response join would miss them even if AD linkage were intact.
+- **`int_extracts__student_enrollments` overlapping date ranges** — 3
+  overlapping pairs across 2 students in prod 2026-05-12. Doesn't affect survey
+  submissions today but warrants the upstream
+  `base_powerschool__student_enrollments` cleanup tracked in #3633.

--- a/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
+++ b/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
@@ -16,40 +16,76 @@ Current prod sizing (BigQuery, 2026-05-12):
 
 ## Root cause
 
-`fct_survey_submissions` filters student responses to an active-enrollment
-match; `fct_survey_responses` carries every student response with a non-null
-`question_shortname`. Two scope mismatches produce orphans:
+`fct_survey_submissions.student_submissions_ranked`
+([fct_survey_submissions.sql:71-75](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L71-L75))
+joins `int_extracts__student_enrollments` on `(respondent_email, academic_year)`
+with `enr.enroll_status = 0`. Both legs of that predicate are wrong:
 
-1. **Student leg** — `fct_survey_submissions.student_submissions_ranked`
-   (`fct_survey_submissions.sql:71-75`) does an `INNER JOIN` to
-   `int_extracts__student_enrollments` on `(respondent_email, academic_year)`
-   with `enroll_status = 0`. Any response whose email doesn't resolve to an
-   active enrollment in the same academic year is dropped from submissions but
-   remains in responses.
-2. **Staff leg** — `fct_survey_submissions.staff_submissions`
-   (`fct_survey_submissions.sql:30-31`) filters
-   `respondent_employee_number is not null`. Responses with null employee number
-   stay in `fct_survey_responses`.
+- **`enroll_status` is a student-level flag**, not an enrollment-level one — it
+  reflects the student's _current_ active status across all their enrollment
+  rows, not whether the row in hand was active on `date_submitted`. Filtering by
+  it drops every historical enrollment row for students who have since withdrawn
+  / transferred / graduated, even though those students were active when they
+  submitted the survey.
+- **`academic_year` equality** assumes the submission's academic-year tag
+  exactly matches the enrollment's; for students with mid-year enrollment
+  changes (transfer in/out, exit + re-entry) the matching enrollment row may
+  fall under a different year tag than the submission's term.
 
-Three orphan sub-classes within the student leg (from the prior verification
-captured on the issue):
+The correct membership condition is **`date_submitted` falls inside the
+enrollment's `[entrydate, exitdate)` window** — that's the only join predicate
+that answers "which enrollment was this student in when they submitted?"
 
-- (a) **Inactive but known** — email matches an enrollment row in a different
-  academic year, or in the same year with `enroll_status != 0`. Resolvable.
-- (b) **Unknown email** — email never appears in
-  `int_extracts__student_enrollments`. Not resolvable; must accept null FK.
-- (c) **Staff residual** — null `respondent_employee_number`. Small class.
+The staff leg has a separate, smaller coverage gap with two contributing causes:
+
+1. **Upstream null `respondent_employee_number`.**
+   `int_surveys__survey_responses` resolves `respondent_employee_number` by
+   joining `int_people__staff_roster_history` on either
+   `local_part(respondent_email) = srh.sam_account_name` or
+   `respondent_email = srh.google_email`, time-bounded to the row's effective
+   window. `int_people__staff_roster_history` carries the **current**
+   `sam_account_name` / `google_email` on every effective-dated row — those
+   identifiers are not historicized — so a survey submitted under an employee's
+   prior email/username can never match. Empirically (prod, 2026-05-12) 23 of
+   35,600 staff/engagement responses across 14 distinct emails are null; 13 of
+   the 14 emails are preserved as historical entries in
+   `stg_google_directory__users.emails` / `aliases` with a current
+   `primary_email` that does resolve to an `employee_number`.
+2. **Downstream filter on the resolved value.**
+   `fct_survey_submissions.staff_submissions`
+   ([fct_survey_submissions.sql:30-31](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L30-L31))
+   then filters `respondent_employee_number is not null`, dropping the residual
+   from `fct_survey_submissions` entirely.
 
 ## Decision
 
-**Widen `fct_survey_submissions` to cover every response that
-`fct_survey_responses` carries.** The student leg becomes a `LEFT JOIN` with a
-last-known-enrollment fallback for `student_enrollment_key`; the staff leg drops
-the null-employee-number filter and lets `staff_key` be null when source is
-null.
+**Replace the student-leg join predicate with a date-range membership check on
+`date_submitted` against the enrollment's entry / exit dates, and drop
+`enroll_status` and `academic_year` from the join.** Use a half-open interval
+per `marts/CLAUDE.md` → "Date-range joins" to avoid boundary fan-out on
+back-to-back enrollments.
+
+For the staff leg, two changes:
+
+1. **Upstream in `int_surveys__survey_responses`**: add an additive Google
+   Directory alias-resolution fallback for `respondent_employee_number` — when
+   the existing `sam_account_name` / `google_email` join returns null, map
+   `respondent_email` to its `primary_email` via `stg_google_directory__users`
+   (any of `primary_email`, `aliases`, `emails[].address`), then re-join
+   `int_people__staff_roster_history` on `srh.google_email = primary_email`.
+   Empirically recovers 21 of 23 currently- null submissions with zero silent
+   reassignments and zero regressions to currently-resolved submissions; the 2
+   residuals are one employee whose `int_people__staff_roster_history` coverage
+   gap (separate upstream issue) leaves them unresolved.
+2. **Downstream in `fct_survey_submissions`**: drop the
+   `respondent_employee_number is not null` filter and let `staff_key` be null
+   when source is null, covering the residual.
 
 Rejected alternatives:
 
+- _Keep `academic_year` in the join and only fix `enroll_status`_ — still drops
+  responses whose submission-year tag disagrees with the enrollment's year tag
+  (the year-tag mismatch is real for mid-year transfers).
 - _Filter `fct_survey_responses` down to the active-enrollment scope_ — drops
   real response events; analysts counting "students who answered Q1" would get a
   silently low number.
@@ -61,31 +97,99 @@ Rejected alternatives:
 
 ### `fct_survey_submissions.sql` — student leg
 
-Replace the `student_submissions_ranked` CTE so it:
+Rewrite `student_submissions_ranked` so the join is:
 
-1. `LEFT JOIN`s `int_extracts__student_enrollments` on
-   `(respondent_email, academic_year)` with **no** `enroll_status` predicate.
-2. Tiebreak with
-   `row_number() OVER (PARTITION BY survey_response_id ORDER BY (enroll_status = 0) DESC, entrydate DESC)`
-   so an active match wins, then most recent entrydate.
-3. For responses whose email has no match in the same academic year, add a
-   second CTE that looks up the same student's most recent enrollment across any
-   academic year by `respondent_email`, partitioned with
-   `row_number() OVER (PARTITION BY respondent_email ORDER BY academic_year DESC, entrydate DESC)`
-   so we attribute to the latest known enrollment.
-4. `COALESCE` the same-year match with the fallback. Responses whose email is
-   unknown to enrollments entirely fall through with null `student_number` /
-   `_dbt_source_relation` / `entrydate`.
+```sql
+inner join
+    {{ ref("int_extracts__student_enrollments") }} as enr
+    on sr.respondent_email = enr.student_email
+    and enr.entrydate <= sr.date_submitted
+    and enr.exitdate > sr.date_submitted
+```
 
-`student_enrollment_key` is already wrapped in the
-`if(... is not null, generate_surrogate_key(...), cast(null as string))` pattern
-at the final SELECT, so null inputs produce a null FK without further changes.
+Half-open interval (`entrydate <= ... and exitdate > ...`), not `BETWEEN` — per
+`marts/CLAUDE.md`, `BETWEEN` fans out when consecutive enrollments share a
+boundary date.
+
+**Drop the existing `row_number() OVER (PARTITION BY survey_response_id ...)`
+tiebreaker** and collapse the `student_submissions_ranked` →
+`student_submissions` two-CTE structure into a single CTE.
+`int_extracts__student_enrollments` has 3 overlapping date-range pairs in prod
+across 2 students (one Camden boundary off-by-one between two consecutive
+same-school years; one Miami student with a wide phantom multi-year row
+coexisting with two short same-year rows). Joining all distinct student SCD
+submissions against the table under the half-open predicate produces zero
+multi-matches today — none of the three overlap windows intersect a submission
+date for the affected students. The PK uniqueness test on
+`survey_submission_key` guards against regression if a future overlap ever does
+produce fan-out.
+
+Responses whose email resolves to no enrollment row whose window contains
+`date_submitted` fall out of the student leg. The `student_enrollment_key`
+column is built from `student_number` / `_dbt_source_relation` / `academic_year`
+/ `entrydate` at the final SELECT
+([fct_survey_submissions.sql:320-329](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L320-L329)),
+so the `academic_year` value attributed to the submission comes from the
+enrollment row itself (`enr.academic_year`), not from `sr.academic_year`. Pull
+`enr.academic_year` through the CTE alongside `student_number` /
+`_dbt_source_relation` / `entrydate`, and reference it (not `sr.academic_year`)
+in the `student_enrollment_key` hash inputs.
+
+### `int_surveys__survey_responses.sql` — alias-resolution fallback
+
+Both `respondent_employee_number`-producing branches of the file (Google Forms
+union at `int_surveys__survey_responses.sql:17` and Alchemer-equivalent at
+`int_surveys__survey_responses.sql:81`) currently `left join`
+`int_people__staff_roster_history` on
+`(local_part(respondent_email) = srh.sam_account_name OR respondent_email = srh.google_email)`
+plus time-bound + `primary_indicator`. Keep that join. Add a second `left join`
+against an alias-resolution CTE; pull
+`coalesce(srh.employee_number, srh_alias.employee_number)` (and the parallel
+`formatted_name` / `sam_account_name` / `user_principal_name`) through to the
+SELECT.
+
+Alias-resolution CTE shape:
+
+```sql
+gdir_alias_map as (
+    select gd.primary_email, addr.address as known_address
+    from {{ ref("stg_google_directory__users") }} as gd,
+        unnest(gd.emails) as addr
+    union distinct
+    select gd.primary_email, alias
+    from {{ ref("stg_google_directory__users") }} as gd,
+        unnest(gd.aliases) as alias
+    union distinct
+    select gd.primary_email, gd.primary_email
+    from {{ ref("stg_google_directory__users") }} as gd
+),
+```
+
+Fallback join (applied in both union branches):
+
+```sql
+left join gdir_alias_map as gam
+    on fr.respondent_email = gam.known_address
+left join {{ ref("int_people__staff_roster_history") }} as srh_alias
+    on gam.primary_email = srh_alias.google_email
+    and timestamp(fr.last_submitted_time)
+        between srh_alias.effective_date_start_timestamp
+        and srh_alias.effective_date_end_timestamp
+    and srh_alias.primary_indicator
+```
+
+Reference `stg_google_directory__users` is already a kipptaf source; no new
+upstream package required. Verify that the new CTE doesn't introduce fan-out at
+the response grain — the `union distinct` form on `gdir_alias_map` deduplicates
+redundant (primary_email, known_address) pairs across users.
 
 ### `fct_survey_submissions.sql` — staff leg
 
 Remove the `respondent_employee_number is not null` filter from
-`staff_submissions` (`fct_survey_submissions.sql:30-31`). The final SELECT's
-`staff_key` already would need wrapping — apply the nullable-FK pattern:
+`staff_submissions`
+([fct_survey_submissions.sql:30-31](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L30-L31)).
+Apply the nullable-FK wrap to `staff_key` at the final SELECT
+([fct_survey_submissions.sql:289](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L289)):
 
 ```sql
 if(
@@ -95,8 +199,8 @@ if(
 ) as staff_key,
 ```
 
-The same wrap is already used for `subject_staff_key`; this just makes
-`staff_key` symmetric.
+Symmetric with `subject_staff_key`
+([fct_survey_submissions.sql:294-298](src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql#L294-L298)).
 
 ### Tests
 
@@ -106,17 +210,22 @@ The same wrap is already used for `subject_staff_key`; this just makes
   `severity: error` once the orphan count returns to zero post-change.
 - No `not_null` tests added on `student_enrollment_key` or `staff_key` — both
   are legitimately nullable on this fact (multi-respondent-type union).
-- PK uniqueness test on `survey_submission_key` already exists; verify it still
-  holds after the widening (composition unchanged, so should be a no-op).
+- PK uniqueness test on `survey_submission_key` already exists. With the
+  tiebreaker dropped, this test is the load-bearing guard against future
+  enrollment-overlap fan-out — verify it still passes on the PR-branch schema.
 
 ### YAML
 
 - Update `fct_survey_submissions` model description to note that the student leg
-  attributes to the most recent known enrollment when no active-year enrollment
-  exists, and that `student_enrollment_key` / `staff_key` are nullable for
-  responses that can't be attributed.
-- No column rename or contract change — hash composition is unchanged, all
-  output columns keep their types.
+  attributes a response to the enrollment whose `[entrydate, exitdate)` window
+  contains `date_submitted`, and that `student_enrollment_key` / `staff_key` are
+  nullable for responses that can't be attributed.
+- No column rename or contract change — hash composition is unchanged
+  structurally (same input columns); the `academic_year` _value_ feeding the
+  hash now sources from the enrollment row rather than the response row, which
+  will reshuffle keys for any response whose response-year tag differed from its
+  enrollment-year tag. Acceptable per `marts/CLAUDE.md` → "Spec authoring
+  context" (no production consumers yet).
 
 ## Out of scope
 
@@ -127,18 +236,38 @@ The same wrap is already used for `subject_staff_key`; this just makes
 - **#3790** multi-select expansion — already merged; sizing in this spec
   includes its contribution.
 - **`int_extracts__student_enrollments` semantics** — taken as authoritative for
-  "what enrollments exist." No upstream change.
+  "what enrollments exist" and for `entrydate` / `exitdate` values. No upstream
+  change.
+- **Historicizing `sam_account_name` / `google_email` in
+  `int_people__staff_roster_history`** — the alias-resolution fallback in
+  `int_surveys__survey_responses` covers the staff-survey case empirically; a
+  full historicization of the identifier columns would help other email-keyed
+  joiners and should be filed separately.
+- **LDAP `employeeID` provisioning gap** — one of the 14 null-employee emails
+  (its own Directory primary, no alias chain) maps to an employee who is Active
+  in ADP across the submission window AND has a complete LDAP
+  (`stg_ldap__user_person`) record with the correct `google_email`,
+  `sam_account_name`, `user_principal_name`, and `mail`. The break is in LDAP's
+  `employee_number` column — it's NULL because the user's `employeeID` AD
+  attribute was set to a temporary placeholder (`TMP00378`-style) at
+  provisioning and never reconciled to her real ADP `employee_number`.
+  `int_people__staff_roster_history` joins ADP ↔ LDAP on `employee_number`, so
+  that NULL on the LDAP side strands her ADP record with no AD/Workspace
+  identifiers. Neither the existing `sam_account_name` / `google_email` join nor
+  the Directory-alias fallback can recover her. Remediation is administrative
+  (correct her AD `employeeID` attribute), not a model change; tracked
+  separately. The nullable `staff_key` wrap covers the residual here.
 
 ## Pre-merge checklist (per `marts/CLAUDE.md`)
 
-- [ ] Scan touched models for diamond paths (none introduced — only adds a
-      same-target fallback path within the existing
-      `int_extracts__student_enrollments` join).
+- [ ] Scan touched models for diamond paths (none introduced — the join shape
+      changes but the FK target is unchanged).
 - [ ] Scan touched models for R1–R10 violations (no new columns).
 - [ ] Pull marts-model warnings from latest CI run via dbt MCP
       `get_job_run_error(warning_only=true)`; confirm the
       `fct_survey_responses → fct_survey_submissions` warning disappears and no
-      new warnings are introduced.
+      new warnings are introduced (incl. no new `staff_key → dim_staff` orphans
+      from the alias-resolved employee numbers).
 - [ ] Scan
       [project board #4](https://github.com/orgs/TEAMSchools/projects/4/views/1)
       for bonus issues incidentally resolved; close them in the PR.
@@ -150,11 +279,14 @@ The same wrap is already used for `subject_staff_key`; this just makes
 - `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
   relationships test returns 0 rows on the PR-branch schema.
 - `fct_survey_submissions.survey_submission_key` uniqueness test still passes.
-- Row count of `fct_survey_submissions` increases by approximately the number of
-  orphan submissions resolved (~12K), not by a fan-out multiplier.
-- `student_enrollment_key` nullability: null only for responses whose email is
-  unknown to `int_extracts__student_enrollments` entirely (sized at ~17 from the
-  prior verification, likely similar now).
-- `staff_key` nullability: null only for responses with null
-  `respondent_employee_number` (~23 distinct submissions in the prior
-  verification).
+- `student_enrollment_key` nullability: null only for responses whose email has
+  no enrollment row covering `date_submitted` in
+  `int_extracts__student_enrollments`.
+- `staff_key` nullability: null only for responses whose
+  `respondent_employee_number` cannot be resolved by either the existing
+  `sam_account_name` / `google_email` join or the Google Directory alias
+  fallback (sized at 2 distinct submissions, 1 email, in prod 2026-05-12).
+- `int_surveys__survey_responses.respondent_employee_number`: no
+  currently-non-null value changes; recovered null count matches the pre-merge
+  verification (21 of 23 currently-null staff/engagement submissions resolve
+  post-change).

--- a/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
+++ b/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
@@ -277,7 +277,16 @@ Symmetric with `subject_staff_key`
 ## Acceptance criteria
 
 - `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
-  relationships test returns 0 rows on the PR-branch schema.
+  relationships test orphan count drops from prod baseline (143,758 response
+  rows / ~9,700 distinct submissions) to a small residual driven by pre-existing
+  upstream gaps, not by this PR's fact-model logic. Empirically (dev build,
+  2026-05-12): student SCD orphans 9,563 → ~134 (~99% reduction); staff SCD
+  orphans 42 → 19; Manager Survey orphans unchanged at ~100 (pre-existing
+  hash-composition mismatch with `int_surveys__manager_survey_details`, out of
+  scope). The student residual (~134) splits into 106 responses submitted
+  outside the AY2025 SCD term window in `stg_google_sheets__reporting__terms`
+  (Ops config gap, out of scope) and 28 responses whose email has no enrollment
+  row covering `date_submitted`.
 - `fct_survey_submissions.survey_submission_key` uniqueness test still passes.
 - `student_enrollment_key` nullability: null only for responses whose email has
   no enrollment row covering `date_submitted` in

--- a/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
+++ b/docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md
@@ -1,0 +1,160 @@
+# `fct_survey_responses → fct_survey_submissions` FK gap — design
+
+Refs #3794. Part of project [#4](https://github.com/orgs/TEAMSchools/projects/4)
+"enrollment FK cluster" batch.
+
+## Problem
+
+After #3793 unified the `survey_submission_key` hash composition on both facts,
+`fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
+relationships test still WARNs. Residual is coverage, not hash drift.
+
+Current prod sizing (BigQuery, 2026-05-12):
+
+- 143,758 orphan response rows
+- 12,261 distinct orphan submissions
+
+## Root cause
+
+`fct_survey_submissions` filters student responses to an active-enrollment
+match; `fct_survey_responses` carries every student response with a non-null
+`question_shortname`. Two scope mismatches produce orphans:
+
+1. **Student leg** — `fct_survey_submissions.student_submissions_ranked`
+   (`fct_survey_submissions.sql:71-75`) does an `INNER JOIN` to
+   `int_extracts__student_enrollments` on `(respondent_email, academic_year)`
+   with `enroll_status = 0`. Any response whose email doesn't resolve to an
+   active enrollment in the same academic year is dropped from submissions but
+   remains in responses.
+2. **Staff leg** — `fct_survey_submissions.staff_submissions`
+   (`fct_survey_submissions.sql:30-31`) filters
+   `respondent_employee_number is not null`. Responses with null employee number
+   stay in `fct_survey_responses`.
+
+Three orphan sub-classes within the student leg (from the prior verification
+captured on the issue):
+
+- (a) **Inactive but known** — email matches an enrollment row in a different
+  academic year, or in the same year with `enroll_status != 0`. Resolvable.
+- (b) **Unknown email** — email never appears in
+  `int_extracts__student_enrollments`. Not resolvable; must accept null FK.
+- (c) **Staff residual** — null `respondent_employee_number`. Small class.
+
+## Decision
+
+**Widen `fct_survey_submissions` to cover every response that
+`fct_survey_responses` carries.** The student leg becomes a `LEFT JOIN` with a
+last-known-enrollment fallback for `student_enrollment_key`; the staff leg drops
+the null-employee-number filter and lets `staff_key` be null when source is
+null.
+
+Rejected alternatives:
+
+- _Filter `fct_survey_responses` down to the active-enrollment scope_ — drops
+  real response events; analysts counting "students who answered Q1" would get a
+  silently low number.
+- _Sentinel "unknown enrollment" submission row_ — pollutes
+  `dim_student_enrollments` with synthetic keys. Strict-chain traversal
+  consumers would treat it as a real enrollment.
+
+## Implementation
+
+### `fct_survey_submissions.sql` — student leg
+
+Replace the `student_submissions_ranked` CTE so it:
+
+1. `LEFT JOIN`s `int_extracts__student_enrollments` on
+   `(respondent_email, academic_year)` with **no** `enroll_status` predicate.
+2. Tiebreak with
+   `row_number() OVER (PARTITION BY survey_response_id ORDER BY (enroll_status = 0) DESC, entrydate DESC)`
+   so an active match wins, then most recent entrydate.
+3. For responses whose email has no match in the same academic year, add a
+   second CTE that looks up the same student's most recent enrollment across any
+   academic year by `respondent_email`, partitioned with
+   `row_number() OVER (PARTITION BY respondent_email ORDER BY academic_year DESC, entrydate DESC)`
+   so we attribute to the latest known enrollment.
+4. `COALESCE` the same-year match with the fallback. Responses whose email is
+   unknown to enrollments entirely fall through with null `student_number` /
+   `_dbt_source_relation` / `entrydate`.
+
+`student_enrollment_key` is already wrapped in the
+`if(... is not null, generate_surrogate_key(...), cast(null as string))` pattern
+at the final SELECT, so null inputs produce a null FK without further changes.
+
+### `fct_survey_submissions.sql` — staff leg
+
+Remove the `respondent_employee_number is not null` filter from
+`staff_submissions` (`fct_survey_submissions.sql:30-31`). The final SELECT's
+`staff_key` already would need wrapping — apply the nullable-FK pattern:
+
+```sql
+if(
+    respondent_employee_number is not null,
+    {{ dbt_utils.generate_surrogate_key(["respondent_employee_number"]) }},
+    cast(null as string)
+) as staff_key,
+```
+
+The same wrap is already used for `subject_staff_key`; this just makes
+`staff_key` symmetric.
+
+### Tests
+
+- Keep
+  `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
+  relationships test at the default mart severity (`warn`); flip to
+  `severity: error` once the orphan count returns to zero post-change.
+- No `not_null` tests added on `student_enrollment_key` or `staff_key` — both
+  are legitimately nullable on this fact (multi-respondent-type union).
+- PK uniqueness test on `survey_submission_key` already exists; verify it still
+  holds after the widening (composition unchanged, so should be a no-op).
+
+### YAML
+
+- Update `fct_survey_submissions` model description to note that the student leg
+  attributes to the most recent known enrollment when no active-year enrollment
+  exists, and that `student_enrollment_key` / `staff_key` are nullable for
+  responses that can't be attributed.
+- No column rename or contract change — hash composition is unchanged, all
+  output columns keep their types.
+
+## Out of scope
+
+- **#3777** (ES Writing bridge coverage) — separate spec, separate PR; same
+  PR-batch label on project board.
+- **#3629** (response-grain upstream refactor) — orthogonal; this fix lives
+  entirely in `fct_survey_submissions`.
+- **#3790** multi-select expansion — already merged; sizing in this spec
+  includes its contribution.
+- **`int_extracts__student_enrollments` semantics** — taken as authoritative for
+  "what enrollments exist." No upstream change.
+
+## Pre-merge checklist (per `marts/CLAUDE.md`)
+
+- [ ] Scan touched models for diamond paths (none introduced — only adds a
+      same-target fallback path within the existing
+      `int_extracts__student_enrollments` join).
+- [ ] Scan touched models for R1–R10 violations (no new columns).
+- [ ] Pull marts-model warnings from latest CI run via dbt MCP
+      `get_job_run_error(warning_only=true)`; confirm the
+      `fct_survey_responses → fct_survey_submissions` warning disappears and no
+      new warnings are introduced.
+- [ ] Scan
+      [project board #4](https://github.com/orgs/TEAMSchools/projects/4/views/1)
+      for bonus issues incidentally resolved; close them in the PR.
+- [ ] Confirm orphan rows return to 0 on the PR-branch schema
+      (`dbt_cloud_pr_<ci_id>_3794_marts`).
+
+## Acceptance criteria
+
+- `fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
+  relationships test returns 0 rows on the PR-branch schema.
+- `fct_survey_submissions.survey_submission_key` uniqueness test still passes.
+- Row count of `fct_survey_submissions` increases by approximately the number of
+  orphan submissions resolved (~12K), not by a fan-out multiplier.
+- `student_enrollment_key` nullability: null only for responses whose email is
+  unknown to `int_extracts__student_enrollments` entirely (sized at ~17 from the
+  prior verification, likely similar now).
+- `staff_key` nullability: null only for responses with null
+  `respondent_employee_number` (~23 distinct submissions in the prior
+  verification).

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -36,13 +36,13 @@ with
     ),
 
     /* Student SCD submissions */
-    student_submissions_ranked as (
-        select
+    student_submissions as (
+        -- TODO: upstream at response grain (#3629)
+        select distinct
             sr.survey_id,
             sr.survey_response_id,
             sr.respondent_email,
             sr.date_submitted,
-            sr.academic_year,
             sr.term_code,
 
             rt.type as term_type,
@@ -56,11 +56,8 @@ with
 
             enr.student_number,
             enr._dbt_source_relation,
+            enr.academic_year,
             enr.entrydate,
-
-            row_number() over (
-                partition by sr.survey_response_id order by enr.entrydate desc
-            ) as rn_enrollment,
         from {{ ref("int_surveys__survey_responses") }} as sr
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
@@ -71,31 +68,9 @@ with
         inner join
             {{ ref("int_extracts__student_enrollments") }} as enr
             on sr.respondent_email = enr.student_email
-            and sr.academic_year = enr.academic_year
-            and enr.enroll_status = 0
+            and enr.entrydate <= date(sr.date_submitted)
+            and enr.exitdate > date(sr.date_submitted)
         where sr.survey_title = 'School Community Diagnostic Student Survey'
-    ),
-
-    student_submissions as (
-        select
-            survey_id,
-            survey_response_id,
-            respondent_email,
-            date_submitted,
-            academic_year,
-            term_code,
-            term_type,
-            rt_code,
-            rt_name,
-            rt_start_date,
-            rt_region,
-            rt_school_id,
-            respondent_type,
-            student_number,
-            _dbt_source_relation,
-            entrydate,
-        from student_submissions_ranked
-        where rn_enrollment = 1
     ),
 
     /* Family SCD submissions from rpt_tableau__school_community_diagnostic */

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -36,7 +36,7 @@ with
 
     /* Student SCD submissions */
     student_submissions as (
-        -- TODO: upstream at response grain (#3629)
+        -- TODO: upstream at response grain (#3899)
         select distinct
             sr.survey_id,
             sr.survey_response_id,

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -28,8 +28,7 @@ with
             and sr.term_code = rt.code
             and rt.type = 'SURVEY'
         where
-            sr.respondent_employee_number is not null
-            and sr.survey_title in (
+            sr.survey_title in (
                 'School Community Diagnostic Staff Survey',
                 'Engagement & Support Surveys'
             )
@@ -261,7 +260,11 @@ select
 
     respondent_type,
 
-    {{ dbt_utils.generate_surrogate_key(["respondent_employee_number"]) }} as staff_key,
+    if(
+        respondent_employee_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["respondent_employee_number"]) }},
+        cast(null as string)
+    ) as staff_key,
 
     cast(null as string) as student_enrollment_key,
     cast(null as string) as student_contact_person_key,

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -65,20 +65,11 @@ with
             and sr.term_code = rt.code
             and rt.type = 'SURVEY'
         inner join
-            -- date-range membership: an enrollment row is active on the
-            -- submission date when its [entrydate, exitdate) window contains
-            -- the date. enroll_status is a student-level flag and is
-            -- intentionally not filtered here.
             {{ ref("int_extracts__student_enrollments") }} as enr
             on sr.respondent_email = enr.student_email
             and enr.entrydate <= date(sr.date_submitted)
             and enr.exitdate > date(sr.date_submitted)
         where sr.survey_title = 'School Community Diagnostic Student Survey'
-        qualify
-            row_number() over (
-                partition by sr.survey_response_id order by enr.entrydate desc
-            )
-            = 1  -- TODO: #3633 overlapping enrollment windows
     ),
 
     /* Family SCD submissions from rpt_tableau__school_community_diagnostic */

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -65,11 +65,20 @@ with
             and sr.term_code = rt.code
             and rt.type = 'SURVEY'
         inner join
+            -- date-range membership: an enrollment row is active on the
+            -- submission date when its [entrydate, exitdate) window contains
+            -- the date. enroll_status is a student-level flag and is
+            -- intentionally not filtered here.
             {{ ref("int_extracts__student_enrollments") }} as enr
             on sr.respondent_email = enr.student_email
             and enr.entrydate <= date(sr.date_submitted)
             and enr.exitdate > date(sr.date_submitted)
         where sr.survey_title = 'School Community Diagnostic Student Survey'
+        qualify
+            row_number() over (
+                partition by sr.survey_response_id order by enr.entrydate desc
+            )
+            = 1  -- TODO: #3633 overlapping enrollment windows
     ),
 
     /* Family SCD submissions from rpt_tableau__school_community_diagnostic */

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -4,10 +4,16 @@ models:
       Survey submission fact table. One row per respondent x
       survey_administration. Records survey completion events across all
       populations (staff, student, family). The respondent_type discriminator
-      determines which respondent FK is populated (exactly one per row).
-      Nullable subject_staff_key is populated only for Manager Survey
-      submissions (role-playing FK to dim_staff for the manager being
-      evaluated). FK to dim_survey_administrations and dim_dates.
+      determines which respondent FK is populated (exactly one per row). For
+      student submissions, student_enrollment_key resolves to the enrollment row
+      whose [entrydate, exitdate) window contains date_submitted. staff_key and
+      student_enrollment_key are nullable for respondents whose identity cannot
+      be resolved (e.g. staff respondents whose employee_number was never
+      linked, or student respondents whose email is not present in
+      int_extracts__student_enrollments). Nullable subject_staff_key is
+      populated only for Manager Survey submissions (role-playing FK to
+      dim_staff for the manager being evaluated). FK to
+      dim_survey_administrations and dim_dates.
     columns:
       - name: survey_submission_key
         data_type: string
@@ -69,7 +75,9 @@ models:
         data_type: string
         description: >-
           FK to dim_staff for the respondent. Populated when respondent_type is
-          staff. Null for student and family.
+          staff AND the upstream respondent_employee_number resolves. Null for
+          student / family respondents AND for staff respondents whose identity
+          cannot be resolved upstream.
 
         constraints:
           - type: foreign_key
@@ -84,8 +92,13 @@ models:
       - name: student_enrollment_key
         data_type: string
         description: >-
-          FK to dim_student_enrollments for the respondent. Populated when
-          respondent_type is student. Null for staff and family.
+          FK to dim_student_enrollments for the respondent, resolved by matching
+          respondent_email to an enrollment row whose [entrydate, exitdate)
+          window contains date_submitted. Populated when respondent_type is
+          student AND such an enrollment exists. Null for staff / family
+          respondents AND for student respondents whose email is not present in
+          int_extracts__student_enrollments or has no enrollment row covering
+          date_submitted.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -5,12 +5,12 @@ models:
       survey_administration. Records survey completion events across all
       populations (staff, student, family). The respondent_type discriminator
       determines which respondent FK is populated (exactly one per row). For
-      student submissions, student_enrollment_key resolves to the enrollment row
-      whose [entrydate, exitdate) window contains date_submitted. staff_key and
-      student_enrollment_key are nullable for respondents whose identity cannot
-      be resolved (e.g. staff respondents whose employee_number was never
-      linked, or student respondents whose email is not present in
-      int_extracts__student_enrollments). Nullable subject_staff_key is
+      student submissions, student_enrollment_key resolves to the enrollment
+      whose entry / exit window contains the submission date. staff_key and
+      student_enrollment_key are nullable: staff submissions whose respondent
+      identity cannot be linked to a staff dimension row, and student
+      submissions whose respondent email does not match any enrollment window,
+      both produce rows with a null respondent FK. Nullable subject_staff_key is
       populated only for Manager Survey submissions (role-playing FK to
       dim_staff for the manager being evaluated). FK to
       dim_survey_administrations and dim_dates.
@@ -75,9 +75,9 @@ models:
         data_type: string
         description: >-
           FK to dim_staff for the respondent. Populated when respondent_type is
-          staff AND the upstream respondent_employee_number resolves. Null for
-          student / family respondents AND for staff respondents whose identity
-          cannot be resolved upstream.
+          staff AND the respondent's identity can be linked to a staff dimension
+          row. Null for student / family respondents, and for staff respondents
+          whose identity cannot be linked.
 
         constraints:
           - type: foreign_key
@@ -92,13 +92,11 @@ models:
       - name: student_enrollment_key
         data_type: string
         description: >-
-          FK to dim_student_enrollments for the respondent, resolved by matching
-          respondent_email to an enrollment row whose [entrydate, exitdate)
-          window contains date_submitted. Populated when respondent_type is
-          student AND such an enrollment exists. Null for staff / family
-          respondents AND for student respondents whose email is not present in
-          int_extracts__student_enrollments or has no enrollment row covering
-          date_submitted.
+          FK to dim_student_enrollments for the respondent. The matching
+          enrollment is the one whose entry / exit window contains the
+          submission date. Populated when respondent_type is student AND such an
+          enrollment exists. Null for staff / family respondents, and for
+          student respondents whose email matches no enrollment window.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -92,11 +92,13 @@ models:
       - name: student_enrollment_key
         data_type: string
         description: >-
-          FK to dim_student_enrollments for the respondent. The matching
-          enrollment is the one whose entry / exit window contains the
-          submission date. Populated when respondent_type is student AND such an
-          enrollment exists. Null for staff / family respondents, and for
-          student respondents whose email matches no enrollment window.
+          FK to dim_student_enrollments for the respondent, resolved by matching
+          respondent_email to an enrollment row whose [entrydate, exitdate)
+          window contains date_submitted. Populated when respondent_type is
+          student AND such an enrollment exists. Null for staff / family
+          respondents AND for student respondents whose email is not present in
+          int_extracts__student_enrollments or has no enrollment row covering
+          date_submitted.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -4,9 +4,9 @@ models:
       Survey submission fact table. One row per respondent x
       survey_administration. Records survey completion events across all
       populations (staff, student, family). The respondent_type discriminator
-      determines which respondent FK is populated. For student submissions,
-      student_enrollment_key resolves to the enrollment row whose [entrydate,
-      exitdate) window contains date_submitted. staff_key and
+      determines which respondent FK is populated (exactly one per row). For
+      student submissions, student_enrollment_key resolves to the enrollment row
+      whose [entrydate, exitdate) window contains date_submitted. staff_key and
       student_enrollment_key are nullable for respondents whose identity cannot
       be resolved (e.g. staff respondents whose employee_number was never
       linked, or student respondents whose email is not present in
@@ -75,9 +75,9 @@ models:
         data_type: string
         description: >-
           FK to dim_staff for the respondent. Populated when respondent_type is
-          staff AND the respondent's identity can be linked to a staff dimension
-          row. Null for student / family respondents, and for staff respondents
-          whose identity cannot be linked.
+          staff AND the upstream respondent_employee_number resolves. Null for
+          student / family respondents AND for staff respondents whose identity
+          cannot be resolved upstream.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -4,13 +4,13 @@ models:
       Survey submission fact table. One row per respondent x
       survey_administration. Records survey completion events across all
       populations (staff, student, family). The respondent_type discriminator
-      determines which respondent FK is populated (exactly one per row). For
-      student submissions, student_enrollment_key resolves to the enrollment
-      whose entry / exit window contains the submission date. staff_key and
-      student_enrollment_key are nullable: staff submissions whose respondent
-      identity cannot be linked to a staff dimension row, and student
-      submissions whose respondent email does not match any enrollment window,
-      both produce rows with a null respondent FK. Nullable subject_staff_key is
+      determines which respondent FK is populated. For student submissions,
+      student_enrollment_key resolves to the enrollment row whose [entrydate,
+      exitdate) window contains date_submitted. staff_key and
+      student_enrollment_key are nullable for respondents whose identity cannot
+      be resolved (e.g. staff respondents whose employee_number was never
+      linked, or student respondents whose email is not present in
+      int_extracts__student_enrollments). Nullable subject_staff_key is
       populated only for Manager Survey submissions (role-playing FK to
       dim_staff for the manager being evaluated). FK to
       dim_survey_administrations and dim_dates.

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
@@ -1,4 +1,15 @@
 with
+    gdir_alias_map as (
+        select gd.primary_email, addr.address as known_address,
+        from {{ ref("stg_google_directory__users") }} as gd, unnest(gd.emails) as addr
+        union distinct
+        select gd.primary_email, alias,
+        from {{ ref("stg_google_directory__users") }} as gd, unnest(gd.aliases) as alias
+        union distinct
+        select gd.primary_email, gd.primary_email,
+        from {{ ref("stg_google_directory__users") }} as gd
+    ),
+
     enriched as (
         select
             fr.form_id as survey_id,
@@ -14,11 +25,19 @@ with
             rt.code as term_code,
             rt.name as term_name,
 
-            srh.employee_number as respondent_employee_number,
+            coalesce(
+                srh.employee_number, srh_alias.employee_number
+            ) as respondent_employee_number,
 
-            srh.formatted_name as respondent_preferred_name,
-            srh.sam_account_name as respondent_samaccountname,
-            srh.user_principal_name as respondent_userprincipalname,
+            coalesce(
+                srh.formatted_name, srh_alias.formatted_name
+            ) as respondent_preferred_name,
+            coalesce(
+                srh.sam_account_name, srh_alias.sam_account_name
+            ) as respondent_samaccountname,
+            coalesce(
+                srh.user_principal_name, srh_alias.user_principal_name
+            ) as respondent_userprincipalname,
 
             safe_cast(fr.text_value as numeric) as answer_value,
 
@@ -55,6 +74,14 @@ with
             between srh.effective_date_start_timestamp
             and srh.effective_date_end_timestamp
             and srh.primary_indicator
+        left join gdir_alias_map as gam on fr.respondent_email = gam.known_address
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh_alias
+            on gam.primary_email = srh_alias.google_email
+            and timestamp(fr.last_submitted_time)
+            between srh_alias.effective_date_start_timestamp
+            and srh_alias.effective_date_end_timestamp
+            and srh_alias.primary_indicator
 
         union all
 
@@ -78,10 +105,19 @@ with
             coalesce(regexp_extract(sr.campaign_name, r'\s(.*)'), rt.code) as term_code,
 
             rt.name as term_name,
-            srh.employee_number as respondent_employee_number,
-            srh.formatted_name as respondent_preferred_name,
-            srh.sam_account_name as respondent_samaccountname,
-            srh.user_principal_name as respondent_userprincipalname,
+
+            coalesce(
+                srh.employee_number, srh_alias.employee_number
+            ) as respondent_employee_number,
+            coalesce(
+                srh.formatted_name, srh_alias.formatted_name
+            ) as respondent_preferred_name,
+            coalesce(
+                srh.sam_account_name, srh_alias.sam_account_name
+            ) as respondent_samaccountname,
+            coalesce(
+                srh.user_principal_name, srh_alias.user_principal_name
+            ) as respondent_userprincipalname,
 
             safe_cast(sr.response_value as numeric) as answer_value,
 
@@ -118,6 +154,14 @@ with
             between srh.effective_date_start_timestamp
             and srh.effective_date_end_timestamp
             and srh.primary_indicator
+        left join gdir_alias_map as gam on ri.respondent_mail = gam.known_address
+        left join
+            {{ ref("int_people__staff_roster_history") }} as srh_alias
+            on gam.primary_email = srh_alias.google_email
+            and sr.response_date_submitted
+            between srh_alias.effective_date_start_timestamp
+            and srh_alias.effective_date_end_timestamp
+            and srh_alias.primary_indicator
     )
 
 select

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
@@ -6,7 +6,7 @@ with
         select gd.primary_email, alias,
         from {{ ref("stg_google_directory__users") }} as gd, unnest(gd.aliases) as alias
         union distinct
-        select gd.primary_email, gd.primary_email,
+        select gd.primary_email, gd.primary_email as known_address,
         from {{ ref("stg_google_directory__users") }} as gd
     ),
 
@@ -74,7 +74,10 @@ with
             between srh.effective_date_start_timestamp
             and srh.effective_date_end_timestamp
             and srh.primary_indicator
-        left join gdir_alias_map as gam on fr.respondent_email = gam.known_address
+        left join
+            gdir_alias_map as gam
+            on srh.employee_number is null
+            and fr.respondent_email = gam.known_address
         left join
             {{ ref("int_people__staff_roster_history") }} as srh_alias
             on gam.primary_email = srh_alias.google_email
@@ -154,7 +157,10 @@ with
             between srh.effective_date_start_timestamp
             and srh.effective_date_end_timestamp
             and srh.primary_indicator
-        left join gdir_alias_map as gam on ri.respondent_mail = gam.known_address
+        left join
+            gdir_alias_map as gam
+            on srh.employee_number is null
+            and ri.respondent_mail = gam.known_address
         left join
             {{ ref("int_people__staff_roster_history") }} as srh_alias
             on gam.primary_email = srh_alias.google_email


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will close the
`fct_survey_responses.survey_submission_key → fct_survey_submissions.survey_submission_key`
FK gap (prod baseline: 143,758 orphan response rows / ~9,700 distinct
orphan submissions) by fixing two upstream join defects and admitting
null-employee staff submissions through the fact.

**Empirical impact (dev verification, 2026-05-12):**

| Respondent type | Prod orphan submissions | Dev orphan submissions |
| --- | --: | --: |
| Student SCD | 9,563 | ~134 (99% reduction) |
| Staff SCD | 42 | 19 (55% reduction) |
| Manager Survey | 99 | ~107 (unchanged — pre-existing hash mismatch) |

Closes #3794.

### Changes

1. **`int_surveys__survey_responses.sql`** — adds a Google Directory
   alias-resolution fallback. When the existing `srh` join on
   `(sam_account_name OR google_email)` returns null, falls through to
   `respondent_email → stg_google_directory__users (emails/aliases/primary) → primary_email → fresh srh row`.
   Coalesces current-first. Recovers 21 of 23 currently-null staff/
   engagement submissions, 0 silent reassignments, 0 regressions.

2. **`fct_survey_submissions.sql` — student leg** — replaces the join
   predicate `(sr.academic_year = enr.academic_year AND enr.enroll_status = 0)`
   with a half-open date-range membership check
   `enr.entrydate <= date(sr.date_submitted) AND enr.exitdate > date(sr.date_submitted)`.
   `enroll_status` was a student-level current-active flag (dropped
   historical enrollments for since-departed students). Collapses the
   `student_submissions_ranked` → `student_submissions` two-CTE structure
   into one with `select distinct` (matching staff/family/manager pattern;
   TODO references #3629 for upstream response-grain refactor). Sources
   `academic_year` from the matched enrollment row.

3. **`fct_survey_submissions.sql` — staff leg** — drops the
   `respondent_employee_number is not null` filter and wraps `staff_key`
   with the nullable-FK `if(... is not null, generate_surrogate_key(...), cast(null as string))`
   pattern, mirroring `subject_staff_key`.

4. **YAML descriptions** — `fct_survey_submissions` model + `staff_key` +
   `student_enrollment_key` descriptions updated to document the
   date-range attribution rule and nullable-FK semantics, source-agnostic
   wording per `marts/CLAUDE.md`.

### Residual orphans (out of scope, follow-ups filed)

- **106 student SCD orphans** — submitted outside the AY2025 SCD term
  window in `stg_google_sheets__reporting__terms` (only 2025-12-01 →
  2026-03-01); 95 of these are post-window April–May 2026 spring activity.
  Ops Google Sheet config gap, separate follow-up.
- **28 student SCD orphans** — emails with no enrollment row (19) or no
  enrollment row covering `date_submitted` (9). Real edge cases.
- **~100 Manager Survey orphans** — pre-existing hash composition mismatch
  between `int_surveys__survey_responses` and
  `int_surveys__manager_survey_details`. Separate follow-up.
- **2 staff SCD orphans** — `jperez@apps.teamschools.org` AD `employeeID`
  attribute set to `TMP*` placeholder; never reconciled to real ADP
  `employee_number`. Administrative remediation, separate follow-up.

Design spec: [`docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md`](docs/superpowers/specs/2026-05-12-survey-responses-fk-gap-design.md).
Implementation plan: [`docs/superpowers/plans/2026-05-12-survey-responses-fk-gap.md`](docs/superpowers/plans/2026-05-12-survey-responses-fk-gap.md).

## AI Assistance

Spec authoring, implementation-plan generation, and SQL drafting were
Claude-assisted (Opus 4.7) under per-task review checkpoints. Data
verification (BigQuery queries against prod + dev schemas, ADP/LDAP
diagnosis of the residual `jperez` case, fan-out audits) and final review
direction were human-directed.

## Self-review

### dbt

- [x] Properties YAML updated for the model whose semantics changed
      (`fct_survey_submissions`). `int_surveys__survey_responses` had no
      column-shape change (additive coalesce fallback, no new columns), so
      its YAML is unchanged.
- [x] No new exposures needed — no new external consumers.
- [ ] **Breaking change?** No column renames, no removed columns, no type
      changes. `survey_submission_key` hash composition is unchanged
      structurally; for student submissions the `academic_year` input now
      sources from `enr.academic_year` rather than `sr.academic_year`,
      which will reshuffle a small subset of student keys whose response-
      year tag differed from their enrollment-year tag. Acceptable per
      `marts/CLAUDE.md` → "Spec authoring context" (no production consumers
      yet for marts).
- [x] No new or modified external sources — no `stage_external_sources`
      run needed.

### General

- [x] No same-day request flag in #data-team needed.
- [ ] Review the Claude Code Review comment on this PR after creation.

## CI checks

- [ ] **Trunk** — pre-push trunk-check passed on every commit. CI will
      re-verify.
- [ ] **dbt Cloud CI** — `dbt build --select state:modified+ --full-refresh`
      will exercise the modified models and their downstream tests on the
      PR-branch schema. Expected: `survey_submission_key` uniqueness
      passes; relationships test against `fct_survey_submissions` WARNs at
      the residual count (~260 distinct orphan submissions, vs prod's
      ~9,700) rather than zero, per the acceptance-criteria update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
