### PR TITLE
fix(kipptaf): retry ADP Workforce Now 5xx responses in-process

### DIFF
--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -17,6 +17,10 @@ from tenacity import (
 )
 
 
+class AdpWorkforceNowError(Exception):
+    """Non-retryable ADP Workforce Now API error (deterministic 4xx response)."""
+
+
 class AdpWorkforceNowResource(ConfigurableResource):
     client_id: str
     client_secret: str
@@ -82,12 +86,16 @@ class AdpWorkforceNowResource(ConfigurableResource):
         except HTTPError as e:
             response_json = response.json()
 
-            if response.status_code == 429:
+            # 429 (rate limited) and 5xx (server-side) errors are transient;
+            # re-raise the HTTPError so tenacity retries with backoff.
+            if response.status_code == 429 or response.status_code >= 500:
                 self._log.warning(msg=response_json)
-                raise  # retryable via tenacity
+                raise
 
+            # other 4xx are deterministic client errors — surface a specific
+            # exception (never a bare Exception) and do not retry.
             self._log.error(msg=response_json)
-            raise Exception(response_json) from e
+            raise AdpWorkforceNowError(response_json) from e
 
     def post(
         self, endpoint: str, subresource: str, verb: str, payload: dict

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -1,7 +1,12 @@
 import json
+import logging
 import pathlib
+import types
 
+import pytest
 from dagster import build_resources
+from requests.exceptions import HTTPError
+from tenacity import wait_none
 
 from teamster.libraries.adp.workforce_now.api.resources import AdpWorkforceNowResource
 
@@ -111,3 +116,76 @@ def test_get_talent_associate_memberships():
     filepath.parent.mkdir(parents=True, exist_ok=True)
 
     json.dump(obj=data, fp=filepath.open(mode="w"))
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, json_body: dict) -> None:
+        self.status_code = status_code
+        self._json_body = json_body
+
+    def json(self) -> dict:
+        return self._json_body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} Server Error", response=self)  # pyright: ignore[reportArgumentType]
+
+
+def _build_offline_resource(request_fn) -> AdpWorkforceNowResource:
+    """Instantiate the resource without the network setup_for_execution path."""
+    adp_wfn = AdpWorkforceNowResource(
+        client_id="x", client_secret="x", cert_filepath="x", key_filepath="x"
+    )
+
+    object.__setattr__(adp_wfn, "_session", types.SimpleNamespace(request=request_fn))
+    object.__setattr__(adp_wfn, "_log", logging.getLogger("test_adp_wfn"))
+
+    return adp_wfn
+
+
+def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx response is transient and must be retried.
+
+    Regression: non-429 errors were re-raised as a bare ``Exception``, which the
+    tenacity ``retry_if_exception_type`` predicate did not match, so 500s failed
+    on the first attempt instead of being retried.
+    """
+    # make tenacity backoff instant for the test
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(500, {"status": 500, "error": "Internal Server Error"})
+        return _FakeResponse(200, {"ok": True})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    response = adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch):
+    """A non-429 4xx is deterministic: raise a specific error without retrying."""
+    from teamster.libraries.adp.workforce_now.api.resources import (
+        AdpWorkforceNowError,
+    )
+
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(400, {"status": 400, "error": "Bad Request"})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    with pytest.raises(AdpWorkforceNowError):
+        adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert calls["n"] == 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Make `AdpWorkforceNowResource._request` retry ADP API **5xx** responses
in-process instead of failing on the first attempt.

The previous code re-raised every non-429 error as a bare `Exception`, which the
tenacity `retry_if_exception_type((ConnectionError, Timeout, HTTPError))`
predicate did **not** match. So a transient ADP `500` escaped the resource's own
retry layer immediately and depended entirely on Dagster run-level retries to
recover (observed in a Day-2 review: 13 `kipptaf/adp/workforce_now/workers` run
failures from an ADP `500`, each burning a full run + restart before
succeeding).

Changes:

- `429` and `5xx` (transient) now re-raise the original `HTTPError`, so tenacity
  retries with backoff (`stop_after_attempt(5)`, `wait_exponential_jitter`).
- Other `4xx` (deterministic client errors) raise a new `AdpWorkforceNowError`
  — a specific exception class, never a bare `Exception` — and are not retried.
  This follows the repo retry convention in `src/teamster/CLAUDE.md`.
- Added offline unit tests for both paths (no live API access required).

## AI Assistance

Human-directed root-cause investigation (Day-2 ops review) and decision to fix.
Claude authored the fix, the unit tests, and this PR following TDD
(red → green) and the repo's tenacity retry convention.

## Self-review

### General

- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [ ] `uv run dagster definitions validate` — not run locally (secrets
      unavailable in this session); covered by the Dagster Cloud branch
      deployment check.
- [x] Verified the module imports cleanly and `AdpWorkforceNowError` resolves.
- [x] New unit tests pass: `test_request_retries_on_server_error`,
      `test_request_does_not_retry_on_client_error` (2 passed). Confirmed RED
      before the fix (500 raised after 1 attempt; missing exception class).
- [x] No downstream break: the two `except Exception` blocks in the workers
      asset still catch `AdpWorkforceNowError` (subclass of `Exception`) and
      `e.args[0]` is unchanged.

## CI checks

- [x] **Trunk** — `trunk check --force` clean locally on both changed files.
- [ ] **dbt Cloud** — n/a (no dbt changes).
- [ ] **Dagster Cloud** — expected to run (touches `src/teamster/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)