### PR TITLE
feat(dbt): add student_section_enrollment_key to fct_assessment_scores_enrollment_scoped (#4089)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-fct-assessment-scores-section-enrollment-fk.md
+++ b/docs/superpowers/plans/2026-06-03-fct-assessment-scores-section-enrollment-fk.md
@@ -10,15 +10,15 @@
 was enrolled in on the date the assessment was given.
 
 **Architecture:** Surface the enrollment-window dates the scaffold already
-computes, then resolve one section per `(student, canonical assessment, source)`
-in a `section_resolver` CTE inside the fact (window-containment tiebreak on
-`coalesce(date_taken, canonical administration date)`), and hash it identically
-to `dim_student_section_enrollments` / the enrollment bridge. Canonical-grain
-interim solution; atomic-grain alternative tracked in
-[#4107](https://github.com/TEAMSchools/teamster/issues/4107).
+computes; resolve one section per `(student, canonical assessment, source)` in a
+new, unit-tested intermediate `int_assessments__resolved_section_enrollments`
+(window-containment tiebreak on
+`coalesce(date_taken, canonical administration date)`); the fact LEFT JOINs it
+and selects the key. Canonical-grain interim solution; atomic-grain alternative
+tracked in [#4107](https://github.com/TEAMSchools/teamster/issues/4107).
 
 **Tech Stack:** dbt (BigQuery), `dbt_utils.generate_surrogate_key`,
-`dbt_utils.deduplicate`. Spec:
+`dbt_utils.deduplicate`, dbt unit tests. Spec:
 [docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md](2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md).
 
 **Working dir:** all commands assume cwd is the worktree root
@@ -28,12 +28,14 @@ interim solution; atomic-grain alternative tracked in
 
 ## File structure
 
-| File                                                                                        | Responsibility                                                   | Change                                                 |
-| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
-| `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql`             | Expected-to-take grain; source of `cc_dcid` + enrollment windows | Modify — project `cc_dateenrolled`, `cc_dateleft`      |
-| `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml`  | Scaffold column docs                                             | Modify — document the two new columns                  |
-| `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`            | Enrollment-scoped scores fact                                    | Modify — add resolver CTE + FK column                  |
-| `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml` | Fact contract + tests                                            | Modify — add column, FK constraint, relationships test |
+| File                                                                                                           | Responsibility                                                     | Change                                                 |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
+| `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql`                                | Expected-to-take grain; source of `cc_dcid` + enrollment windows   | Modify — project `cc_dateenrolled`, `cc_dateleft`      |
+| `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml`                     | Scaffold column docs                                               | Modify — document the two new columns                  |
+| `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql`            | One section enrollment per (student, canonical assessment, source) | **Create**                                             |
+| `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml` | Resolver grain test + unit tests                                   | **Create**                                             |
+| `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`                               | Enrollment-scoped scores fact                                      | Modify — LEFT JOIN resolver + select FK                |
+| `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`                    | Fact contract + tests                                              | Modify — add column, FK constraint, relationships test |
 
 ---
 
@@ -65,8 +67,8 @@ columns immediately after `ia.cc_source_project,`:
 
 - [ ] **Step 2: Emit NULLs in the K-8 replacement branch**
 
-In the `/* K-8 replacement curriculum */` branch, after
-`cast(null as string) as cc_source_project,` add:
+In the `/* K-8 replacement curriculum */` branch, replace the
+`cast(null ...) as cc_dcid` / `cc_source_project` pair with the four-line block:
 
 ```sql
     cast(null as int64) as cc_dcid,
@@ -77,15 +79,8 @@ In the `/* K-8 replacement curriculum */` branch, after
 
 - [ ] **Step 3: Emit NULLs in the all-other-assessments branch**
 
-In the `/* all other assessments */` branch, apply the identical change as Step
-2 (after `cast(null as string) as cc_source_project,`):
-
-```sql
-    cast(null as int64) as cc_dcid,
-    cast(null as string) as cc_source_project,
-    cast(null as date) as cc_dateenrolled,
-    cast(null as date) as cc_dateleft,
-```
+In the `/* all other assessments */` branch, apply the identical change as
+Step 2.
 
 - [ ] **Step 4: Document the columns in the scaffold yml**
 
@@ -117,8 +112,6 @@ contract-enforced for an intermediate; put them with the other `cc_` columns):
 
 - [ ] **Step 5: Install deps (fresh worktree) and build the scaffold in dev**
 
-Run:
-
 ```bash
 uv run dbt deps --project-dir src/dbt/kipptaf
 uv run dbt build --select int_assessments__scaffold \
@@ -126,12 +119,12 @@ uv run dbt build --select int_assessments__scaffold \
   --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
 ```
 
-Expected: build PASS; the `dbt_utils.unique_combination_of_columns` test on
+Expected: build PASS; the `unique_combination_of_columns` test on
 `(illuminate_student_id, assessment_id)` PASSES (unchanged).
 
 - [ ] **Step 6: Verify the columns populate as expected**
 
-Run (BigQuery; replace `zz_cbini_` with your dev schema prefix if different):
+Run (replace `zz_cbini_` with your dev schema prefix if different):
 
 ```sql
 select
@@ -141,8 +134,7 @@ select
 from `teamster-332318.zz_cbini_kipptaf_assessments.int_assessments__scaffold`
 ```
 
-Expected: `n_enrolled_set` equals `n_internal_resolvable` (dates populated for
-exactly the internal-resolvable rows, NULL elsewhere).
+Expected: `n_enrolled_set` equals `n_internal_resolvable`.
 
 - [ ] **Step 7: Commit**
 
@@ -154,32 +146,26 @@ git commit -m "feat(dbt): surface cc_dateenrolled/cc_dateleft on int_assessments
 
 ---
 
-## Task 2: Add the section resolver and FK to the fact
+## Task 2: Create the resolver intermediate (with a deliberately-incomplete tiebreak)
+
+Create the model with the full CTE structure but a **recency-only** dedupe order
+(`cc_dateleft desc`) — the same "latest wins" rule we rejected. Task 3's unit
+test will prove it picks the #3801 phantom, then we fix the order. The
+`is_anchor_in_window` column is computed now but not yet used in the ordering,
+so the red→green change in Task 3 is a one-line edit to the `order_by`.
 
 **Files:**
 
-- Modify:
-  `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`
+- Create:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql`
+- Create:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml`
 
-- [ ] **Step 1: Add the resolver CTEs to the `with` block**
-
-`state_union` is currently the last CTE (no trailing comma — the final `select`
-follows it directly). **First add a comma after `state_union`'s closing `)`**,
-then append these CTEs between it and the `/* internal assessments */` select.
-The new last CTE (`section_resolver`) takes no trailing comma. Note the
-`trunk-ignore` on `section_ranked` — it is referenced only via
-`dbt_utils.deduplicate`, which trips sqlfluff ST03.
+- [ ] **Step 1: Create the model SQL**
 
 ```sql
-    -- Resolves one section enrollment per (student, canonical assessment) for
-    -- internal scored assessments, mirroring the scope of
-    -- bridge_assessment_expectations_enrollment_scoped. When a student maps to
-    -- more than one section for the same canonical assessment, pick the section
-    -- active on the date the test was given (coalesce of the earliest member
-    -- date_taken and the canonical administration date). Window-containment also
-    -- drops cross-year phantom enrollments from the #3801 canonicalization
-    -- defect, since their windows do not contain the real anchor date.
-    section_candidates as (
+with
+    candidates as (
         select
             sc.powerschool_student_number,
             sc.canonical_assessment_id,
@@ -202,7 +188,7 @@ The new last CTE (`section_resolver`) takes no trailing comma. Note the
             and sc.cc_source_project is not null
     ),
 
-    section_anchored as (
+    anchored as (
         select
             *,
             coalesce(
@@ -214,43 +200,353 @@ The new last CTE (`section_resolver`) takes no trailing comma. Note the
                 ),
                 canonical_administered_date
             ) as anchor_date,
-        from section_candidates
+        from candidates
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    section_ranked as (
+    ranked as (
         select
             *,
             coalesce(
                 anchor_date between cc_dateenrolled and cc_dateleft, false
             ) as is_anchor_in_window,
-        from section_anchored
+        from anchored
     ),
 
-    section_resolver as (
+    resolved as (
         {{
             dbt_utils.deduplicate(
-                relation="section_ranked",
+                relation="ranked",
                 partition_by="powerschool_student_number, canonical_assessment_id, _dbt_source_project",
-                order_by="is_anchor_in_window desc, cc_dateleft desc",
+                order_by="cc_dateleft desc",
             )
         }}
     )
+
+select
+    powerschool_student_number,
+    canonical_assessment_id,
+    cc_dcid,
+
+    _dbt_source_project,
+    cc_source_project,
+
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }}
+    as student_section_enrollment_key,
+from resolved
 ```
 
-- [ ] **Step 2: Join the resolver and emit the FK in the internal branch**
+- [ ] **Step 2: Create the properties yml (grain test only — unit tests added in
+      Task 3)**
 
-In the `/* internal assessments */` SELECT, add the FK column immediately after
-the `student_key` column:
+```yaml
+models:
+  - name: int_assessments__resolved_section_enrollments
+    description: >-
+      Resolves one PowerSchool course-section enrollment per (student, canonical
+      assessment) for internal scored assessments, mirroring the scope of
+      bridge_assessment_expectations_enrollment_scoped. When a student maps to
+      more than one section for a canonical assessment, the section active on
+      the date the test was given (coalesce of the earliest member date_taken
+      and the canonical administration date) is selected; this also excludes
+      cross-year phantom enrollments from the #3801 canonicalization defect.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - powerschool_student_number
+              - canonical_assessment_id
+              - _dbt_source_project
+    columns:
+      - name: powerschool_student_number
+        data_type: int64
+      - name: canonical_assessment_id
+        data_type: int64
+      - name: cc_dcid
+        data_type: int64
+      - name: _dbt_source_project
+        data_type: string
+      - name: cc_source_project
+        data_type: string
+      - name: student_section_enrollment_key
+        data_type: string
+        description: >-
+          Surrogate key (cc_dcid + cc_source_project), matching
+          dim_student_section_enrollments.student_section_enrollment_key.
+```
+
+- [ ] **Step 3: Confirm it compiles**
+
+```bash
+uv run dbt compile --select int_assessments__resolved_section_enrollments \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: compiles with no Jinja/macro error. (Do not commit yet — the tiebreak
+is intentionally wrong; Task 3 fixes and commits it.)
+
+---
+
+## Task 3: Unit-test the resolver (red → green) and lock the grain
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml`
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql`
+
+- [ ] **Step 1: Add the phantom-exclusion unit test (the discriminating case)**
+
+Append to the resolver's properties yml (top-level `unit_tests:` key, sibling of
+`models:`):
+
+```yaml
+unit_tests:
+  - name: test_resolved_section_picks_in_window_over_phantom
+    description: >
+      Two candidate sections for one canonical assessment (a #3801 cross-year
+      case): the section whose enrollment window contains the anchor date is
+      picked, not the more-recent out-of-window phantom.
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows:
+          - {
+              powerschool_student_number: 1,
+              canonical_assessment_id: 100,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 111,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2017-09-01",
+              cc_dateleft: "2018-06-15",
+              date_taken: "2018-03-09",
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+          - {
+              powerschool_student_number: 1,
+              canonical_assessment_id: 100,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 222,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2018-08-23",
+              cc_dateleft: "2019-06-29",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+      - input: ref('int_assessments__assessments_canonical')
+        rows:
+          - { canonical_assessment_id: 100, administered_date: "2018-03-04" }
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 1,
+            canonical_assessment_id: 100,
+            cc_dcid: 111,
+          }
+```
+
+- [ ] **Step 2: Run the unit test — expect RED**
+
+```bash
+uv run dbt build --select int_assessments__resolved_section_enrollments \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: FAIL. The recency-only order picks `cc_dcid: 222` (later `cc_dateleft`
+= the 2019 phantom); the data diff shows `cc_dcid 222→111`.
+
+- [ ] **Step 3: Fix the tiebreak — use window-containment first**
+
+In the model SQL, change the `dbt_utils.deduplicate` `order_by` argument from:
+
+```sql
+                order_by="cc_dateleft desc",
+```
+
+to:
+
+```sql
+                order_by="is_anchor_in_window desc, cc_dateleft desc",
+```
+
+- [ ] **Step 4: Run the unit test — expect GREEN**
+
+```bash
+uv run dbt build --select int_assessments__resolved_section_enrollments \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS (picks `cc_dcid: 111`, the in-window 2018 section).
+
+- [ ] **Step 5: Add the remaining scenario unit tests**
+
+Append these three `unit_tests` entries beneath the first:
+
+```yaml
+- name: test_resolved_section_single_candidate_always_resolves
+  description: >
+    With only one candidate section, it is selected even if the anchor date
+    falls outside its enrollment window.
+  model: int_assessments__resolved_section_enrollments
+  given:
+    - input: ref('int_assessments__scaffold')
+      rows:
+        - {
+            powerschool_student_number: 2,
+            canonical_assessment_id: 200,
+            _dbt_source_project: "kippmiami",
+            cc_dcid: 333,
+            cc_source_project: "kippmiami",
+            cc_dateenrolled: "2025-09-01",
+            cc_dateleft: "2026-06-15",
+            date_taken: null,
+            is_internal_assessment: true,
+            is_replacement: false,
+          }
+    - input: ref('int_assessments__assessments_canonical')
+      rows:
+        - { canonical_assessment_id: 200, administered_date: "2099-01-01" }
+  expect:
+    rows:
+      - {
+          powerschool_student_number: 2,
+          canonical_assessment_id: 200,
+          cc_dcid: 333,
+        }
+
+- name: test_resolved_section_none_in_window_falls_back_to_latest
+  description: >
+    When no candidate window contains the anchor, the most recently ended
+    enrollment (latest cc_dateleft) is selected.
+  model: int_assessments__resolved_section_enrollments
+  given:
+    - input: ref('int_assessments__scaffold')
+      rows:
+        - {
+            powerschool_student_number: 3,
+            canonical_assessment_id: 300,
+            _dbt_source_project: "kippcamden",
+            cc_dcid: 444,
+            cc_source_project: "kippcamden",
+            cc_dateenrolled: "2020-09-01",
+            cc_dateleft: "2021-06-15",
+            date_taken: null,
+            is_internal_assessment: true,
+            is_replacement: false,
+          }
+        - {
+            powerschool_student_number: 3,
+            canonical_assessment_id: 300,
+            _dbt_source_project: "kippcamden",
+            cc_dcid: 555,
+            cc_source_project: "kippcamden",
+            cc_dateenrolled: "2021-09-01",
+            cc_dateleft: "2022-06-15",
+            date_taken: null,
+            is_internal_assessment: true,
+            is_replacement: false,
+          }
+    - input: ref('int_assessments__assessments_canonical')
+      rows:
+        - { canonical_assessment_id: 300, administered_date: "2030-01-01" }
+  expect:
+    rows:
+      - {
+          powerschool_student_number: 3,
+          canonical_assessment_id: 300,
+          cc_dcid: 555,
+        }
+
+- name: test_resolved_section_anchor_falls_back_to_admin_date
+  description: >
+    With no recorded date_taken, the anchor falls back to the canonical
+    administration date; the section whose window contains that date is selected
+    (not the more-recent out-of-window section).
+  model: int_assessments__resolved_section_enrollments
+  given:
+    - input: ref('int_assessments__scaffold')
+      rows:
+        - {
+            powerschool_student_number: 4,
+            canonical_assessment_id: 400,
+            _dbt_source_project: "kippnewark",
+            cc_dcid: 666,
+            cc_source_project: "kippnewark",
+            cc_dateenrolled: "2024-09-01",
+            cc_dateleft: "2025-06-15",
+            date_taken: null,
+            is_internal_assessment: true,
+            is_replacement: false,
+          }
+        - {
+            powerschool_student_number: 4,
+            canonical_assessment_id: 400,
+            _dbt_source_project: "kippnewark",
+            cc_dcid: 777,
+            cc_source_project: "kippnewark",
+            cc_dateenrolled: "2025-09-01",
+            cc_dateleft: "2026-06-15",
+            date_taken: null,
+            is_internal_assessment: true,
+            is_replacement: false,
+          }
+    - input: ref('int_assessments__assessments_canonical')
+      rows:
+        - { canonical_assessment_id: 400, administered_date: "2024-11-01" }
+  expect:
+    rows:
+      - {
+          powerschool_student_number: 4,
+          canonical_assessment_id: 400,
+          cc_dcid: 666,
+        }
+```
+
+- [ ] **Step 6: Run all unit tests + the grain test — expect GREEN**
+
+```bash
+uv run dbt build --select int_assessments__resolved_section_enrollments \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS — all four unit tests and the `unique_combination_of_columns`
+grain test pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql \
+        src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+git commit -m "feat(dbt): add int_assessments__resolved_section_enrollments resolver + unit tests (#4089)"
+```
+
+---
+
+## Task 4: Join the resolver into the fact and add the FK column
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`
+
+- [ ] **Step 1: Add the FK column + LEFT JOIN in the internal branch**
+
+In the `/* internal assessments */` SELECT, add the column immediately after the
+`student_key` line:
 
 ```sql
     {{ dbt_utils.generate_surrogate_key(["ia.student_number"]) }} as student_key,
 
-    if(
-        sr.cc_dcid is not null,
-        {{ dbt_utils.generate_surrogate_key(["sr.cc_dcid", "sr.cc_source_project"]) }},
-        cast(null as string)
-    ) as student_section_enrollment_key,
+    sr.student_section_enrollment_key,
 ```
 
 Then add the LEFT JOIN immediately after `from internal_assessments as ia`:
@@ -258,13 +554,13 @@ Then add the LEFT JOIN immediately after `from internal_assessments as ia`:
 ```sql
 from internal_assessments as ia
 left join
-    section_resolver as sr
+    {{ ref("int_assessments__resolved_section_enrollments") }} as sr
     on ia.student_number = sr.powerschool_student_number
     and ia.assessment_id = sr.canonical_assessment_id
     and ia._dbt_source_project = sr._dbt_source_project
 ```
 
-- [ ] **Step 3: Emit NULL for the FK in the state branch**
+- [ ] **Step 2: Emit NULL for the FK in the state branch**
 
 In the `/* state assessments */` SELECT, add immediately after the `student_key`
 `if(...) as student_key,` block (before `su.test_date as test_date_key,`):
@@ -273,31 +569,7 @@ In the `/* state assessments */` SELECT, add immediately after the `student_key`
     cast(null as string) as student_section_enrollment_key,
 ```
 
-- [ ] **Step 4: Compile to verify SQL is valid**
-
-Run:
-
-```bash
-uv run dbt compile --select fct_assessment_scores_enrollment_scoped \
-  --project-dir src/dbt/kipptaf --target dev \
-  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
-```
-
-Expected: compiles with no Jinja/`ref()`/macro error (confirms the
-`dbt_utils.deduplicate` call and the new CTEs render). Column existence is NOT
-checked at compile — BigQuery validates `sr.*` and the new scaffold columns at
-`dbt build` in Task 3, Step 3.
-
----
-
-## Task 3: Add the column to the fact contract and tests
-
-**Files:**
-
-- Modify:
-  `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`
-
-- [ ] **Step 1: Add the column entry with FK constraint and relationships test**
+- [ ] **Step 3: Add the column to the fact yml**
 
 Insert immediately after the `student_key` column block (before
 `test_date_key`):
@@ -324,9 +596,9 @@ Insert immediately after the `student_key` column block (before
           field: student_section_enrollment_key
 ```
 
-- [ ] **Step 2: Update the model description**
+- [ ] **Step 4: Update the model description**
 
-Replace the model `description` with one that names the new FK:
+Replace the model `description` with:
 
 ```yaml
 description: >-
@@ -339,22 +611,20 @@ description: >-
   (via student_section_enrollment_key).
 ```
 
-- [ ] **Step 3: Build the fact in dev and run its tests**
-
-Run:
+- [ ] **Step 5: Build the fact in dev and run its tests**
 
 ```bash
-uv run dbt build --select int_assessments__scaffold fct_assessment_scores_enrollment_scoped \
+uv run dbt build \
+  --select int_assessments__resolved_section_enrollments fct_assessment_scores_enrollment_scoped \
   --project-dir src/dbt/kipptaf --target dev \
   --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
 ```
 
-Expected: build PASS. The `assessment_score_key` `unique` + `not_null` tests
-PASS (no fan-out from the resolver join), and the new
-`student_section_enrollment_key` `relationships` test PASSES (every populated FK
-resolves to `dim_student_section_enrollments`).
+Expected: build PASS. `assessment_score_key` `unique` + `not_null` PASS (no
+fan-out), and the new `student_section_enrollment_key` `relationships` test
+PASSES (every populated FK resolves to `dim_student_section_enrollments`).
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql \
@@ -364,12 +634,13 @@ git commit -m "feat(dbt): add student_section_enrollment_key to fct_assessment_s
 
 ---
 
-## Task 4: Validate behavior and coverage
+## Task 5: Validate coverage and grain on real data
 
-All queries are aggregate / invariant — no student identifiers in output. Run
-against your dev schema (replace `zz_cbini_` if your prefix differs).
+Tiebreak correctness is now locked by the unit tests; these queries confirm
+real-data coverage and the no-fan-out invariant. Aggregate output only — no
+student identifiers. Replace `zz_cbini_` with your dev prefix.
 
-- [ ] **Step 1: Coverage — the FK populates for internal-resolvable rows only**
+- [ ] **Step 1: Coverage — FK populates for internal-resolvable rows only**
 
 ```sql
 select
@@ -378,9 +649,8 @@ select
 from `teamster-332318.zz_cbini_kipptaf_marts.fct_assessment_scores_enrollment_scoped`
 ```
 
-Expected: `n_populated > 0` and `n_populated < n_total` (state/replacement rows
-remain NULL). Treat `n_populated = 0` as a broken join — investigate before
-proceeding.
+Expected: `n_populated > 0` and `n_populated < n_total`. Treat `n_populated = 0`
+as a broken join — investigate before proceeding.
 
 - [ ] **Step 2: Grain — no fan-out from the resolver join**
 
@@ -391,71 +661,26 @@ from `teamster-332318.zz_cbini_kipptaf_marts.fct_assessment_scores_enrollment_sc
 
 Expected: `n_dupes = 0`.
 
-- [ ] **Step 3: Tiebreak correctness — picked section is window-valid when one
-      exists**
-
-Replicate the resolver over the dev scaffold and confirm that whenever a
-candidate whose window contains the anchor exists, the picked candidate is that
-one (i.e. #3801 cross-year phantoms are never picked over a real in-window
-section):
-
-```sql
-with cands as (
-  select
-    powerschool_student_number, canonical_assessment_id, _dbt_source_project,
-    cc_dateenrolled, cc_dateleft, date_taken,
-    c.administered_date as canonical_administered_date,
-  from `teamster-332318.zz_cbini_kipptaf_assessments.int_assessments__scaffold` as sc
-  inner join `teamster-332318.kipptaf_assessments.int_assessments__assessments_canonical` as c
-    using (canonical_assessment_id)
-  where sc.is_internal_assessment and not sc.is_replacement
-    and sc.cc_dcid is not null and sc.cc_source_project is not null
-),
-anchored as (
-  select *,
-    coalesce(min(date_taken) over (
-      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
-    ), canonical_administered_date) as anchor_date,
-  from cands
-),
-ranked as (
-  select *,
-    coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) as in_window,
-    row_number() over (
-      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
-      order by coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) desc,
-               cc_dateleft desc
-    ) as rn,
-    max(cast(coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) as int64)) over (
-      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
-    ) as any_in_window,
-  from anchored
-)
-select countif(rn = 1 and any_in_window = 1 and not in_window) as n_bad_picks,
-from ranked
-```
-
-Expected: `n_bad_picks = 0` (whenever an in-window section exists, it is the one
-picked).
-
-- [ ] **Step 4: Run the trunk linters on the changed files**
+- [ ] **Step 3: Run the trunk linters on the changed/created files**
 
 Run from inside the worktree:
 
 ```bash
 /workspaces/teamster/.trunk/tools/trunk check --force \
   src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql \
+  src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql \
+  src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml \
   src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql \
   src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml \
   src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
 ```
 
-Expected: no issues. If sqlfluff ST06 reports column-ordering in either SQL
-file, reorder per the message and re-run; amend the relevant commit.
+Expected: no issues. If sqlfluff ST06 reports column ordering, reorder per the
+message and amend the relevant commit.
 
 ---
 
-## Task 5: Finalize
+## Task 6: Finalize
 
 - [ ] **Step 1: Confirm clean tree and review the diff**
 
@@ -465,18 +690,18 @@ git log --oneline origin/main..HEAD
 git diff origin/main..HEAD -- src/dbt/kipptaf/models
 ```
 
-Expected: three commits (spec already committed earlier on this branch, plus the
-two feat commits), working tree clean, diff limited to the four files above.
+Expected: spec + plan doc commits plus the three feat commits; working tree
+clean; diff limited to the six files above.
 
 - [ ] **Step 2: Hand off for PR**
 
-Use the `superpowers:finishing-a-development-branch` flow. The verification gate
-is the dev `dbt build` from Task 3 (PASS) plus the Task 4 validation queries. PR
-body uses `.github/pull_request_template.md`; reference `Closes #4089`. The Cube
-follow-up (cube `sql:` SELECT, bridge join fix, section/teacher dims) is out of
-scope and gated on this column materializing — note it in the PR as a follow-up,
-carrying the diamond constraint from the spec (join `dim_students` via
-`student_key` only; do not traverse the enrollment→student edge).
+Use the `superpowers:finishing-a-development-branch` flow. Verification gate:
+the dev `dbt build` from Tasks 3 and 4 (PASS, incl. the four unit tests) plus
+the Task 5 coverage/grain queries. PR body uses
+`.github/pull_request_template.md`; reference `Closes #4089`. Note the Cube
+follow-up as out of scope and gated on this column materializing, carrying the
+diamond constraint from the spec (join `dim_students` via `student_key` only; do
+not traverse the enrollment→student edge).
 
 > **Pushing is not in this plan.** `git push origin main` is blocked, and CI
 > fires on push — coordinate the push/PR with the user per repo conventions.
@@ -487,14 +712,24 @@ carrying the diamond constraint from the spec (join `dim_students` via
 
 - **Hash must match the dim/bridge.** `student_section_enrollment_key` hashes
   `[cc_dcid, cc_source_project]` — `cc_source_project` is the course-enrollment
-  source project, NOT the region-derived `_dbt_source_project`. The enrollment
-  bridge uses the same composition, so a populated FK that fails the
-  relationships test means the hash inputs drifted — recheck Step 2 of Task 2.
+  source project, NOT the region-derived `_dbt_source_project`. A populated FK
+  that fails the relationships test means the hash inputs drifted.
 - **Why `dbt_utils.deduplicate`, not `qualify row_number() = 1`.** Repo
   convention (`src/dbt/CLAUDE.md`) forbids manual `qualify`/`distinct` dedupe;
-  `deduplicate`'s `partition_by` matches the downstream join key so the collapse
-  cannot fan out the fact.
+  `deduplicate`'s `partition_by` IS the resolver's grain and the downstream join
+  key, so the collapse cannot fan out the fact.
+- **Unit-test mechanics** (`dbt:adding-dbt-unit-test`): `dict` format, only the
+  columns used; date values quoted as `"YYYY-MM-DD"` strings; `null` for missing
+  `date_taken`. Both `ref()` inputs must be listed. The resolver's parents
+  (`int_assessments__scaffold` in dev, `int_assessments__assessments_canonical`
+  via `--defer`) must exist before unit tests run — Task 1 builds the scaffold.
 - **Worktree command caveats** (`src/dbt/CLAUDE.md`): always pass
   `--project-dir src/dbt/kipptaf`; `--state` must be the absolute main-repo path
   `/workspaces/teamster/src/dbt/kipptaf/target/prod` (the worktree has no
   `target/prod`).
+- **Resolver name** (`int_assessments__resolved_section_enrollments`) is a
+  proposal — rename consistently across the four files + the fact `ref()` if you
+  prefer another.
+- **Materialization:** the resolver inherits the default intermediate
+  materialization (view). If the fact later hits BigQuery view-nesting or
+  resource limits, set `config: materialized: table` in the resolver yml.

--- a/docs/superpowers/plans/2026-06-03-fct-assessment-scores-section-enrollment-fk.md
+++ b/docs/superpowers/plans/2026-06-03-fct-assessment-scores-section-enrollment-fk.md
@@ -1,0 +1,500 @@
+# `student_section_enrollment_key` on `fct_assessment_scores_enrollment_scoped` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a nullable `student_section_enrollment_key` FK to
+`fct_assessment_scores_enrollment_scoped`, resolved to the section the student
+was enrolled in on the date the assessment was given.
+
+**Architecture:** Surface the enrollment-window dates the scaffold already
+computes, then resolve one section per `(student, canonical assessment, source)`
+in a `section_resolver` CTE inside the fact (window-containment tiebreak on
+`coalesce(date_taken, canonical administration date)`), and hash it identically
+to `dim_student_section_enrollments` / the enrollment bridge. Canonical-grain
+interim solution; atomic-grain alternative tracked in
+[#4107](https://github.com/TEAMSchools/teamster/issues/4107).
+
+**Tech Stack:** dbt (BigQuery), `dbt_utils.generate_surrogate_key`,
+`dbt_utils.deduplicate`. Spec:
+[docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md](2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md).
+
+**Working dir:** all commands assume cwd is the worktree root
+`/workspaces/teamster/.worktrees/cbini/feat/claude-assessment-section-enrollment-fk`.
+
+---
+
+## File structure
+
+| File                                                                                        | Responsibility                                                   | Change                                                 |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
+| `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql`             | Expected-to-take grain; source of `cc_dcid` + enrollment windows | Modify — project `cc_dateenrolled`, `cc_dateleft`      |
+| `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml`  | Scaffold column docs                                             | Modify — document the two new columns                  |
+| `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`            | Enrollment-scoped scores fact                                    | Modify — add resolver CTE + FK column                  |
+| `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml` | Fact contract + tests                                            | Modify — add column, FK constraint, relationships test |
+
+---
+
+## Task 1: Surface enrollment-window dates on the scaffold
+
+The scaffold's `internal_assessments` CTE already selects `ce.cc_dateenrolled`
+and `ce.cc_dateleft` (K-8 and HS branches) and `deduplicate` preserves them —
+they are simply not projected in the final SELECT. Project them; the three
+non-enrollment UNION branches emit `cast(null as date)`.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql`
+- Modify:
+  `src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml`
+
+- [ ] **Step 1: Project the dates in the internal (deduplicate) branch**
+
+In the final SELECT's first branch (`from deduplicate as ia`), add the two
+columns immediately after `ia.cc_source_project,`:
+
+```sql
+    ia.cc_dcid,
+    ia.cc_source_project,
+    ia.cc_dateenrolled,
+    ia.cc_dateleft,
+```
+
+- [ ] **Step 2: Emit NULLs in the K-8 replacement branch**
+
+In the `/* K-8 replacement curriculum */` branch, after
+`cast(null as string) as cc_source_project,` add:
+
+```sql
+    cast(null as int64) as cc_dcid,
+    cast(null as string) as cc_source_project,
+    cast(null as date) as cc_dateenrolled,
+    cast(null as date) as cc_dateleft,
+```
+
+- [ ] **Step 3: Emit NULLs in the all-other-assessments branch**
+
+In the `/* all other assessments */` branch, apply the identical change as Step
+2 (after `cast(null as string) as cc_source_project,`):
+
+```sql
+    cast(null as int64) as cc_dcid,
+    cast(null as string) as cc_source_project,
+    cast(null as date) as cc_dateenrolled,
+    cast(null as date) as cc_dateleft,
+```
+
+- [ ] **Step 4: Document the columns in the scaffold yml**
+
+Add to the `columns:` list of `int_assessments__scaffold` (placement is not
+contract-enforced for an intermediate; put them with the other `cc_` columns):
+
+```yaml
+- name: cc_dateenrolled
+  data_type: date
+  description: >-
+    Date the student enrolled in the matched PowerSchool course section.
+    Populated only for the internal-assessment branch
+    (is_internal_assessment=true and is_replacement=false); null for K-8
+    replacement curriculum and external-assessment rows.
+  config:
+    meta:
+      source_column: int_assessments__course_enrollments.cc_dateenrolled
+- name: cc_dateleft
+  data_type: date
+  description: >-
+    Date the student left the matched PowerSchool course section. Populated only
+    for the internal-assessment branch (is_internal_assessment=true and
+    is_replacement=false); null for K-8 replacement curriculum and
+    external-assessment rows.
+  config:
+    meta:
+      source_column: int_assessments__course_enrollments.cc_dateleft
+```
+
+- [ ] **Step 5: Install deps (fresh worktree) and build the scaffold in dev**
+
+Run:
+
+```bash
+uv run dbt deps --project-dir src/dbt/kipptaf
+uv run dbt build --select int_assessments__scaffold \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: build PASS; the `dbt_utils.unique_combination_of_columns` test on
+`(illuminate_student_id, assessment_id)` PASSES (unchanged).
+
+- [ ] **Step 6: Verify the columns populate as expected**
+
+Run (BigQuery; replace `zz_cbini_` with your dev schema prefix if different):
+
+```sql
+select
+  countif(cc_dateenrolled is not null) as n_enrolled_set,
+  countif(is_internal_assessment and not is_replacement
+          and cc_dcid is not null) as n_internal_resolvable,
+from `teamster-332318.zz_cbini_kipptaf_assessments.int_assessments__scaffold`
+```
+
+Expected: `n_enrolled_set` equals `n_internal_resolvable` (dates populated for
+exactly the internal-resolvable rows, NULL elsewhere).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql \
+        src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+git commit -m "feat(dbt): surface cc_dateenrolled/cc_dateleft on int_assessments__scaffold (#4089)"
+```
+
+---
+
+## Task 2: Add the section resolver and FK to the fact
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`
+
+- [ ] **Step 1: Add the resolver CTEs to the `with` block**
+
+`state_union` is currently the last CTE (no trailing comma — the final `select`
+follows it directly). **First add a comma after `state_union`'s closing `)`**,
+then append these CTEs between it and the `/* internal assessments */` select.
+The new last CTE (`section_resolver`) takes no trailing comma. Note the
+`trunk-ignore` on `section_ranked` — it is referenced only via
+`dbt_utils.deduplicate`, which trips sqlfluff ST03.
+
+```sql
+    -- Resolves one section enrollment per (student, canonical assessment) for
+    -- internal scored assessments, mirroring the scope of
+    -- bridge_assessment_expectations_enrollment_scoped. When a student maps to
+    -- more than one section for the same canonical assessment, pick the section
+    -- active on the date the test was given (coalesce of the earliest member
+    -- date_taken and the canonical administration date). Window-containment also
+    -- drops cross-year phantom enrollments from the #3801 canonicalization
+    -- defect, since their windows do not contain the real anchor date.
+    section_candidates as (
+        select
+            sc.powerschool_student_number,
+            sc.canonical_assessment_id,
+            sc._dbt_source_project,
+            sc.cc_dcid,
+            sc.cc_source_project,
+            sc.cc_dateenrolled,
+            sc.cc_dateleft,
+            sc.date_taken,
+
+            c.administered_date as canonical_administered_date,
+        from {{ ref("int_assessments__scaffold") }} as sc
+        inner join
+            {{ ref("int_assessments__assessments_canonical") }} as c
+            on sc.canonical_assessment_id = c.canonical_assessment_id
+        where
+            sc.is_internal_assessment
+            and not sc.is_replacement
+            and sc.cc_dcid is not null
+            and sc.cc_source_project is not null
+    ),
+
+    section_anchored as (
+        select
+            *,
+            coalesce(
+                min(date_taken) over (
+                    partition by
+                        powerschool_student_number,
+                        canonical_assessment_id,
+                        _dbt_source_project
+                ),
+                canonical_administered_date
+            ) as anchor_date,
+        from section_candidates
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    section_ranked as (
+        select
+            *,
+            coalesce(
+                anchor_date between cc_dateenrolled and cc_dateleft, false
+            ) as is_anchor_in_window,
+        from section_anchored
+    ),
+
+    section_resolver as (
+        {{
+            dbt_utils.deduplicate(
+                relation="section_ranked",
+                partition_by="powerschool_student_number, canonical_assessment_id, _dbt_source_project",
+                order_by="is_anchor_in_window desc, cc_dateleft desc",
+            )
+        }}
+    )
+```
+
+- [ ] **Step 2: Join the resolver and emit the FK in the internal branch**
+
+In the `/* internal assessments */` SELECT, add the FK column immediately after
+the `student_key` column:
+
+```sql
+    {{ dbt_utils.generate_surrogate_key(["ia.student_number"]) }} as student_key,
+
+    if(
+        sr.cc_dcid is not null,
+        {{ dbt_utils.generate_surrogate_key(["sr.cc_dcid", "sr.cc_source_project"]) }},
+        cast(null as string)
+    ) as student_section_enrollment_key,
+```
+
+Then add the LEFT JOIN immediately after `from internal_assessments as ia`:
+
+```sql
+from internal_assessments as ia
+left join
+    section_resolver as sr
+    on ia.student_number = sr.powerschool_student_number
+    and ia.assessment_id = sr.canonical_assessment_id
+    and ia._dbt_source_project = sr._dbt_source_project
+```
+
+- [ ] **Step 3: Emit NULL for the FK in the state branch**
+
+In the `/* state assessments */` SELECT, add immediately after the `student_key`
+`if(...) as student_key,` block (before `su.test_date as test_date_key,`):
+
+```sql
+    cast(null as string) as student_section_enrollment_key,
+```
+
+- [ ] **Step 4: Compile to verify SQL is valid**
+
+Run:
+
+```bash
+uv run dbt compile --select fct_assessment_scores_enrollment_scoped \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: compiles with no Jinja/`ref()`/macro error (confirms the
+`dbt_utils.deduplicate` call and the new CTEs render). Column existence is NOT
+checked at compile — BigQuery validates `sr.*` and the new scaffold columns at
+`dbt build` in Task 3, Step 3.
+
+---
+
+## Task 3: Add the column to the fact contract and tests
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`
+
+- [ ] **Step 1: Add the column entry with FK constraint and relationships test**
+
+Insert immediately after the `student_key` column block (before
+`test_date_key`):
+
+```yaml
+- name: student_section_enrollment_key
+  data_type: string
+  description: >-
+    FK to dim_student_section_enrollments. The student's section enrollment for
+    the assessment's subject, resolved to the section active on the date the
+    assessment was taken (falling back to the administration date). Populated
+    only for internal assessments with a resolvable course-section enrollment;
+    null for state assessments, replacement curriculum, ES Writing, and
+    unresolved internal rows.
+  constraints:
+    - type: foreign_key
+      to: ref('dim_student_section_enrollments')
+      to_columns: [student_section_enrollment_key]
+      warn_unsupported: false
+  data_tests:
+    - relationships:
+        arguments:
+          to: ref('dim_student_section_enrollments')
+          field: student_section_enrollment_key
+```
+
+- [ ] **Step 2: Update the model description**
+
+Replace the model `description` with one that names the new FK:
+
+```yaml
+description: >-
+  Enrollment-scoped assessment score fact table. One row per student x
+  assessment x administration. Covers internal Illuminate assessments and state
+  assessments (NJSLA, NJGPA, FAST). Scores are linked to a student (via
+  student_key), an assessment administration (via
+  assessment_administration_key), and — for internal assessments with a
+  resolvable course-section enrollment — to the student's section enrollment
+  (via student_section_enrollment_key).
+```
+
+- [ ] **Step 3: Build the fact in dev and run its tests**
+
+Run:
+
+```bash
+uv run dbt build --select int_assessments__scaffold fct_assessment_scores_enrollment_scoped \
+  --project-dir src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: build PASS. The `assessment_score_key` `unique` + `not_null` tests
+PASS (no fan-out from the resolver join), and the new
+`student_section_enrollment_key` `relationships` test PASSES (every populated FK
+resolves to `dim_student_section_enrollments`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql \
+        src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+git commit -m "feat(dbt): add student_section_enrollment_key to fct_assessment_scores_enrollment_scoped (#4089)"
+```
+
+---
+
+## Task 4: Validate behavior and coverage
+
+All queries are aggregate / invariant — no student identifiers in output. Run
+against your dev schema (replace `zz_cbini_` if your prefix differs).
+
+- [ ] **Step 1: Coverage — the FK populates for internal-resolvable rows only**
+
+```sql
+select
+  count(*) as n_total,
+  countif(student_section_enrollment_key is not null) as n_populated,
+from `teamster-332318.zz_cbini_kipptaf_marts.fct_assessment_scores_enrollment_scoped`
+```
+
+Expected: `n_populated > 0` and `n_populated < n_total` (state/replacement rows
+remain NULL). Treat `n_populated = 0` as a broken join — investigate before
+proceeding.
+
+- [ ] **Step 2: Grain — no fan-out from the resolver join**
+
+```sql
+select count(*) - count(distinct assessment_score_key) as n_dupes,
+from `teamster-332318.zz_cbini_kipptaf_marts.fct_assessment_scores_enrollment_scoped`
+```
+
+Expected: `n_dupes = 0`.
+
+- [ ] **Step 3: Tiebreak correctness — picked section is window-valid when one
+      exists**
+
+Replicate the resolver over the dev scaffold and confirm that whenever a
+candidate whose window contains the anchor exists, the picked candidate is that
+one (i.e. #3801 cross-year phantoms are never picked over a real in-window
+section):
+
+```sql
+with cands as (
+  select
+    powerschool_student_number, canonical_assessment_id, _dbt_source_project,
+    cc_dateenrolled, cc_dateleft, date_taken,
+    c.administered_date as canonical_administered_date,
+  from `teamster-332318.zz_cbini_kipptaf_assessments.int_assessments__scaffold` as sc
+  inner join `teamster-332318.kipptaf_assessments.int_assessments__assessments_canonical` as c
+    using (canonical_assessment_id)
+  where sc.is_internal_assessment and not sc.is_replacement
+    and sc.cc_dcid is not null and sc.cc_source_project is not null
+),
+anchored as (
+  select *,
+    coalesce(min(date_taken) over (
+      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
+    ), canonical_administered_date) as anchor_date,
+  from cands
+),
+ranked as (
+  select *,
+    coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) as in_window,
+    row_number() over (
+      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
+      order by coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) desc,
+               cc_dateleft desc
+    ) as rn,
+    max(cast(coalesce(anchor_date between cc_dateenrolled and cc_dateleft, false) as int64)) over (
+      partition by powerschool_student_number, canonical_assessment_id, _dbt_source_project
+    ) as any_in_window,
+  from anchored
+)
+select countif(rn = 1 and any_in_window = 1 and not in_window) as n_bad_picks,
+from ranked
+```
+
+Expected: `n_bad_picks = 0` (whenever an in-window section exists, it is the one
+picked).
+
+- [ ] **Step 4: Run the trunk linters on the changed files**
+
+Run from inside the worktree:
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql \
+  src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml \
+  src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+```
+
+Expected: no issues. If sqlfluff ST06 reports column-ordering in either SQL
+file, reorder per the message and re-run; amend the relevant commit.
+
+---
+
+## Task 5: Finalize
+
+- [ ] **Step 1: Confirm clean tree and review the diff**
+
+```bash
+git status -sb
+git log --oneline origin/main..HEAD
+git diff origin/main..HEAD -- src/dbt/kipptaf/models
+```
+
+Expected: three commits (spec already committed earlier on this branch, plus the
+two feat commits), working tree clean, diff limited to the four files above.
+
+- [ ] **Step 2: Hand off for PR**
+
+Use the `superpowers:finishing-a-development-branch` flow. The verification gate
+is the dev `dbt build` from Task 3 (PASS) plus the Task 4 validation queries. PR
+body uses `.github/pull_request_template.md`; reference `Closes #4089`. The Cube
+follow-up (cube `sql:` SELECT, bridge join fix, section/teacher dims) is out of
+scope and gated on this column materializing — note it in the PR as a follow-up,
+carrying the diamond constraint from the spec (join `dim_students` via
+`student_key` only; do not traverse the enrollment→student edge).
+
+> **Pushing is not in this plan.** `git push origin main` is blocked, and CI
+> fires on push — coordinate the push/PR with the user per repo conventions.
+
+---
+
+## Notes for the implementer
+
+- **Hash must match the dim/bridge.** `student_section_enrollment_key` hashes
+  `[cc_dcid, cc_source_project]` — `cc_source_project` is the course-enrollment
+  source project, NOT the region-derived `_dbt_source_project`. The enrollment
+  bridge uses the same composition, so a populated FK that fails the
+  relationships test means the hash inputs drifted — recheck Step 2 of Task 2.
+- **Why `dbt_utils.deduplicate`, not `qualify row_number() = 1`.** Repo
+  convention (`src/dbt/CLAUDE.md`) forbids manual `qualify`/`distinct` dedupe;
+  `deduplicate`'s `partition_by` matches the downstream join key so the collapse
+  cannot fan out the fact.
+- **Worktree command caveats** (`src/dbt/CLAUDE.md`): always pass
+  `--project-dir src/dbt/kipptaf`; `--state` must be the absolute main-repo path
+  `/workspaces/teamster/src/dbt/kipptaf/target/prod` (the worktree has no
+  `target/prod`).

--- a/docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md
+++ b/docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md
@@ -1,0 +1,174 @@
+# Design: `student_section_enrollment_key` on `fct_assessment_scores_enrollment_scoped`
+
+- **Issue:** [#4089](https://github.com/TEAMSchools/teamster/issues/4089)
+- **Date:** 2026-06-03
+- **Status:** Approved — ready for implementation plan
+
+## Background
+
+`fct_assessment_scores_enrollment_scoped` exposes `student_key`,
+`assessment_administration_key`, and `test_date_key`. It has no direct link to
+`dim_student_section_enrollments`, so the fact cannot be joined to the
+section/course/teacher context, and cannot be matched per-student to
+`bridge_assessment_expectations_enrollment_scoped` for completion analysis.
+
+The two existing routes both fail:
+
+- **fact → administration → bridge → enrollment:**
+  `assessment_administration_key` is not student-specific (one administration
+  maps to ~255 section enrollments), and the bridge carries no student column,
+  so the join fans out across every student in the administration.
+- **fact → student → enrollments:** student-correct but subject-blind — a
+  student has many section enrollments and nothing selects the one matching the
+  assessment's subject.
+
+The correct section is the _intersection_ of "this student's" and "expected for
+this administration's subject" — a two-coordinate resolution no single FK
+traversal can express. That intersection is computed upstream in
+`int_assessments__scaffold` (matched on subject_area + region + enrollment-date
+window). Materializing it onto the fact is the fix.
+
+## Goal and scope
+
+Add a nullable FK `student_section_enrollment_key` →
+`dim_student_section_enrollments` to the fact.
+
+Interim canonical-grain solution. The atomic (member-grain) alternative and the
+Kimball denormalization lever are tracked in
+[#4107](https://github.com/TEAMSchools/teamster/issues/4107).
+
+### Coverage
+
+Populated **only** for internal, non-replacement rows with a resolvable section
+enrollment — the exact scope of
+`bridge_assessment_expectations_enrollment_scoped`
+(`is_internal_assessment AND NOT is_replacement AND cc_dcid IS NOT NULL AND cc_source_project IS NOT NULL`).
+NULL for:
+
+- state assessments (NJSLA, NJGPA, FAST) — no PowerSchool course enrollment
+- replacement curriculum — no enrollment by definition
+- ES Writing K-4 Newark/Camden — no course-enrollment row
+- internal rows whose section did not resolve
+
+`student_key` remains the universal student link (covers 100% of rows);
+`student_section_enrollment_key` is additive context for the resolvable subset.
+This mirrors the domain's two-bridge split — `*_enrollment_scoped` (has an
+enrollment, no `student_key`) vs `*_student_scoped` (no enrollment, carries
+`student_key`).
+
+## Resolver (CTE inside the fact)
+
+A `section_resolver` CTE in `fct_assessment_scores_enrollment_scoped.sql`:
+
+- **Source:** `int_assessments__scaffold`, filtered to the coverage scope above
+  (identical to the enrollment bridge → guarantees the picked section is one of
+  the bridge's expectation enrollments, preserving fact↔bridge conformance).
+- **Join `int_assessments__assessments_canonical`** on `canonical_assessment_id`
+  to obtain `canonical_administered_date` (same re-join the bridge uses).
+- **Anchor date:**
+  `coalesce(min(date_taken) per (student, canonical, source), canonical_administered_date)`
+  — the actual sitting date when present, else the scheduled administration
+  date.
+- **Pick rule:**
+  1. exactly one candidate `cc_dcid` → use it (anchor irrelevant);
+  2. multiple candidates → the one whose `[cc_dateenrolled, cc_dateleft]` window
+     contains the anchor;
+  3. still tied → latest `cc_dateleft`.
+- **Resolver grain:** one row per
+  `(powerschool_student_number, canonical_assessment_id, _dbt_source_project)`.
+
+The pick rule self-cleans the dominant ambiguity source: ~0.5% of
+`(student, canonical)` pairs map to multiple sections, and ~71% of those are
+cross-year [#3801](https://github.com/TEAMSchools/teamster/issues/3801) phantoms
+(a duplicated member assessment mis-tagged into another academic year). Those
+phantom enrollments' windows do not contain the real anchor date, so they are
+excluded by construction.
+
+## Wiring into the fact
+
+The **internal branch** LEFT JOINs `section_resolver` on
+`(student_number, canonical_assessment_id, _dbt_source_project)` and emits:
+
+```sql
+if(
+    cc_dcid is not null,
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }},
+    cast(null as string)
+) as student_section_enrollment_key
+```
+
+Hash composition is **identical to `dim_student_section_enrollments` and the
+bridge** — `cc_dcid` + `cc_source_project` (the course-enrollment source
+project, **not** the region-derived `_dbt_source_project`). The **state branch**
+selects `cast(null as string) as student_section_enrollment_key`.
+
+## Additive upstream edit
+
+`int_assessments__scaffold` computes `cc_dateenrolled` / `cc_dateleft` in its
+internal CTE but does not project them. Surface both in the final SELECT (the
+three non-enrollment union branches emit `cast(null as date)`). Additive-only —
+safe for the scaffold's other consumers (the two bridges, `response_rollup`,
+tests, one extract).
+
+## Grain safety and diamond analysis
+
+- **Grain:** the resolver is unique on its join key, so the LEFT JOIN cannot fan
+  the fact. The existing `assessment_score_key` unique test is the backstop;
+  validate populated/null counts in the PR-branch schema after build.
+- **Direct FKs — no diamond:** `student_key`, `assessment_administration_key`,
+  `test_date_key`, and the new `student_section_enrollment_key` point at four
+  distinct dims, none reachable from another. `dim_student_section_enrollments`
+  is genuinely new context, not an FK shortcut to an already-reachable dim. No
+  deep-dim attributes are denormalized onto the row.
+- **Latent transitive overlap (Cube constraint):**
+  `student_section_enrollment_key → dim_student_section_enrollments → student_enrollment_key → dim_student_enrollments → student_key → dim_students`
+  overlaps the direct `student_key → dim_students`. This is inherent to any
+  section/enrollment FK on a student-keyed fact (cf. `fct_grades_term`). It is
+  never exercised — the section FK exists for section/course/teacher/term
+  context; the student is already reached via `student_key`. **Constraint for
+  the Cube follow-up:** join `dim_students` via `student_key` only; declare the
+  `student_section_enrollment_key` path for section/course/teacher/term context,
+  leaving the enrollment→student edge degenerate (per `src/cube/CLAUDE.md`).
+- Pre-existing internal diamonds _under_ `dim_student_section_enrollments` (two
+  paths to `dim_locations`; date FKs to `dim_dates`) are not introduced here and
+  are likewise Cube-join concerns.
+
+## Tests and YAML
+
+- New column in `properties/fct_assessment_scores_enrollment_scoped.yml`:
+  source-agnostic `description`, `foreign_key` constraint
+  (`warn_unsupported: false`) to `dim_student_section_enrollments`, and a
+  nullable `relationships` test (no `not_null` — the FK is nullable).
+- Update the model `description` to note the new FK.
+- No #3801 warn test in scope — #3801 monitoring stays where it lives.
+
+## Hash discipline
+
+New column only; no existing surrogate-key composition changes → zero downstream
+hash churn. This is a "structural add" (new FK where none existed) per the marts
+hash-change rules.
+
+## Out of scope
+
+- **Cube follow-up** (cube `sql:` SELECT, bridge join fix, section/teacher
+  dims): gated on this column landing + materializing, and on cristinabaldor's
+  Cube branch. Carries the diamond constraint above.
+- **Atomic-grain assessment fact + metrics-layer rollup:**
+  [#4107](https://github.com/TEAMSchools/teamster/issues/4107).
+
+## Rejected alternatives
+
+- **Resolve via `int_assessments__response_rollup` (Option B):** its existing
+  `tiebroken_attrs` window orders by _earliest_ `date_taken` (a #3801 location
+  workaround slated for removal) — wrong selection rule, would pick the phantom
+  section, couples a permanent FK to a temporary workaround, and rides along to
+  ~10 unrelated consumers.
+- **Dedicated resolver intermediate model:** viable and more isolated, but the
+  CTE-in-fact keeps this interim change small; the fact PK unique test already
+  guards the grain.
+- **Drop `student_key`, reach student via the enrollment chain:** orphans every
+  row without a section enrollment (all state assessments, replacement, ES
+  Writing) from the student dimension. Non-starter.
+- **Atomic member-grain fact + metrics-layer rollup:** eliminates the tiebreak
+  but blocked — Cube cannot assign performance bands (a data-driven range lookup
+  on an aggregated value). Tracked in #4107.

--- a/docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md
+++ b/docs/superpowers/specs/2026-06-03-fct-assessment-scores-section-enrollment-fk-design.md
@@ -56,9 +56,13 @@ This mirrors the domain's two-bridge split — `*_enrollment_scoped` (has an
 enrollment, no `student_key`) vs `*_student_scoped` (no enrollment, carries
 `student_key`).
 
-## Resolver (CTE inside the fact)
+## Resolver (dedicated intermediate model)
 
-A `section_resolver` CTE in `fct_assessment_scores_enrollment_scoped.sql`:
+A new model `int_assessments__resolved_section_enrollments` resolves one section
+enrollment per `(student, canonical assessment, source)` for internal scored
+assessments. Extracting it (rather than a CTE in the fact) keeps the tiebreak
+logic in a single-purpose, independently unit-testable model with its own grain
+invariant — see _Tests_.
 
 - **Source:** `int_assessments__scaffold`, filtered to the coverage scope above
   (identical to the enrollment bridge → guarantees the picked section is one of
@@ -69,13 +73,19 @@ A `section_resolver` CTE in `fct_assessment_scores_enrollment_scoped.sql`:
   `coalesce(min(date_taken) per (student, canonical, source), canonical_administered_date)`
   — the actual sitting date when present, else the scheduled administration
   date.
-- **Pick rule:**
+- **Pick rule** (via `dbt_utils.deduplicate`, ordered
+  `is_anchor_in_window desc, cc_dateleft desc`):
   1. exactly one candidate `cc_dcid` → use it (anchor irrelevant);
   2. multiple candidates → the one whose `[cc_dateenrolled, cc_dateleft]` window
      contains the anchor;
   3. still tied → latest `cc_dateleft`.
-- **Resolver grain:** one row per
-  `(powerschool_student_number, canonical_assessment_id, _dbt_source_project)`.
+- **Grain / output:** one row per
+  `(powerschool_student_number, canonical_assessment_id, _dbt_source_project)`;
+  emits those keys plus `cc_dcid`, `cc_source_project`, and the computed
+  `student_section_enrollment_key`. Hash composition is **identical to
+  `dim_student_section_enrollments` and the enrollment bridge** — `cc_dcid` +
+  `cc_source_project` (the course-enrollment source project, **not** the
+  region-derived `_dbt_source_project`).
 
 The pick rule self-cleans the dominant ambiguity source: ~0.5% of
 `(student, canonical)` pairs map to multiple sections, and ~71% of those are
@@ -86,21 +96,13 @@ excluded by construction.
 
 ## Wiring into the fact
 
-The **internal branch** LEFT JOINs `section_resolver` on
-`(student_number, canonical_assessment_id, _dbt_source_project)` and emits:
-
-```sql
-if(
-    cc_dcid is not null,
-    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }},
-    cast(null as string)
-) as student_section_enrollment_key
-```
-
-Hash composition is **identical to `dim_student_section_enrollments` and the
-bridge** — `cc_dcid` + `cc_source_project` (the course-enrollment source
-project, **not** the region-derived `_dbt_source_project`). The **state branch**
-selects `cast(null as string) as student_section_enrollment_key`.
+The **internal branch** LEFT JOINs
+`int_assessments__resolved_section_enrollments` on
+`(student_number, canonical_assessment_id, _dbt_source_project)` and selects its
+`student_section_enrollment_key` directly — the LEFT-JOIN miss yields NULL for
+unresolved rows, so no `if(...)` wrap is needed in the fact (the hash and its
+nullability are owned by the intermediate). The **state branch** selects
+`cast(null as string) as student_section_enrollment_key`.
 
 ## Additive upstream edit
 
@@ -112,9 +114,10 @@ tests, one extract).
 
 ## Grain safety and diamond analysis
 
-- **Grain:** the resolver is unique on its join key, so the LEFT JOIN cannot fan
-  the fact. The existing `assessment_score_key` unique test is the backstop;
-  validate populated/null counts in the PR-branch schema after build.
+- **Grain:** the intermediate is unique on its join key (enforced by its own
+  `unique_combination_of_columns` test), so the LEFT JOIN cannot fan the fact.
+  The existing `assessment_score_key` unique test is the backstop; validate
+  populated/null counts in the PR-branch schema after build.
 - **Direct FKs — no diamond:** `student_key`, `assessment_administration_key`,
   `test_date_key`, and the new `student_section_enrollment_key` point at four
   distinct dims, none reachable from another. `dim_student_section_enrollments`
@@ -135,11 +138,21 @@ tests, one extract).
 
 ## Tests and YAML
 
-- New column in `properties/fct_assessment_scores_enrollment_scoped.yml`:
-  source-agnostic `description`, `foreign_key` constraint
+- **Intermediate** (`int_assessments__resolved_section_enrollments`):
+  `dbt_utils.unique_combination_of_columns` on
+  `(powerschool_student_number, canonical_assessment_id, _dbt_source_project)`
+  (the grain invariant), plus a **dbt unit test** locking the tiebreak —
+  scenarios: single candidate (resolves regardless of window), multiple
+  candidates with one in-window (the #3801 phantom-exclusion case), multiple
+  candidates none in-window (falls back to latest `cc_dateleft`), and null
+  `date_taken` (anchor falls back to the administration date). This is the
+  repo's first dbt unit test; it gates materialization and is the deterministic
+  regression guard the prod-data validation queries can't promise.
+- **Fact** (`properties/fct_assessment_scores_enrollment_scoped.yml`): new
+  column with source-agnostic `description`, `foreign_key` constraint
   (`warn_unsupported: false`) to `dim_student_section_enrollments`, and a
-  nullable `relationships` test (no `not_null` — the FK is nullable).
-- Update the model `description` to note the new FK.
+  nullable `relationships` test (no `not_null` — the FK is nullable). Update the
+  model `description` to note the new FK.
 - No #3801 warn test in scope — #3801 monitoring stays where it lives.
 
 ## Hash discipline
@@ -163,9 +176,12 @@ hash-change rules.
   workaround slated for removal) — wrong selection rule, would pick the phantom
   section, couples a permanent FK to a temporary workaround, and rides along to
   ~10 unrelated consumers.
-- **Dedicated resolver intermediate model:** viable and more isolated, but the
-  CTE-in-fact keeps this interim change small; the fact PK unique test already
-  guards the grain.
+- **Resolver as a CTE inside the fact:** keeps the change to one file, but the
+  tiebreak logic can only be unit-tested _through_ the fact (mocking ~4
+  populated inputs with consistent join keys), and the grain invariant has no
+  home of its own. Rejected in favor of the dedicated intermediate once a unit
+  test entered scope — testability and a self-contained grain test outweigh the
+  smaller footprint.
 - **Drop `student_key`, reach student via the enrollment chain:** orphans every
   row without a section enrollment (all state assessments, replacement, ES
   Writing) from the student dimension. Non-starter.

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -22,19 +22,27 @@ with
             and sc.cc_source_project is not null
     ),
 
+    -- earliest date the student actually sat any member of this canonical
+    -- assessment; null when rostered but with no recorded sitting
+    earliest_taken as (
+        select
+            *,
+            min(date_taken) over (
+                partition by
+                    powerschool_student_number,
+                    canonical_assessment_id,
+                    _dbt_source_project
+            ) as earliest_date_taken,
+        from candidates
+    ),
+
+    -- anchor = the sitting date when present, else the scheduled administration
+    -- date; the date each candidate enrollment window is tested against
     anchored as (
         select
             *,
-            coalesce(
-                min(date_taken) over (
-                    partition by
-                        powerschool_student_number,
-                        canonical_assessment_id,
-                        _dbt_source_project
-                ),
-                canonical_administered_date
-            ) as anchor_date,
-        from candidates
+            coalesce(earliest_date_taken, canonical_administered_date) as anchor_date,
+        from earliest_taken
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -1,0 +1,70 @@
+with
+    candidates as (
+        select
+            sc.powerschool_student_number,
+            sc.canonical_assessment_id,
+            sc._dbt_source_project,
+            sc.cc_dcid,
+            sc.cc_source_project,
+            sc.cc_dateenrolled,
+            sc.cc_dateleft,
+            sc.date_taken,
+
+            c.administered_date as canonical_administered_date,
+        from {{ ref("int_assessments__scaffold") }} as sc
+        inner join
+            {{ ref("int_assessments__assessments_canonical") }} as c
+            on sc.canonical_assessment_id = c.canonical_assessment_id
+        where
+            sc.is_internal_assessment
+            and not sc.is_replacement
+            and sc.cc_dcid is not null
+            and sc.cc_source_project is not null
+    ),
+
+    anchored as (
+        select
+            *,
+            coalesce(
+                min(date_taken) over (
+                    partition by
+                        powerschool_student_number,
+                        canonical_assessment_id,
+                        _dbt_source_project
+                ),
+                canonical_administered_date
+            ) as anchor_date,
+        from candidates
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    ranked as (
+        select
+            *,
+            coalesce(
+                anchor_date between cc_dateenrolled and cc_dateleft, false
+            ) as is_anchor_in_window,
+        from anchored
+    ),
+
+    resolved as (
+        {{
+            dbt_utils.deduplicate(
+                relation="ranked",
+                partition_by="powerschool_student_number, canonical_assessment_id, _dbt_source_project",
+                order_by="is_anchor_in_window desc, cc_dateleft desc",
+            )
+        }}
+    )
+
+select
+    powerschool_student_number,
+    canonical_assessment_id,
+    cc_dcid,
+
+    _dbt_source_project,
+    cc_source_project,
+
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }}
+    as student_section_enrollment_key,
+from resolved

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__scaffold.sql
@@ -157,6 +157,8 @@ select
     ia.discipline,
     ia.cc_dcid,
     ia.cc_source_project,
+    ia.cc_dateenrolled,
+    ia.cc_dateleft,
 
     concat('kipp', lower(ia.region)) as _dbt_source_project,
     ia.canonical_assessment_id,
@@ -201,6 +203,8 @@ select
 
     cast(null as int64) as cc_dcid,
     cast(null as string) as cc_source_project,
+    cast(null as date) as cc_dateenrolled,
+    cast(null as date) as cc_dateleft,
 
     concat('kipp', lower(str.region)) as _dbt_source_project,
 
@@ -259,6 +263,8 @@ select
 
     cast(null as int64) as cc_dcid,
     cast(null as string) as cc_source_project,
+    cast(null as date) as cc_dateenrolled,
+    cast(null as date) as cc_dateleft,
 
     concat('kipp', lower(str.region)) as _dbt_source_project,
 

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -18,14 +18,43 @@ models:
     columns:
       - name: powerschool_student_number
         data_type: int64
+        description: >-
+          Student number for the scored student. Pass-through from
+          int_assessments__scaffold.
+        config:
+          meta:
+            source_column: int_assessments__scaffold.powerschool_student_number
       - name: canonical_assessment_id
         data_type: int64
+        description: >-
+          Canonical assessment identifier (groups member assessments into one
+          logical assessment). Pass-through from int_assessments__scaffold.
+        config:
+          meta:
+            source_column: int_assessments__scaffold.canonical_assessment_id
       - name: cc_dcid
         data_type: int64
+        description: >-
+          PowerSchool course-enrollment record id for the resolved section.
+        config:
+          meta:
+            source_column: int_assessments__scaffold.cc_dcid
       - name: _dbt_source_project
         data_type: string
+        description: >-
+          Region-derived dbt source project (kipp{region}) of the assessment;
+          the join key the fact uses to attach this section enrollment.
+        config:
+          meta:
+            source_column: int_assessments__scaffold._dbt_source_project
       - name: cc_source_project
         data_type: string
+        description: >-
+          dbt source project of the matched course enrollment; hashed with
+          cc_dcid into student_section_enrollment_key.
+        config:
+          meta:
+            source_column: int_assessments__scaffold.cc_source_project
       - name: student_section_enrollment_key
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -1,0 +1,196 @@
+models:
+  - name: int_assessments__resolved_section_enrollments
+    description: >-
+      Resolves one PowerSchool course-section enrollment per (student, canonical
+      assessment) for internal scored assessments, mirroring the scope of
+      bridge_assessment_expectations_enrollment_scoped. When a student maps to
+      more than one section for a canonical assessment, the section active on
+      the date the test was given (coalesce of the earliest member date_taken
+      and the canonical administration date) is selected; this also excludes
+      cross-year phantom enrollments from the #3801 canonicalization defect.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - powerschool_student_number
+              - canonical_assessment_id
+              - _dbt_source_project
+    columns:
+      - name: powerschool_student_number
+        data_type: int64
+      - name: canonical_assessment_id
+        data_type: int64
+      - name: cc_dcid
+        data_type: int64
+      - name: _dbt_source_project
+        data_type: string
+      - name: cc_source_project
+        data_type: string
+      - name: student_section_enrollment_key
+        data_type: string
+        description: >-
+          Surrogate key (cc_dcid + cc_source_project), matching
+          dim_student_section_enrollments.student_section_enrollment_key.
+
+unit_tests:
+  - name: test_resolved_section_picks_in_window_over_phantom
+    description: >
+      Two candidate sections for one canonical assessment (a #3801 cross-year
+      case): the section whose enrollment window contains the anchor date is
+      picked, not the more-recent out-of-window phantom.
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows:
+          - {
+              powerschool_student_number: 1,
+              canonical_assessment_id: 100,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 111,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2017-09-01",
+              cc_dateleft: "2018-06-15",
+              date_taken: "2018-03-09",
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+          - {
+              powerschool_student_number: 1,
+              canonical_assessment_id: 100,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 222,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2018-08-23",
+              cc_dateleft: "2019-06-29",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+      - input: ref('int_assessments__assessments_canonical')
+        rows:
+          - { canonical_assessment_id: 100, administered_date: "2018-03-04" }
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 1,
+            canonical_assessment_id: 100,
+            cc_dcid: 111,
+          }
+
+  - name: test_resolved_section_single_candidate_always_resolves
+    description: >
+      With only one candidate section, it is selected even if the anchor date
+      falls outside its enrollment window.
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows:
+          - {
+              powerschool_student_number: 2,
+              canonical_assessment_id: 200,
+              _dbt_source_project: "kippmiami",
+              cc_dcid: 333,
+              cc_source_project: "kippmiami",
+              cc_dateenrolled: "2025-09-01",
+              cc_dateleft: "2026-06-15",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+      - input: ref('int_assessments__assessments_canonical')
+        rows:
+          - { canonical_assessment_id: 200, administered_date: "2099-01-01" }
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 2,
+            canonical_assessment_id: 200,
+            cc_dcid: 333,
+          }
+
+  - name: test_resolved_section_none_in_window_falls_back_to_latest
+    description: >
+      When no candidate window contains the anchor, the most recently ended
+      enrollment (latest cc_dateleft) is selected.
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows:
+          - {
+              powerschool_student_number: 3,
+              canonical_assessment_id: 300,
+              _dbt_source_project: "kippcamden",
+              cc_dcid: 444,
+              cc_source_project: "kippcamden",
+              cc_dateenrolled: "2020-09-01",
+              cc_dateleft: "2021-06-15",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+          - {
+              powerschool_student_number: 3,
+              canonical_assessment_id: 300,
+              _dbt_source_project: "kippcamden",
+              cc_dcid: 555,
+              cc_source_project: "kippcamden",
+              cc_dateenrolled: "2021-09-01",
+              cc_dateleft: "2022-06-15",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+      - input: ref('int_assessments__assessments_canonical')
+        rows:
+          - { canonical_assessment_id: 300, administered_date: "2030-01-01" }
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 3,
+            canonical_assessment_id: 300,
+            cc_dcid: 555,
+          }
+
+  - name: test_resolved_section_anchor_falls_back_to_admin_date
+    description: >
+      With no recorded date_taken, the anchor falls back to the canonical
+      administration date; the section whose window contains that date is
+      selected (not the more-recent out-of-window section).
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows:
+          - {
+              powerschool_student_number: 4,
+              canonical_assessment_id: 400,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 666,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2024-09-01",
+              cc_dateleft: "2025-06-15",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+          - {
+              powerschool_student_number: 4,
+              canonical_assessment_id: 400,
+              _dbt_source_project: "kippnewark",
+              cc_dcid: 777,
+              cc_source_project: "kippnewark",
+              cc_dateenrolled: "2025-09-01",
+              cc_dateleft: "2026-06-15",
+              date_taken: null,
+              is_internal_assessment: true,
+              is_replacement: false,
+            }
+      - input: ref('int_assessments__assessments_canonical')
+        rows:
+          - { canonical_assessment_id: 400, administered_date: "2024-11-01" }
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 4,
+            canonical_assessment_id: 400,
+            cc_dcid: 666,
+          }

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -45,30 +45,30 @@ unit_tests:
           - {
               powerschool_student_number: 1,
               canonical_assessment_id: 100,
-              _dbt_source_project: "kippnewark",
+              _dbt_source_project: kippnewark,
               cc_dcid: 111,
-              cc_source_project: "kippnewark",
-              cc_dateenrolled: "2017-09-01",
-              cc_dateleft: "2018-06-15",
-              date_taken: "2018-03-09",
+              cc_source_project: kippnewark,
+              cc_dateenrolled: 2017-09-01,
+              cc_dateleft: 2018-06-15,
+              date_taken: 2018-03-09,
               is_internal_assessment: true,
               is_replacement: false,
             }
           - {
               powerschool_student_number: 1,
               canonical_assessment_id: 100,
-              _dbt_source_project: "kippnewark",
+              _dbt_source_project: kippnewark,
               cc_dcid: 222,
-              cc_source_project: "kippnewark",
-              cc_dateenrolled: "2018-08-23",
-              cc_dateleft: "2019-06-29",
+              cc_source_project: kippnewark,
+              cc_dateenrolled: 2018-08-23,
+              cc_dateleft: 2019-06-29,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
             }
       - input: ref('int_assessments__assessments_canonical')
         rows:
-          - { canonical_assessment_id: 100, administered_date: "2018-03-04" }
+          - { canonical_assessment_id: 100, administered_date: 2018-03-04 }
     expect:
       rows:
         - {
@@ -88,18 +88,18 @@ unit_tests:
           - {
               powerschool_student_number: 2,
               canonical_assessment_id: 200,
-              _dbt_source_project: "kippmiami",
+              _dbt_source_project: kippmiami,
               cc_dcid: 333,
-              cc_source_project: "kippmiami",
-              cc_dateenrolled: "2025-09-01",
-              cc_dateleft: "2026-06-15",
+              cc_source_project: kippmiami,
+              cc_dateenrolled: 2025-09-01,
+              cc_dateleft: 2026-06-15,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
             }
       - input: ref('int_assessments__assessments_canonical')
         rows:
-          - { canonical_assessment_id: 200, administered_date: "2099-01-01" }
+          - { canonical_assessment_id: 200, administered_date: 2099-01-01 }
     expect:
       rows:
         - {
@@ -119,11 +119,11 @@ unit_tests:
           - {
               powerschool_student_number: 3,
               canonical_assessment_id: 300,
-              _dbt_source_project: "kippcamden",
+              _dbt_source_project: kippcamden,
               cc_dcid: 444,
-              cc_source_project: "kippcamden",
-              cc_dateenrolled: "2020-09-01",
-              cc_dateleft: "2021-06-15",
+              cc_source_project: kippcamden,
+              cc_dateenrolled: 2020-09-01,
+              cc_dateleft: 2021-06-15,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
@@ -131,18 +131,18 @@ unit_tests:
           - {
               powerschool_student_number: 3,
               canonical_assessment_id: 300,
-              _dbt_source_project: "kippcamden",
+              _dbt_source_project: kippcamden,
               cc_dcid: 555,
-              cc_source_project: "kippcamden",
-              cc_dateenrolled: "2021-09-01",
-              cc_dateleft: "2022-06-15",
+              cc_source_project: kippcamden,
+              cc_dateenrolled: 2021-09-01,
+              cc_dateleft: 2022-06-15,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
             }
       - input: ref('int_assessments__assessments_canonical')
         rows:
-          - { canonical_assessment_id: 300, administered_date: "2030-01-01" }
+          - { canonical_assessment_id: 300, administered_date: 2030-01-01 }
     expect:
       rows:
         - {
@@ -163,11 +163,11 @@ unit_tests:
           - {
               powerschool_student_number: 4,
               canonical_assessment_id: 400,
-              _dbt_source_project: "kippnewark",
+              _dbt_source_project: kippnewark,
               cc_dcid: 666,
-              cc_source_project: "kippnewark",
-              cc_dateenrolled: "2024-09-01",
-              cc_dateleft: "2025-06-15",
+              cc_source_project: kippnewark,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
@@ -175,18 +175,18 @@ unit_tests:
           - {
               powerschool_student_number: 4,
               canonical_assessment_id: 400,
-              _dbt_source_project: "kippnewark",
+              _dbt_source_project: kippnewark,
               cc_dcid: 777,
-              cc_source_project: "kippnewark",
-              cc_dateenrolled: "2025-09-01",
-              cc_dateleft: "2026-06-15",
+              cc_source_project: kippnewark,
+              cc_dateenrolled: 2025-09-01,
+              cc_dateleft: 2026-06-15,
               date_taken: null,
               is_internal_assessment: true,
               is_replacement: false,
             }
       - input: ref('int_assessments__assessments_canonical')
         rows:
-          - { canonical_assessment_id: 400, administered_date: "2024-11-01" }
+          - { canonical_assessment_id: 400, administered_date: 2024-11-01 }
     expect:
       rows:
         - {

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -83,6 +83,26 @@ models:
         config:
           meta:
             source_column: int_assessments__course_enrollments._dbt_source_project
+      - name: cc_dateenrolled
+        data_type: date
+        description: >-
+          Date the student enrolled in the matched PowerSchool course section.
+          Populated only for the internal-assessment branch
+          (is_internal_assessment=true and is_replacement=false); null for K-8
+          replacement curriculum and external-assessment rows.
+        config:
+          meta:
+            source_column: int_assessments__course_enrollments.cc_dateenrolled
+      - name: cc_dateleft
+        data_type: date
+        description: >-
+          Date the student left the matched PowerSchool course section.
+          Populated only for the internal-assessment branch
+          (is_internal_assessment=true and is_replacement=false); null for K-8
+          replacement curriculum and external-assessment rows.
+        config:
+          meta:
+            source_column: int_assessments__course_enrollments.cc_dateleft
       - name: _dbt_source_project
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -200,6 +200,9 @@ select
     ia.proficiency_level,
     ia.is_mastery,
 from internal_assessments as ia
+-- ia.assessment_id is canonical-grain: int_assessments__response_rollup aliases
+-- canonical_assessment_id as assessment_id, so it matches the resolver's
+-- canonical_assessment_id join key.
 left join
     {{ ref("int_assessments__resolved_section_enrollments") }} as sr
     on ia.student_number = sr.powerschool_student_number

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -191,6 +191,8 @@ select
 
     {{ dbt_utils.generate_surrogate_key(["ia.student_number"]) }} as student_key,
 
+    sr.student_section_enrollment_key,
+
     ia.test_date as test_date_key,
 
     ia.scale_score,
@@ -198,6 +200,11 @@ select
     ia.proficiency_level,
     ia.is_mastery,
 from internal_assessments as ia
+left join
+    {{ ref("int_assessments__resolved_section_enrollments") }} as sr
+    on ia.student_number = sr.powerschool_student_number
+    and ia.assessment_id = sr.canonical_assessment_id
+    and ia._dbt_source_project = sr._dbt_source_project
 
 union all
 
@@ -235,6 +242,8 @@ select
         {{ dbt_utils.generate_surrogate_key(["su.student_number"]) }},
         cast(null as string)
     ) as student_key,
+
+    cast(null as string) as student_section_enrollment_key,
 
     su.test_date as test_date_key,
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -4,8 +4,10 @@ models:
       Enrollment-scoped assessment score fact table. One row per student x
       assessment x administration. Covers internal Illuminate assessments and
       state assessments (NJSLA, NJGPA, FAST). Scores are linked to a student
-      (via student_key) and an assessment administration (via
-      assessment_administration_key).
+      (via student_key), an assessment administration (via
+      assessment_administration_key), and — for internal assessments with a
+      resolvable course-section enrollment — to the student's section enrollment
+      (via student_section_enrollment_key).
     columns:
       - name: assessment_score_key
         data_type: string
@@ -55,6 +57,25 @@ models:
               arguments:
                 to: ref('dim_students')
                 field: student_key
+      - name: student_section_enrollment_key
+        data_type: string
+        description: >-
+          FK to dim_student_section_enrollments. The student's section
+          enrollment for the assessment's subject, resolved to the section
+          active on the date the assessment was taken (falling back to the
+          administration date). Populated only for internal assessments with a
+          resolvable course-section enrollment; null for state assessments,
+          replacement curriculum, ES Writing, and unresolved internal rows.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_student_section_enrollments')
+            to_columns: [student_section_enrollment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_student_section_enrollments')
+                field: student_section_enrollment_key
       - name: test_date_key
         data_type: date
         description: >-


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will add a nullable `student_section_enrollment_key` FK to `fct_assessment_scores_enrollment_scoped`, linking each internal assessment score to the student's course-section enrollment for that subject — unlocking section/course/teacher context and per-student completion joins to `bridge_assessment_expectations_enrollment_scoped`.

Closes #4089.

The fact only exposed `student_key` + `assessment_administration_key`, and those two keys can't be joined to the enrollment bridge without fanning out (~255 enrollments per administration). This adds the section FK directly to the fact.

Changes:

- **`int_assessments__scaffold`** — additively projects `cc_dateenrolled` / `cc_dateleft` (already computed upstream, just not surfaced).
- **`int_assessments__resolved_section_enrollments`** (new intermediate) — resolves one section per `(student, canonical assessment, source)`. When a student maps to multiple sections, it picks the one whose enrollment window contains `coalesce(date_taken, canonical administration date)`, falling back to the latest enrollment. This window-containment rule also excludes the cross-year phantom enrollments produced by #3801 (≈71% of the multi-section cases). Hashed `[cc_dcid, cc_source_project]` to match the dim and bridge exactly. Ships with a grain uniqueness test and 4 dbt unit tests (the repo's first) locking the tiebreak.
- **`fct_assessment_scores_enrollment_scoped`** — LEFT JOINs the resolver and exposes the FK; NULL for state assessments, replacement curriculum, ES Writing, and unresolved internal rows.

Validated in dev: 13.54M of 14.15M rows populated, 0 PK duplicates (no fan-out), relationships test green.

**Out of scope / follow-ups:**

- Cube wiring (cube `sql:` SELECT, bridge join fix, section/teacher dims) is gated on this column materializing. **Cube constraint:** join `dim_students` via `student_key` only — do not traverse the enrollment to student edge (avoids a `dim_students` diamond).
- Atomic-grain assessment fact alternative: tracked in #4107.

## AI Assistance

This PR was authored by Claude Code under close human direction. The engineer drove every design decision — coverage scope, the date-anchor tiebreak, the dedicated-intermediate vs CTE structure, and the dbt-unit-test approach — through iterative review; Claude did the investigation, drafting, and implementation. Design spec and plan are in `docs/superpowers/`.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — the resolver ships with its properties yml (grain test, column docs, unit tests).
- [x] Exposures — additive column only; no rename/removal, so existing Cube exposure is unaffected. Cube field wiring is a tracked follow-up.
- [x] **Breaking change?** No — purely additive new column on the fact; no existing column renamed or removed, zero surrogate-key hash churn. No rollback coordination needed.
- [x] External sources — none added or modified.

## CI checks

- [ ] **Trunk** — passes. (Ran `trunk check --force` locally on all six files: no issues.)
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not triggered (no Dagster path changes).