### PR TITLE
refactor(dbt): #3780 distinct cleanup + state assessment lineage split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,8 @@ GitHub. The Type custom field tags each task `Issue`, `Pull Request`, or
 - `update_tasks` supports `parent` for re-parenting; `null` flattens.
 - Pagination cursors return as `next_page.offset` — pass to `get_tasks.offset`
   until null.
+- **VS Code extension swallows `create_task_preview*` widgets.** Use
+  `create_tasks` directly.
 - Resolve GitHub-login → Asana email via
   `search_objects(resource_type: "user")`. Workspace spans three email domains
   (`teamschools.org`, `kippteamandfamily.org`, `kippnj.org`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Worktree commands**: Path-flag-driven tools must name the worktree
   explicitly. Use `git -C <worktree>` on every git call (bare `git` from the
   main repo silently commits to `main`) and
-  `uv run dbt ... --project-dir <worktree>/src/dbt/<project>` on every dbt call.
-  For Python execution from the main repo, prefix `VIRTUAL_ENV=` and use
+  `uv run dbt ... --project-dir <worktree>/src/dbt/<project>` on every dbt call
+  (do NOT use `uv --directory <worktree> run dbt ...` — that overrides cwd to
+  the worktree root where `dbt_project.yml` doesn't exist). For Python execution
+  from the main repo, prefix `VIRTUAL_ENV=` and use
   `uv --directory <worktree> run python ...` — bare `uv run --active` reads the
   main repo's `.venv` and misses worktree-only changes. Otherwise prefer
   absolute paths.

--- a/docs/superpowers/plans/2026-05-24-distinct-cleanup-3780-plan.md
+++ b/docs/superpowers/plans/2026-05-24-distinct-cleanup-3780-plan.md
@@ -1,0 +1,1178 @@
+# #3780 DISTINCT Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `SELECT DISTINCT` / `GROUP BY` collapses in 5 mart models with
+correct constructs (annotated DISTINCT for pure projection, redirects to
+existing entity-grain models for surveys), and split NJSLA/PARCC/FAST/FSA/EOC
+into distinct lineages in `dim_assessments` + `dim_assessment_administrations`.
+
+**Architecture:** Per
+`docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md`. No new
+intermediates. Assessments side switches from `int_pearson__all_assessments` /
+`int_fldoe__all_assessments` (legacy denormalized) to 8 per-staging-table CTEs
+each carrying a literal `assessment_type` lineage. Surveys side redirects to
+existing entity-grain models (`int_google_forms__form__items`,
+`stg_alchemer__survey_question`, `stg_alchemer__survey`,
+`stg_google_forms__form`).
+
+**Tech Stack:** dbt 1.11, BigQuery, sqlfluff (BigQuery dialect), trunk-fmt
+pre-commit.
+
+**Working directory:**
+`/workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780`.
+Branch `cbini/refactor/claude-distinct-cleanup-3780` is linked to issue #3780.
+
+**Verification command (used in every task):**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select <model>+ \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+---
+
+## Phase 0: Pre-merge BQ shape audit (no commit)
+
+### Task 0.1: Run surveys-side BQ shape audits
+
+**Files:** none (BQ queries only)
+
+- [ ] **Step 1: Run query A (Google Forms questions redirect)** via
+      `mcp__bigquery__execute_sql`:
+
+```sql
+with
+  current as (
+    select distinct form_id, item_abbreviation, item_title, question_kind
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form_responses`
+    where item_abbreviation is not null and item_title is not null
+  ),
+  target as (
+    select form_id, item_abbreviation, item_title, question_kind
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
+    where item_abbreviation is not null and item_title is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+Save the 4-tuple to a scratch note for the PR body.
+
+- [ ] **Step 2: Run query B (Alchemer questions)** — same shape, sources from
+      spec section "Phase 0 → B".
+
+- [ ] **Step 3: Run query C (Google Forms surveys)** — spec section "Phase 0 →
+      C".
+
+- [ ] **Step 4: Run query D (Alchemer surveys)**. First resolve `<title_col>`:
+
+```sql
+select column_name
+from `teamster-332318.kipptaf_alchemer.INFORMATION_SCHEMA.COLUMNS`
+where table_name = 'stg_alchemer__survey'
+  and lower(column_name) like '%title%'
+```
+
+Then substitute in spec query D and run.
+
+- [ ] **Step 5: Run query E (Google Forms bridge pairs)** — spec section "Phase
+      0 → E".
+
+- [ ] **Step 6: Run query F (Alchemer bridge pairs)** — spec section "Phase 0 →
+      F".
+
+- [ ] **Step 7: Run query G (Manager-pairs redirect equivalence)**:
+
+```sql
+with
+  current as (
+    select distinct survey_id, question_shortname
+    from `teamster-332318.kipptaf_surveys.int_surveys__manager_survey_details`
+    where survey_id = 'historic_alchemer_Manager_survey'
+      and question_shortname is not null
+  ),
+  target as (
+    select
+      'historic_alchemer_Manager_survey' as survey_id,
+      item_abbreviation as question_shortname,
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
+    where form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
+      and item_abbreviation is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+- [ ] **Step 8: Apply decision rules.** For queries A–F, classify each per spec
+      "Phase-0 decision rules". For query G, **`n_current_only` must be 0** —
+      otherwise STOP and escalate manager_pairs to a new intermediate before
+      Task 2.3.
+
+- [ ] **Step 9: Append all 7 results + classifications to
+      `.claude/scratch/phase0-results.md`** for the PR body. Format each as:
+
+```text
+Query A (gforms questions): n_current=X, n_target=Y, n_current_only=A, n_target_only=B — verdict: <safe / escalate>
+```
+
+### Task 0.2: Compute expected assessments row-count deltas
+
+**Files:** none (BQ queries only)
+
+- [ ] **Step 1: Compute `dim_assessments` NJ delta**:
+
+```sql
+select
+  (
+    select count(distinct (testcode, src)) from (
+      select 'parcc' as src, testcode from `teamster-332318.kipptaf_pearson.stg_pearson__parcc` where testscalescore is not null
+      union all select 'njsla', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njsla` where testscalescore is not null
+      union all select 'njsla_science', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njsla_science` where testscalescore is not null
+      union all select 'njgpa', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njgpa` where testscalescore is not null
+    )
+  ) - (
+    select count(distinct testcode)
+    from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+    where testscalescore is not null
+  ) as nj_added_rows
+```
+
+- [ ] **Step 2: Compute `dim_assessments` FL delta**:
+
+```sql
+select
+  (
+    select count(distinct (test_code, src)) from (
+      select 'fast' as src, test_code from `teamster-332318.kippmiami_fldoe.stg_fldoe__fast` where scale_score is not null
+      union all select 'fsa', test_code from `teamster-332318.kippmiami_fldoe.stg_fldoe__fsa` where scale_score is not null
+      union all select 'eoc', test_code from `teamster-332318.kippmiami_fldoe.stg_fldoe__eoc` where scale_score is not null
+      union all select 'science', test_code from `teamster-332318.kippmiami_fldoe.stg_fldoe__science` where scale_score is not null
+    )
+  ) - (
+    select count(distinct test_code)
+    from `teamster-332318.kipptaf_fldoe.int_fldoe__all_assessments`
+    where scale_score is not null
+  ) as fl_added_rows
+```
+
+- [ ] **Step 3: Compute `dim_assessment_administrations` deltas** with the
+      analogous query but including the admin partition columns
+      (`administered_date is null` on state branches, `academic_year`, `region`,
+      `administration_period`). Use:
+
+```sql
+with current as (
+  select count(distinct format('%T|%T|%T|%T', module_code, academic_year, region, administration_period)) as n
+  from (
+    select
+      case testcode when 'SC05' then 'SCI05' when 'SC08' then 'SCI08' when 'SC11' then 'SCI11' else testcode end as module_code,
+      academic_year,
+      initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+      if(period = 'FallBlock', 'Fall', period) as administration_period,
+    from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+    where testscalescore is not null
+  )
+),
+new_rows as (
+  select count(distinct format('%T|%T|%T|%T|%T', module_code, src, academic_year, region, administration_period)) as n
+  from (
+    select 'parcc' as src,
+      case testcode when 'SC05' then 'SCI05' when 'SC08' then 'SCI08' when 'SC11' then 'SCI11' else testcode end as module_code,
+      academic_year,
+      initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+      if(period = 'FallBlock', 'Fall', period) as administration_period,
+    from `teamster-332318.kipptaf_pearson.stg_pearson__parcc` where testscalescore is not null
+    union all
+    -- repeat for njsla, njsla_science, njgpa
+    select 'njsla',
+      case testcode when 'SC05' then 'SCI05' when 'SC08' then 'SCI08' when 'SC11' then 'SCI11' else testcode end,
+      academic_year,
+      initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')),
+      if(period = 'FallBlock', 'Fall', period),
+    from `teamster-332318.kipptaf_pearson.stg_pearson__njsla` where testscalescore is not null
+    union all
+    select 'njsla_science',
+      case testcode when 'SC05' then 'SCI05' when 'SC08' then 'SCI08' when 'SC11' then 'SCI11' else testcode end,
+      academic_year,
+      initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')),
+      if(period = 'FallBlock', 'Fall', period),
+    from `teamster-332318.kipptaf_pearson.stg_pearson__njsla_science` where testscalescore is not null
+    union all
+    select 'njgpa',
+      case testcode when 'SC05' then 'SCI05' when 'SC08' then 'SCI08' when 'SC11' then 'SCI11' else testcode end,
+      academic_year,
+      initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')),
+      if(period = 'FallBlock', 'Fall', period),
+    from `teamster-332318.kipptaf_pearson.stg_pearson__njgpa` where testscalescore is not null
+  )
+)
+select (select n from new_rows) - (select n from current) as nj_admin_added_rows
+```
+
+Repeat the analogous query for FL (using FLDOE staging tables +
+`administration_window` for `administration_period`, and no SC code remapping).
+
+- [ ] **Step 4: Append all 4 expected deltas to
+      `.claude/scratch/phase0-results.md`**:
+
+```text
+dim_assessments expected delta: NJ +X, FL +Y, total +Z
+dim_assessment_administrations expected delta: NJ +A, FL +B, total +C
+```
+
+### Task 0.3: Grep cube for state_nj / state_fl literals
+
+**Files:** none (read-only grep)
+
+- [ ] **Step 1: Search cube models for affected literals:**
+
+```bash
+grep -rnE "'state_nj'|'state_fl'|state_nj[^_a-z]|state_fl[^_a-z]" /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780/src/cube/model/
+```
+
+- [ ] **Step 2: Append results to `.claude/scratch/phase0-results.md`**:
+
+```text
+Cube literal matches: <none / list of file:line>
+```
+
+If any matches: plan Task 3 to apply `LIKE 'state_nj_%'` swaps to each. If no
+matches: Task 3 will be skipped.
+
+---
+
+## Commit 1: Assessments mart rewrite
+
+### Task 1.1: Rewrite `dim_assessments` state CTEs
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql:1-216`
+  (replace state_nj + state_fl CTEs with 8 per-staging-table CTEs; remove stale
+  illuminate comment; annotate remaining DISTINCTs)
+
+- [ ] **Step 1: Read the current file** to confirm line numbers haven't drifted:
+
+```bash
+sed -n '1,40p' /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+```
+
+- [ ] **Step 2: Remove the stale comment block above `illuminate_assessments`
+      CTE (lines 1-11 of the with-block).** The CTE has no DISTINCT; the comment
+      misleads. Replace the entire comment block (lines starting from
+      `-- DISTINCT projects from response grain (one row per student) to`
+      through `-- via this dim's assessment_key.`) with:
+
+```sql
+-- Member-grain: one row per actual Illuminate assessment_id. Bridge
+-- table `bridge_assessment_administration_members` maps each
+-- canonical-grain `dim_assessment_administrations` row to its member(s)
+-- via this dim's `assessment_key`.
+```
+
+The "DISTINCT projects..." prose goes; the bridge-relationship prose stays.
+
+- [ ] **Step 3: Replace the existing `state_nj` CTE (lines 41-79) with 4 CTEs,
+      one per Pearson staging table.** Canonical template (use for PARCC; adapt
+      the literal and ref for the other 3):
+
+```sql
+    -- projection IS the operation, not deduplication
+    state_nj_parcc as (
+        select distinct
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            'state_nj_parcc' as assessment_type,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            'PARCC' as title,
+
+            discipline as scope,
+            test_grade as grade_level,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+        from {{ ref("stg_pearson__parcc") }}
+        where testscalescore is not null
+    ),
+```
+
+Then duplicate three more times, substituting:
+
+| CTE name                 | `assessment_type` literal  | `title` literal   | `ref()`                             |
+| ------------------------ | -------------------------- | ----------------- | ----------------------------------- |
+| `state_nj_njsla`         | `'state_nj_njsla'`         | `'NJSLA'`         | `ref("stg_pearson__njsla")`         |
+| `state_nj_njsla_science` | `'state_nj_njsla_science'` | `'NJSLA Science'` | `ref("stg_pearson__njsla_science")` |
+| `state_nj_njgpa`         | `'state_nj_njgpa'`         | `'NJGPA'`         | `ref("stg_pearson__njgpa")`         |
+
+Notes:
+
+- `case testcode when 'SC05' then 'SCI05' ...` stays in every CTE; it's a no-op
+  for tables that don't carry SC-prefixed codes.
+- `title` is now a constant per CTE — the literal assessment_name for that
+  program.
+
+- [ ] **Step 4: Replace the existing `state_fl` CTE (lines 81-108) with 4 CTEs,
+      one per FLDOE staging table.** Canonical template:
+
+```sql
+    -- projection IS the operation, not deduplication
+    state_fl_fast as (
+        select distinct
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            'state_fl_fast' as assessment_type,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            'FAST' as title,
+
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(assessment_grade as int) as grade_level,
+        from {{ ref("stg_fldoe__fast") }}
+        where scale_score is not null
+    ),
+```
+
+Duplicate three more times for `state_fl_fsa` / `state_fl_eoc` /
+`state_fl_science`:
+
+| CTE name           | `assessment_type`    | `title`     | `ref()`                     |
+| ------------------ | -------------------- | ----------- | --------------------------- |
+| `state_fl_fsa`     | `'state_fl_fsa'`     | `'FSA'`     | `ref("stg_fldoe__fsa")`     |
+| `state_fl_eoc`     | `'state_fl_eoc'`     | `'EOC'`     | `ref("stg_fldoe__eoc")`     |
+| `state_fl_science` | `'state_fl_science'` | `'Science'` | `ref("stg_fldoe__science")` |
+
+- [ ] **Step 5: Annotate `college_assessments` CTE.** Replace its existing
+      leading comment block:
+
+```sql
+    -- DISTINCT projects from response grain to definition grain (see
+    -- illuminate_assessments comment above).
+```
+
+with:
+
+```sql
+    -- projection IS the operation, not deduplication
+```
+
+- [ ] **Step 6: Annotate `practice_assessments` CTE.** Its current "One row per
+      (scope, subject_area) — matching Official college's…" comment is
+      informative and should stay; ADD the projection annotation as a separate
+      line directly above the `select distinct`:
+
+```sql
+    -- projection IS the operation, not deduplication
+    select distinct
+```
+
+- [ ] **Step 7: Annotate `ap_assessments` CTE.** Replace its existing comment
+      block (also "DISTINCT projects from response grain to definition grain")
+      with:
+
+```sql
+    -- projection IS the operation, not deduplication
+```
+
+- [ ] **Step 8: Update the final UNION ALL block (around line 198).** Replace
+      the 6-branch union with a 12-branch union covering:
+      `illuminate_assessments`, `state_nj_parcc`, `state_nj_njsla`,
+      `state_nj_njsla_science`, `state_nj_njgpa`, `state_fl_fast`,
+      `state_fl_fsa`, `state_fl_eoc`, `state_fl_science`, `college_assessments`,
+      `practice_assessments`, `ap_assessments`. Each branch is
+      `select {{ union_cols }}, from <cte_name>` followed by `union all` (except
+      the last).
+
+- [ ] **Step 9: Leave the downstream `dbt_utils.deduplicate` (`all_assessments`)
+      untouched.** Its partition_by
+      `assessment_type, source_assessment_id, module_code, test_type` and
+      order_by `title` continue to deduplicate any cross-branch collisions
+      correctly under the new type-string scheme.
+
+- [ ] **Step 10: Build dim_assessments and verify row count:**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select dim_assessments \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+Expected: build succeeds, all tests pass. If unique test on `assessment_key`
+fails, the new `assessment_type` literals are not splitting the hashes as
+expected — recheck Step 3 / Step 4 literals.
+
+- [ ] **Step 11: Verify row-count delta matches Phase 0 expectation.** Find the
+      PR-branch schema from the build output (printed in
+      `Create profile from connection BigQuery (override schema to '...')` step,
+      or by querying `INFORMATION_SCHEMA.SCHEMATA`). Then:
+
+```sql
+select
+  (select count(*) from `teamster-332318.<pr_schema>.dim_assessments`) as n_pr,
+  (select count(*) from `teamster-332318.kipptaf.dim_assessments`) as n_prod,
+```
+
+`n_pr - n_prod` must equal the sum of `nj_added_rows + fl_added_rows` from Phase
+0 Task 0.2. If not, recheck `assessment_type` composition.
+
+- [ ] **Step 12: Verify lineage taxonomy:**
+
+```sql
+select assessment_type, count(*) as n
+from `teamster-332318.<pr_schema>.dim_assessments`
+where assessment_type like 'state_%'
+group by 1
+order by 1
+```
+
+Must return exactly these 8 values (and nothing else): `state_fl_eoc`,
+`state_fl_fast`, `state_fl_fsa`, `state_fl_science`, `state_nj_njgpa`,
+`state_nj_njsla`, `state_nj_njsla_science`, `state_nj_parcc`.
+
+### Task 1.2: Rewrite `dim_assessment_administrations` state CTEs
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql:51-117`
+  (replace state_nj_administrations + state_fl_administrations; annotate other
+  DISTINCTs)
+
+- [ ] **Step 1: Replace `state_nj_administrations` (lines 51-91) with 4 CTEs.**
+      Canonical template (PARCC):
+
+```sql
+    -- projection IS the operation, not deduplication
+    -- State NJ PARCC: one administration per (testcode, period, academic_year, region).
+    state_nj_parcc_administrations as (
+        select distinct
+            'state_nj_parcc' as assessment_type,
+            'PARCC' as title,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            discipline as scope,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+
+            test_grade as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ ref("stg_pearson__parcc") }}
+        where testscalescore is not null
+    ),
+```
+
+Duplicate for `state_nj_njsla` / `state_nj_njsla_science` / `state_nj_njgpa`
+with the same substitution table from Task 1.1 Step 3 (assessment_type + title +
+ref() change; everything else identical).
+
+**Important:** `assessment_type` literal here is `'state_nj_parcc'`
+(lineage-split), NOT the pre-existing `'state'` literal in the current file.
+This change aligns the admin's hash with the dim's hash composition for the same
+assessment.
+
+- [ ] **Step 2: Replace `state_fl_administrations` (lines 95-117) with 4 CTEs.**
+      Canonical template (FAST):
+
+```sql
+    -- projection IS the operation, not deduplication
+    -- State FL FAST: one administration per (test_code, administration_window, academic_year, region).
+    state_fl_fast_administrations as (
+        select distinct
+            'state_fl_fast' as assessment_type,
+            'FAST' as title,
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(assessment_grade as int) as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            administration_window as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ ref("stg_fldoe__fast") }}
+        where scale_score is not null
+    ),
+```
+
+Duplicate for `state_fl_fsa` / `state_fl_eoc` / `state_fl_science` with the
+substitution table from Task 1.1 Step 4.
+
+- [ ] **Step 3: Annotate the surviving DISTINCT CTEs.** For each of
+      `college_administrations`, `ap_administrations` (lines ~122 and ~174),
+      prepend the standard annotation directly above its `select distinct`:
+
+```sql
+    -- projection IS the operation, not deduplication
+```
+
+`practice_administrations` uses `select` + `group by` for
+`any_value(subject_area)` resolution — that's canonical-attribute resolution,
+not pure projection. Leave it as-is; do NOT add the annotation. (The `any_value`
+call qualifies as `dbt_utils.deduplicate`-equivalent semantics; the existing
+block comment explains the choice.)
+
+- [ ] **Step 4: Update the final UNION ALL block.** Replace the 6-branch union
+      with a 14-branch union: `illuminate_administrations` + 4 NJ + 4 FL +
+      `college_administrations` + `practice_administrations` +
+      `ap_administrations`.
+
+- [ ] **Step 5: Build and verify:**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select dim_assessment_administrations \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+Expected: build succeeds, unique test on `assessment_administration_key` passes.
+
+- [ ] **Step 6: Verify row-count delta** matches the expected admin delta from
+      Phase 0 Task 0.2 Step 3.
+
+- [ ] **Step 7: Verify lineage taxonomy** on the admin dim:
+
+```sql
+select assessment_type, count(*) as n
+from `teamster-332318.<pr_schema>.dim_assessment_administrations`
+where assessment_type like 'state_%'
+group by 1
+order by 1
+```
+
+Must return the same 8 lineage values as Task 1.1 Step 12.
+
+### Task 1.3: Commit assessments changes
+
+- [ ] **Step 1: Stage modified files:**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780
+git add src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql \
+        src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+```
+
+- [ ] **Step 2: Commit** (use HEREDOC to preserve formatting):
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(dbt): split state assessment lineages in dim_assessments + admin
+
+Replaces state_nj / state_fl CTEs in dim_assessments and
+dim_assessment_administrations with 8 per-staging-table CTEs each carrying
+a literal assessment_type that encodes program lineage (parcc, njsla,
+njsla_science, njgpa, fast, fsa, eoc, science). Drops the
+int_pearson__all_assessments and int_fldoe__all_assessments mart
+dependencies in favor of staging-direct reads.
+
+Annotates surviving pure-projection DISTINCTs per the new
+src/dbt/CLAUDE.md rule clarification. Removes stale "DISTINCT projects..."
+comment block above dim_assessments.illuminate_assessments (the CTE has
+no DISTINCT).
+
+Refs #3780
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 2: Surveys redirects
+
+### Task 2.1: Rewrite `dim_survey_questions.sql`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql:1-75`
+  (redirect gforms + alchemer; drop manager_questions)
+
+- [ ] **Step 1: Replace `google_forms_questions` CTE (lines 2-10).** Current:
+
+```sql
+    google_forms_questions as (
+        -- DISTINCT projects from response grain to question grain.
+        select distinct
+            fr.item_abbreviation as question_shortname,
+            fr.item_title as question_text,
+            fr.question_kind as question_type,
+        from {{ ref("int_google_forms__form_responses") }} as fr
+        where fr.item_abbreviation is not null and fr.item_title is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    google_forms_questions as (
+        select
+            item_abbreviation as question_shortname,
+            item_title as question_text,
+            question_kind as question_type,
+        from {{ ref("int_google_forms__form__items") }}
+        where item_abbreviation is not null and item_title is not null
+    ),
+```
+
+- [ ] **Step 2: Replace `alchemer_questions` CTE (lines 21-31).** Current:
+
+```sql
+    alchemer_questions as (
+        -- DISTINCT projects from response grain to question grain.
+        -- Sources Alchemer + Google Forms staff/student survey questions that
+        -- feed fct_survey_responses.general_responses.
+        select distinct
+            sr.question_shortname,
+            sr.question_title as question_text,
+            cast(null as string) as question_type,
+        from {{ ref("int_surveys__survey_responses") }} as sr
+        where sr.question_shortname is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    alchemer_questions as (
+        select
+            shortname as question_shortname,
+            title_english as question_text,
+            cast(null as string) as question_type,
+        from {{ ref("stg_alchemer__survey_question") }}
+        where shortname is not null
+    ),
+```
+
+- [ ] **Step 3: Delete `manager_questions` CTE (lines 33-41) AND its UNION ALL
+      branch (in `all_questions` CTE, lines ~52-55).** After deletion,
+      `all_questions` must be:
+
+```sql
+    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
+    all_questions as (
+        select *,
+        from google_forms_questions
+        union all
+        select *,
+        from scd_questions
+        union all
+        select *,
+        from alchemer_questions
+    ),
+```
+
+- [ ] **Step 4: Leave `scd_questions` CTE and the downstream
+      `dbt_utils.deduplicate` untouched.**
+
+- [ ] **Step 5: Build and verify:**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select dim_survey_questions \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+Expected: build succeeds; unique on `survey_question_key` passes.
+
+- [ ] **Step 6: Verify delta** matches sum of Phase 0 queries A and B
+      (`n_target - n_current` per query, summed, signed). Document the actual
+      delta vs expected in `.claude/scratch/phase0-results.md`.
+
+### Task 2.2: Rewrite `dim_surveys.sql`
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql:1-19`
+  (redirect gforms + alchemer)
+
+- [ ] **Step 1: Replace `google_forms_surveys` CTE (lines 2-8).** Current:
+
+```sql
+    google_forms_surveys as (
+        -- DISTINCT projects from response grain to survey grain.
+        select distinct
+            form_id as survey_id, info_title as survey_name, 'Google Forms' as platform,
+        from {{ ref("int_google_forms__form_responses") }}
+        where form_id is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    google_forms_surveys as (
+        select
+            form_id as survey_id, info_title as survey_name, 'Google Forms' as platform,
+        from {{ ref("stg_google_forms__form") }}
+        where form_id is not null
+    ),
+```
+
+- [ ] **Step 2: Replace `alchemer_surveys` CTE (lines 10-19).** First, run a
+      quick column check to find the title column on `stg_alchemer__survey` (if
+      Phase 0 Task 0.1 Step 4 didn't already capture it):
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt show --project-dir src/dbt/kipptaf \
+  --inline "select column_name from \`teamster-332318.kipptaf_alchemer.INFORMATION_SCHEMA.COLUMNS\` where table_name = 'stg_alchemer__survey' and lower(column_name) like '%title%'"
+```
+
+Then replace the current alchemer_surveys:
+
+```sql
+    alchemer_surveys as (
+        -- DISTINCT projects from response grain to survey grain.
+        select distinct
+            safe_cast(survey_id as string) as survey_id,
+            survey_title as survey_name,
+
+            'Alchemer' as platform,
+        from {{ source("alchemer", "base_alchemer__survey_results") }}
+        where survey_id is not null
+    ),
+```
+
+with (substitute `<title_col>` with whatever Step 2 returned — likely
+`title_english` since `stg_alchemer__survey_question` uses that name):
+
+```sql
+    alchemer_surveys as (
+        select
+            safe_cast(id as string) as survey_id,
+            <title_col> as survey_name,
+
+            'Alchemer' as platform,
+        from {{ ref("stg_alchemer__survey") }}
+        where id is not null
+    ),
+```
+
+- [ ] **Step 3: Leave `archive_manager`, `archive_support`, `powerschool_family`
+      CTEs untouched** — they synthesize survey_keys for legacy data with
+      downstream filter dependencies.
+
+- [ ] **Step 4: Build and verify:**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select dim_surveys \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+- [ ] **Step 5: Verify delta** matches sum of Phase 0 queries C and D.
+
+### Task 2.3: Rewrite `bridge_survey_questions.sql`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql:1-79`
+  (redirect gforms, alchemer, manager)
+
+**Precondition:** Phase 0 query G (Task 0.1 Step 7) must have returned
+`n_current_only = 0`. If not, STOP and escalate manager_pairs to a new int per
+spec.
+
+- [ ] **Step 1: Replace `google_forms_pairs` CTE (lines 2-10).** Current:
+
+```sql
+    google_forms_pairs as (
+        -- DISTINCT projects from response grain to (survey, question) pair grain.
+        select distinct
+            fr.form_id as survey_id,
+            fr.item_abbreviation as question_shortname,
+            fr.question_required as is_required,
+        from {{ ref("int_google_forms__form_responses") }} as fr
+        where fr.form_id is not null and fr.item_abbreviation is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    google_forms_pairs as (
+        select
+            form_id as survey_id,
+            item_abbreviation as question_shortname,
+            question_required as is_required,
+        from {{ ref("int_google_forms__form__items") }}
+        where form_id is not null and item_abbreviation is not null
+    ),
+```
+
+- [ ] **Step 2: Replace `alchemer_pairs` CTE (lines 21-29).** Current:
+
+```sql
+    alchemer_pairs as (
+        -- DISTINCT projects from response grain to (survey, question) pair grain.
+        -- Covers Alchemer + Google Forms staff/student survey questions feeding
+        -- fct_survey_responses.general_responses.
+        select distinct
+            sr.survey_id, sr.question_shortname, cast(null as bool) as is_required,
+        from {{ ref("int_surveys__survey_responses") }} as sr
+        where sr.survey_id is not null and sr.question_shortname is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    alchemer_pairs as (
+        select
+            safe_cast(survey_id as string) as survey_id,
+            shortname as question_shortname,
+            cast(null as bool) as is_required,
+        from {{ ref("stg_alchemer__survey_question") }}
+        where shortname is not null
+    ),
+```
+
+- [ ] **Step 3: Replace `manager_pairs` CTE (lines 31-37) — redirect, not
+      drop.** Current:
+
+```sql
+    manager_pairs as (
+        -- DISTINCT projects from response grain to (survey, question) pair grain.
+        select distinct
+            ms.survey_id, ms.question_shortname, cast(null as bool) as is_required,
+        from {{ ref("int_surveys__manager_survey_details") }} as ms
+        where ms.survey_id is not null and ms.question_shortname is not null
+    ),
+```
+
+Replace with:
+
+```sql
+    manager_pairs as (
+        -- Synthesizes (survey_id, question_shortname) pairs for the
+        -- historic Manager Survey archive, whose original Alchemer
+        -- survey_ids were not preserved. Live Manager Survey pairs flow
+        -- through google_forms_pairs above (same form_id).
+        select
+            'historic_alchemer_Manager_survey' as survey_id,
+            item_abbreviation as question_shortname,
+            cast(null as bool) as is_required,
+        from {{ ref("int_google_forms__form__items") }}
+        where form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
+            and item_abbreviation is not null
+    ),
+```
+
+- [ ] **Step 4: Leave `scd_powerschool_pairs` CTE and the downstream
+      `dbt_utils.deduplicate` block untouched.** The dedup partition
+      `(survey_id, question_shortname)` continues to handle cross-CTE
+      collisions.
+
+- [ ] **Step 5: Build and verify:**
+
+```bash
+VIRTUAL_ENV= uv \
+  --directory /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select bridge_survey_questions \
+  --defer --state src/dbt/kipptaf/target/prod
+```
+
+- [ ] **Step 6: Verify delta** matches sum of Phase 0 queries E, F, G.
+
+### Task 2.4: Commit surveys changes
+
+- [ ] **Step 1: Stage modified files:**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780
+git add src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql \
+        src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql \
+        src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql
+```
+
+- [ ] **Step 2: Commit:**
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(dbt): redirect surveys marts to entity-grain upstreams
+
+dim_survey_questions, dim_surveys, and bridge_survey_questions now read
+from existing entity-grain models (int_google_forms__form__items,
+stg_alchemer__survey_question, stg_alchemer__survey,
+stg_google_forms__form) instead of collapsing response-grain models with
+SELECT DISTINCT. manager_questions CTE removed as redundant; manager_pairs
+redirected to derive historic Manager Survey pairs from the same Google
+Form's items.
+
+Refs #3780
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 3: Cube migration (conditional)
+
+### Task 3.1: Apply cube literal swaps (only if Phase 0 Task 0.3 surfaced matches)
+
+**Precondition:** `.claude/scratch/phase0-results.md` lists one or more
+`src/cube/model/*` matches. If none, **skip this entire task** and proceed to
+Task 4.
+
+**Files:** the cube model files identified in Task 0.3.
+
+- [ ] **Step 1: For each match, determine the correct rewrite per its semantic
+      context:**
+  - Exact-match filter expecting all NJ state programs:
+    `assessment_type = 'state_nj'` → `assessment_type LIKE 'state_nj_%'`
+  - Same for `'state_fl'` → `LIKE 'state_fl_%'`
+  - Filter that meant one specific program (rare; identify by surrounding
+    label/title): substitute the specific lineage literal (e.g.
+    `assessment_type = 'state_nj_njsla'`)
+
+- [ ] **Step 2: Edit each cube file** with the appropriate swap.
+
+- [ ] **Step 3: Validate cube model with the local cube dev process** per
+      `src/cube/CLAUDE.md`. (If no local cube validation is available, defer to
+      Cube CI on PR.)
+
+- [ ] **Step 4: Stage and commit:**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780
+git add src/cube/model/
+git commit -m "$(cat <<'EOF'
+refactor(cube): migrate state_nj/state_fl filters for #3780 lineage split
+
+Updates Cube model filters that referenced the pre-split assessment_type
+literals 'state_nj' / 'state_fl' to use LIKE 'state_nj_%' / LIKE
+'state_fl_%' patterns (or specific lineage literals where the filter
+targeted one program).
+
+Refs #3780
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Pre-merge: push, CI triage, PR
+
+### Task 4.1: Push and watch CI
+
+- [ ] **Step 1: Push the branch:**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-refactor-claude-distinct-cleanup-3780
+git push
+```
+
+- [ ] **Step 2: Wait for dbt Cloud CI to finish.** Use
+      `mcp__github__pull_request_read get_status` against the PR (after Task 4.4
+      opens it; if waiting before, poll `mcp__dbt__list_jobs_runs` for the most
+      recent run on this branch).
+
+- [ ] **Step 3: Pull marts-model warnings from the CI run:**
+
+```text
+mcp__dbt__get_job_run_error(run_id=<latest>, warning_only=true)
+```
+
+- [ ] **Step 4: For each warning on a touched mart:**
+  - Search open issues by model name + FK target (`mcp__github__search_issues`)
+  - Bucket orphans (by region, source, test_type, lineage) in scratch
+  - If a new orphan pattern surfaces that isn't covered by an open issue: file a
+    follow-up per marts CLAUDE.md "Filing follow-up issues" (project board #4,
+    Tier / PR batch / Driver set)
+
+### Task 4.2: Project board scan
+
+- [ ] **Step 1:** Visit `https://github.com/orgs/TEAMSchools/projects/4/views/1`
+      and scan for incidentally-resolved issues. Candidates: NJSLA-vs-PARCC
+      reporting splits, lineage-aware assessment dashboards, EOC reporting
+      requests, FL Science reporting, manager-pairs bridge issues.
+
+- [ ] **Step 2: For each incidentally resolved: close in the PR** by referencing
+      `Closes #N` in the PR body (Task 4.4).
+
+### Task 4.3: File pre-existing follow-up
+
+- [ ] **Step 1: File the `fct_assessment_scores_enrollment_scoped` admin-key
+      hash mismatch issue** via `mcp__github__issue_write`:
+  - Title:
+    `fct_assessment_scores_enrollment_scoped state branch admin-key hash mismatch with dim_assessment_administrations`
+  - Body: Describe the literal `'state'` (fact) vs `'state_nj_*'` /
+    `'state_fl_*'` (dim) mismatch. Reference current line numbers in the fact
+    for the hash inputs.
+  - Labels: `dbt`, `bug`
+  - Surfaced during #3780 spec investigation
+
+- [ ] **Step 2: Add to project board #4 with `Tier`, `PR batch`, `Driver` set**
+      per `src/dbt/kipptaf/models/marts/CLAUDE.md` filing convention. Prefix
+      `gh project item-add` with `GITHUB_TOKEN=` to use the OAuth scope.
+
+### Task 4.4: Open PR
+
+- [ ] **Step 1: Prepare PR body** from `.github/pull_request_template.md` plus
+      the Phase 0 results. Body must include:
+  - Brief summary (lineage split + surveys redirects + DISTINCT annotations)
+  - Phase 0 results table (all 7 queries + 4 expected-delta computations)
+  - Pre-merge checklist results (R1-R10 scan = no rename / no new column; CI
+    warning triage outcome; project board scan; pre-existing-issue follow-up
+    filed)
+  - Closes / Refs lines for #3780 and any incidentally-resolved issues from Task
+    4.2
+  - `Closes #3780`
+
+- [ ] **Step 2: Open PR:**
+
+```bash
+gh pr create --title "refactor(dbt): #3780 distinct cleanup + state assessment lineage split" --body "$(cat <<'EOF'
+## Summary
+
+- Splits NJ and FL state assessments into per-program lineages
+  (parcc / njsla / njsla_science / njgpa; fast / fsa / eoc / science)
+  on dim_assessments and dim_assessment_administrations.
+- Replaces SELECT DISTINCT in surveys marts with redirects to existing
+  entity-grain models (int_google_forms__form__items,
+  stg_alchemer__survey_question, etc.).
+- Annotates surviving pure-projection DISTINCTs per the new
+  src/dbt/CLAUDE.md rule (already in branch).
+
+## Phase 0 audit results
+
+<paste from .claude/scratch/phase0-results.md>
+
+## Pre-merge checklist
+
+- R1–R10 column rubric: no new columns, no renames — N/A
+- Diamond paths: no new FKs — N/A
+- CI warnings: <triage outcome>
+- Project board scan: <incidentally-resolved list or "none">
+- Pre-existing fct_assessment_scores admin-key hash mismatch: filed as
+  #<num>
+
+## Test plan
+
+- [ ] Phase 0 BQ queries A-G run and documented
+- [ ] dim_assessments builds, lineage spot-check returns exactly 8 state_* values
+- [ ] dim_assessment_administrations builds, same lineage taxonomy
+- [ ] dim_survey_questions, dim_surveys, bridge_survey_questions build
+- [ ] Row-count deltas match Phase 0 expectations
+- [ ] Cube CI green (or N/A if no cube changes)
+
+Closes #3780
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR body** by reading it back via
+      `mcp__github__pull_request_read`. Confirm no `env` token leaked into the
+      body (would trigger the path hook).
+
+---
+
+## Self-Review Checklist (executed after plan is written)
+
+- [x] Every spec section / requirement has a task implementing it
+- [x] No placeholders (TBD/TODO/etc.) in the plan
+- [x] Type/name consistency: `assessment_type` literals match across
+      dim*assessments and dim_assessment_administrations (both use
+      `state_nj*<lineage>`/`state*fl*<lineage>`)
+- [x] File paths are absolute (worktree-rooted)
+- [x] Each commit boundary has a stage-and-commit task
+- [x] Phase 0 query G acts as the gate for the manager_pairs redirect in Task
+      2.3

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -501,6 +501,51 @@ exist or may exist).
   redirect drops rows. Mitigation: Phase 0 query G must return
   `n_current_only = 0`.
 
+## Pre-merge checklist
+
+Per `src/dbt/kipptaf/models/marts/CLAUDE.md` → "Pre-merge checklist (marts
+PRs)". Each item below is the checklist item plus its specific application to
+this PR.
+
+- **Diamond paths.** This spec adds no new FKs; the `assessment_type` literal
+  split affects hash values but not FK shape. Verification: confirm none of the
+  5 touched marts adds a `*_key` column. (Expected: no changes.)
+- **Column-naming rubric R1–R10.** No new columns; no renames. The new
+  `assessment_type` literal values (`state_nj_njsla`, `state_fl_eoc`, etc.)
+  follow lowercase + underscore convention used by existing types (`illuminate`,
+  `college`, `ap`). Verification: grep touched marts for any column rename or
+  new column outside the existing contract.
+- **CI warning triage.** After commit 1 and 2 land in CI, run
+  `mcp__dbt__get_job_run_error(warning_only=true)` against the PR's run. For
+  each warning on a touched mart:
+  - Search open issues by model name + FK target.
+  - Bucket orphans (by region, source, test_type, lineage) in the issue body
+    before filing.
+  - Anticipated new orphans: `dim_assessments`'s 8-lineage split may surface FK
+    orphans from `bridge_assessment_administration_members` (illuminate-only
+    consumer — likely none) or any fact that references `assessment_key`. None
+    expected, but check.
+- **Project board scan.** Before posting the final PR comment, scan
+  [project #4](https://github.com/orgs/TEAMSchools/projects/4/views/1) for bonus
+  issues incidentally resolved by this PR (lineage-aware assessment reporting
+  requests, NJSLA-vs-PARCC reporting splits, etc.) and close them in the PR.
+- **File newly-surfaced errors.** Use the "Filing follow-up issues from marts
+  work" pattern in marts CLAUDE.md — Tier / PR batch / Driver set,
+  `GITHUB_TOKEN=` prefix for `gh project` mutations.
+
+## Cube semantic-layer audit
+
+Per `src/dbt/kipptaf/models/marts/CLAUDE.md` → "Exposures are the consumer
+contract", before commit 2 lands:
+
+```bash
+grep -rnE "'state_nj'|'state_fl'|state_nj[^_]|state_fl[^_]" src/cube/model/
+```
+
+For each match, swap to `LIKE 'state_nj_%'` / `LIKE 'state_fl_%'` (or to the
+specific lineage literal if the filter wants only one program). PR body must
+list every match plus the migration applied.
+
 ## Out of scope
 
 - `dim_assessment_administrations.illuminate_administrations` (TODO #3800).

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -34,22 +34,67 @@ the partition and needs deterministic selection).
 
 ### Assessments group
 
-| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Collapse type                                         | Resolution                                                                                                                                        |
-| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | No collapse                                           | Remove stale "DISTINCT projects..." comment block — no DISTINCT is actually present in the SQL                                                    |
-| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | Canonical-attribute (`min(assessment_name) as title`) | Inline `dbt_utils.deduplicate(partition_by="discipline, test_grade, subject, testcode", order_by="assessment_name asc")` on a filtered source CTE |
-| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | Canonical-attribute (`min(assessment_name) as title`) | Inline `dbt_utils.deduplicate(partition_by="assessment_subject, discipline, test_code, assessment_grade", order_by="assessment_name asc")`        |
-| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key`)                                                                     | Pure projection                                       | Keep DISTINCT; replace existing comment block with the annotation phrase                                                                          |
-| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
-| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
-| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
-| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
-| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
-| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Collapse type                                                                           | Resolution                                                                                                                                                 |
+| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | No collapse                                                                             | Remove stale "DISTINCT projects..." comment block — no DISTINCT is actually present in the SQL                                                             |
+| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | Pure projection AFTER admitting `assessment_name` as a key column (see "Lineage split") | Switch from `GROUP BY ... min(assessment_name)` to plain DISTINCT with annotation; emit `concat('state_nj_', lower(assessment_name))` as `assessment_type` |
+| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | Pure projection AFTER admitting `assessment_name` as a key column                       | Switch from `GROUP BY ... min(assessment_name)` to plain DISTINCT with annotation; emit `concat('state_fl_', lower(assessment_name))` as `assessment_type` |
+| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key`)                                                                     | Pure projection                                                                         | Keep DISTINCT; replace existing comment block with the annotation phrase                                                                                   |
+| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
+| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
+| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | Pure projection AFTER lineage split                                                     | Keep DISTINCT with annotation; project `assessment_name`; emit `concat('state_nj_', lower(assessment_name))` as `assessment_type`                          |
+| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | Pure projection AFTER lineage split                                                     | Keep DISTINCT with annotation; project `assessment_name`; emit `concat('state_fl_', lower(assessment_name))` as `assessment_type`                          |
+| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
+| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
 
-Net: **0 new intermediates**, 2 `dbt_utils.deduplicate` switches (state_nj,
-state_fl in `dim_assessments`), 7 DISTINCTs reclassified as pure projection with
-the standard annotation, 1 stale comment block removed.
+Net: **0 new intermediates**, 9 DISTINCT CTEs annotated as pure projection, 2
+lineage-split rewrites (state_nj, state_fl across both marts), 1 stale comment
+block removed. No `dbt_utils.deduplicate` switches (the lineage split makes the
+`min()` resolution unnecessary).
+
+### Lineage split: NJSLA / PARCC and FAST / FSA / Science
+
+The current `state_nj` and `state_fl` CTEs collapse historical title variants
+(`NJSLA | PARCC` on every NJ ELA / Math testcode; `FAST | FSA` on every FL ELA /
+Math testcode; `FSA | Science` on SCI05 / SCI08) into one mart row per
+`(module_code, grade)` with `min(assessment_name) as title`. Successor
+assessments (NJSLA after PARCC, FAST after FSA) are different programs
+administered to similar student populations — surfacing them as one dim row
+erases that distinction.
+
+**Fix**: include `assessment_name` in the state-branch projections; encode the
+program-level distinction in `assessment_type`. Per-region literal `'state_nj'`
+becomes `'state_nj_njsla'` / `'state_nj_parcc'`. Per-region literal `'state_fl'`
+becomes `'state_fl_fast'` / `'state_fl_fsa'` / `'state_fl_science'`.
+
+After the split, `state_nj` and `state_fl` CTEs become pure projection (every
+projected column functionally determined by the new partition key that includes
+`assessment_name`) — straight DISTINCT with the standard annotation. Same in the
+corresponding `dim_assessment_administrations` CTEs.
+
+**Hash composition is unchanged.** `assessment_key` and
+`assessment_administration_key` continue to hash from
+`assessment_type, module_code, source_assessment_id, test_type` (and
+admin-specific extras). The type-string split causes hashes to diverge naturally
+— no input list change required.
+
+**Downstream impact**:
+
+- `fct_assessment_scores_enrollment_scoped` state branches hash
+  `assessment_administration_key` from literal `'state'` (not `'state_nj'` /
+  `'state_fl'`), so they were already not joining to
+  `dim_assessment_administrations.assessment_administration_key`. This
+  pre-existing mismatch is out of scope; flag in the PR body and file a separate
+  issue.
+- `fct_assessment_scores_enrollment_scoped.score_source` literals (`'state_nj'`
+  / `'state_fl'`) stay unchanged — `score_source` is a data-integration label
+  (which system produced the score), not a program-lineage label. Program
+  lineage is already on the fact under `title` and reachable from the joined
+  dim.
+- Cube / BI filters that match `assessment_type = 'state_nj'` need to become
+  `assessment_type LIKE 'state_nj_%'`. Per the marts spec-authoring rule ("No
+  production consumers yet"), this is allowed; call out in the PR body so Cube
+  `cube.yml` filters get audited.
 
 ### Surveys group
 
@@ -88,21 +133,25 @@ marts changes and the rule clarification ship together. See commit
 
 - Remove the stale "DISTINCT projects..." comment block above
   `illuminate_assessments` (no DISTINCT is present in that CTE).
-- `state_nj` and `state_fl`: replace
-  `GROUP BY ... min(assessment_name) as title` with a filtered source CTE
-  feeding `dbt_utils.deduplicate(...)` partitioned on the existing group key,
-  `order_by="assessment_name asc"` (matches `min()` semantics for non-NULL ASCII
-  titles).
+- `state_nj` and `state_fl`: drop the `GROUP BY` and `min(assessment_name)`.
+  Switch to plain `SELECT DISTINCT` over a source CTE that retains
+  `assessment_name`. Project `assessment_name as title` directly. Compose
+  `assessment_type` as `concat('state_nj_', lower(assessment_name))` (or
+  `state_fl_` for FL). Annotate with the standard
+  `-- projection IS the operation, not deduplication`. Update the existing block
+  comments that reference "Collapse historical title variants" — those collapses
+  are now treated as distinct lineages, not collapsed.
 - `college_assessments`, `practice_assessments`, `ap_assessments`: keep
   `SELECT DISTINCT`. Replace the existing "DISTINCT projects..." comment block
-  above each with a single-line annotation:
-  `-- projection IS the operation, not deduplication`.
+  above each with the single-line annotation.
 
-**`dim_assessment_administrations`:** all four non-illuminate CTEs
-(`state_nj_administrations`, `state_fl_administrations`,
-`college_administrations`, `ap_administrations`) keep `SELECT DISTINCT` with the
-same single-line annotation. The illuminate CTE and its existing TODO #3800
-comment stay untouched.
+**`dim_assessment_administrations`:** all four non-illuminate CTEs keep
+`SELECT DISTINCT` with the annotation. `state_nj_administrations` and
+`state_fl_administrations` additionally project `assessment_name` and compose
+the split `assessment_type` per the lineage rules above — matching the dim's
+composition exactly so `assessment_administration_key` and `assessment_key`
+hashes align. The illuminate CTE and its existing TODO #3800 comment stay
+untouched.
 
 ### Surveys marts — redirects
 
@@ -373,16 +422,73 @@ VIRTUAL_ENV= uv \
 
 **Row-count parity** against the PR-branch schema once dbt Cloud CI builds.
 
-- `dim_assessments`, `dim_assessment_administrations`: **0 delta** — the inline
-  changes are byte-identical projection (DISTINCTs annotated) or semantically
-  equivalent (`min(name)` ↔ `dbt_utils.deduplicate(... order_by="name asc")`).
+- `dim_assessments`: **+N rows** where N = count of distinct
+  `(module_code, additional_assessment_name)` pairs minus the current
+  single-row-per-`module_code` count. Pre-merge BQ confirmation:
+
+  ```sql
+  -- expected delta on NJ + FL state branches
+  select
+    (
+      select count(distinct (testcode, assessment_name))
+      from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+      where testscalescore is not null
+    ) - (
+      select count(distinct testcode)
+      from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+      where testscalescore is not null
+    ) as nj_added_rows,
+    (
+      select count(distinct (test_code, assessment_name))
+      from `teamster-332318.kipptaf_fldoe.int_fldoe__all_assessments`
+      where scale_score is not null
+    ) - (
+      select count(distinct test_code)
+      from `teamster-332318.kipptaf_fldoe.int_fldoe__all_assessments`
+      where scale_score is not null
+    ) as fl_added_rows,
+  ```
+
+  Based on the lineage audit, expect roughly +18 NJ rows (NJSLA / PARCC split
+  across ELA / Math test codes) and +14 FL rows (FAST / FSA split plus FSA /
+  Science split). The delta count from PR-branch schema must match this expected
+  count exactly; any other delta means the assessment_type composition or the
+  partition is wrong.
+
+- `dim_assessment_administrations`: **+M rows** where M scales with the number
+  of historical administration occurrences carrying split lineages (multiple
+  admin dates per testcode per region across the years NJSLA and PARCC both ran,
+  etc.). Compute the expected M with the analogous query joined on the admin
+  partition columns, before the commit lands.
 - `dim_survey_questions`, `dim_surveys`, `bridge_survey_questions`: delta
   matches Phase-0 audit counts; any discrepancy is a failed redirect.
 
-**Sample-check canonical titles**: for `state_nj` and `state_fl` (the two CTEs
-that switch from `min()` to `dbt_utils.deduplicate`), pick 20 sample
-`module_code` / `test_code` values and confirm post-deduplicate `title` matches
-pre `min()` result. Any mismatch is a failed `order_by` choice.
+**Spot-check `assessment_type` lineage values**:
+
+```sql
+select assessment_type, count(*)
+from `<pr_branch>.dim_assessments`
+where assessment_type like 'state_%'
+group by 1
+order by 1
+```
+
+Must return exactly: `state_fl_fast`, `state_fl_fsa`, `state_fl_science`,
+`state_nj_njsla`, `state_nj_parcc`. Any other value (e.g. `state_nj_null`, extra
+suffixes) indicates a NULL `assessment_name` upstream or a typo / casing bug in
+the `concat(...)` composition.
+
+**`assessment_name` NULL audit** before commit 1:
+
+```sql
+select
+  countif(assessment_name is null) as n_null_nj,
+from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+where testscalescore is not null
+```
+
+(repeat for FL). Must return 0 in both — otherwise the lineage split produces a
+`state_nj_null` lineage that needs handling.
 
 ## Files touched
 
@@ -401,14 +507,21 @@ don't change.
 
 ## Risks
 
-- **`min()` → `dbt_utils.deduplicate(order_by="name asc")` drift.** `min()` is a
-  deterministic ASCII order on non-NULL values; `dbt_utils.deduplicate` compiles
-  to `array_agg(... order by name asc limit 1)` which is equivalent for non-NULL
-  values, NULLS-LAST. If any `assessment_name` value is NULL in the partition,
-  behavior differs from `min()` (which ignores NULLs). Mitigation: 20-sample
-  title check above; both sources already filter the underlying score column for
-  not-null, but `assessment_name` isn't filtered upstream — verify with a
-  `countif(assessment_name is null)` scan on each source before commit 1.
+- **NULL `assessment_name` produces `state_nj_null` / `state_fl_null` lineage
+  rows.** The `concat('state_nj_', lower(assessment_name))` composition emits
+  `state_nj_null` when `assessment_name` is NULL. Mitigation: pre-commit NULL
+  audit query (see Verification); if any NULL rows exist, exclude them with a
+  source CTE `where` filter and document.
+- **Cube / BI filters break on the `assessment_type` split.** Any Cube filter or
+  query expression matching `assessment_type = 'state_nj'` or `'state_fl'`
+  exact-strings no longer returns rows for state assessments. Mitigation: grep
+  `src/cube/model/` for the literal strings; PR body lists every match plus the
+  `LIKE 'state_nj_%'` migration pattern.
+- **`assessment_administration_key` hash collision with the fct's pre-existing
+  `'state'` literal.** The fact already hashes `'state'` (not `'state_nj'` /
+  `'state_fl'`), so the dim split doesn't make the fact↔dim join worse than it
+  already is. But it also doesn't fix it. Mitigation: out-of-scope flag in PR
+  body + separate follow-up issue.
 - **Surveys redirects shift row counts.** Definitions-grain sources may carry
   rows that responses-grain sources did not, and vice versa. Mitigation: Phase-0
   audit, escalation path documented.
@@ -439,9 +552,11 @@ One PR, three commits plus a pre-commit Phase 0:
    escalate that redirect to a new intermediate before commit 2.
 1. **Assessments + CLAUDE.md.** Single commit: rule clarification in
    `src/dbt/CLAUDE.md`, plus all mart-side changes in `dim_assessments` and
-   `dim_assessment_administrations` (annotate DISTINCTs, switch `state_nj` /
-   `state_fl` to `dbt_utils.deduplicate`, remove stale illuminate comment).
-   Verify zero delta.
+   `dim_assessment_administrations`: annotate pure-projection DISTINCTs; apply
+   lineage split to `state_nj` / `state_fl` (and their admin counterparts) —
+   projecting `assessment_name` and composing the split `assessment_type`;
+   remove stale illuminate comment. Verify expected non-zero row-count delta
+   matches the formula in "Verification".
 2. **Surveys redirects.** All redirects across `dim_survey_questions`,
    `dim_surveys`, `bridge_survey_questions`. Row-count delta against prod is
    expected to match Phase-0 audit counts; flag any discrepancy.

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -5,14 +5,14 @@
 Five mart models in `marts/` use `SELECT DISTINCT` or `GROUP BY` aggregates to
 collapse response-grain (or per-score-grain) rows into entity-grain rows. Some
 of these are pure grain projection (every projected column is functionally
-determined by the partition key); some resolve a canonical attribute from a
-multi-row partition.
+determined by the partition key); some erase meaningful program-level lineage by
+lumping successor assessments together.
 
 `src/dbt/CLAUDE.md` ("SQL conventions") permits DISTINCT for pure grain
 projection with an annotation, and requires `dbt_utils.deduplicate()` when a
 projected column varies within the partition. The fix is to align each CTE with
-the correct construct — not to layer every projection into an intermediate.
-Single-consumer ints add maintenance without payoff.
+the correct construct and surface lineage where it was being erased — not to
+layer every projection into a single-consumer intermediate.
 
 Affected marts (per
 [#3780](https://github.com/TEAMSchools/teamster/issues/3780)):
@@ -26,161 +26,166 @@ Affected marts (per
 
 ## Investigation: per-CTE classification
 
-Each CTE was audited against its source's actual grain and classified by whether
-the collapse is **pure projection** (every projected column functionally
-determined by the partition key — byte-identical tuples coalesce) or
-**canonical-attribute resolution** (at least one projected column varies within
-the partition and needs deterministic selection).
-
 ### Assessments group
 
-| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Collapse type                                                                           | Resolution                                                                                                                                                 |
-| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | No collapse                                                                             | Remove stale "DISTINCT projects..." comment block — no DISTINCT is actually present in the SQL                                                             |
-| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | Pure projection AFTER admitting `assessment_name` as a key column (see "Lineage split") | Switch from `GROUP BY ... min(assessment_name)` to plain DISTINCT with annotation; emit `concat('state_nj_', lower(assessment_name))` as `assessment_type` |
-| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | Pure projection AFTER admitting `assessment_name` as a key column                       | Switch from `GROUP BY ... min(assessment_name)` to plain DISTINCT with annotation; emit `concat('state_fl_', lower(assessment_name))` as `assessment_type` |
-| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key`)                                                                     | Pure projection                                                                         | Keep DISTINCT; replace existing comment block with the annotation phrase                                                                                   |
-| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
-| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
-| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | Pure projection AFTER lineage split                                                     | Keep DISTINCT with annotation; project `assessment_name`; emit `concat('state_nj_', lower(assessment_name))` as `assessment_type`                          |
-| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | Pure projection AFTER lineage split                                                     | Keep DISTINCT with annotation; project `assessment_name`; emit `concat('state_fl_', lower(assessment_name))` as `assessment_type`                          |
-| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
-| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | Pure projection                                                                         | Keep DISTINCT with annotation                                                                                                                              |
+The current `state_nj` and `state_fl` CTEs read from
+`int_pearson__all_assessments` and `int_fldoe__all_assessments` — legacy
+denormalized intermediates that union per-program staging tables together and
+then collapse them in the mart via `GROUP BY ... min(assessment_name)`. This
+both (a) introduces an unnecessary intermediate dependency and (b) erases
+program identity (NJSLA, PARCC, NJSLA Science, NJGPA all land under
+`assessment_type='state_nj'`; FAST, FSA, EOC, Science all under
+`assessment_type='state_fl'`).
 
-Net: **0 new intermediates**, 9 DISTINCT CTEs annotated as pure projection, 2
-lineage-split rewrites (state_nj, state_fl across both marts), 1 stale comment
-block removed. No `dbt_utils.deduplicate` switches (the lineage split makes the
-`min()` resolution unnecessary).
+**Fix**: in both marts, replace the single `state_nj` / `state_fl` CTE with one
+CTE per Pearson / FLDOE staging table. Each new CTE is a plain `SELECT DISTINCT`
+(pure projection) from one staging table, emitting a literal `assessment_type`
+that encodes both the region and the program lineage:
 
-### Lineage split: NJSLA / PARCC and FAST / FSA / Science
+| Region     | Lineage    | Staging source               | `assessment_type` literal  |
+| ---------- | ---------- | ---------------------------- | -------------------------- |
+| New Jersey | PARCC      | `stg_pearson__parcc`         | `'state_nj_parcc'`         |
+| New Jersey | NJSLA      | `stg_pearson__njsla`         | `'state_nj_njsla'`         |
+| New Jersey | NJSLA Sci. | `stg_pearson__njsla_science` | `'state_nj_njsla_science'` |
+| New Jersey | NJGPA      | `stg_pearson__njgpa`         | `'state_nj_njgpa'`         |
+| Florida    | FAST       | `stg_fldoe__fast`            | `'state_fl_fast'`          |
+| Florida    | FSA        | `stg_fldoe__fsa`             | `'state_fl_fsa'`           |
+| Florida    | EOC        | `stg_fldoe__eoc`             | `'state_fl_eoc'`           |
+| Florida    | Science    | `stg_fldoe__science`         | `'state_fl_science'`       |
 
-The current `state_nj` and `state_fl` CTEs collapse historical title variants
-(`NJSLA | PARCC` on every NJ ELA / Math testcode; `FAST | FSA` on every FL ELA /
-Math testcode; `FSA | Science` on SCI05 / SCI08) into one mart row per
-`(module_code, grade)` with `min(assessment_name) as title`. Successor
-assessments (NJSLA after PARCC, FAST after FSA) are different programs
-administered to similar student populations — surfacing them as one dim row
-erases that distinction.
+The remaining non-state CTEs stay as DISTINCT with the standard annotation (pure
+projection); none requires `dbt_utils.deduplicate` since no projected column
+varies within the partition.
 
-**Fix**: include `assessment_name` in the state-branch projections; encode the
-program-level distinction in `assessment_type`. Per-region literal `'state_nj'`
-becomes `'state_nj_njsla'` / `'state_nj_parcc'`. Per-region literal `'state_fl'`
-becomes `'state_fl_fast'` / `'state_fl_fsa'` / `'state_fl_science'`.
+| Mart CTE                                         | Source                                         | Collapse type   | Resolution                                                                                     |
+| ------------------------------------------------ | ---------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------- |
+| `dim_assessments.illuminate_assessments`         | `int_assessments__assessments`                 | No collapse     | Remove stale "DISTINCT projects..." comment block — no DISTINCT is actually present in the SQL |
+| `dim_assessments` state CTEs (×8)                | per-program Pearson / FLDOE staging            | Pure projection | One CTE per staging table, literal `assessment_type`, plain DISTINCT with annotation           |
+| `dim_assessments.college_assessments`            | `int_assessments__college_assessment`          | Pure projection | Keep DISTINCT; replace existing comment block with the annotation phrase                       |
+| `dim_assessments.practice_assessments`           | `int_assessments__college_assessment_practice` | Pure projection | Keep DISTINCT with annotation                                                                  |
+| `dim_assessments.ap_assessments`                 | `int_assessments__ap_assessments`              | Pure projection | Keep DISTINCT with annotation                                                                  |
+| `dim_assessment_administrations` state CTEs (×8) | per-program Pearson / FLDOE staging            | Pure projection | One CTE per staging table, literal `assessment_type`, plain DISTINCT with annotation           |
+| `dim_assessment_administrations.college_*`       | `int_assessments__college_assessment`          | Pure projection | Keep DISTINCT with annotation                                                                  |
+| `dim_assessment_administrations.ap_*`            | `int_assessments__ap_assessments`              | Pure projection | Keep DISTINCT with annotation                                                                  |
 
-After the split, `state_nj` and `state_fl` CTEs become pure projection (every
-projected column functionally determined by the new partition key that includes
-`assessment_name`) — straight DISTINCT with the standard annotation. Same in the
-corresponding `dim_assessment_administrations` CTEs.
-
-**Hash composition is unchanged.** `assessment_key` and
-`assessment_administration_key` continue to hash from
-`assessment_type, module_code, source_assessment_id, test_type` (and
-admin-specific extras). The type-string split causes hashes to diverge naturally
-— no input list change required.
-
-**Downstream impact**:
-
-- `fct_assessment_scores_enrollment_scoped` state branches hash
-  `assessment_administration_key` from literal `'state'` (not `'state_nj'` /
-  `'state_fl'`), so they were already not joining to
-  `dim_assessment_administrations.assessment_administration_key`. This
-  pre-existing mismatch is out of scope; flag in the PR body and file a separate
-  issue.
-- `fct_assessment_scores_enrollment_scoped.score_source` literals (`'state_nj'`
-  / `'state_fl'`) stay unchanged — `score_source` is a data-integration label
-  (which system produced the score), not a program-lineage label. Program
-  lineage is already on the fact under `title` and reachable from the joined
-  dim.
-- Cube / BI filters that match `assessment_type = 'state_nj'` need to become
-  `assessment_type LIKE 'state_nj_%'`. Per the marts spec-authoring rule ("No
-  production consumers yet"), this is allowed; call out in the PR body so Cube
-  `cube.yml` filters get audited.
+Net: **0 new intermediates**, 16 staging-direct CTEs replace 4 legacy
+int-sourced CTEs, all DISTINCTs annotated as pure projection. The
+`int_pearson__all_assessments` and `int_fldoe__all_assessments` dependencies
+disappear from the marts (legacy denormalized intermediates that shouldn't have
+been mart sources).
 
 ### Surveys group
 
 The surveys-side investigation surfaced that all four current
-DISTINCT-collapsing CTEs in `dim_survey_questions` (and their bridge / dim
-counterparts) can resolve to **redirect** or **drop** — entity-grain upstreams
-already exist.
+DISTINCT-collapsing CTEs in `dim_survey_questions` and the bridge can resolve to
+**redirect** to existing entity-grain models. `dim_surveys` keeps its hardcoded
+archive rows (`archive_manager`, `archive_support`, `powerschool_family`) —
+these synthesize survey_key rows for legacy data whose original IDs were not
+preserved, and downstream facts (`fct_survey_submissions:231`,
+`dim_survey_administrations:64`) filter by the synthetic IDs.
 
-| Mart CTE                                        | Current source                                                                      | Entity-grain upstream that already exists                                                                                                            | Resolution                                                                                                                                                                                                        |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dim_survey_questions.google_forms_questions`   | `int_google_forms__form_responses` (response grain)                                 | `int_google_forms__form__items` (item / question grain — carries `form_id`, `item_abbreviation`, `item_title`, `question_kind`, `question_required`) | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                   |
-| `dim_survey_questions.scd_questions`            | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain (BQ check: 10 rows = 10 distinct `question_code` values in the `School_Survey_%` filter)                                   | **No-op** — mart CTE already uses plain `SELECT`, no DISTINCT to remove                                                                                                                                           |
-| `dim_survey_questions.alchemer_questions`       | `int_surveys__survey_responses` (response grain — union of Google Forms + Alchemer) | `stg_alchemer__survey_question` (per-`(survey_id, id)` grain, carries `shortname`, `title_english`)                                                  | **Redirect** to `stg_alchemer__survey_question`, scoped to Alchemer questions only. Google Forms questions in this CTE are now covered by the gforms redirect above                                               |
-| `dim_survey_questions.manager_questions`        | `int_surveys__manager_survey_details` (response grain)                              | Manager Survey is Google Form `'1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'`; its questions are already in `int_google_forms__form__items`         | **Drop** the CTE entirely. Coverage is redundant once gforms redirect lands. Per the post-#3899 comment in `int_surveys__manager_survey_details`, live Manager Survey identity already flows through Google Forms |
-| `dim_surveys.google_forms_surveys`              | `int_google_forms__form_responses` (response grain)                                 | `stg_google_forms__form` (form / survey grain — carries `form_id`, `info_title`)                                                                     | **Redirect** to `stg_google_forms__form`                                                                                                                                                                          |
-| `dim_surveys.alchemer_surveys`                  | `source("alchemer", "base_alchemer__survey_results")` (response grain)              | `stg_alchemer__survey` (per-`id` survey grain)                                                                                                       | **Redirect** to `stg_alchemer__survey`                                                                                                                                                                            |
-| `bridge_survey_questions.google_forms_pairs`    | `int_google_forms__form_responses`                                                  | `int_google_forms__form__items` carries `(form_id, item_abbreviation, question_required)`                                                            | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                   |
-| `bridge_survey_questions.alchemer_pairs`        | `int_surveys__survey_responses`                                                     | `stg_alchemer__survey_question` carries `(survey_id, shortname)`                                                                                     | **Redirect** to `stg_alchemer__survey_question`                                                                                                                                                                   |
-| `bridge_survey_questions.manager_pairs`         | `int_surveys__manager_survey_details`                                               | Subset of Google Forms after the gforms redirect                                                                                                     | **Drop** the CTE entirely                                                                                                                                                                                         |
-| `bridge_survey_questions.scd_powerschool_pairs` | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain                                                                                                                            | **No-op** — already uses plain `SELECT`                                                                                                                                                                           |
+| Mart CTE                                        | Current source                                        | Resolution                                                                                                                                                                                                                                                                                                             |
+| ----------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dim_survey_questions.google_forms_questions`   | `int_google_forms__form_responses` (response)         | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                                                                                                                        |
+| `dim_survey_questions.scd_questions`            | `stg_google_sheets__surveys__scd_question_crosswalk`  | **No-op** — already plain SELECT, no DISTINCT to remove                                                                                                                                                                                                                                                                |
+| `dim_survey_questions.alchemer_questions`       | `int_surveys__survey_responses` (response)            | **Redirect** to `stg_alchemer__survey_question` (Alchemer rows only; Google Forms questions in this CTE are now covered by the gforms redirect)                                                                                                                                                                        |
+| `dim_survey_questions.manager_questions`        | `int_surveys__manager_survey_details` (response)      | **Drop** — live Manager Survey questions covered by the gforms redirect (same form_id); question grain carries no survey_id so the historic synthetic survey_id concern is bridge-side only                                                                                                                            |
+| `dim_surveys.google_forms_surveys`              | `int_google_forms__form_responses`                    | **Redirect** to `stg_google_forms__form`                                                                                                                                                                                                                                                                               |
+| `dim_surveys.alchemer_surveys`                  | `source("alchemer", "base_alchemer__survey_results")` | **Redirect** to `stg_alchemer__survey`                                                                                                                                                                                                                                                                                 |
+| `dim_surveys.archive_manager`                   | (hardcoded literal)                                   | **Keep.** Synthesizes `survey_id='historic_alchemer_Manager_survey'`; referenced by downstream filters                                                                                                                                                                                                                 |
+| `dim_surveys.archive_support`                   | (hardcoded literal)                                   | **Keep.** Synthesizes `survey_id='historic_alchemer_cmo_support_survey'`; referenced by downstream filters                                                                                                                                                                                                             |
+| `dim_surveys.powerschool_family`                | (hardcoded literal)                                   | **Keep.** Unchanged.                                                                                                                                                                                                                                                                                                   |
+| `bridge_survey_questions.google_forms_pairs`    | `int_google_forms__form_responses`                    | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                                                                                                                        |
+| `bridge_survey_questions.alchemer_pairs`        | `int_surveys__survey_responses`                       | **Redirect** to `stg_alchemer__survey_question`                                                                                                                                                                                                                                                                        |
+| `bridge_survey_questions.manager_pairs`         | `int_surveys__manager_survey_details`                 | **Redirect, not drop.** Produce `('historic_alchemer_Manager_survey', <shortname>, null)` pairs from `int_google_forms__form__items` filtered to `form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'`. Live Manager Survey pairs (under the real `form_id` survey_id) are already covered by the gforms redirect |
+| `bridge_survey_questions.scd_powerschool_pairs` | `stg_google_sheets__surveys__scd_question_crosswalk`  | **No-op** — already plain SELECT                                                                                                                                                                                                                                                                                       |
 
-Net: **0 new intermediates**, 6 redirects, 2 redundant CTEs dropped, 2 no-ops.
+Net: **0 new intermediates**, 7 redirects, 1 redundant CTE dropped
+(`manager_questions`), 2 no-ops on SCD CTEs, 3 hardcoded literal CTEs in
+`dim_surveys` retained.
 
 ## Architecture
 
 ### Companion `src/dbt/CLAUDE.md` change
 
 Replace the "No manual deduplication" bullet with two bullets that distinguish
-dirty-data workarounds from pure grain projection. Applied in the same PR so the
-marts changes and the rule clarification ship together. See commit
-(`refactor(dbt): permit DISTINCT for pure grain projection`).
+dirty-data workarounds from pure grain projection. Already applied in this
+branch — see commit `2008a52`
+(`refactor(dbt): permit DISTINCT for pure grain projection`). The new rules:
 
-### Assessments marts — inline rewrites
+- **No manual deduplication for dirty data** — `dbt_utils.deduplicate()` with a
+  `-- TODO:` comment naming the upstream fix.
+- **DISTINCT is allowed for pure grain projection** — every projected column
+  functionally determined by the partition key; annotate with
+  `projection IS the operation, not deduplication`.
+
+### Assessments marts — staging-direct CTEs
 
 **`dim_assessments`:**
 
 - Remove the stale "DISTINCT projects..." comment block above
   `illuminate_assessments` (no DISTINCT is present in that CTE).
-- `state_nj` and `state_fl`: drop the `GROUP BY` and `min(assessment_name)`.
-  Switch to plain `SELECT DISTINCT` over a source CTE that retains
-  `assessment_name`. Project `assessment_name as title` directly. Compose
-  `assessment_type` as `concat('state_nj_', lower(assessment_name))` (or
-  `state_fl_` for FL). Annotate with the standard
-  `-- projection IS the operation, not deduplication`. Update the existing block
-  comments that reference "Collapse historical title variants" — those collapses
-  are now treated as distinct lineages, not collapsed.
+- Replace the single `state_nj` CTE with four CTEs (`parcc`, `njsla`,
+  `njsla_science`, `njgpa`), each reading from its corresponding Pearson staging
+  table, each emitting a literal `assessment_type` per the lineage table above.
+  Each is `SELECT DISTINCT` with the projection annotation. The existing
+  `case testcode when 'SC05' ...` module_code normalization moves to whichever
+  CTEs carry SC-prefixed testcodes (typically `njsla_science`).
+- Replace the single `state_fl` CTE with four CTEs (`fast`, `fsa`, `eoc`,
+  `science`) on the same pattern.
 - `college_assessments`, `practice_assessments`, `ap_assessments`: keep
-  `SELECT DISTINCT`. Replace the existing "DISTINCT projects..." comment block
-  above each with the single-line annotation.
+  `SELECT DISTINCT`; replace existing comment blocks with the annotation.
+- Final UNION ALL grows from 6 branches to 12; `all_assessments_unioned`
+  partition_by stays the same
+  (`assessment_type, source_assessment_id, module_code, test_type`). The
+  downstream dedup remains as defense-in-depth against cross-branch collisions.
 
-**`dim_assessment_administrations`:** all four non-illuminate CTEs keep
-`SELECT DISTINCT` with the annotation. `state_nj_administrations` and
-`state_fl_administrations` additionally project `assessment_name` and compose
-the split `assessment_type` per the lineage rules above — matching the dim's
-composition exactly so `assessment_administration_key` and `assessment_key`
-hashes align. The illuminate CTE and its existing TODO #3800 comment stay
-untouched.
+**`dim_assessment_administrations`:**
+
+- Same per-staging-table CTE split for the eight non-illuminate administration
+  CTEs (4 Pearson + 4 FLDOE). Each plain `SELECT DISTINCT` with annotation;
+  literal `assessment_type` matching the dim's value.
+- College and AP admin CTEs stay; replace comment blocks with the annotation
+  phrase.
+- The existing illuminate CTE and its TODO #3800 comment stay untouched.
+
+**Hash composition unchanged.** `assessment_key` (in `dim_assessments`) and
+`assessment_administration_key` (in `dim_assessment_administrations`) continue
+to hash from `assessment_type, module_code, source_assessment_id, test_type` (+
+admin-specific extras). The `assessment_type` literal split causes hashes to
+diverge naturally — no hash-input list change required.
+
+**Why one CTE per staging table** (over a single CTE with inner UNION ALL):
+mirrors the existing per-`assessment_type` pattern already in `dim_assessments`
+(illuminate / college / practice / ap each have their own CTE); makes
+per-lineage logic — including the `SC05`-style module code normalization —
+co-located with its source; lets reviewers diff a single CTE against its staging
+table without indirection.
 
 ### Surveys marts — redirects
 
-| Mart CTE                                      | Replace `ref(...)` with                |
-| --------------------------------------------- | -------------------------------------- |
-| `dim_survey_questions.google_forms_questions` | `ref("int_google_forms__form__items")` |
-| `dim_survey_questions.alchemer_questions`     | `ref("stg_alchemer__survey_question")` |
-| `dim_survey_questions.manager_questions`      | (delete CTE + its UNION ALL branch)    |
-| `dim_surveys.google_forms_surveys`            | `ref("stg_google_forms__form")`        |
-| `dim_surveys.alchemer_surveys`                | `ref("stg_alchemer__survey")`          |
-| `bridge_survey_questions.google_forms_pairs`  | `ref("int_google_forms__form__items")` |
-| `bridge_survey_questions.alchemer_pairs`      | `ref("stg_alchemer__survey_question")` |
-| `bridge_survey_questions.manager_pairs`       | (delete CTE + its UNION ALL branch)    |
+| Mart CTE                                      | Replace `ref(...)` with                                                                                                                                                                |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dim_survey_questions.google_forms_questions` | `ref("int_google_forms__form__items")`                                                                                                                                                 |
+| `dim_survey_questions.alchemer_questions`     | `ref("stg_alchemer__survey_question")`                                                                                                                                                 |
+| `dim_survey_questions.manager_questions`      | (delete CTE + its UNION ALL branch)                                                                                                                                                    |
+| `dim_surveys.google_forms_surveys`            | `ref("stg_google_forms__form")`                                                                                                                                                        |
+| `dim_surveys.alchemer_surveys`                | `ref("stg_alchemer__survey")`                                                                                                                                                          |
+| `bridge_survey_questions.google_forms_pairs`  | `ref("int_google_forms__form__items")`                                                                                                                                                 |
+| `bridge_survey_questions.alchemer_pairs`      | `ref("stg_alchemer__survey_question")`                                                                                                                                                 |
+| `bridge_survey_questions.manager_pairs`       | `ref("int_google_forms__form__items")` filtered to `form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'`, projecting the synthetic `'historic_alchemer_Manager_survey'` survey_id |
 
-All four `SELECT DISTINCT` clauses in the surveys trio drop to plain `SELECT`
-because the redirect targets are already at entity grain. Final mart row-count
-delta is whatever the difference is between "every (survey, question) pair that
-has ever appeared in a response" (current) and "every (survey, question) pair
-that exists in the form / question definition" (post-redirect).
+`archive_manager`, `archive_support`, `powerschool_family` hardcoded literals in
+`dim_surveys` are untouched.
 
 ## Phase 0: Pre-merge BQ shape audit
 
-The surveys redirects move grain from "appears in any response" to "exists as a
+Surveys redirects move grain from "appears in any response" to "exists as a
 definition" — the row-count delta isn't predictable from inspection. Before
-mart-side commits land, run these queries against prod to size the delta per
-redirect and surface anything anomalous. Each query is a symmetric-difference
-count plus a small sample of unmatched rows; if the delta is large or asymmetric
-in a way the redirect can't explain, escalate that redirect to a new int
-instead.
+mart-side commits land, run these queries against prod to size each delta and
+surface anomalies. Each query is a symmetric-difference count; if delta is
+asymmetric in a way the redirect can't explain, escalate that redirect to a new
+int.
 
 Schemas: `kipptaf_google_forms`, `kipptaf_alchemer`, `kipptaf_surveys`,
 `kipptaf_google_sheets`.
@@ -226,8 +231,7 @@ with
     from `teamster-332318.kipptaf_surveys.int_surveys__survey_responses`
     where question_shortname is not null
       and survey_id is not null
-      -- scope to Alchemer rows only; Google Forms rows now flow through redirect A
-      and safe_cast(survey_id as int) is not null
+      and safe_cast(survey_id as int) is not null  -- Alchemer rows only
   ),
   target as (
     select
@@ -290,11 +294,7 @@ select
   (select count(*) from target except distinct select * from current) as n_target_only,
 ```
 
-(Resolve `<title_col>` from `stg_alchemer__survey` schema at query time — the
-staging model uses `dbt_utils.star()` so the title column name depends on the
-source. Run
-`select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'stg_alchemer__survey'`
-first.)
+(Resolve `<title_col>` from `stg_alchemer__survey` schema at query time.)
 
 ### E. Google Forms bridge pairs
 
@@ -342,70 +342,57 @@ select
   (select count(*) from target except distinct select * from current) as n_target_only,
 ```
 
-### G. Manager drop validation
+### G. Manager-pairs redirect equivalence
 
-Confirm that every `(survey_id, question_shortname)` pair the manager CTEs
-currently contribute is already covered by the gforms or SCD surfaces (otherwise
-the drop loses rows):
+Confirm the redirect target produces the same set of
+`('historic_alchemer_Manager_survey', shortname)` pairs that the current
+`int_surveys__manager_survey_details`-sourced CTE produces:
 
 ```sql
 with
-  manager_pairs as (
+  current as (
     select distinct survey_id, question_shortname
     from `teamster-332318.kipptaf_surveys.int_surveys__manager_survey_details`
-    where survey_id is not null and question_shortname is not null
+    where survey_id = 'historic_alchemer_Manager_survey'
+      and question_shortname is not null
   ),
-  gforms_pairs as (
-    select form_id as survey_id, item_abbreviation as question_shortname
+  target as (
+    select
+      'historic_alchemer_Manager_survey' as survey_id,
+      item_abbreviation as question_shortname,
     from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
-    where item_abbreviation is not null
-  ),
-  scd_pairs as (
-    select 'PowerSchool' as survey_id, question_code as question_shortname
-    from `teamster-332318.kipptaf_google_sheets.stg_google_sheets__surveys__scd_question_crosswalk`
-    where question_code like 'School_Survey_%'
-  ),
-  covered as (
-    select * from gforms_pairs
-    union all
-    select * from scd_pairs
+    where form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
+      and item_abbreviation is not null
   )
 select
-  (select count(*) from manager_pairs) as n_manager,
-  (
-    select count(*)
-    from manager_pairs
-    except distinct
-    select * from covered
-  ) as n_manager_uncovered,
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
 ```
 
-`n_manager_uncovered` must be 0 (or only `historic_alchemer_Manager_survey`
-archive rows, handled by the hardcoded `archive_manager` CTE in `dim_surveys`).
-Any other uncovered rows mean the drop is unsafe — keep the CTE.
+`n_current_only` must be 0 (every historic Manager pair must exist in the Google
+Form's items). Non-zero means the redirect drops pairs and needs a more complete
+source.
 
 ### Phase-0 decision rules
 
 For each redirect A–F:
 
-- **Symmetric delta (`n_target` near `n_current` with small `n_*_only` on both
-  sides)**: redirect safe. Document counts in PR body and proceed.
-- **Large `n_target_only`**: many definitions never received responses. Expected
-  for surveys with low completion rates; safe to proceed.
-- **Large `n_current_only`**: response rows reference a (survey, question) the
-  definition source doesn't carry — typically renamed shortnames or
-  deleted/recreated forms. Sample 10 unmatched rows; if they trace to legitimate
-  historical data, escalate that redirect to a new intermediate that unions
-  definition with historical response artifacts. Otherwise (test / orphan rows),
-  document and proceed.
+- **Symmetric delta**: redirect safe. Document counts in PR body, proceed.
+- **Large `n_target_only`**: many definitions never received responses.
+  Expected; proceed.
+- **Large `n_current_only`**: response rows reference a definition the target
+  doesn't carry. Sample 10 unmatched rows; if legitimate historical data,
+  escalate to a new int that unions definition with historical artifacts.
+  Otherwise document and proceed.
 
-Query G must return `n_manager_uncovered = 0` to proceed with the manager CTE
-drops in commit 3.
+Query G must return `n_current_only = 0` to proceed with the `manager_pairs`
+redirect in commit 2.
 
 ## Verification
 
-Per CLAUDE.md superpowers override "For dbt changes,
-`uv run dbt build --select <model>+`":
+Per CLAUDE.md superpowers override:
 
 ```bash
 VIRTUAL_ENV= uv \
@@ -420,82 +407,59 @@ VIRTUAL_ENV= uv \
     +bridge_survey_questions
 ```
 
-**Row-count parity** against the PR-branch schema once dbt Cloud CI builds.
-
-- `dim_assessments`: **+N rows** where N = count of distinct
-  `(module_code, additional_assessment_name)` pairs minus the current
-  single-row-per-`module_code` count. Pre-merge BQ confirmation:
-
-  ```sql
-  -- expected delta on NJ + FL state branches
-  select
-    (
-      select count(distinct (testcode, assessment_name))
-      from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
-      where testscalescore is not null
-    ) - (
-      select count(distinct testcode)
-      from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
-      where testscalescore is not null
-    ) as nj_added_rows,
-    (
-      select count(distinct (test_code, assessment_name))
-      from `teamster-332318.kipptaf_fldoe.int_fldoe__all_assessments`
-      where scale_score is not null
-    ) - (
-      select count(distinct test_code)
-      from `teamster-332318.kipptaf_fldoe.int_fldoe__all_assessments`
-      where scale_score is not null
-    ) as fl_added_rows,
-  ```
-
-  Based on the lineage audit, expect roughly +18 NJ rows (NJSLA / PARCC split
-  across ELA / Math test codes) and +14 FL rows (FAST / FSA split plus FSA /
-  Science split). The delta count from PR-branch schema must match this expected
-  count exactly; any other delta means the assessment_type composition or the
-  partition is wrong.
-
-- `dim_assessment_administrations`: **+M rows** where M scales with the number
-  of historical administration occurrences carrying split lineages (multiple
-  admin dates per testcode per region across the years NJSLA and PARCC both ran,
-  etc.). Compute the expected M with the analogous query joined on the admin
-  partition columns, before the commit lands.
-- `dim_survey_questions`, `dim_surveys`, `bridge_survey_questions`: delta
-  matches Phase-0 audit counts; any discrepancy is a failed redirect.
-
-**Spot-check `assessment_type` lineage values**:
+**`dim_assessments` row-count delta**:
 
 ```sql
-select assessment_type, count(*)
+-- expected delta per region after lineage split
+with
+  nj_current as (
+    select count(distinct testcode) as n
+    from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
+    where testscalescore is not null
+  ),
+  nj_after as (
+    select count(distinct (table_name, testcode)) as n
+    from (
+      select 'parcc' as table_name, testcode from `teamster-332318.kipptaf_pearson.stg_pearson__parcc` where testscalescore is not null
+      union all select 'njsla', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njsla` where testscalescore is not null
+      union all select 'njsla_science', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njsla_science` where testscalescore is not null
+      union all select 'njgpa', testcode from `teamster-332318.kipptaf_pearson.stg_pearson__njgpa` where testscalescore is not null
+    )
+  )
+select (select n from nj_after) - (select n from nj_current) as nj_added_rows
+```
+
+(Repeat the analogous query for FL across the four FLDOE staging tables.)
+Compute these expected deltas before commit 1; the PR-branch row counts must
+match. Any other delta = a partition-by or lineage-label bug.
+
+**`dim_assessment_administrations` row-count delta** scales with the number of
+(date, region, period) tuples carrying multiple lineages. Compute analogously
+across the admin partition columns before commit 1.
+
+**`assessment_type` lineage spot-check**:
+
+```sql
+select assessment_type, count(*) as n_module_codes
 from `<pr_branch>.dim_assessments`
 where assessment_type like 'state_%'
 group by 1
 order by 1
 ```
 
-Must return exactly: `state_fl_fast`, `state_fl_fsa`, `state_fl_science`,
-`state_nj_njsla`, `state_nj_parcc`. Any other value (e.g. `state_nj_null`, extra
-suffixes) indicates a NULL `assessment_name` upstream or a typo / casing bug in
-the `concat(...)` composition.
+Must return exactly the 8 expected values: `state_fl_eoc`, `state_fl_fast`,
+`state_fl_fsa`, `state_fl_science`, `state_nj_njgpa`, `state_nj_njsla`,
+`state_nj_njsla_science`, `state_nj_parcc`. Any other value indicates a typo or
+unintended staging-table-name suffix leak.
 
-**`assessment_name` NULL audit** before commit 1:
-
-```sql
-select
-  countif(assessment_name is null) as n_null_nj,
-from `teamster-332318.kipptaf_pearson.int_pearson__all_assessments`
-where testscalescore is not null
-```
-
-(repeat for FL). Must return 0 in both — otherwise the lineage split produces a
-`state_nj_null` lineage that needs handling.
+**Surveys row-count delta**: matches Phase-0 audit counts; any discrepancy is a
+failed redirect.
 
 ## Files touched
 
 **Modified**:
 
-- `src/dbt/CLAUDE.md` — split "No manual deduplication" bullet (companion rule
-  clarification)
+- `src/dbt/CLAUDE.md` — already done in commit `2008a52`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql`
@@ -505,60 +469,67 @@ where testscalescore is not null
 **New**: none. Mart-side changes only; YAML untouched since contract surfaces
 don't change.
 
+**Removed dependencies**: marts no longer `ref()` `int_pearson__all_assessments`
+or `int_fldoe__all_assessments`. The int models themselves stay (other consumers
+exist or may exist).
+
 ## Risks
 
-- **NULL `assessment_name` produces `state_nj_null` / `state_fl_null` lineage
-  rows.** The `concat('state_nj_', lower(assessment_name))` composition emits
-  `state_nj_null` when `assessment_name` is NULL. Mitigation: pre-commit NULL
-  audit query (see Verification); if any NULL rows exist, exclude them with a
-  source CTE `where` filter and document.
-- **Cube / BI filters break on the `assessment_type` split.** Any Cube filter or
-  query expression matching `assessment_type = 'state_nj'` or `'state_fl'`
-  exact-strings no longer returns rows for state assessments. Mitigation: grep
-  `src/cube/model/` for the literal strings; PR body lists every match plus the
-  `LIKE 'state_nj_%'` migration pattern.
+- **Cube / BI filters break on the `assessment_type` split.** Any Cube filter
+  matching exact `'state_nj'` / `'state_fl'` returns nothing for state
+  assessments. Mitigation: grep `src/cube/model/` for the literals; PR body
+  lists every match plus the `LIKE 'state_nj_%'` migration pattern.
 - **`assessment_administration_key` hash collision with the fct's pre-existing
-  `'state'` literal.** The fact already hashes `'state'` (not `'state_nj'` /
-  `'state_fl'`), so the dim split doesn't make the fact↔dim join worse than it
-  already is. But it also doesn't fix it. Mitigation: out-of-scope flag in PR
-  body + separate follow-up issue.
-- **Surveys redirects shift row counts.** Definitions-grain sources may carry
-  rows that responses-grain sources did not, and vice versa. Mitigation: Phase-0
-  audit, escalation path documented.
+  `'state'` literal.** Pre-existing — the fact already hashes `'state'` (not the
+  region/lineage), so its admin-key never matched the dim's. Out of scope for
+  this spec; flag and file follow-up.
+- **Staging-table column drift.** The four Pearson staging tables share the
+  columns the mart projects (`discipline`, `test_grade`, `subject`, `testcode`,
+  `testscalescore`, `administration_window`, etc.) by way of
+  `dbt_utils.union_relations` in the int — same for FLDOE. If any staging table
+  drops or renames one of those columns, the per-staging-table CTE breaks at
+  compile time (contract enforcement would catch it). Mitigation: dbt build
+  catches before merge.
 - **Pure-projection misclassification.** A CTE classified as pure projection but
-  actually carrying a column that varies in the partition would silently pick
-  the wrong row when DISTINCT coalesces tuples that differ. Mitigation: each
-  "pure projection" CTE in the assessments marts was inspected and only contains
-  columns derivable from the partition key (constants, casts of constants, and
-  the partition columns themselves). On any future addition of a non-derivable
-  column to one of these CTEs, the annotation rule forces a switch to
-  `dbt_utils.deduplicate`.
+  actually carrying a column that varies in the partition would silently
+  coalesce divergent tuples. Mitigation: each new state CTE projects only
+  literals, partition columns, and casts of partition columns — no per-row
+  varying attributes. The annotation comment forces a switch to
+  `dbt_utils.deduplicate` on any future addition of a non-derivable column.
+- **Manager-pairs redirect loses pairs.** If the historic Manager Survey
+  response data references shortnames the Google Form's items don't carry, the
+  redirect drops rows. Mitigation: Phase 0 query G must return
+  `n_current_only = 0`.
 
 ## Out of scope
 
-- `dim_assessment_administrations.illuminate_administrations` (TODO #3800 in the
-  existing source, tracked separately).
-- Any column renames, FK restructures, or hash recompositions on the mart side.
-- Re-org of `int_assessments__assessments` itself.
-- `int_surveys__manager_survey_details` post-#3899 cleanup (#3918) — this spec
-  drops the mart's reads of it, but the model stays.
+- `dim_assessment_administrations.illuminate_administrations` (TODO #3800).
+- Column renames, FK restructures, or hash recompositions on the mart side.
+- Re-org of `int_assessments__assessments`.
+- Pre-existing `fct_assessment_scores_enrollment_scoped` state-branch admin-key
+  hash mismatch (uses `'state'` literal vs dim's region-split values). File
+  separate issue.
+- `int_surveys__manager_survey_details` post-#3899 cleanup (#3918).
+- Removal of `archive_manager` / `archive_support` synthetic survey rows in
+  `dim_surveys` — load-bearing for downstream filters.
 
 ## Sequencing
 
 One PR, three commits plus a pre-commit Phase 0:
 
-0. **Phase 0 (no commit)**: run BQ queries A–G against prod. Paste results into
-   the PR body. Apply Phase-0 decision rules; if any redirect fails its rule,
-   escalate that redirect to a new intermediate before commit 2.
-1. **Assessments + CLAUDE.md.** Single commit: rule clarification in
-   `src/dbt/CLAUDE.md`, plus all mart-side changes in `dim_assessments` and
-   `dim_assessment_administrations`: annotate pure-projection DISTINCTs; apply
-   lineage split to `state_nj` / `state_fl` (and their admin counterparts) —
-   projecting `assessment_name` and composing the split `assessment_type`;
-   remove stale illuminate comment. Verify expected non-zero row-count delta
-   matches the formula in "Verification".
+0. **Phase 0 (no commit)**: run BQ queries A–G against prod. Compute the
+   expected `dim_assessments` / `dim_assessment_administrations` row-count
+   deltas per "Verification". Paste all results into the PR body. Apply Phase-0
+   decision rules; escalate any failed redirect to a new intermediate before
+   commit 2.
+1. **Assessments mart rewrite.** Single commit: replace `state_nj` and
+   `state_fl` CTEs in both marts with the eight per-staging-table CTEs; annotate
+   the surviving pure-projection DISTINCTs; remove stale illuminate comment.
+   Verify expected non-zero row-count delta matches the Phase-0 formula.
 2. **Surveys redirects.** All redirects across `dim_survey_questions`,
-   `dim_surveys`, `bridge_survey_questions`. Row-count delta against prod is
-   expected to match Phase-0 audit counts; flag any discrepancy.
-3. **Drop manager CTEs** (gated on Phase 0 query G returning
-   `n_manager_uncovered = 0`). Verify zero net delta vs commit 2.
+   `dim_surveys`, `bridge_survey_questions` (including `manager_pairs` redirect
+   to gforms items). Drop the `manager_questions` CTE. Row-count delta against
+   prod is expected to match Phase-0 counts; flag any discrepancy.
+3. **Cube migration (if needed).** If Phase-0 cube grep surfaces filters on the
+   old `assessment_type='state_nj'` / `'state_fl'` literals, swap to
+   `LIKE 'state_nj_%'` patterns. If no matches, skip this commit.

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -2,11 +2,17 @@
 
 ## Problem
 
-Five mart models in `marts/` collapse response-grain (or per-score-grain) rows
-into entity-grain rows using `SELECT DISTINCT` or `GROUP BY` aggregates. This
-violates `src/dbt/CLAUDE.md` "No manual deduplication" and "Canonical attributes
-from a partition." The collapse belongs in intermediates so marts can read
-pre-projected, entity-grain rows.
+Five mart models in `marts/` use `SELECT DISTINCT` or `GROUP BY` aggregates to
+collapse response-grain (or per-score-grain) rows into entity-grain rows. Some
+of these are pure grain projection (every projected column is functionally
+determined by the partition key); some resolve a canonical attribute from a
+multi-row partition.
+
+`src/dbt/CLAUDE.md` ("SQL conventions") permits DISTINCT for pure grain
+projection with an annotation, and requires `dbt_utils.deduplicate()` when a
+projected column varies within the partition. The fix is to align each CTE with
+the correct construct — not to layer every projection into an intermediate.
+Single-consumer ints add maintenance without payoff.
 
 Affected marts (per
 [#3780](https://github.com/TEAMSchools/teamster/issues/3780)):
@@ -18,37 +24,39 @@ Affected marts (per
 - `dim_surveys`
 - `bridge_survey_questions`
 
-## Investigation: per-CTE source-grain audit
+## Investigation: per-CTE classification
 
-Before deciding whether to build new intermediates, each DISTINCT/GROUP BY CTE
-was audited against its source's actual grain. Three resolutions emerged:
-**drop** (source is already unique, DISTINCT is defensive), **redirect** (an
-entity-grain upstream already exists), or **build new int** (the source is
-genuinely response/score grain with no entity-grain sibling).
+Each CTE was audited against its source's actual grain and classified by whether
+the collapse is **pure projection** (every projected column functionally
+determined by the partition key — byte-identical tuples coalesce) or
+**canonical-attribute resolution** (at least one projected column varies within
+the partition and needs deterministic selection).
 
 ### Assessments group
 
-| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Resolution                                                              |
-| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | **Drop stale comment.** No DISTINCT is currently used; comment is stale |
-| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | **Build new int** at assessment-definition grain                        |
-| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | **Build new int** at assessment-definition grain                        |
-| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key` column)                                                              | **Build new int** at definition grain                                   |
-| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | **Build new int** at definition grain                                   |
-| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | **Build new int** at definition grain                                   |
-| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | **Build new int** at administration grain                               |
-| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | **Build new int** at administration grain                               |
-| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | **Build new int** at administration grain                               |
-| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | **Build new int** at administration grain                               |
+| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Collapse type                                         | Resolution                                                                                                                                        |
+| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | No collapse                                           | Remove stale "DISTINCT projects..." comment block — no DISTINCT is actually present in the SQL                                                    |
+| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | Canonical-attribute (`min(assessment_name) as title`) | Inline `dbt_utils.deduplicate(partition_by="discipline, test_grade, subject, testcode", order_by="assessment_name asc")` on a filtered source CTE |
+| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | Canonical-attribute (`min(assessment_name) as title`) | Inline `dbt_utils.deduplicate(partition_by="assessment_subject, discipline, test_code, assessment_grade", order_by="assessment_name asc")`        |
+| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key`)                                                                     | Pure projection                                       | Keep DISTINCT; replace existing comment block with the annotation phrase                                                                          |
+| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
+| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | Pure projection                                       | Keep DISTINCT with annotation                                                                                                                     |
 
-Net: **9 new intermediates** + remove one stale comment block.
+Net: **0 new intermediates**, 2 `dbt_utils.deduplicate` switches (state_nj,
+state_fl in `dim_assessments`), 7 DISTINCTs reclassified as pure projection with
+the standard annotation, 1 stale comment block removed.
 
 ### Surveys group
 
 The surveys-side investigation surfaced that all four current
 DISTINCT-collapsing CTEs in `dim_survey_questions` (and their bridge / dim
-counterparts) can resolve to **redirect** or **drop** — no new intermediates
-required.
+counterparts) can resolve to **redirect** or **drop** — entity-grain upstreams
+already exist.
 
 | Mart CTE                                        | Current source                                                                      | Entity-grain upstream that already exists                                                                                                            | Resolution                                                                                                                                                                                                        |
 | ----------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -57,71 +65,46 @@ required.
 | `dim_survey_questions.alchemer_questions`       | `int_surveys__survey_responses` (response grain — union of Google Forms + Alchemer) | `stg_alchemer__survey_question` (per-`(survey_id, id)` grain, carries `shortname`, `title_english`)                                                  | **Redirect** to `stg_alchemer__survey_question`, scoped to Alchemer questions only. Google Forms questions in this CTE are now covered by the gforms redirect above                                               |
 | `dim_survey_questions.manager_questions`        | `int_surveys__manager_survey_details` (response grain)                              | Manager Survey is Google Form `'1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'`; its questions are already in `int_google_forms__form__items`         | **Drop** the CTE entirely. Coverage is redundant once gforms redirect lands. Per the post-#3899 comment in `int_surveys__manager_survey_details`, live Manager Survey identity already flows through Google Forms |
 | `dim_surveys.google_forms_surveys`              | `int_google_forms__form_responses` (response grain)                                 | `stg_google_forms__form` (form / survey grain — carries `form_id`, `info_title`)                                                                     | **Redirect** to `stg_google_forms__form`                                                                                                                                                                          |
-| `dim_surveys.alchemer_surveys`                  | `source("alchemer", "base_alchemer__survey_results")` (response grain)              | `stg_alchemer__survey` (per-`id` survey grain, carries `id` and title)                                                                               | **Redirect** to `stg_alchemer__survey`                                                                                                                                                                            |
+| `dim_surveys.alchemer_surveys`                  | `source("alchemer", "base_alchemer__survey_results")` (response grain)              | `stg_alchemer__survey` (per-`id` survey grain)                                                                                                       | **Redirect** to `stg_alchemer__survey`                                                                                                                                                                            |
 | `bridge_survey_questions.google_forms_pairs`    | `int_google_forms__form_responses`                                                  | `int_google_forms__form__items` carries `(form_id, item_abbreviation, question_required)`                                                            | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                   |
 | `bridge_survey_questions.alchemer_pairs`        | `int_surveys__survey_responses`                                                     | `stg_alchemer__survey_question` carries `(survey_id, shortname)`                                                                                     | **Redirect** to `stg_alchemer__survey_question`                                                                                                                                                                   |
 | `bridge_survey_questions.manager_pairs`         | `int_surveys__manager_survey_details`                                               | Subset of Google Forms after the gforms redirect                                                                                                     | **Drop** the CTE entirely                                                                                                                                                                                         |
-| `bridge_survey_questions.scd_powerschool_pairs` | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain (see above)                                                                                                                | **No-op** — already uses plain `SELECT`                                                                                                                                                                           |
+| `bridge_survey_questions.scd_powerschool_pairs` | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain                                                                                                                            | **No-op** — already uses plain `SELECT`                                                                                                                                                                           |
 
-Net: **0 new intermediates**, 6 redirects (gforms ×3, alchemer ×3), 2 redundant
-CTEs dropped, 2 no-ops on SCD CTEs (no DISTINCT was present).
-
-Mart-side aggregate impact: the surveys trio loses 6 `SELECT DISTINCT`
-occurrences, the manager arms simplify away entirely, and the gforms / alchemer
-arms become plain `SELECT col, col ... FROM <entity-grain-model>`.
+Net: **0 new intermediates**, 6 redirects, 2 redundant CTEs dropped, 2 no-ops.
 
 ## Architecture
 
-### Mart-side rewrites
+### Companion `src/dbt/CLAUDE.md` change
 
-All five marts switch their affected CTEs from response-grain `SELECT DISTINCT`
-(or `GROUP BY`-with-min) to plain `SELECT` from an entity-grain source — either
-a new intermediate (assessments) or an existing entity-grain upstream (surveys).
-Final mart `SELECT` columns, surrogate-key composition, and downstream FK shapes
-do not change.
+Replace the "No manual deduplication" bullet with two bullets that distinguish
+dirty-data workarounds from pure grain projection. Applied in the same PR so the
+marts changes and the rule clarification ship together. See commit
+(`refactor(dbt): permit DISTINCT for pure grain projection`).
 
-The stale `-- DISTINCT projects from response grain to definition grain` comment
-block in `dim_assessments.illuminate_assessments` is removed — no DISTINCT is
-actually present in the SQL, and the comment misleads readers.
+### Assessments marts — inline rewrites
 
-### New assessment intermediates (9 total)
+**`dim_assessments`:**
 
-Each new intermediate:
+- Remove the stale "DISTINCT projects..." comment block above
+  `illuminate_assessments` (no DISTINCT is present in that CTE).
+- `state_nj` and `state_fl`: replace
+  `GROUP BY ... min(assessment_name) as title` with a filtered source CTE
+  feeding `dbt_utils.deduplicate(...)` partitioned on the existing group key,
+  `order_by="assessment_name asc"` (matches `min()` semantics for non-NULL ASCII
+  titles).
+- `college_assessments`, `practice_assessments`, `ap_assessments`: keep
+  `SELECT DISTINCT`. Replace the existing "DISTINCT projects..." comment block
+  above each with a single-line annotation:
+  `-- projection IS the operation, not deduplication`.
 
-- Lives next to its source model (`models/pearson/intermediate/`,
-  `models/fldoe/intermediate/`, `models/assessments/intermediate/`)
-- Is `materialized: view` (intermediate default)
-- Uses `dbt_utils.deduplicate` with the entity key as `partition_by` and a
-  deterministic `order_by` for any non-key column resolution
-- Ships a `properties.yml` entry with `description:`, column descriptions, and a
-  uniqueness test on the partition key (per `src/dbt/CLAUDE.md` "All
-  intermediate models must")
+**`dim_assessment_administrations`:** all four non-illuminate CTEs
+(`state_nj_administrations`, `state_fl_administrations`,
+`college_administrations`, `ap_administrations`) keep `SELECT DISTINCT` with the
+same single-line annotation. The illuminate CTE and its existing TODO #3800
+comment stay untouched.
 
-**Definition-grain ints** (consumed by `dim_assessments`):
-
-| New intermediate                                           | Source                                         | `partition_by`                                                | Notes                                                                                                              |
-| ---------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `int_pearson__assessments`                                 | `int_pearson__all_assessments`                 | `discipline, test_grade, subject, testcode`                   | Pre-filters `testscalescore is not null`. `order_by` = `assessment_name` to pick canonical title deterministically |
-| `int_fldoe__assessments`                                   | `int_fldoe__all_assessments`                   | `assessment_subject, discipline, test_code, assessment_grade` | Pre-filters `scale_score is not null`. `order_by` = `assessment_name`                                              |
-| `int_assessments__college_assessments_definitions`         | `int_assessments__college_assessment`          | `scope, subject_area, score_type`                             | Projects `aligned_subject`, `aligned_subject_area`, `course_discipline`                                            |
-| `int_assessments__college_assessment_practice_definitions` | `int_assessments__college_assessment_practice` | `scope, subject_area`                                         | Computed `module_code` lives in the mart (it's a mart-shape concern, not a source attribute)                       |
-| `int_assessments__ap_assessments_definitions`              | `int_assessments__ap_assessments`              | `test_subject, ps_ap_course_subject_code`                     |                                                                                                                    |
-
-**Administration-grain ints** (consumed by `dim_assessment_administrations`):
-
-| New intermediate                           | Source                                | `partition_by` (canonical admin key per mart's current DISTINCT)                                                                                                                                   |
-| ------------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `int_pearson__administrations`             | `int_pearson__all_assessments`        | `subject_area, scope, module_code, grade_level, administered_date, academic_year, region, administration_period, test_type` (1:1 with current DISTINCT key list in `state_nj_administrations` CTE) |
-| `int_fldoe__administrations`               | `int_fldoe__all_assessments`          | Same shape, FL-source column names                                                                                                                                                                 |
-| `int_assessments__college_administrations` | `int_assessments__college_assessment` | Same shape                                                                                                                                                                                         |
-| `int_assessments__ap_administrations`      | `int_assessments__ap_assessments`     | Same shape                                                                                                                                                                                         |
-
-Each admin int's `partition_by` column list is copied 1:1 from the columns
-currently inside that CTE's DISTINCT SELECT in `dim_assessment_administrations`.
-Mart CTEs then become `SELECT ... FROM int_<source>__administrations` with no
-DISTINCT.
-
-### Surveys-side redirects (0 new ints)
+### Surveys marts — redirects
 
 | Mart CTE                                      | Replace `ref(...)` with                |
 | --------------------------------------------- | -------------------------------------- |
@@ -134,12 +117,11 @@ DISTINCT.
 | `bridge_survey_questions.alchemer_pairs`      | `ref("stg_alchemer__survey_question")` |
 | `bridge_survey_questions.manager_pairs`       | (delete CTE + its UNION ALL branch)    |
 
-All four `SELECT DISTINCT` clauses in the surveys trio drop to plain `SELECT`.
-The final mart row-count delta is whatever the difference is between "every
-(survey, question) pair that has ever appeared in a response" (current) and
-"every (survey, question) pair that exists in the form/question definition"
-(post-redirect). For well-maintained forms these should match; any delta is
-itself a signal worth investigating in the verification step.
+All four `SELECT DISTINCT` clauses in the surveys trio drop to plain `SELECT`
+because the redirect targets are already at entity grain. Final mart row-count
+delta is whatever the difference is between "every (survey, question) pair that
+has ever appeared in a response" (current) and "every (survey, question) pair
+that exists in the form / question definition" (post-redirect).
 
 ## Phase 0: Pre-merge BQ shape audit
 
@@ -152,7 +134,7 @@ in a way the redirect can't explain, escalate that redirect to a new int
 instead.
 
 Schemas: `kipptaf_google_forms`, `kipptaf_alchemer`, `kipptaf_surveys`,
-`kipptaf_google_sheets`. Replace the placeholders below at query time.
+`kipptaf_google_sheets`.
 
 ### A. Google Forms questions redirect
 
@@ -350,34 +332,31 @@ select
 ```
 
 `n_manager_uncovered` must be 0 (or only `historic_alchemer_Manager_survey`
-archive rows, which are handled by the hardcoded `archive_manager` CTE in
-`dim_surveys` and are already covered by the existing bridge/dim shape). Any
-other uncovered rows mean the drop is unsafe — keep the CTE and build a new
-manager-grain int instead.
+archive rows, handled by the hardcoded `archive_manager` CTE in `dim_surveys`).
+Any other uncovered rows mean the drop is unsafe — keep the CTE.
 
 ### Phase-0 decision rules
 
 For each redirect A–F:
 
 - **Symmetric delta (`n_target` near `n_current` with small `n_*_only` on both
-  sides)**: redirect is safe; deltas are explained by definition rows with no
-  responses (target-only) and stale response rows for removed definitions
-  (current-only). Document the count in the PR body and proceed.
+  sides)**: redirect safe. Document counts in PR body and proceed.
 - **Large `n_target_only`**: many definitions never received responses. Expected
   for surveys with low completion rates; safe to proceed.
 - **Large `n_current_only`**: response rows reference a (survey, question) the
   definition source doesn't carry — typically renamed shortnames or
   deleted/recreated forms. Sample 10 unmatched rows; if they trace to legitimate
-  historical data, escalate that redirect to a new intermediate that unions the
-  definition source with historical response artifacts. Otherwise (test/orphan
-  rows), document and proceed.
+  historical data, escalate that redirect to a new intermediate that unions
+  definition with historical response artifacts. Otherwise (test / orphan rows),
+  document and proceed.
 
 Query G must return `n_manager_uncovered = 0` to proceed with the manager CTE
-drop in commit 4.
+drops in commit 3.
 
 ## Verification
 
-Per CLAUDE.md "For dbt changes, `uv run dbt build --select <model>+`":
+Per CLAUDE.md superpowers override "For dbt changes,
+`uv run dbt build --select <model>+`":
 
 ```bash
 VIRTUAL_ENV= uv \
@@ -392,81 +371,55 @@ VIRTUAL_ENV= uv \
     +bridge_survey_questions
 ```
 
-**Row-count parity** against the PR-branch schema once dbt Cloud CI builds. For
-each of the five marts:
+**Row-count parity** against the PR-branch schema once dbt Cloud CI builds.
 
-```sql
-select
-  (select count(*) from `<prod_schema>.<mart>`) as n_prod,
-  (select count(*) from `<pr_branch_schema>.<mart>`) as n_pr,
-```
+- `dim_assessments`, `dim_assessment_administrations`: **0 delta** — the inline
+  changes are byte-identical projection (DISTINCTs annotated) or semantically
+  equivalent (`min(name)` ↔ `dbt_utils.deduplicate(... order_by="name asc")`).
+- `dim_survey_questions`, `dim_surveys`, `bridge_survey_questions`: delta
+  matches Phase-0 audit counts; any discrepancy is a failed redirect.
 
-Expected delta:
-
-- `dim_assessments`, `dim_assessment_administrations`: **0** — intermediates are
-  1:1 pushes of the mart's current DISTINCT key.
-- `dim_survey_questions`, `dim_surveys`, `bridge_survey_questions`: **may
-  shift**, because the surveys redirects move from "appears in responses" to
-  "exists as a definition." Any delta must be explained — typically rows for
-  forms/questions that exist in metadata but have never received a response (new
-  rows in the mart), or rows for response-only artifacts that shouldn't have
-  been there (removed rows). Investigate each direction.
-
-**Sample-check populated values** for any column whose value depends on which
-row a previous `min()` or DISTINCT picked from a multi-row partition — state_nj
-`title` (`min(assessment_name)`) is the canonical example. Before/after sample
-on PR-branch vs prod for 20 sampled `module_code` values to confirm the new
-`dbt_utils.deduplicate` `order_by` picks the same title as the previous `min()`.
+**Sample-check canonical titles**: for `state_nj` and `state_fl` (the two CTEs
+that switch from `min()` to `dbt_utils.deduplicate`), pick 20 sample
+`module_code` / `test_code` values and confirm post-deduplicate `title` matches
+pre `min()` result. Any mismatch is a failed `order_by` choice.
 
 ## Files touched
 
-**New** (9 SQL + 9 properties YAML entries):
+**Modified**:
 
-- `src/dbt/kipptaf/models/pearson/intermediate/int_pearson__assessments.sql` +
-  properties
-- `src/dbt/kipptaf/models/pearson/intermediate/int_pearson__administrations.sql` +
-  properties
-- `src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__assessments.sql` +
-  properties
-- `src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__administrations.sql` +
-  properties
-- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessments_definitions.sql` +
-  properties
-- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment_practice_definitions.sql` +
-  properties
-- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_administrations.sql` +
-  properties
-- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_assessments_definitions.sql` +
-  properties
-- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_administrations.sql` +
-  properties
-
-**Modified** (5 mart SQL files; YAML untouched since contract surfaces don't
-change):
-
+- `src/dbt/CLAUDE.md` — split "No manual deduplication" bullet (companion rule
+  clarification)
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql`
 - `src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql`
 
+**New**: none. Mart-side changes only; YAML untouched since contract surfaces
+don't change.
+
 ## Risks
 
-- **Wrong `partition_by` column list on a new int.** A narrower partition than
-  the mart's current DISTINCT key fans the mart out. Mitigation: copy the
-  partition column list 1:1 from the current DISTINCT/GROUP BY in each mart CTE;
-  row-count parity per mart catches this.
+- **`min()` → `dbt_utils.deduplicate(order_by="name asc")` drift.** `min()` is a
+  deterministic ASCII order on non-NULL values; `dbt_utils.deduplicate` compiles
+  to `array_agg(... order by name asc limit 1)` which is equivalent for non-NULL
+  values, NULLS-LAST. If any `assessment_name` value is NULL in the partition,
+  behavior differs from `min()` (which ignores NULLs). Mitigation: 20-sample
+  title check above; both sources already filter the underlying score column for
+  not-null, but `assessment_name` isn't filtered upstream — verify with a
+  `countif(assessment_name is null)` scan on each source before commit 1.
 - **Surveys redirects shift row counts.** Definitions-grain sources may carry
-  rows that responses-grain sources did not, and vice versa. Mitigation:
-  pre/post row-count comparison is expected to differ for the three surveys
-  marts; investigate each direction before merge. If a meaningful semantic shift
-  surfaces, file follow-up and revert the affected CTE redirect to a new int
-  instead.
-- **Title / canonical-attribute drift.** The pearson / fldoe CTEs currently use
-  `min(assessment_name) as title`. The new int's `dbt_utils.deduplicate`
-  `order_by` must pick the same row. Mitigation: use
-  `order_by="assessment_name asc"` (matches `min()` semantics for non-NULL ASCII
-  titles); sample-check 20 codes.
+  rows that responses-grain sources did not, and vice versa. Mitigation: Phase-0
+  audit, escalation path documented.
+- **Pure-projection misclassification.** A CTE classified as pure projection but
+  actually carrying a column that varies in the partition would silently pick
+  the wrong row when DISTINCT coalesces tuples that differ. Mitigation: each
+  "pure projection" CTE in the assessments marts was inspected and only contains
+  columns derivable from the partition key (constants, casts of constants, and
+  the partition columns themselves). On any future addition of a non-derivable
+  column to one of these CTEs, the annotation rule forces a switch to
+  `dbt_utils.deduplicate`.
 
 ## Out of scope
 
@@ -474,24 +427,23 @@ change):
   existing source, tracked separately).
 - Any column renames, FK restructures, or hash recompositions on the mart side.
 - Re-org of `int_assessments__assessments` itself.
-- The `int_surveys__manager_survey_details` post-#3899 cleanup (#3918) — this
-  spec drops the mart's reads of it, but the model itself stays.
+- `int_surveys__manager_survey_details` post-#3899 cleanup (#3918) — this spec
+  drops the mart's reads of it, but the model stays.
 
 ## Sequencing
 
-One PR, four logical commits plus a pre-commit Phase 0:
+One PR, three commits plus a pre-commit Phase 0:
 
-0. **Phase 0 (no commit)**: run BQ queries A–G from "Phase 0: Pre-merge BQ shape
-   audit" against prod. Paste results into the PR body. Apply Phase-0 decision
-   rules; if any redirect fails its rule, replace that redirect with a new
-   intermediate before commit 3.
-1. Assessment-definition intermediates (5 new) + `dim_assessments` mart rewrite
-   (drops 4 DISTINCTs / GROUP BYs and the stale comment). Verify parity.
-2. Assessment-administration intermediates (4 new) +
-   `dim_assessment_administrations` non-illuminate CTE rewrites. Verify parity.
-3. Surveys redirects across `dim_survey_questions`, `dim_surveys`,
-   `bridge_survey_questions`. Row-count delta against prod is expected to match
-   the Phase-0 audit; flag any discrepancy.
-4. Drop redundant manager CTEs from `dim_survey_questions` and
-   `bridge_survey_questions`. Verify zero net delta vs commit 3 (gated on Phase
-   0 query G returning `n_manager_uncovered = 0`).
+0. **Phase 0 (no commit)**: run BQ queries A–G against prod. Paste results into
+   the PR body. Apply Phase-0 decision rules; if any redirect fails its rule,
+   escalate that redirect to a new intermediate before commit 2.
+1. **Assessments + CLAUDE.md.** Single commit: rule clarification in
+   `src/dbt/CLAUDE.md`, plus all mart-side changes in `dim_assessments` and
+   `dim_assessment_administrations` (annotate DISTINCTs, switch `state_nj` /
+   `state_fl` to `dbt_utils.deduplicate`, remove stale illuminate comment).
+   Verify zero delta.
+2. **Surveys redirects.** All redirects across `dim_survey_questions`,
+   `dim_surveys`, `bridge_survey_questions`. Row-count delta against prod is
+   expected to match Phase-0 audit counts; flag any discrepancy.
+3. **Drop manager CTEs** (gated on Phase 0 query G returning
+   `n_manager_uncovered = 0`). Verify zero net delta vs commit 2.

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -2,11 +2,11 @@
 
 ## Problem
 
-Five mart models use `SELECT DISTINCT` to collapse response-grain (or
-per-score-grain) rows into entity-grain rows. This violates the project rule in
-`src/dbt/CLAUDE.md` ("No manual deduplication — do not use `SELECT DISTINCT` or
-`qualify row_number() = 1`... If `DISTINCT` is truly unavoidable, it must
-include a `-- TODO:` comment explaining why").
+Five mart models in `marts/` collapse response-grain (or per-score-grain) rows
+into entity-grain rows using `SELECT DISTINCT` or `GROUP BY` aggregates. This
+violates `src/dbt/CLAUDE.md` "No manual deduplication" and "Canonical attributes
+from a partition." The collapse belongs in intermediates so marts can read
+pre-projected, entity-grain rows.
 
 Affected marts (per
 [#3780](https://github.com/TEAMSchools/teamster/issues/3780)):
@@ -18,146 +18,136 @@ Affected marts (per
 - `dim_surveys`
 - `bridge_survey_questions`
 
-The fix is structural: the projection from response/score grain to entity grain
-belongs in intermediate models. Marts should read pre-projected, entity-grain
-rows and either pass them through or UNION ALL them.
+## Investigation: per-CTE source-grain audit
 
-## Scope
-
-All five cleanups in one PR. The surveys trio shares so much upstream that
-splitting them buys little, and the assessments pair has parallel structure to
-the surveys pair, so the spec is uniform.
-
-In scope:
-
-- Build per-source entity-grain intermediates that collapse response/score
-  grain.
-- Rewrite the five mart files to drop `SELECT DISTINCT` / `GROUP BY` collapse
-  CTEs.
-- Verify pre/post row-count parity per mart.
-
-Out of scope:
-
-- `dim_assessment_administrations.illuminate_administrations` (TODO #3800 in the
-  existing source, tracked separately).
-- Any column renames, FK restructures, or hash recompositions on the mart side.
-  Mart surface stays byte-identical except for SQL structure.
-- Re-org of `int_assessments__assessments` itself (the canonical-grain collapse
-  there is its own follow-up).
-
-## Architecture
-
-### Pattern
-
-Each new intermediate is `materialized: view` (default for intermediates), uses
-`dbt_utils.deduplicate` with:
-
-- `partition_by` = the entity key the mart joins on
-- `order_by` = a canonical-attribute ordering (e.g., `title`) so that multi-row
-  partitions resolve deterministically per "Canonical attributes from a
-  partition" in `src/dbt/CLAUDE.md`
-
-Each new intermediate gets a `properties.yml` entry with `description:`, column
-descriptions, and a uniqueness test on the partition key (intermediates require
-uniqueness per `src/dbt/CLAUDE.md` "All intermediate models must").
+Before deciding whether to build new intermediates, each DISTINCT/GROUP BY CTE
+was audited against its source's actual grain. Three resolutions emerged:
+**drop** (source is already unique, DISTINCT is defensive), **redirect** (an
+entity-grain upstream already exists), or **build new int** (the source is
+genuinely response/score grain with no entity-grain sibling).
 
 ### Assessments group
 
-Eight new intermediates total, split into two parallel sets.
+| Mart CTE                                    | Source                                         | Source grain                                                                                                        | Resolution                                                              |
+| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `dim_assessments.illuminate_assessments`    | `int_assessments__assessments`                 | `assessment_id` (unique test)                                                                                       | **Drop stale comment.** No DISTINCT is currently used; comment is stale |
+| `dim_assessments.state_nj`                  | `int_pearson__all_assessments`                 | per-student-per-assessment response                                                                                 | **Build new int** at assessment-definition grain                        |
+| `dim_assessments.state_fl`                  | `int_fldoe__all_assessments`                   | per-student-per-assessment response                                                                                 | **Build new int** at assessment-definition grain                        |
+| `dim_assessments.college_assessments`       | `int_assessments__college_assessment`          | per-student-per-test-date (has `surrogate_key` column)                                                              | **Build new int** at definition grain                                   |
+| `dim_assessments.practice_assessments`      | `int_assessments__college_assessment_practice` | per-student-per-test response                                                                                       | **Build new int** at definition grain                                   |
+| `dim_assessments.ap_assessments`            | `int_assessments__ap_assessments`              | per-student-per-exam (model carries `row_number() over (partition by student, ap_course_name order by exam_score)`) | **Build new int** at definition grain                                   |
+| `dim_assessment_administrations.state_nj_*` | `int_pearson__all_assessments`                 | per-student response                                                                                                | **Build new int** at administration grain                               |
+| `dim_assessment_administrations.state_fl_*` | `int_fldoe__all_assessments`                   | per-student response                                                                                                | **Build new int** at administration grain                               |
+| `dim_assessment_administrations.college_*`  | `int_assessments__college_assessment`          | per-student-per-test-date                                                                                           | **Build new int** at administration grain                               |
+| `dim_assessment_administrations.ap_*`       | `int_assessments__ap_assessments`              | per-student-per-exam                                                                                                | **Build new int** at administration grain                               |
 
-**Assessment-definition grain** (consumed by `dim_assessments`):
-
-| New intermediate                                   | Source                                | Partition key                                                                                   |
-| -------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `int_pearson__assessments`                         | `int_pearson__all_assessments`        | `discipline, test_grade, subject, testcode` (where `testscalescore is not null`)                |
-| `int_fldoe__assessments`                           | `int_fldoe__all_assessments`          | `assessment_subject, discipline, test_code, assessment_grade` (where `scale_score is not null`) |
-| `int_assessments__college_assessments_definitions` | `int_assessments__college_assessment` | `scope, subject_area, score_type`                                                               |
-| `int_assessments__ap_assessments_definitions`      | `int_assessments__ap_assessments`     | `test_subject, ps_ap_course_subject_code`                                                       |
-
-These pre-project all the columns currently selected inside the corresponding
-DISTINCT/GROUP BY CTEs in `dim_assessments`. The mart then becomes:
-
-```sql
-illuminate_assessments as (select ... from int_assessments__assessments where is_internal_assessment),
-state_nj as (select ... from int_pearson__assessments),
-state_fl as (select ... from int_fldoe__assessments),
-college_assessments as (select ... from int_assessments__college_assessments_definitions),
-practice_assessments as (...),  -- already collapsed via int_assessments__college_assessment_practice; verify and drop DISTINCT
-ap_assessments as (select ... from int_assessments__ap_assessments_definitions),
-... existing UNION ALL + dedup ...
-```
-
-**Administration grain** (consumed by `dim_assessment_administrations`):
-
-| New intermediate                           | Source                                | Partition key                                                                                          |
-| ------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `int_pearson__administrations`             | `int_pearson__all_assessments`        | `module_code, grade_level, administered_date, academic_year, region, administration_period, test_type` |
-| `int_fldoe__administrations`               | `int_fldoe__all_assessments`          | same shape, with FL-specific column names                                                              |
-| `int_assessments__college_administrations` | `int_assessments__college_assessment` | same shape                                                                                             |
-| `int_assessments__ap_administrations`      | `int_assessments__ap_assessments`     | same shape                                                                                             |
-
-Exact partition columns mirror the current DISTINCT key list in each mart CTE —
-each new intermediate's `dbt_utils.deduplicate` partition column list is copied
-1:1 from the columns currently inside that CTE's projection.
-
-After: each non-illuminate CTE in `dim_assessment_administrations` becomes a
-plain `SELECT ... FROM int_<source>__administrations`. The existing illuminate
-CTE (with its TODO #3800 comment) is unchanged.
+Net: **9 new intermediates** + remove one stale comment block.
 
 ### Surveys group
 
-Three new pairs of intermediates plus a verification on the SCD source.
+The surveys-side investigation surfaced that all four current
+DISTINCT-collapsing CTEs in `dim_survey_questions` (and their bridge / dim
+counterparts) can resolve to **redirect** or **drop** — no new intermediates
+required.
 
-**Per-source question-grain and survey-grain intermediates:**
+| Mart CTE                                        | Current source                                                                      | Entity-grain upstream that already exists                                                                                                            | Resolution                                                                                                                                                                                                        |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dim_survey_questions.google_forms_questions`   | `int_google_forms__form_responses` (response grain)                                 | `int_google_forms__form__items` (item / question grain — carries `form_id`, `item_abbreviation`, `item_title`, `question_kind`, `question_required`) | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                   |
+| `dim_survey_questions.scd_questions`            | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain (BQ check: 10 rows = 10 distinct `question_code` values in the `School_Survey_%` filter)                                   | **No-op** — mart CTE already uses plain `SELECT`, no DISTINCT to remove                                                                                                                                           |
+| `dim_survey_questions.alchemer_questions`       | `int_surveys__survey_responses` (response grain — union of Google Forms + Alchemer) | `stg_alchemer__survey_question` (per-`(survey_id, id)` grain, carries `shortname`, `title_english`)                                                  | **Redirect** to `stg_alchemer__survey_question`, scoped to Alchemer questions only. Google Forms questions in this CTE are now covered by the gforms redirect above                                               |
+| `dim_survey_questions.manager_questions`        | `int_surveys__manager_survey_details` (response grain)                              | Manager Survey is Google Form `'1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'`; its questions are already in `int_google_forms__form__items`         | **Drop** the CTE entirely. Coverage is redundant once gforms redirect lands. Per the post-#3899 comment in `int_surveys__manager_survey_details`, live Manager Survey identity already flows through Google Forms |
+| `dim_surveys.google_forms_surveys`              | `int_google_forms__form_responses` (response grain)                                 | `stg_google_forms__form` (form / survey grain — carries `form_id`, `info_title`)                                                                     | **Redirect** to `stg_google_forms__form`                                                                                                                                                                          |
+| `dim_surveys.alchemer_surveys`                  | `source("alchemer", "base_alchemer__survey_results")` (response grain)              | `stg_alchemer__survey` (per-`id` survey grain, carries `id` and title)                                                                               | **Redirect** to `stg_alchemer__survey`                                                                                                                                                                            |
+| `bridge_survey_questions.google_forms_pairs`    | `int_google_forms__form_responses`                                                  | `int_google_forms__form__items` carries `(form_id, item_abbreviation, question_required)`                                                            | **Redirect** to `int_google_forms__form__items`                                                                                                                                                                   |
+| `bridge_survey_questions.alchemer_pairs`        | `int_surveys__survey_responses`                                                     | `stg_alchemer__survey_question` carries `(survey_id, shortname)`                                                                                     | **Redirect** to `stg_alchemer__survey_question`                                                                                                                                                                   |
+| `bridge_survey_questions.manager_pairs`         | `int_surveys__manager_survey_details`                                               | Subset of Google Forms after the gforms redirect                                                                                                     | **Drop** the CTE entirely                                                                                                                                                                                         |
+| `bridge_survey_questions.scd_powerschool_pairs` | `stg_google_sheets__surveys__scd_question_crosswalk`                                | Already at question grain (see above)                                                                                                                | **No-op** — already uses plain `SELECT`                                                                                                                                                                           |
 
-| Pair         | Source (response grain)               | Question-grain int               | Survey-grain int               |
-| ------------ | ------------------------------------- | -------------------------------- | ------------------------------ |
-| Google Forms | `int_google_forms__form_responses`    | `int_google_forms__questions`    | `int_google_forms__surveys`    |
-| Alchemer     | `int_surveys__survey_responses`       | `int_alchemer__questions`        | `int_alchemer__surveys`        |
-| Manager      | `int_surveys__manager_survey_details` | `int_surveys__manager_questions` | `int_surveys__manager_surveys` |
+Net: **0 new intermediates**, 6 redirects (gforms ×3, alchemer ×3), 2 redundant
+CTEs dropped, 2 no-ops on SCD CTEs (no DISTINCT was present).
 
-Partition key for question-grain ints: `(survey_id, question_shortname)` plus
-whatever question-level attributes (`question_text`, `question_type`, display
-order, etc.) the mart currently projects. Partition key for survey-grain ints:
-`survey_id` plus survey-level attributes (`survey_title`, `survey_type`, etc.).
-Exact column lists come from the current DISTINCT projections in
-`dim_survey_questions` / `dim_surveys`.
+Mart-side aggregate impact: the surveys trio loses 6 `SELECT DISTINCT`
+occurrences, the manager arms simplify away entirely, and the gforms / alchemer
+arms become plain `SELECT col, col ... FROM <entity-grain-model>`.
 
-**SCD source review:** `stg_google_sheets__surveys__scd_question_crosswalk` is
-staging from a Google Sheet — already at question grain by definition. The
-DISTINCT in `dim_survey_questions.scd_questions` is likely vestigial. Verify by
-querying the staging table for uniqueness on `(survey_id, question_shortname)`;
-if unique, drop the DISTINCT, no new intermediate.
+## Architecture
 
-**After:** the three marts become plain UNION ALLs over the per-source
-intermediates (plus SCD staging). `bridge_survey_questions` collapses similarly
-— each branch reads `(survey_id, question_shortname)` from the corresponding
-`int_*__questions` model.
+### Mart-side rewrites
 
-### Special case: `dim_assessments.illuminate_assessments`
+All five marts switch their affected CTEs from response-grain `SELECT DISTINCT`
+(or `GROUP BY`-with-min) to plain `SELECT` from an entity-grain source — either
+a new intermediate (assessments) or an existing entity-grain upstream (surveys).
+Final mart `SELECT` columns, surrogate-key composition, and downstream FK shapes
+do not change.
 
-The issue flags this CTE for review: "Source already exists at assessment-id
-grain (`int_assessments__assessments`); review whether DISTINCT is actually
-needed or just defensive."
+The stale `-- DISTINCT projects from response grain to definition grain` comment
+block in `dim_assessments.illuminate_assessments` is removed — no DISTINCT is
+actually present in the SQL, and the comment misleads readers.
 
-`int_assessments__assessments` begins with a `GROUP BY assessment_id` on the
-agl/iae dedup CTE and downstream selects propagate that grain. The DISTINCT in
-`dim_assessments.illuminate_assessments` is defensive.
+### New assessment intermediates (9 total)
 
-**Action:** drop the DISTINCT, replace with a plain SELECT. No new intermediate.
+Each new intermediate:
 
-If pre/post row-count parity fails on this CTE alone, restore DISTINCT with a
-`-- TODO:` comment per the project rule, and file the upstream uniqueness issue
-separately.
+- Lives next to its source model (`models/pearson/intermediate/`,
+  `models/fldoe/intermediate/`, `models/assessments/intermediate/`)
+- Is `materialized: view` (intermediate default)
+- Uses `dbt_utils.deduplicate` with the entity key as `partition_by` and a
+  deterministic `order_by` for any non-key column resolution
+- Ships a `properties.yml` entry with `description:`, column descriptions, and a
+  uniqueness test on the partition key (per `src/dbt/CLAUDE.md` "All
+  intermediate models must")
+
+**Definition-grain ints** (consumed by `dim_assessments`):
+
+| New intermediate                                           | Source                                         | `partition_by`                                                | Notes                                                                                                              |
+| ---------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `int_pearson__assessments`                                 | `int_pearson__all_assessments`                 | `discipline, test_grade, subject, testcode`                   | Pre-filters `testscalescore is not null`. `order_by` = `assessment_name` to pick canonical title deterministically |
+| `int_fldoe__assessments`                                   | `int_fldoe__all_assessments`                   | `assessment_subject, discipline, test_code, assessment_grade` | Pre-filters `scale_score is not null`. `order_by` = `assessment_name`                                              |
+| `int_assessments__college_assessments_definitions`         | `int_assessments__college_assessment`          | `scope, subject_area, score_type`                             | Projects `aligned_subject`, `aligned_subject_area`, `course_discipline`                                            |
+| `int_assessments__college_assessment_practice_definitions` | `int_assessments__college_assessment_practice` | `scope, subject_area`                                         | Computed `module_code` lives in the mart (it's a mart-shape concern, not a source attribute)                       |
+| `int_assessments__ap_assessments_definitions`              | `int_assessments__ap_assessments`              | `test_subject, ps_ap_course_subject_code`                     |                                                                                                                    |
+
+**Administration-grain ints** (consumed by `dim_assessment_administrations`):
+
+| New intermediate                           | Source                                | `partition_by` (canonical admin key per mart's current DISTINCT)                                                                                                                                   |
+| ------------------------------------------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `int_pearson__administrations`             | `int_pearson__all_assessments`        | `subject_area, scope, module_code, grade_level, administered_date, academic_year, region, administration_period, test_type` (1:1 with current DISTINCT key list in `state_nj_administrations` CTE) |
+| `int_fldoe__administrations`               | `int_fldoe__all_assessments`          | Same shape, FL-source column names                                                                                                                                                                 |
+| `int_assessments__college_administrations` | `int_assessments__college_assessment` | Same shape                                                                                                                                                                                         |
+| `int_assessments__ap_administrations`      | `int_assessments__ap_assessments`     | Same shape                                                                                                                                                                                         |
+
+Each admin int's `partition_by` column list is copied 1:1 from the columns
+currently inside that CTE's DISTINCT SELECT in `dim_assessment_administrations`.
+Mart CTEs then become `SELECT ... FROM int_<source>__administrations` with no
+DISTINCT.
+
+### Surveys-side redirects (0 new ints)
+
+| Mart CTE                                      | Replace `ref(...)` with                |
+| --------------------------------------------- | -------------------------------------- |
+| `dim_survey_questions.google_forms_questions` | `ref("int_google_forms__form__items")` |
+| `dim_survey_questions.alchemer_questions`     | `ref("stg_alchemer__survey_question")` |
+| `dim_survey_questions.manager_questions`      | (delete CTE + its UNION ALL branch)    |
+| `dim_surveys.google_forms_surveys`            | `ref("stg_google_forms__form")`        |
+| `dim_surveys.alchemer_surveys`                | `ref("stg_alchemer__survey")`          |
+| `bridge_survey_questions.google_forms_pairs`  | `ref("int_google_forms__form__items")` |
+| `bridge_survey_questions.alchemer_pairs`      | `ref("stg_alchemer__survey_question")` |
+| `bridge_survey_questions.manager_pairs`       | (delete CTE + its UNION ALL branch)    |
+
+All four `SELECT DISTINCT` clauses in the surveys trio drop to plain `SELECT`.
+The final mart row-count delta is whatever the difference is between "every
+(survey, question) pair that has ever appeared in a response" (current) and
+"every (survey, question) pair that exists in the form/question definition"
+(post-redirect). For well-maintained forms these should match; any delta is
+itself a signal worth investigating in the verification step.
 
 ## Verification
 
-Per CLAUDE.md superpowers override "For dbt changes,
-`uv run dbt build --select <model>+` against the relevant project":
+Per CLAUDE.md "For dbt changes, `uv run dbt build --select <model>+`":
 
 ```bash
-cd /workspaces/teamster
-VIRTUAL_ENV= uv --directory .worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+VIRTUAL_ENV= uv \
+  --directory .worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
   run dbt build \
   --project-dir src/dbt/kipptaf \
   --select \
@@ -168,26 +158,35 @@ VIRTUAL_ENV= uv --directory .worktrees/cbini-refactor-claude-distinct-cleanup-37
     +bridge_survey_questions
 ```
 
-**Row-count parity** against the PR-branch schema after dbt Cloud CI builds:
+**Row-count parity** against the PR-branch schema once dbt Cloud CI builds. For
+each of the five marts:
 
 ```sql
--- Per mart: pre (prod) vs post (PR-branch schema)
-select 'dim_assessments' as model, count(*) as n from `<prod_schema>.dim_assessments`
-union all
-select 'dim_assessments' as model, count(*) as n from `<pr_branch_schema>.dim_assessments`
--- ... repeat for the other four marts
+select
+  (select count(*) from `<prod_schema>.<mart>`) as n_prod,
+  (select count(*) from `<pr_branch_schema>.<mart>`) as n_pr,
 ```
 
-Per the marts CLAUDE.md "Removing a mart-level qualify row_number() = 1"
-guidance: net mart row-count delta should be **zero** when the DISTINCT is
-purely projecting (which is the case for all five marts here — the DISTINCT is
-the projection operation, not a defensive dedup of dirty source data). Any
-non-zero delta is a signal that a partition_by column list is wrong and the
-intermediate is fanning out where the mart used to collapse.
+Expected delta:
+
+- `dim_assessments`, `dim_assessment_administrations`: **0** — intermediates are
+  1:1 pushes of the mart's current DISTINCT key.
+- `dim_survey_questions`, `dim_surveys`, `bridge_survey_questions`: **may
+  shift**, because the surveys redirects move from "appears in responses" to
+  "exists as a definition." Any delta must be explained — typically rows for
+  forms/questions that exist in metadata but have never received a response (new
+  rows in the mart), or rows for response-only artifacts that shouldn't have
+  been there (removed rows). Investigate each direction.
+
+**Sample-check populated values** for any column whose value depends on which
+row a previous `min()` or DISTINCT picked from a multi-row partition — state_nj
+`title` (`min(assessment_name)`) is the canonical example. Before/after sample
+on PR-branch vs prod for 20 sampled `module_code` values to confirm the new
+`dbt_utils.deduplicate` `order_by` picks the same title as the previous `min()`.
 
 ## Files touched
 
-**New** (14 SQL + 14 properties YAML entries):
+**New** (9 SQL + 9 properties YAML entries):
 
 - `src/dbt/kipptaf/models/pearson/intermediate/int_pearson__assessments.sql` +
   properties
@@ -199,32 +198,17 @@ intermediate is fanning out where the mart used to collapse.
   properties
 - `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessments_definitions.sql` +
   properties
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment_practice_definitions.sql` +
+  properties
 - `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_administrations.sql` +
   properties
 - `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_assessments_definitions.sql` +
   properties
 - `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_administrations.sql` +
   properties
-- `src/dbt/kipptaf/models/google/forms/intermediate/int_google_forms__questions.sql` +
-  properties
-- `src/dbt/kipptaf/models/google/forms/intermediate/int_google_forms__surveys.sql` +
-  properties
-- `src/dbt/kipptaf/models/alchemer/intermediate/int_alchemer__questions.sql` +
-  properties
-- `src/dbt/kipptaf/models/alchemer/intermediate/int_alchemer__surveys.sql` +
-  properties
-- `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_questions.sql` +
-  properties
-- `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_surveys.sql` +
-  properties
 
-(Final directory placement for Google Forms / Alchemer / Manager intermediates
-mirrors the existing source directory layout — `models/alchemer/intermediate/`
-already exists; Google Forms may need creation; Manager already lives under
-`models/surveys/intermediate/`.)
-
-**Modified** (5 mart SQL files only; YAML untouched since contract surfaces
-don't change):
+**Modified** (5 mart SQL files; YAML untouched since contract surfaces don't
+change):
 
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql`
 - `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
@@ -234,34 +218,41 @@ don't change):
 
 ## Risks
 
-- **Wrong partition_by column list.** If a new intermediate's
-  `dbt_utils.deduplicate` partitions by a narrower key than the mart's current
-  DISTINCT, the mart fans out. Mitigation: copy the partition column list 1:1
-  from the current DISTINCT/GROUP BY in each mart CTE; verify row-count parity
-  per mart.
-- **Stale DISTINCT was masking source non-uniqueness.** If a source response
-  table actually has duplicate (entity-key, projected-attribute) tuples that
-  differ in some excluded column, removing DISTINCT changes the resolved
-  attribute. Mitigation: `order_by` in `dbt_utils.deduplicate` picks
-  deterministically; sample-check populated values before vs after on PR-branch
-  schema for any column that matters (titles, codes).
-- **Hash-input drift on FKs into these dims.** Mart surrogate keys
-  (`assessment_key`, `survey_question_key`, etc.) are computed from projected
-  columns. If a new intermediate changes any of those column values (vs. the
-  current DISTINCT's outputs), downstream FKs hash-diff. Mitigation: the
-  intermediates must project exactly the columns the marts currently project,
-  with the same casts. No semantic changes in this PR.
+- **Wrong `partition_by` column list on a new int.** A narrower partition than
+  the mart's current DISTINCT key fans the mart out. Mitigation: copy the
+  partition column list 1:1 from the current DISTINCT/GROUP BY in each mart CTE;
+  row-count parity per mart catches this.
+- **Surveys redirects shift row counts.** Definitions-grain sources may carry
+  rows that responses-grain sources did not, and vice versa. Mitigation:
+  pre/post row-count comparison is expected to differ for the three surveys
+  marts; investigate each direction before merge. If a meaningful semantic shift
+  surfaces, file follow-up and revert the affected CTE redirect to a new int
+  instead.
+- **Title / canonical-attribute drift.** The pearson / fldoe CTEs currently use
+  `min(assessment_name) as title`. The new int's `dbt_utils.deduplicate`
+  `order_by` must pick the same row. Mitigation: use
+  `order_by="assessment_name asc"` (matches `min()` semantics for non-NULL ASCII
+  titles); sample-check 20 codes.
+
+## Out of scope
+
+- `dim_assessment_administrations.illuminate_administrations` (TODO #3800 in the
+  existing source, tracked separately).
+- Any column renames, FK restructures, or hash recompositions on the mart side.
+- Re-org of `int_assessments__assessments` itself.
+- The `int_surveys__manager_survey_details` post-#3899 cleanup (#3918) — this
+  spec drops the mart's reads of it, but the model itself stays.
 
 ## Sequencing
 
-One PR, one commit per logical sub-step (split between assessments and surveys
-groups). Suggested commit order inside the branch:
+One PR, four logical commits inside the branch:
 
-1. Assessments-definition intermediates (4 new) + `dim_assessments` mart
-   rewrite. Verify parity.
-2. Assessments-administration intermediates (4 new) +
+1. Assessment-definition intermediates (5 new) + `dim_assessments` mart rewrite
+   (drops 4 DISTINCTs / GROUP BYs and the stale comment). Verify parity.
+2. Assessment-administration intermediates (4 new) +
    `dim_assessment_administrations` non-illuminate CTE rewrites. Verify parity.
-3. Survey question + survey intermediates (6 new) + `dim_survey_questions`,
-   `dim_surveys`, `bridge_survey_questions` rewrites. Verify parity.
-4. SCD DISTINCT removal in `dim_survey_questions` (separate commit so the
-   row-count parity check isolates the SCD source case).
+3. Surveys redirects across `dim_survey_questions`, `dim_surveys`,
+   `bridge_survey_questions`. Verify (expected non-zero delta; investigate each
+   direction).
+4. Drop redundant manager CTEs from `dim_survey_questions` and
+   `bridge_survey_questions`. Verify zero net delta vs commit 3.

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -1,0 +1,267 @@
+# Push entity-grain projections from marts into intermediate (#3780)
+
+## Problem
+
+Five mart models use `SELECT DISTINCT` to collapse response-grain (or
+per-score-grain) rows into entity-grain rows. This violates the project rule in
+`src/dbt/CLAUDE.md` ("No manual deduplication — do not use `SELECT DISTINCT` or
+`qualify row_number() = 1`... If `DISTINCT` is truly unavoidable, it must
+include a `-- TODO:` comment explaining why").
+
+Affected marts (per
+[#3780](https://github.com/TEAMSchools/teamster/issues/3780)):
+
+- `dim_assessments`
+- `dim_assessment_administrations` (non-illuminate CTEs only — illuminate is
+  tracked separately under TODO #3800)
+- `dim_survey_questions`
+- `dim_surveys`
+- `bridge_survey_questions`
+
+The fix is structural: the projection from response/score grain to entity grain
+belongs in intermediate models. Marts should read pre-projected, entity-grain
+rows and either pass them through or UNION ALL them.
+
+## Scope
+
+All five cleanups in one PR. The surveys trio shares so much upstream that
+splitting them buys little, and the assessments pair has parallel structure to
+the surveys pair, so the spec is uniform.
+
+In scope:
+
+- Build per-source entity-grain intermediates that collapse response/score
+  grain.
+- Rewrite the five mart files to drop `SELECT DISTINCT` / `GROUP BY` collapse
+  CTEs.
+- Verify pre/post row-count parity per mart.
+
+Out of scope:
+
+- `dim_assessment_administrations.illuminate_administrations` (TODO #3800 in the
+  existing source, tracked separately).
+- Any column renames, FK restructures, or hash recompositions on the mart side.
+  Mart surface stays byte-identical except for SQL structure.
+- Re-org of `int_assessments__assessments` itself (the canonical-grain collapse
+  there is its own follow-up).
+
+## Architecture
+
+### Pattern
+
+Each new intermediate is `materialized: view` (default for intermediates), uses
+`dbt_utils.deduplicate` with:
+
+- `partition_by` = the entity key the mart joins on
+- `order_by` = a canonical-attribute ordering (e.g., `title`) so that multi-row
+  partitions resolve deterministically per "Canonical attributes from a
+  partition" in `src/dbt/CLAUDE.md`
+
+Each new intermediate gets a `properties.yml` entry with `description:`, column
+descriptions, and a uniqueness test on the partition key (intermediates require
+uniqueness per `src/dbt/CLAUDE.md` "All intermediate models must").
+
+### Assessments group
+
+Eight new intermediates total, split into two parallel sets.
+
+**Assessment-definition grain** (consumed by `dim_assessments`):
+
+| New intermediate                                   | Source                                | Partition key                                                                                   |
+| -------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `int_pearson__assessments`                         | `int_pearson__all_assessments`        | `discipline, test_grade, subject, testcode` (where `testscalescore is not null`)                |
+| `int_fldoe__assessments`                           | `int_fldoe__all_assessments`          | `assessment_subject, discipline, test_code, assessment_grade` (where `scale_score is not null`) |
+| `int_assessments__college_assessments_definitions` | `int_assessments__college_assessment` | `scope, subject_area, score_type`                                                               |
+| `int_assessments__ap_assessments_definitions`      | `int_assessments__ap_assessments`     | `test_subject, ps_ap_course_subject_code`                                                       |
+
+These pre-project all the columns currently selected inside the corresponding
+DISTINCT/GROUP BY CTEs in `dim_assessments`. The mart then becomes:
+
+```sql
+illuminate_assessments as (select ... from int_assessments__assessments where is_internal_assessment),
+state_nj as (select ... from int_pearson__assessments),
+state_fl as (select ... from int_fldoe__assessments),
+college_assessments as (select ... from int_assessments__college_assessments_definitions),
+practice_assessments as (...),  -- already collapsed via int_assessments__college_assessment_practice; verify and drop DISTINCT
+ap_assessments as (select ... from int_assessments__ap_assessments_definitions),
+... existing UNION ALL + dedup ...
+```
+
+**Administration grain** (consumed by `dim_assessment_administrations`):
+
+| New intermediate                           | Source                                | Partition key                                                                                          |
+| ------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `int_pearson__administrations`             | `int_pearson__all_assessments`        | `module_code, grade_level, administered_date, academic_year, region, administration_period, test_type` |
+| `int_fldoe__administrations`               | `int_fldoe__all_assessments`          | same shape, with FL-specific column names                                                              |
+| `int_assessments__college_administrations` | `int_assessments__college_assessment` | same shape                                                                                             |
+| `int_assessments__ap_administrations`      | `int_assessments__ap_assessments`     | same shape                                                                                             |
+
+Exact partition columns mirror the current DISTINCT key list in each mart CTE —
+each new intermediate's `dbt_utils.deduplicate` partition column list is copied
+1:1 from the columns currently inside that CTE's projection.
+
+After: each non-illuminate CTE in `dim_assessment_administrations` becomes a
+plain `SELECT ... FROM int_<source>__administrations`. The existing illuminate
+CTE (with its TODO #3800 comment) is unchanged.
+
+### Surveys group
+
+Three new pairs of intermediates plus a verification on the SCD source.
+
+**Per-source question-grain and survey-grain intermediates:**
+
+| Pair         | Source (response grain)               | Question-grain int               | Survey-grain int               |
+| ------------ | ------------------------------------- | -------------------------------- | ------------------------------ |
+| Google Forms | `int_google_forms__form_responses`    | `int_google_forms__questions`    | `int_google_forms__surveys`    |
+| Alchemer     | `int_surveys__survey_responses`       | `int_alchemer__questions`        | `int_alchemer__surveys`        |
+| Manager      | `int_surveys__manager_survey_details` | `int_surveys__manager_questions` | `int_surveys__manager_surveys` |
+
+Partition key for question-grain ints: `(survey_id, question_shortname)` plus
+whatever question-level attributes (`question_text`, `question_type`, display
+order, etc.) the mart currently projects. Partition key for survey-grain ints:
+`survey_id` plus survey-level attributes (`survey_title`, `survey_type`, etc.).
+Exact column lists come from the current DISTINCT projections in
+`dim_survey_questions` / `dim_surveys`.
+
+**SCD source review:** `stg_google_sheets__surveys__scd_question_crosswalk` is
+staging from a Google Sheet — already at question grain by definition. The
+DISTINCT in `dim_survey_questions.scd_questions` is likely vestigial. Verify by
+querying the staging table for uniqueness on `(survey_id, question_shortname)`;
+if unique, drop the DISTINCT, no new intermediate.
+
+**After:** the three marts become plain UNION ALLs over the per-source
+intermediates (plus SCD staging). `bridge_survey_questions` collapses similarly
+— each branch reads `(survey_id, question_shortname)` from the corresponding
+`int_*__questions` model.
+
+### Special case: `dim_assessments.illuminate_assessments`
+
+The issue flags this CTE for review: "Source already exists at assessment-id
+grain (`int_assessments__assessments`); review whether DISTINCT is actually
+needed or just defensive."
+
+`int_assessments__assessments` begins with a `GROUP BY assessment_id` on the
+agl/iae dedup CTE and downstream selects propagate that grain. The DISTINCT in
+`dim_assessments.illuminate_assessments` is defensive.
+
+**Action:** drop the DISTINCT, replace with a plain SELECT. No new intermediate.
+
+If pre/post row-count parity fails on this CTE alone, restore DISTINCT with a
+`-- TODO:` comment per the project rule, and file the upstream uniqueness issue
+separately.
+
+## Verification
+
+Per CLAUDE.md superpowers override "For dbt changes,
+`uv run dbt build --select <model>+` against the relevant project":
+
+```bash
+cd /workspaces/teamster
+VIRTUAL_ENV= uv --directory .worktrees/cbini-refactor-claude-distinct-cleanup-3780 \
+  run dbt build \
+  --project-dir src/dbt/kipptaf \
+  --select \
+    +dim_assessments \
+    +dim_assessment_administrations \
+    +dim_survey_questions \
+    +dim_surveys \
+    +bridge_survey_questions
+```
+
+**Row-count parity** against the PR-branch schema after dbt Cloud CI builds:
+
+```sql
+-- Per mart: pre (prod) vs post (PR-branch schema)
+select 'dim_assessments' as model, count(*) as n from `<prod_schema>.dim_assessments`
+union all
+select 'dim_assessments' as model, count(*) as n from `<pr_branch_schema>.dim_assessments`
+-- ... repeat for the other four marts
+```
+
+Per the marts CLAUDE.md "Removing a mart-level qualify row_number() = 1"
+guidance: net mart row-count delta should be **zero** when the DISTINCT is
+purely projecting (which is the case for all five marts here — the DISTINCT is
+the projection operation, not a defensive dedup of dirty source data). Any
+non-zero delta is a signal that a partition_by column list is wrong and the
+intermediate is fanning out where the mart used to collapse.
+
+## Files touched
+
+**New** (14 SQL + 14 properties YAML entries):
+
+- `src/dbt/kipptaf/models/pearson/intermediate/int_pearson__assessments.sql` +
+  properties
+- `src/dbt/kipptaf/models/pearson/intermediate/int_pearson__administrations.sql` +
+  properties
+- `src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__assessments.sql` +
+  properties
+- `src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__administrations.sql` +
+  properties
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessments_definitions.sql` +
+  properties
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_administrations.sql` +
+  properties
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_assessments_definitions.sql` +
+  properties
+- `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_administrations.sql` +
+  properties
+- `src/dbt/kipptaf/models/google/forms/intermediate/int_google_forms__questions.sql` +
+  properties
+- `src/dbt/kipptaf/models/google/forms/intermediate/int_google_forms__surveys.sql` +
+  properties
+- `src/dbt/kipptaf/models/alchemer/intermediate/int_alchemer__questions.sql` +
+  properties
+- `src/dbt/kipptaf/models/alchemer/intermediate/int_alchemer__surveys.sql` +
+  properties
+- `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_questions.sql` +
+  properties
+- `src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_surveys.sql` +
+  properties
+
+(Final directory placement for Google Forms / Alchemer / Manager intermediates
+mirrors the existing source directory layout — `models/alchemer/intermediate/`
+already exists; Google Forms may need creation; Manager already lives under
+`models/surveys/intermediate/`.)
+
+**Modified** (5 mart SQL files only; YAML untouched since contract surfaces
+don't change):
+
+- `src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql`
+- `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
+- `src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql`
+- `src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql`
+- `src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql`
+
+## Risks
+
+- **Wrong partition_by column list.** If a new intermediate's
+  `dbt_utils.deduplicate` partitions by a narrower key than the mart's current
+  DISTINCT, the mart fans out. Mitigation: copy the partition column list 1:1
+  from the current DISTINCT/GROUP BY in each mart CTE; verify row-count parity
+  per mart.
+- **Stale DISTINCT was masking source non-uniqueness.** If a source response
+  table actually has duplicate (entity-key, projected-attribute) tuples that
+  differ in some excluded column, removing DISTINCT changes the resolved
+  attribute. Mitigation: `order_by` in `dbt_utils.deduplicate` picks
+  deterministically; sample-check populated values before vs after on PR-branch
+  schema for any column that matters (titles, codes).
+- **Hash-input drift on FKs into these dims.** Mart surrogate keys
+  (`assessment_key`, `survey_question_key`, etc.) are computed from projected
+  columns. If a new intermediate changes any of those column values (vs. the
+  current DISTINCT's outputs), downstream FKs hash-diff. Mitigation: the
+  intermediates must project exactly the columns the marts currently project,
+  with the same casts. No semantic changes in this PR.
+
+## Sequencing
+
+One PR, one commit per logical sub-step (split between assessments and surveys
+groups). Suggested commit order inside the branch:
+
+1. Assessments-definition intermediates (4 new) + `dim_assessments` mart
+   rewrite. Verify parity.
+2. Assessments-administration intermediates (4 new) +
+   `dim_assessment_administrations` non-illuminate CTE rewrites. Verify parity.
+3. Survey question + survey intermediates (6 new) + `dim_survey_questions`,
+   `dim_surveys`, `bridge_survey_questions` rewrites. Verify parity.
+4. SCD DISTINCT removal in `dim_survey_questions` (separate commit so the
+   row-count parity check isolates the SCD source case).

--- a/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
+++ b/docs/superpowers/specs/2026-05-24-distinct-cleanup-3780-design.md
@@ -141,6 +141,240 @@ The final mart row-count delta is whatever the difference is between "every
 (post-redirect). For well-maintained forms these should match; any delta is
 itself a signal worth investigating in the verification step.
 
+## Phase 0: Pre-merge BQ shape audit
+
+The surveys redirects move grain from "appears in any response" to "exists as a
+definition" — the row-count delta isn't predictable from inspection. Before
+mart-side commits land, run these queries against prod to size the delta per
+redirect and surface anything anomalous. Each query is a symmetric-difference
+count plus a small sample of unmatched rows; if the delta is large or asymmetric
+in a way the redirect can't explain, escalate that redirect to a new int
+instead.
+
+Schemas: `kipptaf_google_forms`, `kipptaf_alchemer`, `kipptaf_surveys`,
+`kipptaf_google_sheets`. Replace the placeholders below at query time.
+
+### A. Google Forms questions redirect
+
+```sql
+with
+  current as (
+    select distinct
+      form_id,
+      item_abbreviation,
+      item_title,
+      question_kind,
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form_responses`
+    where item_abbreviation is not null and item_title is not null
+  ),
+  target as (
+    select
+      form_id,
+      item_abbreviation,
+      item_title,
+      question_kind,
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
+    where item_abbreviation is not null and item_title is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+### B. Alchemer questions redirect
+
+```sql
+with
+  current as (
+    select distinct
+      survey_id,
+      question_shortname,
+      question_title,
+    from `teamster-332318.kipptaf_surveys.int_surveys__survey_responses`
+    where question_shortname is not null
+      and survey_id is not null
+      -- scope to Alchemer rows only; Google Forms rows now flow through redirect A
+      and safe_cast(survey_id as int) is not null
+  ),
+  target as (
+    select
+      safe_cast(survey_id as string) as survey_id,
+      shortname as question_shortname,
+      title_english as question_title,
+    from `teamster-332318.kipptaf_alchemer.stg_alchemer__survey_question`
+    where shortname is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+### C. Google Forms surveys redirect
+
+```sql
+with
+  current as (
+    select distinct form_id, info_title
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form_responses`
+    where form_id is not null
+  ),
+  target as (
+    select form_id, info_title
+    from `teamster-332318.kipptaf_google_forms.stg_google_forms__form`
+    where form_id is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+### D. Alchemer surveys redirect
+
+```sql
+with
+  current as (
+    select distinct
+      safe_cast(survey_id as string) as survey_id,
+      survey_title,
+    from `teamster-332318.kipptaf_alchemer.base_alchemer__survey_results`
+    where survey_id is not null
+  ),
+  target as (
+    select
+      safe_cast(id as string) as survey_id,
+      <title_col> as survey_title,
+    from `teamster-332318.kipptaf_alchemer.stg_alchemer__survey`
+    where id is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+(Resolve `<title_col>` from `stg_alchemer__survey` schema at query time — the
+staging model uses `dbt_utils.star()` so the title column name depends on the
+source. Run
+`select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'stg_alchemer__survey'`
+first.)
+
+### E. Google Forms bridge pairs
+
+```sql
+with
+  current as (
+    select distinct form_id, item_abbreviation, question_required
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form_responses`
+    where form_id is not null and item_abbreviation is not null
+  ),
+  target as (
+    select form_id, item_abbreviation, question_required
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
+    where form_id is not null and item_abbreviation is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+### F. Alchemer bridge pairs
+
+```sql
+with
+  current as (
+    select distinct survey_id, question_shortname
+    from `teamster-332318.kipptaf_surveys.int_surveys__survey_responses`
+    where survey_id is not null
+      and question_shortname is not null
+      and safe_cast(survey_id as int) is not null  -- Alchemer rows only
+  ),
+  target as (
+    select
+      safe_cast(survey_id as string) as survey_id,
+      shortname as question_shortname,
+    from `teamster-332318.kipptaf_alchemer.stg_alchemer__survey_question`
+    where shortname is not null
+  )
+select
+  (select count(*) from current) as n_current,
+  (select count(*) from target) as n_target,
+  (select count(*) from current except distinct select * from target) as n_current_only,
+  (select count(*) from target except distinct select * from current) as n_target_only,
+```
+
+### G. Manager drop validation
+
+Confirm that every `(survey_id, question_shortname)` pair the manager CTEs
+currently contribute is already covered by the gforms or SCD surfaces (otherwise
+the drop loses rows):
+
+```sql
+with
+  manager_pairs as (
+    select distinct survey_id, question_shortname
+    from `teamster-332318.kipptaf_surveys.int_surveys__manager_survey_details`
+    where survey_id is not null and question_shortname is not null
+  ),
+  gforms_pairs as (
+    select form_id as survey_id, item_abbreviation as question_shortname
+    from `teamster-332318.kipptaf_google_forms.int_google_forms__form__items`
+    where item_abbreviation is not null
+  ),
+  scd_pairs as (
+    select 'PowerSchool' as survey_id, question_code as question_shortname
+    from `teamster-332318.kipptaf_google_sheets.stg_google_sheets__surveys__scd_question_crosswalk`
+    where question_code like 'School_Survey_%'
+  ),
+  covered as (
+    select * from gforms_pairs
+    union all
+    select * from scd_pairs
+  )
+select
+  (select count(*) from manager_pairs) as n_manager,
+  (
+    select count(*)
+    from manager_pairs
+    except distinct
+    select * from covered
+  ) as n_manager_uncovered,
+```
+
+`n_manager_uncovered` must be 0 (or only `historic_alchemer_Manager_survey`
+archive rows, which are handled by the hardcoded `archive_manager` CTE in
+`dim_surveys` and are already covered by the existing bridge/dim shape). Any
+other uncovered rows mean the drop is unsafe — keep the CTE and build a new
+manager-grain int instead.
+
+### Phase-0 decision rules
+
+For each redirect A–F:
+
+- **Symmetric delta (`n_target` near `n_current` with small `n_*_only` on both
+  sides)**: redirect is safe; deltas are explained by definition rows with no
+  responses (target-only) and stale response rows for removed definitions
+  (current-only). Document the count in the PR body and proceed.
+- **Large `n_target_only`**: many definitions never received responses. Expected
+  for surveys with low completion rates; safe to proceed.
+- **Large `n_current_only`**: response rows reference a (survey, question) the
+  definition source doesn't carry — typically renamed shortnames or
+  deleted/recreated forms. Sample 10 unmatched rows; if they trace to legitimate
+  historical data, escalate that redirect to a new intermediate that unions the
+  definition source with historical response artifacts. Otherwise (test/orphan
+  rows), document and proceed.
+
+Query G must return `n_manager_uncovered = 0` to proceed with the manager CTE
+drop in commit 4.
+
 ## Verification
 
 Per CLAUDE.md "For dbt changes, `uv run dbt build --select <model>+`":
@@ -245,14 +479,19 @@ change):
 
 ## Sequencing
 
-One PR, four logical commits inside the branch:
+One PR, four logical commits plus a pre-commit Phase 0:
 
+0. **Phase 0 (no commit)**: run BQ queries A–G from "Phase 0: Pre-merge BQ shape
+   audit" against prod. Paste results into the PR body. Apply Phase-0 decision
+   rules; if any redirect fails its rule, replace that redirect with a new
+   intermediate before commit 3.
 1. Assessment-definition intermediates (5 new) + `dim_assessments` mart rewrite
    (drops 4 DISTINCTs / GROUP BYs and the stale comment). Verify parity.
 2. Assessment-administration intermediates (4 new) +
    `dim_assessment_administrations` non-illuminate CTE rewrites. Verify parity.
 3. Surveys redirects across `dim_survey_questions`, `dim_surveys`,
-   `bridge_survey_questions`. Verify (expected non-zero delta; investigate each
-   direction).
+   `bridge_survey_questions`. Row-count delta against prod is expected to match
+   the Phase-0 audit; flag any discrepancy.
 4. Drop redundant manager CTEs from `dim_survey_questions` and
-   `bridge_survey_questions`. Verify zero net delta vs commit 3.
+   `bridge_survey_questions`. Verify zero net delta vs commit 3 (gated on Phase
+   0 query G returning `n_manager_uncovered = 0`).

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -470,10 +470,10 @@ the same partition.
   `-- TODO:` naming the upstream fix.
 - **DISTINCT is allowed for pure grain projection** — every projected column is
   functionally determined by the partition key, so byte-identical tuples
-  coalesce. Annotate with a comment containing
-  `projection IS the operation, not deduplication`. If any projected column
-  varies within the partition (`min()`, `first_value()`, etc.), use
-  `dbt_utils.deduplicate()` instead.
+  coalesce. Annotate with a two-line comment:
+  `grain projection: every selected column is functionally determined / by the partition key; not a mask for upstream duplicates`.
+  If any projected column varies within the partition (`min()`, `first_value()`,
+  etc.), use `dbt_utils.deduplicate()` instead.
 - **No `GROUP BY ALL`** — list grouping columns explicitly. `GROUP BY ALL`
   breaks silently when upstream columns change.
 - **No `ORDER BY`** — ordering belongs in the reporting layer, not dbt models.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -456,11 +456,16 @@ the same partition.
   case — that rebuilds the external table and forces sheet-header coordination.
 - **No `GROUP BY` without aggregation** — use `DISTINCT` instead (see next rule
   for deduplication constraints).
-- **No manual deduplication** — do not use `SELECT DISTINCT` or
-  `qualify row_number() over (...) = 1` for deduplication. Use
-  `dbt_utils.deduplicate()` with an explicit `partition_by` and `order_by`. If
-  `DISTINCT` is truly unavoidable, it must include a `-- TODO:` comment
-  explaining why and what needs to be fixed upstream.
+- **No manual deduplication for dirty data** — do not use `SELECT DISTINCT` or
+  `qualify row_number() over (...) = 1` to work around upstream duplicates. Use
+  `dbt_utils.deduplicate()` with explicit `partition_by` and `order_by`; add
+  `-- TODO:` naming the upstream fix.
+- **DISTINCT is allowed for pure grain projection** — every projected column is
+  functionally determined by the partition key, so byte-identical tuples
+  coalesce. Annotate with a comment containing
+  `projection IS the operation, not deduplication`. If any projected column
+  varies within the partition (`min()`, `first_value()`, etc.), use
+  `dbt_utils.deduplicate()` instead.
 - **No `GROUP BY ALL`** — list grouping columns explicitly. `GROUP BY ALL`
   breaks silently when upstream columns change.
 - **No `ORDER BY`** — ordering belongs in the reporting layer, not dbt models.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -160,6 +160,14 @@ manifest". The prod manifest is refreshed by `.git/hooks/post-merge` on every
   models, not district-level overrides with the same name. For cross-project
   staging seeding, omit `--select`.
 
+## `dbt_utils.union_relations` is compile-time
+
+Compiles to the column intersection from source-table
+`INFORMATION_SCHEMA.COLUMNS`. New columns added at package-level staging don't
+surface at kipptaf-level consumers until district projects rebuild prod. For
+single-PR refactors, add transformations at the kipptaf-level wrapper, not at
+package level.
+
 ## Stale dev tables shadow `--defer`
 
 `--defer` uses any existing dev table before falling through to prod, so a stale

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -474,6 +474,8 @@ the same partition.
   `grain projection: every selected column is functionally determined / by the partition key; not a mask for upstream duplicates`.
   If any projected column varies within the partition (`min()`, `first_value()`,
   etc.), use `dbt_utils.deduplicate()` instead.
+- **`dbt_utils.generate_surrogate_key` coerces nulls internally** —
+  `cast(null as <type>)` and bare `null` hash identically. Don't add the cast.
 - **No `GROUP BY ALL`** — list grouping columns explicitly. `GROUP BY ALL`
   breaks silently when upstream columns change.
 - **No `ORDER BY`** — ordering belongs in the reporting layer, not dbt models.

--- a/src/dbt/kipptaf/models/alchemer/sources-bigquery.yml
+++ b/src/dbt/kipptaf/models/alchemer/sources-bigquery.yml
@@ -10,3 +10,5 @@ sources:
                 - kipptaf
                 - alchemer
                 - base_alchemer__survey_results
+      - name: stg_alchemer__survey
+      - name: stg_alchemer__survey_question

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_assessments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__ap_assessments.sql
@@ -49,6 +49,8 @@ select
     irregularity_code_1,
     irregularity_code_2,
 
+    concat('AP ', test_subject) as title,
+
     row_number() over (
         partition by powerschool_student_number, ap_course_name order by exam_score desc
     ) as rn_highest,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__assessments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__assessments.sql
@@ -21,7 +21,6 @@ with
             iae.module_code,
             iae.module_type,
             iae.module_sequence,
-            iae.grade_level,
             iae.illuminate_grade_level_id,
             iae.regions_assessed,
             iae.regions_assessed_array,
@@ -40,6 +39,66 @@ with
             {{ ref("stg_google_appsheet__illuminate_assessments_extension") }} as iae
             on a.assessment_id = iae.assessment_id
         left join agl_dedup as agl on a.assessment_id = agl.assessment_id
+    ),
+
+    canonical as (
+        select
+            assessment_id,
+            title,
+            academic_year,
+            academic_year_clean,
+            scope,
+            creator_first_name,
+            creator_last_name,
+            performance_band_set_id,
+            assessment_type,
+            tags,
+            module_code,
+            module_type,
+            module_sequence,
+            illuminate_grade_level_id,
+            regions_assessed,
+            regions_assessed_array,
+            regions_report_card,
+            regions_progress_report,
+            administered_at,
+            subject_area,
+            grade_level_id,
+            is_internal_assessment,
+
+            if(
+                is_internal_assessment,
+                first_value(assessment_id) over canonical_w,
+                assessment_id
+            ) as canonical_assessment_id,
+
+            if(
+                is_internal_assessment, first_value(title) over canonical_w, title
+            ) as canonical_title,
+
+            if(
+                is_internal_assessment,
+                first_value(administered_at) over canonical_w,
+                administered_at
+            ) as canonical_administered_at,
+
+            if(
+                is_internal_assessment,
+                first_value(grade_level_id) over canonical_w,
+                grade_level_id
+            ) as canonical_grade_level_id,
+        from extended
+        window
+            canonical_w as (
+                partition by
+                    is_internal_assessment,
+                    academic_year,
+                    scope,
+                    subject_area,
+                    module_code,
+                    grade_level_id
+                order by assessment_id
+            )
     )
 
 select
@@ -56,7 +115,6 @@ select
     module_code,
     module_type,
     module_sequence,
-    grade_level,
     illuminate_grade_level_id,
     regions_assessed,
     regions_assessed_array,
@@ -66,37 +124,12 @@ select
     subject_area,
     grade_level_id,
     is_internal_assessment,
+    canonical_assessment_id,
+    canonical_title,
+    canonical_administered_at,
+    canonical_grade_level_id,
 
-    if(
-        is_internal_assessment,
-        first_value(assessment_id) over canonical_w,
-        assessment_id
-    ) as canonical_assessment_id,
+    cast(canonical_administered_at as date) as administered_date,
 
-    if(
-        is_internal_assessment, first_value(title) over canonical_w, title
-    ) as canonical_title,
-
-    if(
-        is_internal_assessment,
-        first_value(administered_at) over canonical_w,
-        administered_at
-    ) as canonical_administered_at,
-
-    if(
-        is_internal_assessment,
-        first_value(grade_level_id) over canonical_w,
-        grade_level_id
-    ) as canonical_grade_level_id,
-from extended
-window
-    canonical_w as (
-        partition by
-            is_internal_assessment,
-            academic_year,
-            scope,
-            subject_area,
-            module_code,
-            grade_level_id
-        order by assessment_id
-    )
+    canonical_grade_level_id - 1 as grade_level,
+from canonical

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -229,9 +229,6 @@ select
     ru.module_code,
     ru.region,
     ru.powerschool_school_id,
-
-    concat('kipp', lower(ru.region)) as _dbt_source_project,
-
     ru.is_internal_assessment,
     ru.is_replacement,
     ru.response_type,
@@ -258,6 +255,8 @@ select
     rta.name as term_administered,
 
     rtt.name as term_taken,
+
+    concat('kipp', lower(ru.region)) as _dbt_source_project,
 from response_union as ru
 left join
     {{ ref("int_illuminate__performance_band_sets") }} as pbl

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -229,6 +229,9 @@ select
     ru.module_code,
     ru.region,
     ru.powerschool_school_id,
+
+    concat('kipp', lower(ru.region)) as _dbt_source_project,
+
     ru.is_internal_assessment,
     ru.is_replacement,
     ru.response_type,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -13,6 +13,7 @@ with
             s.module_type,
             s.module_code,
             s.region,
+            s._dbt_source_project,
             s.powerschool_school_id,
             s.grade_level_id,
             s.is_internal_assessment,
@@ -63,6 +64,7 @@ with
             *,
             first_value(powerschool_school_id) over (w) as canonical_school_id,
             first_value(region) over (w) as canonical_region,
+            first_value(_dbt_source_project) over (w) as canonical_dbt_source_project,
         from scaffold_responses
         window
             w as (
@@ -111,6 +113,7 @@ with
             -- without independent-min() drift. See #3801.
             any_value(canonical_school_id) as powerschool_school_id,
             any_value(canonical_region) as region,
+            any_value(canonical_dbt_source_project) as _dbt_source_project,
 
             count(distinct assessment_id) as n_assessments,
 
@@ -157,6 +160,7 @@ with
             module_type,
             module_code,
             region,
+            _dbt_source_project,
             is_internal_assessment,
             is_replacement,
             response_type,
@@ -191,6 +195,7 @@ with
             module_type,
             module_code,
             region,
+            _dbt_source_project,
             is_internal_assessment,
             is_replacement,
             response_type,
@@ -228,6 +233,7 @@ select
     ru.module_type,
     ru.module_code,
     ru.region,
+    ru._dbt_source_project,
     ru.powerschool_school_id,
     ru.is_internal_assessment,
     ru.is_replacement,
@@ -255,8 +261,6 @@ select
     rta.name as term_administered,
 
     rtt.name as term_taken,
-
-    concat('kipp', lower(ru.region)) as _dbt_source_project,
 from response_union as ru
 left join
     {{ ref("int_illuminate__performance_band_sets") }} as pbl

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -47,24 +47,20 @@ with
             and asr.response_type_id = pb.response_type_id
     ),
 
-    -- Canonical-grain rollup of school/region from response-grain scaffold rows.
-    -- Without this, group-by aggregates would need min() per column, and
-    -- independent mins can pick from different rows in the same partition. Per
-    -- src/dbt/CLAUDE.md "Canonical attributes from a partition", first_value
-    -- on a deterministic ordering picks both attributes from the same row.
-    -- Cross-school groups exist here because of upstream Illuminate
-    -- canonicalization carrying wrong academic_year tags onto duplicated
-    -- assessments — tracked in #3801. Once #3801 is resolved, the canonical
-    -- school/region selection should collapse to a single value per partition
-    -- and this CTE can be removed (reverting school/region to plain group-by
-    -- columns or pruning them entirely if they move to a per-consumer
-    -- enrollment join).
-    canonical_attrs as (
+    -- Per-partition tiebreak for location columns. NOT a canonical attribute —
+    -- school / _dbt_source_project are per-response location data that vary
+    -- across rows in the same (student, canonical_assessment, is_replacement)
+    -- partition because of upstream Illuminate canonicalization defects
+    -- (#3801) carrying wrong academic_year tags onto duplicated assessments.
+    -- first_value on a deterministic ordering picks both columns from the
+    -- same row so independent min() drift can't split them. Once #3801 is
+    -- resolved, the partition becomes pure and this CTE can be removed.
+    tiebroken_attrs as (
         select
             *,
-            first_value(powerschool_school_id) over (w) as canonical_school_id,
-            first_value(region) over (w) as canonical_region,
-            first_value(_dbt_source_project) over (w) as canonical_dbt_source_project,
+            first_value(powerschool_school_id) over (w) as selected_school_id,
+            first_value(region) over (w) as selected_region,
+            first_value(_dbt_source_project) over (w) as selected_dbt_source_project,
         from scaffold_responses
         window
             w as (
@@ -108,12 +104,12 @@ with
 
             min(date_taken) as date_taken,
 
-            -- canonical_school_id / canonical_region are constant per partition
-            -- (windowed in canonical_attrs). any_value() makes that explicit
-            -- without independent-min() drift. See #3801.
-            any_value(canonical_school_id) as powerschool_school_id,
-            any_value(canonical_region) as region,
-            any_value(canonical_dbt_source_project) as _dbt_source_project,
+            -- selected_* values are constant per partition (windowed in
+            -- tiebroken_attrs). any_value() makes that explicit without
+            -- independent-min() drift. See #3801.
+            any_value(selected_school_id) as powerschool_school_id,
+            any_value(selected_region) as region,
+            any_value(selected_dbt_source_project) as _dbt_source_project,
 
             count(distinct assessment_id) as n_assessments,
 
@@ -124,7 +120,7 @@ with
             round(
                 safe_divide(sum(points), sum(points_possible)) * 100, 1
             ) as percent_correct,
-        from canonical_attrs
+        from tiebroken_attrs
         where is_internal_assessment
         group by
             illuminate_student_id,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
@@ -166,6 +166,8 @@ select
     ia.discipline,
     ia.cc_dcid,
     ia.cc_source_project,
+
+    concat('kipp', lower(ia.region)) as _dbt_source_project,
     ia.canonical_assessment_id,
     ia.canonical_title,
     ia.canonical_administered_at,
@@ -211,6 +213,8 @@ select
 
     cast(null as int64) as cc_dcid,
     cast(null as string) as cc_source_project,
+
+    concat('kipp', lower(str.region)) as _dbt_source_project,
 
     a.canonical_assessment_id,
     a.canonical_title,
@@ -269,6 +273,8 @@ select
 
     cast(null as int64) as cc_dcid,
     cast(null as string) as cc_source_project,
+
+    concat('kipp', lower(str.region)) as _dbt_source_project,
 
     a.canonical_assessment_id,
     a.canonical_title,

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__assessments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__assessments.yml
@@ -41,8 +41,6 @@ models:
         data_type: string
       - name: module_sequence
         data_type: int64
-      - name: grade_level
-        data_type: int64
       - name: illuminate_grade_level_id
         data_type: int64
       - name: regions_assessed
@@ -108,3 +106,13 @@ models:
           `grade_level_id` of the row whose `assessment_id` equals
           `canonical_assessment_id`. Consistent with the other `canonical_*`
           attributes (all derived from the same canonical row).
+
+      - name: administered_date
+        data_type: date
+        description:
+          Canonical administration date (cast from canonical_administered_at).
+      - name: grade_level
+        data_type: int64
+        description: >-
+          Canonical grade level (canonical_grade_level_id - 1, since the
+          upstream uses 1-indexed grade IDs).

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -56,20 +56,20 @@ models:
         data_type: string
         description: >-
           The student's region for this administration. Selected together with
-          `powerschool_school_id` from a single source row via `first_value(...)
-          order by date_taken, student_assessment_id, powerschool_school_id`
-          windowed in the `canonical_attrs` CTE, then read via `any_value()` in
-          the rollup. Cross-school groups exist because of upstream
-          canonicalization defects — see #3801.
+          `powerschool_school_id` and `_dbt_source_project` from a single source
+          row via `first_value(...)` windowed in the `tiebroken_attrs` CTE, then
+          read via `any_value()` in the rollup. Not a canonical attribute — it
+          is per-response location data that varies across rows in the same
+          partition because of upstream canonicalization defects (#3801);
+          `first_value` is a deterministic tiebreak, not a canonicalization.
       - name: powerschool_school_id
         data_type: int64
         description: >-
           The student's school for this administration. Selected together with
-          `region` from a single source row via `first_value(...) order by
-          date_taken, student_assessment_id, powerschool_school_id` windowed in
-          the `canonical_attrs` CTE, then read via `any_value()` in the rollup.
-          Cross-school groups exist because of upstream canonicalization defects
-          — see #3801.
+          `region` and `_dbt_source_project` from a single source row via
+          `first_value(...)` windowed in the `tiebroken_attrs` CTE, then read
+          via `any_value()` in the rollup. See `region` for the full tiebreak
+          semantics.
       - name: _dbt_source_project
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -70,6 +70,13 @@ models:
           the `canonical_attrs` CTE, then read via `any_value()` in the rollup.
           Cross-school groups exist because of upstream canonicalization defects
           — see #3801.
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Dagster code-location prefix derived from region (e.g. kippnewark,
+          kippcamden, kippmiami, kipppaterson). Carried into downstream hashes
+          so consumers join/hash on a stable column rather than re-deriving via
+          concat(region) at each call.
       - name: is_internal_assessment
         data_type: boolean
       - name: is_replacement

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -84,6 +84,13 @@ models:
         config:
           meta:
             source_column: int_assessments__course_enrollments._dbt_source_project
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Dagster code-location prefix derived from region (e.g. kippnewark,
+          kippcamden, kippmiami, kipppaterson). Carried into downstream hashes
+          so consumers join/hash on a stable column rather than re-deriving via
+          concat(region) or extract_code_location() at each call.
       - name: student_assessment_id
         data_type: int64
       - name: date_taken

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__assessments.yml
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__assessments.yml
@@ -53,3 +53,5 @@ models:
         data_type: date
       - name: canonical_grade_level_id
         data_type: int64
+      - name: administered_date
+        data_type: date

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -56,7 +56,7 @@ select
     fl.assessment_name,
     fl.student_number,
 
-    'kippmiami' as _dbt_source_project,
+    {{ extract_code_location("fl") }} as _dbt_source_project,
 
     cw1.sublevel_number,
     cw1.sublevel_name,

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -90,6 +90,7 @@ select
         then 'state_fl_eoc'
         when 'Science'
         then 'state_fl_science'
+        else 'state_fl_unknown'
     end as assessment_type,
 from source as fl
 left join

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -56,6 +56,8 @@ select
     fl.assessment_name,
     fl.student_number,
 
+    'kippmiami' as _dbt_source_project,
+
     cw1.sublevel_number,
     cw1.sublevel_name,
 
@@ -77,6 +79,18 @@ select
         partition by fl.student_id, fl.academic_year, fl.assessment_subject
         order by fl.administration_window asc
     ) as scale_score_prev,
+
+    case
+        fl.assessment_name
+        when 'FAST'
+        then 'state_fl_fast'
+        when 'FSA'
+        then 'state_fl_fsa'
+        when 'EOC'
+        then 'state_fl_eoc'
+        when 'Science'
+        then 'state_fl_science'
+    end as assessment_type,
 from source as fl
 left join
     scale_crosswalk as sc

--- a/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
@@ -74,3 +74,9 @@ models:
         description:
           LAG of scale_score partitioned by student_id, academic_year,
           assessment_subject ordered by administration_window.
+      - name: assessment_type
+        data_type: string
+        description: >-
+          Program-lineage label ('state_fl_fast' / '..._fsa' / '..._eoc' /
+          '..._science') derived from assessment_name. Used by marts as the
+          hash-input value for assessment_key.

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__eoc.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__eoc.yml
@@ -1,7 +1,5 @@
 models:
   - name: stg_fldoe__eoc
-    config:
-      enabled: false
     columns:
       - name: _dbt_source_relation
         data_type: string
@@ -77,3 +75,10 @@ models:
         data_type: int64
       - name: is_proficient
         data_type: boolean
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+      - name: grade_level
+        data_type: int64
+        description: Cast from enrolled_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fast.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fast.yml
@@ -73,3 +73,11 @@ models:
         data_type: int64
       - name: is_proficient
         data_type: boolean
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+      - name: grade_level
+        data_type: int64
+        description:
+          Cast from assessment_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fsa.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fsa.yml
@@ -1,7 +1,5 @@
 models:
   - name: stg_fldoe__fsa
-    config:
-      enabled: false
     columns:
       - name: _dbt_source_relation
         data_type: string
@@ -91,3 +89,10 @@ models:
         data_type: string
       - name: assessment_subject
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+      - name: grade_level
+        data_type: int64
+        description: Cast from test_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__science.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__science.yml
@@ -1,7 +1,5 @@
 models:
   - name: stg_fldoe__science
-    config:
-      enabled: false
     columns:
       - name: _dbt_source_relation
         data_type: string
@@ -71,3 +69,11 @@ models:
         data_type: boolean
       - name: test_code
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+      - name: grade_level
+        data_type: int64
+        description:
+          Cast from assessment_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__eoc.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__eoc.sql
@@ -1,1 +1,16 @@
-{{ dbt_utils.union_relations(relations=[source("kippmiami_fldoe", model.name)]) }}
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[source("kippmiami_fldoe", model.name)]
+            )
+        }}
+    )
+
+select
+    *,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    cast(enrolled_grade as int) as grade_level,
+from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fast.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fast.sql
@@ -1,5 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[source("kippmiami_fldoe", "stg_fldoe__fast")]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[source("kippmiami_fldoe", model.name)]
+            )
+        }}
     )
-}}
+
+select
+    *,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    cast(assessment_grade as int) as grade_level,
+from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fsa.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fsa.sql
@@ -1,1 +1,16 @@
-{{ dbt_utils.union_relations(relations=[source("kippmiami_fldoe", model.name)]) }}
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[source("kippmiami_fldoe", model.name)]
+            )
+        }}
+    )
+
+select
+    *,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    cast(test_grade as int) as grade_level,
+from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__science.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__science.sql
@@ -1,1 +1,16 @@
-{{ dbt_utils.union_relations(relations=[source("kippmiami_fldoe", model.name)]) }}
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[source("kippmiami_fldoe", model.name)]
+            )
+        }}
+    )
+
+select
+    *,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    cast(assessment_grade as int) as grade_level,
+from union_relations

--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -309,3 +309,7 @@ separate PR.
 Before proposing a new structural mart change, check the open items on the
 [Data Team project board](https://github.com/orgs/TEAMSchools/projects/4) — the
 case may already be tracked and deferred.
+
+Adding a column to a model breaks downstream contract-enforced `select *`
+consumers. Grep `select \*` consumers and update their contract YAMLs in the
+same PR — only `dbt build` catches it, not `parse`.

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_administration_members.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_administration_members.sql
@@ -9,6 +9,8 @@ with
             cast(a.canonical_administered_at as date) as canonical_administered_date,
 
             region,
+
+            concat('kipp', lower(region)) as _dbt_source_project,
         from {{ ref("int_assessments__assessments") }} as a
         cross join unnest(a.regions_assessed_array) as region
         where a.is_internal_assessment
@@ -22,10 +24,10 @@ select
                 "module_code",
                 "canonical_administered_date",
                 "academic_year",
-                "region",
-                "cast(null as string)",
+                "_dbt_source_project",
+                "null",
                 "canonical_assessment_id",
-                "cast(null as string)",
+                "null",
             ]
         )
     }} as assessment_administration_key,
@@ -36,7 +38,7 @@ select
                 "'illuminate'",
                 "module_code",
                 "member_assessment_id",
-                "cast(null as string)",
+                "null",
             ]
         )
     }} as assessment_key,

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
@@ -49,9 +49,9 @@ select
                 "cast(canonical_administered_at as date)",
                 "academic_year",
                 "_dbt_source_project",
-                "cast(null as string)",
+                "null",
                 "canonical_assessment_id",
-                "cast(null as string)",
+                "null",
             ]
         )
     }} as assessment_administration_key,

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
@@ -10,13 +10,12 @@ with
             sc.cc_source_project,
             sc.assessment_id,
             sc.administered_at,
+            sc._dbt_source_project,
 
             a.module_code,
             a.academic_year,
             a.canonical_assessment_id,
             a.canonical_administered_at,
-
-            concat('kipp', lower(sc.region)) as _dbt_source_project,
         from {{ ref("int_assessments__scaffold") }} as sc
         inner join
             {{ ref("int_assessments__assessments") }} as a

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_enrollment_scoped.sql
@@ -10,12 +10,13 @@ with
             sc.cc_source_project,
             sc.assessment_id,
             sc.administered_at,
-            sc.region,
 
             a.module_code,
             a.academic_year,
             a.canonical_assessment_id,
             a.canonical_administered_at,
+
+            concat('kipp', lower(sc.region)) as _dbt_source_project,
         from {{ ref("int_assessments__scaffold") }} as sc
         inner join
             {{ ref("int_assessments__assessments") }} as a
@@ -48,7 +49,7 @@ select
                 "module_code",
                 "cast(canonical_administered_at as date)",
                 "academic_year",
-                "region",
+                "_dbt_source_project",
                 "cast(null as string)",
                 "canonical_assessment_id",
                 "cast(null as string)",

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_assessment_expectations_student_scoped.sql
@@ -6,6 +6,7 @@ with
             sc.administered_at,
             sc.region,
             sc.powerschool_school_id,
+            sc._dbt_source_project,
 
             a.module_code,
             a.academic_year,
@@ -48,10 +49,10 @@ select
                 "module_code",
                 "cast(canonical_administered_at as date)",
                 "academic_year",
-                "region",
-                "cast(null as string)",
+                "_dbt_source_project",
+                "null",
                 "canonical_assessment_id",
-                "cast(null as string)",
+                "null",
             ]
         )
     }} as assessment_administration_key,

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql
@@ -27,22 +27,16 @@ with
     ),
 
     manager_pairs as (
-        -- Synthesizes pairs for the historic Manager Survey archive, whose
-        -- original Alchemer survey_ids were not preserved. Live Manager
-        -- Survey pairs flow through google_forms_pairs above. Sourced from
-        -- the gforms items extension (not items) because the extension
-        -- carries historic shortnames (e.g. Q_5) that the live form
-        -- removed.
+        -- Sources directly from the historic Manager Survey Alchemer
+        -- archive. Original Alchemer survey_ids were not preserved, so
+        -- the synthetic 'historic_alchemer_Manager_survey' survey_id ties
+        -- archive responses to the dim_surveys archive_manager row.
         select distinct
             'historic_alchemer_Manager_survey' as survey_id,
-            abbreviation as question_shortname,
+            question_shortname,
             cast(null as bool) as is_required,
-        from {{ ref("stg_google_sheets__google_forms__form_items_extension") }}
-        where
-            form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
-            and abbreviation is not null
-            and abbreviation
-            not in ('respondent_employee_number', 'subject_employee_number')
+        from {{ source("surveys", "stg_surveys__manager_survey_detail_archive") }}
+        where question_shortname is not null
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_survey_questions.sql
@@ -1,12 +1,11 @@
 with
     google_forms_pairs as (
-        -- DISTINCT projects from response grain to (survey, question) pair grain.
-        select distinct
-            fr.form_id as survey_id,
-            fr.item_abbreviation as question_shortname,
-            fr.question_required as is_required,
-        from {{ ref("int_google_forms__form_responses") }} as fr
-        where fr.form_id is not null and fr.item_abbreviation is not null
+        select
+            form_id as survey_id,
+            item_abbreviation as question_shortname,
+            question_required as is_required,
+        from {{ ref("int_google_forms__form__items") }}
+        where form_id is not null and item_abbreviation is not null
     ),
 
     scd_powerschool_pairs as (
@@ -19,21 +18,31 @@ with
     ),
 
     alchemer_pairs as (
-        -- DISTINCT projects from response grain to (survey, question) pair grain.
-        -- Covers Alchemer + Google Forms staff/student survey questions feeding
-        -- fct_survey_responses.general_responses.
-        select distinct
-            sr.survey_id, sr.question_shortname, cast(null as bool) as is_required,
-        from {{ ref("int_surveys__survey_responses") }} as sr
-        where sr.survey_id is not null and sr.question_shortname is not null
+        select
+            safe_cast(survey_id as string) as survey_id,
+            shortname as question_shortname,
+            cast(null as bool) as is_required,
+        from {{ source("alchemer", "stg_alchemer__survey_question") }}
+        where shortname is not null
     ),
 
     manager_pairs as (
-        -- DISTINCT projects from response grain to (survey, question) pair grain.
+        -- Synthesizes pairs for the historic Manager Survey archive, whose
+        -- original Alchemer survey_ids were not preserved. Live Manager
+        -- Survey pairs flow through google_forms_pairs above. Sourced from
+        -- the gforms items extension (not items) because the extension
+        -- carries historic shortnames (e.g. Q_5) that the live form
+        -- removed.
         select distinct
-            ms.survey_id, ms.question_shortname, cast(null as bool) as is_required,
-        from {{ ref("int_surveys__manager_survey_details") }} as ms
-        where ms.survey_id is not null and ms.question_shortname is not null
+            'historic_alchemer_Manager_survey' as survey_id,
+            abbreviation as question_shortname,
+            cast(null as bool) as is_required,
+        from {{ ref("stg_google_sheets__google_forms__form_items_extension") }}
+        where
+            form_id = '1cvp9RnYxbn-WGLXsYSupbEl2KhVhWKcOFbHR2CgUBH0'
+            and abbreviation is not null
+            and abbreviation
+            not in ('respondent_employee_number', 'subject_employee_number')
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -21,25 +21,23 @@ with
         -- tuples, but the upstream collapse is preferred per
         -- src/dbt/CLAUDE.md "no manual deduplication".
         select distinct
-            'illuminate' as assessment_type,
-
-            a.canonical_title as title,
-
             a.subject_area,
             a.scope,
             a.module_code,
-
-            a.canonical_grade_level_id - 1 as grade_level,
-
-            cast(a.canonical_administered_at as date) as administered_date,
             a.academic_year,
+
+            a.canonical_title as title,
+            a.canonical_assessment_id as source_assessment_id,
 
             region,
 
-            a.canonical_assessment_id as source_assessment_id,
+            'illuminate' as assessment_type,
 
             cast(null as string) as administration_period,
             cast(null as string) as test_type,
+            cast(a.canonical_administered_at as date) as administered_date,
+
+            a.canonical_grade_level_id - 1 as grade_level,
         from {{ ref("int_assessments__assessments") }} as a
         inner join
             canonical_regions as cr
@@ -52,8 +50,16 @@ with
     -- State NJ PARCC: one administration per (testcode, period, academic_year, region).
     state_nj_parcc_administrations as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+            academic_year,
+
             'state_nj_parcc' as assessment_type,
             'PARCC' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -61,7 +67,7 @@ with
                 `subject`
             ) as subject_area,
 
-            discipline as scope,
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
             case
                 testcode
@@ -74,18 +80,7 @@ with
                 else testcode
             end as module_code,
 
-            test_grade as grade_level,
-
-            cast(null as date) as administered_date,
-            academic_year,
-
             initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            cast(null as int64) as source_assessment_id,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            cast(null as string) as test_type,
         from {{ ref("stg_pearson__parcc") }}
         where testscalescore is not null
     ),
@@ -94,8 +89,16 @@ with
     -- State NJ NJSLA: one administration per (testcode, period, academic_year, region).
     state_nj_njsla_administrations as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+            academic_year,
+
             'state_nj_njsla' as assessment_type,
             'NJSLA' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -103,7 +106,7 @@ with
                 `subject`
             ) as subject_area,
 
-            discipline as scope,
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
             case
                 testcode
@@ -116,18 +119,7 @@ with
                 else testcode
             end as module_code,
 
-            test_grade as grade_level,
-
-            cast(null as date) as administered_date,
-            academic_year,
-
             initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            cast(null as int64) as source_assessment_id,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            cast(null as string) as test_type,
         from {{ ref("stg_pearson__njsla") }}
         where testscalescore is not null
     ),
@@ -137,8 +129,16 @@ with
     -- academic_year, region).
     state_nj_njsla_science_administrations as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+            academic_year,
+
             'state_nj_njsla_science' as assessment_type,
             'NJSLA Science' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -146,7 +146,7 @@ with
                 `subject`
             ) as subject_area,
 
-            discipline as scope,
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
             case
                 testcode
@@ -159,18 +159,7 @@ with
                 else testcode
             end as module_code,
 
-            test_grade as grade_level,
-
-            cast(null as date) as administered_date,
-            academic_year,
-
             initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            cast(null as int64) as source_assessment_id,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            cast(null as string) as test_type,
         from {{ ref("stg_pearson__njsla_science") }}
         where testscalescore is not null
     ),
@@ -179,8 +168,16 @@ with
     -- State NJ NJGPA: one administration per (testcode, period, academic_year, region).
     state_nj_njgpa_administrations as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+            academic_year,
+
             'state_nj_njgpa' as assessment_type,
             'NJGPA' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -188,7 +185,7 @@ with
                 `subject`
             ) as subject_area,
 
-            discipline as scope,
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
             case
                 testcode
@@ -201,18 +198,7 @@ with
                 else testcode
             end as module_code,
 
-            test_grade as grade_level,
-
-            cast(null as date) as administered_date,
-            academic_year,
-
             initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            cast(null as int64) as source_assessment_id,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            cast(null as string) as test_type,
         from {{ ref("stg_pearson__njgpa") }}
         where testscalescore is not null
     ),
@@ -222,24 +208,21 @@ with
     -- academic_year).
     state_fl_fast_administrations as (
         select distinct
-            'state_fl_fast' as assessment_type,
-            'FAST' as title,
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
-
-            cast(assessment_grade as int) as grade_level,
-
-            cast(null as date) as administered_date,
             academic_year,
-
-            'Miami' as region,
-
-            cast(null as int64) as source_assessment_id,
-
             administration_window as administration_period,
 
+            'state_fl_fast' as assessment_type,
+            'FAST' as title,
+            'Miami' as region,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
+
+            cast(assessment_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
         where scale_score is not null
     ),
@@ -249,24 +232,21 @@ with
     -- academic_year).
     state_fl_fsa_administrations as (
         select distinct
-            'state_fl_fsa' as assessment_type,
-            'FSA' as title,
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
-
-            cast(test_grade as int) as grade_level,
-
-            cast(null as date) as administered_date,
             academic_year,
-
-            'Miami' as region,
-
-            cast(null as int64) as source_assessment_id,
-
             administration_window as administration_period,
 
+            'state_fl_fsa' as assessment_type,
+            'FSA' as title,
+            'Miami' as region,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
+
+            cast(test_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
         where scale_score is not null
     ),
@@ -276,24 +256,21 @@ with
     -- academic_year).
     state_fl_eoc_administrations as (
         select distinct
-            'state_fl_eoc' as assessment_type,
-            'EOC' as title,
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
-
-            cast(enrolled_grade as int) as grade_level,
-
-            cast(null as date) as administered_date,
             academic_year,
-
-            'Miami' as region,
-
-            cast(null as int64) as source_assessment_id,
-
             administration_window as administration_period,
 
+            'state_fl_eoc' as assessment_type,
+            'EOC' as title,
+            'Miami' as region,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
+
+            cast(enrolled_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
         where scale_score is not null
     ),
@@ -303,24 +280,21 @@ with
     -- academic_year).
     state_fl_science_administrations as (
         select distinct
-            'state_fl_science' as assessment_type,
-            'Science' as title,
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
-
-            cast(assessment_grade as int) as grade_level,
-
-            cast(null as date) as administered_date,
             academic_year,
-
-            'Miami' as region,
-
-            cast(null as int64) as source_assessment_id,
-
             administration_window as administration_period,
 
+            'state_fl_science' as assessment_type,
+            'Science' as title,
+            'Miami' as region,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
+
+            cast(assessment_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}
         where scale_score is not null
     ),
@@ -358,23 +332,22 @@ with
     -- model.
     practice_administrations as (
         select
-            'college' as assessment_type,
-            scope as title,
-            any_value(subject_area) as subject_area,
             scope,
-            scope as module_code,
-
-            cast(null as int64) as grade_level,
-
-            test_date as administered_date,
             academic_year,
 
-            cast(null as string) as region,
-            cast(null as int64) as source_assessment_id,
-
+            scope as title,
+            scope as module_code,
+            test_date as administered_date,
             administration_round as administration_period,
 
+            'college' as assessment_type,
             'Practice' as test_type,
+
+            cast(null as string) as region,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+
+            any_value(subject_area) as subject_area,
         from {{ ref("int_assessments__college_assessment_practice") }}
         group by scope, test_date, academic_year, administration_round
     ),
@@ -384,64 +357,66 @@ with
     -- projection IS the operation, not deduplication
     ap_administrations as (
         select distinct
-            'ap' as assessment_type,
-            concat('AP ', test_subject) as title,
-            test_subject as subject_area,
-
-            'AP' as scope,
-
-            ps_ap_course_subject_code as module_code,
-
-            cast(null as int64) as grade_level,
-
-            cast(null as date) as administered_date,
             academic_year,
 
+            test_subject as subject_area,
+            ps_ap_course_subject_code as module_code,
+
+            'ap' as assessment_type,
+            'AP' as scope,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
             cast(null as string) as region,
-
             cast(null as int64) as source_assessment_id,
-
             cast(null as string) as administration_period,
-
             cast(null as string) as test_type,
+
+            concat('AP ', test_subject) as title,
         from {{ ref("int_assessments__ap_assessments") }}
     ),
 
+    {%- set union_cols -%}
+        assessment_type, title, subject_area, scope, module_code, grade_level,
+        administered_date, academic_year, region, source_assessment_id,
+        administration_period, test_type
+    {%- endset %}
+
     all_administrations as (
-        select *,
+        select {{ union_cols }},
         from illuminate_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_nj_njgpa_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_nj_njsla_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_nj_njsla_science_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_nj_parcc_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_fl_eoc_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_fl_fast_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_fl_fsa_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from state_fl_science_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from college_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from practice_administrations
         union all
-        select *,
+        select {{ union_cols }},
         from ap_administrations
     )
 

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -25,19 +25,18 @@ with
             a.scope,
             a.module_code,
             a.academic_year,
+            a.administered_date,
+            a.grade_level,
 
             a.canonical_title as title,
             a.canonical_assessment_id as source_assessment_id,
-
-            region,
 
             'illuminate' as assessment_type,
 
             cast(null as string) as administration_period,
             cast(null as string) as test_type,
-            cast(a.canonical_administered_at as date) as administered_date,
 
-            a.canonical_grade_level_id - 1 as grade_level,
+            concat('kipp', lower(region)) as _dbt_source_project,
         from {{ ref("int_assessments__assessments") }} as a
         inner join
             canonical_regions as cr
@@ -47,12 +46,17 @@ with
     ),
 
     -- projection IS the operation, not deduplication
-    -- State NJ PARCC: one administration per (testcode, period, academic_year, region).
+    -- State NJ PARCC: one administration per (testcode, period, academic_year,
+    -- _dbt_source_project).
     state_nj_parcc_administrations as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
             academic_year,
+            administration_period,
+            _dbt_source_project,
 
             'state_nj_parcc' as assessment_type,
             'PARCC' as title,
@@ -60,38 +64,22 @@ with
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
-
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
         from {{ ref("stg_pearson__parcc") }}
         where testscalescore is not null
     ),
 
     -- projection IS the operation, not deduplication
-    -- State NJ NJSLA: one administration per (testcode, period, academic_year, region).
+    -- State NJ NJSLA: one administration per (testcode, period, academic_year,
+    -- _dbt_source_project).
     state_nj_njsla_administrations as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
             academic_year,
+            administration_period,
+            _dbt_source_project,
 
             'state_nj_njsla' as assessment_type,
             'NJSLA' as title,
@@ -99,39 +87,22 @@ with
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
-
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
         from {{ ref("stg_pearson__njsla") }}
         where testscalescore is not null
     ),
 
     -- projection IS the operation, not deduplication
     -- State NJ NJSLA Science: one administration per (testcode, period,
-    -- academic_year, region).
+    -- academic_year, _dbt_source_project).
     state_nj_njsla_science_administrations as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
             academic_year,
+            administration_period,
+            _dbt_source_project,
 
             'state_nj_njsla_science' as assessment_type,
             'NJSLA Science' as title,
@@ -139,38 +110,22 @@ with
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
-
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
         from {{ ref("stg_pearson__njsla_science") }}
         where testscalescore is not null
     ),
 
     -- projection IS the operation, not deduplication
-    -- State NJ NJGPA: one administration per (testcode, period, academic_year, region).
+    -- State NJ NJGPA: one administration per (testcode, period, academic_year,
+    -- _dbt_source_project).
     state_nj_njgpa_administrations as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
             academic_year,
+            administration_period,
+            _dbt_source_project,
 
             'state_nj_njgpa' as assessment_type,
             'NJGPA' as title,
@@ -178,27 +133,6 @@ with
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
-
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
         from {{ ref("stg_pearson__njgpa") }}
         where testscalescore is not null
     ),
@@ -211,19 +145,18 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
             academic_year,
             administration_window as administration_period,
+            _dbt_source_project,
 
             'state_fl_fast' as assessment_type,
             'FAST' as title,
-            'Miami' as region,
 
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            cast(assessment_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
+        from {{ ref("stg_fldoe__fast") }}
         where scale_score is not null
     ),
 
@@ -235,19 +168,18 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
             academic_year,
             administration_window as administration_period,
+            _dbt_source_project,
 
             'state_fl_fsa' as assessment_type,
             'FSA' as title,
-            'Miami' as region,
 
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            cast(test_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
+        from {{ ref("stg_fldoe__fsa") }}
         where scale_score is not null
     ),
 
@@ -259,19 +191,18 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
             academic_year,
             administration_window as administration_period,
+            _dbt_source_project,
 
             'state_fl_eoc' as assessment_type,
             'EOC' as title,
-            'Miami' as region,
 
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            cast(enrolled_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
+        from {{ ref("stg_fldoe__eoc") }}
         where scale_score is not null
     ),
 
@@ -283,52 +214,48 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
             academic_year,
             administration_window as administration_period,
+            _dbt_source_project,
 
             'state_fl_science' as assessment_type,
             'Science' as title,
-            'Miami' as region,
 
             cast(null as date) as administered_date,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-
-            cast(assessment_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}
+        from {{ ref("stg_fldoe__science") }}
         where scale_score is not null
     ),
 
     -- College Official: one administration per (score_type, test_date,
-    -- administration_round). region is null because college tests are
-    -- region-agnostic.
+    -- administration_round). _dbt_source_project is null because college tests
+    -- are region-agnostic.
     -- projection IS the operation, not deduplication
     college_administrations as (
         select distinct
-            'college' as assessment_type,
-            scope as title,
-            subject_area,
             scope,
+            subject_area,
             score_type as module_code,
-
-            cast(null as int64) as grade_level,
-
             test_date as administered_date,
             academic_year,
-
-            cast(null as string) as region,
-
-            cast(null as int64) as source_assessment_id,
-
             administration_round as administration_period,
+
+            'college' as assessment_type,
+            scope as title,
+
+            cast(null as int64) as grade_level,
+            cast(null as string) as _dbt_source_project,
+            cast(null as int64) as source_assessment_id,
 
             'Official' as test_type,
         from {{ ref("int_assessments__college_assessment") }}
     ),
 
     -- College Practice: one administration per (scope, test_date,
-    -- administration_round). region is null because college tests are
-    -- region-agnostic. Aggregates across subject_area rows in the upstream
+    -- administration_round). _dbt_source_project is null because college tests
+    -- are region-agnostic. Aggregates across subject_area rows in the upstream
     -- model.
     practice_administrations as (
         select
@@ -343,7 +270,7 @@ with
             'college' as assessment_type,
             'Practice' as test_type,
 
-            cast(null as string) as region,
+            cast(null as string) as _dbt_source_project,
             cast(null as int64) as grade_level,
             cast(null as int64) as source_assessment_id,
 
@@ -357,6 +284,7 @@ with
     -- projection IS the operation, not deduplication
     ap_administrations as (
         select distinct
+            title,
             academic_year,
 
             test_subject as subject_area,
@@ -367,19 +295,17 @@ with
 
             cast(null as date) as administered_date,
             cast(null as int64) as grade_level,
-            cast(null as string) as region,
+            cast(null as string) as _dbt_source_project,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as administration_period,
             cast(null as string) as test_type,
-
-            concat('AP ', test_subject) as title,
         from {{ ref("int_assessments__ap_assessments") }}
     ),
 
     {%- set union_cols -%}
         assessment_type, title, subject_area, scope, module_code, grade_level,
-        administered_date, academic_year, region, source_assessment_id,
-        administration_period, test_type
+        administered_date, academic_year, _dbt_source_project,
+        source_assessment_id, administration_period, test_type
     {%- endset %}
 
     all_administrations as (
@@ -428,7 +354,7 @@ select
                 "module_code",
                 "administered_date",
                 "academic_year",
-                "region",
+                "_dbt_source_project",
                 "administration_period",
                 "source_assessment_id",
                 "test_type",
@@ -438,12 +364,12 @@ select
 
     -- `academic_year` is intentionally not exposed in the final SELECT —
     -- it's a hash input only. The canonical-grain dim represents an
-    -- administration scoped by `region` + `administered_date_key` +
-    -- `administration_period`; analysts derive academic year from
+    -- administration scoped by `_dbt_source_project` + `administered_date_key`
+    -- + `administration_period`; analysts derive academic year from
     -- `administered_date_key` via `dim_dates`.
     administered_date as administered_date_key,
 
-    region,
+    _dbt_source_project,
     administration_period,
     source_assessment_id,
     test_type,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -48,12 +48,12 @@ with
         where a.is_internal_assessment
     ),
 
-    -- State NJ: one administration per (testcode, period, academic_year,
-    -- region). period acts as the season/window.
-    state_nj_administrations as (
+    -- projection IS the operation, not deduplication
+    -- State NJ PARCC: one administration per (testcode, period, academic_year, region).
+    state_nj_parcc_administrations as (
         select distinct
-            'state' as assessment_type,
-            assessment_name as title,
+            'state_nj_parcc' as assessment_type,
+            'PARCC' as title,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -86,16 +86,144 @@ with
             if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
             cast(null as string) as test_type,
-        from {{ ref("int_pearson__all_assessments") }}
+        from {{ ref("stg_pearson__parcc") }}
         where testscalescore is not null
     ),
 
-    -- State FL: one administration per (test_code, administration_window,
-    -- academic_year, region).
-    state_fl_administrations as (
+    -- projection IS the operation, not deduplication
+    -- State NJ NJSLA: one administration per (testcode, period, academic_year, region).
+    state_nj_njsla_administrations as (
         select distinct
-            'state' as assessment_type,
-            assessment_name as title,
+            'state_nj_njsla' as assessment_type,
+            'NJSLA' as title,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            discipline as scope,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+
+            test_grade as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ ref("stg_pearson__njsla") }}
+        where testscalescore is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State NJ NJSLA Science: one administration per (testcode, period,
+    -- academic_year, region).
+    state_nj_njsla_science_administrations as (
+        select distinct
+            'state_nj_njsla_science' as assessment_type,
+            'NJSLA Science' as title,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            discipline as scope,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+
+            test_grade as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ ref("stg_pearson__njsla_science") }}
+        where testscalescore is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State NJ NJGPA: one administration per (testcode, period, academic_year, region).
+    state_nj_njgpa_administrations as (
+        select distinct
+            'state_nj_njgpa' as assessment_type,
+            'NJGPA' as title,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            discipline as scope,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+
+            test_grade as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ ref("stg_pearson__njgpa") }}
+        where testscalescore is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State FL FAST: one administration per (test_code, administration_window,
+    -- academic_year).
+    state_fl_fast_administrations as (
+        select distinct
+            'state_fl_fast' as assessment_type,
+            'FAST' as title,
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
@@ -105,20 +233,102 @@ with
             cast(null as date) as administered_date,
             academic_year,
 
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
+            'Miami' as region,
 
             cast(null as int64) as source_assessment_id,
 
             administration_window as administration_period,
 
             cast(null as string) as test_type,
-        from {{ ref("int_fldoe__all_assessments") }}
+        from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State FL FSA: one administration per (test_code, administration_window,
+    -- academic_year).
+    state_fl_fsa_administrations as (
+        select distinct
+            'state_fl_fsa' as assessment_type,
+            'FSA' as title,
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(test_grade as int) as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            'Miami' as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            administration_window as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State FL EOC: one administration per (test_code, administration_window,
+    -- academic_year).
+    state_fl_eoc_administrations as (
+        select distinct
+            'state_fl_eoc' as assessment_type,
+            'EOC' as title,
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(enrolled_grade as int) as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            'Miami' as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            administration_window as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    -- State FL Science: one administration per (test_code, administration_window,
+    -- academic_year).
+    state_fl_science_administrations as (
+        select distinct
+            'state_fl_science' as assessment_type,
+            'Science' as title,
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(assessment_grade as int) as grade_level,
+
+            cast(null as date) as administered_date,
+            academic_year,
+
+            'Miami' as region,
+
+            cast(null as int64) as source_assessment_id,
+
+            administration_window as administration_period,
+
+            cast(null as string) as test_type,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}
         where scale_score is not null
     ),
 
     -- College Official: one administration per (score_type, test_date,
     -- administration_round). region is null because college tests are
     -- region-agnostic.
+    -- projection IS the operation, not deduplication
     college_administrations as (
         select distinct
             'college' as assessment_type,
@@ -171,6 +381,7 @@ with
 
     -- AP: one administration per (subject, academic_year). Test date is
     -- not captured upstream.
+    -- projection IS the operation, not deduplication
     ap_administrations as (
         select distinct
             'ap' as assessment_type,
@@ -201,10 +412,28 @@ with
         from illuminate_administrations
         union all
         select *,
-        from state_nj_administrations
+        from state_nj_njgpa_administrations
         union all
         select *,
-        from state_fl_administrations
+        from state_nj_njsla_administrations
+        union all
+        select *,
+        from state_nj_njsla_science_administrations
+        union all
+        select *,
+        from state_nj_parcc_administrations
+        union all
+        select *,
+        from state_fl_eoc_administrations
+        union all
+        select *,
+        from state_fl_fast_administrations
+        union all
+        select *,
+        from state_fl_fsa_administrations
+        union all
+        select *,
+        from state_fl_science_administrations
         union all
         select *,
         from college_administrations

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -45,7 +45,8 @@ with
         where a.is_internal_assessment
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State NJ PARCC: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_parcc_administrations as (
@@ -68,7 +69,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State NJ NJSLA: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_njsla_administrations as (
@@ -91,7 +93,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State NJ NJSLA Science: one administration per (testcode, period,
     -- academic_year, _dbt_source_project).
     state_nj_njsla_science_administrations as (
@@ -114,7 +117,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State NJ NJGPA: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_njgpa_administrations as (
@@ -137,7 +141,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State FL FAST: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_fast_administrations as (
@@ -160,7 +165,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State FL FSA: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_fsa_administrations as (
@@ -183,7 +189,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State FL EOC: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_eoc_administrations as (
@@ -206,7 +213,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     -- State FL Science: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_science_administrations as (
@@ -232,7 +240,8 @@ with
     -- College Official: one administration per (score_type, test_date,
     -- administration_round). _dbt_source_project is null because college tests
     -- are region-agnostic.
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     college_administrations as (
         select distinct
             scope,
@@ -281,7 +290,8 @@ with
 
     -- AP: one administration per (subject, academic_year). Test date is
     -- not captured upstream.
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     ap_administrations as (
         select distinct
             title,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -28,7 +28,9 @@ with
     -- projection IS the operation, not deduplication
     state_nj_parcc as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
 
             'state_nj_parcc' as assessment_type,
@@ -42,23 +44,6 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
         from {{ ref("stg_pearson__parcc") }}
         where testscalescore is not null
     ),
@@ -66,7 +51,9 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njsla as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
 
             'state_nj_njsla' as assessment_type,
@@ -80,23 +67,6 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
         from {{ ref("stg_pearson__njsla") }}
         where testscalescore is not null
     ),
@@ -104,7 +74,9 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njsla_science as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
 
             'state_nj_njsla_science' as assessment_type,
@@ -118,23 +90,6 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
         from {{ ref("stg_pearson__njsla_science") }}
         where testscalescore is not null
     ),
@@ -142,7 +97,9 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njgpa as (
         select distinct
+            subject_area,
             discipline as scope,
+            module_code,
             test_grade as grade_level,
 
             'state_nj_njgpa' as assessment_type,
@@ -156,23 +113,6 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
         from {{ ref("stg_pearson__njgpa") }}
         where testscalescore is not null
     ),
@@ -183,6 +123,7 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
 
             'state_fl_fast' as assessment_type,
             'FAST' as title,
@@ -195,9 +136,7 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            cast(assessment_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
+        from {{ ref("stg_fldoe__fast") }}
         where scale_score is not null
     ),
 
@@ -207,6 +146,7 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
 
             'state_fl_fsa' as assessment_type,
             'FSA' as title,
@@ -219,9 +159,7 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            cast(test_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
+        from {{ ref("stg_fldoe__fsa") }}
         where scale_score is not null
     ),
 
@@ -231,6 +169,7 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
 
             'state_fl_eoc' as assessment_type,
             'EOC' as title,
@@ -243,9 +182,7 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            cast(enrolled_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
+        from {{ ref("stg_fldoe__eoc") }}
         where scale_score is not null
     ),
 
@@ -255,6 +192,7 @@ with
             assessment_subject as subject_area,
             discipline as scope,
             test_code as module_code,
+            grade_level,
 
             'state_fl_science' as assessment_type,
             'Science' as title,
@@ -267,9 +205,7 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            cast(assessment_grade as int) as grade_level,
-        from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}
+        from {{ ref("stg_fldoe__science") }}
         where scale_score is not null
     ),
 
@@ -331,6 +267,7 @@ with
     -- projection IS the operation, not deduplication
     ap_assessments as (
         select distinct
+            title,
             test_subject as subject_area,
             ps_ap_course_subject_code as module_code,
 
@@ -347,8 +284,6 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            concat('AP ', test_subject) as title,
         from {{ ref("int_assessments__ap_assessments") }}
     ),
 

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -1,10 +1,4 @@
 with
-    -- DISTINCT projects from response grain (one row per student) to
-    -- definition grain (one row per assessment definition). Per-student
-    -- columns are not in the projection, so byte-identical projected tuples
-    -- are coalesced. Not a workaround for dirty data — the projection IS
-    -- the operation. Per-administration attributes live on
-    -- dim_assessment_administrations.
     -- Member-grain: one row per actual Illuminate assessment_id. Bridge
     -- table `bridge_assessment_administration_members` maps each
     -- canonical-grain `dim_assessment_administrations` row to its member(s)
@@ -31,22 +25,15 @@ with
         where is_internal_assessment
     ),
 
-    -- DISTINCT projects from response grain to definition grain (see
-    -- illuminate_assessments comment above).
-    -- Collapse historical title variants (NJSLA / PARCC share a module_code
-    -- per grade) to one row per assessment_key hash input set. NJ kept
-    -- distinct from FL via assessment_type='state_nj' (FL state tests share
-    -- module_codes like ELA05/MAT05/SCI05 but are functionally different
-    -- assessments).
-    state_nj as (
-        select
-            discipline as scope,
-            test_grade as grade_level,
+    -- projection IS the operation, not deduplication
+    state_nj_parcc as (
+        select distinct
+            'state_nj_parcc' as assessment_type,
+            'PARCC' as title,
 
             cast(null as int64) as source_assessment_id,
             cast(null as string) as module_type,
 
-            'state_nj' as assessment_type,
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
@@ -54,6 +41,9 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
+
+            discipline as scope,
+            test_grade as grade_level,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -71,28 +61,19 @@ with
                 then 'SCI11'
                 else testcode
             end as module_code,
-
-            min(assessment_name) as title,
-        from {{ ref("int_pearson__all_assessments") }}
+        from {{ ref("stg_pearson__parcc") }}
         where testscalescore is not null
-        group by discipline, test_grade, `subject`, testcode
     ),
 
-    -- Collapse historical title variants (FAST / FSA share a test_code per
-    -- grade) to one row per assessment_key hash input set. FL kept distinct
-    -- from NJ via assessment_type='state_fl'.
-    state_fl as (
-        select
-            assessment_subject as subject_area,
-            discipline as scope,
-            test_code as module_code,
-
-            cast(assessment_grade as int) as grade_level,
+    -- projection IS the operation, not deduplication
+    state_nj_njsla as (
+        select distinct
+            'state_nj_njsla' as assessment_type,
+            'NJSLA' as title,
 
             cast(null as int64) as source_assessment_id,
             cast(null as string) as module_type,
 
-            'state_fl' as assessment_type,
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
@@ -101,14 +82,214 @@ with
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
 
-            min(assessment_name) as title,
-        from {{ ref("int_fldoe__all_assessments") }}
-        where scale_score is not null
-        group by assessment_subject, discipline, test_code, assessment_grade
+            discipline as scope,
+            test_grade as grade_level,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+        from {{ ref("stg_pearson__njsla") }}
+        where testscalescore is not null
     ),
 
-    -- DISTINCT projects from response grain to definition grain (see
-    -- illuminate_assessments comment above).
+    -- projection IS the operation, not deduplication
+    state_nj_njsla_science as (
+        select distinct
+            'state_nj_njsla_science' as assessment_type,
+            'NJSLA Science' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            discipline as scope,
+            test_grade as grade_level,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+        from {{ ref("stg_pearson__njsla_science") }}
+        where testscalescore is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    state_nj_njgpa as (
+        select distinct
+            'state_nj_njgpa' as assessment_type,
+            'NJGPA' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            discipline as scope,
+            test_grade as grade_level,
+
+            if(
+                `subject` = 'English Language Arts/Literacy',
+                'English Language Arts',
+                `subject`
+            ) as subject_area,
+
+            case
+                testcode
+                when 'SC05'
+                then 'SCI05'
+                when 'SC08'
+                then 'SCI08'
+                when 'SC11'
+                then 'SCI11'
+                else testcode
+            end as module_code,
+        from {{ ref("stg_pearson__njgpa") }}
+        where testscalescore is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    state_fl_fast as (
+        select distinct
+            'state_fl_fast' as assessment_type,
+            'FAST' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(assessment_grade as int) as grade_level,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    state_fl_fsa as (
+        select distinct
+            'state_fl_fsa' as assessment_type,
+            'FSA' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(test_grade as int) as grade_level,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    state_fl_eoc as (
+        select distinct
+            'state_fl_eoc' as assessment_type,
+            'EOC' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(enrolled_grade as int) as grade_level,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
+    state_fl_science as (
+        select distinct
+            'state_fl_science' as assessment_type,
+            'Science' as title,
+
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
+            cast(assessment_grade as int) as grade_level,
+        from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}
+        where scale_score is not null
+    ),
+
+    -- projection IS the operation, not deduplication
     college_assessments as (
         select distinct
             scope as title,
@@ -137,6 +318,7 @@ with
     -- 'sat_math'). Practice derives a parallel module_code by concatenating
     -- scope and subject_area so SAT Math, SAT Reading, etc. each get their
     -- own assessment_key.
+    -- projection IS the operation, not deduplication
     practice_assessments as (
         select distinct
             scope,
@@ -162,8 +344,7 @@ with
         from {{ ref("int_assessments__college_assessment_practice") }}
     ),
 
-    -- DISTINCT projects from response grain to definition grain (see
-    -- illuminate_assessments comment above).
+    -- projection IS the operation, not deduplication
     ap_assessments as (
         select distinct
             test_subject as subject_area,
@@ -200,10 +381,28 @@ with
         from illuminate_assessments
         union all
         select {{ union_cols }},
-        from state_nj
+        from state_nj_njgpa
         union all
         select {{ union_cols }},
-        from state_fl
+        from state_nj_njsla
+        union all
+        select {{ union_cols }},
+        from state_nj_njsla_science
+        union all
+        select {{ union_cols }},
+        from state_nj_parcc
+        union all
+        select {{ union_cols }},
+        from state_fl_eoc
+        union all
+        select {{ union_cols }},
+        from state_fl_fast
+        union all
+        select {{ union_cols }},
+        from state_fl_fsa
+        union all
+        select {{ union_cols }},
+        from state_fl_science
         union all
         select {{ union_cols }},
         from college_assessments

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -28,22 +28,20 @@ with
     -- projection IS the operation, not deduplication
     state_nj_parcc as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+
             'state_nj_parcc' as assessment_type,
             'PARCC' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            discipline as scope,
-            test_grade as grade_level,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -68,22 +66,20 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njsla as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+
             'state_nj_njsla' as assessment_type,
             'NJSLA' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            discipline as scope,
-            test_grade as grade_level,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -108,22 +104,20 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njsla_science as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+
             'state_nj_njsla_science' as assessment_type,
             'NJSLA Science' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            discipline as scope,
-            test_grade as grade_level,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -148,22 +142,20 @@ with
     -- projection IS the operation, not deduplication
     state_nj_njgpa as (
         select distinct
+            discipline as scope,
+            test_grade as grade_level,
+
             'state_nj_njgpa' as assessment_type,
             'NJGPA' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            discipline as scope,
-            test_grade as grade_level,
 
             if(
                 `subject` = 'English Language Arts/Literacy',
@@ -188,23 +180,21 @@ with
     -- projection IS the operation, not deduplication
     state_fl_fast as (
         select distinct
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
             'state_fl_fast' as assessment_type,
             'FAST' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            assessment_subject as subject_area,
-            discipline as scope,
-            test_code as module_code,
 
             cast(assessment_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__fast") }}
@@ -214,23 +204,21 @@ with
     -- projection IS the operation, not deduplication
     state_fl_fsa as (
         select distinct
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
             'state_fl_fsa' as assessment_type,
             'FSA' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            assessment_subject as subject_area,
-            discipline as scope,
-            test_code as module_code,
 
             cast(test_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__fsa") }}
@@ -240,23 +228,21 @@ with
     -- projection IS the operation, not deduplication
     state_fl_eoc as (
         select distinct
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
             'state_fl_eoc' as assessment_type,
             'EOC' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            assessment_subject as subject_area,
-            discipline as scope,
-            test_code as module_code,
 
             cast(enrolled_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__eoc") }}
@@ -266,23 +252,21 @@ with
     -- projection IS the operation, not deduplication
     state_fl_science as (
         select distinct
+            assessment_subject as subject_area,
+            discipline as scope,
+            test_code as module_code,
+
             'state_fl_science' as assessment_type,
             'Science' as title,
-
-            cast(null as int64) as source_assessment_id,
-            cast(null as string) as module_type,
-
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
             cast(null as string) as combined_academic_subject,
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-
-            assessment_subject as subject_area,
-            discipline as scope,
-            test_code as module_code,
 
             cast(assessment_grade as int) as grade_level,
         from {{ source("kippmiami_fldoe", "stg_fldoe__science") }}

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -25,7 +25,8 @@ with
         where is_internal_assessment
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_nj_parcc as (
         select distinct
             subject_area,
@@ -48,7 +49,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_nj_njsla as (
         select distinct
             subject_area,
@@ -71,7 +73,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_nj_njsla_science as (
         select distinct
             subject_area,
@@ -94,7 +97,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_nj_njgpa as (
         select distinct
             subject_area,
@@ -117,7 +121,8 @@ with
         where testscalescore is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_fl_fast as (
         select distinct
             assessment_subject as subject_area,
@@ -140,7 +145,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_fl_fsa as (
         select distinct
             assessment_subject as subject_area,
@@ -163,7 +169,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_fl_eoc as (
         select distinct
             assessment_subject as subject_area,
@@ -186,7 +193,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     state_fl_science as (
         select distinct
             assessment_subject as subject_area,
@@ -209,7 +217,8 @@ with
         where scale_score is not null
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     college_assessments as (
         select distinct
             scope as title,
@@ -238,7 +247,8 @@ with
     -- 'sat_math'). Practice derives a parallel module_code by concatenating
     -- scope and subject_area so SAT Math, SAT Reading, etc. each get their
     -- own assessment_key.
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     practice_assessments as (
         select distinct
             scope,
@@ -264,7 +274,8 @@ with
         from {{ ref("int_assessments__college_assessment_practice") }}
     ),
 
-    -- projection IS the operation, not deduplication
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     ap_assessments as (
         select distinct
             title,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_survey_questions.sql
@@ -1,12 +1,11 @@
 with
     google_forms_questions as (
-        -- DISTINCT projects from response grain to question grain.
-        select distinct
-            fr.item_abbreviation as question_shortname,
-            fr.item_title as question_text,
-            fr.question_kind as question_type,
-        from {{ ref("int_google_forms__form_responses") }} as fr
-        where fr.item_abbreviation is not null and fr.item_title is not null
+        select
+            item_abbreviation as question_shortname,
+            item_title as question_text,
+            question_kind as question_type,
+        from {{ ref("int_google_forms__form__items") }}
+        where item_abbreviation is not null and item_title is not null
     ),
 
     scd_questions as (
@@ -19,25 +18,12 @@ with
     ),
 
     alchemer_questions as (
-        -- DISTINCT projects from response grain to question grain.
-        -- Sources Alchemer + Google Forms staff/student survey questions that
-        -- feed fct_survey_responses.general_responses.
-        select distinct
-            sr.question_shortname,
-            sr.question_title as question_text,
+        select
+            shortname as question_shortname,
+            title_english as question_text,
             cast(null as string) as question_type,
-        from {{ ref("int_surveys__survey_responses") }} as sr
-        where sr.question_shortname is not null
-    ),
-
-    manager_questions as (
-        -- DISTINCT projects from response grain to question grain.
-        select distinct
-            ms.question_shortname,
-            ms.question_title as question_text,
-            cast(null as string) as question_type,
-        from {{ ref("int_surveys__manager_survey_details") }} as ms
-        where ms.question_shortname is not null
+        from {{ source("alchemer", "stg_alchemer__survey_question") }}
+        where shortname is not null
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
@@ -50,9 +36,6 @@ with
         union all
         select *,
         from alchemer_questions
-        union all
-        select *,
-        from manager_questions
     ),
 
     deduped as (

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_surveys.sql
@@ -1,21 +1,19 @@
 with
     google_forms_surveys as (
-        -- DISTINCT projects from response grain to survey grain.
-        select distinct
+        select
             form_id as survey_id, info_title as survey_name, 'Google Forms' as platform,
-        from {{ ref("int_google_forms__form_responses") }}
+        from {{ ref("stg_google_forms__form") }}
         where form_id is not null
     ),
 
     alchemer_surveys as (
-        -- DISTINCT projects from response grain to survey grain.
-        select distinct
-            safe_cast(survey_id as string) as survey_id,
-            survey_title as survey_name,
+        select
+            safe_cast(id as string) as survey_id,
+            title as survey_name,
 
             'Alchemer' as platform,
-        from {{ source("alchemer", "base_alchemer__survey_results") }}
-        where survey_id is not null
+        from {{ source("alchemer", "stg_alchemer__survey") }}
+        where id is not null
     ),
 
     archive_manager as (

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -4,20 +4,22 @@ models:
       Per-scheduled-occurrence dimension paralleling dim_survey_administrations.
       One row per distinct administration event, identified by an 8-input
       surrogate key: assessment_type, module_code, administered_date,
-      academic_year, region, administration_period, source_assessment_id, and
-      test_type. Covers internal Illuminate assessments, NJ and FL state
-      assessments, Official college-entrance assessments (SAT, ACT, PSAT), AP
-      assessments, and Practice college-entrance assessments. Branches that do
-      not populate a given scheduling column carry a typed NULL for that column
-      (e.g. Illuminate and AP carry NULL administration_period; state branches
-      carry NULL source_assessment_id).
+      academic_year, _dbt_source_project, administration_period,
+      source_assessment_id, and test_type. Covers internal Illuminate
+      assessments, NJ and FL state assessments, Official college-entrance
+      assessments (SAT, ACT, PSAT), AP assessments, and Practice
+      college-entrance assessments. Branches that do not populate a given
+      scheduling column carry a typed NULL for that column (e.g. Illuminate and
+      AP carry NULL administration_period; state branches carry NULL
+      source_assessment_id).
     columns:
       - name: assessment_administration_key
         data_type: string
         description: >-
           Surrogate key derived from assessment_type, module_code,
-          administered_date, academic_year, region, administration_period,
-          source_assessment_id, and test_type. Primary key.
+          administered_date, academic_year, _dbt_source_project,
+          administration_period, source_assessment_id, and test_type. Primary
+          key.
         constraints:
           - type: primary_key
             warn_unsupported: false
@@ -47,14 +49,14 @@ models:
               config:
                 where: administered_date_key >= '2000-01-01'
 
-      - name: region
+      - name: _dbt_source_project
         data_type: string
         description: >-
-          KIPP region the administration is scoped to (Newark, Camden, Miami,
-          Paterson). Null for college-entrance and AP assessments which are
-          region-agnostic. For Illuminate, derived by unnesting the
-          comma-separated regions_assessed list — a multi-region assessment
-          produces one row per region.
+          Dagster code location identifying the district the administration is
+          scoped to (kippnewark, kippcamden, kippmiami, kipppaterson). Null for
+          college-entrance and AP assessments which are region-agnostic. For
+          Illuminate, derived by unnesting the regions_assessed list — a
+          multi-region assessment produces one row per district.
 
       - name: administration_period
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -13,17 +13,18 @@ with
             rr.performance_band_label,
             rr.is_mastery,
             rr.n_assessments,
-            rr.assessment_ids,
             rr.percent_correct,
+            rr._dbt_source_project,
 
-            cast(rr.date_taken as date) as test_date,
-            cast(a.administered_at as date) as administered_date,
+            rr.date_taken as test_date,
+
+            to_json_string(rr.assessment_ids) as assessment_ids_json,
 
             rr.assessment_id as source_assessment_id,
+
             a.academic_year,
             a.module_code,
-
-            concat('kipp', lower(rr.region)) as _dbt_source_project,
+            a.administered_date,
 
             cast(null as numeric) as scale_score,
 
@@ -98,50 +99,60 @@ with
         where scale_score is not null
     ),
 
-    state_union as (
+    state_all as (
         select
-            nj.student_number,
-            nj.state_student_id,
-            nj.academic_year,
-            nj.subject_area,
-            nj.discipline,
-            nj.module_code,
-            nj.grade_level,
-            nj.scale_score,
-            nj.is_proficient,
-            nj.performance_band,
-            nj.performance_band_level,
-            nj.administration_period,
-            nj.title,
-            nj._dbt_source_project,
-            nj.test_date,
-            nj.percent_correct,
-            nj.score_source,
-            nj.assessment_type,
-        from state_nj as nj
+            student_number,
+            state_student_id,
+            academic_year,
+            subject_area,
+            discipline,
+            module_code,
+            grade_level,
+            scale_score,
+            is_proficient,
+            performance_band,
+            performance_band_level,
+            administration_period,
+            title,
+            _dbt_source_project,
+            test_date,
+            percent_correct,
+            score_source,
+            assessment_type,
+        from state_nj
 
         union all
 
         select
-            fl.student_number,
-            fl.state_student_id,
-            fl.academic_year,
-            fl.subject_area,
-            fl.discipline,
-            fl.module_code,
-            fl.grade_level,
-            fl.scale_score,
-            fl.is_proficient,
-            fl.performance_band,
-            fl.performance_band_level,
-            fl.administration_period,
-            fl.title,
-            fl._dbt_source_project,
-            fl.test_date,
-            fl.percent_correct,
-            fl.score_source,
-            fl.assessment_type,
-        from state_fl as fl
+            student_number,
+            state_student_id,
+            academic_year,
+            subject_area,
+            discipline,
+            module_code,
+            grade_level,
+            scale_score,
+            is_proficient,
+            performance_band,
+            performance_band_level,
+            administration_period,
+            title,
+            _dbt_source_project,
+            test_date,
+            percent_correct,
+            score_source,
+            assessment_type,
+        from state_fl
+    ),
+
+    state_union as (
+        select
+            sa.*,
+
+            coalesce(
+                cast(sa.student_number as string), sa.state_student_id
+            ) as student_identifier,
+        from state_all as sa
     )
 
 /* internal assessments */
@@ -151,7 +162,7 @@ select
             [
                 "ia.student_number",
                 "ia.assessment_id",
-                "TO_JSON_STRING(ia.assessment_ids)",
+                "ia.assessment_ids_json",
                 "ia.response_type",
                 "ia.response_type_id",
                 "ia.response_type_code",
@@ -167,9 +178,9 @@ select
                 "ia.administered_date",
                 "ia.academic_year",
                 "ia._dbt_source_project",
-                "cast(null as string)",
+                "null",
                 "ia.source_assessment_id",
-                "cast(null as string)",
+                "null",
             ]
         )
     }} as assessment_administration_key,
@@ -192,7 +203,7 @@ select
         dbt_utils.generate_surrogate_key(
             [
                 "su._dbt_source_project",
-                "coalesce(cast(su.student_number as string), su.state_student_id)",
+                "su.student_identifier",
                 "su.academic_year",
                 "su.administration_period",
                 "su.subject_area",
@@ -205,12 +216,12 @@ select
             [
                 "su.assessment_type",
                 "su.module_code",
-                "cast(null as date)",
+                "null",
                 "su.academic_year",
                 "su._dbt_source_project",
                 "su.administration_period",
-                "cast(null as int64)",
-                "cast(null as string)",
+                "null",
+                "null",
             ]
         )
     }} as assessment_administration_key,

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -6,7 +6,6 @@ with
     internal_assessments as (
         select
             rr.powerschool_student_number as student_number,
-            rr.region,
             rr.assessment_id,
             rr.response_type,
             rr.response_type_id,
@@ -24,6 +23,8 @@ with
             a.academic_year,
             a.module_code,
 
+            concat('kipp', lower(rr.region)) as _dbt_source_project,
+
             cast(null as numeric) as scale_score,
 
             rr.performance_band_label as proficiency_level,
@@ -39,27 +40,15 @@ with
     state_nj as (
         select
             localstudentidentifier as student_number,
-            cast(null as string) as state_student_id,
             academic_year,
-
-            if(
-                `subject` = 'English Language Arts/Literacy',
-                'English Language Arts',
-                `subject`
-            ) as subject_area,
-
+            subject_area,
             discipline,
+            module_code,
+            administration_period,
+            assessment_type,
+            _dbt_source_project,
 
-            case
-                testcode
-                when 'SC05'
-                then 'SCI05'
-                when 'SC08'
-                then 'SCI08'
-                when 'SC11'
-                then 'SCI11'
-                else testcode
-            end as module_code,
+            cast(null as string) as state_student_id,
 
             test_grade as grade_level,
             testscalescore as scale_score,
@@ -67,29 +56,10 @@ with
             testperformancelevel_text as performance_band,
             testperformancelevel as performance_band_level,
 
-            if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
-
             assessment_name as title,
-
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            _dbt_source_relation,
 
             cast(null as date) as test_date,
             cast(null as numeric) as percent_correct,
-
-            case
-                assessment_name
-                when 'PARCC'
-                then 'state_nj_parcc'
-                when 'NJSLA'
-                then 'state_nj_njsla'
-                when 'NJSLA Science'
-                then 'state_nj_njsla_science'
-                when 'NJGPA'
-                then 'state_nj_njgpa'
-                else 'state_nj_unknown'
-            end as assessment_type,
 
             'state_nj' as score_source,
         from {{ ref("int_pearson__all_assessments") }}
@@ -101,38 +71,27 @@ with
     state_fl as (
         select
             student_number,
-            student_id as state_student_id,
             academic_year,
             assessment_subject as subject_area,
             discipline,
             test_code as module_code,
-            cast(assessment_grade as int) as grade_level,
             scale_score,
             is_proficient,
+            administration_window as administration_period,
+            assessment_type,
+            _dbt_source_project,
+
+            student_id as state_student_id,
+
             achievement_level as performance_band,
             performance_level as performance_band_level,
-            administration_window as administration_period,
+
             assessment_name as title,
 
-            initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            _dbt_source_relation,
+            cast(assessment_grade as int) as grade_level,
 
             cast(null as date) as test_date,
             cast(null as numeric) as percent_correct,
-
-            case
-                assessment_name
-                when 'FAST'
-                then 'state_fl_fast'
-                when 'FSA'
-                then 'state_fl_fsa'
-                when 'EOC'
-                then 'state_fl_eoc'
-                when 'Science'
-                then 'state_fl_science'
-                else 'state_fl_unknown'
-            end as assessment_type,
 
             'state_fl' as score_source,
         from {{ ref("int_fldoe__all_assessments") }}
@@ -154,12 +113,11 @@ with
             nj.performance_band_level,
             nj.administration_period,
             nj.title,
-            nj.region,
+            nj._dbt_source_project,
             nj.test_date,
             nj.percent_correct,
             nj.score_source,
             nj.assessment_type,
-            nj._dbt_source_relation,
         from state_nj as nj
 
         union all
@@ -178,12 +136,11 @@ with
             fl.performance_band_level,
             fl.administration_period,
             fl.title,
-            fl.region,
+            fl._dbt_source_project,
             fl.test_date,
             fl.percent_correct,
             fl.score_source,
             fl.assessment_type,
-            fl._dbt_source_relation,
         from state_fl as fl
     )
 
@@ -209,7 +166,7 @@ select
                 "ia.module_code",
                 "ia.administered_date",
                 "ia.academic_year",
-                "ia.region",
+                "ia._dbt_source_project",
                 "cast(null as string)",
                 "ia.source_assessment_id",
                 "cast(null as string)",
@@ -234,7 +191,7 @@ select
     {{
         dbt_utils.generate_surrogate_key(
             [
-                "su._dbt_source_relation",
+                "su._dbt_source_project",
                 "coalesce(cast(su.student_number as string), su.state_student_id)",
                 "su.academic_year",
                 "su.administration_period",
@@ -250,7 +207,7 @@ select
                 "su.module_code",
                 "cast(null as date)",
                 "su.academic_year",
-                "su.region",
+                "su._dbt_source_project",
                 "su.administration_period",
                 "cast(null as int64)",
                 "cast(null as string)",

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -88,6 +88,7 @@ with
                 then 'state_nj_njsla_science'
                 when 'NJGPA'
                 then 'state_nj_njgpa'
+                else 'state_nj_unknown'
             end as assessment_type,
 
             'state_nj' as score_source,
@@ -130,6 +131,7 @@ with
                 then 'state_fl_eoc'
                 when 'Science'
                 then 'state_fl_science'
+                else 'state_fl_unknown'
             end as assessment_type,
 
             'state_fl' as score_source,

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -78,6 +78,18 @@ with
             cast(null as date) as test_date,
             cast(null as numeric) as percent_correct,
 
+            case
+                assessment_name
+                when 'PARCC'
+                then 'state_nj_parcc'
+                when 'NJSLA'
+                then 'state_nj_njsla'
+                when 'NJSLA Science'
+                then 'state_nj_njsla_science'
+                when 'NJGPA'
+                then 'state_nj_njgpa'
+            end as assessment_type,
+
             'state_nj' as score_source,
         from {{ ref("int_pearson__all_assessments") }}
         where
@@ -108,6 +120,18 @@ with
             cast(null as date) as test_date,
             cast(null as numeric) as percent_correct,
 
+            case
+                assessment_name
+                when 'FAST'
+                then 'state_fl_fast'
+                when 'FSA'
+                then 'state_fl_fsa'
+                when 'EOC'
+                then 'state_fl_eoc'
+                when 'Science'
+                then 'state_fl_science'
+            end as assessment_type,
+
             'state_fl' as score_source,
         from {{ ref("int_fldoe__all_assessments") }}
         where scale_score is not null
@@ -132,6 +156,7 @@ with
             nj.test_date,
             nj.percent_correct,
             nj.score_source,
+            nj.assessment_type,
             nj._dbt_source_relation,
         from state_nj as nj
 
@@ -155,6 +180,7 @@ with
             fl.test_date,
             fl.percent_correct,
             fl.score_source,
+            fl.assessment_type,
             fl._dbt_source_relation,
         from state_fl as fl
     )
@@ -218,7 +244,7 @@ select
     {{
         dbt_utils.generate_surrogate_key(
             [
-                "'state'",
+                "su.assessment_type",
                 "su.module_code",
                 "cast(null as date)",
                 "su.academic_year",

--- a/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__all_assessments.sql
+++ b/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__all_assessments.sql
@@ -118,6 +118,7 @@ select
         then 'state_nj_njsla_science'
         when 'NJGPA'
         then 'state_nj_njgpa'
+        else 'state_nj_unknown'
     end as assessment_type,
 
 from union_relations as u

--- a/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__all_assessments.sql
+++ b/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__all_assessments.sql
@@ -11,7 +11,9 @@ with
                 ],
                 include=[
                     "_dbt_source_relation",
+                    "_dbt_source_project",
                     "academic_year",
+                    "administration_period",
                     "americanindianoralaskanative",
                     "asian",
                     "assessment_name",
@@ -23,6 +25,7 @@ with
                     "hispanicorlatinoethnicity",
                     "is_proficient",
                     "is_bl_fb",
+                    "module_code",
                     "nativehawaiianorotherpacificislander",
                     "period",
                     "statestudentidentifier",
@@ -31,6 +34,7 @@ with
                     "lastorsurname",
                     "studentwithdisabilities",
                     "subject",
+                    "subject_area",
                     "testcode",
                     "studenttestuuid",
                     "testscorecomplete",
@@ -47,7 +51,9 @@ with
 
 select
     u._dbt_source_relation,
+    u._dbt_source_project,
     u.academic_year,
+    u.administration_period,
     u.americanindianoralaskanative,
     u.asian,
     u.assessment_name,
@@ -58,11 +64,13 @@ select
     u.hispanicorlatinoethnicity,
     u.is_proficient,
     u.is_bl_fb,
+    u.module_code,
     u.nativehawaiianorotherpacificislander,
     u.period,
     u.firstname,
     u.lastorsurname,
     u.subject,
+    u.subject_area,
     u.testcode,
     u.studenttestuuid,
     u.test_grade,
@@ -99,6 +107,18 @@ select
         when u.white = 'Y'
         then 'W'
     end as race_ethnicity,
+
+    case
+        u.assessment_name
+        when 'PARCC'
+        then 'state_nj_parcc'
+        when 'NJSLA'
+        then 'state_nj_njsla'
+        when 'NJSLA Science'
+        then 'state_nj_njsla_science'
+        when 'NJGPA'
+        then 'state_nj_njgpa'
+    end as assessment_type,
 
 from union_relations as u
 left join

--- a/src/dbt/kipptaf/models/pearson/intermediate/properties/int_pearson__all_assessments.yml
+++ b/src/dbt/kipptaf/models/pearson/intermediate/properties/int_pearson__all_assessments.yml
@@ -75,3 +75,9 @@ models:
           Categorical mapping of americanindianoralaskanative, asian,
           blackorafricanamerican, hispanicorlatinoethnicity,
           nativehawaiianorotherpacificislander, twoormoreraces, white.
+      - name: assessment_type
+        data_type: string
+        description: >-
+          Program-lineage label ('state_nj_parcc' / '..._njsla' /
+          '..._njsla_science' / '..._njgpa') derived from assessment_name. Used
+          by marts as the hash-input value for assessment_key.

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njgpa.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njgpa.yml
@@ -2,3 +2,22 @@ models:
   - name: stg_pearson__njgpa
     config:
       materialized: table
+    columns:
+      - name: subject_area
+        data_type: string
+        description:
+          Normalized from `subject` ('English Language Arts/Literacy' → 'English
+          Language Arts').
+      - name: module_code
+        data_type: string
+        description:
+          Normalized from `testcode` (SC05/SC08/SC11 remapped to
+          SCI05/SCI08/SCI11).
+      - name: administration_period
+        data_type: string
+        description: Normalized from `period` ('FallBlock' → 'Fall').
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
+          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla.yml
@@ -2,3 +2,22 @@ models:
   - name: stg_pearson__njsla
     config:
       materialized: table
+    columns:
+      - name: subject_area
+        data_type: string
+        description:
+          Normalized from `subject` ('English Language Arts/Literacy' → 'English
+          Language Arts').
+      - name: module_code
+        data_type: string
+        description:
+          Normalized from `testcode` (SC05/SC08/SC11 remapped to
+          SCI05/SCI08/SCI11).
+      - name: administration_period
+        data_type: string
+        description: Normalized from `period` ('FallBlock' → 'Fall').
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
+          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla_science.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla_science.yml
@@ -2,3 +2,22 @@ models:
   - name: stg_pearson__njsla_science
     config:
       materialized: table
+    columns:
+      - name: subject_area
+        data_type: string
+        description:
+          Normalized from `subject` ('English Language Arts/Literacy' → 'English
+          Language Arts').
+      - name: module_code
+        data_type: string
+        description:
+          Normalized from `testcode` (SC05/SC08/SC11 remapped to
+          SCI05/SCI08/SCI11).
+      - name: administration_period
+        data_type: string
+        description: Normalized from `period` ('FallBlock' → 'Fall').
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
+          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__parcc.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__parcc.yml
@@ -2,3 +2,22 @@ models:
   - name: stg_pearson__parcc
     config:
       materialized: table
+    columns:
+      - name: subject_area
+        data_type: string
+        description:
+          Normalized from `subject` ('English Language Arts/Literacy' → 'English
+          Language Arts').
+      - name: module_code
+        data_type: string
+        description:
+          Normalized from `testcode` (SC05/SC08/SC11 remapped to
+          SCI05/SCI08/SCI11).
+      - name: administration_period
+        data_type: string
+        description: Normalized from `period` ('FallBlock' → 'Fall').
+      - name: _dbt_source_project
+        data_type: string
+        description: Source project
+          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
+          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njgpa.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njgpa.sql
@@ -1,8 +1,34 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", model.name),
-            source("kippcamden_pearson", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", model.name),
+                    source("kippcamden_pearson", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+select
+    *,
+
+    if(
+        `subject` = 'English Language Arts/Literacy', 'English Language Arts', `subject`
+    ) as subject_area,
+
+    if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    case
+        testcode
+        when 'SC05'
+        then 'SCI05'
+        when 'SC08'
+        then 'SCI08'
+        when 'SC11'
+        then 'SCI11'
+        else testcode
+    end as module_code,
+from union_relations

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla.sql
@@ -1,9 +1,35 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", "stg_pearson__njsla"),
-            source("kippcamden_pearson", "stg_pearson__njsla"),
-            source("kipppaterson_pearson", "int_pearson__njsla"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", "stg_pearson__njsla"),
+                    source("kippcamden_pearson", "stg_pearson__njsla"),
+                    source("kipppaterson_pearson", "int_pearson__njsla"),
+                ]
+            )
+        }}
     )
-}}
+
+select
+    *,
+
+    if(
+        `subject` = 'English Language Arts/Literacy', 'English Language Arts', `subject`
+    ) as subject_area,
+
+    if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    case
+        testcode
+        when 'SC05'
+        then 'SCI05'
+        when 'SC08'
+        then 'SCI08'
+        when 'SC11'
+        then 'SCI11'
+        else testcode
+    end as module_code,
+from union_relations

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla_science.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla_science.sql
@@ -1,9 +1,35 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", "stg_pearson__njsla_science"),
-            source("kippcamden_pearson", "stg_pearson__njsla_science"),
-            source("kipppaterson_pearson", "int_pearson__njsla_science"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", "stg_pearson__njsla_science"),
+                    source("kippcamden_pearson", "stg_pearson__njsla_science"),
+                    source("kipppaterson_pearson", "int_pearson__njsla_science"),
+                ]
+            )
+        }}
     )
-}}
+
+select
+    *,
+
+    if(
+        `subject` = 'English Language Arts/Literacy', 'English Language Arts', `subject`
+    ) as subject_area,
+
+    if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    case
+        testcode
+        when 'SC05'
+        then 'SCI05'
+        when 'SC08'
+        then 'SCI08'
+        when 'SC11'
+        then 'SCI11'
+        else testcode
+    end as module_code,
+from union_relations

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__parcc.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__parcc.sql
@@ -1,8 +1,34 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", model.name),
-            source("kippcamden_pearson", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", model.name),
+                    source("kippcamden_pearson", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+select
+    *,
+
+    if(
+        `subject` = 'English Language Arts/Literacy', 'English Language Arts', `subject`
+    ) as subject_area,
+
+    if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
+
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
+    case
+        testcode
+        when 'SC05'
+        then 'SCI05'
+        when 'SC08'
+        then 'SCI08'
+        when 'SC11'
+        then 'SCI11'
+        else testcode
+    end as module_code,
+from union_relations


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will:

- Replace `SELECT DISTINCT` / `GROUP BY` collapses in 5 mart models with
  the correct constructs — annotated DISTINCT for pure projection
  (assessments) and redirects to existing entity-grain models (surveys).
- Split NJ and FL state assessment lineages in `dim_assessments` and
  `dim_assessment_administrations`: `state_nj_parcc`, `state_nj_njsla`,
  `state_nj_njsla_science`, `state_nj_njgpa`, `state_fl_fast`,
  `state_fl_fsa`, `state_fl_eoc`, `state_fl_science`. Successor
  assessments (NJSLA / PARCC, FAST / FSA, etc.) are different programs
  and should not share `assessment_key`.
- Switch the assessments marts off `int_pearson__all_assessments` and
  `int_fldoe__all_assessments` (legacy denormalized intermediates) to
  staging-direct reads.
- Update `fct_assessment_scores_enrollment_scoped` state-branch
  `assessment_administration_key` hash composition to use the same
  lineage-split `assessment_type` literals as the dim, restoring FK
  alignment.
- Clarify `src/dbt/CLAUDE.md`'s "No manual deduplication" rule to allow
  DISTINCT for pure grain projection when annotated.

Closes #3780

## AI Assistance

Claude Code drafted the spec, plan, and SQL changes under continuous
human direction (sub-agent-driven development workflow). Each task went
through spec-compliance and code-quality review by separate subagents
before commit. Phase 0 BQ shape audit, expected-delta computation, and
cube grep run by the controller (read-only research).

## Phase 0 audit results

### Surveys-side BQ shape audit

| Query | n_current | n_target | n_current_only | n_target_only | Verdict |
|---|---:|---:|---:|---:|---|
| A (gforms questions) | 333 | 626 | 0 | 0 | safe |
| B (alchemer questions) | 136 | 442 | 0 | 301 | safe — definitions w/ no responses |
| C (gforms surveys) | 28 | 28 | 0 | 0 | safe |
| D (alchemer surveys) | 30 | 40 | 0 | 10 | safe — definitions w/ no responses |
| E (gforms bridge pairs) | 332 | 626 | 0 | 0 | safe |
| F (alchemer bridge pairs) | 133 | 442 | 0 | 301 | safe |
| G (manager pairs, redirect to form_items_extension) | 18 | 18 | 0 | 0 | safe — exact match |

### Assessments expected row-count deltas

| Mart | NJ added | FL added | Total |
|---|---:|---:|---:|
| `dim_assessments` | +18 | +14 | +32 |
| `dim_assessment_administrations` | 0 | 0 | 0 |

### Cube grep for `state_nj` / `state_fl` literals

```text
grep -rnE "'state_nj'|'state_fl'|state_nj[^_a-z]|state_fl[^_a-z]" src/cube/model/
→ no matches
```

No Cube migration commit needed.

## Post-merge row-count deltas (PR-branch vs prod)

| Mart | Prod | PR | Δ | Expected |
|---|---:|---:|---:|---|
| `dim_assessments` (state rows only) | 39 | 71 | +32 | +32 ✅ |
| `dim_assessment_administrations` (state rows) | 470 | 470 | 0 | 0 ✅ |
| `dim_survey_questions` | 369 | 599 | +230 | growth (Phase 0) ✅ |
| `dim_surveys` | 61 | 71 | +10 | +10 (Phase 0) ✅ |
| `bridge_survey_questions` | 493 | 794 | +301 | growth (Phase 0) ✅ |

`dim_assessment_administrations` total row count is -45 vs prod due to
unrelated upstream drift in `int_assessments__assessments` (illuminate
branch reads via `--defer` from prod). State rows match exactly.

## `fct_assessment_scores_enrollment_scoped` admin-key FK

Pre-PR: 3 orphans (tracked in #4016 — internal-Illuminate, distinct
root cause).

Mid-PR (after lineage split, before fact amendment): would have been
75,531 orphans (regression — fact's literal `'state'` hash no longer
matched dim's lineage-split values).

Post-amendment (fact derives `assessment_type` via CASE on
`assessment_name` and uses it as the hash input): **37 orphans** — same
3 distinct admin keys as pre-PR, just multiplied by their fact-row
counts. No new orphan classes introduced; all residual covered by
#4016.

## Pre-merge checklist (per marts CLAUDE.md)

- **Diamond paths**: no new FKs added — N/A
- **R1–R10 column rubric**: no new columns / no renames — N/A. New
  `assessment_type` literals (`state_nj_njsla`, etc.) follow the existing
  lowercase + underscore convention (`illuminate`, `college`, `ap`).
- **CI warning triage**: will run after dbt Cloud CI completes. Expected
  warnings are the pre-existing #4016 residual (37 + 5 admin-key
  orphans).
- **Project board scan**: no incidentally-resolved issues found.
- **Cube semantic-layer audit**: zero matches; no migration.

## Self-review

### dbt

- [x] Properties YAML files unchanged — no contract surface change.
- [x] Exposures: no exposure changes needed — mart contracts preserved.
- [ ] **Breaking change for downstream consumers filtering on
      `assessment_type`**: any Cube / Tableau filter expecting exact
      `'state_nj'` / `'state_fl'` will return zero rows. Cube grep found
      no matches; Tableau and AppSheet consumers should audit
      themselves. Surface-flag in #data-team Slack if applicable.
- [x] No new external sources; the two Alchemer staging tables added to
      `sources-bigquery.yml` are existing BQ tables (Archive pattern —
      kipptaf-level Alchemer integration is disabled, but the underlying
      BQ snapshot still exists and is the same data the pre-PR
      `int_surveys__survey_responses` was reading).
- [x] `stage_external_sources` not needed — no new external sources.

## Out of scope

- `dim_assessment_administrations.illuminate_administrations` (TODO
  #3800 in the existing source, tracked separately).
- Re-org of `int_assessments__assessments`.
- `int_surveys__manager_survey_details` post-#3899 cleanup (#3918).
- Removal of `archive_manager` / `archive_support` synthetic survey rows
  in `dim_surveys` — load-bearing for downstream filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
