### PR TITLE
perf(dbt-kipptaf): revert 3 rpt_tableau__gradebook_* reports to views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,8 +332,11 @@ wide tables, paginate with `WHERE ordinal_position > N`.
 SELECT-only constraints apply.
 
 Pre-merge queries against PR-branch schema use
-`dbt_cloud_pr_<ci_id>_<pr_num>_<schema>` — prod `<schema>` lacks unmerged
-renames.
+`dbt_cloud_pr_<job_definition_id>_<pr_num>_<schema>`. `<job_definition_id>` is
+the dbt Cloud CI job ID (stable across runs); read from
+`mcp__dbt__get_job_run_details(run_id)` step name
+`"Create profile from connection BigQuery (override schema to '...')"`. Prod
+`<schema>` lacks unmerged renames.
 
 Chained joins through PR-branch marts (mart-view → mart-view → upstream-view)
 hit BigQuery's 16-view nesting limit. Query materialized prod tables instead, or

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -99,6 +99,19 @@ Every `dbt` invocation appends to `<project>/logs/dbt.log` (full output, not
 truncated). When a background build's captured output is incomplete, read that
 file before re-running the build.
 
+## `dbt ls --output json` stdout is mixed
+
+Stdout interleaves dbt log lines with JSON records. Pipe through `grep '^{'`
+before parsing.
+
+## Table→view materialization conversion needs a drop
+
+`create or replace view` does not drop a pre-existing table at the same path —
+the conversion silently keeps serving the stale table. Ship table→view
+conversions with either an explicit
+`DROP TABLE IF EXISTS <project>.<dataset>.<model>` at deploy time, or run
+`dbt build --select <model> --full-refresh` once after merge.
+
 ## dbt Cloud CI state comparison
 
 `state:modified+` hashes every source node through `{{ target.name }}`

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_es_comments.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_es_comments.yml
@@ -1,7 +1,5 @@
 models:
   - name: rpt_tableau__gradebook_es_comments
-    config:
-      materialized: table
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
@@ -1,7 +1,5 @@
 models:
   - name: rpt_tableau__gradebook_gpa
-    config:
-      materialized: table
     columns:
       - name: _dbt_source_relation
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_ms_hs_comments.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_ms_hs_comments.yml
@@ -1,7 +1,5 @@
 models:
   - name: rpt_tableau__gradebook_ms_hs_comments
-    config:
-      materialized: table
     columns:
       - name: academic_year
         data_type: int64


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will eliminate ~$10.30/week of redundant BigQuery materialization spend by reverting three Tableau gradebook reports to views.

BigQuery `INFORMATION_SCHEMA.JOBS` analysis for 2026-05-11 to 2026-05-13:

| Model | Builds/2.5d | Direct reads | Build cost | b/r ratio |
|---|---:|---:|---:|---:|
| `rpt_tableau__gradebook_ms_hs_comments` | 357 | 4 | $4.26 | 89× |
| `rpt_tableau__gradebook_es_comments` | 352 | 4 | $4.20 | 88× |
| `rpt_tableau__gradebook_gpa` | 344 | 4 | $1.86 | 86× |

The mirrored conversion for `rpt_tableau__gradebook_audit` shipped on 2026-05-11 via commit 5ba6a5a3c with the same rationale.

### View nesting safety

Verified against `INFORMATION_SCHEMA.TABLES`: deepest linear view chain (gradebook_ms_hs / es) is 6 levels of consecutive views — well below BigQuery's 16-view nesting cap. `gpa` is 3 levels. No cross-project refs touch these models (no `dependencies.yml` in repo, no hardcoded `teamster-332318.kipptaf_*` references in sibling projects).

### Scope

Narrow change — only the materialization config is removed. The structural refactor in #3606 (split `gradebook_audit_flags` into student/teacher children, add `int_tableau__gradebook_audit_teacher_aggs` table, eliminate `GROUP BY ALL`, etc.) is independent and not included here.

## AI Assistance

Authored by Claude Code with human-directed scope. The decision to ship this narrow change separately from #3606 came from cost data analysis showing #3606 has been sitting open for a month with merge conflicts while spend on these 3 models continues unabated.

This PR also updates `CLAUDE.md` and `src/dbt/CLAUDE.md` with three learnings from this session: corrected dbt CI PR-schema variable, `dbt ls --output json` stdout filtering, and the table→view conversion drop requirement.

## Self-review

### dbt

- [x] Properties files updated for all modified models
- [x] Existing exposure `gradebook_and_gpa_dashboard` already covers these models — no exposure changes needed
- [x] **Breaking change?** No. Column output schemas are unchanged. Tableau reads against `kipptaf_tableau.rpt_tableau__gradebook_*` continue to work identically — only the materialization shape changes.

## CI checks

- [x] **Trunk** — passes (pre-commit ran clean)
- [x] **dbt Cloud** — passes; verified `SELECT *` against all 3 views in PR-branch schema `dbt_cloud_pr_70403104388001_3909_tableau`
- [ ] **Dagster Cloud** — not triggered (dbt-only change)

## Deploy

`create or replace view` does NOT drop a pre-existing table at the same path. The prior table will keep serving Tableau reads until explicitly removed. Choose one at merge time:

```sql
DROP TABLE IF EXISTS `teamster-332318.kipptaf_tableau.rpt_tableau__gradebook_ms_hs_comments`;
DROP TABLE IF EXISTS `teamster-332318.kipptaf_tableau.rpt_tableau__gradebook_es_comments`;
DROP TABLE IF EXISTS `teamster-332318.kipptaf_tableau.rpt_tableau__gradebook_gpa`;
```

— or — run `dbt build --select rpt_tableau__gradebook_ms_hs_comments rpt_tableau__gradebook_es_comments rpt_tableau__gradebook_gpa --full-refresh` once after merge.

## Post-deploy verification

- [ ] Confirm all 3 objects appear as `VIEW` (not `BASE TABLE`) in `kipptaf_tableau.INFORMATION_SCHEMA.TABLES`
- [ ] Re-run BigQuery `INFORMATION_SCHEMA.JOBS` analysis 1 week post-merge: expect ~zero build cost on these 3 models, no commensurate spike in `tableau@` user spend
- [ ] Monitor Tableau extract refresh times for the `gradebook_and_gpa_dashboard` exposure

Refs #3589