### PR TITLE
docs(claude): add cross-district query and PowerSchool GPA gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,12 @@ For NULL-safe distinct counts on composite keys, use
 `count(distinct format("%T|%T", a, b))` — `concat()` returns NULL when any arg
 is NULL and silently miscounts violations.
 
+**Cross-district queries**: Always use `teamster-332318.kipptaf_*` datasets for
+queries spanning multiple districts — never manually `UNION ALL` across
+`kippnewark_*`, `kippcamden_*`, `kippmiami_*`. Extract district from
+`_dbt_source_relation` with
+`REGEXP_EXTRACT(_dbt_source_relation, r'`(kipp[^`]+\_<source>)`')`.
+
 ### dbt MCP
 
 Auth via `scripts/dbt-mcp-launch.sh` — do not add `DBT_TOKEN` to `.mcp.json`

--- a/src/dbt/powerschool/CLAUDE.md
+++ b/src/dbt/powerschool/CLAUDE.md
@@ -38,3 +38,11 @@ project.
 The `odbc/` vs `sftp/` split exists because some schools pull data via live
 Oracle ODBC tunnel and others via SFTP file drops. Only one should be enabled
 per deployment.
+
+## GPA Gotchas
+
+- **`storecode = 'Y1'` only**: Q1–Q4 records have `gpa_points = 0` by design —
+  only `storecode = 'Y1'` rows are used in GPA calculations.
+- **`districtentrydate` null placeholder**: PowerSchool stores null/missing
+  dates as `1899-xx-xx`. Derive network tenure from `MIN(academic_year)` in
+  storedgrades instead.


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will add two operational rules to CLAUDE.md files surfaced during a GPA data quality audit session:

- **`CLAUDE.md`** (root): require `kipptaf_*` datasets for all cross-district BigQuery queries; ban manual `UNION ALL` across regional datasets. Includes the `_dbt_source_relation` REGEXP_EXTRACT pattern for district identification.
- **`src/dbt/powerschool/CLAUDE.md`**: document two PowerSchool storedgrades gotchas — `storecode = 'Y1'` only for GPA calculations, and the `districtentrydate` 1899 null placeholder.

Both additions were validated against CLAUDE.md editing standards (behavior-changing, no rationale padding) before commit.

## AI Assistance

Claude Code authored both additions based on corrections made during a live data audit session (human-directed). Human reviewed and approved wording before apply.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Docs _(skip if no schedule, sensor, or integration changes)_

_No schedule/sensor/integration changes — docs section N/A._

## CI checks

- [ ] **Trunk** — passes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214826939804071