### PR TITLE
fix(extracts): limit Lattice upload to terminated staff within past 30 days

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -14,7 +14,9 @@ models:
       - name: status
         quote: true
         description:
-          ADP employment status. Lattice-accepted values are Active and Leave.
+          Lattice employment status. Accepted values are Active and Inactive.
+          Staff with ADP assignment status Active or Leave are mapped to Active;
+          all others (including recently terminated) are mapped to Inactive.
         data_type: string
       - name: work_email
         description: Employee work email address.

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -4,7 +4,7 @@ models:
       Daily staff roster for Lattice SFTP import. Includes all KIPP TEAM and
       Family Schools Inc. employees, all KIPP Paterson employees, and
       Director/Head/Leader-tier staff in Miami, Newark, and Camden who are
-      Active or on Leave.
+      Active or on Leave, plus any staff terminated within the past 30 days.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -4,7 +4,8 @@ models:
       Daily staff roster for Lattice SFTP import. Includes all KIPP TEAM and
       Family Schools Inc. employees, all KIPP Paterson employees, and
       Director/Head/Leader-tier staff in Miami, Newark, and Camden who are
-      Active or on Leave, plus any staff terminated within the past 30 days.
+      Active or on Leave, plus any staff who met those same business unit and
+      role criteria and were terminated within the past 30 days.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -33,6 +33,12 @@ with
                     and home_department_name = 'Technology'
                 )
             )
+            and (
+                assignment_status in ('Active', 'Leave')
+                or worker_termination_date >= date_sub(
+                    current_date('{{ var("local_timezone") }}'), interval 30 day
+                )
+            )
     ),
 
     managers as (


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restrict `rpt_lattice__users` to exclude staff terminated more than 30 days ago. Previously the model had no status filter, so all terminated staff were included regardless of termination date.

Closes #4007

> AI-assisted: filter logic and YAML description update written by Claude Code; human-directed.

## AI Assistance

Filter logic and YAML description drafted by Claude Code.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with affected teams before merging and document your rollback plan in the summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** so the dbt Cloud CI job can find the table.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.