### PR TITLE
fix(dbt): project file upload filename into survey_responses answer

### DIFF
--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_responses.sql
@@ -16,7 +16,7 @@ with
             fr.info_title as survey_title,
             fr.response_id as survey_response_id,
             fr.question_id as survey_question_id,
-            fr.text_value as answer,
+            coalesce(fr.text_value, fr.file_upload_file_name) as answer,
             fr.item_title as question_title,
             fr.item_abbreviation as question_shortname,
             fr.respondent_email,

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_responses.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_responses.yml
@@ -6,8 +6,9 @@ models:
       question_shortname, answer). Google Forms grid and check-all-that-apply
       questions produce multiple rows per (response, question_id) — one per row
       shortname or selected option — so the natural grain extends to shortname +
-      answer. Marts that need per-shortname or per-question rollups project to
-      that grain themselves.
+      answer. File-upload questions emit one row per uploaded file with the
+      filename projected into `answer`. Marts that need per-shortname or
+      per-question rollups project to that grain themselves.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will eliminate the 8 residual duplicates on `int_surveys__survey_responses` by projecting `file_upload_file_name` into the `answer` column for Google Forms File Upload questions.

Root cause: upstream `int_google_forms__form_responses` emits one row per uploaded file (analogous to grid / check-all-that-apply patterns), but the survey model projected only `text_value` as `answer`. File-upload rows have NULL `text_value` and NULL `item_abbreviation`, so N uploaded files for the same response collapsed to N identical `(survey_id, response_id, question_id, NULL, NULL)` tuples.

All 8 residual dupes traced to one form (`1SoCq9ZlmpvHjquepv4ei1XhtRWR0Vo7vbJE0sBz3yxo`) on two file-upload questions — Resume and Certification uploads. `coalesce(text_value, file_upload_file_name)` gives each file a distinguishing answer value, mirroring how each selected option becomes a row in check-all-that-apply. Verified against current prod data: zero residual dupes across the whole Google Forms branch.

Closes #3784

## AI Assistance

Investigation, fix, and verification were Claude-assisted via `/superpowers:systematic-debugging`; reviewed and directed by @cbini.

## Self-review

### dbt

- [x] No new model — modifying existing `int_*` SQL and yml description only
- [x] No external sources touched
- [x] No contract / column rename — only the value projected into existing `answer` column

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes; verified locally with `dbt build --select int_surveys__survey_responses+`

🤖 Generated with [Claude Code](https://claude.com/claude-code)