### PR TITLE
fix(kipptaf): widen ADP WFN retry predicate and add request timeout

### DIFF
--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -62,9 +62,10 @@ class AdpWorkforceNowResource(ConfigurableResource):
     @retry(
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=10, max=60),
-        retry=retry_if_exception_type(HTTPError),
+        retry=retry_if_exception_type((RequestsConnectionError, Timeout, HTTPError)),
     )
     def _request(self, method: str, url: str, **kwargs) -> Response:
+        kwargs.setdefault("timeout", (10, 60))
         response = self._session.request(method=method, url=url, **kwargs)
 
         try:

--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -81,11 +81,12 @@ class AdpWorkforceNowResource(ConfigurableResource):
             return response
         except HTTPError as e:
             response_json = response.json()
-            self._log.error(msg=response_json)
 
             if response.status_code == 429:
+                self._log.warning(msg=response_json)
                 raise  # retryable via tenacity
 
+            self._log.error(msg=response_json)
             raise Exception(response_json) from e
 
     def post(


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR will close the retry-predicate gap that caused run `77f24f58` (`kipptaf__adp__workforce_now__workers`, 2026-05-19) to fail without retry: ADP's `hr/v2/workers` server tore down the TLS connection mid-body-read after 29 successful pages, raising `ssl.SSLError: [SSL] record layer failure`. The tenacity wrapper on `_request` was `retry_if_exception_type(HTTPError)` only — `SSLError` subclasses `RequestsConnectionError`, not `HTTPError`, so the predicate didn't match and the first transient fault propagated. Dagster's run-level retry recovered the workload, but the asset-level retry should have absorbed it.

Two changes to [src/teamster/libraries/adp/workforce_now/api/resources.py](src/teamster/libraries/adp/workforce_now/api/resources.py):

- Widen the `_request` tenacity predicate to `(RequestsConnectionError, Timeout, HTTPError)` per the standard documented in [src/teamster/CLAUDE.md](src/teamster/CLAUDE.md). Matches the predicate already in use on `_fetch_access_token`.
- Default `timeout=(10, 60)` on the session request (via `kwargs.setdefault`) as defense-in-depth so a hung handshake or stalled chunk read converts to a `Timeout` that the widened predicate retries, instead of blocking the step indefinitely.

## AI Assistance

AI-authored after diagnostic investigation (cbini directed); each step verified against the run's compute logs and source.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [x] Existing `tests/resources/test_resource_adp_workforce_now.py` integration suite: 4 passed, 1 unrelated failure (`test_get_talent_associate_memberships` — endpoint authorization, pre-existing).
- [x] Module import-checks clean.

## CI checks

- [ ] **Trunk** — passes
- [ ] **Dagster Cloud** — passes or not triggered

Refs #3965
