### PR TITLE
perf(amplify-mclass-sftp-sensor): prune unchanged subtrees via dir_mtimes cursor

### DIFF
--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -20,6 +20,8 @@ from dagster_shared import check
 
 from teamster.libraries.ssh.resources import SSHResource
 
+DIR_MTIMES_KEY = "__dir_mtimes"
+
 
 def build_amplify_mclass_sftp_sensor(
     code_location: str,
@@ -56,7 +58,7 @@ def build_amplify_mclass_sftp_sensor(
         run_request_kwargs = []
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
-        dir_mtimes: dict[str, float] = cursor.get("__dir_mtimes__", {})
+        dir_mtimes = cursor.pop(DIR_MTIMES_KEY, {})
 
         with (
             ssh_amplify.get_connection() as connection,
@@ -125,7 +127,7 @@ def build_amplify_mclass_sftp_sensor(
                 )
             )
 
-        cursor["__dir_mtimes__"] = dir_mtimes
+        cursor[DIR_MTIMES_KEY] = dir_mtimes
 
         return SensorResult(run_requests=run_requests, cursor=json.dumps(obj=cursor))
 

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -56,13 +56,16 @@ def build_amplify_mclass_sftp_sensor(
         run_request_kwargs = []
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
+        dir_mtimes: dict[str, float] = cursor.get("__dir_mtimes__", {})
 
         with (
             ssh_amplify.get_connection() as connection,
             connection.open_sftp() as sftp_client,
         ):
             files = ssh_amplify.listdir_attr_r(
-                sftp_client=sftp_client, remote_dir=remote_dir_regex
+                sftp_client=sftp_client,
+                remote_dir=remote_dir_regex,
+                dir_mtimes=dir_mtimes,
             )
 
         for asset in asset_selection:
@@ -121,6 +124,8 @@ def build_amplify_mclass_sftp_sensor(
                     asset_selection=[g["asset_key"] for g in group],
                 )
             )
+
+        cursor["__dir_mtimes__"] = dir_mtimes
 
         return SensorResult(run_requests=run_requests, cursor=json.dumps(obj=cursor))
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will cut the per-tick work the Amplify mClass SFTP sensor does when Amplify's directory tree is stable, by passing a `dir_mtimes` cache through the sensor cursor so unchanged subdirectories are skipped during recursion.

The sensor was calling `SSHResource.listdir_attr_r()` unconditionally every tick — a full recursive walk of the Amplify drop tree. Twice in the 2026-05-13/14 day-2 window (kippnewark + kipppaterson) the listing exceeded Dagster's 600s sensor execution cap and the tick failed with `DagsterUserCodeUnreachableError`. Both recovered on the next tick (single-tick blips, no run impact), but the failure mode is structural.

`SSHResource.listdir_attr_r` already accepts a `dir_mtimes: dict[str, float]` that prunes recursion into subdirs whose `st_mtime <= cached_mtime` (see `src/teamster/libraries/ssh/resources.py:55-71`). This PR just wires that through:

- Read `__dir_mtimes__` from the existing cursor JSON (reserved key, namespaced underscore so it can't collide with `asset.key.to_python_identifier()` output)
- Pass it into `listdir_attr_r` — the function mutates it in place
- Persist back to the cursor

First tick after deploy starts with an empty dict, does a full walk, populates the cache. Subsequent ticks short-circuit on unchanged subdirs.

## AI Assistance

AI-assisted: Claude diagnosed the two day-2 sensor timeouts, identified the existing unused `dir_mtimes` parameter, and wired it through. Human-directed: triage and approval of approach.

Refs #3924

## Self-review

### Dagster

- [x] Skipped `uv run dagster definitions validate` — codespace env-var gaps misfire it per `src/teamster/CLAUDE.md`. Verified via `uv run python -c "from teamster.libraries.amplify.mclass.sftp import sensors"` instead.
- [ ] `uv run pytest tests/test_dagster_definitions.py` — N/A, no test changes; sensor factory has no direct test.

### Caveat

Some SFTP servers don't bump directory `st_mtime` when files inside change. If Amplify's server doesn't, the pruning is a no-op (safe, but ineffective). Worth watching tick durations on `kippnewark__amplify__mclass__sftp_asset_job_sensor` and `kipppaterson__amplify__mclass__sftp_asset_job_sensor` post-deploy. Fallback plan: tick-rotated subdir traversal (separate change).

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud
