### PR TITLE
fix(dbt): phone_interview_score int cast + is_mastery on student-scoped assessments

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__smartrecruiters.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__smartrecruiters.yml
@@ -2,7 +2,7 @@ models:
   - name: rpt_tableau__smartrecruiters
     columns:
       - name: phone_interview_score
-        data_type: string
+        data_type: int64
       - name: application_id
         data_type: string
       - name: reason_for_rejection

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__smartrecruiters.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__smartrecruiters.sql
@@ -20,7 +20,7 @@ with
             a.time_in_application_state_in_review,
             a.time_in_application_state_lead,
             a.school_shared_with,
-            a.application_field_phone_interview_score as phone_interview_score,
+            a.phone_interview_score,
             a.application_reason_for_rejection as reason_for_rejection,
             a.recruiters as recruiter_multiple,
             a.subject_preference as subject_preference_multiple,

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_student_scoped.sql
@@ -113,6 +113,38 @@ select
     ca.running_max_scale_score,
 
     cast(null as string) as proficiency_level,
+
+    -- TODO(#4045): extract College Board benchmarks to a lookup table.
+    -- Section benchmarks (EBRW/Math) and Combined College-Ready totals per
+    -- rpt_tableau__college_assessment_dashboard_benchmark_calcs. ACT and
+    -- subscore rows (Math Test / Reading Test) have no benchmark; leave NULL.
+    case
+        ca.score_type
+        when 'sat_ebrw'
+        then ca.scale_score >= 480
+        when 'sat_math'
+        then ca.scale_score >= 530
+        when 'sat_total_score'
+        then ca.scale_score >= 1010
+        when 'psat10_ebrw'
+        then ca.scale_score >= 430
+        when 'psat10_math_section'
+        then ca.scale_score >= 480
+        when 'psat10_total'
+        then ca.scale_score >= 910
+        when 'psatnmsqt_ebrw'
+        then ca.scale_score >= 430
+        when 'psatnmsqt_math_section'
+        then ca.scale_score >= 480
+        when 'psatnmsqt_total'
+        then ca.scale_score >= 910
+        when 'psat89_ebrw'
+        then ca.scale_score >= 410
+        when 'psat89_math_section'
+        then ca.scale_score >= 450
+        when 'psat89_total'
+        then ca.scale_score >= 860
+    end as is_mastery,
 from college_assessments as ca
 
 union all
@@ -163,6 +195,13 @@ select
     cast(null as numeric) as running_max_scale_score,
 
     cast(null as string) as proficiency_level,
+
+    case
+        when pa.scope = 'SAT' and pa.subject_area = 'Math'
+        then pa.scale_score >= 530
+        when pa.scope = 'SAT' and pa.subject_area = 'Combined'
+        then pa.scale_score >= 1010
+    end as is_mastery,
 from practice_assessments as pa
 
 union all
@@ -214,4 +253,6 @@ select
     case
         when ap.exam_score >= 3 then 'Qualified' else 'Not Qualified'
     end as proficiency_level,
+
+    ap.exam_score >= 3 as is_mastery,
 from ap_assessments as ap

--- a/src/dbt/kipptaf/models/marts/facts/fct_job_candidate_applications.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_job_candidate_applications.sql
@@ -58,7 +58,7 @@ select
     app.time_in_application_status_interview_phone_screen_requested,
     app.time_in_application_status_interview_phone_screen_complete,
 
-    app.application_field_phone_interview_score as phone_interview_score,
+    app.phone_interview_score,
     app.application_url as url,
 
     safe_cast(

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -106,3 +106,13 @@ models:
         description: >-
           Proficiency classification. For AP: Qualified (score >= 3) or Not
           Qualified. Null for college-entrance assessments.
+
+      - name: is_mastery
+        data_type: boolean
+        description: >-
+          TRUE if the student met the mastery / proficiency threshold for this
+          assessment. College Board section benchmarks (EBRW, Math) and Combined
+          College-Ready totals for SAT / PSAT 8/9 / PSAT10 / NMSQT; practice
+          (mock) SAT uses the official SAT cutoffs. AP: exam_score >= 3. NULL
+          for ACT, sub-section scores (Math Test / Reading Test), and practice
+          ACT or SAT Reading / Writing rows that have no defined benchmark.

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
@@ -275,7 +275,7 @@ models:
           status. Cast from source string at the mart layer.
 
       - name: phone_interview_score
-        data_type: string
+        data_type: int64
         description: Score assigned during the phone interview.
 
       - name: url

--- a/src/dbt/kipptaf/models/smartrecruiters/staging/properties/stg_smartrecruiters__applications.yml
+++ b/src/dbt/kipptaf/models/smartrecruiters/staging/properties/stg_smartrecruiters__applications.yml
@@ -145,5 +145,7 @@ models:
         data_type: datetime
       - name: resume_score
         data_type: int64
+      - name: phone_interview_score
+        data_type: int64
       - name: school_shared_with
         data_type: string

--- a/src/dbt/kipptaf/models/smartrecruiters/staging/stg_smartrecruiters__applications.sql
+++ b/src/dbt/kipptaf/models/smartrecruiters/staging/stg_smartrecruiters__applications.sql
@@ -74,6 +74,9 @@ with
                 time_in_application_status_interview_phone_screen_requested as int
             ) as time_in_application_status_interview_phone_screen_requested,
             cast(application_field_resume_score as int) as resume_score,
+            cast(
+                application_field_phone_interview_score as int
+            ) as phone_interview_score,
 
             cast(average_rating as numeric) as average_rating,
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Two unblockers for Cube semantic-layer work, bundled because both are small marts-layer type/column fixes touched in similar files.

- **#3837** — Cast `application_field_phone_interview_score` to `int64` in `stg_smartrecruiters__applications` (mirrors the existing `resume_score` pattern), and propagate the type through `fct_job_candidate_applications` and `rpt_tableau__smartrecruiters`. Unblocks Cube `talent` cube's `avg_phone_interview_score` measure.
- **#3840** — Add `is_mastery` (BOOLEAN) to `fct_assessment_scores_student_scoped`. Inline `CASE` per the existing AP-branch pattern. Cutoffs:
  - SAT / PSAT 8/9 / PSAT10 / PSAT NMSQT EBRW + Math: official College Board section benchmarks
  - SAT / PSAT 8/9 / PSAT10 / PSAT NMSQT Combined totals: College Board College-Ready cutoffs
  - Practice (mock SAT through Illuminate): reuses SAT cutoffs for Math + Combined
  - AP: `exam_score >= 3` (matches the existing `proficiency_level` CASE)
  - ACT, sub-section scores (Math Test / Reading Test), practice SAT Reading/Writing, practice ACT: `NULL` (no defined benchmark)

Unblocks Cube `assessment_scores_student_scoped` mastery-rate measures.

Inline thresholds duplicate values already in `rpt_tableau__college_assessment_dashboard_benchmark_calcs`. Followup #4045 tracks extracting them to a shared lookup.

Closes #3837. Closes #3840. Refs #4045.

## AI Assistance

AI-authored under direction: investigation of upstream types/cutoffs, file edits, and dbt build verification (`uv run dbt build --select stg_smartrecruiters__applications+ fct_assessment_scores_student_scoped` against dev, all 23 tests pass). Threshold mapping and decision to keep thresholds inline (with followup issue) were human-directed via clarifying questions.

## Self-review

### dbt

- [x] `[model_name].yml` updated for all touched models (`stg_smartrecruiters__applications`, `fct_job_candidate_applications`, `fct_assessment_scores_student_scoped`, `rpt_tableau__smartrecruiters`)
- [x] No new external sources; no `stage_external_sources` needed
- [x] Not a breaking column rename — added a column (`is_mastery`) and changed a column's declared type (`phone_interview_score`: string → int64). No downstream `select *` consumers found via grep
- [x] No new exposures needed (mart already exposed via `cube.yml`)

## CI checks

- [x] Local `uv run dbt build --select stg_smartrecruiters__applications+ fct_assessment_scores_student_scoped` against dev: PASS=23 WARN=0 ERROR=0
- [ ] **Trunk** — pre-commit format pass clean
- [ ] **dbt Cloud** — pending CI
- [ ] **Dagster Cloud** — pending CI