### PR TITLE
test(dbt): guard primary-exclusivity invariant for Cube manager resolver

### DIFF
--- a/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
+++ b/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
@@ -1,186 +1,216 @@
-# Staff Reporting-Relationships Dim Design
+# Point-in-Time Role-Playing Manager for Cube
 
 **Date:** 2026-05-28 **Status:** Active **Issue:**
 [#3838](https://github.com/TEAMSchools/teamster/issues/3838)
 
 ## Overview
 
-Add a person-grained, point-in-time dimension —
-`dim_staff_reporting_relationships` — that exposes "who was this staff member's
-manager on date D." It lets the gradebook, observations, and surveys Cube cubes
-surface a teacher's / observed staff's / survey subject's manager via a single
-date-range join plus a role-playing `staff_manager` cube (`extends: staff`),
-without denormalizing manager attributes onto `dim_staff` and without each
-consuming cube re-deriving a fragile multi-table period intersection.
+Let the gradebook, observations, and surveys Cube cubes surface a teacher's /
+observed staff's / survey subject's **manager as of the record date** via a
+single date-range join plus a role-playing `staff_manager` cube
+(`extends: staff`) — without denormalizing manager attributes onto `dim_staff`,
+and without each consuming cube re-deriving a fragile multi-table period
+intersection.
+
+The manager-at-a-date resolution is built as a shared **Cube period-intersection
+cube** (`staff_reporting_relationships`), per the cube-model spec's design
+decision _"Period intersection lives in Cube SQL, not dbt."_ The only dbt change
+is a **guard test** protecting the invariant the resolver's grain depends on.
 
 This supersedes the original #3838 plan (denormalize `manager_name` /
 `manager_staff_key` onto `dim_staff`), which violated the marts strict-chain
 rule and was current-only.
 
-## Goals
+## Decision: resolve in Cube SQL, not a dbt dim
 
-- A reusable dbt mart dim, keyed by the subordinate's `staff_key`, that answers
-  "manager at a point in time" with one date-range join.
-- Strict-chain compliant: `dim_staff` is untouched; manager identity is a role
-  FK (`manager_staff_key`) reachable by traversal, not a denormalized name.
-- Resolve the primary-assignment + reporting-relationship period intersection
-  **once, upstream**, so gradebook / observations / surveys cubes each do a
-  single clean join.
+Two strict-chain-compliant placements were considered for the
+primary-assignment + reporting-relationship intersection:
 
-## Non-goals
+- **Cube SQL** (chosen) — a shared `staff_reporting_relationships` cube whose
+  `sql:` block computes the intersection, mirroring `staff_work_history`.
+- **dbt dim** — a new `dim_staff_reporting_relationships` mart at
+  `(staff_key, effective_start_date)` grain.
 
-- **Cube YAML implementation** (the `staff_reporting_relationships` cube, the
-  `staff_manager extends staff` alias, the per-fact joins) — that lands in the
-  Cube model work on `cristinabaldor/feat/claude-cube-model-yaml-design`. This
-  spec covers the dbt dim only, and documents the intended Cube consumption for
-  context.
-- **The "who can see their data today" access chain** — the `queryRewrite`
-  `dim_staff.reporting_chain` segment is a separate current-transitive-closure
-  security mechanism, already scoped to the cube-infra follow-up. Out of scope.
-- **Widening manager history** — pre-2021 NJ (Dayforce-era) manager coverage is
-  owned by [#3869](https://github.com/TEAMSchools/teamster/issues/3869). This
-  dim reads downstream of that and will gain coverage when #3869 ships.
+Cube SQL wins because:
 
-## Background: why this isn't reachable today
+1. **Convention.** The cube-model spec explicitly decides _"Period intersection
+   lives in Cube SQL, not dbt … dbt handles structural transformations and
+   stable business rules; Cube owns presentation-layer shaping."_
+   `staff_work_history` is already built this way.
+2. **Zero dbt footprint.** No new mart to maintain, contract, or rebuild.
+3. **Nesting is not a differentiator.** An inline Cube cube adds no persisted
+   view level; a dbt dim would have to be materialized as a `table` to match
+   that. Both are safe (validated below).
 
-`dim_work_assignment_reporting_relationships` already carries
-`manager_staff_key` (role FK → `dim_staff`, SCD2 by effective period), but it
-can't serve the consumer question as-is:
+Trade-off accepted: the unique-grain guarantee rests on the
+**primary-exclusivity invariant** (≤1 primary assignment per staff at any
+instant), which a dbt dim would enforce via its own PK uniqueness test. Cube SQL
+has no such test, so we add a standalone dbt guard test (below) regardless of
+placement.
 
-1. **Key mismatch.** It's keyed by `work_assignment_key`. The facts carry a
-   _person_ FK (`teacher_staff_key`, `observer_staff_key`, `subject_staff_key` —
-   i.e. `staff_key`). There is no shared join key; reaching it requires hopping
-   through `dim_staff_work_assignments`.
-2. **Grain mismatch / fan-out.** `staff_key` is **not unique** in
-   `dim_staff_work_assignments` — a person can hold multiple assignments (e.g.
-   teacher + coach). So `staff_key → work_assignment_key` is one-to-many, and
-   there is no single "this person's manager at date D" row addressable by
-   `staff_key` without first picking the **primary** assignment at that date.
+## Why it isn't a single existing join
 
-So "manager at date D" is a three-table, point-in-time intersection:
+The facts carry a _person_ FK (`teacher_staff_key`, `observer_staff_key`,
+`subject_staff_key` — i.e. `staff_key`), but the manager lives at
+_work-assignment_ grain. "Manager at date D" is therefore a three-table,
+point-in-time intersection:
 
 ```text
-primary assignment @ D        (dim_work_assignment_primary,                SCD2)
-  → reporting-relationship @ D (dim_work_assignment_reporting_relationships, SCD2)
-    → manager_staff_key        (role FK → dim_staff)
+primary assignment @ D         (dim_work_assignment_primary,                SCD2)
+  -> reporting-relationship @ D (dim_work_assignment_reporting_relationships, SCD2)
+    -> manager_staff_key         (role FK -> dim_staff)
 ```
 
-Pushing that 3-table date overlap into every consuming cube would repeat fragile
-period-intersection SQL and invite grain blow-ups. This dim computes it once.
+`staff_key` is **not unique** in `dim_staff_work_assignments` (a person can hold
+multiple assignments — e.g. teacher + coach), so the **primary** assignment at
+date D must be resolved before the manager. The primary flag is itself SCD2
+(`dim_work_assignment_primary`), so this is a genuine period intersection, not a
+filter. A bare `is_primary` predicate on a join cannot express it — the flag and
+the join keys live in three separately date-versioned tables.
 
-## Source models (all marts; intra-mart refs)
+## Design
 
-| Model                                         | Grain                                   | Columns used                                                                               |
-| --------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `dim_staff_work_assignments`                  | 1 / `work_assignment_key` (Type 1)      | `work_assignment_key`, `staff_key`                                                         |
-| `dim_work_assignment_primary`                 | 1 / `(work_assignment_key, eff. start)` | `work_assignment_key`, `is_primary_position`, `effective_start_date`, `effective_end_date` |
-| `dim_work_assignment_reporting_relationships` | 1 / `(work_assignment_key, eff. start)` | `work_assignment_key`, `manager_staff_key`, `effective_start_date`, `effective_end_date`   |
+### Cube: `staff_reporting_relationships` (period-intersection cube)
 
-All three are mart dims; `dim_staff_reporting_relationships` references them as
-intra-mart refs (permitted per `marts/CLAUDE.md`). No new intermediate model is
-required — the inputs are already SCD2-shaped.
+`public: false`. The `staff_` prefix keeps it under `queryRewrite`'s
+`startsWith("staff")` staff-access gate. Reference `sql:` (validated against
+prod — see Validation):
 
-## Design: `dim_staff_reporting_relationships`
+```sql
+SELECT
+  swa.staff_key,
+  rr.manager_staff_key,
+  GREATEST(wap.effective_start_date, rr.effective_start_date) AS effective_start_date,
+  LEAST(wap.effective_end_date,   rr.effective_end_date)      AS effective_end_date
+FROM kipptaf_marts.dim_work_assignment_primary wap
+JOIN kipptaf_marts.dim_staff_work_assignments swa
+  ON wap.work_assignment_key = swa.work_assignment_key
+  AND swa.staff_key IS NOT NULL          -- assignment must be attributable to a person
+JOIN kipptaf_marts.dim_work_assignment_reporting_relationships rr
+  ON rr.work_assignment_key = wap.work_assignment_key
+  AND wap.effective_start_date <= rr.effective_end_date   -- period overlap
+  AND wap.effective_end_date   >= rr.effective_start_date
+WHERE wap.is_primary_position           -- the "hard requirement for primary"
+```
 
-**Location:** `src/dbt/kipptaf/models/marts/dimensions/` (+ `properties/`).
+- **PK dimension:**
+  `CONCAT(staff_key, '|', CAST(effective_start_date AS STRING))` (Pattern 3
+  convention — no surrogate spans the intersection rows).
+- **Dimensions:** `staff_key`, `manager_staff_key`, `effective_start_date`
+  (time), `effective_end_date`. `manager_staff_key` carries `meta: {pii: false}`
+  (a surrogate, not an identifier); manager identifiers come through the
+  `staff_manager` join.
+- **`dates` join** is `one_to_many` (one span -> many days) if the cube is ever
+  queried standalone; consumers must apply a date filter. As a join _target_
+  from facts it is `many_to_one` (validated).
 
-**Grain:** one row per `(staff_key, effective_start_date)` — the subordinate's
-manager over a contiguous effective period.
+### Cube: `staff_manager` role alias + per-fact join
 
-**Columns:**
+```yaml
+cubes:
+  - name: staff_manager # role alias - inherits all staff dimensions
+    extends: staff
+    public: false
+```
 
-| Column                             | Type    | Notes                                                                      |
-| ---------------------------------- | ------- | -------------------------------------------------------------------------- |
-| `staff_reporting_relationship_key` | string  | PK = `generate_surrogate_key(["staff_key", "effective_start_date"])`       |
-| `staff_key`                        | string  | Subordinate. FK → `dim_staff`.                                             |
-| `manager_staff_key`                | string  | Role FK → `dim_staff`. Nullable (no number mapping, or pre-#3869 history). |
-| `effective_start_date`             | date    | `GREATEST` of the two source spans' starts.                                |
-| `effective_end_date`               | date    | `LEAST` of the two source spans' ends. `9999-12-31` sentinel for open.     |
-| `is_current`                       | boolean | `effective_end_date = '9999-12-31'`.                                       |
+Each staff-keyed fact joins the resolver, then the resolver (or the fact)
+reaches `staff_manager` on `manager_staff_key`:
 
-**Build logic:**
+```yaml
+joins:
+  - name: staff_reporting_relationships
+    relationship: many_to_one
+    sql: >
+      {staff_reporting_relationships.staff_key} = {CUBE}.teacher_staff_key AND
+      CAST({CUBE}.observed_date_key AS TIMESTAMP)
+          BETWEEN CAST({staff_reporting_relationships.effective_start_date} AS
+      TIMESTAMP)
+          AND     CAST({staff_reporting_relationships.effective_end_date}   AS
+      TIMESTAMP)
+```
 
-1. **Primary spans per staff.** From `dim_work_assignment_primary` filtered to
-   `is_primary_position = true`, joined to `dim_staff_work_assignments` on
-   `work_assignment_key` to attach `staff_key`. Yields, per staff, the periods
-   during which a given assignment was their primary assignment.
-2. **Manager spans.** From `dim_work_assignment_reporting_relationships` —
-   `work_assignment_key`, `manager_staff_key`, effective span.
-3. **Intersect** (1) and (2) on `work_assignment_key` where the periods overlap:
-   - `effective_start_date = GREATEST(primary.start, reporting.start)`
-   - `effective_end_date   = LEAST(primary.end,   reporting.end)`
-   - keep rows where `effective_start_date <= effective_end_date`
-4. Project to `staff_key` grain (the primary filter guarantees ≤1 primary
-   assignment per staff at any instant — see "Uniqueness" below).
+`BETWEEN` is inclusive — these spans are end-dated to day-before-next-start, so
+inclusive bounds match exactly one span (validated: zero fan-out). Manager name
+= `staff_manager.full_name`, reached purely by traversal. Detail views add
+`staff_manager_*` PII fields to the relevant `excludes:` list.
 
-Both sources use the `9999-12-31` open-ended sentinel (no NULL), so `GREATEST` /
-`LEAST` are NULL-safe without `COALESCE`.
+### dbt: primary-exclusivity guard test
 
-**Materialization:** `table` (override in `properties/...yml` per
-`src/dbt/CLAUDE.md`). The model sits atop three view-materialized dims; a table
-avoids deep view nesting and keeps the Cube-side date-range join from
-compounding toward BigQuery's 16-view limit at query time.
+A singular test (`tests/`) asserting no staff has two _distinct_ primary
+assignments with overlapping effective periods — the invariant the resolver's
+unique grain depends on:
 
-**Nullable FK handling:** `manager_staff_key` is already null-wrapped at source
-(`if(... is not null, surrogate, null)`); carry it through unchanged. No
-`not_null` test on it. `staff_key` is the PK input and must be non-null, but
-`dim_staff_work_assignments.staff_key` is itself nullable (assignments whose
-`associate_oid` has no active number mapping). Filter `staff_key is not null` in
-step 1 — a work assignment not attributable to a person cannot anchor a
-person-grained row.
+```sql
+with primary_spans as (
+    select
+        swa.staff_key,
+        wap.work_assignment_key,
+        wap.effective_start_date,
+        wap.effective_end_date,
+    from {{ ref("dim_work_assignment_primary") }} as wap
+    inner join {{ ref("dim_staff_work_assignments") }} as swa
+        on wap.work_assignment_key = swa.work_assignment_key
+    where wap.is_primary_position and swa.staff_key is not null
+)
 
-## Tests
+select a.staff_key
+from primary_spans as a
+inner join primary_spans as b
+    on a.staff_key = b.staff_key
+    and a.work_assignment_key < b.work_assignment_key
+    and a.effective_start_date <= b.effective_end_date
+    and a.effective_end_date >= b.effective_start_date
+```
 
-- `unique` + `not_null` on `staff_reporting_relationship_key`.
-- `relationships` on `staff_key` → `dim_staff.staff_key`.
-- `relationships` on `manager_staff_key` → `dim_staff.staff_key` (nullable FK;
-  passes on NULLs).
-- `dbt_utils.expression_is_true: effective_start_date <= effective_end_date`
-  (mirrors the guard on `dim_work_assignment_primary`).
-- Contract enforced + `materialized: table` via `properties` yml.
+`meta.dagster.ref` -> `dim_work_assignment_primary`. Default `warn` severity is
+acceptable (it's a drift detector, not a build-blocker) — or `error` if we want
+CI to fail hard on a future violation. Decide at implementation.
 
-## Intended Cube consumption (separate work — documented for context)
+## Validation (prod `kipptaf_marts`, 2026-05-28)
 
-In the Cube model project:
+The reference SQL above was run against prod:
 
-- A standalone cube `staff_reporting_relationships` (`public: false`,
-  `sql_table: kipptaf_marts.dim_staff_reporting_relationships`). The `staff_`
-  prefix keeps it under `queryRewrite`'s `startsWith("staff")` gate.
-- A role alias `staff_manager` (`extends: staff`, `public: false`) joined from
-  `staff_reporting_relationships` on `manager_staff_key`.
-- Each staff-keyed fact date-range-joins it, `many_to_one` (same shape as the
-  student ELL/IEP/meal status dims):
+| Check                                                  | Result                                                   |
+| ------------------------------------------------------ | -------------------------------------------------------- |
+| Resolver grain unique on `(staff_key, eff_start)`      | 10,387 rows = 10,387 distinct PKs, 3,231 staff           |
+| Concurrent-primary fan-out                             | none                                                     |
+| `manager_staff_key` NULL in intersected set            | 0                                                        |
+| `fct_staff_observations` date-range join multiplicity  | 47,585 obs; **0 fan-out** (`max=1`); 47,537 one, 48 none |
+| Nesting (resolver + `dim_staff` joined twice) executes | yes — all source dims are views; clean run               |
 
-  ```text
-  {staff_reporting_relationships.staff_key} = {CUBE}.<role>_staff_key
-  AND CAST({CUBE}.<record_date_key> AS TIMESTAMP)
-      BETWEEN CAST({staff_reporting_relationships.effective_start_date} AS TIMESTAMP)
-      AND     CAST({staff_reporting_relationships.effective_end_date}   AS TIMESTAMP)
-  ```
+The 48 zero-match observations are dated before the teacher's primary/reporting
+span begins; they correctly resolve to a NULL manager via `LEFT JOIN`.
 
-- Manager name = `staff_manager.full_name`, reached purely by traversal. Detail
-  views add `staff_manager_*` PII fields to the relevant `excludes:` list.
+## Scope & ownership
 
-## Open questions / verify at implementation
+- **This branch / issue (dbt):** the primary-exclusivity guard test + this spec.
+- **Cube-model branch** (`cristinabaldor/feat/claude-cube-model-yaml-design`):
+  the `staff_reporting_relationships` and `staff_manager` cubes + the per-fact
+  joins. They depend on the `staff` cube, which exists only on that branch, so
+  they are authored there. This spec supersedes that spec's current-manager
+  gradebook note.
 
-1. **Primary exclusivity.** The `(staff_key, effective_start_date)` PK assumes
-   at most one assignment is `is_primary_position = true` per staff at any
-   instant. Verify in prod before trusting the surrogate; if two assignments are
-   ever concurrently primary, the intersection fans out and the grain needs a
-   tiebreaker (or the PK must include `work_assignment_key`, changing the
-   grain).
-2. **Coverage.** Confirm populated `manager_staff_key` rates per region/era
-   (expect NULLs pre-#3869 for NJ). Treat high-NULL as a coverage gap, not a
-   broken join.
-3. **Staff with no primary assignment** (e.g. pending hires, gaps) simply have
-   no row for that period; consumers `LEFT JOIN` and see a NULL manager. Confirm
-   that's the desired behavior for gradebook/observations denominators.
+## Out of scope (follow-up)
 
-## Validation plan
+The "who can see a person's data **today**" reporting chain — the `queryRewrite`
+`dim_staff.reporting_chain` segment (`src/cube/cube.js`) — is a separate
+current-transitive-closure access mechanism, already scoped to the cube-infra
+follow-up. Not addressed here.
 
-- `uv run dbt build --select dim_staff_reporting_relationships+` against
-  `kipptaf` (worktree project dir).
-- Spot-check a known staff member with a manager change and/or multiple
-  assignments: confirm one row per contiguous manager period, correct
-  `manager_staff_key` per `effective_*` window, `is_current` on the open period.
-- Confirm PK uniqueness holds in prod-shaped data (open question 1).
+## Open questions
+
+1. **Guard-test severity** — `warn` (drift detector) vs `error` (hard CI fail).
+2. **#3869 coverage** — pre-2021 NJ (Dayforce-era) manager history. Prod shows 0
+   NULL managers in the primary-assignment set today, so impact is low; revisit
+   if historical gradebook/observation analysis surfaces gaps.
+3. **No-primary-assignment staff** (pre-hire, gaps) resolve to NULL manager for
+   that date. Confirm acceptable for gradebook/observations denominators.
+
+## Validation plan (implementation)
+
+- dbt:
+  `uv run dbt build --select dim_work_assignment_primary test_staff_primary_assignment_no_overlap`
+  against `kipptaf` (worktree).
+- Cube (on the cube-model branch): compile the resolver via `/sql`, confirm
+  nesting and `WHERE`-free `many_to_one` behavior, spot-check a known
+  manager-change teacher resolves the correct manager per observation date.

--- a/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
+++ b/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
@@ -1,0 +1,186 @@
+# Staff Reporting-Relationships Dim Design
+
+**Date:** 2026-05-28 **Status:** Active **Issue:**
+[#3838](https://github.com/TEAMSchools/teamster/issues/3838)
+
+## Overview
+
+Add a person-grained, point-in-time dimension —
+`dim_staff_reporting_relationships` — that exposes "who was this staff member's
+manager on date D." It lets the gradebook, observations, and surveys Cube cubes
+surface a teacher's / observed staff's / survey subject's manager via a single
+date-range join plus a role-playing `staff_manager` cube (`extends: staff`),
+without denormalizing manager attributes onto `dim_staff` and without each
+consuming cube re-deriving a fragile multi-table period intersection.
+
+This supersedes the original #3838 plan (denormalize `manager_name` /
+`manager_staff_key` onto `dim_staff`), which violated the marts strict-chain
+rule and was current-only.
+
+## Goals
+
+- A reusable dbt mart dim, keyed by the subordinate's `staff_key`, that answers
+  "manager at a point in time" with one date-range join.
+- Strict-chain compliant: `dim_staff` is untouched; manager identity is a role
+  FK (`manager_staff_key`) reachable by traversal, not a denormalized name.
+- Resolve the primary-assignment + reporting-relationship period intersection
+  **once, upstream**, so gradebook / observations / surveys cubes each do a
+  single clean join.
+
+## Non-goals
+
+- **Cube YAML implementation** (the `staff_reporting_relationships` cube, the
+  `staff_manager extends staff` alias, the per-fact joins) — that lands in the
+  Cube model work on `cristinabaldor/feat/claude-cube-model-yaml-design`. This
+  spec covers the dbt dim only, and documents the intended Cube consumption for
+  context.
+- **The "who can see their data today" access chain** — the `queryRewrite`
+  `dim_staff.reporting_chain` segment is a separate current-transitive-closure
+  security mechanism, already scoped to the cube-infra follow-up. Out of scope.
+- **Widening manager history** — pre-2021 NJ (Dayforce-era) manager coverage is
+  owned by [#3869](https://github.com/TEAMSchools/teamster/issues/3869). This
+  dim reads downstream of that and will gain coverage when #3869 ships.
+
+## Background: why this isn't reachable today
+
+`dim_work_assignment_reporting_relationships` already carries
+`manager_staff_key` (role FK → `dim_staff`, SCD2 by effective period), but it
+can't serve the consumer question as-is:
+
+1. **Key mismatch.** It's keyed by `work_assignment_key`. The facts carry a
+   _person_ FK (`teacher_staff_key`, `observer_staff_key`, `subject_staff_key` —
+   i.e. `staff_key`). There is no shared join key; reaching it requires hopping
+   through `dim_staff_work_assignments`.
+2. **Grain mismatch / fan-out.** `staff_key` is **not unique** in
+   `dim_staff_work_assignments` — a person can hold multiple assignments (e.g.
+   teacher + coach). So `staff_key → work_assignment_key` is one-to-many, and
+   there is no single "this person's manager at date D" row addressable by
+   `staff_key` without first picking the **primary** assignment at that date.
+
+So "manager at date D" is a three-table, point-in-time intersection:
+
+```text
+primary assignment @ D        (dim_work_assignment_primary,                SCD2)
+  → reporting-relationship @ D (dim_work_assignment_reporting_relationships, SCD2)
+    → manager_staff_key        (role FK → dim_staff)
+```
+
+Pushing that 3-table date overlap into every consuming cube would repeat fragile
+period-intersection SQL and invite grain blow-ups. This dim computes it once.
+
+## Source models (all marts; intra-mart refs)
+
+| Model                                         | Grain                                   | Columns used                                                                               |
+| --------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `dim_staff_work_assignments`                  | 1 / `work_assignment_key` (Type 1)      | `work_assignment_key`, `staff_key`                                                         |
+| `dim_work_assignment_primary`                 | 1 / `(work_assignment_key, eff. start)` | `work_assignment_key`, `is_primary_position`, `effective_start_date`, `effective_end_date` |
+| `dim_work_assignment_reporting_relationships` | 1 / `(work_assignment_key, eff. start)` | `work_assignment_key`, `manager_staff_key`, `effective_start_date`, `effective_end_date`   |
+
+All three are mart dims; `dim_staff_reporting_relationships` references them as
+intra-mart refs (permitted per `marts/CLAUDE.md`). No new intermediate model is
+required — the inputs are already SCD2-shaped.
+
+## Design: `dim_staff_reporting_relationships`
+
+**Location:** `src/dbt/kipptaf/models/marts/dimensions/` (+ `properties/`).
+
+**Grain:** one row per `(staff_key, effective_start_date)` — the subordinate's
+manager over a contiguous effective period.
+
+**Columns:**
+
+| Column                             | Type    | Notes                                                                      |
+| ---------------------------------- | ------- | -------------------------------------------------------------------------- |
+| `staff_reporting_relationship_key` | string  | PK = `generate_surrogate_key(["staff_key", "effective_start_date"])`       |
+| `staff_key`                        | string  | Subordinate. FK → `dim_staff`.                                             |
+| `manager_staff_key`                | string  | Role FK → `dim_staff`. Nullable (no number mapping, or pre-#3869 history). |
+| `effective_start_date`             | date    | `GREATEST` of the two source spans' starts.                                |
+| `effective_end_date`               | date    | `LEAST` of the two source spans' ends. `9999-12-31` sentinel for open.     |
+| `is_current`                       | boolean | `effective_end_date = '9999-12-31'`.                                       |
+
+**Build logic:**
+
+1. **Primary spans per staff.** From `dim_work_assignment_primary` filtered to
+   `is_primary_position = true`, joined to `dim_staff_work_assignments` on
+   `work_assignment_key` to attach `staff_key`. Yields, per staff, the periods
+   during which a given assignment was their primary assignment.
+2. **Manager spans.** From `dim_work_assignment_reporting_relationships` —
+   `work_assignment_key`, `manager_staff_key`, effective span.
+3. **Intersect** (1) and (2) on `work_assignment_key` where the periods overlap:
+   - `effective_start_date = GREATEST(primary.start, reporting.start)`
+   - `effective_end_date   = LEAST(primary.end,   reporting.end)`
+   - keep rows where `effective_start_date <= effective_end_date`
+4. Project to `staff_key` grain (the primary filter guarantees ≤1 primary
+   assignment per staff at any instant — see "Uniqueness" below).
+
+Both sources use the `9999-12-31` open-ended sentinel (no NULL), so `GREATEST` /
+`LEAST` are NULL-safe without `COALESCE`.
+
+**Materialization:** `table` (override in `properties/...yml` per
+`src/dbt/CLAUDE.md`). The model sits atop three view-materialized dims; a table
+avoids deep view nesting and keeps the Cube-side date-range join from
+compounding toward BigQuery's 16-view limit at query time.
+
+**Nullable FK handling:** `manager_staff_key` is already null-wrapped at source
+(`if(... is not null, surrogate, null)`); carry it through unchanged. No
+`not_null` test on it. `staff_key` is the PK input and must be non-null, but
+`dim_staff_work_assignments.staff_key` is itself nullable (assignments whose
+`associate_oid` has no active number mapping). Filter `staff_key is not null` in
+step 1 — a work assignment not attributable to a person cannot anchor a
+person-grained row.
+
+## Tests
+
+- `unique` + `not_null` on `staff_reporting_relationship_key`.
+- `relationships` on `staff_key` → `dim_staff.staff_key`.
+- `relationships` on `manager_staff_key` → `dim_staff.staff_key` (nullable FK;
+  passes on NULLs).
+- `dbt_utils.expression_is_true: effective_start_date <= effective_end_date`
+  (mirrors the guard on `dim_work_assignment_primary`).
+- Contract enforced + `materialized: table` via `properties` yml.
+
+## Intended Cube consumption (separate work — documented for context)
+
+In the Cube model project:
+
+- A standalone cube `staff_reporting_relationships` (`public: false`,
+  `sql_table: kipptaf_marts.dim_staff_reporting_relationships`). The `staff_`
+  prefix keeps it under `queryRewrite`'s `startsWith("staff")` gate.
+- A role alias `staff_manager` (`extends: staff`, `public: false`) joined from
+  `staff_reporting_relationships` on `manager_staff_key`.
+- Each staff-keyed fact date-range-joins it, `many_to_one` (same shape as the
+  student ELL/IEP/meal status dims):
+
+  ```text
+  {staff_reporting_relationships.staff_key} = {CUBE}.<role>_staff_key
+  AND CAST({CUBE}.<record_date_key> AS TIMESTAMP)
+      BETWEEN CAST({staff_reporting_relationships.effective_start_date} AS TIMESTAMP)
+      AND     CAST({staff_reporting_relationships.effective_end_date}   AS TIMESTAMP)
+  ```
+
+- Manager name = `staff_manager.full_name`, reached purely by traversal. Detail
+  views add `staff_manager_*` PII fields to the relevant `excludes:` list.
+
+## Open questions / verify at implementation
+
+1. **Primary exclusivity.** The `(staff_key, effective_start_date)` PK assumes
+   at most one assignment is `is_primary_position = true` per staff at any
+   instant. Verify in prod before trusting the surrogate; if two assignments are
+   ever concurrently primary, the intersection fans out and the grain needs a
+   tiebreaker (or the PK must include `work_assignment_key`, changing the
+   grain).
+2. **Coverage.** Confirm populated `manager_staff_key` rates per region/era
+   (expect NULLs pre-#3869 for NJ). Treat high-NULL as a coverage gap, not a
+   broken join.
+3. **Staff with no primary assignment** (e.g. pending hires, gaps) simply have
+   no row for that period; consumers `LEFT JOIN` and see a NULL manager. Confirm
+   that's the desired behavior for gradebook/observations denominators.
+
+## Validation plan
+
+- `uv run dbt build --select dim_staff_reporting_relationships+` against
+  `kipptaf` (worktree project dir).
+- Spot-check a known staff member with a manager change and/or multiple
+  assignments: confirm one row per contiguous manager period, correct
+  `manager_staff_key` per `effective_*` window, `is_current` on the open period.
+- Confirm PK uniqueness holds in prod-shaped data (open question 1).

--- a/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
+++ b/docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md
@@ -120,6 +120,8 @@ reaches `staff_manager` on `manager_staff_key`:
 joins:
   - name: staff_reporting_relationships
     relationship: many_to_one
+    # inclusive BETWEEN — spans are end-dated to day-before-next-start, so each
+    # record date matches exactly one span (prod-validated: zero fan-out)
     sql: >
       {staff_reporting_relationships.staff_key} = {CUBE}.teacher_staff_key AND
       CAST({CUBE}.observed_date_key AS TIMESTAMP)
@@ -136,30 +138,37 @@ inclusive bounds match exactly one span (validated: zero fan-out). Manager name
 
 ### dbt: primary-exclusivity guard test
 
-A singular test (`tests/`) asserting no staff has two _distinct_ primary
-assignments with overlapping effective periods — the invariant the resolver's
-unique grain depends on:
+A singular test
+(`tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql`)
+asserting no staff has two primary assignments with overlapping effective
+periods — the invariant the resolver's unique grain depends on. Implemented with
+a `lead()` ordered-window check (mirroring the sibling
+`dim_student_*_status__no_overlapping_spans` tests), not the self-join shown in
+earlier drafts — semantically equivalent for sorted spans and more efficient:
 
 ```sql
-with primary_spans as (
-    select
-        swa.staff_key,
-        wap.work_assignment_key,
-        wap.effective_start_date,
-        wap.effective_end_date,
-    from {{ ref("dim_work_assignment_primary") }} as wap
-    inner join {{ ref("dim_staff_work_assignments") }} as swa
-        on wap.work_assignment_key = swa.work_assignment_key
-    where wap.is_primary_position and swa.staff_key is not null
-)
+with
+    primary_spans as (
+        select
+            wap.effective_start_date,
+            wap.effective_end_date,
 
-select a.staff_key
-from primary_spans as a
-inner join primary_spans as b
-    on a.staff_key = b.staff_key
-    and a.work_assignment_key < b.work_assignment_key
-    and a.effective_start_date <= b.effective_end_date
-    and a.effective_end_date >= b.effective_start_date
+            swa.staff_key,
+
+            lead(wap.effective_start_date) over (
+                partition by swa.staff_key order by wap.effective_start_date
+            ) as next_start,
+        from {{ ref("dim_work_assignment_primary") }} as wap
+        -- work_assignment_key is swa's PK: exactly one staff_key per primary
+        -- span, so this join cannot fan out the lead() ordering
+        inner join {{ ref("dim_staff_work_assignments") }} as swa
+            on wap.work_assignment_key = swa.work_assignment_key
+        where wap.is_primary_position and swa.staff_key is not null
+    )
+
+select staff_key, effective_start_date, effective_end_date, next_start,
+from primary_spans
+where next_start is not null and next_start <= effective_end_date
 ```
 
 `meta.dagster.ref` -> `dim_work_assignment_primary`. Default `warn` severity is
@@ -209,7 +218,7 @@ follow-up. Not addressed here.
 ## Validation plan (implementation)
 
 - dbt:
-  `uv run dbt build --select dim_work_assignment_primary test_staff_primary_assignment_no_overlap`
+  `uv run dbt build --select dim_work_assignment_primary dim_work_assignment_primary__no_overlapping_primary_spans`
   against `kipptaf` (worktree).
 - Cube (on the cube-model branch): compile the resolver via `/sql`, confirm
   nesting and `WHERE`-free `many_to_one` behavior, spot-check a known

--- a/src/dbt/kipptaf/tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql
+++ b/src/dbt/kipptaf/tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql
@@ -1,0 +1,21 @@
+with
+    primary_spans as (
+        select
+            wap.effective_start_date,
+            wap.effective_end_date,
+
+            swa.staff_key,
+
+            lead(wap.effective_start_date) over (
+                partition by swa.staff_key order by wap.effective_start_date
+            ) as next_start,
+        from {{ ref("dim_work_assignment_primary") }} as wap
+        inner join
+            {{ ref("dim_staff_work_assignments") }} as swa
+            on wap.work_assignment_key = swa.work_assignment_key
+        where wap.is_primary_position and swa.staff_key is not null
+    )
+
+select staff_key, effective_start_date, effective_end_date, next_start,
+from primary_spans
+where next_start is not null and next_start <= effective_end_date

--- a/src/dbt/kipptaf/tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql
+++ b/src/dbt/kipptaf/tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql
@@ -10,6 +10,8 @@ with
                 partition by swa.staff_key order by wap.effective_start_date
             ) as next_start,
         from {{ ref("dim_work_assignment_primary") }} as wap
+        -- work_assignment_key is swa's PK: exactly one staff_key per primary
+        -- span, so this join cannot fan out the lead() ordering
         inner join
             {{ ref("dim_staff_work_assignments") }} as swa
             on wap.work_assignment_key = swa.work_assignment_key

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -28,6 +28,23 @@ data_tests:
           ref:
             name: base_powerschool__course_enrollments
 
+  - name: dim_work_assignment_primary__no_overlapping_primary_spans
+    description: >-
+      Within a `staff_key` partition, the primary-position spans (joined from
+      `dim_work_assignment_primary` to `dim_staff_work_assignments`, filtered to
+      `is_primary_position`) must not overlap. A `lead(effective_start_date)`
+      value less than or equal to the current row's `effective_end_date` means a
+      staff member had two simultaneously-primary work assignments — which would
+      fan out any point-in-time lookup that resolves a single primary assignment
+      per staff at a date (e.g. the Cube `staff_reporting_relationships` manager
+      resolver). Guards the primary-exclusivity invariant that resolver's grain
+      depends on.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: dim_work_assignment_primary
+
   - name: dim_student_iep_status__no_overlapping_spans
     description: >-
       Within a `student_key` partition, consecutive IEP status spans must not


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request adds the dbt guard test that protects the invariant behind a point-in-time, role-playing **manager** in the Cube gradebook/observations/surveys views — resolved without denormalizing manager attributes onto `dim_staff`.

The manager-resolver design itself is being incorporated into the cube-model spec (#3658 / PR #3755) — the `staff_reporting_relationships` (period-intersection cube) + `staff_manager` (`extends: staff`) approach supersedes that spec's current-manager gradebook note. This PR carries only the **dbt slice** of that work.

**In this PR:**

- `tests/dim_work_assignment_primary__no_overlapping_primary_spans.sql` — a singular test asserting no staff has two simultaneously-primary work assignments (`lead()` overlap check over `dim_work_assignment_primary` joined to `dim_staff_work_assignments`, filtered to `is_primary_position`). This primary-exclusivity invariant underpins the unique grain of the Cube resolver; it holds today but had no test. **Passes against prod (0 violations).**
- `docs/superpowers/specs/2026-05-28-staff-reporting-relationships-dim-design.md` — design record + prod validation evidence for the resolver. (Disposition pending: keep as a standalone deep-dive, or fold into the #3755 spec.)

**Validated against prod (`kipptaf_marts`):** resolver grain unique (10,387 rows = 10,387 PKs, 3,231 staff); real-fact join to `fct_staff_observations` is `many_to_one` (0 fan-out across 47,585 observations); 0 NULL managers in the intersected set.

**Out of scope:** the `staff_reporting_relationships` + `staff_manager` cubes themselves — they land in the #3755 spec implementation, against the `staff` base cube.

## AI Assistance

Collaboratively authored with Claude Code: design direction, the strict-chain pushback, and the Cube-vs-dbt placement decision were human-directed; Claude validated the resolver against prod, wrote the spec and the guard test, and verified the test passes.

## Self-review

### dbt

- [x] Properties entry (description + `meta.dagster.ref` → `dim_work_assignment_primary`) included for the new singular test. No new model, so no `[model_name].yml` model properties file applies.
- [x] No exposure change — no dashboard/application consumes a new or renamed model.
- [x] Not a breaking change — no contracted-model column renames/removals.
- [x] No external source added or modified.

## CI checks

- [ ] **Trunk** — lint-clean locally (`trunk check --force` on both files).
- [ ] **dbt Cloud** — the new test runs in CI.
- [ ] **Dagster Cloud** — not triggered (no Dagster paths changed).

Refs #3658