### PR TITLE
feat(cube,dbt): drop is_ell from dim_students

### DIFF
--- a/src/cube/model/cubes/students/students.yml
+++ b/src/cube/model/cubes/students/students.yml
@@ -99,13 +99,3 @@ cubes:
         sql: is_gifted
         type: boolean
         public: true
-
-      - name: is_ell
-        description: >-
-          TRUE if the student is currently classified as an English Language
-          Learner per the PowerSchool student core fields. Reflects current
-          status only — does not reflect historical enrollment-date-window LEP
-          status.
-        sql: is_ell
-        type: boolean
-        public: true

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
@@ -28,8 +28,6 @@ select
 
     coalesce(njs.gifted_and_talented, suf.gifted_and_talented, 'N') != 'N' as is_gifted,
 
-    scf.lep_status as is_ell,
-
     case
         when s.ethnicity = 'B'
         then 'Black/African American'
@@ -80,7 +78,3 @@ left join
     {{ ref("stg_powerschool__s_nj_stu_x") }} as njs
     on s.dcid = njs.studentsdcid
     and {{ union_dataset_join_clause(left_alias="s", right_alias="njs") }}
-left join
-    {{ ref("stg_powerschool__studentcorefields") }} as scf
-    on s.dcid = scf.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="scf") }}

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -123,19 +123,6 @@ models:
               stg_powerschool__s_nj_stu_x, stg_powerschool__u_studentsuserfields
             source_column: gifted_and_talented
 
-      - name: is_ell
-        data_type: boolean
-        description: >-
-          TRUE if the student is currently classified as an English Language
-          Learner per the PowerSchool student core fields. Reflects current
-          status only — does not reflect historical enrollment-date-window LEP
-          status.
-        config:
-          meta:
-            source_system: PowerSchool
-            source_model: stg_powerschool__studentcorefields
-            source_column: lep_status
-
       - name: race
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__studentcorefields.yml
@@ -3,10 +3,10 @@ models:
     description: >-
       Cross-region union of the PowerSchool student core-fields extension table.
       One row per student per region. Carries the per-student `lep_status` and
-      `spedlep` flags consumed by `dim_students.is_ell`,
-      `dim_student_ell_status` (Miami leg), and `dim_student_iep_status`
-      (Paterson + Miami leg). Functionally an intermediate — uniqueness and
-      contract enforcement live on the per-region staging models.
+      `spedlep` flags consumed by `dim_student_ell_status` (Miami leg) and
+      `dim_student_iep_status` (Paterson + Miami leg). Functionally an
+      intermediate — uniqueness and contract enforcement live on the per-region
+      staging models.
     columns:
       - name: studentsdcid
         data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Remove the redundant current-state `is_ell` from `dim_students` now that
`dim_student_ell_status` (added in #3960) is the canonical ELL source for Cube.

- `dim_students.sql` — drop `scf.lep_status as is_ell` and the
  `stg_powerschool__studentcorefields` LEFT JOIN.
- `properties/dim_students.yml` — drop the `is_ell` column entry.
- `src/cube/model/cubes/students/students.yml` — drop the `is_ell` dimension
  (dead code: no view exposed it; the cube is `public: false` and the
  attendance views already source `is_ell` from `dim_student_ell_status`).
- `stg_powerschool__studentcorefields.yml` — update description to drop the
  `dim_students.is_ell` consumer reference.

Closes #3989

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

AI-assisted: identifying that issue #3989's "Suggested approach" steps 1 & 2
were already implemented (the attendance views already use
`dim_student_ell_status`), narrowing the scope to the four remaining edits,
applying them, and running `dbt build --select dim_students+`. Human-directed:
the choice to drop `is_ell` entirely vs. retain as a current-state convenience.

## Self-review

### General

- [x] Update **due date** and **assignee** on the TEAMster Asana Project
- [x] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated alongside the model
- [x] No exposure changes needed — Cube exposure (`cube_semantic_layer`)
      already covers `dim_students`; column removal is reflected in the cube
      YAML edits in this PR
- [x] **Breaking change?** Removing a contracted column. No external
      consumers reference `dim_students.is_ell` — confirmed via grep across
      `src/cube/`, `src/dbt/`, and `src/teamster/`. Attendance views already
      source `is_ell` from `dim_student_ell_status`.
- [x] No external source changes

## CI checks

- [ ] **Trunk** — pre-commit ran clean
- [ ] **dbt Cloud** — pending
- [ ] **Dagster Cloud** — not triggered (no Dagster paths changed)

## Verification

- `uv run dbt build --select dim_students+` against the worktree:
  `dim_students` view created successfully; all three of its tests
  (`unique student_key`, `not_null student_key`,
  `not_null lea_student_identifier`) pass. The one ERROR and five WARNs in the
  run are pre-existing and unrelated (stale `int_powerschool__student_enrollment_union`
  defer table; relationships warnings on other dims/facts).
