### PR TITLE
test(claude-hooks): assert exit 0 in all deny helpers + mktemp stderr (#4091)

### DIFF
--- a/tests/hooks/helpers.sh
+++ b/tests/hooks/helpers.sh
@@ -29,11 +29,13 @@ _is_deny() {
 # Usage: expect_deny_exit0 <description> <hook_script> <json_input>
 expect_deny_exit0() {
   local desc="$1" hook="$2" input="$3"
-  local stdout stderr exit_code
-  stdout=$(echo "${input}" | bash "${hook}" 2>/tmp/_hook_stderr)
+  local stdout stderr exit_code tmpfile
+  # Per-invocation temp file (mktemp) — a fixed /tmp path races under parallel runs.
+  tmpfile=$(mktemp)
+  stdout=$(printf '%s' "${input}" | bash "${hook}" 2>"${tmpfile}")
   exit_code=$?
-  stderr=$(cat /tmp/_hook_stderr)
-  rm -f /tmp/_hook_stderr
+  stderr=$(cat "${tmpfile}")
+  rm -f "${tmpfile}"
   local ok=true
   if [[ ${exit_code} -ne 0 ]]; then
     ok=false
@@ -78,15 +80,8 @@ make_input2() {
 # expect_deny_json <description> <json>
 expect_deny_json() {
   local desc="$1" input="$2"
-  local output
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [deny]: ${desc}"
-  else
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should deny]: ${desc}"
-  fi
+  # Validate the full protocol (exit 0 + deny on stdout + not on stderr).
+  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow_json() {
@@ -108,15 +103,7 @@ expect_allow_json() {
 # Usage: expect_deny_raw <description> <hook_script> <raw_input>
 expect_deny_raw() {
   local desc="$1" hook="$2" input="$3"
-  local output
-  output=$(printf '%s' "${input}" | bash "${hook}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [deny]: ${desc}"
-  else
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should deny]: ${desc}"
-  fi
+  expect_deny_exit0 "${desc}" "${hook}" "${input}"
 }
 
 # Pipe an arbitrary raw string to a named hook and assert it allows.
@@ -137,16 +124,9 @@ expect_allow_raw() {
 # Run hook with two-field input and check result
 expect_deny2() {
   local desc="$1" tool="$2" f1="$3" v1="$4" f2="$5" v2="$6"
-  local input output
+  local input
   input=$(make_input2 "${tool}" "${f1}" "${v1}" "${f2}" "${v2}")
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [deny]: ${desc}"
-  else
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should deny]: ${desc}"
-  fi
+  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow2() {
@@ -167,17 +147,9 @@ expect_allow2() {
 # expect_deny <description> <tool_name> <field> <value>
 expect_deny() {
   local desc="$1" tool="$2" field="$3" value="$4"
-  local input output
+  local input
   input=$(make_input "${tool}" "${field}" "${value}")
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [deny]: ${desc}"
-  else
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should deny]: ${desc}"
-    ERRORS+="\n       tool=${tool} ${field}=$(echo "${value}" | head -c 80)"
-  fi
+  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow() {
@@ -208,21 +180,23 @@ check_output() {
     tool="$3"
     content_val="$4"
   fi
-  local input output
+  local input
   input=$(jq -n --arg tn "${tool}" --arg c "${content_val}" \
     '{tool_name: $tn, tool_response: {content: $c, stdout: $c, stderr: ""}}')
 
-  output=$(echo "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
-
-  if [[ ${expect} == "deny" ]] && _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [deny]: ${desc}"
-  elif [[ ${expect} == "clean" ]] && ! _is_deny "${output}"; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [clean]: ${desc}"
+  if [[ ${expect} == "deny" ]]; then
+    # Full protocol: exit 0 + deny on stdout + not on stderr.
+    expect_deny_exit0 "${desc}" "${OUTPUT_HOOK}" "${input}"
   else
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [expected ${expect}]: ${desc}"
+    local output
+    output=$(printf '%s' "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
+    if _is_deny "${output}"; then
+      FAIL=$((FAIL + 1))
+      ERRORS+="\n  ${RED}FAIL${NC} [expected clean]: ${desc}"
+    else
+      PASS=$((PASS + 1))
+      echo -e "  ${GREEN}PASS${NC} [clean]: ${desc}"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this addresses the two deferred test-infrastructure findings from
the #4096 review (re-confirmed as the follow-up during #4097's review):

- **Finding 2 — deny helpers did not validate exit code.** `expect_deny`,
  `expect_deny_json`, `expect_deny_raw`, `expect_deny2`, and `check_output`'s
  deny path checked only that deny JSON appeared on stdout — not that the hook
  exited 0. Claude Code treats a non-zero exit as a non-blocking error (the deny
  is ignored and the tool runs), so a hook that printed deny JSON but exited 1
  would pass these tests while being ineffective in production. All
  deny-expecting helpers now route through `expect_deny_exit0`, which validates
  the full protocol: exit 0 + deny JSON on stdout + deny JSON NOT on stderr.
- **Finding 3 — shared `/tmp` stderr path.** `expect_deny_exit0` wrote stderr to
  a fixed `/tmp` file; two concurrent runs would race on it. Now uses a
  per-invocation `mktemp`.

No hook behavior changes — `helpers.sh` only.

Refs #4091.

## AI Assistance

Authored by Claude Code. Findings raised by the automated PR review on #4096 /
#4097; implemented and validated here.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [ ] Review the Claude Code Review comment posted on this PR.

## CI checks

- [ ] Trunk — passes.
- [ ] dbt Cloud — passes or not triggered (no dbt changes).
- [ ] Dagster Cloud — passes or not triggered (no Dagster changes).

## Test evidence

Full suite stays 7/7 green against unchanged hooks (confirming the hooks already
satisfy exit 0 on every deny). A teeth check with deliberately non-compliant
fake hooks confirms the stricter assertion now works: a compliant deny+exit0
PASSes, while deny+exit1 and deny-on-stderr-only both FAIL.