### PR TITLE
feat(promo): add `is_summer_school_eligible` to DeansList promo extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__promo_status.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__promo_status.yml
@@ -57,3 +57,5 @@ models:
         data_type: string
       - name: promo_status_math
         data_type: string
+      - name: is_summer_school_eligible
+        data_type: boolean

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
@@ -42,10 +42,10 @@ select
 
     ae.athletic_eligibility,
 
-    ss.dcid is not null as is_summer_school_eligible,
-
     null as promo_status_qa_math,
     null as grades_y1_credits_enrolled,
+
+    ss.dcid is not null as is_summer_school_eligible,
 
     if(
         p.attendance_status = 'Off-Track',

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
@@ -17,7 +17,7 @@ with
         {{
             dbt_utils.deduplicate(
                 relation=ref("int_powerschool__log"),
-                partition_by="student_number, log_type, academic_year",
+                partition_by="_dbt_source_relation, studentid, log_type, academic_year",
                 order_by="entry_date desc",
             )
         }}
@@ -139,7 +139,9 @@ left join
     and term = ae.quarter
 left join
     summer_school as ss
-    on co.student_number = ss.student_number
+    on co.studentid = ss.studentid
     and co.academic_year = ss.academic_year
     and ss.log_type = 'ARFR (Summer School)'
+    and {{ union_dataset_join_clause(left_alias="co", right_alias="ss") }}
+
 where co.academic_year = {{ var("current_academic_year") }} and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
@@ -11,6 +11,16 @@ with
                 )
             )
 
+    ),
+
+    summer_school as (
+        {{
+            dbt_utils.deduplicate(
+                relation=ref("int_powerschool__log"),
+                partition_by="student_number, log_type, academic_year",
+                order_by="entry_date desc",
+            )
+        }}
     )
 
 select
@@ -31,6 +41,8 @@ select
     p.projected_credits_cum as grades_y1_credits_projected,
 
     ae.athletic_eligibility,
+
+    ss.dcid is not null as is_summer_school_eligible,
 
     null as promo_status_qa_math,
     null as grades_y1_credits_enrolled,
@@ -125,4 +137,9 @@ left join
     on co.student_number = ae.student_number
     and co.academic_year = ae.academic_year
     and term = ae.quarter
+left join
+    summer_school as ss
+    on co.student_number = ss.student_number
+    and co.academic_year = ss.academic_year
+    and ss.log_type = 'ARFR (Summer School)'
 where co.academic_year = {{ var("current_academic_year") }} and co.rn_year = 1

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
@@ -1,0 +1,21 @@
+select
+    log.dcid,
+    log.logtypeid,
+    log.entry_date,
+    log.entry,
+    log.academic_year,
+
+    gen.name as log_type,
+
+    s.student_number,
+
+    initcap(regexp_extract(log._dbt_source_relation, r'kipp(\w+)_')) as region
+from {{ ref("stg_powerschool__log") }} as `log`
+inner join
+    {{ ref("stg_powerschool__gen") }} as gen
+    on log.logtypeid = gen.id
+    and gen.cat = 'logtype'
+inner join
+    {{ ref("stg_powerschool__students") }} as s
+    on log.studentid = s.id
+    and {{ union_dataset_join_clause(left_alias="log", right_alias="s") }}

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
@@ -9,12 +9,13 @@ select
 
     s.student_number,
 
-    initcap(regexp_extract(log._dbt_source_relation, r'kipp(\w+)_')) as region
+    initcap(regexp_extract(log._dbt_source_relation, r'kipp(\w+)_')) as region,
 from {{ ref("stg_powerschool__log") }} as `log`
 inner join
     {{ ref("stg_powerschool__gen") }} as gen
     on log.logtypeid = gen.id
     and gen.cat = 'logtype'
+    and {{ union_dataset_join_clause(left_alias="log", right_alias="gen") }}
 inner join
     {{ ref("stg_powerschool__students") }} as s
     on log.studentid = s.id

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
@@ -1,4 +1,6 @@
 select
+    log._dbt_source_relation,
+    log.studentid,
     log.dcid,
     log.logtypeid,
     log.entry_date,
@@ -6,17 +8,9 @@ select
     log.academic_year,
 
     gen.name as log_type,
-
-    s.student_number,
-
-    initcap(regexp_extract(log._dbt_source_relation, r'kipp(\w+)_')) as region,
 from {{ ref("stg_powerschool__log") }} as `log`
 inner join
     {{ ref("stg_powerschool__gen") }} as gen
     on log.logtypeid = gen.id
     and gen.cat = 'logtype'
     and {{ union_dataset_join_clause(left_alias="log", right_alias="gen") }}
-inner join
-    {{ ref("stg_powerschool__students") }} as s
-    on log.studentid = s.id
-    and {{ union_dataset_join_clause(left_alias="log", right_alias="s") }}

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
@@ -1,0 +1,19 @@
+models:
+  - name: int_powerschool__log
+    columns:
+      - name: dcid
+        data_type: int64
+      - name: logtypeid
+        data_type: int64
+      - name: entry_date
+        data_type: date
+      - name: entry
+        data_type: string
+      - name: academic_year
+        data_type: int64
+      - name: log_type
+        data_type: string
+      - name: student_number
+        data_type: int64
+      - name: region
+        data_type: string

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
@@ -3,6 +3,10 @@ models:
     columns:
       - name: dcid
         data_type: int64
+      - name: _dbt_source_relation
+        data_type: string
+      - name: studentid
+        data_type: int64
       - name: logtypeid
         data_type: int64
       - name: entry_date
@@ -12,8 +16,4 @@ models:
       - name: academic_year
         data_type: int64
       - name: log_type
-        data_type: string
-      - name: student_number
-        data_type: int64
-      - name: region
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will create a new int view for logs similar to spenrollments and add a boolean for report cards that will flag if a student will be promoted if they attend summer school (NJ, 3-8).

## AI Assistance

> 0 clanker assistance on this one

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [x] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [x] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [x] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
