### PR TITLE
fix(claude-hooks): credential-file paths + 1Password verbs in denylists (#4091)

### DIFF
--- a/.claude/hooks/check-sensitive.sh
+++ b/.claude/hooks/check-sensitive.sh
@@ -94,8 +94,10 @@ fi
 # Section 1: All tools — path-based protection
 # ═══════════════════════════════════════════════════════════════════
 
-# 1. Sensitive file/directory patterns (case-insensitive)
-if echo "${no_content}" | grep -qiE '\.env[.a-z]*|(^|[ /])(\.ssh|\.kube|\.pem|\.key|\.cer|secrets\.json|credentials\.json|secret-volume)([ /]|$)|(^|[ /])(\.?/)?env(/|[ ]|$)|\.devcontainer/tpl/'; then
+# 1. Sensitive file/directory patterns (case-insensitive). Credential files added
+#    (#23): gcloud ADC application_default_credentials.json, git-credentials,
+#    netrc, and the 1Password CLI config dir (.config/op).
+if echo "${no_content}" | grep -qiE '\.env[.a-z]*|(^|[ /])(\.ssh|\.kube|\.pem|\.key|\.cer|secrets\.json|credentials\.json|application_default_credentials\.json|\.git-credentials|\.netrc|secret-volume)([ /]|$)|(^|[ /])(\.?/)?env(/|[ ]|$)|\.config/op([ /]|$)|\.devcontainer/tpl/'; then
   deny
 fi
 
@@ -147,8 +149,10 @@ if [[ ${tool_name} == "bash" ]]; then
     deny
   fi
 
-  # 4. 1Password CLI escalation — prevent using a leaked token to access vault
-  if echo "${sanitized}" | grep -qE '\bop\b.*\b(vault|item|read|run|document|inject)\b'; then
+  # 4. 1Password CLI escalation — prevent using a leaked token to access the vault
+  #    or mint new credentials. Verbs extended (#14): signin/account/user/
+  #    service-account/connect and plural items.
+  if echo "${sanitized}" | grep -qE '\bop\b.*\b(vault|item|items|read|run|document|inject|signin|account|user|service-account|connect)\b'; then
     deny
   fi
 
@@ -272,7 +276,8 @@ fi
 # URL, which would otherwise exfiltrate unscanned. Gated by a write-verb name
 # pattern so read-only MCP tools (bigquery/dagster/dbt get_/list_/search_) are
 # untouched. Scans the raw value corpus (${path}, before quote-strip/normalize)
-# so op:// and "service_account" JSON survive. Regex mirrors check-output.sh.
+# so op:// and "service_account" JSON survive. Regex mirrors check-output.sh —
+# update BOTH if adding a token type.
 if [[ ${tool_name} == webfetch ]] ||
   [[ ${tool_name} =~ ^mcp__.*(create|update|write|add|comment|upload|send|post|put|delete|append|insert|merge|push|reply) ]]; then
   if echo "${path}" | grep -qiE 'op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIza[0-9A-Za-z_-]{35}|ya29\.[0-9A-Za-z_-]+|goog_[a-zA-Z0-9_-]+|eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}|ops_eyJ[A-Za-z0-9_-]{50,}|AKIA[0-9A-Z]{16}|(postgres(ql)?|mysql|mongodb(\+srv)?)://[^[:space:]]+:[^[:space:]]+@|"type"[[:space:]]*:[[:space:]]*"service_account"|gh[pusor]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}'; then

--- a/tests/hooks/test_env_protection.sh
+++ b/tests/hooks/test_env_protection.sh
@@ -151,4 +151,23 @@ expect_allow 'echo $LC_ALL (real locale var)' Bash command 'echo $LC_ALL'
 expect_allow 'echo $LC_CTYPE (real locale var)' Bash command 'echo $LC_CTYPE'
 # trunk-ignore-end(shellcheck/SC2016)
 
+# ─── Pattern 4 (#14): 1Password credential-minting verbs ─────────────────────
+echo ""
+echo -e "${YELLOW}Pattern 4 (#14): 1Password CLI verbs${NC}"
+
+expect_deny "op signin" Bash command "op signin my.1password.com"
+expect_deny "op account get" Bash command "op account get"
+expect_deny "op user list" Bash command "op user list"
+expect_deny "op service-account create" Bash command "op service-account create ci"
+expect_deny "op connect token create" Bash command "op connect token create"
+expect_deny "op items (plural)" Bash command "op items list"
+# existing verbs still blocked
+expect_deny "op vault list" Bash command "op vault list"
+expect_deny "op read uri" Bash command "op read op-uri/vault/item/field"
+
+# controls — op without an escalation verb, and non-op commands
+expect_allow "op --version (no verb)" Bash command "op --version"
+expect_allow "non-op command mentioning account" Bash command "echo monthly account summary"
+expect_allow "cp (not the op word)" Bash command "cp user_data.csv /tmp/dest"
+
 print_summary "Env Protection"

--- a/tests/hooks/test_sensitive_paths.sh
+++ b/tests/hooks/test_sensitive_paths.sh
@@ -177,4 +177,19 @@ expect_deny_exit0 "PreToolUse bash printenv deny exits 0" "${HOOK}" \
   "$(make_input Bash command printenv)"
 # trunk-ignore-end(shellcheck/SC2312)
 
+# ─── #23: additional credential files ───────────────────────────────────────
+echo ""
+echo -e "${YELLOW}#23: credential files${NC}"
+
+expect_deny "gcloud ADC json" Read file_path "/home/vscode/.config/gcloud/application_default_credentials.json"
+expect_deny ".git-credentials" Read file_path "/home/vscode/.git-credentials"
+expect_deny ".netrc" Read file_path "/home/vscode/.netrc"
+expect_deny "1Password config dir" Read file_path "/home/vscode/.config/op/config"
+expect_deny "git-credentials via Bash" Bash command "cat ~/.git-credentials"
+expect_deny2 "ADC via Grep" Grep pattern "token" path "/home/vscode/.config/gcloud/application_default_credentials.json"
+
+# controls — lookalike non-credential files stay allowed
+expect_allow "normal data.json" Read file_path "/workspaces/teamster/data.json"
+expect_allow "netrc substring in a normal name" Read file_path "/workspaces/teamster/src/netrcutils.py"
+
 print_summary "Sensitive Paths"


### PR DESCRIPTION
## Summary & Motivation

When merged, this closes the two remaining Important denylist gaps from #4091:

- **#23 — credential files in Rule 1 (Section 1, all tools).** Added the gcloud
  application-default credentials file, the `git-credentials` file, the `netrc`
  file, and the 1Password CLI config dir (`.config/op`). These join the existing
  sensitive-path set (SSH dir, key/cert files, etc.), so reads/greps/MCP-path
  references to them are blocked.
- **#14 — 1Password CLI verbs in Rule 4 (Bash only).** Extended the escalation
  guard beyond `vault/item/read/run/document/inject` to also cover the
  credential-minting / account paths: `signin`, `account`, `user`,
  `service-account`, `connect`, and plural `items`. (`whoami` is intentionally
  left allowed — it is read-only identity info, and the suite asserts it.)
- **#5 — reciprocal cross-reference comment** in Section 4 so the egress regex
  and `check-output.sh`'s regex are kept in sync ("update BOTH if adding a
  token type").

Failing tests written first; the suite caught one over-reach (I had initially
added `whoami`, which an existing allow-test flagged — removed). Full hook suite
**8/8 green**, shellcheck clean.

Refs #4091.

## AI Assistance

Authored by Claude Code. Each gap was reproduced (red test) before the fix; the
protected `check-sensitive.sh` was applied and committed by the human.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [ ] Review the Claude Code Review comment posted on this PR.

## CI checks

- [ ] Trunk — passes.
- [ ] dbt Cloud — passes or not triggered (no dbt changes).
- [ ] Dagster Cloud — passes or not triggered (no Dagster changes).

## Test evidence

`test_sensitive_paths.sh` +8 (#23: deny the four credential files via Read /
Bash / Grep; allow lookalike non-credential filenames). `test_env_protection.sh`
+11 (#14: deny the new verbs incl. existing-verb controls; allow `op --version`
and non-op commands). Full suite 8/8.

## Remaining on #4091 after this

#15 (encoding-bypass variants — deferred as the most FP-prone), #3 (egress
deny tests), and minors #27/#31/#32 — one small final batch closes the issue.