### PR TITLE
refactor(dagster): drop dep-code-version gate

### DIFF
--- a/src/teamster/core/CLAUDE.md
+++ b/src/teamster/core/CLAUDE.md
@@ -109,16 +109,18 @@ deploy rollover, the materialization may be stamped with the new deployment's
 code version. `code_version_changed()` returns false permanently — manual
 materialization is the only fix. See dagster-io/dagster#33708.
 
-**Deploy ordering gate**: `_dep_code_version_pending` in
-`_build_dbt_condition()` blocks materialization when a direct dependency has
-`code_version_changed().since(newly_updated())`. Applied to tables and
-union_relations views via `guard_dep_code_version=True`; plain views opt out
-(`guard_dep_code_version=False`). **The gate is scoped per code location** via
-`guard_dep_selection=AssetSelection.key_prefixes(code_location)` —
-cross-code-location deps (kipptaf reading kippmiami via dbt `source()`) bypass
-the gate. When debugging "downstream table not auto-materializing despite
-code_version_changed," check whether a same-CL parent has stuck SINCE memory;
-cross-CL parents are excluded by design.
+**No dep-code-version gate**: `_build_dbt_condition()` does NOT block
+materialization when a direct dep has
+`code_version_changed().since(newly_updated())`. A previous gate did, but the
+operator is cursor-based — its SINCE memory could capture phantom "true" state
+from any past tick (sensor restart, condition change, manifest re-parse) and
+never reset on a FRESH dep (no `newly_updated` event to clear it), producing
+permanent deadlocks. The in-CL race the gate nominally prevented is already
+covered by dbt's intra-build DAG ordering plus `any_deps_missing` /
+`any_deps_in_progress`; cross-CL races fail at BigQuery query time (recoverable,
+not silent corruption). If a downstream table looks "stuck," the cause is
+elsewhere — start with `any_deps_missing` / `any_deps_in_progress` evaluator
+nodes.
 
 **Dep fan-out rule**: An unpartitioned dep of a partitioned asset fans out to
 ALL partitions on every materialization. To preserve per-partition triggering,

--- a/src/teamster/core/CLAUDE.md
+++ b/src/teamster/core/CLAUDE.md
@@ -109,15 +109,16 @@ deploy rollover, the materialization may be stamped with the new deployment's
 code version. `code_version_changed()` returns false permanently — manual
 materialization is the only fix. See dagster-io/dagster#33708.
 
-**Deploy ordering gate**: `_dep_code_version_pending` blocks materialization
-when a direct dependency has `code_version_changed().since(newly_updated())` —
-prevents schema errors when a deploy adds columns through a TABLE → VIEW chain.
-Applied in `_build_dbt_condition()` to tables and union_relations views via the
-default `guard_dep_code_version=True`. Plain views opt out
-(`dbt_view_automation_condition` passes `False`): a view never bakes parent
-columns into stored state, so a pending parent code change can't poison it, and
-the guard would only strand the view's own `code_version_changed` refresh behind
-unrelated upstream churn.
+**Deploy ordering gate**: `_dep_code_version_pending` in
+`_build_dbt_condition()` blocks materialization when a direct dependency has
+`code_version_changed().since(newly_updated())`. Applied to tables and
+union_relations views via `guard_dep_code_version=True`; plain views opt out
+(`guard_dep_code_version=False`). **The gate is scoped per code location** via
+`guard_dep_selection=AssetSelection.key_prefixes(code_location)` —
+cross-code-location deps (kipptaf reading kippmiami via dbt `source()`) bypass
+the gate. When debugging "downstream table not auto-materializing despite
+code_version_changed," check whether a same-CL parent has stuck SINCE memory;
+cross-CL parents are excluded by design.
 
 **Dep fan-out rule**: An unpartitioned dep of a partitioned asset fans out to
 ALL partitions on every materialization. To preserve per-partition triggering,

--- a/src/teamster/core/automation_conditions.py
+++ b/src/teamster/core/automation_conditions.py
@@ -51,6 +51,7 @@ DepsAutomationCondition._get_dep_keys = _patched_get_dep_keys
 def _build_dbt_condition(
     *extra_triggers: AutomationCondition,
     guard_dep_code_version: bool = True,
+    guard_dep_selection: AssetSelection | None = None,
 ) -> AutomationCondition:
     """Build a dbt automation condition with the shared structure.
 
@@ -67,9 +68,12 @@ def _build_dbt_condition(
     - any_deps_match(code_version_changed) gate (when guard_dep_code_version
       is True) to block materialization when a direct dependency has an
       unapplied code change (prevents schema errors when a deploy adds
-      columns through a dependency chain). Plain views set this False because
-      they recompile on read — a pending parent code change can't poison a
-      view's stored state.
+      columns through a dependency chain). When guard_dep_selection is set,
+      the gate only considers deps matching that selection — used to scope
+      to same-code-location deps and avoid cross-CL deadlock when upstream
+      sensors don't reach the dep. Plain views set this False because they
+      recompile on read — a pending parent code change can't poison a view's
+      stored state.
     """
     triggers: AutomationCondition = AutomationCondition.newly_missing()
     for trigger in extra_triggers:
@@ -89,11 +93,14 @@ def _build_dbt_condition(
     )
 
     if guard_dep_code_version:
-        condition = condition & ~AutomationCondition.any_deps_match(
+        gate = AutomationCondition.any_deps_match(
             AutomationCondition.code_version_changed().since(
                 AutomationCondition.newly_updated()
             )
         )
+        if guard_dep_selection is not None:
+            gate = gate.allow(guard_dep_selection)
+        condition = condition & ~gate
 
     return condition
 
@@ -174,7 +181,13 @@ def dbt_view_automation_condition() -> AutomationCondition:
     return _build_dbt_condition(guard_dep_code_version=False)
 
 
-def dbt_union_relations_automation_condition() -> AutomationCondition:
+def _same_code_location_selection(code_location: str | None) -> AssetSelection | None:
+    return AssetSelection.key_prefixes(code_location) if code_location else None
+
+
+def dbt_union_relations_automation_condition(
+    code_location: str | None = None,
+) -> AutomationCondition:
     """Automation condition for dbt views using the union_relations macro.
 
     These views have compiled SQL that resolves column lists at run time.
@@ -188,11 +201,20 @@ def dbt_union_relations_automation_condition() -> AutomationCondition:
 
     Does NOT trigger on upstream data changes (any_deps_updated) to avoid
     unnecessary Dagster credit and Kubernetes resource costs.
+
+    When code_location is set, the dep-code-version gate only considers deps
+    in the same code location — cross-CL deps with stale stored code don't
+    deadlock this asset.
     """
-    return _build_dbt_condition(_build_any_ancestor_code_version_changed())
+    return _build_dbt_condition(
+        _build_any_ancestor_code_version_changed(),
+        guard_dep_selection=_same_code_location_selection(code_location),
+    )
 
 
-def dbt_table_automation_condition() -> AutomationCondition:
+def dbt_table_automation_condition(
+    code_location: str | None = None,
+) -> AutomationCondition:
     """Automation condition for dbt TABLE models.
 
     Tables store physical data and must re-materialize when upstream changes.
@@ -203,7 +225,12 @@ def dbt_table_automation_condition() -> AutomationCondition:
 
     Triggers: newly_missing, any_deps_updated (direct + through views),
     code_version_changed.
+
+    When code_location is set, the dep-code-version gate only considers deps
+    in the same code location — cross-CL deps with stale stored code don't
+    deadlock this asset.
     """
     return _build_dbt_condition(
-        _build_any_ancestor_updated(view_selection=_VIEW_SELECTION)
+        _build_any_ancestor_updated(view_selection=_VIEW_SELECTION),
+        guard_dep_selection=_same_code_location_selection(code_location),
     )

--- a/src/teamster/core/automation_conditions.py
+++ b/src/teamster/core/automation_conditions.py
@@ -50,8 +50,6 @@ DepsAutomationCondition._get_dep_keys = _patched_get_dep_keys
 
 def _build_dbt_condition(
     *extra_triggers: AutomationCondition,
-    guard_dep_code_version: bool = True,
-    guard_dep_selection: AssetSelection | None = None,
 ) -> AutomationCondition:
     """Build a dbt automation condition with the shared structure.
 
@@ -65,21 +63,24 @@ def _build_dbt_condition(
     - any_deps_missing ignoring external source assets
     - initial_evaluation omitted from .since() reset to avoid suppressing
       newly_missing permanently
-    - any_deps_match(code_version_changed) gate (when guard_dep_code_version
-      is True) to block materialization when a direct dependency has an
-      unapplied code change (prevents schema errors when a deploy adds
-      columns through a dependency chain). When guard_dep_selection is set,
-      the gate only considers deps matching that selection — used to scope
-      to same-code-location deps and avoid cross-CL deadlock when upstream
-      sensors don't reach the dep. Plain views set this False because they
-      recompile on read — a pending parent code change can't poison a view's
-      stored state.
+
+    There is no dep-code-version gate. A previous version of this builder
+    blocked materialization when a direct dep had
+    ``code_version_changed().since(newly_updated())``; that operator is
+    cursor-based (compares to the evaluator's prior tick, not the dep's
+    stored materialization), so the SINCE memory could capture phantom
+    "true" state from any past tick — sensor restart, condition tree
+    change, manifest re-parse — and never reset when the dep was already
+    in sync (no ``newly_updated`` event to clear it). The gate produced
+    permanent deadlocks on FRESH deps while the in-CL race it nominally
+    prevented was already covered by dbt's intra-build DAG ordering plus
+    ``any_deps_missing`` / ``any_deps_in_progress``.
     """
     triggers: AutomationCondition = AutomationCondition.newly_missing()
     for trigger in extra_triggers:
         triggers = triggers | trigger
 
-    condition = (
+    return (
         AutomationCondition.in_latest_time_window()
         & (
             triggers.since(_SINCE_LAST_HANDLED)
@@ -91,18 +92,6 @@ def _build_dbt_condition(
         & ~AutomationCondition.any_deps_in_progress()
         & ~AutomationCondition.in_progress()
     )
-
-    if guard_dep_code_version:
-        gate = AutomationCondition.any_deps_match(
-            AutomationCondition.code_version_changed().since(
-                AutomationCondition.newly_updated()
-            )
-        )
-        if guard_dep_selection is not None:
-            gate = gate.allow(guard_dep_selection)
-        condition = condition & ~gate
-
-    return condition
 
 
 def _build_any_ancestor_updated(
@@ -170,24 +159,12 @@ def dbt_view_automation_condition() -> AutomationCondition:
     Views are computed on read and don't store physical data. Only re-runs
     when the view's own definition changes — NOT on upstream data changes.
 
-    Skips the `any_deps_match(code_version_changed)` guard that tables and
-    union_relations views inherit: a plain view never bakes parent columns
-    into stored state, so a pending parent code change can't poison it. The
-    guard would otherwise strand the view's own code-version refresh behind
-    unrelated upstream churn.
-
     Triggers: newly_missing, code_version_changed.
     """
-    return _build_dbt_condition(guard_dep_code_version=False)
+    return _build_dbt_condition()
 
 
-def _same_code_location_selection(code_location: str | None) -> AssetSelection | None:
-    return AssetSelection.key_prefixes(code_location) if code_location else None
-
-
-def dbt_union_relations_automation_condition(
-    code_location: str | None = None,
-) -> AutomationCondition:
+def dbt_union_relations_automation_condition() -> AutomationCondition:
     """Automation condition for dbt views using the union_relations macro.
 
     These views have compiled SQL that resolves column lists at run time.
@@ -201,20 +178,11 @@ def dbt_union_relations_automation_condition(
 
     Does NOT trigger on upstream data changes (any_deps_updated) to avoid
     unnecessary Dagster credit and Kubernetes resource costs.
-
-    When code_location is set, the dep-code-version gate only considers deps
-    in the same code location — cross-CL deps with stale stored code don't
-    deadlock this asset.
     """
-    return _build_dbt_condition(
-        _build_any_ancestor_code_version_changed(),
-        guard_dep_selection=_same_code_location_selection(code_location),
-    )
+    return _build_dbt_condition(_build_any_ancestor_code_version_changed())
 
 
-def dbt_table_automation_condition(
-    code_location: str | None = None,
-) -> AutomationCondition:
+def dbt_table_automation_condition() -> AutomationCondition:
     """Automation condition for dbt TABLE models.
 
     Tables store physical data and must re-materialize when upstream changes.
@@ -225,12 +193,7 @@ def dbt_table_automation_condition(
 
     Triggers: newly_missing, any_deps_updated (direct + through views),
     code_version_changed.
-
-    When code_location is set, the dep-code-version gate only considers deps
-    in the same code location — cross-CL deps with stale stored code don't
-    deadlock this asset.
     """
     return _build_dbt_condition(
-        _build_any_ancestor_updated(view_selection=_VIEW_SELECTION),
-        guard_dep_selection=_same_code_location_selection(code_location),
+        _build_any_ancestor_updated(view_selection=_VIEW_SELECTION)
     )

--- a/src/teamster/libraries/dbt/dagster_dbt_translator.py
+++ b/src/teamster/libraries/dbt/dagster_dbt_translator.py
@@ -47,12 +47,14 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         if materialized == "view" and "union_relations" in dbt_resource_props.get(
             "raw_code", ""
         ):
-            return dbt_union_relations_automation_condition()
+            return dbt_union_relations_automation_condition(
+                code_location=self.code_location
+            )
 
         if materialized in ["view", "ephemeral"]:
             return dbt_view_automation_condition()
         else:
-            return dbt_table_automation_condition()
+            return dbt_table_automation_condition(code_location=self.code_location)
 
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> str | None:
         group = super().get_group_name(dbt_resource_props)

--- a/src/teamster/libraries/dbt/dagster_dbt_translator.py
+++ b/src/teamster/libraries/dbt/dagster_dbt_translator.py
@@ -47,14 +47,12 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         if materialized == "view" and "union_relations" in dbt_resource_props.get(
             "raw_code", ""
         ):
-            return dbt_union_relations_automation_condition(
-                code_location=self.code_location
-            )
+            return dbt_union_relations_automation_condition()
 
         if materialized in ["view", "ephemeral"]:
             return dbt_view_automation_condition()
         else:
-            return dbt_table_automation_condition(code_location=self.code_location)
+            return dbt_table_automation_condition()
 
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> str | None:
         group = super().get_group_name(dbt_resource_props)

--- a/tests/test_automation_conditions.py
+++ b/tests/test_automation_conditions.py
@@ -845,6 +845,100 @@ def test_view_not_blocked_by_parent_pending_code_version():
     assert result.get_num_requested(AssetKey("my_view")) == 1
 
 
+def test_table_gate_scoped_to_same_code_location():
+    """When code_location is passed, the dep-code-version gate only considers
+    deps under that code-location key prefix. Cross-CL deps with unapplied
+    code changes don't block — they're typically materialized by a different
+    sensor and would deadlock the downstream otherwise.
+    """
+
+    @asset(key=["other_cl", "upstream"], tags=_TABLE_TAG, code_version="1")
+    def cross_cl_upstream_v1():
+        return 1
+
+    @asset(
+        key=["my_cl", "downstream"],
+        deps=[cross_cl_upstream_v1],
+        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        code_version="1",
+        tags=_TABLE_TAG,
+    )
+    def downstream_v1():
+        return 2
+
+    instance = DagsterInstance.ephemeral()
+    defs1 = Definitions(assets=[cross_cl_upstream_v1, downstream_v1])
+    materialize(assets=[cross_cl_upstream_v1, downstream_v1], instance=instance)
+    result = evaluate_automation_conditions(defs=defs1, instance=instance)
+    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
+
+    @asset(key=["other_cl", "upstream"], tags=_TABLE_TAG, code_version="2")
+    def cross_cl_upstream_v2():
+        return 1
+
+    @asset(
+        key=["my_cl", "downstream"],
+        deps=[cross_cl_upstream_v2],
+        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        code_version="2",
+        tags=_TABLE_TAG,
+    )
+    def downstream_v2():
+        return 2
+
+    defs2 = Definitions(assets=[cross_cl_upstream_v2, downstream_v2])
+    result = evaluate_automation_conditions(
+        defs=defs2, instance=instance, cursor=result.cursor
+    )
+    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 1
+
+
+def test_table_gate_still_blocks_same_code_location_deps():
+    """Same-CL deps with unapplied code changes still gate downstream
+    materialization — scoping only excludes cross-CL deps.
+    """
+
+    @asset(key=["my_cl", "upstream"], tags=_TABLE_TAG, code_version="1")
+    def same_cl_upstream_v1():
+        return 1
+
+    @asset(
+        key=["my_cl", "downstream"],
+        deps=[same_cl_upstream_v1],
+        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        code_version="1",
+        tags=_TABLE_TAG,
+    )
+    def downstream_v1():
+        return 2
+
+    instance = DagsterInstance.ephemeral()
+    defs1 = Definitions(assets=[same_cl_upstream_v1, downstream_v1])
+    materialize(assets=[same_cl_upstream_v1, downstream_v1], instance=instance)
+    result = evaluate_automation_conditions(defs=defs1, instance=instance)
+    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
+
+    @asset(key=["my_cl", "upstream"], tags=_TABLE_TAG, code_version="2")
+    def same_cl_upstream_v2():
+        return 1
+
+    @asset(
+        key=["my_cl", "downstream"],
+        deps=[same_cl_upstream_v2],
+        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        code_version="2",
+        tags=_TABLE_TAG,
+    )
+    def downstream_v2():
+        return 2
+
+    defs2 = Definitions(assets=[same_cl_upstream_v2, downstream_v2])
+    result = evaluate_automation_conditions(
+        defs=defs2, instance=instance, cursor=result.cursor
+    )
+    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
+
+
 class TestKipptafDbtAssets:
     """Integration tests using the real kipptaf dbt manifest.
 

--- a/tests/test_automation_conditions.py
+++ b/tests/test_automation_conditions.py
@@ -793,13 +793,8 @@ def test_view_code_version_change_blocked_by_missing_deps_then_unblocked():
 
 
 def test_view_not_blocked_by_parent_pending_code_version():
-    """Plain views must recompile on their own code_version change even when
-    a direct parent has a pending (newly_updated-since) code-version change.
-
-    Tables and union_relations views inherit the guard because they can bake
-    stale parent schema into their stored output; plain views resolve columns
-    at read time, so the guard would only strand legitimate view refreshes
-    behind unrelated upstream churn.
+    """A view must recompile on its own code_version change even when a
+    direct parent has a pending code-version change.
     """
 
     @asset(key="upstream_table", tags=_TABLE_TAG, code_version="1")
@@ -822,8 +817,6 @@ def test_view_not_blocked_by_parent_pending_code_version():
     result = evaluate_automation_conditions(defs=defs_v1, instance=instance)
     assert result.get_num_requested(AssetKey("my_view")) == 0
 
-    # Parent gets a new code version, but isn't re-materialized. View's own
-    # code version also changes — the guard would otherwise block.
     @asset(key="upstream_table", tags=_TABLE_TAG, code_version="2")
     def upstream_table_v2():
         return 1
@@ -845,98 +838,54 @@ def test_view_not_blocked_by_parent_pending_code_version():
     assert result.get_num_requested(AssetKey("my_view")) == 1
 
 
-def test_table_gate_scoped_to_same_code_location():
-    """When code_location is passed, the dep-code-version gate only considers
-    deps under that code-location key prefix. Cross-CL deps with unapplied
-    code changes don't block — they're typically materialized by a different
-    sensor and would deadlock the downstream otherwise.
+def test_table_not_blocked_by_parent_pending_code_version():
+    """A table must re-materialize on its own code_version change even when
+    a direct parent has a pending code-version change. The previous
+    dep-code-version gate captured phantom SINCE memory and produced
+    permanent deadlocks on FRESH deps; intra-build dbt DAG ordering plus
+    ``any_deps_in_progress`` / ``any_deps_missing`` already cover the
+    in-CL race.
     """
 
-    @asset(key=["other_cl", "upstream"], tags=_TABLE_TAG, code_version="1")
-    def cross_cl_upstream_v1():
+    @asset(key="upstream_table", tags=_TABLE_TAG, code_version="1")
+    def upstream_table_v1():
         return 1
 
     @asset(
-        key=["my_cl", "downstream"],
-        deps=[cross_cl_upstream_v1],
-        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        key="my_table",
+        deps=[upstream_table_v1],
+        automation_condition=_get_table_condition(),
         code_version="1",
         tags=_TABLE_TAG,
     )
-    def downstream_v1():
+    def my_table_v1():
         return 2
 
     instance = DagsterInstance.ephemeral()
-    defs1 = Definitions(assets=[cross_cl_upstream_v1, downstream_v1])
-    materialize(assets=[cross_cl_upstream_v1, downstream_v1], instance=instance)
-    result = evaluate_automation_conditions(defs=defs1, instance=instance)
-    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
+    defs_v1 = Definitions(assets=[upstream_table_v1, my_table_v1])
+    materialize(assets=[upstream_table_v1, my_table_v1], instance=instance)
+    result = evaluate_automation_conditions(defs=defs_v1, instance=instance)
+    assert result.get_num_requested(AssetKey("my_table")) == 0
 
-    @asset(key=["other_cl", "upstream"], tags=_TABLE_TAG, code_version="2")
-    def cross_cl_upstream_v2():
+    @asset(key="upstream_table", tags=_TABLE_TAG, code_version="2")
+    def upstream_table_v2():
         return 1
 
     @asset(
-        key=["my_cl", "downstream"],
-        deps=[cross_cl_upstream_v2],
-        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
+        key="my_table",
+        deps=[upstream_table_v2],
+        automation_condition=_get_table_condition(),
         code_version="2",
         tags=_TABLE_TAG,
     )
-    def downstream_v2():
+    def my_table_v2():
         return 2
 
-    defs2 = Definitions(assets=[cross_cl_upstream_v2, downstream_v2])
+    defs_v2 = Definitions(assets=[upstream_table_v2, my_table_v2])
     result = evaluate_automation_conditions(
-        defs=defs2, instance=instance, cursor=result.cursor
+        defs=defs_v2, instance=instance, cursor=result.cursor
     )
-    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 1
-
-
-def test_table_gate_still_blocks_same_code_location_deps():
-    """Same-CL deps with unapplied code changes still gate downstream
-    materialization — scoping only excludes cross-CL deps.
-    """
-
-    @asset(key=["my_cl", "upstream"], tags=_TABLE_TAG, code_version="1")
-    def same_cl_upstream_v1():
-        return 1
-
-    @asset(
-        key=["my_cl", "downstream"],
-        deps=[same_cl_upstream_v1],
-        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
-        code_version="1",
-        tags=_TABLE_TAG,
-    )
-    def downstream_v1():
-        return 2
-
-    instance = DagsterInstance.ephemeral()
-    defs1 = Definitions(assets=[same_cl_upstream_v1, downstream_v1])
-    materialize(assets=[same_cl_upstream_v1, downstream_v1], instance=instance)
-    result = evaluate_automation_conditions(defs=defs1, instance=instance)
-    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
-
-    @asset(key=["my_cl", "upstream"], tags=_TABLE_TAG, code_version="2")
-    def same_cl_upstream_v2():
-        return 1
-
-    @asset(
-        key=["my_cl", "downstream"],
-        deps=[same_cl_upstream_v2],
-        automation_condition=dbt_table_automation_condition(code_location="my_cl"),
-        code_version="2",
-        tags=_TABLE_TAG,
-    )
-    def downstream_v2():
-        return 2
-
-    defs2 = Definitions(assets=[same_cl_upstream_v2, downstream_v2])
-    result = evaluate_automation_conditions(
-        defs=defs2, instance=instance, cursor=result.cursor
-    )
-    assert result.get_num_requested(AssetKey(["my_cl", "downstream"])) == 0
+    assert result.get_num_requested(AssetKey("my_table")) == 1
 
 
 class TestKipptafDbtAssets:


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR removes the `_dep_code_version_pending` gate from `_build_dbt_condition` entirely (tables, union_relations views, and the now-unused parameter). The translator no longer plumbs `code_location` through to condition factories.

### Background

Discovered while diagnosing a 305-run kipptaf__dbt_assets failure cascade on 2026-05-21/22. PR #3820 added a `_dbt_source_project` column to `kipptaf/powerschool/stg_powerschool__courses` and to `dim_courses`'s hash inputs. Every downstream `dim_courses` view re-creation failed with `Name _dbt_source_project not found inside c` because the kipptaf-level staging table was never rematerialized to pick up the new column. The Dagster automation condition evaluator showed the gate firing on `kippmiami/powerschool/stg_powerschool__courses ((code_version_changed) SINCE (newly_updated)) = [1/1]`.

### What we learned

Confirmed via `mcp__dagster__get_asset_staleness`: all four regional `stg_powerschool__courses` assets (kippmiami, kippnewark, kippcamden, kipppaterson) are **FRESH** — current code_version matches stored mat code_version. There is no actual divergence anywhere in kipptaf's parents.

Yet `code_version_changed().since(newly_updated())` evaluates `[1/1]` for kippmiami's row in kipptaf's gate evaluator. The reason: `code_version_changed()` is a **cursor-based transition detector** (compares to the evaluator's prior tick, not the dep's stored materialization tag). The SINCE memory wraps that into "transition observed at some point since dep's last mat" — but the cursor can be perturbed by sensor restarts, condition tree changes, or manifest re-parses, capturing phantom "true" state that never resets on a FRESH dep (no `newly_updated` event will fire to clear it).

### Why drop the gate instead of scoping it

An earlier version of this PR (now superseded) scoped the gate to same-code-location deps via `AssetSelection.key_prefixes(code_location)`. That worked for today's incident but post-hoc rationalized the mechanism — phantom SINCE can also strike same-CL parents, just less often.

The race the gate nominally prevents:

- **Within a code location**: a deploy adds a column to a parent and a downstream that references it. Both have `code_version_changed=TRUE` in the same auto-mat tick, both are requested into the same `<code_location>__dbt_assets` run, and dbt's intra-build DAG ordering materializes parent first. No race. (Also: `~any_deps_missing()` and `~any_deps_in_progress()` already cover the parent-not-ready cases.)
- **Cross code location**: parent and downstream are in different dbt builds — a race is possible. The failure mode is the downstream task fails with a BigQuery schema error and is retried (manual or auto-retry). Not data corruption, not silent wrongness. The escape valve (manual `launch_run`) already exists.

Net assessment: the gate's belt-and-suspenders within-CL protection is moot, and its cross-CL protection trades a recoverable retry-once race for permanent false-positive deadlocks. The cure is worse than the disease.

### Root-cause fix not in scope

A true root-cause fix exists: a custom `BuiltinAutomationCondition` that compares current code_version against the dep's stored mat code_version directly (no cursor, no SINCE memory). The owner of this branch chose not to build that custom operand — drop the gate and rely on dbt's intra-build DAG ordering instead.

### Diff

- `_build_dbt_condition` loses `guard_dep_code_version` and `guard_dep_selection` parameters; the entire `if guard_dep_code_version:` block is removed.
- `dbt_view_automation_condition`, `dbt_union_relations_automation_condition`, and `dbt_table_automation_condition` simplified to call `_build_dbt_condition(...)` with their trigger trees only.
- Translator passes no extra args.
- New `test_table_not_blocked_by_parent_pending_code_version` mirrors the existing view test for tables.
- The two interim "scoped gate" tests are removed.
- CLAUDE.md in `src/teamster/core/` rewritten to document the gate's absence and what to investigate when a downstream looks stuck.

Closes #4003

## AI Assistance

Claude Code (Opus 4.7, 1M ctx) drove the systematic-debugging investigation across multiple iterations: enumerating gate semantics, reading Dagster's `CodeVersionChangedCondition.evaluate()` source to disprove a "drop SINCE only" fix that would have lost race protection between transition ticks, then designing the same-CL-scoped gate, then disproving that framing using `get_asset_staleness` data showing parents are FRESH, and finally landing on the gate-removal change. The conditional logic and tests were AI-authored; each fix attempt and disproof was discussed with the human reviewer before committing.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [x] `tests/test_automation_conditions.py` — `test_table_not_blocked_by_parent_pending_code_version` covers the new behavior; existing `test_view_not_blocked_by_parent_pending_code_version` continues to pass.
- [x] All in-scope pytest tests pass locally (20 passed, 16 deselected for pre-existing failures or environment-variable-dependent integration tests unrelated to this change).
- [ ] Run `uv run dagster definitions validate` — requires secrets unavailable to the Claude session; reviewer to confirm.
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` — same as above.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — N/A (no dbt changes).
- [ ] **Dagster Cloud** — passes.
