### PR TITLE
perf(dbt-kipptaf): shift topline materialization from 14 weeklies to int_topline__student_metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ secret-volume
 dagster-tmp
 .claude/settings.local.json
 .claude/scratch/
+.claude/scheduled_tasks.lock
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,macos,windows,python,dbt
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos,windows,python,dbt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,17 @@ Chained joins through PR-branch marts (mart-view → mart-view → upstream-view
 hit BigQuery's 16-view nesting limit. Query materialized prod tables instead, or
 split the query.
 
+Two BQ query-shape failure modes (not interchangeable):
+
+- `exceeds the maximum allowed number of nested views` — chain depth >16.
+  Materialize a mid-chain model.
+- `Resources exceeded during query execution: Not enough resources for query planning - query is too complex`
+  — fan-out width, can fire well below 16. Materialize the fan-out point.
+
+`INFORMATION_SCHEMA.JOBS.referenced_tables` lists base tables reached via view
+expansion, NOT a directly-selected view. To find consumers of a view, filter by
+`REGEXP_CONTAINS(query, '<view_name>')`.
+
 For NULL-safe distinct counts on composite keys, use
 `count(distinct format("%T|%T", a, b))` — `concat()` returns NULL when any arg
 is NULL and silently miscounts violations.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -104,6 +104,11 @@ file before re-running the build.
 Stdout interleaves dbt log lines with JSON records. Pipe through `grep '^{'`
 before parsing.
 
+## Materialization overrides go in properties yml
+
+Use `config: materialized: <kind>` in `properties/<model>.yml`, not inline
+`{{ config(...) }}` in SQL. Create the yml if absent.
+
 ## Table→view materialization conversion needs a drop
 
 `create or replace view` does not drop a pre-existing table at the same path —

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__ada_running_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__ada_running_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__ada_running_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__ada_running_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__ada_running_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__ada_running_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_contacts_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_contacts_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__attendance_contacts_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_contacts_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_contacts_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__attendance_contacts_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_interventions_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_interventions_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__attendance_interventions_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_interventions_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__attendance_interventions_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__attendance_interventions_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_entrance_exams_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_entrance_exams_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__college_entrance_exams_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_entrance_exams_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_entrance_exams_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__college_entrance_exams_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_matriculation_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_matriculation_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__college_matriculation_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_matriculation_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__college_matriculation_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__college_matriculation_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__dibels_pm_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__dibels_pm_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__dibels_pm_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__dibels_pm_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__dibels_pm_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__dibels_pm_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_cumulative_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_cumulative_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__gpa_cumulative_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_cumulative_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_cumulative_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__gpa_cumulative_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_term_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_term_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__gpa_term_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_term_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__gpa_term_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__gpa_term_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_diagnostic_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_diagnostic_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__iready_diagnostic_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_diagnostic_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_diagnostic_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__iready_diagnostic_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_lessons_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_lessons_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__iready_lessons_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_lessons_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__iready_lessons_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__iready_lessons_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__microgoals_assigned_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__microgoals_assigned_weekly.yml
@@ -1,5 +1,7 @@
 models:
   - name: int_topline__microgoals_assigned_weekly
+    config:
+      materialized: table
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__microgoals_assigned_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__microgoals_assigned_weekly.yml
@@ -1,7 +1,5 @@
 models:
   - name: int_topline__microgoals_assigned_weekly
-    config:
-      materialized: table
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__school_community_diagnostic_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__school_community_diagnostic_weekly.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__school_community_diagnostic_weekly
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__school_community_diagnostic_weekly.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__school_community_diagnostic_weekly.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__school_community_diagnostic_weekly
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__seats_staffed_weekly_aggregations.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__seats_staffed_weekly_aggregations.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__seats_staffed_weekly_aggregations
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__seats_staffed_weekly_aggregations.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__seats_staffed_weekly_aggregations.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__seats_staffed_weekly_aggregations
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__staff_retention.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__staff_retention.yml
@@ -1,4 +1,2 @@
 models:
   - name: int_topline__staff_retention
-    config:
-      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__staff_retention.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__staff_retention.yml
@@ -1,2 +1,4 @@
 models:
   - name: int_topline__staff_retention
+    config:
+      materialized: table

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_metrics.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_metrics.yml
@@ -1,0 +1,4 @@
+models:
+  - name: int_topline__student_metrics
+    config:
+      materialized: table


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will reduce topline build cost by shifting the materialization point upward in the cascade dashboard chain:

- 14 `int_topline__*_weekly` models: `table` → `view`
- `int_topline__student_metrics`: `view` → `table`

Net diff: -28 lines across 14 yml files, +4 lines (new properties yml), +1 line `.gitignore` — the branch history shows a revert/reapply cycle from CI debugging that the squash merge will flatten.

### What we tried first

Initial approach (commit `08715eab4`): flip 14 weeklies to views, leave `student_metrics` as a view. dbt Cloud CI failed:

```text
Database Error in model rpt_tableau__topline_cascade_dashboard
  Resources exceeded during query execution:
  Not enough resources for query planning - query is too complex.
```

With both `student_metrics` and the 14 weeklies as views, the cascade dashboard's compiled SQL spans 5+ levels of view expansion. The 16-view nesting limit was not the binding constraint; query plan complexity was.

### Why this works

```text
Before:
  cascade_dashboard (view)
    └─ dashboard_aggregations (view)
       └─ student_metrics (view)
          └─ 14 weeklies (tables, building 88–1,188× / wk each)
             └─ staging chain

After:
  cascade_dashboard (view)
    └─ dashboard_aggregations (view)
       └─ student_metrics (TABLE — single materialization point)
          └─ 14 weeklies (views — no longer materialized)
             └─ staging chain
```

The cascade dashboard SQL now stops expanding at `student_metrics` (a table reference). The 14 weeklies are inlined only inside `student_metrics`'s build — a single 14-way UNION rather than a cascading multi-level expansion.

### Expected impact

- 14 weekly model builds (~8,500 jobs / wk) eliminated
- One `student_metrics` materialization replaces the weekly fanout
- Tableau cascade dashboard reads one stored table instead of expanding 14 view chains
- Dagster automation: when `student_metrics` shifts shape from view to table, its automation condition adjusts; downstream weekly materialization frequencies adapt automatically
- Annualized build savings estimate: ~$1,000+/yr (refine post-deploy from `INFORMATION_SCHEMA.JOBS`)

### Pre-existing issues flagged for follow-up (not addressed in this PR)

- **Missing uniqueness tests on 13 of 14 weeklies**: only `int_topline__microgoals_assigned_weekly` has a `dbt_utils.unique_combination_of_columns` test today. The other 13 are bare `name:` entries with no `data_tests:` block. `src/dbt/CLAUDE.md` requires uniqueness tests on all intermediate models. This is a pre-existing gap, not introduced by this PR. Worth opening a follow-up issue.
- **`BETWEEN` date-range join in `int_topline__seats_staffed_weekly_aggregations.sql`**: `cal.week_start_monday between st.valid_from and st.valid_to`. `src/dbt/CLAUDE.md` flags `BETWEEN` on date-range joins as a fan-out risk vs half-open intervals. Pre-existing; was previously contained by table materialization, now exposed at read time. Follow-up.

## AI Assistance

Authored by Claude Code. Pivot to the upward-materialization approach came after CI feedback — the "query is too complex" failure confirmed that pure view-conversion of the weeklies doesn't fit the cascade dashboard's existing view chain. Verified locally with `dbt parse` and against the PR-branch schema with `SELECT * LIMIT 100` across all 14 new views, `int_topline__student_metrics`, and `rpt_tableau__topline_cascade_dashboard` — all return rows successfully.

## Self-review

### dbt

- [x] New properties file `int_topline__student_metrics.yml` created (model previously had no per-model yml)
- [x] 14 weekly yml files: `materialized: table` override removed; falls back to project intermediate default (view)
- [x] Uniqueness tests: **NOT addressed here** — 13 of 14 weeklies lack a uniqueness test (pre-existing gap), only `microgoals_assigned_weekly` has one. Flagged for follow-up above.
- [x] **Breaking change?** No. Column output schemas unchanged. Downstream views (`int_topline__dashboard_aggregations`, `rpt_tableau__topline_cascade_dashboard`) continue to work identically.

## CI checks

- [x] **Trunk** — passes (pre-commit ran clean)
- [x] **dbt Cloud** — passes (run `70403207426473`, 1m 43s)
- [ ] **Dagster Cloud** — not triggered (dbt-only change)

## Deploy

`int_topline__student_metrics` is currently a view in prod. After merge it becomes a table; dbt's `create or replace table` handles the view→table direction automatically.

For the 14 weeklies (currently tables → becoming views), the table→view drop requirement applies. Pick one at deploy time:

- `dbt build --select int_topline__student_metrics int_topline__ada_running_weekly int_topline__attendance_contacts_weekly int_topline__attendance_interventions_weekly int_topline__college_entrance_exams_weekly int_topline__college_matriculation_weekly int_topline__dibels_pm_weekly int_topline__gpa_cumulative_weekly int_topline__gpa_term_weekly int_topline__iready_diagnostic_weekly int_topline__iready_lessons_weekly int_topline__microgoals_assigned_weekly int_topline__school_community_diagnostic_weekly int_topline__seats_staffed_weekly_aggregations int_topline__staff_retention --full-refresh`
- OR explicit `DROP TABLE` for the 14 weeklies followed by normal Dagster materialization

## Post-deploy verification

- [ ] Confirm `int_topline__student_metrics` appears as `BASE TABLE` and all 14 weeklies appear as `VIEW` in `kipptaf_topline.INFORMATION_SCHEMA.TABLES`
- [ ] Monitor Tableau cascade dashboard refresh times for 1 week — current baseline is 31.8s wall / 3,764 slot-s / 6 GiB per refresh; expect this to drop because the read now hits a single materialized table
- [ ] Re-run `INFORMATION_SCHEMA.JOBS` build-cost analysis 1 week post-merge to size the actual savings

Refs #3589