### PR TITLE
fix(claude-hooks): outbound secret-value egress scan + check-output schema fallback (#4091)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,11 +28,17 @@ regression test suite (`expect_deny_exit0`) enforces both invariants.
 
 ## What is blocked
 
-**WebFetch / MCP input scanning** — PreToolUse scans URLs and query strings for
-sensitive keywords (e.g., `/auth` in URL paths, `JWT` / `secret` / `credential`
-/ `signing key` in context7 query strings). Symptom: "Cannot access sensitive
-path" with no further detail. Rephrase the URL or query (generic terms like
-"user context", "header format") to get past it.
+**Outbound secret-value egress scan** (PreToolUse, Section 4) — write-capable
+MCP tools (tool name contains
+`create`/`update`/`write`/`add`/`comment`/`upload`/
+`send`/`post`/`put`/`delete`/`append`/`insert`/`merge`/`push`/`reply`) and
+WebFetch URLs are scanned for secret VALUES (`op://` refs, private-key headers,
+cloud tokens, connection strings — the same pattern set as `check-output.sh`). A
+match is blocked to stop exfiltration. Practical effect: a GitHub issue/PR write
+or an Asana/Drive write whose body contains a real-looking secret is denied —
+redact it (e.g. `op://…` → `op-uri`). Read-only MCP tools (bigquery / dagster /
+dbt `get_`/`list_`/`search_`) are not scanned. There is no keyword-based URL
+scanner — only secret-value shapes match.
 
 **Secret paths** (all tools blocked) — dotenv files, private key/cert files, SSH
 directory, secret-volume, credentials JSON files, devcontainer template

--- a/.claude/hooks/check-output.sh
+++ b/.claude/hooks/check-output.sh
@@ -27,8 +27,10 @@ fi
 # Scan output from tools that can return sensitive content (names normalized)
 [[ ! ${tool_name} =~ ^(bash|read|grep|notebookedit|webfetch|websearch|mcp__.*)$ ]] && exit 0
 
-# Extract all string values from tool_response (Claude Code's PostToolUse payload key)
-combined=$(jq -r '[.tool_response | .. | strings] | join(" ")' <<<"${input}")
+# Extract all string values from tool_response (Claude Code's PostToolUse payload
+# key). Fall back to the whole payload when .tool_response is absent so a
+# payload-key drift (content under a different key) can't skip scanning (#20).
+combined=$(jq -r '[(.tool_response // .) | .. | strings] | join(" ")' <<<"${input}")
 
 # Attempt to decode and re-scan long base64 strings (catches encoded secrets)
 blobs=$(echo "${combined}" | grep -oE '[A-Za-z0-9+/]{40,}={0,2}' || true)

--- a/.claude/hooks/check-sensitive.sh
+++ b/.claude/hooks/check-sensitive.sh
@@ -263,3 +263,19 @@ if [[ ${tool_name} == mcp__bigquery__* ]]; then
     ;;
   esac
 fi
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 4: Outbound egress — secret-VALUE scan
+# ═══════════════════════════════════════════════════════════════════
+# Section 1 matches sensitive PATHS; this catches secret VALUES being SENT to a
+# write-capable MCP tool (GitHub/Drive/Asana/Slack/... writes) or in a WebFetch
+# URL, which would otherwise exfiltrate unscanned. Gated by a write-verb name
+# pattern so read-only MCP tools (bigquery/dagster/dbt get_/list_/search_) are
+# untouched. Scans the raw value corpus (${path}, before quote-strip/normalize)
+# so op:// and "service_account" JSON survive. Regex mirrors check-output.sh.
+if [[ ${tool_name} == webfetch ]] ||
+  [[ ${tool_name} =~ ^mcp__.*(create|update|write|add|comment|upload|send|post|put|delete|append|insert|merge|push|reply) ]]; then
+  if echo "${path}" | grep -qiE 'op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIza[0-9A-Za-z_-]{35}|ya29\.[0-9A-Za-z_-]+|goog_[a-zA-Z0-9_-]+|eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}|ops_eyJ[A-Za-z0-9_-]{50,}|AKIA[0-9A-Z]{16}|(postgres(ql)?|mysql|mongodb(\+srv)?)://[^[:space:]]+:[^[:space:]]+@|"type"[[:space:]]*:[[:space:]]*"service_account"|gh[pusor]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}'; then
+    deny
+  fi
+fi

--- a/tests/hooks/test_egress.sh
+++ b/tests/hooks/test_egress.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Tests for outbound secret-VALUE egress scanning (#22): a write-capable MCP
+# tool (or WebFetch URL) must not carry a secret value off-box. Read-capable
+# MCP tools are NOT scanned (a reference passed to a reader is not exfiltration).
+#
+# Usage: bash tests/hooks/test_egress.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/hooks/helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+echo ""
+echo "========================================="
+echo " Egress value-scan (check-sensitive.sh)"
+echo "========================================="
+
+echo ""
+echo -e "${YELLOW}#22: write-capable MCP tools must not send secret values${NC}"
+
+# trunk-ignore-begin(shellcheck/SC2312): jq -n produces static JSON, return value irrelevant
+expect_deny_json "github issue_write body w/ 1pw reference" \
+  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"see op://vault/item/field"}}')"
+expect_deny_json "github add_issue_comment w/ priv-key header" \
+  "$(jq -n '{tool_name:"mcp__github__add_issue_comment", tool_input:{body:"-----BEGIN PRIVATE KEY-----"}}')"
+expect_deny_json "drive create_file w/ google oauth token" \
+  "$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__create_file", tool_input:{content:"ya29.a0AfH6SMBexampletokenvalue"}}')"
+expect_deny_json "asana create_tasks w/ gh token" \
+  "$(jq -n '{tool_name:"mcp__claude_ai_Asana__create_tasks", tool_input:{html_notes:"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"}}')"
+expect_deny_json "WebFetch url carrying a 1pw reference" \
+  "$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://x.example/?u=op://vault/i/f"}}')"
+
+echo ""
+echo -e "${YELLOW}#22: read-capable tools and benign writes still allowed${NC}"
+
+# read-capable MCP tool: a reference passed in is not exfiltration → allow
+expect_allow_json "dagster get_run arg w/ 1pw reference (read tool)" \
+  "$(jq -n '{tool_name:"mcp__dagster__get_run", tool_input:{runId:"op://vault/i/f"}}')"
+expect_allow_json "github issue_write benign body" \
+  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"normal description text"}}')"
+expect_allow_json "WebFetch benign url" \
+  "$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://example.com/docs/guide"}}')"
+# trunk-ignore-end(shellcheck/SC2312)
+
+print_summary "Egress value-scan"

--- a/tests/hooks/test_output_scanner.sh
+++ b/tests/hooks/test_output_scanner.sh
@@ -132,4 +132,19 @@ expect_deny_exit0 "scans .tool_response stderr (bash -x trace path)" "${OUTPUT_H
     '{tool_name: "Bash", tool_response: {stdout: "", stderr: $c}}')"
 # trunk-ignore-end(shellcheck/SC2312)
 
+# ─── Schema fallback (#6e/#20): payload under a non-tool_response key ────────
+# A scanned tool whose payload arrives under a key other than .tool_response
+# must still be scanned (otherwise a payload-key drift re-opens full passthrough).
+echo ""
+echo -e "${YELLOW}PostToolUse: payload-key drift fallback (#20)${NC}"
+
+# trunk-ignore-begin(shellcheck/SC2312)
+expect_deny_exit0 "secret under .output (not .tool_response)" "${OUTPUT_HOOK}" \
+  "$(jq -n '{tool_name:"Bash", output:{stdout:"leaked op://vault/item/field"}}')"
+expect_deny_exit0 "secret at top level (no tool_response)" "${OUTPUT_HOOK}" \
+  "$(jq -n '{tool_name:"mcp__github__issue_read", result:"op://vault/item/field"}')"
+# trunk-ignore-end(shellcheck/SC2312)
+# control: clean .tool_response output still passes (fallback no overreach)
+check_output "clean .tool_response still clean" clean "rows: 5"
+
 print_summary "Output Scanner"


### PR DESCRIPTION
## Summary & Motivation

When merged, this is the final planned hardening batch (Batch 5) for #4091:

- **#22 — outbound secret-value egress scan (new Section 4 in `check-sensitive.sh`).**
  Sections 1-3 match sensitive PATHS / read-only enforcement; this catches a
  secret VALUE being SENT to a write-capable MCP tool (GitHub / Drive / Asana /
  Slack writes — gated by a write-verb name pattern) or carried in a WebFetch
  URL. Reuses `check-output.sh`'s secret-pattern set (1Password-style references,
  private-key headers, cloud tokens, connection strings, service-account JSON,
  GitHub tokens). Read-only MCP tools (bigquery / dagster / dbt
  `get_`/`list_`/`search_`) are not scanned.
- **#6e/#20 — `check-output.sh` schema fallback.** It read only `.tool_response`,
  so a payload arriving under a different key skipped scanning entirely. Now
  falls back to the whole payload when `.tool_response` is absent.
- **#21 — doc reconciliation.** `.claude/CLAUDE.md` documented a WebFetch/MCP
  URL-keyword scanner that never existed in code. Replaced that paragraph with an
  accurate description of the Section 4 egress scan. No keyword URL scanner is
  built — only secret-value shapes match (not trivially evaded, low
  false-positive rate).

Failing-test-first; full hook suite 8/8 green (new Egress suite 8, Output Scanner
+2 for #20). shellcheck clean (only the pre-existing trunk-ignored decode loop).

Operational note: the #22 scan covers GitHub MCP writes, so a PR/issue/comment
body containing a real secret-shaped value will be denied — redact such values.

Refs #4091.

## AI Assistance

Authored by Claude Code via the systematic-debugging workflow — each gap
reproduced against the live hooks before the fix, failing test first. The
protected hook files were applied and committed by the human.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [ ] Review the Claude Code Review comment posted on this PR.

## CI checks

- [ ] Trunk — passes.
- [ ] dbt Cloud — passes or not triggered (no dbt changes).
- [ ] Dagster Cloud — passes or not triggered (no Dagster changes).

## Test evidence

New `tests/hooks/test_egress.sh`: write-MCP / WebFetch carrying a secret value →
deny; read-only MCP tool with a reference, benign write, benign URL → allow. Plus
two payload-key-drift cases in `test_output_scanner.sh`. Full suite 8/8 against
the patched hooks.