### PR TITLE
feat(dbt): add stg_kippadb__kipp_aid staging model

### DIFF
--- a/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
+++ b/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
@@ -1,0 +1,37 @@
+models:
+  - name: stg_kippadb__kipp_aid
+    columns:
+      - name: id
+        data_type: string
+        data_tests:
+          - unique:
+              config:
+                severity: error
+      - name: name
+        data_type: string
+      - name: created_by_id
+        data_type: string
+      - name: created_date
+        data_type: timestamp
+      - name: last_activity_date
+        data_type: date
+      - name: last_modified_by_id
+        data_type: string
+      - name: last_modified_date
+        data_type: timestamp
+      - name: system_modstamp
+        data_type: timestamp
+      - name: amount
+        data_type: numeric
+      - name: date
+        data_type: date
+      - name: kipp_aid_count
+        data_type: numeric
+      - name: notes
+        data_type: string
+      - name: status
+        data_type: string
+      - name: student
+        data_type: string
+      - name: type
+        data_type: string

--- a/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
+++ b/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
@@ -1,0 +1,18 @@
+select
+    id,
+    `name`,
+    createdbyid as created_by_id,
+    createddate as created_date,
+    lastactivitydate as last_activity_date,
+    lastmodifiedbyid as last_modified_by_id,
+    lastmodifieddate as last_modified_date,
+    systemmodstamp as system_modstamp,
+    amount__c as amount,
+    date__c as `date`,
+    kipp_aid_count__c as kipp_aid_count,
+    notes__c as notes,
+    status__c as status,
+    student__c as student,
+    type__c as `type`,
+from {{ source("kippadb", "kipp_aid") }}
+where not isdeleted


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

Add a staging model for the Salesforce `KIPP_Aid__c` object, bringing it in line with the other `kippadb` staging models.

- `stg_kippadb__kipp_aid.sql` — flat select against `{{ source("kippadb", "kipp_aid") }}` (already declared in `sources-bigquery.yml`), `__c` suffixes stripped and columns snake_cased, reserved/keyword-like columns backticked (`name`, `date`, `type`), `_airbyte_*` plumbing columns dropped, and the standard soft-delete filter `where not isdeleted`.
- `stg_kippadb__kipp_aid.yml` — minimal properties file matching the existing kippadb staging models (column + `data_type`), plus a `unique` test on `id` (`severity: error`).

Grain verified: `id` is unique at 3,533 rows; all rows currently have `IsDeleted = false`. The model builds clean (`dbt build`) and trunk is green.

**AI Assistance:** Claude Code authored the model and YAML, profiled the source table, and built/tested it; column naming, the soft-delete convention, and the uniqueness test were human-directed via the existing kippadb pattern.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — n/a (no downstream consumer added)
- [ ] **Breaking change?** — no, additive only
- [ ] If adding or modifying an external source, run `stage_external_sources` with `--target staging` — n/a, this is a BQ-native source (`kipptaf_kippadb.KIPP_Aid__c`), not an external/GCS source

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)