### PR TITLE
fix(kipptaf): filter dibels bm goals calculations to At/Above goal type only

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__dibels_bm_goals_calculations.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__dibels_bm_goals_calculations.yml
@@ -20,13 +20,13 @@ models:
       - name: grade_range_goal
         data_type: float64
       - name: n_admin_season_school_gl_all
-        data_type: float64
+        data_type: int64
       - name: n_admin_season_school_gl_at_above
         data_type: int64
       - name: n_admin_season_school_gl_bl_wb
         data_type: int64
       - name: n_admin_season_region_gl_all
-        data_type: float64
+        data_type: int64
       - name: n_admin_season_region_gl_at_above
         data_type: int64
       - name: n_admin_season_region_gl_bl_wb

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__dibels_bm_goals_calculations.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__dibels_bm_goals_calculations.sql
@@ -156,13 +156,40 @@ with
     )
 
 select
-    * except (grade_goal_type),
+    c.academic_year,
+    c.region,
+    c.assessment_grade,
+    c.assessment_grade_int,
+    c.period,
+    c.benchmark_goal_season,
+    c.school,
 
-    (n_admin_season_school_gl_at_above_expected - n_admin_season_school_gl_at_above)
+    c.grade_goal,
+    c.grade_range_goal,
+    c.n_admin_season_school_gl_all,
+    c.n_admin_season_school_gl_at_above,
+    c.n_admin_season_region_gl_all,
+    c.n_admin_season_region_gl_at_above,
+    c.n_admin_season_school_gl_at_above_expected,
+    c.n_admin_season_region_gl_at_above_expected,
+
+    b.n_admin_season_school_gl_bl_wb,
+    b.n_admin_season_region_gl_bl_wb,
+
+    (c.n_admin_season_school_gl_at_above_expected - c.n_admin_season_school_gl_at_above)
     * 1.5 as n_admin_season_school_gl_at_above_gap,
 
-    (n_admin_season_region_gl_at_above_expected - n_admin_season_region_gl_at_above)
+    (c.n_admin_season_region_gl_at_above_expected - c.n_admin_season_region_gl_at_above)
     * 1.5 as n_admin_season_region_gl_at_above_gap,
 
-from needed_count_calcs
-where grade_goal_type = 'At/Above'
+from needed_count_calcs as c
+left join
+    needed_count_calcs as b
+    on c.academic_year = b.academic_year
+    and c.region = b.region
+    and c.assessment_grade = b.assessment_grade
+    and c.period = b.period
+    and c.benchmark_goal_season = b.benchmark_goal_season
+    and c.school = b.school
+    and b.grade_goal_type = 'Well Below'
+where c.grade_goal_type = 'At/Above'

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__dibels_bm_goals_calculations.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__dibels_bm_goals_calculations.sql
@@ -10,6 +10,7 @@ with
 
             e.school,
 
+            f.grade_goal_type,
             f.grade_goal,
             f.grade_range_goal,
 
@@ -125,34 +126,20 @@ with
             assessment_grade_int,
             period,
             benchmark_goal_season,
+            grade_goal_type,
             school,
 
-            max(grade_goal) as grade_goal,
-
-            max(grade_range_goal) as grade_range_goal,
-
-            avg(n_admin_season_school_gl_all) as n_admin_season_school_gl_all,
-
-            sum(n_admin_season_school_gl_at_above) as n_admin_season_school_gl_at_above,
-
-            sum(n_admin_season_school_gl_bl_wb) as n_admin_season_school_gl_bl_wb,
-
-            avg(n_admin_season_region_gl_all) as n_admin_season_region_gl_all,
-
-            sum(n_admin_season_region_gl_at_above) as n_admin_season_region_gl_at_above,
-
-            sum(n_admin_season_region_gl_bl_wb) as n_admin_season_region_gl_bl_wb,
+            grade_goal,
+            grade_range_goal,
+            n_admin_season_school_gl_all,
+            n_admin_season_school_gl_at_above,
+            n_admin_season_school_gl_bl_wb,
+            n_admin_season_region_gl_all,
+            n_admin_season_region_gl_at_above,
+            n_admin_season_region_gl_bl_wb,
 
         from roster
         where rn = 1
-        group by
-            academic_year,
-            region,
-            assessment_grade,
-            assessment_grade_int,
-            period,
-            benchmark_goal_season,
-            school
     ),
 
     needed_count_calcs as (
@@ -169,7 +156,7 @@ with
     )
 
 select
-    *,
+    * except (grade_goal_type),
 
     (n_admin_season_school_gl_at_above_expected - n_admin_season_school_gl_at_above)
     * 1.5 as n_admin_season_school_gl_at_above_gap,
@@ -178,3 +165,4 @@ select
     * 1.5 as n_admin_season_region_gl_at_above_gap,
 
 from needed_count_calcs
+where grade_goal_type = 'At/Above'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix `rpt_gsheets__dibels_bm_goals_calculations` to correctly select grade goals by filtering to `grade_goal_type = 'At/Above'` in the final SELECT, rather than relying on `max(grade_goal)` aggregation across multiple goal-type rows.

**Root cause of the old bug**: The previous model grouped rows and used `max(grade_goal)` to collapse At/Above and Well Below goal rows. For upper grades (5–8) where the Well Below goal is numerically larger than the At/Above goal, `max()` silently picked the Well Below value. This caused incorrect expected counts and gap calculations for Camden grades 5–8, Newark grades 7–8, and Paterson grades 6–7.

**Fix**: Propagate `grade_goal_type` through the CTEs and filter `where grade_goal_type = 'At/Above'` in the final SELECT, dropping the `max()`/`avg()`/`sum()` aggregation layer entirely. The `* except (grade_goal_type)` removes the helper column from the output contract.

**Also fixes**: `n_admin_season_school_gl_all` and `n_admin_season_region_gl_all` were declared `float64` in the YAML (artifact of the old `avg()` aggregation). Now declared `int64`, matching the `count()` window function output.

## AI Assistance

Claude Code (claude-sonnet-4-6) identified the root cause (`max()` picking Well Below goal for upper grades), proposed and implemented the refactor, and updated the YAML properties file. Human-directed: branch creation, final SQL validation, gap-column impact analysis against prod data.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — updated `rpt_gsheets__dibels_bm_goals_calculations.yml`
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Output schema is unchanged (same columns, same names). `grade_goal` and `grade_range_goal` values will differ for upper-grade rows where the old model was using the Well Below goal value.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.