### PR TITLE
feat(dbt): update grad plan tracking exposure URL

### DIFF
--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -770,7 +770,7 @@ exposures:
     type: analysis
     owner:
       name: Data Team - grangel
-    url: https://docs.google.com/spreadsheets/d/1QBe6NQ7aZF5Z_3_G4BMbiXsgTacmlH4QKPKcsxmtygI
+    url: https://docs.google.com/spreadsheets/d/1pp-1OBUQrRQMskC2WwG91s79LsRWkPluv5evJ8TJS2E
     depends_on:
       - ref("rpt_gsheets__grad_plan_tracking")
     config:


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will update the Google Sheets URL in the `rpt_gsheets__grad_plan_tracking` dbt exposure to point to the new spreadsheet (`1pp-1OBUQrRQMskC2WwG91s79LsRWkPluv5evJ8TJS2E`).

AI-assisted: URL update identified and applied by Claude Code; human-directed.

## AI Assistance

Claude Code applied the one-line URL change in `google-sheets.yml`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model will break downstream exposures.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`**

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.