### PR TITLE
fix(dbt): null-safe student_key in fct_assessment_scores_*

### DIFF
--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -231,7 +231,7 @@ select
     }} as assessment_administration_key,
 
     if(
-        su.student_number is not null,
+        ds.lea_student_identifier is not null,
         {{ dbt_utils.generate_surrogate_key(["su.student_number"]) }},
         cast(null as string)
     ) as student_key,
@@ -244,3 +244,5 @@ select
 
     su.is_proficient as is_mastery,
 from state_union as su
+left join
+    {{ ref("dim_students") }} as ds on su.student_number = ds.lea_student_identifier

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
@@ -176,7 +176,11 @@ select
         )
     }} as assessment_score_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ap.student_number"]) }} as student_key,
+    if(
+        ap.student_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["ap.student_number"]) }},
+        cast(null as string)
+    ) as student_key,
 
     {{
         dbt_utils.generate_surrogate_key(

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
@@ -83,7 +83,11 @@ select
         )
     }} as assessment_score_key,
 
-    {{ dbt_utils.generate_surrogate_key(["ca.student_number"]) }} as student_key,
+    if(
+        ca.student_number is not null,
+        {{ dbt_utils.generate_surrogate_key(["ca.student_number"]) }},
+        cast(null as string)
+    ) as student_key,
 
     {{
         dbt_utils.generate_surrogate_key(

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -41,9 +41,9 @@ models:
           FK to dim_students. Hashed on student_number (PowerSchool-sourced for
           internal Illuminate, NJ Pearson localstudentidentifier, and FL via
           FLEID lookup in int_fldoe__all_assessments). Null when the source
-          identifier does not resolve to a PowerSchool student (residual: ~12 FL
-          students missing FLEID in PS lookup, ~8 NJ Paterson Pearson identifier
-          mismatches — both tracked separately).
+          identifier does not resolve to a row in dim_students — for state
+          assessments, a left join validates that student_number exists in
+          dim_students before hashing.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -21,10 +21,11 @@ models:
       - name: student_key
         data_type: string
         description: >-
-          FK to dim_students. Derived from student_number. Null for college
-          branch rows whose CollegeBoard ID has no entry in the sat_id_crosswalk
-          Google Sheet (PSAT score arrives keyed by cb_id; unmatched rows carry
-          NULL student_number).
+          FK to dim_students. Derived from student_number. Null when the
+          CollegeBoard ID has no entry in the corresponding crosswalk Google
+          Sheet (PSAT scores arrive keyed by cb_id via sat_id_crosswalk; AP
+          scores arrive keyed by ap_number_ap_id via ap_id_crosswalk). Unmatched
+          rows carry NULL student_number.
 
         constraints:
           - type: foreign_key

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -21,7 +21,10 @@ models:
       - name: student_key
         data_type: string
         description: >-
-          FK to dim_students. Derived from student_number.
+          FK to dim_students. Derived from student_number. Null for college
+          branch rows whose CollegeBoard ID has no entry in the sat_id_crosswalk
+          Google Sheet (PSAT score arrives keyed by cb_id; unmatched rows carry
+          NULL student_number).
 
         constraints:
           - type: foreign_key


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will eliminate the two `relationships` test
> warnings on `fct_assessment_scores_*.student_key → dim_students.student_key`
> surfaced in #4002.

Two independent root causes (verified against current prod data, which diverged from the issue body's row counts):

1. **`fct_assessment_scores_student_scoped` — 1539 rows, 1 placeholder key.** The college branch was hashing `student_number` directly with `generate_surrogate_key`. Every PSAT score whose CollegeBoard ID has no entry in `stg_google_sheets__collegeboard__sat_id_crosswalk` arrives with `powerschool_student_number = NULL`, and `generate_surrogate_key` maps every NULL to the deterministic placeholder hash. Now wrapped in the standard nullable-FK `if(... is not null, ..., null)` pattern.

2. **`fct_assessment_scores_enrollment_scoped` — 8 rows, 3 distinct keys.** Three Paterson NJSLA-2024 takers exist in `int_pearson__all_assessments` but are absent from `stg_powerschool__students` across every district (no `dcid` / `enroll_status` filter involved). The state branch now left-joins `dim_students` and only emits a non-NULL `student_key` when `lea_student_identifier` resolves. Underlying Paterson SIS data discrepancy escalated separately as an Asana subtask under the issue's parent task.

Both relationships tests against `dim_students` return 0 rows in the PR-branch build.

## AI Assistance

Claude Code authored all changes under direct human direction (analysis, fix design, and Asana escalation chosen by the user).

## Self-review

### dbt

- [x] No new models / properties files needed (edits to existing files).
- [x] No exposure changes; semantics of the FK column unchanged.
- [x] Not a breaking change — column type and grain unchanged. Rows that previously surfaced as orphans now carry `student_key = NULL`.
- [x] No external source changes.

## CI checks

- [ ] **Trunk**
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud**

Refs #4002