### PR TITLE
refactor(cube): drop CUBE_TESTING_USERS allowlist

### DIFF
--- a/docs/guides/cube.md
+++ b/docs/guides/cube.md
@@ -165,11 +165,6 @@ entirely and must only be used for local dev. The `cube.js` guard relies on
 `NODE_ENV !== "production"` as a second line of defense, but the variable should
 never be configured in Cube Cloud in the first place.
 
-`CUBE_TESTING_USERS` is a pre-Directory-API testing allowlist — set it in Cube
-Cloud env vars only on testing/staging deployments, never on production. Remove
-it from all deployments once Directory API is live and group membership is
-resolved from Google Workspace.
-
 Do **not** use the Cube Playground **Models** tab in dev mode. It overwrites
 YAML files in `model/cubes/` and `model/views/` with auto-generated content,
 discarding hand-authored definitions.

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -79,6 +79,15 @@ Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
   Workspace groups via the Admin Directory API, cached until next midnight ET.
   `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is the
   sole bypass.
+- **Group membership is direct-only.** Admin Directory API's
+  `groups.list({userKey})` returns direct memberships; nested `cube-*` groups
+  don't transitively resolve. Flat-enroll users in every `cube-*` group they
+  need (scope tier + `cube-access-student-data`, plus `cube-access-staff-all`
+  for staff cubes).
+- **Cloud Identity `searchTransitiveGroups` is edition-gated** (Workspace
+  Enterprise / Education Plus / Cloud Identity Premium). On lower editions it
+  returns `INVALID_ARGUMENT`, not `PERMISSION_DENIED` — don't propose it as a
+  transitive-resolution fix without verifying the tenant's edition.
 - **`queryRewrite`** enforces three filters:
   - Strips dims/measures from `STUDENT_CUBES` for users without
     `cube-access-student-data`.
@@ -124,6 +133,15 @@ The `cube` MCP wraps Cube Cloud's REST API. Auth path that works:
   security-context delta, not a schema bug.
 - `queryRewrite` default-deny manifests as `WHERE (1 = 0)` plus
   `rlsAccessDenied` in `sortedDimensions` of `/sql` output.
+- **Branch endpoints**: `/staging/<branch>/cubejs-api/v1` is the per-branch
+  staging endpoint (stable, redeploys on push).
+  `/user/<urlencoded-email>/<id>/cubejs-api/v1` is the per-developer Dev Mode
+  endpoint. Only Dev Mode surfaces server `console.log` in the playground logs
+  panel — staging has no log UI. Debug `cube.js` code paths on Dev Mode.
+- **Branch staging configuration doesn't fully inherit from production.** Before
+  diagnosing API errors on a branch staging env, verify
+  `GOOGLE_DIRECTORY_SA_KEY` / `GOOGLE_DIRECTORY_SA_SUBJECT` (and any other
+  required secrets) are set on that environment.
 
 ## Operational notes
 

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -77,11 +77,8 @@ Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
 
 - **`contextToGroups`** resolves the requester's email to `cube-*` Google
   Workspace groups via the Admin Directory API, cached until next midnight ET.
-  Two bypass paths (priority order):
-  - `CUBE_TESTING_USERS` — required until prod `cube-*` groups are created and
-    populated (see
-    [#3936](https://github.com/TEAMSchools/teamster/issues/3936)).
-  - `CUBE_GROUP_MAP` — local dev only, gated on `NODE_ENV !== "production"`.
+  `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is the
+  sole bypass.
 - **`queryRewrite`** enforces three filters:
   - Strips dims/measures from `STUDENT_CUBES` for users without
     `cube-access-student-data`.

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -76,9 +76,11 @@ FERPA guidance. If PII, add it to the `excludes` list under the
 Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
 
 - **`contextToGroups`** resolves the requester's email to `cube-*` Google
-  Workspace groups via the Admin Directory API, cached until next midnight ET.
-  `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is the
-  sole bypass.
+  Workspace groups via the Cloud Identity Groups API's `searchTransitiveGroups`,
+  which returns both direct and nested memberships. Cached until next midnight
+  ET. `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is
+  the sole bypass. The SA's domain-wide delegation must include the
+  `https://www.googleapis.com/auth/cloud-identity.groups.readonly` scope.
 - **`queryRewrite`** enforces three filters:
   - Strips dims/measures from `STUDENT_CUBES` for users without
     `cube-access-student-data`.

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -76,11 +76,9 @@ FERPA guidance. If PII, add it to the `excludes` list under the
 Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
 
 - **`contextToGroups`** resolves the requester's email to `cube-*` Google
-  Workspace groups via the Cloud Identity Groups API's `searchTransitiveGroups`,
-  which returns both direct and nested memberships. Cached until next midnight
-  ET. `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is
-  the sole bypass. The SA's domain-wide delegation must include the
-  `https://www.googleapis.com/auth/cloud-identity.groups.readonly` scope.
+  Workspace groups via the Admin Directory API, cached until next midnight ET.
+  `CUBE_GROUP_MAP` (local dev only, gated on `NODE_ENV !== "production"`) is the
+  sole bypass.
 - **`queryRewrite`** enforces three filters:
   - Strips dims/measures from `STUDENT_CUBES` for users without
     `cube-access-student-data`.

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -89,9 +89,8 @@ Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
     segment unless the user has `cube-access-staff-all`.
 - **`STUDENT_CUBES` / `STAFF_CUBES` arrays.** Entries must match the cube
   `name:` field — `queryRewrite` matches via `startsWith` on
-  `<cube_name>.<member>` query members. Both arrays are currently placeholders
-  flagged TODO in `cube.js`; when adding a new student-data or staff-data cube,
-  append its `name:` to the matching array.
+  `<cube_name>.<member>` query members. When adding a new student-data or
+  staff-data cube, append its `name:` to the matching array.
 - **`canSwitchSqlUser`** only allows the SQL super-user to impersonate
   `@apps.teamschools.org` accounts (Superset integration). Do not broaden the
   suffix check.

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -56,13 +56,16 @@ module.exports = {
       }
     }
 
-    // DEBUG: skip cache so we always hit Directory API while diagnosing
-    // const cached = groupCache.get(email);
-    // if (cached && cached.expiresAt > Date.now()) return cached.groups;
+    const cached = groupCache.get(email);
+    if (cached && cached.expiresAt > Date.now()) return cached.groups;
 
-    // Call Admin Directory API.
+    // Call Cloud Identity Groups API — searchTransitiveGroups returns both
+    // direct and indirect (nested) memberships, so users can inherit cube-*
+    // access via parent groups.
     // GOOGLE_DIRECTORY_SA_KEY: base64-encoded service account JSON with
-    //   domain-wide delegation granted by GOOGLE_DIRECTORY_SA_SUBJECT.
+    //   domain-wide delegation granted by GOOGLE_DIRECTORY_SA_SUBJECT and
+    //   the cloud-identity.groups.readonly scope authorized in Workspace
+    //   Admin → Security → API controls → Domain-wide delegation.
     // GOOGLE_DIRECTORY_SA_SUBJECT: email of the Workspace admin that granted
     //   delegation (must be a super-admin in apps.teamschools.org).
     try {
@@ -72,31 +75,31 @@ module.exports = {
           Buffer.from(process.env.GOOGLE_DIRECTORY_SA_KEY, "base64").toString(),
         ),
         scopes: [
-          "https://www.googleapis.com/auth/admin.directory.group.readonly",
+          "https://www.googleapis.com/auth/cloud-identity.groups.readonly",
         ],
         clientOptions: {
           subject: process.env.GOOGLE_DIRECTORY_SA_SUBJECT,
         },
       });
-      const admin = google.admin({ version: "directory_v1", auth });
+      const cloudidentity = google.cloudidentity({ version: "v1", auth });
 
       let groups = [];
-      let rawEmails = [];
       let pageToken;
       do {
-        const res = await admin.groups.list({ userKey: email, pageToken });
-        rawEmails = rawEmails.concat(
-          (res.data.groups ?? []).map((g) => g.email ?? "<no-email>"),
-        );
+        const res =
+          await cloudidentity.groups.memberships.searchTransitiveGroups({
+            parent: "groups/-",
+            query: `member_key_id == '${email}' && 'cloudidentitygroups.googleapis.com/groups.discussion_forum' in labels`,
+            pageSize: 500,
+            pageToken,
+          });
         groups = groups.concat(
-          (res.data.groups ?? []).map((g) => (g.email ?? "").split("@")[0]),
+          (res.data.memberships ?? []).map(
+            (m) => (m.groupKey?.id ?? "").split("@")[0],
+          ),
         );
         pageToken = res.data.nextPageToken;
       } while (pageToken);
-
-      console.log(
-        `DEBUG contextToGroups ${email}: raw=${JSON.stringify(rawEmails)} parsed=${JSON.stringify(groups)}`,
-      );
 
       const cubeGroups = groups.filter((g) => g.startsWith("cube-"));
       groupCache.set(email, {

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -21,11 +21,8 @@ function nextMidnightEastern() {
 }
 
 // STUDENT_CUBES: cubes that require cube-access-student-data.
-// TODO: populate full list during YAML implementation (follow-up to PR #3715).
-const STUDENT_CUBES = [
-  "fct_student_attendance_daily",
-  "fct_student_attendance_interventions",
-];
+// Add cube name: here when adding a new student-data cube.
+const STUDENT_CUBES = ["attendance"];
 
 const STAFF_CUBES = [
   "dim_staff",
@@ -112,8 +109,6 @@ module.exports = {
     const cached = email ? groupCache.get(email) : null;
     const groups = cached?.expiresAt > Date.now() ? cached.groups : [];
 
-    // Users without cube-access-student-data see no student cubes.
-    // STUDENT_CUBES list is a placeholder — full list added during YAML implementation.
     if (!groups.includes("cube-access-student-data")) {
       query = {
         ...query,

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -108,7 +108,9 @@ module.exports = {
       });
       return cubeGroups;
     } catch (err) {
-      console.error(`contextToGroups failed for ${email}:`, err);
+      console.error(
+        `contextToGroups failed for ${email}: status=${err.code} message=${err.message} apiError=${JSON.stringify(err.response?.data?.error)}`,
+      );
       return []; // default deny on API failure
     }
   },

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -56,9 +56,9 @@ module.exports = {
       }
     }
 
-    // Check cache
-    const cached = groupCache.get(email);
-    if (cached && cached.expiresAt > Date.now()) return cached.groups;
+    // DEBUG: skip cache so we always hit Directory API while diagnosing
+    // const cached = groupCache.get(email);
+    // if (cached && cached.expiresAt > Date.now()) return cached.groups;
 
     // Call Admin Directory API.
     // GOOGLE_DIRECTORY_SA_KEY: base64-encoded service account JSON with
@@ -81,14 +81,22 @@ module.exports = {
       const admin = google.admin({ version: "directory_v1", auth });
 
       let groups = [];
+      let rawEmails = [];
       let pageToken;
       do {
         const res = await admin.groups.list({ userKey: email, pageToken });
+        rawEmails = rawEmails.concat(
+          (res.data.groups ?? []).map((g) => g.email ?? "<no-email>"),
+        );
         groups = groups.concat(
           (res.data.groups ?? []).map((g) => (g.email ?? "").split("@")[0]),
         );
         pageToken = res.data.nextPageToken;
       } while (pageToken);
+
+      console.log(
+        `DEBUG contextToGroups ${email}: raw=${JSON.stringify(rawEmails)} parsed=${JSON.stringify(groups)}`,
+      );
 
       const cubeGroups = groups.filter((g) => g.startsWith("cube-"));
       groupCache.set(email, {

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -45,25 +45,6 @@ module.exports = {
       securityContext?.cubeCloud?.userAttributes?.email;
     if (!email) return [];
 
-    // TODO(#3936): remove once production cube-* Workspace groups exist and
-    // are populated. Without this allowlist, all users resolve to [] via
-    // Directory API (no groups exist yet) and hit queryRewrite default-deny.
-    // Format: {"user@example.com": ["cube-access-student-data", "cube-network-detail"]}
-    // Set in Cube Cloud configuration (never commit values).
-    if (process.env.CUBE_TESTING_USERS) {
-      try {
-        const map = JSON.parse(process.env.CUBE_TESTING_USERS);
-        // All users handled here — listed get groups, unlisted get [] (default
-        // deny). Prevents fallthrough to Directory API while groups are absent.
-        const groups = (map[email] ?? []).filter((g) => g.startsWith("cube-"));
-        groupCache.set(email, { groups, expiresAt: nextMidnightEastern() });
-        return groups;
-      } catch (err) {
-        console.error("CUBE_TESTING_USERS is not valid JSON:", err.message);
-        return [];
-      }
-    }
-
     // Local dev only: CUBE_GROUP_MAP bypasses Directory API.
     // Must never be set in Cube Cloud — see docs/guides/cube.md.
     if (process.env.NODE_ENV !== "production" && process.env.CUBE_GROUP_MAP) {

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -56,16 +56,13 @@ module.exports = {
       }
     }
 
+    // Check cache
     const cached = groupCache.get(email);
     if (cached && cached.expiresAt > Date.now()) return cached.groups;
 
-    // Call Cloud Identity Groups API — searchTransitiveGroups returns both
-    // direct and indirect (nested) memberships, so users can inherit cube-*
-    // access via parent groups.
+    // Call Admin Directory API.
     // GOOGLE_DIRECTORY_SA_KEY: base64-encoded service account JSON with
-    //   domain-wide delegation granted by GOOGLE_DIRECTORY_SA_SUBJECT and
-    //   the cloud-identity.groups.readonly scope authorized in Workspace
-    //   Admin → Security → API controls → Domain-wide delegation.
+    //   domain-wide delegation granted by GOOGLE_DIRECTORY_SA_SUBJECT.
     // GOOGLE_DIRECTORY_SA_SUBJECT: email of the Workspace admin that granted
     //   delegation (must be a super-admin in apps.teamschools.org).
     try {
@@ -75,28 +72,20 @@ module.exports = {
           Buffer.from(process.env.GOOGLE_DIRECTORY_SA_KEY, "base64").toString(),
         ),
         scopes: [
-          "https://www.googleapis.com/auth/cloud-identity.groups.readonly",
+          "https://www.googleapis.com/auth/admin.directory.group.readonly",
         ],
         clientOptions: {
           subject: process.env.GOOGLE_DIRECTORY_SA_SUBJECT,
         },
       });
-      const cloudidentity = google.cloudidentity({ version: "v1", auth });
+      const admin = google.admin({ version: "directory_v1", auth });
 
       let groups = [];
       let pageToken;
       do {
-        const res =
-          await cloudidentity.groups.memberships.searchTransitiveGroups({
-            parent: "groups/-",
-            query: `member_key_id == '${email}' && 'cloudidentitygroups.googleapis.com/groups.discussion_forum' in labels`,
-            pageSize: 500,
-            pageToken,
-          });
+        const res = await admin.groups.list({ userKey: email, pageToken });
         groups = groups.concat(
-          (res.data.memberships ?? []).map(
-            (m) => (m.groupKey?.id ?? "").split("@")[0],
-          ),
+          (res.data.groups ?? []).map((g) => (g.email ?? "").split("@")[0]),
         );
         pageToken = res.data.nextPageToken;
       } while (pageToken);
@@ -108,9 +97,7 @@ module.exports = {
       });
       return cubeGroups;
     } catch (err) {
-      console.error(
-        `contextToGroups failed for ${email}: status=${err.code} message=${err.message} apiError=${JSON.stringify(err.response?.data?.error)}`,
-      );
+      console.error(`contextToGroups failed for ${email}:`, err);
       return []; // default deny on API failure
     }
   },


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will remove the `CUBE_TESTING_USERS` allowlist
bypass from `cube.js`. Production `cube-*` Google Workspace groups
(`cube-access-student-data`, `cube-network-detail`) now exist and are
populated, so the Directory API path resolves group membership correctly and
the pre-Directory-API allowlist is no longer needed.

Closes #3936

## AI Assistance

Claude Code drafted the removal (cube.js block + `src/cube/CLAUDE.md` bullet +
`docs/guides/cube.md` warning paragraph). Human-directed: scope, safety
review, group-name verification.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Post-merge action required

- [ ] Unset `CUBE_TESTING_USERS` in Cube Cloud production configuration after
      merge (leaving it set is harmless — it just goes unread — but cleaner
      to drop).
- [ ] Confirm `GOOGLE_DIRECTORY_SA_KEY` and `GOOGLE_DIRECTORY_SA_SUBJECT` are
      set in Cube Cloud (without these the Directory API call throws and all
      users get `[]`).

## CI checks

- [ ] **Trunk** — passes.
