### PR TITLE
fix(libraries/ssh): re-enable ssh-rsa host keys for edplan SFTP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   explicitly. Use `git -C <worktree>` on every git call (bare `git` from the
   main repo silently commits to `main`) and
   `uv run dbt ... --project-dir <worktree>/src/dbt/<project>` on every dbt call.
-  Otherwise prefer absolute paths.
+  For Python execution from the main repo, prefix `VIRTUAL_ENV=` and use
+  `uv --directory <worktree> run python ...` — bare `uv run --active` reads the
+  main repo's `.venv` and misses worktree-only changes. Otherwise prefer
+  absolute paths.
 
 - **Branch switch**: `gh issue develop <number> --name <branch> --checkout`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,12 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   `.trunk/tools/trunk check --force <files>` to verify before claiming the
   change is lint-clean.
 
-- **Linter**: Use `# trunk-ignore(<linter>/<rule>)` with a reason comment — not
-  linter-native disable syntax. Binary:
+- **Linter**: Suppress with `# trunk-ignore(linter/rule): reason` (e.g.
+  `# trunk-ignore(bandit/B603): static argv, no shell`) on the line immediately
+  before the flagged line — not linter-native disable syntax. Wrapping the
+  reason onto extra comment lines silently breaks the suppression (trunk only
+  honors the directive on the adjacent line), and CI also flags it with
+  `trunk/ignore-does-nothing`. Binary:
   `/workspaces/teamster/.trunk/tools/trunk`.
 
 - **Markdown**: Always specify a language on fenced code blocks (MD040). Use

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -162,7 +162,11 @@ the request method. For network-call retries, the predicate must include
 `(RequestsConnectionError, Timeout, HTTPError)` — `HTTPError` alone misses
 `ConnectTimeout`. For runtime-parameterized retry loops (e.g.
 `with_powerschool_retry`), use `tenacity.Retrying` — a manual
-`for attempt in range(...)` has no backoff.
+`for attempt in range(...)` has no backoff. Avoid broad base classes whose
+subclasses include deterministic config errors (e.g.
+`paramiko.ssh_exception.SSHException` covers `IncompatiblePeer`,
+`BadHostKeyException`, `BadAuthenticationType`). List transient subclasses
+explicitly.
 
 **Don't `log.exception` inside retry-wrapped helpers**. GCP Error Reporting
 files groups at ERROR severity, so logging a traceback inside a context manager

--- a/src/teamster/core/resources.py
+++ b/src/teamster/core/resources.py
@@ -17,11 +17,15 @@ from teamster.libraries.powerschool.sis.odbc.resources import PowerSchoolODBCRes
 from teamster.libraries.ssh.resources import SSHResource
 from teamster.libraries.zendesk.resources import ZendeskResource
 
+# `DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT` is `"0"` in full deployments and `"1"` in
+# branch deployments — always compare to `"1"`, never truthy.
+IS_BRANCH_DEPLOYMENT = os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1"
+
 GCS_RESOURCE = GCSResource(project=GCS_PROJECT_NAME)
 
 
 def get_io_manager_gcs_pickle(code_location: str) -> GCSIOManager:
-    if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1":
+    if IS_BRANCH_DEPLOYMENT:
         code_location = "test"
 
     return GCSIOManager(
@@ -30,7 +34,7 @@ def get_io_manager_gcs_pickle(code_location: str) -> GCSIOManager:
 
 
 def get_io_manager_gcs_avro(code_location: str, test: bool = False) -> GCSIOManager:
-    if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1":
+    if IS_BRANCH_DEPLOYMENT:
         code_location = "test"
         test = True
 
@@ -43,7 +47,7 @@ def get_io_manager_gcs_avro(code_location: str, test: bool = False) -> GCSIOMana
 
 
 def get_io_manager_gcs_file(code_location: str, test: bool = False) -> GCSIOManager:
-    if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1":
+    if IS_BRANCH_DEPLOYMENT:
         code_location = "test"
         test = True
 
@@ -56,7 +60,7 @@ def get_io_manager_gcs_file(code_location: str, test: bool = False) -> GCSIOMana
 
 
 def get_dbt_cli_resource(dbt_project: DbtProject) -> DbtCliResource:
-    if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT") == "1":
+    if IS_BRANCH_DEPLOYMENT:
         return DbtCliResource(project_dir=dbt_project, target="defer")
     return DbtCliResource(project_dir=dbt_project)
 
@@ -118,6 +122,10 @@ SSH_EDPLAN = SSHResource(
     # occasionally exceed that during peak periods, causing transient TimeoutError
     # on connect. 30s tolerates those without masking a truly unreachable host.
     timeout=30,
+    # secureftp.easyiep.com (GlobalSCAPE EFT 8.1) advertises only `ssh-rsa`
+    # (SHA-1 RSA) host keys. paramiko 5.0 dropped ssh-rsa from defaults; opt
+    # back in for this host only.
+    enable_legacy_rsa=True,
 )
 
 SSH_IREADY = SSHResource(

--- a/src/teamster/libraries/edplan/CLAUDE.md
+++ b/src/teamster/libraries/edplan/CLAUDE.md
@@ -10,3 +10,9 @@ EdPlan SFTP server for new files and emits a `RunRequest` when a file newer than
 the cursor is found. Single-asset sensor (one job per code location).
 
 **`schema.py`**: Avro schemas for EdPlan SFTP file formats.
+
+## Notes
+
+- Backing host `secureftp.easyiep.com` is **GlobalSCAPE EFT 8.1**, advertises
+  only `ssh-rsa` host-key algorithms. `SSH_EDPLAN` sets
+  `enable_legacy_rsa=True`.

--- a/src/teamster/libraries/ssh/CLAUDE.md
+++ b/src/teamster/libraries/ssh/CLAUDE.md
@@ -14,6 +14,7 @@ Extended SSH/SFTP resource used by every SFTP-based integration. Wraps
 | -------------------- | ------------- | ----------------------------------------------------------------- |
 | `tunnel_remote_host` | `str \| None` | Remote bind host for local port forwarding                        |
 | `test`               | `bool`        | If `True`, reads SSH password from env var instead of secret file |
+| `enable_legacy_rsa`  | `bool`        | Re-enable paramiko's dropped `ssh-rsa` host-key algorithm         |
 
 ## Notes
 
@@ -23,3 +24,8 @@ Extended SSH/SFTP resource used by every SFTP-based integration. Wraps
 - In production, the PowerSchool SSH password is read from
   `/etc/secret-volume/powerschool_ssh_password.txt`; in test mode it reads from
   the `password` field directly
+- paramiko 5.0 dropped `ssh-rsa` from default `Transport._preferred_keys`.
+  Servers advertising only `ssh-rsa` (e.g. GlobalSCAPE EFT) fail with
+  `IncompatiblePeer: no acceptable host key`. Set `enable_legacy_rsa=True` on
+  the resource. Diagnose with `ssh -vv <host>` — the
+  `peer server KEXINIT proposal` line shows the offered host-key algorithms.

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -113,7 +113,9 @@ class SSHResource(DagsterSSHResource):
         return files
 
     def open_ssh_tunnel(self) -> subprocess.Popen[bytes]:
-        # trunk-ignore(bandit/B603)
+        # trunk-ignore(bandit/B603): args are a fixed argv list (no shell, no
+        # user input). Host/port/username/tunnel target come from the resource
+        # config (EnvVar at Dagster init), not from runtime user input.
         ssh_tunnel = subprocess.Popen(
             args=[
                 "sshpass",

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -1,5 +1,6 @@
 import socket
 import subprocess
+import threading
 import time
 from pathlib import Path
 from stat import S_ISDIR, S_ISREG
@@ -14,6 +15,12 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential_jitter,
 )
+
+# Serializes mutation of `Transport._preferred_keys` across concurrent
+# `enable_legacy_rsa` connects in the same process — without it, two threads
+# can interleave save/restore and leak `ssh-rsa` past the legacy resource's
+# call (Thread B captures A's mutated value as "original" and restores to it).
+_PREFERRED_KEYS_LOCK = threading.Lock()
 
 
 class SSHTunnelError(Exception):
@@ -51,16 +58,16 @@ class SSHResource(DagsterSSHResource):
 
         # Append ssh-rsa to the class-level preferred host-key algorithms for
         # the duration of this connect. paramiko reads the class attr via
-        # _filter_algorithm("keys") at KEXINIT time. Concurrent connects from
-        # other enable_legacy_rsa resources in the same process can race on
-        # the restore — worst case is a retried IncompatiblePeer, not a
-        # correctness bug.
-        original_preferred_keys: tuple[str, ...] = Transport._preferred_keys
-        Transport._preferred_keys = original_preferred_keys + ("ssh-rsa",)
-        try:
-            return super().get_connection()
-        finally:
-            Transport._preferred_keys = original_preferred_keys
+        # _filter_algorithm("keys") at KEXINIT time. The module-level lock
+        # serializes save/restore so concurrent connects can't leak ssh-rsa
+        # beyond the legacy resource's call window.
+        with _PREFERRED_KEYS_LOCK:
+            original_preferred_keys: tuple[str, ...] = Transport._preferred_keys
+            Transport._preferred_keys = original_preferred_keys + ("ssh-rsa",)
+            try:
+                return super().get_connection()
+            finally:
+                Transport._preferred_keys = original_preferred_keys
 
     def listdir_attr_r(
         self,
@@ -106,6 +113,7 @@ class SSHResource(DagsterSSHResource):
         return files
 
     def open_ssh_tunnel(self) -> subprocess.Popen[bytes]:
+        # trunk-ignore(bandit/B603)
         ssh_tunnel = subprocess.Popen(
             args=[
                 "sshpass",

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -113,9 +113,7 @@ class SSHResource(DagsterSSHResource):
         return files
 
     def open_ssh_tunnel(self) -> subprocess.Popen[bytes]:
-        # trunk-ignore(bandit/B603): args are a fixed argv list (no shell, no
-        # user input). Host/port/username/tunnel target come from the resource
-        # config (EnvVar at Dagster init), not from runtime user input.
+        # trunk-ignore(bandit/B603): static argv, no shell; inputs are EnvVar resource config
         ssh_tunnel = subprocess.Popen(
             args=[
                 "sshpass",

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -6,8 +6,8 @@ from stat import S_ISDIR, S_ISREG
 
 from dagster_shared import check
 from dagster_ssh import SSHResource as DagsterSSHResource
-from paramiko import SFTPAttributes, SFTPClient, SSHClient
-from paramiko.ssh_exception import SSHException
+from paramiko import SFTPAttributes, SFTPClient, SSHClient, Transport
+from paramiko.ssh_exception import NoValidConnectionsError
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -23,15 +23,44 @@ class SSHTunnelError(Exception):
 class SSHResource(DagsterSSHResource):
     tunnel_remote_host: str | None = None
     test: bool = False
+    # paramiko 5.0 dropped `ssh-rsa` (SHA-1 RSA host keys) from its default
+    # _preferred_keys. Set True to re-enable ssh-rsa for servers that only
+    # advertise it (otherwise KEX negotiation fails with IncompatiblePeer).
+    enable_legacy_rsa: bool = False
 
     @retry(
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=2, max=30),
-        retry=retry_if_exception_type((SSHException, TimeoutError, socket.gaierror)),
+        # Only retry true transients. SSHException is too broad — it covers
+        # IncompatiblePeer / BadHostKeyException / BadAuthenticationType, which
+        # are deterministic config failures that will fail identically on every
+        # attempt and burn ~30s per call.
+        retry=retry_if_exception_type(
+            (
+                NoValidConnectionsError,
+                TimeoutError,
+                socket.gaierror,
+                ConnectionResetError,
+            )
+        ),
         reraise=True,
     )
     def get_connection(self) -> SSHClient:
-        return super().get_connection()
+        if not self.enable_legacy_rsa:
+            return super().get_connection()
+
+        # Append ssh-rsa to the class-level preferred host-key algorithms for
+        # the duration of this connect. paramiko reads the class attr via
+        # _filter_algorithm("keys") at KEXINIT time. Concurrent connects from
+        # other enable_legacy_rsa resources in the same process can race on
+        # the restore — worst case is a retried IncompatiblePeer, not a
+        # correctness bug.
+        original_preferred_keys: tuple[str, ...] = Transport._preferred_keys
+        Transport._preferred_keys = original_preferred_keys + ("ssh-rsa",)
+        try:
+            return super().get_connection()
+        finally:
+            Transport._preferred_keys = original_preferred_keys
 
     def listdir_attr_r(
         self,
@@ -77,7 +106,6 @@ class SSHResource(DagsterSSHResource):
         return files
 
     def open_ssh_tunnel(self) -> subprocess.Popen[bytes]:
-        # trunk-ignore(bandit/B603)
         ssh_tunnel = subprocess.Popen(
             args=[
                 "sshpass",
@@ -122,6 +150,8 @@ class SSHResource(DagsterSSHResource):
                 ssh_tunnel.kill()
                 raise SSHTunnelError(stdout)
 
+        # Prevent a race condition with the ssh tunnel becoming fully established
+        # before downstream code (e.g. PowerSchool ODBC) opens a forwarded port.
         time.sleep(1.0)
 
         return ssh_tunnel


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Restore edplan SFTP ingestion for kippcamden and kippnewark. The host
`secureftp.easyiep.com` (GlobalSCAPE EFT 8.1) advertises only `ssh-rsa` as its
host-key algorithm, which paramiko 5.0 dropped from its default `_preferred_keys`.
Negotiation failed deterministically with `paramiko.ssh_exception.IncompatiblePeer:
no acceptable host key`, blocking three consecutive nights of
`<loc>__edplan__njsmart_powerschool` materializations and producing 100/100
failed ticks per location for the two edplan SFTP sensors.

This PR:

1. Adds an opt-in `enable_legacy_rsa: bool = False` field on `SSHResource`. When
   set, `get_connection()` appends `"ssh-rsa"` to `paramiko.Transport._preferred_keys`
   for the duration of the connect (restored in `finally`).
2. Enables the flag on `SSH_EDPLAN` only — every other SFTP resource keeps
   paramiko's modern defaults.
3. Narrows the tenacity retry predicate on `get_connection()` from
   `(SSHException, TimeoutError, socket.gaierror)` to
   `(NoValidConnectionsError, TimeoutError, socket.gaierror, ConnectionResetError)`.
   The old predicate caught deterministic config failures (`IncompatiblePeer`,
   `BadHostKeyException`, `BadAuthenticationType`) and burned ~30s × 5 retries
   on each one — confirmed in the run logs for the failed njsmart_powerschool
   runs (5 connect attempts in 33s before raising).
4. Hoists the duplicated branch-deployment environment-variable check (4 inline
   copies) to a module-level `IS_BRANCH_DEPLOYMENT` constant.
5. Documents the post-handshake `time.sleep(1.0)` in `open_ssh_tunnel()` as a
   race-condition guard for downstream forwarded-port consumers.

A separate backfill of `kippcamden__edplan__njsmart_powerschool` and
`kippnewark__edplan__njsmart_powerschool` for 2026-05-16, 05-17, 05-18 should
follow once this merges.

## AI Assistance

AI-assisted: full diagnosis (sensor / run / pod log correlation, paramiko
internals investigation, fix design and implementation) plus this PR body.
Human-directed: confirmed the failure mode with a local `ssh -vv` against the
host, vetoed the use of `getattr`/`setattr` over direct attribute access,
approved the `IS_BRANCH_DEPLOYMENT` refactor, and supplied the rationale for
the existing `time.sleep(1.0)`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.
