### PR TITLE
fix(dbt): use KIPP student_number for Paterson pearson_local_student_identifier

### DIFF
--- a/src/dbt/kipppaterson/models/pearson/intermediate/int_pearson__njsla.sql
+++ b/src/dbt/kipppaterson/models/pearson/intermediate/int_pearson__njsla.sql
@@ -1,21 +1,4 @@
-with
-    paterson_id_map as (
-        select
-            scf.prevstudentid as paterson_district_sis_id,
-            s.student_number as kipp_student_number,
-        from {{ ref("stg_powerschool__students") }} as s
-        inner join
-            {{ ref("stg_powerschool__studentcorefields") }} as scf
-            on s.dcid = scf.studentsdcid
-        where s.enroll_status in (0, 2, 3) and scf.prevstudentid is not null
-    )
-
-select
-    raw.* replace (
-        coalesce(
-            m.kipp_student_number, raw.localstudentidentifier
-        ) as localstudentidentifier
-    ),
-from {{ ref("stg_pearson__njsla") }} as raw
-left join
-    paterson_id_map as m on raw.localstudentidentifier = m.paterson_district_sis_id
+-- Pearson reports the KIPP student_number directly as LocalStudentIdentifier
+-- for Paterson (#4103), so no district-id translation is needed. Retained as a
+-- pass-through because kipptaf sources Paterson Pearson from this intermediate.
+select *, from {{ ref("stg_pearson__njsla") }}

--- a/src/dbt/kipppaterson/models/pearson/intermediate/int_pearson__njsla_science.sql
+++ b/src/dbt/kipppaterson/models/pearson/intermediate/int_pearson__njsla_science.sql
@@ -1,21 +1,4 @@
-with
-    paterson_id_map as (
-        select
-            scf.prevstudentid as paterson_district_sis_id,
-            s.student_number as kipp_student_number,
-        from {{ ref("stg_powerschool__students") }} as s
-        inner join
-            {{ ref("stg_powerschool__studentcorefields") }} as scf
-            on s.dcid = scf.studentsdcid
-        where s.enroll_status in (0, 2, 3) and scf.prevstudentid is not null
-    )
-
-select
-    raw.* replace (
-        coalesce(
-            m.kipp_student_number, raw.localstudentidentifier
-        ) as localstudentidentifier
-    ),
-from {{ ref("stg_pearson__njsla_science") }} as raw
-left join
-    paterson_id_map as m on raw.localstudentidentifier = m.paterson_district_sis_id
+-- Pearson reports the KIPP student_number directly as LocalStudentIdentifier
+-- for Paterson (#4103), so no district-id translation is needed. Retained as a
+-- pass-through because kipptaf sources Paterson Pearson from this intermediate.
+select *, from {{ ref("stg_pearson__njsla_science") }}

--- a/src/dbt/kipppaterson/models/pearson/intermediate/properties/int_pearson__njsla.yml
+++ b/src/dbt/kipppaterson/models/pearson/intermediate/properties/int_pearson__njsla.yml
@@ -1,11 +1,10 @@
 models:
   - name: int_pearson__njsla
     description: |
-      Paterson NJSLA assessment rows with `localstudentidentifier` translated
-      from the Paterson district SIS ID to the canonical KIPP
-      `student_number` via PowerSchool's `prevstudentid` lookup. Rows whose
-      `localstudentidentifier` does not match any Paterson PS record fall
-      through unchanged.
+      Paterson NJSLA assessment rows, passed through from `stg_pearson__njsla`.
+      Pearson reports the canonical KIPP `student_number` in its
+      LocalStudentIdentifier field, so no district-level ID translation is
+      applied.
     columns:
       - name: studenttestuuid
         description: Pearson per-test-attempt UUID. Unique grain.
@@ -14,6 +13,5 @@ models:
           - not_null
       - name: localstudentidentifier
         description: |
-          KIPP `student_number` for students matched via Paterson PowerSchool
-          `prevstudentid`; falls through to the original Paterson district SIS
-          ID for unmatched rows (orphans without a PS record).
+          Pearson's reported LocalStudentIdentifier, passed through unchanged.
+          For Paterson this is the KIPP `student_number`.

--- a/src/dbt/kipppaterson/models/pearson/intermediate/properties/int_pearson__njsla_science.yml
+++ b/src/dbt/kipppaterson/models/pearson/intermediate/properties/int_pearson__njsla_science.yml
@@ -1,11 +1,10 @@
 models:
   - name: int_pearson__njsla_science
     description: |
-      Paterson NJSLA Science assessment rows with `localstudentidentifier`
-      translated from the Paterson district SIS ID to the canonical KIPP
-      `student_number` via PowerSchool's `prevstudentid` lookup. Rows whose
-      `localstudentidentifier` does not match any Paterson PS record fall
-      through unchanged.
+      Paterson NJSLA Science assessment rows, passed through from
+      `stg_pearson__njsla_science`. Pearson reports the canonical KIPP
+      `student_number` in its LocalStudentIdentifier field, so no
+      district-level ID translation is applied.
     columns:
       - name: studenttestuuid
         description: Pearson per-test-attempt UUID. Unique grain.
@@ -14,6 +13,5 @@ models:
           - not_null
       - name: localstudentidentifier
         description: |
-          KIPP `student_number` for students matched via Paterson PowerSchool
-          `prevstudentid`; falls through to the original Paterson district SIS
-          ID for unmatched rows (orphans without a PS record).
+          Pearson's reported LocalStudentIdentifier, passed through unchanged.
+          For Paterson this is the KIPP `student_number`.

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -44,6 +44,11 @@ with
 select
     ar.* except (lep_status, lunchstatus, spedlep, prevstudentid),
 
+    -- Pearson reports the KIPP student_number as LocalStudentIdentifier for all
+    -- NJ regions, including Paterson (#4103); no legacy district-id translation
+    -- is needed. prevstudentid is the pre-KIPP Paterson SIS id and never matches.
+    ar.student_number as pearson_local_student_identifier,
+
     /* regional differences */
     suf.fleid,
     suf.newark_enrollment_number,
@@ -193,12 +198,6 @@ select
         )
         + 1
     ) as salesforce_graduation_year,
-
-    if(
-        ar.region = 'Paterson' and ar.academic_year <= 2024,
-        ar.prevstudentid,
-        ar.student_number
-    ) as pearson_local_student_identifier,
 
 from with_region as ar
 left join

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
@@ -681,5 +681,6 @@ models:
       - name: pearson_local_student_identifier
         data_type: int64
         description:
-          Student previous student ID number. Conditional on academic_year,
-          prevstudentid, region, student_number.
+          The student's KIPP `student_number`, used to join NJ Pearson
+          state-assessment records, where it is reported as the
+          LocalStudentIdentifier.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restore Paterson NJSLA / NJSLA Science results to the NJ state-assessment reporting models (`rpt_tableau__state_assessments_dashboard`, `int_tableau__state_assessments_demographic_comps`), which currently show zero Paterson rows.

Root cause: Paterson Pearson reports the KIPP `student_number` as its LocalStudentIdentifier for every year, but `base_powerschool__student_enrollments` assumed it reported the legacy district SIS id (`prevstudentid`) for `academic_year <= 2024`. That forced the enrollment-side `pearson_local_student_identifier` to a value that never matches the assessment side, so the reporting models' inner join dropped all Paterson rows. The legacy id never appears in Pearson data (0 of 440 assessment rows), and the matching student_number is exclusive to Paterson (400000-400999 block, disjoint from other regions).

Changes:

- `base_powerschool__student_enrollments` — set `pearson_local_student_identifier = student_number` for all NJ regions (drop the Paterson `academic_year <= 2024` legacy-id branch). This is the only behavioral change; it touches no reporting model or mart.
- `kipppaterson` `int_pearson__njsla` / `int_pearson__njsla_science` — simplify to pass-throughs. Their `paterson_id_map` translation was vestigial (the join never matched, so the `coalesce` always returned the raw value); output is byte-identical.

Closes #4103

## AI Assistance

Diagnosis (warehouse reconciliation across staging, intermediate, marts, and reporting) and implementation were AI-assisted with Claude Code, human-directed and reviewed. PR #3780 was investigated and ruled out as the cause.

## Self-review

### dbt

- No new models — existing models modified only. No properties/contract changes (the touched models are `base_`/intermediate, not contracted).
- No exposure changes — `pearson_local_student_identifier` already existed; only its derivation changed.
- Not a breaking change — no contracted column renamed or removed.
- No external-source changes.
- Verified locally: both projects `dbt parse` clean; all three files `trunk check` clean; the data outcome confirmed against the warehouse — with this key, all 440 of 440 Paterson assessment rows now match enrollment.

### Cross-project note

dbt Cloud CI builds only the kipptaf side (`base_powerschool__student_enrollments+`). The two kipppaterson pass-throughs are not CI-covered, but are parse-clean and provably output-identical to the prior models.

## Resolved alongside this PR

8 AY2024 (2024-25) assessment rows previously carried a malformed Pearson-submitted LocalStudentIdentifier that matched no PowerSchool student_number. Ops has since added the corresponding entries to `src_google_sheets__pearson__student_crosswalk` (confirmed in the warehouse), so those rows now resolve to the correct student_number via the existing crosswalk coalesce. Combined with this PR, Paterson coverage is 440 of 440.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
