### PR TITLE
fix(dbt/kipppaterson): route kipppaterson/models/pearson into kipppaterson_pearson schema

### DIFF
--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -37,6 +37,8 @@ models:
         staging:
           +contract:
             enforced: true
+    pearson:
+      +schema: pearson
   amplify:
     dds:
       +enabled: false


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR will add a `+schema: pearson` override under `models.kipppaterson.pearson` in `src/dbt/kipppaterson/dbt_project.yml` so that the Phase A `int_pearson__njsla` and `int_pearson__njsla_science` models (merged in #3958) land in the `kipppaterson_pearson` BigQuery schema instead of plain `kipppaterson`.

**Phase A bug fix.** Surfaced while preparing Phase B (kipptaf wiring + crosswalk removal) for #3882. The original Phase A added the intermediates but did not configure their schema. The imported `pearson` package sets `+schema: pearson` in its own `dbt_project.yml` — which is what makes the source-system staging models land in `kipppaterson_pearson` — but that config does not apply to `kipppaterson/models/pearson/intermediate/` because those are kipppaterson-project models, not imported-package models.

Without this fix:

- Models land in `kipppaterson` schema (verified via `dbt build --target dev`).
- Dagster derives 2-element asset keys (`kipppaterson/int_pearson__njsla`) instead of the 3-element form (`kipppaterson/pearson/int_pearson__njsla`).
- Phase B's `sources-kipppaterson.yml` declarations point at `kipppaterson_pearson.int_pearson__njsla` — which would not exist.

Phase B is blocked until this merges and Dagster materializes the intermediates into the correct schema.

## AI Assistance

AI-assisted: Claude Code identified the missing schema config during Phase B preparation, traced the convention to the pearson source-system package's `dbt_project.yml`, and applied the fix. Human-directed: scope confirmation that this is a Phase A bug worth a separate small PR.

## Self-review

### dbt

- [x] Schema override added under `models.kipppaterson.pearson`
- [x] Local `uv run dbt build --target dev --full-refresh` puts models in `zz_<user>_kipppaterson_pearson` (verified)
- [x] All 4 tests still pass (`unique` + `not_null` on `studenttestuuid` for both models)
- [x] No breaking change — kipppaterson code only; consuming kipptaf union models will continue to source from prod `kipppaterson_pearson` (no change to source declarations until #3882 Phase B PR)

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes (kipppaterson change; kipptaf CI is a no-op)
- [ ] **Dagster Cloud** — passes or not triggered

Refs #3882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)