### PR TITLE
fix(amplify-mclass-sftp-sensor): drop unsound dir_mtimes prune

### DIFF
--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -146,7 +146,10 @@ with partition dimension values via `regex_pattern_replace()`.
 extract partition keys from named groups, emit `RunRequest`s grouped by
 `(job_name, partition_key)`. Sensor cursors should store max file mtime from
 matched files, not `now.timestamp()` — wall-clock cursors skip files with older
-mtimes.
+mtimes. `listdir_attr_r`'s `dir_mtimes` subtree-prune is only sound when the
+SFTP server advances parent-dir mtime on entry changes — Amplify mClass does
+not. Before opting a new sensor into `dir_mtimes=`, verify with
+`dir.st_mtime >= max(child.st_mtime)` across the watched tree.
 
 **Fiscal year**: July 1 start. `FiscalYear` class and
 `FiscalYearPartitionsDefinition` in `core/utils/classes.py`.

--- a/src/teamster/libraries/amplify/CLAUDE.md
+++ b/src/teamster/libraries/amplify/CLAUDE.md
@@ -31,4 +31,5 @@ API.
 **`sensors.py`** (`build_amplify_mclass_sftp_sensor()`): SFTP sensor that
 detects new mClass files using `SSHResource.listdir_attr_r()`, matching paths
 against asset `remote_dir_regex`/`remote_file_regex` metadata. Extracts
-partition keys from regex named groups.
+partition keys from regex named groups. The Amplify mClass SFTP server returns
+stale directory mtimes — do not pass `dir_mtimes=` to `listdir_attr_r`.

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -20,8 +20,6 @@ from dagster_shared import check
 
 from teamster.libraries.ssh.resources import SSHResource
 
-DIR_MTIMES_KEY = "__dir_mtimes"
-
 
 def build_amplify_mclass_sftp_sensor(
     code_location: str,
@@ -58,7 +56,6 @@ def build_amplify_mclass_sftp_sensor(
         run_request_kwargs = []
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
-        dir_mtimes = cursor.pop(DIR_MTIMES_KEY, {})
 
         with (
             ssh_amplify.get_connection() as connection,
@@ -67,7 +64,6 @@ def build_amplify_mclass_sftp_sensor(
             files = ssh_amplify.listdir_attr_r(
                 sftp_client=sftp_client,
                 remote_dir=remote_dir_regex,
-                dir_mtimes=dir_mtimes,
             )
 
         for asset in asset_selection:
@@ -126,8 +122,6 @@ def build_amplify_mclass_sftp_sensor(
                     asset_selection=[g["asset_key"] for g in group],
                 )
             )
-
-        cursor[DIR_MTIMES_KEY] = dir_mtimes
 
         return SensorResult(run_requests=run_requests, cursor=json.dumps(obj=cursor))
 

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -94,6 +94,18 @@ class SSHResource(DagsterSSHResource):
         min_mtime: float | None = None,
         dir_mtimes: dict[str, float] | None = None,
     ) -> list[tuple[SFTPAttributes, str]]:
+        """Recursively list SFTP files with attributes.
+
+        The ``dir_mtimes`` parameter enables subtree pruning: a directory whose
+        ``st_mtime`` has not advanced since the cached value is skipped. This
+        is only sound when the SFTP server advances parent-directory mtime on
+        entry adds/removes/renames (POSIX semantics). Not all SFTP servers
+        honor this — Amplify mClass returns stale directory mtimes, causing the
+        prune to silently drop new files. Before opting a new sensor into
+        ``dir_mtimes``, verify the server propagates by checking whether any
+        directory's ``st_mtime`` is older than the max ``st_mtime`` of its
+        descendants; if so, do not pass ``dir_mtimes``.
+        """
         if exclude_dirs is None:
             exclude_dirs = []
 


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will restore mClass SFTP ingestion for Newark and Paterson.

Both `kippnewark__amplify__mclass__sftp_asset_job_sensor` and `kipppaterson__amplify__mclass__sftp_asset_job_sensor` have not spawned a run since 2026-05-14 ~08:40 UTC, despite vendor uploads landing on the Amplify SFTP since then.

**Root cause:** Commits 84cc25a56 + 729b06c3f (2026-05-14 14:40–14:48 UTC) wired a `dir_mtimes` cursor into `build_amplify_mclass_sftp_sensor` to skip recursion into subdirectories whose `st_mtime` hadn't advanced. The optimization assumes POSIX dir-mtime propagation. The Amplify mClass SFTP server does not honor that assumption — directory mtimes go stale, so the prune skips `/BM` and `/PM` on every tick after the first post-deploy walk and `listdir_attr_r` returns an empty file list.

**Evidence:**

- Last SUCCESS tick: 2026-05-14T08:42:36Z (Newark) / 08:37:59Z (Paterson)
- Every tick since: SKIPPED "empty result", 5–12s duration
- GKE logs show per-asset header lines firing (sensors.py:77) but per-file lines (sensors.py:101) never fire — confirming `files` is empty
- Filenames are date-stamped (unique per upload) so the failure isn't in-place overwrites
- ADP WFN SFTP sensor (also using `dir_mtimes`) remains healthy — that server propagates mtime correctly, so the prune is sound there

**Fix:**

- Remove `DIR_MTIMES_KEY` and the `dir_mtimes=` kwarg from `build_amplify_mclass_sftp_sensor`
- Keep `dir_mtimes` parameter on `listdir_attr_r` (ADP WFN sensor uses it)
- Docstring on `listdir_attr_r` documenting the POSIX assumption and verification method
- CLAUDE.md notes in `src/teamster/` and `src/teamster/libraries/amplify/`

**Backfill:** After deploy, the first tick re-walks `/BM` and `/PM`. Each asset's per-file `last_run` cursor is still set to ~2026-05-14, so any file with `st_mtime > 2026-05-14` produces a `RunRequest`. No manual cursor reset needed.

**Follow-up (separate issue planned):** Add a Dagster op that audits all SFTP `SSHResource`s for dir-mtime propagation so future opt-ins to `dir_mtimes` are de-risked.

Closes #3972

## AI Assistance

AI-assisted: systematic debugging (live Dagster tick history audit, log evidence, root-cause analysis), code edits, CLAUDE.md notes. Human-directed: scope decisions (keep optimization in library vs. remove; ship fix now vs. wider audit first); fix-options approval at each step.

## Self-review

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location

### Docs

- [ ] If adding or changing a schedule or sensor, regenerate the automations catalog: `uv run scripts/gen-automations-doc.py`

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — N/A (no dbt changes)
- [ ] **Dagster Cloud** — passes