### PR TITLE
refactor(libraries/ssh): caller-owned SFTP connection for listdir_attr_r

### DIFF
--- a/src/teamster/code_locations/kipptaf/adp/payroll/sensors.py
+++ b/src/teamster/code_locations/kipptaf/adp/payroll/sensors.py
@@ -32,9 +32,14 @@ def adp_payroll_sftp_sensor(
 
     tick_cursor = float(context.cursor or "0.0")
 
-    files = ssh_couchdrop.listdir_attr_r(
-        remote_dir=f"/teamster-{CODE_LOCATION}/couchdrop/adp/payroll"
-    )
+    with (
+        ssh_couchdrop.get_connection() as connection,
+        connection.open_sftp() as sftp_client,
+    ):
+        files = ssh_couchdrop.listdir_attr_r(
+            sftp_client=sftp_client,
+            remote_dir=f"/teamster-{CODE_LOCATION}/couchdrop/adp/payroll",
+        )
 
     add_dynamic_partition_keys = set()
 

--- a/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
+++ b/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
@@ -31,11 +31,16 @@ def adp_wfn_sftp_sensor(
     dir_mtimes = cursor.pop(DIR_MTIMES_KEY, {})
     min_mtime = min(cursor.values(), default=0)
 
-    files = ssh_adp_workforce_now.listdir_attr_r(
-        exclude_dirs=["./payroll"],
-        min_mtime=min_mtime,
-        dir_mtimes=dir_mtimes,
-    )
+    with (
+        ssh_adp_workforce_now.get_connection() as connection,
+        connection.open_sftp() as sftp_client,
+    ):
+        files = ssh_adp_workforce_now.listdir_attr_r(
+            sftp_client=sftp_client,
+            exclude_dirs=["./payroll"],
+            min_mtime=min_mtime,
+            dir_mtimes=dir_mtimes,
+        )
 
     for asset in assets:
         asset_metadata = asset.metadata_by_key[asset.key]

--- a/src/teamster/code_locations/kipptaf/deanslist/sensors.py
+++ b/src/teamster/code_locations/kipptaf/deanslist/sensors.py
@@ -29,7 +29,13 @@ def deanslist_sftp_sensor(context: SensorEvaluationContext, ssh_deanslist: SSHRe
     asset_selection = []
     cursor: dict = json.loads(context.cursor or "{}")
 
-    files = ssh_deanslist.listdir_attr_r("reconcile_report_files")
+    with (
+        ssh_deanslist.get_connection() as connection,
+        connection.open_sftp() as sftp_client,
+    ):
+        files = ssh_deanslist.listdir_attr_r(
+            sftp_client=sftp_client, remote_dir="reconcile_report_files"
+        )
 
     for asset in assets:
         asset_metadata = asset.metadata_by_key[asset.key]

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -57,7 +57,13 @@ def build_amplify_mclass_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        files = ssh_amplify.listdir_attr_r(remote_dir=remote_dir_regex)
+        with (
+            ssh_amplify.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh_amplify.listdir_attr_r(
+                sftp_client=sftp_client, remote_dir=remote_dir_regex
+            )
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/edplan/sensors.py
+++ b/src/teamster/libraries/edplan/sensors.py
@@ -37,7 +37,13 @@ def build_edplan_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        files = ssh_edplan.listdir_attr_r("Reports")
+        with (
+            ssh_edplan.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh_edplan.listdir_attr_r(
+                sftp_client=sftp_client, remote_dir="Reports"
+            )
 
         asset_identifier = asset.key.to_python_identifier()
         context.log.info(asset_identifier)

--- a/src/teamster/libraries/iready/sensors.py
+++ b/src/teamster/libraries/iready/sensors.py
@@ -58,7 +58,13 @@ def build_iready_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        files = ssh_iready.listdir_attr_r(remote_dir=remote_dir_regex)
+        with (
+            ssh_iready.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh_iready.listdir_attr_r(
+                sftp_client=sftp_client, remote_dir=remote_dir_regex
+            )
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/renlearn/sensors.py
+++ b/src/teamster/libraries/renlearn/sensors.py
@@ -59,7 +59,11 @@ def build_renlearn_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        files = ssh_renlearn.listdir_attr_r()
+        with (
+            ssh_renlearn.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh_renlearn.listdir_attr_r(sftp_client=sftp_client)
 
         for asset in asset_selection:
             asset_metadata = asset.metadata_by_key[asset.key]

--- a/src/teamster/libraries/sftp/assets.py
+++ b/src/teamster/libraries/sftp/assets.py
@@ -138,9 +138,15 @@ def build_sftp_file_asset(
             regexp=remote_file_regex, partition_key=partition_key
         )
 
-        files = ssh.listdir_attr_r(
-            remote_dir=remote_dir_regex_composed, exclude_dirs=exclude_dirs
-        )
+        with (
+            ssh.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh.listdir_attr_r(
+                sftp_client=sftp_client,
+                remote_dir=remote_dir_regex_composed,
+                exclude_dirs=exclude_dirs,
+            )
 
         files.sort(key=lambda x: x[0].st_mtime or 0, reverse=True)
 
@@ -265,9 +271,15 @@ def build_sftp_archive_asset(
             regexp=remote_file_regex, partition_key=partition_key
         )
 
-        files = ssh.listdir_attr_r(
-            remote_dir=remote_dir_regex_composed, exclude_dirs=exclude_dirs
-        )
+        with (
+            ssh.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh.listdir_attr_r(
+                sftp_client=sftp_client,
+                remote_dir=remote_dir_regex_composed,
+                exclude_dirs=exclude_dirs,
+            )
 
         file_matches = [
             path
@@ -417,9 +429,15 @@ def build_sftp_folder_asset(
             regexp=remote_file_regex, partition_key=partition_key
         )
 
-        files = ssh.listdir_attr_r(
-            remote_dir=remote_dir_regex_composed, exclude_dirs=exclude_dirs
-        )
+        with (
+            ssh.get_connection() as connection,
+            connection.open_sftp() as sftp_client,
+        ):
+            files = ssh.listdir_attr_r(
+                sftp_client=sftp_client,
+                remote_dir=remote_dir_regex_composed,
+                exclude_dirs=exclude_dirs,
+            )
 
         file_matches = [
             path

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -35,14 +35,25 @@ class SSHResource(DagsterSSHResource):
         exclude_dirs: list[str] | None = None,
         min_mtime: float | None = None,
         dir_mtimes: dict[str, float] | None = None,
-        files: list[tuple[SFTPAttributes, str]] | None = None,
     ) -> list[tuple[SFTPAttributes, str]]:
-        if exclude_dirs is None:
-            exclude_dirs = []
+        return self._listdir_attr_r(
+            sftp_client=sftp_client,
+            remote_dir=remote_dir,
+            exclude_dirs=exclude_dirs if exclude_dirs is not None else [],
+            min_mtime=min_mtime,
+            dir_mtimes=dir_mtimes,
+            files=[],
+        )
 
-        if files is None:
-            files = []
-
+    def _listdir_attr_r(
+        self,
+        sftp_client: SFTPClient,
+        remote_dir: str,
+        exclude_dirs: list[str],
+        min_mtime: float | None,
+        dir_mtimes: dict[str, float] | None,
+        files: list[tuple[SFTPAttributes, str]],
+    ) -> list[tuple[SFTPAttributes, str]]:
         if remote_dir in exclude_dirs:
             return files
 
@@ -56,13 +67,13 @@ class SSHResource(DagsterSSHResource):
                     if cached_mtime is not None and mtime <= cached_mtime:
                         continue
 
-                self.listdir_attr_r(
+                self._listdir_attr_r(
                     sftp_client=sftp_client,
                     remote_dir=path,
                     exclude_dirs=exclude_dirs,
-                    files=files,
                     min_mtime=min_mtime,
                     dir_mtimes=dir_mtimes,
+                    files=files,
                 )
 
                 if dir_mtimes is not None:

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -5,7 +5,7 @@ from stat import S_ISDIR, S_ISREG
 
 from dagster_shared import check
 from dagster_ssh import SSHResource as DagsterSSHResource
-from paramiko import SFTPAttributes, SFTPClient
+from paramiko import SFTPAttributes, SFTPClient, SSHClient
 from paramiko.ssh_exception import SSHException
 from tenacity import (
     retry,
@@ -25,35 +25,21 @@ class SSHResource(DagsterSSHResource):
         retry=retry_if_exception_type(SSHException),
         reraise=True,
     )
+    def get_connection(self) -> SSHClient:
+        return super().get_connection()
+
     def listdir_attr_r(
         self,
+        sftp_client: SFTPClient,
         remote_dir: str = ".",
         exclude_dirs: list[str] | None = None,
         min_mtime: float | None = None,
         dir_mtimes: dict[str, float] | None = None,
+        files: list[tuple[SFTPAttributes, str]] | None = None,
     ) -> list[tuple[SFTPAttributes, str]]:
         if exclude_dirs is None:
             exclude_dirs = []
 
-        with self.get_connection() as connection:
-            with connection.open_sftp() as sftp_client:
-                return self._inner_listdir_attr_r(
-                    sftp_client=sftp_client,
-                    remote_dir=remote_dir,
-                    exclude_dirs=exclude_dirs,
-                    min_mtime=min_mtime,
-                    dir_mtimes=dir_mtimes,
-                )
-
-    def _inner_listdir_attr_r(
-        self,
-        sftp_client: SFTPClient,
-        remote_dir: str,
-        exclude_dirs: list[str],
-        files: list | None = None,
-        min_mtime: float | None = None,
-        dir_mtimes: dict[str, float] | None = None,
-    ) -> list[tuple[SFTPAttributes, str]]:
         if files is None:
             files = []
 
@@ -70,7 +56,7 @@ class SSHResource(DagsterSSHResource):
                     if cached_mtime is not None and mtime <= cached_mtime:
                         continue
 
-                self._inner_listdir_attr_r(
+                self.listdir_attr_r(
                     sftp_client=sftp_client,
                     remote_dir=path,
                     exclude_dirs=exclude_dirs,

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -36,27 +36,13 @@ class SSHResource(DagsterSSHResource):
         min_mtime: float | None = None,
         dir_mtimes: dict[str, float] | None = None,
     ) -> list[tuple[SFTPAttributes, str]]:
-        return self._listdir_attr_r(
-            sftp_client=sftp_client,
-            remote_dir=remote_dir,
-            exclude_dirs=exclude_dirs if exclude_dirs is not None else [],
-            min_mtime=min_mtime,
-            dir_mtimes=dir_mtimes,
-            files=[],
-        )
+        if exclude_dirs is None:
+            exclude_dirs = []
 
-    def _listdir_attr_r(
-        self,
-        sftp_client: SFTPClient,
-        remote_dir: str,
-        exclude_dirs: list[str],
-        min_mtime: float | None,
-        dir_mtimes: dict[str, float] | None,
-        files: list[tuple[SFTPAttributes, str]],
-    ) -> list[tuple[SFTPAttributes, str]]:
         if remote_dir in exclude_dirs:
-            return files
+            return []
 
+        files: list[tuple[SFTPAttributes, str]] = []
         for file in sftp_client.listdir_attr(remote_dir):
             path = str(pathlib.Path(remote_dir) / file.filename)
             mtime = check.not_none(value=file.st_mtime)
@@ -67,13 +53,14 @@ class SSHResource(DagsterSSHResource):
                     if cached_mtime is not None and mtime <= cached_mtime:
                         continue
 
-                self._listdir_attr_r(
-                    sftp_client=sftp_client,
-                    remote_dir=path,
-                    exclude_dirs=exclude_dirs,
-                    min_mtime=min_mtime,
-                    dir_mtimes=dir_mtimes,
-                    files=files,
+                files.extend(
+                    self.listdir_attr_r(
+                        sftp_client=sftp_client,
+                        remote_dir=path,
+                        exclude_dirs=exclude_dirs,
+                        min_mtime=min_mtime,
+                        dir_mtimes=dir_mtimes,
+                    )
                 )
 
                 if dir_mtimes is not None:

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -15,6 +15,10 @@ from tenacity import (
 )
 
 
+class SSHTunnelError(Exception):
+    """Raised when the sshpass tunnel subprocess emits unexpected stdout."""
+
+
 class SSHResource(DagsterSSHResource):
     tunnel_remote_host: str | None = None
     test: bool = False
@@ -71,7 +75,7 @@ class SSHResource(DagsterSSHResource):
 
         return files
 
-    def open_ssh_tunnel(self):
+    def open_ssh_tunnel(self) -> subprocess.Popen[bytes]:
         # trunk-ignore(bandit/B603)
         ssh_tunnel = subprocess.Popen(
             args=[
@@ -114,7 +118,7 @@ class SSHResource(DagsterSSHResource):
                     break
                 else:
                     ssh_tunnel.kill()
-                    raise Exception(stdout)
+                    raise SSHTunnelError(stdout)
 
         time.sleep(1.0)
 

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -1,6 +1,6 @@
-import pathlib
 import subprocess
 import time
+from pathlib import Path
 from stat import S_ISDIR, S_ISREG
 
 from dagster_shared import check
@@ -48,7 +48,7 @@ class SSHResource(DagsterSSHResource):
 
         files: list[tuple[SFTPAttributes, str]] = []
         for file in sftp_client.listdir_attr(remote_dir):
-            path = str(pathlib.Path(remote_dir) / file.filename)
+            path = str(Path(remote_dir) / file.filename)
             mtime = check.not_none(value=file.st_mtime)
 
             if S_ISDIR(check.not_none(value=file.st_mode)):
@@ -101,24 +101,25 @@ class SSHResource(DagsterSSHResource):
             stderr=subprocess.STDOUT,
         )
 
-        while True:
-            if ssh_tunnel.stdout is not None:
-                stdout = ssh_tunnel.stdout.readline()
-                self.log.debug(msg=stdout)
+        stdout_stream = check.not_none(value=ssh_tunnel.stdout)
 
-                if stdout in [
-                    (
-                        f"Warning: Permanently added '[{self.remote_host}]:"
-                        f"{self.remote_port}' (RSA) to the list of known hosts.\r\n"
-                    ).encode(),
-                    b"A secure connection to your server has been established.\n",
-                ]:
-                    continue
-                elif stdout == b"To disconnect, simply close this window.\n":
-                    break
-                else:
-                    ssh_tunnel.kill()
-                    raise SSHTunnelError(stdout)
+        while True:
+            stdout = stdout_stream.readline()
+            self.log.debug(msg=stdout)
+
+            if stdout in [
+                (
+                    f"Warning: Permanently added '[{self.remote_host}]:"
+                    f"{self.remote_port}' (RSA) to the list of known hosts.\r\n"
+                ).encode(),
+                b"A secure connection to your server has been established.\n",
+            ]:
+                continue
+            elif stdout == b"To disconnect, simply close this window.\n":
+                break
+            else:
+                ssh_tunnel.kill()
+                raise SSHTunnelError(stdout)
 
         time.sleep(1.0)
 

--- a/src/teamster/libraries/titan/sensors.py
+++ b/src/teamster/libraries/titan/sensors.py
@@ -39,7 +39,13 @@ def build_titan_sftp_sensor(
         cursor: dict = json.loads(context.cursor or "{}")
 
         try:
-            files = ssh_titan.listdir_attr_r(exclude_dirs=exclude_dirs)
+            with (
+                ssh_titan.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                files = ssh_titan.listdir_attr_r(
+                    sftp_client=sftp_client, exclude_dirs=exclude_dirs
+                )
         except SSHException as e:
             return SkipReason(str(e))
 

--- a/tests/resources/test_resource_ssh.py
+++ b/tests/resources/test_resource_ssh.py
@@ -7,7 +7,11 @@ from teamster.libraries.ssh.resources import SSHResource
 def _test_listdir_attr_r(ssh: SSHResource, remote_dir: str = "~"):
     ssh.setup_for_execution(context=build_init_resource_context())
 
-    files = ssh.listdir_attr_r(remote_dir=remote_dir)
+    with (
+        ssh.get_connection() as connection,
+        connection.open_sftp() as sftp_client,
+    ):
+        files = ssh.listdir_attr_r(sftp_client=sftp_client, remote_dir=remote_dir)
 
     for f in files:
         print(f)

--- a/tests/resources/test_resource_ssh_listdir.py
+++ b/tests/resources/test_resource_ssh_listdir.py
@@ -52,7 +52,7 @@ def test_min_mtime_filters_old_files():
     with build_resources(
         {"ssh": SSHResource(remote_host="fake-host", username="u", password="p")}
     ) as resources:
-        files = resources.ssh._inner_listdir_attr_r(
+        files = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],
@@ -76,7 +76,7 @@ def test_min_mtime_none_returns_all_files():
     with build_resources(
         {"ssh": SSHResource(remote_host="fake-host", username="u", password="p")}
     ) as resources:
-        files = resources.ssh._inner_listdir_attr_r(
+        files = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],
@@ -103,7 +103,7 @@ def test_dir_mtimes_skips_unchanged_subtree():
     ) as resources:
         # dir_mtimes says subdir was last seen at mtime=100 — unchanged, skip it
         dir_mtimes = {"subdir": 100}
-        files = resources.ssh._inner_listdir_attr_r(
+        files = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],
@@ -133,7 +133,7 @@ def test_dir_mtimes_traverses_changed_subtree():
     ) as resources:
         # dir_mtimes says subdir was last seen at mtime=100 — changed, traverse it
         dir_mtimes = {"subdir": 100}
-        files = resources.ssh._inner_listdir_attr_r(
+        files = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],
@@ -162,7 +162,7 @@ def test_dir_mtimes_traverses_unseen_directory():
     ) as resources:
         # empty dir_mtimes — newdir is unseen, must traverse
         dir_mtimes: dict[str, float] = {}
-        files = resources.ssh._inner_listdir_attr_r(
+        files = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],
@@ -187,7 +187,7 @@ def test_dir_mtimes_none_returns_list_only():
     with build_resources(
         {"ssh": SSHResource(remote_host="fake-host", username="u", password="p")}
     ) as resources:
-        result = resources.ssh._inner_listdir_attr_r(
+        result = resources.ssh.listdir_attr_r(
             sftp_client=sftp,
             remote_dir=".",
             exclude_dirs=[],


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will move the `tenacity` retry on `SSHResource` from `listdir_attr_r` onto `get_connection()` — where `SSHException` actually originates (banner timeout, kex, auth) — and hand connection ownership to callers. `listdir_attr_r` now takes a pre-opened `SFTPClient`, and the public/`_inner_` recursion split collapses into a single method.

Motivated by two new GCP Error Reporting groups (`CO7X67XY7MG3YA`, `CPuG15Xz8J-doAE`) — both paramiko `_check_banner` traceback frames from a transient renlearn SFTP banner timeout. The existing retry recovered cleanly, but the retry was wrapped around the wrong method, which was also doing the recursive walk.

Refs #3912

## AI Assistance

> Claude-assisted: investigation of the GCP error groups, refactor design, edits across all 10 call sites + tests. Human-directed: scope and structural decisions (retry placement, caller-owned connection).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster

- [x] All touched modules import cleanly (`teamster.libraries.ssh.resources`, all 7 sensors, `libraries/sftp/assets.py`).
- [x] `tests/resources/test_resource_ssh_listdir.py` — 6/6 mocked unit tests pass.
- [x] Caller updates uniform across sensors and asset factories.

## CI checks

- [ ] **Trunk** — pre-commit `trunk fmt` clean.
- [ ] **dbt Cloud** — N/A (no dbt changes).
- [ ] **Dagster Cloud** — branch deploy will validate full definitions load.