### PR TITLE
test(powerschool): validate enrollment fteid belongs to school+year

### DIFF
--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -12,7 +12,6 @@ data_tests:
       reference one of PowerSchool's 999999-scoped FTEs, not a real-school FTE
       carried over from prior enrollment.
     config:
-      severity: warn
       meta:
         dagster:
           ref:

--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -1,0 +1,19 @@
+data_tests:
+  - name: test_int_powerschool__ps_enrollment_all__fteid_belongs_to_school_year
+    description: >-
+      Every enrollment row's `fteid` must point to an FTE record whose
+      `schoolid` and `yearid` match the enrollment's. PowerSchool defines each
+      FTE per `(schoolid, yearid)`; assigning a student an `fteid` from a
+      different school or year produces silent NULLs in
+      `int_powerschool__ps_adaadm_daily_ctod` because the `(fteid,
+      attendance_conversion_id)` join in that model resolves only when the FTE
+      matches the school's bell-schedule conversion config. Schools at sentinel
+      `schoolid = 999999` (graduated students) are included — they should
+      reference one of PowerSchool's 999999-scoped FTEs, not a real-school FTE
+      carried over from prior enrollment.
+    config:
+      severity: warn
+      meta:
+        dagster:
+          ref:
+            name: int_powerschool__ps_enrollment_all

--- a/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__fteid_belongs_to_school_year.sql
+++ b/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__fteid_belongs_to_school_year.sql
@@ -1,0 +1,13 @@
+select
+    e.studentid,
+    e.student_number,
+    e.schoolid,
+    e.yearid,
+    e.fteid,
+    f.schoolid as fte_schoolid,
+    f.yearid as fte_yearid,
+from {{ ref("int_powerschool__ps_enrollment_all") }} as e
+left join {{ ref("stg_powerschool__fte") }} as f on e.fteid = f.id
+where
+    e.fteid is not null
+    and (f.id is null or f.schoolid != e.schoolid or f.yearid != e.yearid)

--- a/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__fteid_belongs_to_school_year.sql
+++ b/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__fteid_belongs_to_school_year.sql
@@ -4,6 +4,7 @@ select
     e.schoolid,
     e.yearid,
     e.fteid,
+
     f.schoolid as fte_schoolid,
     f.yearid as fte_yearid,
 from {{ ref("int_powerschool__ps_enrollment_all") }} as e


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Add a singular dbt test on `int_powerschool__ps_enrollment_all` asserting that every enrollment row's `fteid` resolves to an FTE record whose `schoolid` and `yearid` match the enrollment's. PowerSchool scopes each FTE per `(schoolid, yearid)`, but the application does not enforce that a student's assigned FTE belongs to their enrolling school — when it doesn't, every daily row in `int_powerschool__ps_adaadm_daily_ctod` for that student is left-joined to nothing in `stg_powerschool__attendance_conversion_items` (the `(fteid, attendance_conversion_id)` pair has no codeday row), producing silent `attendancevalue = NULL`. That in turn causes inner-join drops in `int_powerschool__district_entry_date`, producing stale district-entry dates after re-enrollments.

Severity is `warn` so historical config drift surfaces without blocking the build. Once the PowerSchool cleanup in #4036 is complete, flip to `error`.

Refs #4036

## AI Assistance

Authored by Claude Code:

- Verified the issue's diagnosis against the warehouse — actual scope was 1 student affected in 2025-26, not 315 as the original summary stated. Posted the correction as an issue comment.
- Traced `fteid` / `attendance_conversion_id` lineage from the daily fact back to PowerSchool's `STUDENTS` / `REENROLLMENTS` / `BELL_SCHEDULE` source tables to identify the simplest invariant (FTE must belong to its enrollment's school + year).
- Drafted the singular test and properties YAML; user directed the framing — test on the furthest-up student-linked surface, include `schoolid = 999999` rows as graduated-student cleanup targets, include `yearid is null` rows, severity `warn`.
- Verified the test compiles and runs against `kippcamden` prod (740 historical hits, all expected cleanup targets per #4036).

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — singular test description placed in `src/dbt/powerschool/tests/properties.yml` per the singular-test description placement convention.
- [x] **Breaking change?** No — `warn`-severity test addition with no schema or model changes.

## CI checks

- [ ] **Trunk** — fmt ran clean at commit; verify check on the PR.
- [ ] **dbt Cloud** — should pass; test runs at warn severity.