### PR TITLE
fix(dbt): dedup growth partition in int_assessments__college_assessment

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment.sql
@@ -99,6 +99,24 @@ with
         from scores
     ),
 
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    growth_candidates as (
+        select *
+        from case_calcs
+        where subject_area in ('Composite', 'Combined') and test_date is not null
+    ),
+
+    -- TODO(#3802): remove dedup once Salesforce dup records cleaned up
+    growth_dedup as (
+        {{
+            dbt_utils.deduplicate(
+                relation="growth_candidates",
+                partition_by="student_number, scope, test_date",
+                order_by="surrogate_key",
+            )
+        }}
+    ),
+
     growth as (
         select
             academic_year,
@@ -111,8 +129,7 @@ with
                 partition by student_number, scope order by test_date asc
             ) as previous_total_score_change,
 
-        from case_calcs
-        where subject_area in ('Composite', 'Combined') and test_date is not null
+        from growth_dedup
     ),
 
     max_score as (

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment.sql
@@ -101,12 +101,12 @@ with
 
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     growth_candidates as (
-        select *
+        select
+            academic_year, student_number, scope, test_date, scale_score, surrogate_key,
         from case_calcs
         where subject_area in ('Composite', 'Combined') and test_date is not null
     ),
 
-    -- TODO(#3802): remove dedup once Salesforce dup records cleaned up
     growth_dedup as (
         {{
             dbt_utils.deduplicate(

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__college_assessment.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__college_assessment.yml
@@ -1,5 +1,13 @@
 models:
   - name: int_assessments__college_assessment
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - score_type
+              - test_date
+              - rn_highest
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_rollup.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_rollup.yml
@@ -2,3 +2,10 @@ models:
   - name: int_kippadb__standardized_test_rollup
     config:
       materialized: ephemeral
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - school_specific_id
+              - test_type
+              - test_subject

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
@@ -9,6 +9,16 @@ models:
               `date` is null or `date` >= '2000-01-01'
           config:
             severity: warn
+      # TODO(#3802): remove warn once Salesforce dup records cleaned up
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - contact
+              - test_type
+              - score_type
+              - date
+          config:
+            severity: warn
     columns:
       - name: id
         data_type: string

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
@@ -15,6 +15,7 @@ models:
               - contact
               - test_type
               - score_type
+              - ap_course_name
               - date
           config:
             severity: warn

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__standardized_test_unpivot.yml
@@ -9,7 +9,6 @@ models:
               `date` is null or `date` >= '2000-01-01'
           config:
             severity: warn
-      # TODO(#3802): remove warn once Salesforce dup records cleaned up
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix the snapshot MERGE failure in `snapshot_kippadb__standardized_test_rollup` ([Dagster run ad37b146-...](https://kipptaf.dagster.cloud/prod/runs/ad37b146-0ee3-4427-ae38-41fb580aea0b)) and add uniqueness tests so regressions surface at build time rather than at snapshot MERGE time.

Root cause (full trace in #4052): Salesforce `Standardized_Test__c` has duplicate records on the same SAT administration (#3802). `int_kippadb__standardized_test_unpivot.rn_highest` correctly tie-breaks the dup, but `int_assessments__college_assessment` re-fanned the surviving `rn_highest = 1` rows back to 2 via its `growth` left join &mdash; `growth` had 2 rows per `(student_number, scope, test_date)` from the duplicate `sat_total_score` rows, and the join condition had no row tiebreaker. That fan-out propagated into `int_kippadb__standardized_test_rollup`, breaking the snapshot's `unique_key (school_specific_id, test_type, test_subject)`.

Fix: dedup `growth` to one row per `(student_number, scope, test_date)` before the `lag()` and the join, via `dbt_utils.deduplicate`. Add uniqueness tests on both layers.

Verified locally: `dbt build` against the chain rebuilds clean, both new uniqueness tests pass, snapshot MERGE succeeds.

## AI Assistance

Claude Code authored the diagnosis (Dagster log triage, BigQuery row-count traces back through the unpivot/case_calcs/score_calcs chain), the fix shape, the tests, and the issue body. Human-directed: choice of model-side fix vs. rollup-local dedup vs. source cleanup; decision to add tests; PR/branch flow.

## Self-review

### dbt

- [x] No new models; no new exposures needed
- [x] No contract changes; no breaking-change coordination required
- [x] No external sources touched

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud

Closes #4052
Refs #3802