### PR TITLE
fix(dbt): cover ES Writing in student-scoped assessment expectations bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,9 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Markdown**: Always specify a language on fenced code blocks (MD040). Use
   `text` only when no real language applies.
 
+- **Markdown headings**: increment by one level (markdownlint MD001). `#` title
+  goes directly to `##` — never jump to `###`.
+
 - **Claude CLI**: Not on `$PATH` — user must run `claude` commands in their
   terminal, not via Bash tool.
 

--- a/docs/superpowers/plans/2026-05-12-es-writing-bridge-coverage-plan.md
+++ b/docs/superpowers/plans/2026-05-12-es-writing-bridge-coverage-plan.md
@@ -45,7 +45,7 @@ and `--project-dir <worktree>/src/dbt/kipptaf` on every dbt call (per
 
 ---
 
-### Task 1: Promote `_dbt_source_project` to `base_powerschool__course_enrollments`
+## Task 1: Promote `_dbt_source_project` to `base_powerschool__course_enrollments`
 
 **Files:**
 
@@ -133,7 +133,7 @@ from _dbt_source_relation at every join. Refs #3777 #3142."
 
 ---
 
-### Task 2: Promote `_dbt_source_project` to `base_powerschool__student_enrollments`
+## Task 2: Promote `_dbt_source_project` to `base_powerschool__student_enrollments`
 
 **Files:**
 
@@ -205,7 +205,7 @@ collapse both names into one. Refs #3777 #3142."
 
 ---
 
-### Task 3: Use `_dbt_source_project` in `int_assessments__course_enrollments` and close the dedup collision
+## Task 3: Use `_dbt_source_project` in `int_assessments__course_enrollments` and close the dedup collision
 
 **Files:**
 
@@ -323,7 +323,7 @@ where the prior all-NULL plumbing left the partition blind. Refs #3777."
 
 ---
 
-### Task 4: Rename `cc_source_relation` → `cc_source_project` in `int_assessments__scaffold`
+## Task 4: Rename `cc_source_relation` → `cc_source_project` in `int_assessments__scaffold`
 
 **Files:**
 
@@ -410,7 +410,7 @@ Refs #3777 #3820."
 
 ---
 
-### Task 5: Swap `student_section_enrollment_key` hash on both producer and consumer (atomic)
+## Task 5: Swap `student_section_enrollment_key` hash on both producer and consumer (atomic)
 
 **Files:**
 
@@ -563,7 +563,7 @@ stay deferred. Refs #3777 #3820."
 
 ---
 
-### Task 6: Widen `bridge_assessment_expectations_student_scoped` to admit ES Writing
+## Task 6: Widen `bridge_assessment_expectations_student_scoped` to admit ES Writing
 
 **Files:**
 
@@ -652,7 +652,7 @@ represent (replacements OR ES Writing). Closes #3777."
 
 ---
 
-### Task 7: Pre-merge verification and PR-branch CI confirmation
+## Task 7: Pre-merge verification and PR-branch CI confirmation
 
 **Files:** no SQL/YAML changes — verification only.
 

--- a/docs/superpowers/plans/2026-05-12-es-writing-bridge-coverage-plan.md
+++ b/docs/superpowers/plans/2026-05-12-es-writing-bridge-coverage-plan.md
@@ -1,0 +1,776 @@
+# ES Writing Bridge Coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the FK gap that excludes ES Writing assessment expectations from
+both expectation bridges, while incidentally fixing a cross-district
+student-number dedup collision risk and migrating
+`student_section_enrollment_key` to a region-only hash.
+
+**Architecture:** Three layered changes upstream → downstream: (1) promote
+`_dbt_source_project = regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` as a
+materialized column on two base union models; (2) recompose
+`student_section_enrollment_key` on both producer
+(`dim_student_section_enrollments`) and consumer
+(`bridge_assessment_expectations_enrollment_scoped`) to hash
+`(cc_dcid, _dbt_source_project)`; (3) widen
+`bridge_assessment_expectations_student_scoped` to admit ES Writing rows
+alongside replacements.
+
+**Tech Stack:** dbt 1.11 + BigQuery; `uv run` for all dbt invocations;
+trunk-managed sqlfluff/yamllint at commit/push time.
+
+**Spec:**
+[docs/superpowers/specs/2026-05-12-es-writing-bridge-coverage-design.md](../specs/2026-05-12-es-writing-bridge-coverage-design.md)
+
+**Worktree:**
+`/workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage`.
+All commands below assume this path. Use `git -C <worktree>` on every git call
+and `--project-dir <worktree>/src/dbt/kipptaf` on every dbt call (per
+`CLAUDE.md` worktree-commands rule).
+
+**Build flag conventions** (per `src/dbt/CLAUDE.md`):
+
+- Dev builds depending on Google Sheets externals require
+  `--defer --state=src/dbt/kipptaf/target/prod/` (path is relative to
+  `--project-dir`).
+- If the prod manifest is stale, regenerate:
+  `uv run dbt parse --target prod --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf --target-path target/prod`
+- Before trusting any FK relationships warning on a dev build, clone the parent
+  dim from prod:
+  `uv run dbt clone --select <parent> --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf --state src/dbt/kipptaf/target/prod/`
+
+---
+
+### Task 1: Promote `_dbt_source_project` to `base_powerschool__course_enrollments`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql`
+- Check:
+  `src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml`
+  (only edit if it currently lists all output columns — otherwise the new column
+  is auto-discovered since the model is intermediate-tier, contract-disabled by
+  default)
+
+- [ ] **Step 1: Read the existing model and YAML**
+
+Read both files in full. Confirm the model is `dbt_utils.union_relations` over 4
+district sources and selects `ur.* except (...)` plus joined columns. Confirm
+there is no existing `_dbt_source_project` column.
+
+- [ ] **Step 2: Add `_dbt_source_project` to the SELECT**
+
+In `base_powerschool__course_enrollments.sql`, add the column to the trailing
+SELECT. Place it adjacent to the existing `region` derivation (line 54) for
+readability — both come from the same regex source:
+
+```sql
+regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+
+initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
+```
+
+Note: the new regex uses `(kipp\w+)_` (capturing `kippnewark`), not `kipp(\w+)_`
+(capturing `newark`). Keep both — `region` is the user-facing short form,
+`_dbt_source_project` is the full code-location plumbing per #3142.
+
+- [ ] **Step 3: If properties YAML enumerates all columns, add
+      `_dbt_source_project`**
+
+If `properties/base_powerschool__course_enrollments.yml` lists every column
+under `columns:`, add an entry:
+
+```yaml
+- name: _dbt_source_project
+  description: |
+    Region prefix extracted from `_dbt_source_relation` via
+    `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
+    in downstream surrogate keys, consistent across all upstream union
+    tables. See #3142.
+```
+
+If the YAML only lists a few columns with tests (typical for intermediate base
+models), no YAML change is needed — the column is contract-free.
+
+- [ ] **Step 4: Build the model and verify**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage
+uv run dbt build \
+  --select base_powerschool__course_enrollments \
+  --project-dir src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: 1 model created, all tests pass. If the model has no per-column tests
+on the new column, only the upstream uniqueness test runs — that's fine.
+
+- [ ] **Step 5: Verify column is populated**
+
+```bash
+uv run dbt show \
+  --inline "select _dbt_source_project, count(*) as n from {{ ref('base_powerschool__course_enrollments') }} group by 1" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf
+```
+
+Expected: rows like `kippnewark | <n>`, `kippcamden | <n>`, etc. No NULL bucket.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "feat(dbt): add _dbt_source_project to base_powerschool__course_enrollments
+
+Scoped slice of #3142. Materializes the region-prefix discriminator so
+downstream marts can hash on it directly instead of regex-extracting
+from _dbt_source_relation at every join. Refs #3777 #3142."
+```
+
+---
+
+### Task 2: Promote `_dbt_source_project` to `base_powerschool__student_enrollments`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql`
+- Check:
+  `src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml`
+
+This model already has a `code_location` column (line 34) using the identical
+`(kipp\w+)_` regex. The plan is to **add `_dbt_source_project` as a parallel
+column with the same value** and leave `code_location` in place for existing
+consumers. Collapsing the two is deferred to full #3142.
+
+- [ ] **Step 1: Read both files**
+
+Confirm `code_location` is present at the same regex spec we'd use. Confirm no
+`_dbt_source_project` column yet.
+
+- [ ] **Step 2: Add `_dbt_source_project` alongside `code_location`**
+
+In `base_powerschool__student_enrollments.sql`, add immediately above the
+existing `code_location` line:
+
+```sql
+regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as code_location,
+```
+
+(Yes, the two expressions are identical. This is intentional —
+`_dbt_source_project` is the #3142 canonical name; `code_location` stays for now
+to avoid touching existing consumers. The duplicate disappears under full
+#3142.)
+
+- [ ] **Step 3: If properties YAML enumerates all columns, add
+      `_dbt_source_project`**
+
+Same logic as Task 1 Step 3. The description text should match Task 1's.
+
+- [ ] **Step 4: Build the model and verify**
+
+```bash
+uv run dbt build \
+  --select base_powerschool__student_enrollments \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: 1 model created, all tests pass.
+
+- [ ] **Step 5: Verify column populated and equal to `code_location`**
+
+```bash
+uv run dbt show \
+  --inline "select countif(_dbt_source_project = code_location) as n_match, countif(_dbt_source_project != code_location) as n_mismatch, countif(_dbt_source_project is null) as n_null from {{ ref('base_powerschool__student_enrollments') }}" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf
+```
+
+Expected: `n_match = total`, `n_mismatch = 0`, `n_null = 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "feat(dbt): add _dbt_source_project to base_powerschool__student_enrollments
+
+Parallel to the existing code_location column for now; full #3142 will
+collapse both names into one. Refs #3777 #3142."
+```
+
+---
+
+### Task 3: Use `_dbt_source_project` in `int_assessments__course_enrollments` and close the dedup collision
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql`
+- Check:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml`
+
+- [ ] **Step 1: Read the model and YAML**
+
+Confirm two `union all` branches: K-12 (from
+`base_powerschool__course_enrollments`, lines ~4-36) and ES Writing (from
+`base_powerschool__student_enrollments`, lines ~40-64). Confirm the trailing
+`dbt_utils.deduplicate` (lines ~67-72) partitions by
+`(powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled)`.
+
+- [ ] **Step 2: Add `_dbt_source_project` to both branches**
+
+K-12 branch — add adjacent to the existing `ce._dbt_source_relation` (line 14):
+
+```sql
+ce.cc_dcid,
+ce._dbt_source_relation,
+ce._dbt_source_project,
+```
+
+ES Writing branch — replace line 55
+(`cast(null as string) as _dbt_source_relation,`) with two lines:
+
+```sql
+cast(null as int64) as cc_dcid,
+cast(null as string) as _dbt_source_relation,
+co._dbt_source_project,
+```
+
+Leave `cc_dcid` NULL (no PS course-enrollment row exists). Leave
+`_dbt_source_relation` NULL (the value would be
+`..._base_powerschool__student_enrollments`, which is asymmetric vs K-12's
+`..._base_powerschool__course_enrollments`; downstream consumers that want a
+region discriminator should use `_dbt_source_project`).
+
+Verify ST06 column-order rule (plain refs grouped, then literals, then casts) —
+keep `co._dbt_source_project` in the plain-refs cluster, not after the
+`cast(null...)` lines. Adjust ordering if sqlfluff would complain.
+
+- [ ] **Step 3: Add `_dbt_source_project` to the trailing dedup `partition_by`**
+
+Change:
+
+```sql
+{{
+    dbt_utils.deduplicate(
+        relation="enrollments_union",
+        partition_by="powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled",
+        order_by="cc_dateleft desc",
+    )
+}}
+```
+
+to:
+
+```sql
+{{
+    dbt_utils.deduplicate(
+        relation="enrollments_union",
+        partition_by="_dbt_source_project, powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled",
+        order_by="cc_dateleft desc",
+    )
+}}
+```
+
+- [ ] **Step 4: Update the properties YAML if it enumerates columns**
+
+If the YAML has a full `columns:` list, add `_dbt_source_project` with the
+description from Task 1 Step 3. If it only carries uniqueness / data tests, no
+change.
+
+- [ ] **Step 5: Build the model + downstream uniqueness check**
+
+```bash
+uv run dbt build \
+  --select int_assessments__course_enrollments \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: model builds, uniqueness test passes. Row count should be **≥** prior
+baseline (collapsed cross-district duplicates are now preserved).
+
+- [ ] **Step 6: Spot-check row count delta**
+
+```bash
+uv run dbt show \
+  --inline "select count(*) as n from {{ ref('int_assessments__course_enrollments') }}" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf
+```
+
+Compare against prod for the same model (BigQuery MCP, table
+`teamster-332318.kipptaf_assessments.int_assessments__course_enrollments`). Net
+delta should be small (most cross-district student_number collisions don't
+actually overlap on AY+subject+date), or zero. A negative delta means a
+regression — stop and investigate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "fix(dbt): plumb _dbt_source_project through int_assessments__course_enrollments
+
+Carries the region discriminator on both K-12 and ES Writing branches
+and includes it in the trailing dedup partition. Closes a silent
+cross-district student-number collision risk in the ES Writing branch
+where the prior all-NULL plumbing left the partition blind. Refs #3777."
+```
+
+---
+
+### Task 4: Rename `cc_source_relation` → `cc_source_project` in `int_assessments__scaffold`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql`
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml`
+
+- [ ] **Step 1: Read both files**
+
+Confirm `cc_source_relation` appears at lines 74 (K-8 internal branch), 124 (HS
+branch), 168 (final SELECT pass-through), 213 (replacement branch hardcodes
+NULL), 271 (external branch hardcodes NULL). Confirm the YAML has a
+`cc_source_relation` column entry with
+`source_column: int_assessments__course_enrollments._dbt_source_relation`.
+
+- [ ] **Step 2: Update SQL — replace `_dbt_source_relation` reads with
+      `_dbt_source_project` reads, and rename the alias to `cc_source_project`**
+
+K-8 branch (line 74):
+
+```sql
+ce._dbt_source_project as cc_source_project,
+```
+
+HS branch (line 124):
+
+```sql
+ce._dbt_source_project as cc_source_project,
+```
+
+Final SELECT (line 168) — rename the pass-through:
+
+```sql
+ia.cc_source_project,
+```
+
+Replacement branch (line 213) and external branch (line 271):
+
+```sql
+cast(null as string) as cc_source_project,
+```
+
+- [ ] **Step 3: Update properties YAML**
+
+Rename the column entry from `cc_source_relation` to `cc_source_project`. Update
+`config.meta.source_column` to
+`int_assessments__course_enrollments._dbt_source_project`. Rewrite the
+description to describe the new semantics (region prefix, not the full
+source-relation).
+
+- [ ] **Step 4: Build the model**
+
+```bash
+uv run dbt build \
+  --select int_assessments__scaffold \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: parses, builds, tests pass.
+
+- [ ] **Step 5: Verify column rename**
+
+```bash
+uv run dbt show \
+  --inline "select cc_source_project, count(*) as n from {{ ref('int_assessments__scaffold') }} where is_internal_assessment group by 1 order by 2 desc" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf
+```
+
+Expected: buckets like `kippnewark`, `kippcamden`, `kippmiami`, `kipppaterson`,
+plus a NULL bucket for replacement-branch rows.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "refactor(dbt): rename int_assessments__scaffold.cc_source_relation to cc_source_project
+
+Carries the region prefix instead of the full _dbt_source_relation,
+preparing the downstream hash swap on student_section_enrollment_key.
+Refs #3777 #3820."
+```
+
+---
+
+### Task 5: Swap `student_section_enrollment_key` hash on both producer and consumer (atomic)
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql`
+- Check:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml`
+  and
+  `src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml`
+
+**Atomicity:** Both files commit together. Between the two changes the FK
+relationships test would fail; do not commit half the change.
+
+- [ ] **Step 1: Read both SQL files and any properties YAMLs**
+
+Confirm:
+
+- `dim_student_section_enrollments.sql:74` hashes
+  `student_section_enrollment_key` from `(cc_dcid, _dbt_source_relation)`.
+- `bridge_assessment_expectations_enrollment_scoped.sql:42-43` hashes from
+  `(cc_dcid, cc_source_relation)`.
+
+- [ ] **Step 2: Swap hash composition on `dim_student_section_enrollments`**
+
+Replace lines 73-75:
+
+```sql
+{{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
+    as student_section_enrollment_key,
+```
+
+The CTE `course_enrollments_joined` already selects `cc._dbt_source_relation`
+(line 18); ALSO select `cc._dbt_source_project` there so it is available at the
+outer SELECT:
+
+```sql
+cc.cc_dcid,
+cc.sections_dcid,
+cc._dbt_source_project,
+cc.cc_academic_year,
+```
+
+(`_dbt_source_relation` stays on the CTE because it's still used by the
+`replace()` workaround on `course_section_key` at lines 86-90 — that workaround
+is #3820's broader sweep and stays for now.)
+
+Leave the `// TODO` comment block above `course_section_key` (lines 77-81) but
+add a sentence noting `student_section_enrollment_key` has been migrated to
+`_dbt_source_project` and the remaining keys await full #3820.
+
+- [ ] **Step 3: Swap hash composition on
+      `bridge_assessment_expectations_enrollment_scoped`**
+
+The bridge currently selects `sc.cc_source_relation` from
+`int_assessments__scaffold`. Task 4 already renamed that to `cc_source_project`.
+Update the bridge:
+
+- Line 10: `sc.cc_source_project,` (replacing `sc.cc_source_relation,`)
+- Line 25-27 comment: rewrite to reference the student-scoped bridge as the home
+  for NULL-cc_dcid rows:
+
+  ```sql
+  -- ES Writing and other NULL-cc_dcid rows are excluded here because
+  -- cc_dcid + _dbt_source_project form the student_section_enrollment_key
+  -- and NULL cc_dcid would collide on the placeholder hash. Those rows
+  -- live in bridge_assessment_expectations_student_scoped instead.
+  ```
+
+- Line 31-32: rename the filter from `cc_source_relation is not null` to
+  `cc_source_project is not null` (combined with `cc_dcid is not null`, ES
+  Writing rows still excluded).
+- Line 38: hash input list becomes
+  `["cc_dcid", "_dbt_source_project", "assessment_id", "administered_at"]` for
+  `assessment_expectation_key`. **Critical:** this changes
+  `assessment_expectation_key` hash composition too. Verify the bridge's PK
+  uniqueness test still passes; downstream consumers of
+  `assessment_expectation_key` need the same migration if any — grep for it (see
+  Step 4 below).
+- Line 42: hash input list becomes `["cc_dcid", "_dbt_source_project"]` for
+  `student_section_enrollment_key`.
+
+The new name is `_dbt_source_project` (not `cc_source_project`) in the hash
+input because that matches the producer dim's column name. The bridge's local
+alias `cc_source_project` becomes a pass-through; consider dropping the `cc_`
+prefix and using `_dbt_source_project` directly throughout the bridge for
+symmetry — verify column-order rules first.
+
+- [ ] **Step 4: Check for downstream consumers of `assessment_expectation_key`**
+
+```bash
+grep -rn "assessment_expectation_key" /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf/models
+```
+
+If anything OTHER than the two bridges references this key, the migration scope
+expands — stop and flag to user. Both bridges produce the key as a PK; nothing
+should FK to it. Expected: only model-internal references.
+
+- [ ] **Step 5: Update properties YAMLs**
+
+If either bridge or dim YAML has a `description` mentioning the hash inputs,
+update to reference `_dbt_source_project`. No column-name changes in the YAMLs
+for these models (the columns are surrogate keys, opaque to consumers).
+
+- [ ] **Step 6: Build both models and run their tests together**
+
+```bash
+uv run dbt build \
+  --select dim_student_section_enrollments bridge_assessment_expectations_enrollment_scoped \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: both build, PK uniqueness passes on both, FK relationships test
+`bridge_assessment_expectations_enrollment_scoped.student_section_enrollment_key → dim_student_section_enrollments.student_section_enrollment_key`
+passes (both sides now hash identically on `_dbt_source_project`).
+
+If the relationships test reports orphans, the most likely cause is the
+`replace()` workaround on `course_section_key` still using the old composition —
+verify the producer/consumer **on the `_section_enrollment_key` only**, not
+`course_section_key`.
+
+- [ ] **Step 7: Spot-check via BigQuery MCP that row counts are unchanged on the
+      dim**
+
+```sql
+select count(*) as n_pre
+from `teamster-332318.kipptaf_marts.dim_student_section_enrollments`
+```
+
+vs. the PR-branch schema (`dbt_cloud_pr_<ci_id>_<pr_num>_marts` once CI runs, or
+the dev schema for local).
+
+Expected: identical row counts. Hash change is a value change, not a row change.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "refactor(dbt): migrate student_section_enrollment_key to region-prefix hash
+
+Both producer (dim_student_section_enrollments) and consumer
+(bridge_assessment_expectations_enrollment_scoped) now hash
+(cc_dcid, _dbt_source_project) instead of (cc_dcid, _dbt_source_relation).
+First wave of #3820; other surrogate keys in dim_courses,
+dim_course_sections, and the course_section_key replace() workaround
+stay deferred. Refs #3777 #3820."
+```
+
+---
+
+### Task 6: Widen `bridge_assessment_expectations_student_scoped` to admit ES Writing
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql`
+- Check:
+  `src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml`
+
+- [ ] **Step 1: Read the model and YAML**
+
+Confirm the current `WHERE` (line 31) is
+`sc.is_replacement and sc.powerschool_student_number is not null` with no
+`is_internal_assessment` filter.
+
+- [ ] **Step 2: Widen the WHERE clause**
+
+Replace line 31:
+
+```sql
+where
+    sc.is_internal_assessment
+    and (sc.is_replacement or sc.cc_dcid is null)
+    and sc.powerschool_student_number is not null
+```
+
+- [ ] **Step 3: Update model description in properties YAML**
+
+Set the model description to:
+
+```yaml
+description: |
+  Bridges internal assessment expectations that cannot be attributed to
+  a student section enrollment to their student and assessment
+  administration. Covers two classes: replacement assessments (which
+  have no enrollment by definition) and ES Writing in grades K-4
+  Newark/Camden (where no PowerSchool course-enrollment row exists for
+  the writing program). Rows whose expectations can be attributed to a
+  section enrollment live in `bridge_assessment_expectations_enrollment_scoped`.
+```
+
+Also update `bridge_assessment_expectations_enrollment_scoped`'s YAML
+description to mirror — state it only covers rows with a resolvable section
+enrollment; ES Writing and replacements live in the student-scoped bridge.
+
+- [ ] **Step 4: Build and test**
+
+```bash
+uv run dbt build \
+  --select bridge_assessment_expectations_student_scoped bridge_assessment_expectations_enrollment_scoped \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: both build; uniqueness tests pass; FK tests pass with expanded row set
+on student-scoped bridge.
+
+- [ ] **Step 5: Verify row-count delta and ES Writing coverage**
+
+```bash
+uv run dbt show --inline "
+  select
+      (select count(*) from {{ ref('bridge_assessment_expectations_student_scoped') }}) as n_student_scoped,
+      (
+          select count(*)
+          from {{ ref('bridge_assessment_expectations_student_scoped') }} b
+          inner join {{ ref('int_assessments__scaffold') }} sc using (assessment_id)
+          where sc.is_internal_assessment and not sc.is_replacement and sc.cc_dcid is null
+      ) as n_es_writing_in_bridge
+" --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf
+```
+
+Expected: `n_student_scoped` ≈ 116,776; `n_es_writing_in_bridge` ≈ 116,776 (≈
+the previously-excluded class). Compare against the prod baseline (1,856 rows) —
+net delta should be ≈ +114,920.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage add -u
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage commit -m "fix(dbt): include ES Writing in bridge_assessment_expectations_student_scoped
+
+Widens the bridge filter from is_replacement-only to admit any
+internal-assessment row that the enrollment-scoped bridge cannot
+represent (replacements OR ES Writing). Closes #3777."
+```
+
+---
+
+### Task 7: Pre-merge verification and PR-branch CI confirmation
+
+**Files:** no SQL/YAML changes — verification only.
+
+- [ ] **Step 1: Build the full subgraph end-to-end**
+
+```bash
+uv run dbt build \
+  --select +bridge_assessment_expectations_student_scoped +bridge_assessment_expectations_enrollment_scoped +dim_student_section_enrollments \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage/src/dbt/kipptaf \
+  --defer --state=src/dbt/kipptaf/target/prod/
+```
+
+Expected: all upstream + the three targets build, all tests pass.
+
+- [ ] **Step 2: Diamond-path and R1-R10 scan**
+
+Re-read each changed mart file. For each, confirm:
+
+- No new diamond paths introduced (per `marts/CLAUDE.md` "Strict-chain
+  traversal").
+- No new mart columns violate R1-R10 (`_dbt_source_project` and
+  `cc_source_project` are plumbing per R8 — stays in intermediate, not surfaced
+  in any mart SELECT).
+
+- [ ] **Step 3: Push the branch and wait for dbt Cloud CI**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-es-writing-bridge-coverage push
+```
+
+dbt Cloud CI runs `dbt build --select state:modified+ --full-refresh` on target
+staging.
+
+- [ ] **Step 4: Pull marts warnings from the CI run**
+
+After CI completes, use `mcp__dbt__get_job_run_error` with `warning_only=true`.
+Confirm:
+
+- The previously-WARNing
+  `bridge_assessment_expectations_enrollment_scoped.assessment_administration_key → dim_assessment_administrations`
+  test (or whichever was warning, per the issue body) is unchanged or improved.
+- No new bridge / dim / scaffold warnings surfaced.
+- No new orphans on `student_section_enrollment_key` FK.
+
+- [ ] **Step 5: Project board scan**
+
+Visit https://github.com/orgs/TEAMSchools/projects/4/views/1. For each open
+issue, check the title against changed models; close any incidentally resolved
+(none expected besides #3777, but #3142 and #3820 deserve a comment noting
+wave-1 progress).
+
+- [ ] **Step 6: Run BigQuery sizing query against the PR-branch schema**
+
+Once CI has materialized the PR-branch schema
+(`dbt_cloud_pr_<ci_id>_<pr_num>_marts`), run via BigQuery MCP:
+
+```sql
+select count(*) as n_student_scoped
+from `teamster-332318.dbt_cloud_pr_<ci_id>_<pr_num>_marts.bridge_assessment_expectations_student_scoped`
+```
+
+Expected: ≈ 116,776 (was 1,856 in prod).
+
+- [ ] **Step 7: Open the PR**
+
+Use `.github/pull_request_template.md` as the body. Title:
+`fix(dbt): include ES Writing in student-scoped expectations bridge (#3777)`.
+Body references #3777 (closes), #3142 (partial), #3820 (partial).
+
+```bash
+gh pr create --title "fix(dbt): include ES Writing in student-scoped expectations bridge" --body "$(cat <<'EOF'
+## Summary
+- Adds `_dbt_source_project` materialized column to two base PowerSchool union models (slice of #3142).
+- Migrates `student_section_enrollment_key` on both producer and consumer to hash `(cc_dcid, _dbt_source_project)` (slice of #3820).
+- Widens `bridge_assessment_expectations_student_scoped` filter to admit ES Writing rows alongside replacements.
+
+## Test plan
+- [ ] dbt Cloud CI passes on the full subgraph.
+- [ ] `bridge_assessment_expectations_student_scoped` row count ≈ 116,776 (was 1,856).
+- [ ] `dim_student_section_enrollments` row count unchanged; PK uniqueness passes.
+- [ ] `bridge_assessment_expectations_enrollment_scoped → dim_student_section_enrollments` relationships test orphan count unchanged.
+- [ ] No new bridge / dim / scaffold warnings on the latest CI run.
+
+Closes #3777. Partial progress on #3142 and #3820.
+EOF
+)"
+```
+
+---
+
+## Spec Coverage Map
+
+| Spec section                                                                     | Plan task                  |
+| -------------------------------------------------------------------------------- | -------------------------- |
+| Promote `_dbt_source_project` on `base_powerschool__course_enrollments`          | Task 1                     |
+| Promote `_dbt_source_project` on `base_powerschool__student_enrollments`         | Task 2                     |
+| Update `int_assessments__course_enrollments` (both branches + dedup)             | Task 3                     |
+| Rename `cc_source_relation` → `cc_source_project` in `int_assessments__scaffold` | Task 4                     |
+| Hash swap on `dim_student_section_enrollments`                                   | Task 5                     |
+| Hash swap + filter rename on `bridge_assessment_expectations_enrollment_scoped`  | Task 5                     |
+| Widen `bridge_assessment_expectations_student_scoped` WHERE clause               | Task 6                     |
+| YAML description updates on both bridges                                         | Task 6 (description block) |
+| Pre-merge checklist (warnings sweep, project board, sizing)                      | Task 7                     |
+
+## Notes for the engineer
+
+- **Trunk:** Don't run `trunk fmt` or `trunk check` manually — pre-commit hooks
+  format SQL/YAML at commit time. If a hook reports issues at commit time, fix
+  and re-commit (do not `--no-verify`).
+- **Stale dev tables:** If a relationships test reports orphans on
+  `student_section_enrollment_key` after Task 5, the parent dim may have
+  stale-defer data. `dbt clone --select dim_student_section_enrollments` from
+  staging before re-running.
+- **No production consumers:** per `marts/CLAUDE.md` "Spec authoring context",
+  hash churn is free — no compat shims needed.
+- **Properties YAML reads:** before modifying any model, read its properties
+  YAML in full (per `src/dbt/CLAUDE.md` YAML conventions). Copy-paste rot is the
+  most common gotcha.
+- **Worktree commands:** always `git -C <worktree>` and
+  `--project-dir <worktree>/src/dbt/kipptaf`. Bare `git` from the main repo
+  silently commits to `main`.

--- a/docs/superpowers/specs/2026-05-12-es-writing-bridge-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-12-es-writing-bridge-coverage-design.md
@@ -1,0 +1,164 @@
+# ES Writing bridge coverage — design
+
+Refs #3777. Part of project [#4](https://github.com/orgs/TEAMSchools/projects/4)
+"enrollment FK cluster" batch.
+
+## Problem
+
+ES Writing (grades K-4 in Newark and Camden) assessment expectations don't
+appear in either bridge linking student section enrollments to scheduled
+assessment administrations. The expectations exist in
+`int_assessments__scaffold` but are filtered out of both bridges, so the network
+can't slice ES Writing administrations by student/section in the dimensional
+model.
+
+Current scaffold sizing (BigQuery, 2026-05-12):
+
+- 116,776 internal-assessment, non-replacement rows with `cc_dcid IS NULL` — the
+  ES Writing class.
+- 1,856 replacement-assessment rows with `cc_dcid IS NULL` — fully contained
+  inside the NULL-cc_dcid set. These already flow into
+  `bridge_assessment_expectations_student_scoped` via the `is_replacement`
+  filter.
+- 0 internal-assessment rows with `cc_dcid IS NULL` and a null
+  `powerschool_student_number` — every ES Writing row has a resolvable student.
+
+## Root cause
+
+`int_assessments__course_enrollments` builds the ES Writing branch (lines 41-64)
+from `base_powerschool__student_enrollments` (student-grain), hardcoding
+`cc_dcid = NULL` and `_dbt_source_relation = NULL` because no underlying
+course-section enrollment row exists. The `base_powerschool__course_enrollments`
+source has no ES Writing equivalent.
+
+`bridge_assessment_expectations_enrollment_scoped` filters
+`WHERE cc_dcid IS NOT NULL AND cc_source_relation IS NOT NULL` (lines 28-32).
+The model comment correctly notes that allowing NULL inputs would collide on the
+placeholder hash of `student_section_enrollment_key`.
+
+`bridge_assessment_expectations_student_scoped` filters `WHERE is_replacement`
+(line 31). All current student-scoped rows have NULL `cc_dcid` — the bridge is
+already the "no section context" path, just currently constrained to one of two
+cases (replacement). ES Writing is the second case and is excluded.
+
+## Decision
+
+**Widen the `bridge_assessment_expectations_student_scoped` filter to admit
+every internal-assessment row that the enrollment-scoped bridge cannot
+represent.** Concretely: replacements OR ES Writing (i.e. any internal row with
+NULL section context). Do not synthesize a fake `cc_dcid`, do not add a third
+bridge.
+
+Rejected alternatives:
+
+- _Synthesize a deterministic `cc_dcid` from the student enrollment row_ —
+  manufactures a section relationship that doesn't exist; downstream consumers
+  traversing `dim_student_section_enrollments → dim_sections` would treat it as
+  real. Also requires the same synthesis in `dim_student_section_enrollments`,
+  expanding scope.
+- _Add a third bridge
+  `bridge_assessment_expectations_enrollment_scoped__no_section`_ — unnecessary;
+  the student-scoped bridge already encodes the "no-section-context" grain. The
+  current `is_replacement` filter is a coincidence of historical rollout, not a
+  semantic boundary.
+- _Drop the `cc_dcid IS NOT NULL` filter on the enrollment-scoped bridge_ — the
+  PK would collapse for NULL-cc_dcid rows (placeholder hash collision), failing
+  the uniqueness test. Even with a fallback discriminator, the resulting
+  `student_section_enrollment_key` would not link to anything in
+  `dim_student_section_enrollments`.
+
+## Implementation
+
+### `bridge_assessment_expectations_student_scoped.sql`
+
+Replace the `WHERE` clause (line 31):
+
+```sql
+where
+    sc.is_internal_assessment
+    and (sc.is_replacement or sc.cc_dcid is null)
+    and sc.powerschool_student_number is not null
+```
+
+`is_internal_assessment` is added explicitly to mirror the producer side and
+prevent external assessments (which also have `cc_dcid IS NULL`) from leaking
+in. Confirmed against current scaffold:
+
+- Internal + non-replacement + NULL cc_dcid: 116,776 (ES Writing)
+- Internal + replacement: 1,856 (already covered today)
+- External + NULL cc_dcid: 1.6M rows — must stay excluded
+
+Row count change: +114,920 net rows in
+`bridge_assessment_expectations_student_scoped` (116,776 ES Writing minus the
+1,856 replacement rows already counted). No grain change.
+
+### `bridge_assessment_expectations_enrollment_scoped.sql`
+
+No SQL change. Update the inline comment (lines 23-27) to point at the
+student-scoped bridge as the home for NULL-cc_dcid rows rather than implying
+they have no representation.
+
+### YAML
+
+- `bridge_assessment_expectations_student_scoped` model description: state that
+  the bridge carries internal assessment expectations that cannot be attributed
+  to a student section enrollment — replacements and ES Writing.
+- `bridge_assessment_expectations_enrollment_scoped` model description: state
+  that it only covers expectations with a resolvable section enrollment; ES
+  Writing and replacements live in the student-scoped bridge.
+- Tests: existing PK uniqueness on `assessment_expectation_key` continues to
+  hold — composition unchanged. Relationships test
+  `bridge_assessment_expectations_student_scoped.assessment_administration_key → dim_assessment_administrations`
+  must still pass after widening; verify in PR-branch CI.
+
+## Out of scope
+
+- **#3794** (survey responses FK gap) — separate spec, separate PR; same
+  PR-batch label on project board.
+- **#3817** (regions_assessed tagging) — moved off project 4; ops follow-up
+  only.
+- **`int_assessments__course_enrollments` ES Writing branch refactor** — no
+  change. The NULL `cc_dcid` is the truthful representation of "no section
+  enrollment exists." Synthesizing a value would propagate fiction downstream.
+- **`dim_student_section_enrollments` ES Writing coverage** — out of scope. ES
+  Writing intentionally has no section enrollment to dimensionalize.
+
+## Pre-merge checklist (per `marts/CLAUDE.md`)
+
+- [ ] Scan touched models for diamond paths (none introduced — only widens an
+      existing WHERE filter).
+- [ ] Scan touched models for R1–R10 violations (no new columns; existing
+      `cc_dcid`/`cc_source_relation` references are upstream-only and not
+      exposed in mart SELECTs).
+- [ ] Pull marts-model warnings from latest CI run via dbt MCP
+      `get_job_run_error(warning_only=true)`; confirm no new bridge warnings
+      surface for the widened row set (FK to `dim_assessment_administrations`,
+      FK to `dim_students`).
+- [ ] Scan
+      [project board #4](https://github.com/orgs/TEAMSchools/projects/4/views/1)
+      for bonus issues incidentally resolved; close them in the PR.
+- [ ] Confirm `bridge_assessment_expectations_student_scoped` PK uniqueness test
+      passes on the PR-branch schema with the expanded row set.
+
+## Acceptance criteria
+
+- `bridge_assessment_expectations_student_scoped` row count increases by
+  approximately +114,920 (the ES Writing class), with no fan-out.
+- All ES Writing administrations now appear in
+  `bridge_assessment_expectations_student_scoped`. Verify via:
+
+  ```sql
+  select count(*) as n_es_writing_admins_in_bridge
+  from `teamster-332318.kipptaf_marts.bridge_assessment_expectations_student_scoped` b
+  inner join `teamster-332318.kipptaf_assessments.int_assessments__scaffold` sc
+      using (assessment_id)
+  where sc.is_internal_assessment
+      and not sc.is_replacement
+      and sc.cc_dcid is null
+  ```
+
+  Expected ≈ 116,776.
+
+- `bridge_assessment_expectations_enrollment_scoped` row count unchanged.
+- PK uniqueness on both bridges still passes.
+- No new failing or warning relationships tests on either bridge.

--- a/docs/superpowers/specs/2026-05-12-es-writing-bridge-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-12-es-writing-bridge-coverage-design.md
@@ -1,7 +1,10 @@
 # ES Writing bridge coverage — design
 
 Refs #3777. Part of project [#4](https://github.com/orgs/TEAMSchools/projects/4)
-"enrollment FK cluster" batch.
+"enrollment FK cluster" batch. Ships a scoped slice of #3142
+(`_dbt_source_project` promotion on two union models) and #3820 (region-prefix
+hash on `student_section_enrollment_key`) as the additive upstream edits this
+fix requires.
 
 ## Problem
 
@@ -41,33 +44,127 @@ placeholder hash of `student_section_enrollment_key`.
 already the "no section context" path, just currently constrained to one of two
 cases (replacement). ES Writing is the second case and is excluded.
 
+### Secondary defect (discovered while drafting)
+
+`int_assessments__course_enrollments.sql` lines 67-72 dedupes on
+`(powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled)`
+with no source-region discriminator. PowerSchool `student_number` values are
+district-scoped; a Newark student #1234 and a Camden student #1234 doing ES
+Writing in the same AY/subject_area/enrollment date would silently collapse to
+one row. The K-8/HS branches dodge this via `cc_dcid` (globally distinct within
+the partition), but the ES Writing branch's all-NULL plumbing leaves the
+partition blind.
+
+### Tertiary defect (discovered while drafting)
+
+The K-8/HS branches inherit `_dbt_source_relation` from
+`base_powerschool__course_enrollments` (suffix
+`..._base_powerschool__course_enrollments`). If the ES Writing branch were fixed
+by carrying `co._dbt_source_relation` from
+`base_powerschool__student_enrollments`, its rows would carry suffix
+`..._base_powerschool__student_enrollments` instead. Same district, different
+table-name suffix — the value is no longer a region-only identifier. This is
+exactly the fragility #3820 documents, and the column-promotion pattern from
+#3142 is the canonical fix.
+
 ## Decision
 
-**Widen the `bridge_assessment_expectations_student_scoped` filter to admit
-every internal-assessment row that the enrollment-scoped bridge cannot
-represent.** Concretely: replacements OR ES Writing (i.e. any internal row with
-NULL section context). Do not synthesize a fake `cc_dcid`, do not add a third
-bridge.
+Three changes, ordered upstream → downstream:
+
+1. **(Scoped #3142)** Promote `_dbt_source_project` as a materialized column on
+   the two base union models this PR touches:
+   `base_powerschool__course_enrollments` and
+   `base_powerschool__student_enrollments`. Value:
+   `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` — the same logic
+   `extract_code_location()` already uses.
+2. **(Scoped #3820)** Recompose `student_section_enrollment_key` on both the
+   producer (`dim_student_section_enrollments`) and the consumer
+   (`bridge_assessment_expectations_enrollment_scoped`) to hash
+   `(cc_dcid, _dbt_source_project)` instead of
+   `(cc_dcid, _dbt_source_relation)`. Region-only suffix is consistent across
+   all upstream union tables and removes the cross-source-relation fragility.
+3. **(#3777 core)** Widen the `bridge_assessment_expectations_student_scoped`
+   filter to admit every internal-assessment row that the enrollment-scoped
+   bridge cannot represent: replacements OR ES Writing (i.e. any internal row
+   with NULL section context).
 
 Rejected alternatives:
 
 - _Synthesize a deterministic `cc_dcid` from the student enrollment row_ —
   manufactures a section relationship that doesn't exist; downstream consumers
   traversing `dim_student_section_enrollments → dim_sections` would treat it as
-  real. Also requires the same synthesis in `dim_student_section_enrollments`,
-  expanding scope.
+  real.
 - _Add a third bridge
   `bridge_assessment_expectations_enrollment_scoped__no_section`_ — unnecessary;
   the student-scoped bridge already encodes the "no-section-context" grain. The
-  current `is_replacement` filter is a coincidence of historical rollout, not a
-  semantic boundary.
+  current `is_replacement` filter is a coincidence of historical rollout.
 - _Drop the `cc_dcid IS NOT NULL` filter on the enrollment-scoped bridge_ — the
   PK would collapse for NULL-cc_dcid rows (placeholder hash collision), failing
-  the uniqueness test. Even with a fallback discriminator, the resulting
-  `student_section_enrollment_key` would not link to anything in
-  `dim_student_section_enrollments`.
+  the uniqueness test.
+- _Use `_dbt_source_relation` (not `_dbt_source_project`) as the ES Writing
+  discriminator_ — fixes the dedup collision but propagates the table-name
+  asymmetry that #3820 calls out; cleaner to do the column-promotion now.
+- _Ship the full #3142 (all 73 union models) in this PR_ — out of scope;
+  marts/CLAUDE.md permits the additive upstream edit only for the models this
+  PR's join/hash changes touch.
 
 ## Implementation
+
+### `base_powerschool__course_enrollments` (additive upstream)
+
+Add a materialized `_dbt_source_project` column. The model is a
+`dbt_utils.union_relations` view; add the column to the post-union SELECT:
+
+```sql
+select
+    *,
+    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+from {{ dbt_utils.union_relations(...) }}
+```
+
+Apply the same change to `base_powerschool__student_enrollments`. Both base
+models are intermediate-tier (`contract: enforced: false` per `dbt_project.yml`
+defaults), so no properties YAML column entry is required; add to descriptions
+only if a properties YAML already exists for the model.
+
+The remaining 71 union models touched by full #3142 are out of scope; the new
+column lives alongside `_dbt_source_relation` until #3142 ships and the macro
+`extract_code_location` is renamed / retired. Reference `_dbt_source_project`
+explicitly in dependent SELECTs rather than `SELECT *` to make the dependency
+visible.
+
+### `int_assessments__course_enrollments.sql`
+
+- K-12 branch (lines 4-36): add `ce._dbt_source_project` to the SELECT.
+- ES Writing branch (lines 40-64): replace
+  `cast(null as string) as _dbt_source_relation` with `co._dbt_source_project`.
+  Leave `cc_dcid = NULL` — there is genuinely no course-enrollment row to
+  attribute. (Leave `_dbt_source_relation` NULL too — only `_dbt_source_project`
+  is reliable across the two source tables.)
+- Trailing dedup (lines 67-72): add `_dbt_source_project` to `partition_by`.
+  Closes the cross-district student-number collision risk.
+
+### `int_assessments__scaffold.sql`
+
+- K-8 internal branch (lines 74) and HS internal branch (line 124): replace
+  `ce._dbt_source_relation as cc_source_relation` with
+  `ce._dbt_source_project as cc_source_project`.
+- Replacement branch (line 213) and external branch (line 271): replace
+  `cast(null as string) as cc_source_relation` with
+  `cast(null as string) as cc_source_project`. (These branches have no
+  enrollment context.)
+- Final SELECT and properties YAML: rename `cc_source_relation` →
+  `cc_source_project`. Update `config.meta.source_column` accordingly.
+
+### `bridge_assessment_expectations_enrollment_scoped.sql`
+
+- Rename SELECT reference and hash input from `cc_source_relation` to
+  `cc_source_project`.
+- WHERE clause: `cc_source_relation IS NOT NULL` →
+  `cc_source_project IS NOT NULL`. (Combined with `cc_dcid IS NOT NULL`, ES
+  Writing rows are still excluded.)
+- Inline comment (lines 23-27): update to reference the student-scoped bridge as
+  the home for NULL-cc_dcid rows.
 
 ### `bridge_assessment_expectations_student_scoped.sql`
 
@@ -80,65 +177,102 @@ where
     and sc.powerschool_student_number is not null
 ```
 
-`is_internal_assessment` is added explicitly to mirror the producer side and
-prevent external assessments (which also have `cc_dcid IS NULL`) from leaking
-in. Confirmed against current scaffold:
+`is_internal_assessment` is added explicitly to keep external assessments (which
+also have `cc_dcid IS NULL`) out of the bridge. Confirmed against current
+scaffold:
 
 - Internal + non-replacement + NULL cc_dcid: 116,776 (ES Writing)
-- Internal + replacement: 1,856 (already covered today)
+- Internal + replacement: 1,856 (already covered today, all internal)
 - External + NULL cc_dcid: 1.6M rows — must stay excluded
 
-Row count change: +114,920 net rows in
-`bridge_assessment_expectations_student_scoped` (116,776 ES Writing minus the
-1,856 replacement rows already counted). No grain change.
+Row count change: +114,920 net rows. No grain change.
 
-### `bridge_assessment_expectations_enrollment_scoped.sql`
+### `dim_student_section_enrollments.sql`
 
-No SQL change. Update the inline comment (lines 23-27) to point at the
-student-scoped bridge as the home for NULL-cc_dcid rows rather than implying
-they have no representation.
+Swap `student_section_enrollment_key` hash composition (line 74):
 
-### YAML
+```sql
+{{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
+    as student_section_enrollment_key,
+```
 
-- `bridge_assessment_expectations_student_scoped` model description: state that
-  the bridge carries internal assessment expectations that cannot be attributed
-  to a student section enrollment — replacements and ES Writing.
-- `bridge_assessment_expectations_enrollment_scoped` model description: state
-  that it only covers expectations with a resolvable section enrollment; ES
-  Writing and replacements live in the student-scoped bridge.
-- Tests: existing PK uniqueness on `assessment_expectation_key` continues to
-  hold — composition unchanged. Relationships test
+The `replace()` workaround on `course_section_key` (lines 79-93) stays — that's
+`course_section_key`'s alignment problem (dim_course_sections built from
+`base_powerschool__sections`), and ships under #3820's full sweep, not here.
+Update the TODO comment to flag that `student_section_enrollment_key` has been
+migrated to `_dbt_source_project` and the remaining keys await #3820.
+
+### YAML updates
+
+- `bridge_assessment_expectations_student_scoped`: description states the bridge
+  carries internal assessment expectations that cannot be attributed to a
+  student section enrollment — replacements and ES Writing.
+- `bridge_assessment_expectations_enrollment_scoped`: description states it only
+  covers expectations with a resolvable section enrollment; ES Writing and
+  replacements live in the student-scoped bridge.
+- `int_assessments__scaffold`: rename `cc_source_relation` column entry to
+  `cc_source_project`; update `source_column`.
+- `int_assessments__course_enrollments`: add `_dbt_source_project` column entry;
+  describe as the region prefix extracted from `_dbt_source_relation`.
+- `base_powerschool__course_enrollments` and
+  `base_powerschool__student_enrollments`: add `_dbt_source_project` column to
+  any existing properties YAML; if no properties YAML exists, skip.
+
+### Tests
+
+- Existing PK uniqueness on both bridges continues to hold —
+  `assessment_expectation_key` composition unchanged.
+- `dim_student_section_enrollments` PK uniqueness
+  (`student_section_enrollment_key`) — verify on PR-branch CI. Hash composition
+  changed from `(cc_dcid, _dbt_source_relation)` to
+  `(cc_dcid, _dbt_source_project)`; collision risk in theory only if two
+  source-relations produce the same `cc_dcid` within the same region (not
+  observed; PS `dcid` is globally unique within a district).
+- `bridge_assessment_expectations_enrollment_scoped.student_section_enrollment_key → dim_student_section_enrollments.student_section_enrollment_key`
+  relationships test must still pass after both sides swap to
+  `_dbt_source_project`. Verify on PR-branch CI.
+- Relationships test
   `bridge_assessment_expectations_student_scoped.assessment_administration_key → dim_assessment_administrations`
-  must still pass after widening; verify in PR-branch CI.
+  continues to pass with the expanded row set.
 
 ## Out of scope
 
+- **#3142** full implementation (71 remaining union models, macro rename, 268
+  `union_dataset_join_clause` replacements, macro retirement) — this PR ships
+  the column on 2 of 73 union models, scoped to the join/hash composition we're
+  touching.
+- **#3820** other affected files — `dim_courses.sql`, `dim_course_sections.sql`,
+  and the `course_section_key` `replace()` hack on
+  `dim_student_section_enrollments`. This PR migrates only
+  `student_section_enrollment_key`.
 - **#3794** (survey responses FK gap) — separate spec, separate PR; same
-  PR-batch label on project board.
-- **#3817** (regions_assessed tagging) — moved off project 4; ops follow-up
-  only.
-- **`int_assessments__course_enrollments` ES Writing branch refactor** — no
-  change. The NULL `cc_dcid` is the truthful representation of "no section
-  enrollment exists." Synthesizing a value would propagate fiction downstream.
-- **`dim_student_section_enrollments` ES Writing coverage** — out of scope. ES
-  Writing intentionally has no section enrollment to dimensionalize.
+  PR-batch label.
+- **#3817** (regions_assessed tagging) — off project 4; ops follow-up.
+- **`dim_student_section_enrollments` ES Writing coverage** — ES Writing
+  intentionally has no section enrollment to dimensionalize; the student-scoped
+  bridge is the correct home.
 
 ## Pre-merge checklist (per `marts/CLAUDE.md`)
 
-- [ ] Scan touched models for diamond paths (none introduced — only widens an
-      existing WHERE filter).
-- [ ] Scan touched models for R1–R10 violations (no new columns; existing
-      `cc_dcid`/`cc_source_relation` references are upstream-only and not
-      exposed in mart SELECTs).
+- [ ] Scan touched models for diamond paths (none introduced).
+- [ ] Scan touched models for R1–R10 violations. `_dbt_source_project` and
+      `cc_source_project` are plumbing — kept in intermediate layers, never
+      surfaced in a mart SELECT (R8).
 - [ ] Pull marts-model warnings from latest CI run via dbt MCP
-      `get_job_run_error(warning_only=true)`; confirm no new bridge warnings
-      surface for the widened row set (FK to `dim_assessment_administrations`,
-      FK to `dim_students`).
+      `get_job_run_error(warning_only=true)`; confirm no new bridge or dim
+      warnings surface (FK to `dim_assessment_administrations`, FK to
+      `dim_students`, `student_section_enrollment_key` uniqueness).
 - [ ] Scan
       [project board #4](https://github.com/orgs/TEAMSchools/projects/4/views/1)
-      for bonus issues incidentally resolved; close them in the PR.
-- [ ] Confirm `bridge_assessment_expectations_student_scoped` PK uniqueness test
-      passes on the PR-branch schema with the expanded row set.
+      for bonus issues incidentally resolved; close them in the PR (#3777
+      closes; partial progress on #3142 / #3820 documented but they stay open).
+- [ ] Confirm `bridge_assessment_expectations_student_scoped` PK uniqueness
+      passes on PR-branch schema with the expanded row set.
+- [ ] Confirm `dim_student_section_enrollments.student_section_enrollment_key`
+      uniqueness passes with the swapped hash composition.
+- [ ] Confirm
+      `bridge_assessment_expectations_enrollment_scoped → dim_student_section_enrollments`
+      relationships test passes (both sides now hash on `_dbt_source_project`).
 
 ## Acceptance criteria
 
@@ -160,5 +294,14 @@ they have no representation.
   Expected ≈ 116,776.
 
 - `bridge_assessment_expectations_enrollment_scoped` row count unchanged.
-- PK uniqueness on both bridges still passes.
-- No new failing or warning relationships tests on either bridge.
+- `dim_student_section_enrollments` row count unchanged; PK uniqueness still
+  passes.
+- `bridge_assessment_expectations_enrollment_scoped.student_section_enrollment_key → dim_student_section_enrollments.student_section_enrollment_key`
+  relationships test orphan count unchanged from current prod (no new drift
+  introduced by the hash swap).
+- `int_assessments__course_enrollments` row count: verify no rows lost through
+  the addition of `_dbt_source_project` to the dedup partition (any net change
+  should be an _increase_ — previously-collapsed cross-district duplicates now
+  preserved).
+- PK uniqueness on `int_assessments__course_enrollments` still passes with the
+  widened partition.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -494,6 +494,9 @@ alias.
 - Data and column semantics — code values, identifier formats, join keys, grain
   notes — belong in the model's `description:` (or `config.meta`), not
   CLAUDE.md. CLAUDE.md is for workflow conventions and tooling guidance only.
+- YAML `description:` is for what/why a column or model computes. Don't put
+  TODOs, history, migration plumbing, or tracking-issue refs (`#3142`, etc.) in
+  descriptions — those go in inline SQL comments at the derivation site.
 
 ### Legacy `base_` prefix
 

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
@@ -59,7 +59,7 @@ with
             co.academic_year + 1 as illuminate_academic_year,
             co.grade_level + 1 as illuminate_grade_level_id,
 
-            false as is_advanced_math,
+            false as is_advanced_math_student,
         from {{ ref("base_powerschool__student_enrollments") }} as co
         where co.region in ('Newark', 'Camden') and co.grade_level <= 4
     )

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
@@ -11,7 +11,6 @@ with
             ce.discipline,
             ce.is_foundations,
             ce.cc_dcid,
-            ce._dbt_source_relation,
             ce._dbt_source_project,
 
             co.region,
@@ -22,7 +21,7 @@ with
 
             max(ce.is_advanced_math) over (
                 partition by
-                    ce._dbt_source_relation,
+                    ce._dbt_source_project,
                     ce.cc_studentid,
                     ce.cc_academic_year,
                     ce.courses_credittype
@@ -53,7 +52,6 @@ with
             false as is_foundations,
 
             cast(null as int64) as cc_dcid,
-            cast(null as string) as _dbt_source_relation,
 
             co._dbt_source_project,
             co.region,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
@@ -12,6 +12,7 @@ with
             ce.is_foundations,
             ce.cc_dcid,
             ce._dbt_source_relation,
+            ce._dbt_source_project,
 
             co.region,
 
@@ -54,6 +55,7 @@ with
             cast(null as int64) as cc_dcid,
             cast(null as string) as _dbt_source_relation,
 
+            co._dbt_source_project,
             co.region,
 
             co.academic_year + 1 as illuminate_academic_year,
@@ -67,7 +69,7 @@ with
     {{
         dbt_utils.deduplicate(
             relation="enrollments_union",
-            partition_by="powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled",
+            partition_by="_dbt_source_project, powerschool_student_number, illuminate_academic_year, illuminate_subject_area, cc_dateenrolled",
             order_by="cc_dateleft desc",
         )
     }}

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
@@ -71,7 +71,7 @@ with
             ce.discipline,
             ce.cc_dcid,
 
-            ce._dbt_source_relation as cc_source_relation,
+            ce._dbt_source_project as cc_source_project,
         from assessment_region_scaffold as a
         inner join
             {{ ref("int_illuminate__student_session_aff") }} as ssa
@@ -121,7 +121,7 @@ with
             ce.discipline,
             ce.cc_dcid,
 
-            ce._dbt_source_relation as cc_source_relation,
+            ce._dbt_source_project as cc_source_project,
         from assessment_region_scaffold as a
         inner join
             {{ ref("int_assessments__course_enrollments") }} as ce
@@ -165,7 +165,7 @@ select
     ia.module_code,
     ia.discipline,
     ia.cc_dcid,
-    ia.cc_source_relation,
+    ia.cc_source_project,
     ia.canonical_assessment_id,
     ia.canonical_title,
     ia.canonical_administered_at,
@@ -210,7 +210,7 @@ select
     null as discipline,
 
     cast(null as int64) as cc_dcid,
-    cast(null as string) as cc_source_relation,
+    cast(null as string) as cc_source_project,
 
     a.canonical_assessment_id,
     a.canonical_title,
@@ -268,7 +268,7 @@ select
     null as discipline,
 
     cast(null as int64) as cc_dcid,
-    cast(null as string) as cc_source_relation,
+    cast(null as string) as cc_source_project,
 
     a.canonical_assessment_id,
     a.canonical_title,

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -12,6 +12,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
+              - _dbt_source_project
               - powerschool_student_number
               - illuminate_academic_year
               - illuminate_subject_area
@@ -28,6 +29,8 @@ models:
       - name: cc_dateleft
         data_type: date
       - name: illuminate_subject_area
+        data_type: string
+      - name: discipline
         data_type: string
       - name: is_foundations
         data_type: boolean

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -50,6 +50,16 @@ models:
         config:
           meta:
             source_column: base_powerschool__course_enrollments._dbt_source_relation
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Region prefix extracted from _dbt_source_relation (e.g. kippnewark,
+          kippcamden, kippmiami, kipppaterson). Used as a discriminator in
+          downstream surrogate keys and as part of the dedup partition_by to
+          prevent cross-district student_number collisions. See #3142.
+        config:
+          meta:
+            source_column: base_powerschool__course_enrollments._dbt_source_project
       - name: region
         data_type: string
       - name: illuminate_academic_year

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -46,10 +46,11 @@ models:
       - name: _dbt_source_project
         data_type: string
         description: >-
-          Region prefix identifying the source district project (e.g.
-          kippnewark, kippcamden, kippmiami, kipppaterson). Used as a
-          discriminator in downstream surrogate keys and as part of the dedup
-          partition_by to prevent cross-district student_number collisions.
+          Region prefix (e.g. kippnewark, kippcamden, kippmiami, kipppaterson)
+          plumbed through from the upstream PowerSchool union models. Carried on
+          both K-12 and ES Writing branches and used as the region discriminator
+          in the trailing dedup partition and downstream surrogate keys
+          (student_section_enrollment_key). See #3142.
         config:
           meta:
             source_column: base_powerschool__course_enrollments._dbt_source_project

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -49,8 +49,7 @@ models:
           Region prefix identifying the source district project (e.g.
           kippnewark, kippcamden, kippmiami, kipppaterson). Used as a
           discriminator in downstream surrogate keys and as part of the dedup
-          partition_by to prevent cross-district student_number collisions. See
-          #3142.
+          partition_by to prevent cross-district student_number collisions.
         config:
           meta:
             source_column: base_powerschool__course_enrollments._dbt_source_project

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -40,23 +40,14 @@ models:
         config:
           meta:
             source_column: base_powerschool__course_enrollments.cc_dcid
-      - name: _dbt_source_relation
-        data_type: string
-        description: >-
-          dbt union-relation metadata string identifying the source district
-          project. Required upstream for the cc_dcid + _dbt_source_relation
-          composite that uniquely identifies a course enrollment across the four
-          district projects.
-        config:
-          meta:
-            source_column: base_powerschool__course_enrollments._dbt_source_relation
       - name: _dbt_source_project
         data_type: string
         description: >-
-          Region prefix extracted from _dbt_source_relation (e.g. kippnewark,
-          kippcamden, kippmiami, kipppaterson). Used as a discriminator in
-          downstream surrogate keys and as part of the dedup partition_by to
-          prevent cross-district student_number collisions. See #3142.
+          Region prefix identifying the source district project (e.g.
+          kippnewark, kippcamden, kippmiami, kipppaterson). Used as a
+          discriminator in downstream surrogate keys and as part of the dedup
+          partition_by to prevent cross-district student_number collisions. See
+          #3142.
         config:
           meta:
             source_column: base_powerschool__course_enrollments._dbt_source_project

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -71,17 +71,19 @@ models:
         config:
           meta:
             source_column: int_assessments__course_enrollments.cc_dcid
-      - name: cc_source_relation
+      - name: cc_source_project
         data_type: string
         description: >-
-          dbt union-relation metadata string identifying the source district
-          project for the matched course enrollment. Populated only for the
-          internal-assessment branch; null for K-8 replacement curriculum and
-          external-assessment rows. Pairs with cc_dcid to uniquely identify a
-          course enrollment across the four district projects.
+          Region prefix (e.g. kippnewark, kippcamden, kippmiami, kipppaterson)
+          identifying the source district project for the matched course
+          enrollment, carried via _dbt_source_project from the upstream union
+          tables. Populated only for the internal-assessment branch; null for
+          K-8 replacement curriculum and external-assessment rows. Used as a
+          discriminator component in downstream surrogate keys such as
+          student_section_enrollment_key (see #3142).
         config:
           meta:
-            source_column: int_assessments__course_enrollments._dbt_source_relation
+            source_column: int_assessments__course_enrollments._dbt_source_project
       - name: student_assessment_id
         data_type: int64
       - name: date_taken

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -80,7 +80,7 @@ models:
           tables. Populated only for the internal-assessment branch; null for
           K-8 replacement curriculum and external-assessment rows. Used as a
           discriminator component in downstream surrogate keys such as
-          student_section_enrollment_key (see #3142).
+          student_section_enrollment_key.
         config:
           meta:
             source_column: int_assessments__course_enrollments._dbt_source_project

--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -160,6 +160,10 @@ Intermediates may rename or transform columns (e.g. scaffold's
 `int_assessments__assessments.academic_year`); the consumer must re-join the
 source-of-truth model rather than trust the matching column name.
 
+Before swapping the input list of any `generate_surrogate_key()` on a dim/fact,
+grep every consumer that hashes the same composition and migrate producer + all
+consumers in one atomic commit.
+
 ## `_dbt_source_project` joins and hashes
 
 When a marts fix touches joins or surrogate-key composition involving

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
@@ -7,7 +7,7 @@ with
     expectations as (
         select
             sc.cc_dcid,
-            sc.cc_source_relation,
+            sc.cc_source_project,
             sc.assessment_id,
             sc.administered_at,
             sc.region,
@@ -20,26 +20,25 @@ with
         inner join
             {{ ref("int_assessments__assessments") }} as a
             on sc.assessment_id = a.assessment_id
-        -- ES Writing rows in int_assessments__course_enrollments synthesize
-        -- NULL cc_dcid (no PowerSchool course-enrollment record exists for
-        -- those students). Excluded here because cc_dcid + cc_source_relation
-        -- form the student_section_enrollment_key — NULL inputs would all hash
-        -- to the same generate_surrogate_key placeholder and collide on the PK.
+        -- ES Writing and other NULL-cc_dcid rows are excluded here because
+        -- cc_dcid + _dbt_source_project form the student_section_enrollment_key
+        -- and NULL cc_dcid would collide on the placeholder hash. Those rows
+        -- live in bridge_assessment_expectations_student_scoped instead.
         where
             sc.is_internal_assessment
             and not sc.is_replacement
             and sc.cc_dcid is not null
-            and sc.cc_source_relation is not null
+            and sc.cc_source_project is not null
     )
 
 select
     {{
         dbt_utils.generate_surrogate_key(
-            ["cc_dcid", "cc_source_relation", "assessment_id", "administered_at"]
+            ["cc_dcid", "cc_source_project", "assessment_id", "administered_at"]
         )
     }} as assessment_expectation_key,
 
-    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_relation"]) }}
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }}
     as student_section_enrollment_key,
 
     {{

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
@@ -28,10 +28,7 @@ with
             and sc.powerschool_school_id = rt.school_id
             and sc.region = rt.region
             and rt.type = 'RT'
-        where
-            sc.is_internal_assessment
-            and (sc.is_replacement or sc.cc_dcid is null)
-            and sc.powerschool_student_number is not null
+        where sc.is_internal_assessment and (sc.is_replacement or sc.cc_dcid is null)
     )
 
 select

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
@@ -28,7 +28,10 @@ with
             and sc.powerschool_school_id = rt.school_id
             and sc.region = rt.region
             and rt.type = 'RT'
-        where sc.is_replacement and sc.powerschool_student_number is not null
+        where
+            sc.is_internal_assessment
+            and (sc.is_replacement or sc.cc_dcid is null)
+            and sc.powerschool_student_number is not null
     )
 
 select

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
@@ -1,10 +1,12 @@
 models:
   - name: bridge_assessment_expectations_enrollment_scoped
-    description: >-
-      Factless many-to-many bridge linking student section enrollments to
-      scheduled assessment administrations. One row per (student section
-      enrollment x assessment administration). Replaces the internal-assessment
-      portion of the deleted dim_student_assessment_expectations.
+    description: |
+      Bridges internal assessment expectations whose section enrollment can
+      be resolved (a PowerSchool course-enrollment row exists for the
+      assessed subject) to their student section enrollment and assessment
+      administration. Expectations without a resolvable section enrollment
+      — replacement assessments and ES Writing in grades K-4 Newark/Camden
+      — live in `bridge_assessment_expectations_student_scoped`.
     columns:
       - name: assessment_expectation_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
@@ -1,19 +1,13 @@
 models:
   - name: bridge_assessment_expectations_student_scoped
-    description: >-
-      Factless many-to-many bridge linking students to scheduled assessment
-      administrations for K-8 replacement-curriculum assessments where there is
-      no section enrollment context. One row per (student x assessment
-      administration). Replaces the K-8 replacement portion of the deleted
-      dim_student_assessment_expectations. Sources only the `is_replacement`
-      branch of int_assessments__scaffold; teacher-created Illuminate items that
-      live on the non-internal scaffold branch are excluded because they have no
-      corresponding row in dim_assessment_administrations and would produce 100%
-      FK orphans. Hash inputs mirror the illuminate branch of
-      dim_assessment_administrations exactly — int_assessments__assessments is
-      re-joined to recover the canonical `grade_level` and `academic_year` (the
-      scaffold's `grade_level_id` is illuminate-indexed and its `academic_year`
-      is `academic_year_clean`, neither of which match the dim's hash inputs).
+    description: |
+      Bridges internal assessment expectations that cannot be attributed to
+      a student section enrollment to their student and assessment
+      administration. Covers two classes: replacement assessments (which
+      have no enrollment by definition) and ES Writing in grades K-4
+      Newark/Camden (where no PowerSchool course-enrollment row exists for
+      the writing program). Rows whose expectations can be attributed to a
+      section enrollment live in `bridge_assessment_expectations_enrollment_scoped`.
     columns:
       - name: assessment_expectation_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -59,7 +59,7 @@ with
         {{
             dbt_utils.deduplicate(
                 relation="course_enrollments_joined",
-                partition_by="cc_dcid, _dbt_source_relation",
+                partition_by="cc_dcid, _dbt_source_project",
                 order_by="enr_entrydate desc",
             )
         }}

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -16,6 +16,7 @@ with
     course_enrollments_joined as (
         select
             cc._dbt_source_relation,
+            cc._dbt_source_project,
             cc.cc_dcid,
             cc.sections_dcid,
             cc.cc_academic_year,
@@ -71,14 +72,16 @@ select
     is_dropped_section,
     is_dropped_course,
 
-    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_relation"]) }}
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
     as student_section_enrollment_key,
 
     -- FK source_relation must match dim_course_sections, which is built from
     -- base_powerschool__sections. Rewrite cc's source relation to the parent's.
     -- TODO: replace() is a no-op if a future district uses a different base
     -- model name. Long-term fix: hash region prefix only, consistent across
-    -- producer and consumer (#3820).
+    -- producer and consumer (#3820). student_section_enrollment_key has been
+    -- migrated to _dbt_source_project (this wave); course_section_key and the
+    -- remaining surrogate keys still await full #3820.
     {{
         dbt_utils.generate_surrogate_key(
             [

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -12,7 +12,7 @@ models:
       - name: student_section_enrollment_key
         data_type: string
         description: >-
-          Surrogate key derived from cc_dcid and _dbt_source_relation. Primary
+          Surrogate key derived from cc_dcid and _dbt_source_project. Primary
           key for this dimension — unique per CC record per region.
         constraints:
           - type: primary_key

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
@@ -2,6 +2,7 @@ with
     course_enrollments as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             cc_studentid,
             cc_academic_year,
             cc_schoolid,
@@ -52,7 +53,7 @@ select
         )
     }} as grades_assignment_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ce.cc_dcid", "ce._dbt_source_relation"]) }}
+    {{ dbt_utils.generate_surrogate_key(["ce.cc_dcid", "ce._dbt_source_project"]) }}
     as student_section_enrollment_key,
 
     {{

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_category.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_category.sql
@@ -2,6 +2,7 @@ with
     course_enrollments as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             cc_studentid,
             cc_abs_sectionid,
             cc_dcid,
@@ -39,7 +40,7 @@ select
         )
     }} as grades_category_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ce.cc_dcid", "ce._dbt_source_relation"]) }}
+    {{ dbt_utils.generate_surrogate_key(["ce.cc_dcid", "ce._dbt_source_project"]) }}
     as student_section_enrollment_key,
 
     if(

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
@@ -31,24 +31,8 @@ select
         )
     }} as grades_term_key,
 
-    -- FK source_relation must match dim_student_section_enrollments, which is
-    -- built from base_powerschool__course_enrollments. Rewrite fg's source
-    -- relation to the parent's so the hash inputs align.
-    -- TODO: replace() is a no-op if a future district uses a different base
-    -- model name. Long-term fix: hash region prefix only, consistent across
-    -- producer and consumer (#3678 follow-up).
-    {{
-        dbt_utils.generate_surrogate_key(
-            [
-                "fg.cc_dcid",
-                (
-                    "replace(fg._dbt_source_relation,"
-                    " 'base_powerschool__final_grades',"
-                    " 'base_powerschool__course_enrollments')"
-                ),
-            ]
-        )
-    }} as student_section_enrollment_key,
+    {{ dbt_utils.generate_surrogate_key(["fg.cc_dcid", "fg._dbt_source_project"]) }}
+    as student_section_enrollment_key,
 
     {{
         dbt_utils.generate_surrogate_key(

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -25,7 +25,7 @@ models:
         data_type: string
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
-          cc_dcid and _dbt_source_relation.
+          cc_dcid and _dbt_source_project.
         constraints:
           - type: foreign_key
             to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -24,7 +24,7 @@ models:
         data_type: string
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
-          cc_dcid and _dbt_source_relation.
+          cc_dcid and _dbt_source_project.
         constraints:
           - type: foreign_key
             to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -24,7 +24,7 @@ models:
         data_type: string
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
-          cc_dcid and _dbt_source_relation.
+          cc_dcid and _dbt_source_project.
         constraints:
           - type: foreign_key
             to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -51,6 +51,8 @@ select
     csc.is_advanced_math,
     csc.discipline,
 
+    regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+
     initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
 
     if(cx.ap_course_subject is not null, true, false) as is_ap_course,

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -51,6 +51,8 @@ select
     csc.is_advanced_math,
     csc.discipline,
 
+    -- materialized region-prefix discriminator for downstream surrogate-key
+    -- composition; replaces per-consumer extract_code_location() per #3142
     regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
 
     initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -31,6 +31,7 @@ with
         select
             *,
 
+            regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
             regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as code_location,
 
             initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -31,6 +31,9 @@ with
         select
             *,
 
+            -- materialized region-prefix discriminator for downstream surrogate-key
+            -- composition; replaces per-consumer extract_code_location() per #3142.
+            -- code_location is the prior name; both will collapse when #3142 ships.
             regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
             regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as code_location,
 

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
@@ -485,7 +485,7 @@ models:
           Region prefix extracted from `_dbt_source_relation` via
           `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
           in downstream surrogate keys, consistent across all upstream union
-          tables. See #3142.
+          tables.
       - name: region
         data_type: string
         description: Derived from _dbt_source_relation.

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
@@ -479,6 +479,13 @@ models:
         data_type: boolean
       - name: discipline
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: |
+          Region prefix extracted from `_dbt_source_relation` via
+          `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
+          in downstream surrogate keys, consistent across all upstream union
+          tables. See #3142.
       - name: region
         data_type: string
         description: Derived from _dbt_source_relation.

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
@@ -532,7 +532,7 @@ models:
           Region prefix extracted from `_dbt_source_relation` via
           `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
           in downstream surrogate keys, consistent across all upstream union
-          tables. See #3142.
+          tables.
       - name: code_location
         data_type: string
       - name: region

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
@@ -526,6 +526,13 @@ models:
         data_type: string
       - name: school_level
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: |
+          Region prefix extracted from `_dbt_source_relation` via
+          `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
+          in downstream surrogate keys, consistent across all upstream union
+          tables. See #3142.
       - name: code_location
         data_type: string
       - name: region


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will surface ES Writing (grades K-4 Newark and
Camden) assessment expectations in the dimensional model. The expectations
existed in `int_assessments__scaffold` but were filtered out of both bridges,
because the ES Writing branch synthesizes `cc_dcid = NULL` (no PowerSchool
course-enrollment row exists) and both bridges historically excluded NULL-cc_dcid
rows.

Three layered changes, upstream → downstream:

1. **Scoped slice of #3142** — promote `_dbt_source_project` (region prefix
   `kippnewark` / `kippcamden` / `kippmiami` / `kipppaterson` extracted from
   `_dbt_source_relation`) as a materialized column on the two
   `dbt_utils.union_relations` base models this PR's joins touch
   (`base_powerschool__course_enrollments`,
   `base_powerschool__student_enrollments`). 2 of 73 union models — the
   remaining 71 stay on `_dbt_source_relation` until full #3142 ships.

2. **Scoped slice of #3820** — migrate `student_section_enrollment_key`'s
   surrogate-key composition from `(cc_dcid, _dbt_source_relation)` to
   `(cc_dcid, _dbt_source_project)` across the producer
   (`dim_student_section_enrollments`) and all four consumers
   (`bridge_assessment_expectations_enrollment_scoped`, `fct_grades_term`,
   `fct_grades_category`, `fct_grades_assignments`). Removes the
   `replace('base_powerschool__final_grades', 'base_powerschool__course_enrollments')`
   workaround on `fct_grades_term`. `course_section_key` and other surrogate
   keys remain deferred to full #3820.

3. **#3777 core** — widen the `bridge_assessment_expectations_student_scoped`
   filter to admit every internal-assessment row without resolvable section
   context (`is_replacement OR cc_dcid IS NULL`), adding `is_internal_assessment`
   to keep the 1.6M external-assessment rows out. Net result: +116,776 ES Writing
   expectation rows in the student-scoped bridge.

Also fixes a latent dedup defect in `int_assessments__course_enrollments`: adds
`_dbt_source_project` to the dedup `partition_by` so cross-district PowerSchool
student-number collisions can no longer silently collapse rows. Drops
now-unused `_dbt_source_relation` plumbing from
`int_assessments__course_enrollments` (scaffold no longer reads it after Task
4's rename).

## AI Assistance

Spec, plan, and implementation authored by Claude Code (Opus 4.7); human
direction on scope boundaries (which slices of #3142 and #3820 to ship in this
PR, expansion to cover the 3 grades-fact consumers, cleanup of dead
`_dbt_source_relation` carries) and per-task review checkpoints.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address
      valid feedback; dismiss false positives with a brief reply explaining
      why.

### dbt

- [x] Properties YAMLs updated for every touched model (descriptions and
      `source_column` meta tracked through `_dbt_source_project` plumbing).
- [x] No exposure updates needed — surrogate-key value change is FK-internal;
      no column added or removed at the mart boundary.
- [x] **Not a breaking change** — `student_section_enrollment_key` is a hash
      value, not a column rename. Both producer and all four consumers swap
      together in this PR; relationships tests verified PASS with 0 orphans
      locally.
- [x] No external sources added.

## CI checks

- [x] **Trunk** — pending CI.
- [x] **dbt Cloud** — pending CI. Full subgraph build locally:
      PASS=307 WARN=12 ERROR=0; 12 WARN tests are all pre-existing.
- [x] **Dagster Cloud** — not triggered (no Dagster paths touched).

## Verification (local)

- `bridge_assessment_expectations_student_scoped`: 1,856 → 118,632 rows
  (+116,776 ES Writing class). PK uniqueness PASS.
- `bridge_assessment_expectations_enrollment_scoped`: row count unchanged.
- `dim_student_section_enrollments`: row count unchanged, PK uniqueness PASS.
- All 4 consumers of `student_section_enrollment_key` pass the FK
  relationships test against the migrated dim — 0 orphans.
- 5 of 6 touched marts row-count stable (hash migration is value-neutral).
- Diamond-path scan clean; R1–R10 scan clean (no plumbing leakage to mart
  SELECTs).

Closes #3777.

Refs #3142 — partial: ships `_dbt_source_project` on 2 of 73 union models
(`base_powerschool__course_enrollments`,
`base_powerschool__student_enrollments`). 71 remaining union models, the
`extract_code_location` macro rename, and the 268 `union_dataset_join_clause`
replacements remain.

Refs #3820 — partial: migrates `student_section_enrollment_key` only.
`course_section_key`'s `replace()` workaround on
`dim_student_section_enrollments`, and the other affected surrogate keys
(`dim_courses`, `dim_course_sections`), remain.
