### PR TITLE
fix(dbt): exclude ELA11 from NJ state assessments demographic comps

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
@@ -223,8 +223,6 @@ with
             and e.academic_year >= 2018
             and e.grade_level > 2
             and e.school_level != 'OD'
-            -- ELA11 was not a valid NJSLA test for Spring 2018-2019
-            and a.aligned_test_code != 'ELA11'
 
         union all
 

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
@@ -128,6 +128,8 @@ with
             and e.academic_year >= 2018
             and e.grade_level > 2
             and e.school_level != 'OD'
+            -- ELA11 was not a valid NJSLA test for Spring 2018-2019
+            and a.aligned_test_code != 'ELA11'
 
         union all
 
@@ -221,6 +223,8 @@ with
             and e.academic_year >= 2018
             and e.grade_level > 2
             and e.school_level != 'OD'
+            -- ELA11 was not a valid NJSLA test for Spring 2018-2019
+            and a.aligned_test_code != 'ELA11'
 
         union all
 

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__state_assessments_demographic_comps.sql
@@ -128,7 +128,8 @@ with
             and e.academic_year >= 2018
             and e.grade_level > 2
             and e.school_level != 'OD'
-            -- ELA11 was not a valid NJSLA test for Spring 2018-2019
+            -- ELA11 was not a recognized NJSLA test code (Spring 2019, academic_year
+            -- = 2018)
             and a.aligned_test_code != 'ELA11'
 
         union all

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__state_assessments_demographic_comps.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__state_assessments_demographic_comps.yml
@@ -39,9 +39,10 @@ models:
         description: >
           Subject-and-grade test code (e.g. ELA03, MAT08, ELAGP). ALG01 is not
           split by school level; the downstream rpt strips any suffix before
-          joining to benchmark data. ELA11 is excluded from NJ scores: it was
-          not a valid NJSLA test for Spring 2018-2019 and NJ published no
-          comparison benchmarks for it.
+          joining to benchmark data. ELA11 is excluded from NJ scores across all
+          years: it appeared in Spring 2019 (academic_year = 2018) data but was
+          not a recognized NJSLA test code and NJ published no comparison
+          benchmarks for it.
       - name: total_proficient_students
         data_type: float64
         description: Rounded count of students who scored proficient or above.

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__state_assessments_demographic_comps.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__state_assessments_demographic_comps.yml
@@ -39,7 +39,9 @@ models:
         description: >
           Subject-and-grade test code (e.g. ELA03, MAT08, ELAGP). ALG01 is not
           split by school level; the downstream rpt strips any suffix before
-          joining to benchmark data.
+          joining to benchmark data. ELA11 is excluded from NJ scores: it was
+          not a valid NJSLA test for Spring 2018-2019 and NJ published no
+          comparison benchmarks for it.
       - name: total_proficient_students
         data_type: float64
         description: Rounded count of students who scored proficient or above.


### PR DESCRIPTION
## Summary

- Excludes `ELA11` from the NJ official scores branch of `int_tableau__state_assessments_demographic_comps`
- ELA11 appears in our NJSLA Spring 2019 data (141 Newark students, tested May 2 2019) but NJ did not publish state or city-level comparison benchmarks for this test code — it does not appear in the NJ DOE's published Spring 2018-19 NJSLA results
- Without comparison data in the Google Sheet, these rows produce NULL `school_level` / `grade_range_band` / `discipline` and are not usable in the dashboard
- NJ prelim branch unaffected (prelim only covers academic_year >= 2024; ELA11 data is from 2018)
- FL branch unaffected (FL assessments use different test codes)
- `rpt_tableau__state_assessments_dashboard` (individual student scores) intentionally retains ELA11 — student-level scores are valid even without published benchmarks; the exclusion is only for the demographic comps comparison
- Documents the exclusion in the model YAML

## Test plan

- [x] `int_tableau__state_assessments_demographic_comps` builds cleanly (PASS=3 WARN=0 ERROR=0)
- [x] Zero rows with `test_code = 'ELA11'` and `district_state = 'KTAF NJ'` in the output
- [x] Only ELA08/SCI08 2023 remain null (pending Jabari's PS fix for Grade 8 students at HS-classified schools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)