### PR TITLE
fix(dbt): null-wrap student_key on practice branch of fct_assessment_scores_student_scoped

### DIFF
--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
@@ -83,7 +83,11 @@ select
         )
     }} as assessment_score_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ca.student_number"]) }} as student_key,
+    if(
+        ca.student_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["ca.student_number"]) }},
+        cast(null as string)
+    ) as student_key,
 
     {{
         dbt_utils.generate_surrogate_key(
@@ -127,7 +131,11 @@ select
         )
     }} as assessment_score_key,
 
-    {{ dbt_utils.generate_surrogate_key(["pa.student_number"]) }} as student_key,
+    if(
+        pa.student_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["pa.student_number"]) }},
+        cast(null as string)
+    ) as student_key,
 
     {{
         dbt_utils.generate_surrogate_key(
@@ -172,7 +180,11 @@ select
         )
     }} as assessment_score_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ap.student_number"]) }} as student_key,
+    if(
+        ap.student_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["ap.student_number"]) }},
+        cast(null as string)
+    ) as student_key,
 
     {{
         dbt_utils.generate_surrogate_key(

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -21,10 +21,10 @@ models:
       - name: student_key
         data_type: string
         description: >-
-          FK to dim_students. Derived from student_number. Null when the source
-          record has no PowerSchool student_number (e.g., SAT/ACT scores in
-          int_assessments__college_assessment that did not resolve to a
-          PowerSchool student).
+          FK to dim_students. Derived from student_number. Null in any branch
+          (college, practice, AP) when the source identifier did not resolve to
+          a PowerSchool student — typically a College Board / AP file row whose
+          external ID has no entry in the corresponding crosswalk.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -21,7 +21,10 @@ models:
       - name: student_key
         data_type: string
         description: >-
-          FK to dim_students. Derived from student_number.
+          FK to dim_students. Derived from student_number. Null when the source
+          record has no PowerSchool student_number (e.g., SAT/ACT scores in
+          int_assessments__college_assessment that did not resolve to a
+          PowerSchool student).
 
         constraints:
           - type: foreign_key


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Add the nullable-FK guard to the **practice (mock SAT/ACT)** branch of
`fct_assessment_scores_student_scoped.student_key`, completing the
consistency pattern across all three branches.

**Context after rebase on main:** PR #4014 (merged) already wrapped the
college and AP branches, eliminating the original 1,539-row `relationships`
warn on this fact's `student_key` FK. This PR's residual scope is the third
branch (practice), which #4014 missed. `int_assessments__college_assessment_practice`
shows 0 NULL `student_number` rows in prod today, so the wrap is defensive —
matches the pattern documented in `src/dbt/CLAUDE.md` → "Nullable surrogate
keys" and is consistent with how the college and AP siblings already handle
the case.

Verified locally (`dbt build --select fct_assessment_scores_student_scoped`,
`--target dev --defer --state .../target/prod`): PASS=6, WARN=0, ERROR=0.

## AI Assistance

AI-authored: diagnosis, SQL/YAML edits, merge-conflict resolution.
Human-directed: scope (fix Bug 1 only), worktree decision, PR open,
conflict-resolution call.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an exposure for all models consumed downstream
- [x] **Breaking change?** No — `student_key` for practice rows with NULL
      `student_number` previously emitted the deterministic null-placeholder
      hash and now emits NULL. 0 such rows in prod today, so no actual values
      change. No mart consumer joins through that placeholder.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with `--target staging` (n/a — no source change)

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3991
