### PR TITLE
fix(collegeboard): test on cb_id, accept alphanumeric record_locator

### DIFF
--- a/src/dbt/kipptaf/models/collegeboard/intermediate/properties/int_collegeboard__psat_unpivot.yml
+++ b/src/dbt/kipptaf/models/collegeboard/intermediate/properties/int_collegeboard__psat_unpivot.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - powerschool_student_number
+              - cb_id
               - latest_psat_date
               - score_type
           config:
@@ -16,6 +16,10 @@ models:
         data_type: int64
       - name: powerschool_student_number
         data_type: int64
+        data_tests:
+          - not_null:
+              config:
+                severity: warn
       - name: academic_year
         data_type: int64
       - name: administration_round

--- a/src/dbt/kipptaf/models/collegeboard/intermediate/properties/int_collegeboard__sat_unpivot.yml
+++ b/src/dbt/kipptaf/models/collegeboard/intermediate/properties/int_collegeboard__sat_unpivot.yml
@@ -6,11 +6,17 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - powerschool_student_number
+              - cb_id
               - rn_admin
           config:
             severity: error
     columns:
+      - name: powerschool_student_number
+        data_type: int64
+        data_tests:
+          - not_null:
+              config:
+                severity: warn
       - name: ai_code
         data_type: string
       - name: ai_name
@@ -108,7 +114,7 @@ models:
       - name: percentile_state_total
         data_type: int64
       - name: record_locator
-        data_type: int64
+        data_type: string
       - name: sat_adv_math
         data_type: int64
       - name: sat_comm_evidence
@@ -184,8 +190,6 @@ models:
       - name: sat_grade
         data_type: string
         description: Categorical mapping of sat_grade.
-      - name: powerschool_student_number
-        data_type: int64
       - name: test_name
         data_type: string
         description: Computed expression.

--- a/src/dbt/kipptaf/models/collegeboard/staging/properties/stg_collegeboard__sat.yml
+++ b/src/dbt/kipptaf/models/collegeboard/staging/properties/stg_collegeboard__sat.yml
@@ -389,17 +389,17 @@ models:
       - name: admin6_sat_math_test
         data_type: numeric
       - name: admin1_record_locator
-        data_type: int64
+        data_type: string
       - name: admin2_record_locator
-        data_type: int64
+        data_type: string
       - name: admin3_record_locator
-        data_type: int64
+        data_type: string
       - name: admin4_record_locator
-        data_type: int64
+        data_type: string
       - name: admin5_record_locator
-        data_type: int64
+        data_type: string
       - name: admin6_record_locator
-        data_type: int64
+        data_type: string
       - name: admin1_college_reportable
         data_type: boolean
       - name: admin2_college_reportable

--- a/src/dbt/kipptaf/models/collegeboard/staging/stg_collegeboard__sat.sql
+++ b/src/dbt/kipptaf/models/collegeboard/staging/stg_collegeboard__sat.sql
@@ -201,24 +201,12 @@ select
     cast(admin5_sat_math_test as numeric) as admin5_sat_math_test,
     cast(admin6_sat_math_test as numeric) as admin6_sat_math_test,
 
-    cast(
-        coalesce(latest_record_locator, latest_registration_num) as int
-    ) as admin1_record_locator,
-    cast(
-        coalesce(admin2_record_locator, admin2_registration_num) as int
-    ) as admin2_record_locator,
-    cast(
-        coalesce(admin3_record_locator, admin3_registration_num) as int
-    ) as admin3_record_locator,
-    cast(
-        coalesce(admin4_record_locator, admin4_registration_num) as int
-    ) as admin4_record_locator,
-    cast(
-        coalesce(admin5_record_locator, admin5_registration_num) as int
-    ) as admin5_record_locator,
-    cast(
-        coalesce(admin6_record_locator, admin6_registration_num) as int
-    ) as admin6_record_locator,
+    coalesce(latest_record_locator, latest_registration_num) as admin1_record_locator,
+    coalesce(admin2_record_locator, admin2_registration_num) as admin2_record_locator,
+    coalesce(admin3_record_locator, admin3_registration_num) as admin3_record_locator,
+    coalesce(admin4_record_locator, admin4_registration_num) as admin4_record_locator,
+    coalesce(admin5_record_locator, admin5_registration_num) as admin5_record_locator,
+    coalesce(admin6_record_locator, admin6_registration_num) as admin6_record_locator,
 
     case
         when college_reportable = 'N'

--- a/src/teamster/__init__.py
+++ b/src/teamster/__init__.py
@@ -1,1 +1,10 @@
+import logging
+
 GCS_PROJECT_NAME = "teamster-332318"
+
+# Paramiko's Transport.run() background thread logs socket.error at ERROR
+# before the exception propagates to SSHResource.get_connection()'s tenacity
+# retry. The retry then recovers, but GCP Error Reporting has already filed a
+# group. Silence the redundant ERROR; genuine unrecovered failures still log
+# at the Dagster run level.
+logging.getLogger("paramiko.transport").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will unblock the kipptaf `__ASSET_JOB` and clean up false-positive Error Reporting noise:

- Move `int_collegeboard__{psat,sat}_unpivot` uniqueness tests from the crosswalk-derived `powerschool_student_number` to the natural source PK `cb_id`. NULL psn from missing crosswalk rows no longer collides on itself and blocks the build; gaps surface via a new `not_null: warn` on `powerschool_student_number` instead.
- Drop the `int` cast on `stg_collegeboard__sat.admin{1..6}_record_locator`. College Board has begun issuing alphanumeric `S`-prefixed locators for digital-test rows (405 of 1717 in the latest partition); the cast was failing with `Bad int64 value: S002015066` and blocking the SAT staging build since 2026-05-20.
- Silence paramiko's `Transport.run()` background-thread ERROR log. Paramiko logs `socket.error` at ERROR before the exception propagates to `SSHResource.get_connection()`'s tenacity retry. The retry recovers, but Error Reporting has already filed a group. Two such groups have been open since 2026-05-07; muting the redundant logger removes the false-positive path while leaving Dagster's run-level ERROR intact for genuine retry exhaustion.

Closes #3981.

## AI Assistance

Authored by Claude Code as a follow-up to the 2026-05-21 day-2 root-cause analysis. The structural test changes and SAT cast decision were directed by the human (rejecting an initial coalesce-based dedupe fix that risked psn/cb_id namespace collisions).

## Self-review

### Dagster

- [x] `uv run dbt parse --project-dir src/dbt/kipptaf --no-partial-parse` clean.

### dbt

- [x] Properties YAMLs updated for type/test changes.
- [x] `dbt parse` clean.
- [x] `trunk check --force` on all modified files clean.

### Operational

- [ ] After merge, rebuild `int_collegeboard__{psat,sat}_unpivot` to clear the FAILED asset check state.
- [ ] Ops still needs to populate the missing 119 PSAT crosswalk rows for full data coverage; the new `not_null: warn` surfaces these going forward.