### PR TITLE
fix(extracts): use active_override in leadership PM reminders filter

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__leadership_pm_reminders.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__leadership_pm_reminders.sql
@@ -21,7 +21,7 @@ where
     l.academic_year = {{ var("current_academic_year") }}
     and (l.round_completion_self = 0 or l.round_completion_manager = 0)
     and l.active_assignment
-    and a.app_selection_active
+    and coalesce(a.active_override, a.app_selection_active)
     and sr.assignment_status in ('Active', 'Leave')
 group by
     l.preferred_name_lastfirst,


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will use `active_override` from `stg_google_appsheet__leadership_development__active_users` as the authoritative filter in `rpt_gsheets__leadership_pm_reminders` when set, falling back to `app_selection_active` when null. Previously only `app_selection_active` was checked, so explicit overrides had no effect.

Closes #3904

_AI-assisted: Claude identified and implemented the `coalesce(active_override, app_selection_active)` fix; human-directed._

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model will break downstream exposures.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`**

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.