### PR TITLE
test(sftp): audit dir-mtime propagation across SFTP servers

### DIFF
--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -8,6 +8,7 @@ unset (e.g. CI without 1Password access).
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from dagster import EnvVar
@@ -39,7 +40,7 @@ def _password_ssh(
         resolved_port = port
         if port_env is not None:
             resolved_port = int(check.not_none(value=EnvVar(port_env).get_value()))
-        kwargs: dict = {
+        kwargs: dict[str, Any] = {
             "remote_host": EnvVar(host_env),
             "remote_port": resolved_port,
             "username": EnvVar(user_env),

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -1,0 +1,259 @@
+"""Per-server SSHResource fixtures for SFTP integration tests.
+
+Authentication is handled by the root ``tests/conftest.py`` session-scoped
+fixture that bootstraps 1Password secrets into ``os.environ`` on first run.
+Individual fixtures here skip when their required environment variables are
+unset (e.g. CI without 1Password access).
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pytest
+from dagster import EnvVar
+from dagster_shared import check
+
+from teamster.libraries.ssh.resources import SSHResource
+
+
+@dataclass(frozen=True)
+class SFTPServer:
+    name: str
+    env_vars: tuple[str, ...]
+    builder: Callable[[], SSHResource]
+    remote_dir: str
+    exclude_dirs: tuple[str, ...] = ()
+
+
+def _password_ssh(
+    *,
+    host_env: str,
+    user_env: str,
+    pass_env: str,
+    port: int = 22,
+    port_env: str | None = None,
+    timeout: int | None = None,
+    enable_legacy_rsa: bool = False,
+) -> Callable[[], SSHResource]:
+    def build() -> SSHResource:
+        resolved_port = port
+        if port_env is not None:
+            resolved_port = int(check.not_none(value=EnvVar(port_env).get_value()))
+        kwargs: dict = {
+            "remote_host": EnvVar(host_env),
+            "remote_port": resolved_port,
+            "username": EnvVar(user_env),
+            "password": EnvVar(pass_env),
+            "test": True,
+        }
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if enable_legacy_rsa:
+            kwargs["enable_legacy_rsa"] = enable_legacy_rsa
+        return SSHResource(**kwargs)
+
+    return build
+
+
+def _egencia() -> SSHResource:
+    return SSHResource(
+        remote_host=EnvVar("EGENCIA_SFTP_HOST"),
+        remote_port=22,
+        username=EnvVar("EGENCIA_SFTP_USERNAME"),
+        key_file="/etc/secret-volume/id_rsa_egencia",
+        test=True,
+    )
+
+
+SFTP_SERVERS: tuple[SFTPServer, ...] = (
+    SFTPServer(
+        name="amplify",
+        env_vars=(
+            "AMPLIFY_SFTP_HOST",
+            "AMPLIFY_SFTP_USERNAME",
+            "AMPLIFY_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="AMPLIFY_SFTP_HOST",
+            user_env="AMPLIFY_SFTP_USERNAME",
+            pass_env="AMPLIFY_SFTP_PASSWORD",
+        ),
+        remote_dir="/",
+    ),
+    SFTPServer(
+        name="adp_workforce_now",
+        env_vars=("ADP_SFTP_HOST_IP", "ADP_SFTP_USERNAME", "ADP_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="ADP_SFTP_HOST_IP",
+            user_env="ADP_SFTP_USERNAME",
+            pass_env="ADP_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+        exclude_dirs=("./payroll",),
+    ),
+    SFTPServer(
+        name="clever",
+        env_vars=("CLEVER_SFTP_HOST", "CLEVER_SFTP_USERNAME", "CLEVER_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="CLEVER_SFTP_HOST",
+            user_env="CLEVER_SFTP_USERNAME",
+            pass_env="CLEVER_SFTP_PASSWORD",
+            timeout=30,
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="couchdrop",
+        env_vars=(
+            "COUCHDROP_SFTP_HOST",
+            "COUCHDROP_SFTP_USERNAME",
+            "COUCHDROP_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="COUCHDROP_SFTP_HOST",
+            user_env="COUCHDROP_SFTP_USERNAME",
+            pass_env="COUCHDROP_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="coupa",
+        env_vars=("COUPA_SFTP_HOST", "COUPA_SFTP_USERNAME", "COUPA_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="COUPA_SFTP_HOST",
+            user_env="COUPA_SFTP_USERNAME",
+            pass_env="COUPA_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="deanslist",
+        env_vars=(
+            "DEANSLIST_SFTP_HOST",
+            "DEANSLIST_SFTP_USERNAME",
+            "DEANSLIST_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="DEANSLIST_SFTP_HOST",
+            user_env="DEANSLIST_SFTP_USERNAME",
+            pass_env="DEANSLIST_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="edplan",
+        env_vars=("EDPLAN_SFTP_HOST", "EDPLAN_SFTP_USERNAME", "EDPLAN_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="EDPLAN_SFTP_HOST",
+            user_env="EDPLAN_SFTP_USERNAME",
+            pass_env="EDPLAN_SFTP_PASSWORD",
+            timeout=30,
+            enable_legacy_rsa=True,
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="egencia",
+        env_vars=("EGENCIA_SFTP_HOST", "EGENCIA_SFTP_USERNAME"),
+        builder=_egencia,
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="idauto",
+        env_vars=("KTAF_SFTP_HOST_IP", "KTAF_SFTP_USERNAME", "KTAF_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="KTAF_SFTP_HOST_IP",
+            user_env="KTAF_SFTP_USERNAME",
+            pass_env="KTAF_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="illuminate",
+        env_vars=(
+            "ILLUMINATE_SFTP_HOST",
+            "ILLUMINATE_SFTP_USERNAME",
+            "ILLUMINATE_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="ILLUMINATE_SFTP_HOST",
+            user_env="ILLUMINATE_SFTP_USERNAME",
+            pass_env="ILLUMINATE_SFTP_PASSWORD",
+            timeout=30,
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="iready",
+        env_vars=("IREADY_SFTP_HOST", "IREADY_SFTP_USERNAME", "IREADY_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="IREADY_SFTP_HOST",
+            user_env="IREADY_SFTP_USERNAME",
+            pass_env="IREADY_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="lattice",
+        env_vars=(
+            "LATTICE_SFTP_HOST",
+            "LATTICE_SFTP_USERNAME",
+            "LATTICE_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="LATTICE_SFTP_HOST",
+            user_env="LATTICE_SFTP_USERNAME",
+            pass_env="LATTICE_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="littlesis",
+        env_vars=(
+            "LITTLESIS_SFTP_HOST",
+            "LITTLESIS_SFTP_PORT",
+            "LITTLESIS_SFTP_USERNAME",
+            "LITTLESIS_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="LITTLESIS_SFTP_HOST",
+            user_env="LITTLESIS_SFTP_USERNAME",
+            pass_env="LITTLESIS_SFTP_PASSWORD",
+            port_env="LITTLESIS_SFTP_PORT",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="renlearn",
+        env_vars=(
+            "RENLEARN_SFTP_HOST",
+            "RENLEARN_SFTP_USERNAME",
+            "RENLEARN_SFTP_PASSWORD",
+        ),
+        builder=_password_ssh(
+            host_env="RENLEARN_SFTP_HOST",
+            user_env="RENLEARN_SFTP_USERNAME",
+            pass_env="RENLEARN_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+    SFTPServer(
+        name="titan",
+        env_vars=("TITAN_SFTP_HOST", "TITAN_SFTP_USERNAME", "TITAN_SFTP_PASSWORD"),
+        builder=_password_ssh(
+            host_env="TITAN_SFTP_HOST",
+            user_env="TITAN_SFTP_USERNAME",
+            pass_env="TITAN_SFTP_PASSWORD",
+        ),
+        remote_dir=".",
+    ),
+)
+
+
+@pytest.fixture(params=SFTP_SERVERS, ids=lambda s: s.name)
+def sftp_server(request: pytest.FixtureRequest) -> SFTPServer:
+    server: SFTPServer = request.param
+    missing = [name for name in server.env_vars if EnvVar(name).get_value() is None]
+    if missing:
+        pytest.skip(f"missing environment variables: {', '.join(missing)}")
+    return server

--- a/tests/resources/test_resource_ssh_dir_mtime_propagation.py
+++ b/tests/resources/test_resource_ssh_dir_mtime_propagation.py
@@ -22,6 +22,7 @@ from stat import S_ISDIR, S_ISREG
 import pytest
 from dagster import build_resources
 from dagster_shared import check
+from paramiko import SFTPClient
 
 # Bounded walk to keep each server's test under a minute or so.
 _MAX_DIRS = 200
@@ -45,13 +46,20 @@ def _join(parent: str, name: str) -> str:
 
 
 def _walk(
-    sftp,
+    sftp: SFTPClient,
     root: str,
     exclude: frozenset[str],
     max_dirs: int,
     max_depth: int,
 ) -> list[_Violation]:
-    """BFS the tree under ``root``; collect dir-mtime propagation violations."""
+    """BFS the tree under ``root``; collect dir-mtime propagation violations.
+
+    The root directory itself is not audited — only its descendants — because
+    we can't observe root's own ``st_mtime`` via ``listdir_attr`` without
+    statting it from a hypothetical parent. Servers with stale root mtimes
+    will surface elsewhere in the tree as long as the prune would ever
+    recurse past root.
+    """
     violations: list[_Violation] = []
     queue: deque[tuple[str, float, int]] = deque()
 

--- a/tests/resources/test_resource_ssh_dir_mtime_propagation.py
+++ b/tests/resources/test_resource_ssh_dir_mtime_propagation.py
@@ -1,0 +1,136 @@
+"""Passive audit of SFTP directory mtime propagation.
+
+If a directory's ``st_mtime`` is older than the max ``st_mtime`` of its
+children, the server doesn't advance dir mtime on entry changes. Sensors
+using ``listdir_attr_r(dir_mtimes=)`` against such a server silently drop
+data (see #3972).
+
+Each parametrized test connects to one SFTP server, walks a bounded portion
+of the tree, and fails if it finds any directory whose ``st_mtime`` is older
+than its newest child. Absence of a smoking gun is suggestive but not proof
+of propagation; the test is intended as a forward-looking opt-in safety
+check, not a positive guarantee.
+
+Requires the credentials bootstrapped by ``tests/conftest.py``. Per-server
+skip when the relevant environment variables are unset.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+from stat import S_ISDIR, S_ISREG
+
+import pytest
+from dagster import build_resources
+from dagster_shared import check
+
+# Bounded walk to keep each server's test under a minute or so.
+_MAX_DIRS = 200
+_MAX_DEPTH = 4
+
+
+@dataclass(frozen=True)
+class _Violation:
+    dir_path: str
+    dir_mtime: float
+    child_path: str
+    child_mtime: float
+
+
+def _normalize(path: str) -> str:
+    return path.rstrip("/") or path
+
+
+def _join(parent: str, name: str) -> str:
+    return f"{_normalize(parent)}/{name}"
+
+
+def _walk(
+    sftp,
+    root: str,
+    exclude: frozenset[str],
+    max_dirs: int,
+    max_depth: int,
+) -> list[_Violation]:
+    """BFS the tree under ``root``; collect dir-mtime propagation violations."""
+    violations: list[_Violation] = []
+    queue: deque[tuple[str, float, int]] = deque()
+
+    try:
+        root_entries = sftp.listdir_attr(root)
+    except OSError:
+        return violations
+
+    for entry in root_entries:
+        if entry.filename in (".", ".."):
+            continue
+        if not S_ISDIR(check.not_none(value=entry.st_mode)):
+            continue
+        path = _join(root, entry.filename)
+        if path in exclude:
+            continue
+        queue.append((path, check.not_none(value=entry.st_mtime), 0))
+
+    visited = 0
+    while queue and visited < max_dirs:
+        dir_path, dir_mtime, depth = queue.popleft()
+        visited += 1
+
+        try:
+            children = sftp.listdir_attr(dir_path)
+        except OSError:
+            continue
+
+        max_child_mtime = 0.0
+        max_child_path = ""
+        for child in children:
+            mode = check.not_none(value=child.st_mode)
+            if not (S_ISREG(mode) or S_ISDIR(mode)):
+                continue
+            mtime = check.not_none(value=child.st_mtime)
+            if mtime > max_child_mtime:
+                max_child_mtime = mtime
+                max_child_path = _join(dir_path, child.filename)
+            if S_ISDIR(mode) and depth + 1 < max_depth:
+                sub_path = _join(dir_path, child.filename)
+                if sub_path not in exclude:
+                    queue.append((sub_path, mtime, depth + 1))
+
+        if max_child_mtime > dir_mtime:
+            violations.append(
+                _Violation(
+                    dir_path=dir_path,
+                    dir_mtime=dir_mtime,
+                    child_path=max_child_path,
+                    child_mtime=max_child_mtime,
+                )
+            )
+
+    return violations
+
+
+def test_dir_mtime_propagates(sftp_server) -> None:
+    """Server should advance directory ``st_mtime`` on child changes."""
+    with build_resources({"ssh": sftp_server.builder()}) as resources:
+        with (
+            resources.ssh.get_connection() as connection,
+            connection.open_sftp() as sftp,
+        ):
+            violations = _walk(
+                sftp=sftp,
+                root=sftp_server.remote_dir,
+                exclude=frozenset(sftp_server.exclude_dirs),
+                max_dirs=_MAX_DIRS,
+                max_depth=_MAX_DEPTH,
+            )
+
+    if violations:
+        sample = "\n".join(
+            f"  {v.dir_path!r} mtime={v.dir_mtime} < child {v.child_path!r} "
+            f"mtime={v.child_mtime}"
+            for v in violations[:5]
+        )
+        pytest.fail(
+            f"{sftp_server.name}: {len(violations)} directory mtime propagation "
+            f"violation(s) (showing up to 5):\n{sample}\n"
+            "Do not pass `dir_mtimes=` to listdir_attr_r for this server."
+        )


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will add an opt-in integration test that detects SFTP servers where `listdir_attr_r(dir_mtimes=)` would silently drop data — the failure mode behind #3972.

The test walks each SFTP server's directory tree (bounded to 200 directories / depth 4) and fails when any directory's `st_mtime` is older than the max `st_mtime` of its children. That mismatch is the smoking-gun signature of a server that doesn't propagate parent-dir mtime on entry changes; servers exhibiting it cannot safely opt into the `dir_mtimes=` subtree-prune optimization.

Lives at `tests/resources/test_resource_ssh_dir_mtime_propagation.py` with a sibling `conftest.py` that registers one parametrized fixture per SFTP `SSHResource`. Authentication piggybacks on the root `tests/conftest.py` 1Password bootstrap — no new credential plumbing. Per-server skip when the relevant environment variables are unset, so the test exits cleanly in CI without 1Password access.

## Initial audit findings

Run via `uv run pytest tests/resources/test_resource_ssh_dir_mtime_propagation.py` in a codespace with 1Password bootstrap:

| Result | Servers |
|---|---|
| PASSED (3) | `littlesis`, `renlearn`, `titan` |
| SKIPPED (1) | `lattice` (environment variables not bootstrapped — separate config issue) |
| FAILED (11) | `amplify`, `adp_workforce_now`, `clever`, `couchdrop`, `coupa`, `deanslist`, `edplan`, `egencia`, `idauto`, `illuminate`, `iready` |

Only **two** sensors have ever wired `dir_mtimes=` into `listdir_attr_r`:

- `libraries/amplify/mclass/sftp/sensors.py` — already removed in #3973
- `code_locations/kipptaf/adp/workforce_now/sftp/sensors.py` — **still using it in production**

The ADP WFN sensor produces SUCCESS ticks today because its file-level `min_mtime` filter and the current vendor upload pattern happen to align with subtrees that do propagate. But the audit shows ADP WFN's server has the same structural fragility as Amplify did before 5/14 — a layout shift on the vendor side could silently break ingestion the same way. **Removing `dir_mtimes=` from the ADP WFN sensor will be filed as a separate PR.**

The other 9 failing servers don't currently opt into the optimization, so their violations are latent. The test's value for those servers is forward-looking: it prevents future opt-ins on servers that would silently drop data.

## Why a passive walk rather than an active probe?

An active probe (upload-check-delete) would give a definitive answer but writes to production SFTP servers — clutter risk, vendor confusion, and requires a known-safe write path on each. The passive walk is fully read-only. A smoking-gun failure is definitive proof of non-propagation; absence of a smoking gun is suggestive but not proof. That trade-off is the right one for an opt-in safety check.

## CI behavior

The test only runs when explicitly invoked (`uv run pytest tests/resources/...`). Default CI doesn't trigger it. It's intended as a developer tool — run before opting a sensor into `dir_mtimes=` to verify the server is safe.

Closes #3974

## AI Assistance

AI-assisted: test design (passive vs. active probe trade-off, bounded walk parameters), conftest and test code, audit execution and result interpretation, scope decisions (separating ADP WFN removal into its own PR). Human-directed: choice of probe method (passive), server scope (all SFTP resources), placement (`tests/resources/`, opt-in), and PR sequence.

## Self-review

### Dagster

- [x] Test collects cleanly (`uv run pytest --collect-only`): 15 tests parametrized
- [x] Live audit run completed (3 passed / 1 skipped / 11 failed) — findings above

### Docs

- [x] No new schedule or sensor — no automations catalog update needed

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — N/A (no dbt changes)
- [ ] **Dagster Cloud** — N/A (test-only, no asset changes)