### PR TITLE
chore(dbt): strip stale #3633 refs from kipptaf marts + CLAUDE.md

### DIFF
--- a/docs/superpowers/plans/2026-05-23-strip-stale-3633-refs.md
+++ b/docs/superpowers/plans/2026-05-23-strip-stale-3633-refs.md
@@ -1,0 +1,460 @@
+# Strip stale `#3633` references in dbt marts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove three stale `#3633` references from kipptaf dbt files (one
+no-op SQL workaround, one comment refresh, one CLAUDE.md parenthetical), closing
+#3901.
+
+**Architecture:** Three independent, small file edits on branch
+`cbini/chore/claude-strip-stale-3633-refs` (linked to #3901). Worktree at
+`.worktrees/cbini-chore-claude-strip-stale-3633-refs/`. Task 1 deletes a
+verified no-op `dbt_utils.deduplicate` CTE (BQ-verified 0 fan-out / 784,568 cc
+rows). Task 2 rewrites a SQL comment to drop `#3633` and point at #4020 (the new
+tracking issue for the load-bearing multi-stint dedup). Task 3 strips a
+`(#3633)` parenthetical from `src/dbt/kipptaf/CLAUDE.md`. No tests are added —
+the existing uniqueness test on `dim_student_section_enrollments` proves the
+Task 1 change is safe.
+
+**Tech Stack:** dbt 1.11+ / BigQuery / git worktree
+
+---
+
+## File Structure
+
+All edits land in the existing worktree. No new files created.
+
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql`
+  (Task 1)
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql`
+  (Task 2)
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/CLAUDE.md`
+  (Task 3)
+
+---
+
+## Task 1: Remove no-op `dbt_utils.deduplicate` from `dim_student_section_enrollments`
+
+**Files:**
+
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql:16-67`
+
+**Context:**
+
+`course_enrollments_joined` is referenced only as a string by
+`dbt_utils.deduplicate(relation="course_enrollments_joined")`. Once that call is
+removed, the `# trunk-ignore(sqlfluff/ST03)` directive on line 16 is no longer
+needed — `course_enrollments_joined` will be referenced directly by name in the
+final `from` clause. BQ verification (2026-05-23): 0 fan-out across 784,568 cc
+rows; the half-open interval join (`>= entrydate AND < exitdate`) already
+prevents the overlap.
+
+The `dbt_utils.deduplicate` macro and its surrounding TODO comment (lines 57-67)
+collapse to a single-line `from course_enrollments_joined` reference. The final
+`SELECT` (line 69 onwards) currently reads `from course_enrollments_deduped`;
+that becomes `from course_enrollments_joined`.
+
+- [ ] **Step 1: Read current file state**
+
+Run via the Read tool:
+`.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql`
+(lines 14-114).
+
+Expected current shape (lines 14-67):
+
+```sql
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
+    course_enrollments_joined as (
+        select
+            cc._dbt_source_relation,
+            cc._dbt_source_project,
+            cc.cc_dcid,
+            cc.sections_dcid,
+            cc.cc_academic_year,
+            cc.cc_dateenrolled,
+            cc.cc_dateleft,
+            cc.is_dropped_section,
+            cc.is_dropped_course,
+
+            enr._dbt_source_project as enr_source_project,
+            enr.student_number as enr_student_number,
+            enr.academic_year as enr_academic_year,
+            enr.entrydate as enr_entrydate,
+
+            rt.`type` as rt_type,
+            rt.code as rt_code,
+            rt.name as rt_name,
+            rt.start_date as rt_start_date,
+            rt.region as rt_region,
+            rt.school_id as rt_school_id,
+        from {{ ref("base_powerschool__course_enrollments") }} as cc
+        left join
+            student_enrollments as enr
+            on cc.cc_studentid = enr.studentid
+            and cc.sections_schoolid = enr.schoolid
+            and cc.cc_yearid = enr.yearid
+            and cc.cc_dateenrolled >= enr.entrydate
+            and cc.cc_dateenrolled < enr.exitdate
+            and cc._dbt_source_project = enr._dbt_source_project
+        left join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on cc.cc_abs_termid = rt.powerschool_term_id
+            and cc.sections_schoolid = rt.school_id
+            and cc.region = rt.region
+            and rt.`type` = 'RT'
+    ),
+
+    -- TODO: overlapping enrollment records at same school cause join
+    -- fan-out; deduplicate picks latest entrydate (#3633)
+    course_enrollments_deduped as (
+        {{
+            dbt_utils.deduplicate(
+                relation="course_enrollments_joined",
+                partition_by="cc_dcid, _dbt_source_project",
+                order_by="enr_entrydate desc",
+            )
+        }}
+    )
+
+select
+```
+
+- [ ] **Step 2: Remove the `trunk-ignore` directive on line 16**
+
+Use the Edit tool. The CTE will be referenced directly by name after this
+change, so the ST03 suppression is dead.
+
+`old_string`:
+
+```sql
+    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
+    course_enrollments_joined as (
+```
+
+`new_string`:
+
+```sql
+    course_enrollments_joined as (
+```
+
+- [ ] **Step 3: Remove the `course_enrollments_deduped` CTE and its TODO
+      comment**
+
+Use the Edit tool. Replace the closing `),` of `course_enrollments_joined` +
+blank line + TODO + CTE block with just a closing `)` (no trailing comma — it's
+now the last CTE) and a single blank line.
+
+`old_string`:
+
+```sql
+    ),
+
+    -- TODO: overlapping enrollment records at same school cause join
+    -- fan-out; deduplicate picks latest entrydate (#3633)
+    course_enrollments_deduped as (
+        {{
+            dbt_utils.deduplicate(
+                relation="course_enrollments_joined",
+                partition_by="cc_dcid, _dbt_source_project",
+                order_by="enr_entrydate desc",
+            )
+        }}
+    )
+
+select
+```
+
+`new_string`:
+
+```sql
+    )
+
+select
+```
+
+- [ ] **Step 4: Switch the final `from` reference**
+
+Use the Edit tool.
+
+`old_string`:
+
+```sql
+from course_enrollments_deduped
+```
+
+`new_string`:
+
+```sql
+from course_enrollments_joined
+```
+
+- [ ] **Step 5: Parse the project to confirm no syntax errors**
+
+Run:
+
+```bash
+uv --directory /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs run dbt parse --project-dir /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf
+```
+
+Expected: `Update freshness…` / `Found N models…` summary with no errors.
+
+- [ ] **Step 6: Build the model and run its uniqueness test against dev**
+
+Run:
+
+```bash
+uv --directory /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs run dbt build --select dim_student_section_enrollments --project-dir /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf --defer --state src/dbt/kipptaf/target/prod
+```
+
+Expected: 1 view created (`dim_student_section_enrollments`), uniqueness test on
+`student_section_enrollment_key` passes (`PASS`).
+
+If the prod manifest is stale ("Could not find manifest" or column-missing
+errors), regenerate first:
+
+```bash
+uv --directory /workspaces/teamster run dbt parse --target prod --project-dir src/dbt/kipptaf --target-path target/prod
+```
+
+…then re-run Step 6.
+
+- [ ] **Step 7: Compare row count against prod**
+
+Run via `mcp__bigquery__execute_sql`:
+
+```sql
+select
+  (select count(*) from `teamster-332318.kipptaf_dbt_dev_<user>.dim_student_section_enrollments`) as dev_n,
+  (select count(*) from `teamster-332318.kipptaf_analytics.dim_student_section_enrollments`) as prod_n
+```
+
+Replace `<user>` with the dev schema suffix (check
+`<repo-root>/.dbt/profiles.yml` if unsure). Expected: `dev_n == prod_n`. Any
+delta invalidates the no-op claim — stop and report.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs add -u
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs commit -m "refactor(dbt): drop no-op dedup from dim_student_section_enrollments
+
+The dbt_utils.deduplicate on (cc_dcid, _dbt_source_project) is a no-op:
+0 fan-out across 784,568 cc rows (verified prod 2026-05-23). The
+half-open interval join already prevents the overlap that the dedup
+was meant to absorb. Drop the CTE and the now-dead trunk-ignore
+suppression. Refs #3901."
+```
+
+---
+
+## Task 2: Refresh TODO comment in `rpt_gsheets__school_metrics_extract`
+
+**Files:**
+
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql:442-447`
+
+**Context:**
+
+The `select distinct` in `section_school_context` is load-bearing (50 collapsed
+rows / 9,335 raw, verified 2026-05-23) but the **cause** is multi-stint
+enrollments at the same school, not the date-range overlap that #3633 originally
+described. Drop `#3633`; point at the new tracking issue #4020.
+
+- [ ] **Step 1: Rewrite the TODO comment**
+
+Use the Edit tool.
+
+`old_string`:
+
+```sql
+    -- TODO: #3633 — SELECT DISTINCT needed because
+    -- base_powerschool__student_enrollments has genuinely overlapping date
+    -- ranges for some students, producing duplicate (studentid, schoolid) rows.
+    -- enroll_status filter intentionally omitted: a wider net is needed here so
+    -- that transferred students' section records still resolve to a school/region
+    -- even if their latest enrollment row has enroll_status != 0.
+```
+
+`new_string`:
+
+```sql
+    -- TODO: #4020 — int_extracts__student_enrollments carries one row per
+    -- enrollment stint, so a student with a transfer-out + transfer-back at
+    -- the same school produces duplicate (studentid, schoolid) rows. SELECT
+    -- DISTINCT collapses them for the downstream join. enroll_status filter
+    -- intentionally omitted: a wider net is needed so transferred students'
+    -- section records still resolve to a school/region even when their latest
+    -- enrollment row has enroll_status != 0.
+```
+
+- [ ] **Step 2: Parse the project**
+
+Run:
+
+```bash
+uv --directory /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs run dbt parse --project-dir /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf
+```
+
+Expected: no errors. (Comment-only change; parse exists to catch fence
+accidents.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs add -u
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs commit -m "docs(dbt): refresh stale #3633 TODO in rpt_gsheets__school_metrics_extract
+
+The select distinct is load-bearing (50 collapsed rows verified prod
+2026-05-23) but the cause is multi-stint enrollments at the same
+school, not the date-range overlap #3633 described. Point at #4020,
+which tracks migrating this consumer off select distinct. Refs #3901."
+```
+
+---
+
+## Task 3: Strip `(#3633)` parenthetical from `src/dbt/kipptaf/CLAUDE.md`
+
+**Files:**
+
+- Modify:
+  `.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt/kipptaf/CLAUDE.md:121`
+
+**Context:**
+
+The line currently reads
+`Canonical-grain consumers (1 row per logical school) should use stg_google_sheets__people__locations instead (#3633).`
+The surrounding paragraph already documents the canonical-grain guidance on its
+own merits. The `(#3633)` parenthetical points at a closed issue
+(`int_people__location_crosswalk` deduplication, completed 2026-04-22) and adds
+no behavioral signal.
+
+- [ ] **Step 1: Strip the `(#3633)` parenthetical**
+
+Use the Edit tool.
+
+`old_string`:
+
+```text
+Canonical-grain consumers (1 row per logical school) should use
+`stg_google_sheets__people__locations` instead (#3633).
+```
+
+`new_string`:
+
+```text
+Canonical-grain consumers (1 row per logical school) should use
+`stg_google_sheets__people__locations` instead.
+```
+
+- [ ] **Step 2: Confirm no other `#3633` refs remain in the worktree**
+
+Run:
+
+```bash
+grep -rnE '#3633\b' /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs/src/dbt
+```
+
+Expected: no output (exit 1).
+
+If grep returns any line, stop and report — it indicates a missed reference.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs add -u
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs commit -m "docs(claude-md): strip closed #3633 ref from kipptaf CLAUDE.md
+
+#3633 (int_people__location_crosswalk dedup) closed completed
+2026-04-22. The surrounding paragraph documents the canonical-grain
+guidance without the issue ref. Refs #3901."
+```
+
+---
+
+## Task 4: Push branch and open PR
+
+**Files:**
+
+- No file changes — this task only pushes and opens the PR via
+  `mcp__github__create_pull_request`.
+
+**Context:**
+
+PR body follows `.github/pull_request_template.md`. Closes #3901; refs #4020 for
+the spawned follow-up. Includes the BQ verification numbers from the spec so
+reviewers can confirm the no-op claim without re-running the queries.
+
+- [ ] **Step 1: Read the PR template**
+
+Read
+`.worktrees/cbini-chore-claude-strip-stale-3633-refs/.github/pull_request_template.md`
+via the Read tool.
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini-chore-claude-strip-stale-3633-refs push
+```
+
+Expected: trunk pre-push hook runs sqlfluff/yamllint/markdownlint; push
+succeeds.
+
+If pre-push reports any issue, stop, fix, re-stage, create a new commit (do not
+amend), and re-push.
+
+- [ ] **Step 3: Open the PR**
+
+Use `mcp__github__create_pull_request` with:
+
+- owner: `TEAMSchools`
+- repo: `teamster`
+- base: `main`
+- head: `cbini/chore/claude-strip-stale-3633-refs`
+- title: `chore(dbt): strip stale #3633 refs from kipptaf marts + CLAUDE.md`
+- body: (use the `.github/pull_request_template.md` shape, filling in)
+  - Summary & Motivation: three bullets, one per task. Cite the no-op
+    verification (0 fan-out / 784,568 cc rows) for Task 1 and the load-bearing
+    finding (50 collapsed rows / 9,335 raw) for Task 2.
+  - AI Assistance: spec authoring, plan writing, implementation AI-assisted
+    (Claude Code); BQ verification SQL human-directed.
+  - Row count impact: `dim_student_section_enrollments` unchanged vs. prod (the
+    dedup it removes is a no-op). `rpt_gsheets__school_metrics_extract`
+    comment-only diff. `src/dbt/kipptaf/CLAUDE.md` doc-only diff.
+  - Self-review boxes checked: no new models, no exposure changes, no breaking
+    changes, no external source changes, CLAUDE.md updated.
+  - Issue links: `Closes #3901`, `Refs #4020`.
+  - CI checks: Trunk passes (pre-push enforced), dbt Cloud expected green.
+
+- [ ] **Step 4: Confirm PR creation**
+
+Verify the returned PR URL and check that the body matches intent (no `env`
+leaks, issue refs render). Surface the PR URL to the user.
+
+---
+
+## Self-Review Checklist
+
+- **Spec coverage:**
+  - Change 1 (`dim_student_section_enrollments` no-op dedup removal) → Task 1.
+  - Change 2 (`rpt_gsheets__school_metrics_extract` comment refresh) → Task 2.
+  - Change 3 (`src/dbt/kipptaf/CLAUDE.md` `(#3633)` strip) → Task 3.
+  - PR/verification → Task 4 + Task 1 Step 5-7.
+
+- **Placeholder scan:** None. Every step has exact paths, exact commands, exact
+  strings to replace.
+
+- **Type consistency:** N/A — no new types introduced. CTE name change
+  (`course_enrollments_deduped` → `course_enrollments_joined`) flows
+  consistently from Task 1 Step 3 → Step 4.

--- a/docs/superpowers/specs/2026-05-23-strip-stale-3633-refs-design.md
+++ b/docs/superpowers/specs/2026-05-23-strip-stale-3633-refs-design.md
@@ -1,0 +1,92 @@
+# Strip stale `#3633` references in dbt marts + verify residual workarounds
+
+Date: 2026-05-23 Tracks:
+[#3901](https://github.com/TEAMSchools/teamster/issues/3901) Spawns:
+[#4020](https://github.com/TEAMSchools/teamster/issues/4020)
+
+## Context
+
+Issue #3901 listed seven files carrying stale `-- TODO: #3629 / #3633 / #3635`
+references to closed issues, asking for a doc-only ref refresh. Verification on
+2026-05-23 showed the issue body is materially stale:
+
+- All originally-listed survey-domain files (`fct_survey_submissions`,
+  `dim_survey_administrations`, `dim_surveys`, `dim_survey_questions`,
+  `bridge_survey_questions`) have zero remaining stale refs — fully refactored
+  when #3899 closed (2026-05-14).
+- All originally-listed attendance/grades facts (`fct_student_attendance_daily`,
+  `fct_student_attendance_streaks`, `fct_grades_assignments`) have zero
+  remaining stale refs — fixed via #3916 (closes #3900, 2026-05-14).
+- The originally-listed `src/dbt/CLAUDE.md` "Enrollment join fan-out" guidance
+  was relocated to `src/dbt/kipptaf/CLAUDE.md` "Known Upstream Issues" in #3916;
+  the relocated text at line 121 still carries `(#3633)`.
+
+Two consumers of the same upstream-overlap pattern that #3900 was meant to
+eliminate were **not** in #3900's acceptance scope and still carry the
+workaround comments referencing `#3633`:
+
+- `src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql:58`
+- `src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql:442`
+
+Empirical verification (prod, 2026-05-23) shows these two are not equivalent:
+
+- `dim_student_section_enrollments` dedup is a **no-op** — 0 fan-out / 784,568
+  cc rows. The half-open interval join (`>= entrydate AND < exitdate`) already
+  prevents the overlap.
+- `rpt_gsheets__school_metrics_extract` `SELECT DISTINCT` is **load-bearing** —
+  collapses 50 multi-stint same-school enrollments (Newark 26, Camden 10, Miami
+  8, Paterson 6) for AY 2025 / grade ≤ 8. Cause is multi-stint enrollments
+  (transfer out + back), not the date-range overlap pattern #3900 originally
+  described. Tracked separately in #4020.
+
+## Changes
+
+### 1. `src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql`
+
+Remove the no-op `course_enrollments_deduped` CTE and its TODO comment. Remove
+the `# trunk-ignore(sqlfluff/ST03)` directive on `course_enrollments_joined` (no
+longer needed once that CTE is referenced directly by name in the final SELECT).
+Final `from course_enrollments_deduped` becomes
+`from course_enrollments_joined`.
+
+Hash inputs unchanged. Row count unchanged (verified above).
+
+### 2. `src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql:442`
+
+Keep `select distinct` (project rule allows DISTINCT with a TODO). Rewrite the
+comment to drop `#3633` and accurately describe the multi-stint cause, pointing
+at #4020:
+
+```sql
+-- TODO: #4020 — int_extracts__student_enrollments carries one row per
+-- enrollment stint, so a student with a transfer-out + transfer-back at the
+-- same school produces duplicate (studentid, schoolid) rows. SELECT DISTINCT
+-- collapses them for the downstream join. enroll_status filter intentionally
+-- omitted: a wider net is needed so transferred students' section records
+-- still resolve to a school/region even when their latest enrollment row has
+-- enroll_status != 0.
+```
+
+### 3. `src/dbt/kipptaf/CLAUDE.md:121`
+
+Strip the trailing `(#3633)` parenthetical. The surrounding paragraph documents
+the canonical-grain guidance on its own merits.
+
+## Verification
+
+- `uv run dbt parse --project-dir <worktree>/src/dbt/kipptaf` — no errors.
+- `uv run dbt build --select dim_student_section_enrollments+1 --project-dir <worktree>/src/dbt/kipptaf`
+  against the PR-branch schema — row count matches prod, uniqueness test passes.
+- Trunk fmt/check fires via pre-commit and pre-push hooks.
+- dbt Cloud CI: PR-branch build of `dim_student_section_enrollments` should
+  match prod row-for-row (no-op dedup removal).
+  `rpt_gsheets__school_metrics_extract` diff is comment-only.
+
+## Out of scope
+
+- Migrating the `rpt_gsheets` `select distinct` to `dbt_utils.deduplicate`, or
+  building a per-(student, school) helper on `int_extracts__student_enrollments`
+  — tracked in #4020.
+- Reopening #3900. Its closure via #3916 was correct per its own acceptance
+  scope; the residual `rpt_gsheets` case is a different mechanism (multi-stint
+  enrollments, not overlapping date ranges).

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -118,7 +118,7 @@ Facebook, Illuminate Fivetran, Instagram.
 (alternate spelling of `location_name`) — consumers that join on an aliased name
 (e.g., `fct_staff_observations` on `gro.school_name`) must use this model.
 Canonical-grain consumers (1 row per logical school) should use
-`stg_google_sheets__people__locations` instead (#3633).
+`stg_google_sheets__people__locations` instead.
 
 **`stg_google_sheets__people__campus_crosswalk`** uniqueness grain is
 `Location_Name` only. `Name` is the parent campus and repeats across sibling

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
@@ -439,12 +439,13 @@ with
         }}
     ),
 
-    -- TODO: #3633 — SELECT DISTINCT needed because
-    -- base_powerschool__student_enrollments has genuinely overlapping date
-    -- ranges for some students, producing duplicate (studentid, schoolid) rows.
-    -- enroll_status filter intentionally omitted: a wider net is needed here so
-    -- that transferred students' section records still resolve to a school/region
-    -- even if their latest enrollment row has enroll_status != 0.
+    -- TODO: #4020 — int_extracts__student_enrollments carries one row per
+    -- enrollment stint, so a student with a transfer-out + transfer-back at
+    -- the same school produces duplicate (studentid, schoolid) rows. SELECT
+    -- DISTINCT collapses them for the downstream join. enroll_status filter
+    -- intentionally omitted: a wider net is needed so transferred students'
+    -- section records still resolve to a school/region even when their latest
+    -- enrollment row has enroll_status != 0.
     section_school_context as (
         select distinct _dbt_source_relation, studentid, schoolid, school, region,
         from {{ ref("int_extracts__student_enrollments") }}

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -13,7 +13,6 @@ with
         from {{ ref("int_powerschool__student_enrollment_union") }}
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
     course_enrollments_joined as (
         select
             cc._dbt_source_relation,
@@ -52,18 +51,6 @@ with
             and cc.sections_schoolid = rt.school_id
             and cc.region = rt.region
             and rt.`type` = 'RT'
-    ),
-
-    -- TODO: overlapping enrollment records at same school cause join
-    -- fan-out; deduplicate picks latest entrydate (#3633)
-    course_enrollments_deduped as (
-        {{
-            dbt_utils.deduplicate(
-                relation="course_enrollments_joined",
-                partition_by="cc_dcid, _dbt_source_project",
-                order_by="enr_entrydate desc",
-            )
-        }}
     )
 
 select
@@ -110,4 +97,4 @@ select
         }},
         cast(null as string)
     ) as term_key,
-from course_enrollments_deduped
+from course_enrollments_joined

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -103,9 +103,3 @@ models:
           TRUE if all enrollments for this student x course x year were dropped,
           meaning the entire course was abandoned rather than just a section
           transfer.
-
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - student_section_enrollment_key


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will:

- **Drop a verified no-op `dbt_utils.deduplicate` from `dim_student_section_enrollments`**. Empirically validated on prod 2026-05-23: 0 fan-out across 784,568 `cc` rows. The half-open interval join (`>= entrydate AND < exitdate`) already prevents the overlap the dedup was meant to absorb. Removing the CTE also removes a now-dead `# trunk-ignore(sqlfluff/ST03)` suppression.
- **Refresh the stale `#3633` TODO on the `section_school_context` CTE in `rpt_gsheets__school_metrics_extract`**. The `SELECT DISTINCT` is load-bearing (50 collapsed rows / 9,335 raw at AY 2025, grade ≤ 8), but the cause is multi-stint enrollments at the same school (transfer-out + transfer-back), not the date-range overlap that closed `#3633` originally hypothesized. Comment now points at `#4020`, which tracks migrating the consumer off `select distinct`.
- **Strip a stale `(#3633)` parenthetical from `src/dbt/kipptaf/CLAUDE.md`** in the "Known Upstream Issues" section. `#3633` (`int_people__location_crosswalk` dedup) closed completed 2026-04-22; the surrounding paragraph documents the canonical-grain guidance on its own.
- **Drop the redundant model-level `dbt_utils.unique_combination_of_columns` from `properties/dim_student_section_enrollments.yml`** (surfaced by review). The column-level `unique` test on `student_section_enrollment_key` covers the same condition, per `src/dbt/CLAUDE.md`.

## AI Assistance

Spec authoring, implementation plan, and edits AI-assisted (Claude Code). BigQuery verification SQL and the no-op / load-bearing determination human-directed.

## Row count impact

- `dim_student_section_enrollments`: unchanged (the dedup it removes is a no-op).
- `rpt_gsheets__school_metrics_extract`: comment-only diff, output unchanged.
- `src/dbt/kipptaf/CLAUDE.md`: doc-only diff.
- `properties/dim_student_section_enrollments.yml`: removes a redundant test; column-level `unique` retained.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] No new models — properties file updated to remove a redundant test only.
- [x] No exposure changes — no mart column add/remove/rename.
- [x] No breaking changes — `dim_student_section_enrollments` row count unchanged; `rpt_gsheets__school_metrics_extract` comment-only.
- [x] No external source changes — no `stage_external_sources` run needed.

### Docs

- [x] CLAUDE.md updated (`src/dbt/kipptaf/CLAUDE.md`).

## Issue links

- Closes #3901
- Closes #4023 (redundant uniqueness test cleanup)
- Refs #4020 (spawned: tracks migrating the `rpt_gsheets` consumer off `select distinct`)

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — expected to pass; `dim_student_section_enrollments` output unchanged, other diffs are comment- or test-only.
- [ ] **Dagster Cloud** — not triggered (no Dagster code changes).