### PR TITLE
fix(adp-wfn-sftp-sensor): drop unsound dir_mtimes prune

### DIFF
--- a/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
+++ b/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
@@ -26,6 +26,8 @@ def adp_wfn_sftp_sensor(
     run_requests = []
     cursor: dict = json.loads(context.cursor or "{}")
 
+    cursor.pop("__dir_mtimes", None)
+
     min_mtime = min(cursor.values(), default=0)
 
     with (

--- a/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
+++ b/src/teamster/code_locations/kipptaf/adp/workforce_now/sftp/sensors.py
@@ -14,8 +14,6 @@ from teamster.code_locations.kipptaf import CODE_LOCATION
 from teamster.code_locations.kipptaf.adp.workforce_now.sftp.assets import assets
 from teamster.libraries.ssh.resources import SSHResource
 
-DIR_MTIMES_KEY = "__dir_mtimes"
-
 
 @sensor(
     name=f"{CODE_LOCATION}__adp__workforce_now__sftp_assets_sensor",
@@ -28,7 +26,6 @@ def adp_wfn_sftp_sensor(
     run_requests = []
     cursor: dict = json.loads(context.cursor or "{}")
 
-    dir_mtimes = cursor.pop(DIR_MTIMES_KEY, {})
     min_mtime = min(cursor.values(), default=0)
 
     with (
@@ -39,7 +36,6 @@ def adp_wfn_sftp_sensor(
             sftp_client=sftp_client,
             exclude_dirs=["./payroll"],
             min_mtime=min_mtime,
-            dir_mtimes=dir_mtimes,
         )
 
     for asset in assets:
@@ -73,8 +69,6 @@ def adp_wfn_sftp_sensor(
 
         if max_mtime > last_run:
             cursor[asset_identifier] = max_mtime
-
-    cursor[DIR_MTIMES_KEY] = dir_mtimes
 
     if run_requests:
         return SensorResult(run_requests=run_requests, cursor=json.dumps(obj=cursor))


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will remove the structurally-unsound `dir_mtimes=` optimization from the ADP WFN SFTP sensor before it causes a silent data outage.

The `dir_mtimes` subtree-prune in `listdir_attr_r` assumes POSIX dir-mtime propagation. The audit added in #3975 found that the ADP WFN SFTP server **has propagation violations** — directories whose `st_mtime` is older than their newest child, the smoking-gun signature of a server that doesn't advance parent-dir mtime on entry changes. Same structural failure mode that hit Amplify mClass in #3972 (kippnewark + kipppaterson missed six days of data).

The sensor still produces SUCCESS ticks today (confirmed via Dagster MCP tick history before opening this PR). That's because the file-level `min_mtime` filter and the current vendor upload pattern happen to align with the subtrees that do propagate. But the optimization is operating on borrowed time — any vendor layout change could expose a non-propagating subtree and silently break ingestion, exactly the failure mode behind #3972.

**Fix:** remove the `dir_mtimes` wiring while the sensor is still healthy. The sensor falls back to a full recursive walk every 10 minutes — gated by the existing `exclude_dirs=["./payroll"]` and the file-level `min_mtime` filter, same shape as the fixed Amplify sensor. No behavior change for any file that's already been processed; on the first tick after deploy, the cursor's per-asset `last_run` values are unchanged, so backfill is automatic for anything the prune may have been silently skipping.

After this merges, no production sensor uses `dir_mtimes=` anymore. The parameter stays on `listdir_attr_r` (documented as conditionally-sound) for any future opt-in, guarded by the audit test in #3975.

## AI Assistance

AI-assisted: applying the same fix pattern that worked on Amplify (#3973), commit message, PR body. Human-directed: decision to remove the optimization from ADP WFN as a separate PR (rather than expanding scope on either #3973 or #3975).

## Self-review

### Dagster

- [x] Smoke-tested the import path (`uv run python -c "from teamster.code_locations.kipptaf.adp.workforce_now.sftp.sensors import adp_wfn_sftp_sensor"`) — clean.
- [ ] Run `uv run dagster definitions validate -m teamster.code_locations.kipptaf.definitions` — defer to CI per `src/teamster/CLAUDE.md` (validate is unreliable in codespace without 1Password environment variables).
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` — defer to CI.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — N/A (no dbt changes)
- [ ] **Dagster Cloud** — branch deploy will validate.

Closes #3976