### PR TITLE
feat(dbt): add Maher fund tag-parsing columns to stg_kippadb__kipp_aid

### DIFF
--- a/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
+++ b/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
@@ -57,3 +57,5 @@ models:
         description:
           The note with the MAHER_FUND tag and its surrounding whitespace
           removed; equals the original note when untagged.
+      - name: academic_year
+        data_type: int64

--- a/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
+++ b/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
@@ -35,3 +35,25 @@ models:
         data_type: string
       - name: type
         data_type: string
+      - name: is_maher
+        data_type: boolean
+        description:
+          True when the note carries the appended MAHER_FUND marker tag
+          identifying the record as a Maher Fund award; false otherwise,
+          including when the note is null or empty.
+      - name: fund_type
+        data_type: string
+        description:
+          Funding classification parsed from the MAHER_FUND tag's type field
+          (Emergency, Enrichment, or Unclassified); null when the note is
+          untagged.
+      - name: doc_type
+        data_type: string
+        description:
+          Source purchase-order or expense-report reference parsed from the
+          MAHER_FUND tag's doc field; null when the note is untagged.
+      - name: notes_clean
+        data_type: string
+        description:
+          The note with the MAHER_FUND tag and its surrounding whitespace
+          removed; equals the original note when untagged.

--- a/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
+++ b/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__kipp_aid.yml
@@ -7,6 +7,28 @@ models:
           - unique:
               config:
                 severity: error
+      - name: is_maher
+        data_type: boolean
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+        description:
+          True when the note carries the appended MAHER_FUND marker tag
+          identifying the record as a Maher Fund award; false otherwise,
+          including when the note is null or empty.
+      - name: fund_type
+        data_type: string
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [Emergency, Enrichment, Unclassified]
+              config:
+                severity: warn
+        description:
+          Funding classification parsed from the MAHER_FUND tag's type field
+          (Emergency, Enrichment, or Unclassified); null when the note is
+          untagged.
       - name: name
         data_type: string
       - name: created_by_id
@@ -35,18 +57,6 @@ models:
         data_type: string
       - name: type
         data_type: string
-      - name: is_maher
-        data_type: boolean
-        description:
-          True when the note carries the appended MAHER_FUND marker tag
-          identifying the record as a Maher Fund award; false otherwise,
-          including when the note is null or empty.
-      - name: fund_type
-        data_type: string
-        description:
-          Funding classification parsed from the MAHER_FUND tag's type field
-          (Emergency, Enrichment, or Unclassified); null when the note is
-          untagged.
       - name: doc_type
         data_type: string
         description:
@@ -56,6 +66,10 @@ models:
         data_type: string
         description:
           The note with the MAHER_FUND tag and its surrounding whitespace
-          removed; equals the original note when untagged.
+          removed; equals the original note when untagged, and null when the
+          note is null.
       - name: academic_year
         data_type: int64
+        description:
+          Academic year (July-June) that the award's date falls in, expressed as
+          the start year.

--- a/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
+++ b/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
@@ -16,7 +16,7 @@ select
     type__c as `type`,
 
     /* parsed from the appended [MAHER_FUND|v1|type=...|doc=...] marker tag */
-    coalesce(regexp_contains(notes__c, r'\[MAHER_FUND\|'), false) as is_maher,
+    coalesce(regexp_contains(notes__c, r'\[MAHER_FUND\|[^\]]*\]'), false) as is_maher,
     regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?type=([A-Za-z]+)') as fund_type,
     regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?doc=([^\|\]]*)') as doc_type,
     trim(regexp_replace(notes__c, r'\s*\[MAHER_FUND\|[^\]]*\]\s*', '')) as notes_clean,

--- a/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
+++ b/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
@@ -14,5 +14,11 @@ select
     status__c as status,
     student__c as student,
     type__c as `type`,
+
+    /* parsed from the appended [MAHER_FUND|v1|type=...|doc=...] marker tag */
+    coalesce(regexp_contains(notes__c, r'\[MAHER_FUND\|'), false) as is_maher,
+    regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?type=([A-Za-z]+)') as fund_type,
+    regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?doc=([^\|\]]*)') as doc_type,
+    trim(regexp_replace(notes__c, r'\s*\[MAHER_FUND\|[^\]]*\]\s*', '')) as notes_clean,
 from {{ source("kippadb", "kipp_aid") }}
 where not isdeleted

--- a/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
+++ b/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__kipp_aid.sql
@@ -20,5 +20,8 @@ select
     regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?type=([A-Za-z]+)') as fund_type,
     regexp_extract(notes__c, r'\[MAHER_FUND\|[^\]]*?doc=([^\|\]]*)') as doc_type,
     trim(regexp_replace(notes__c, r'\s*\[MAHER_FUND\|[^\]]*\]\s*', '')) as notes_clean,
+
+    {{ date_to_fiscal_year(date_field="date__c", start_month=7, year_source="start") }}
+    as academic_year,
 from {{ source("kippadb", "kipp_aid") }}
 where not isdeleted


### PR DESCRIPTION
## Summary & Motivation

When merged, this adds regex-derived columns to `stg_kippadb__kipp_aid` that parse the `MAHER_FUND` marker tag — **square-bracket** form `[MAHER_FUND|v1|type=...|doc=...]` (backticked here so it renders literally) — appended to `notes` on Maher Fund aid records:

- `is_maher` (boolean) — true when the note carries a complete tag; `coalesce(..., false)` so null/empty/untagged notes are false, never null. Regex requires the closing bracket so partial/malformed markers don't match.
- `fund_type` — `Emergency` / `Enrichment` / `Unclassified`, parsed from the tag's `type` (with an `accepted_values` warn test)
- `doc_type` — the source PO/Exp (or name) reference, parsed from the tag's `doc`
- `notes_clean` — the note with the tag and its surrounding whitespace stripped
- `academic_year` — fiscal/academic year (Jul–Jun) of the award date

These are inert (false / null / passthrough) on today's data and only light up once the tagging update is applied to existing records. Closes #4109.

Naming note: `doc_type` holds a document *reference* (e.g. `PO K31948`), not a category — kept as-is for now; can rename to `source_doc` if downstream prefers.

**AI assistance:** the column SQL/regex, contract YAML, tests, and local validation were drafted with Claude Code; naming and review are human-directed.

## Self-review

### dbt

- [x] Properties file updated with the new contracted columns, tests, and descriptions
- [x] **Breaking change?** No — additive columns only; no renames or removals
- [ ] exposure — n/a (no new dashboard/app consumer)
- [ ] external source — n/a

Verified locally: `dbt build --select stg_kippadb__kipp_aid` passes (contract enforced; `unique`, `not_null`, `accepted_values` tests green); regex behavior confirmed against tagged, untagged, empty, and null notes.

## CI checks

- [x] **Trunk** — passes locally (`trunk check` clean)
- [ ] **dbt Cloud** — pending CI
