### PR TITLE
fix(adp): retry transient WFN 5xx instead of failing on non-JSON body

### DIFF
--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -7,7 +7,7 @@ from pydantic import PrivateAttr
 from requests import Response
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from requests.exceptions import HTTPError, Timeout
+from requests.exceptions import HTTPError, JSONDecodeError, Timeout
 from requests_oauthlib import OAuth2Session
 from tenacity import (
     retry,
@@ -84,18 +84,26 @@ class AdpWorkforceNowResource(ConfigurableResource):
 
             return response
         except HTTPError as e:
-            response_json = response.json()
-
             # 429 (rate limited) and 5xx (server-side) errors are transient;
-            # re-raise the HTTPError so tenacity retries with backoff.
+            # re-raise the HTTPError so tenacity retries with backoff. Check the
+            # status code *before* parsing the body: gateway 5xx responses (e.g.
+            # a 504 HTML page) are not JSON, and JSONDecodeError is not in the
+            # retry predicate, so parsing here would convert a retryable error
+            # into a non-retryable one.
             if response.status_code == 429 or response.status_code >= 500:
-                self._log.warning(msg=response_json)
+                self._log.warning(msg=response.text)
                 raise
 
             # other 4xx are deterministic client errors — surface a specific
-            # exception (never a bare Exception) and do not retry.
-            self._log.error(msg=response_json)
-            raise AdpWorkforceNowError(response_json) from e
+            # exception (never a bare Exception) and do not retry. Guard the JSON
+            # parse: a 4xx body may also be non-JSON.
+            try:
+                detail = response.json()
+            except JSONDecodeError:
+                detail = response.text
+
+            self._log.error(msg=detail)
+            raise AdpWorkforceNowError(detail) from e
 
     def post(
         self, endpoint: str, subresource: str, verb: str, payload: dict

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -8,7 +8,10 @@ from dagster import build_resources
 from requests.exceptions import HTTPError, JSONDecodeError
 from tenacity import RetryError, wait_none
 
-from teamster.libraries.adp.workforce_now.api.resources import AdpWorkforceNowResource
+from teamster.libraries.adp.workforce_now.api.resources import (
+    AdpWorkforceNowError,
+    AdpWorkforceNowResource,
+)
 
 
 def get_adp_wfn_resource() -> AdpWorkforceNowResource:
@@ -183,10 +186,6 @@ def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
 
 def test_request_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch):
     """A non-429 4xx is deterministic: raise a specific error without retrying."""
-    from teamster.libraries.adp.workforce_now.api.resources import (
-        AdpWorkforceNowError,
-    )
-
     monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
 
     calls = {"n": 0}
@@ -265,10 +264,6 @@ def test_request_non_json_client_error_raises_adp_error(
     The deterministic-4xx branch must tolerate a non-JSON body instead of
     crashing on ``response.json()``.
     """
-    from teamster.libraries.adp.workforce_now.api.resources import (
-        AdpWorkforceNowError,
-    )
-
     monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
 
     calls = {"n": 0}

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -5,8 +5,8 @@ import types
 
 import pytest
 from dagster import build_resources
-from requests.exceptions import HTTPError
-from tenacity import wait_none
+from requests.exceptions import HTTPError, JSONDecodeError
+from tenacity import RetryError, wait_none
 
 from teamster.libraries.adp.workforce_now.api.resources import AdpWorkforceNowResource
 
@@ -119,11 +119,23 @@ def test_get_talent_associate_memberships():
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, json_body: dict) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        json_body: dict,
+        *,
+        text: str = "",
+        json_raises: bool = False,
+    ) -> None:
         self.status_code = status_code
         self._json_body = json_body
+        self.text = text
+        self._json_raises = json_raises
 
     def json(self) -> dict:
+        if self._json_raises:
+            raise JSONDecodeError("Expecting value", "", 0)
+
         return self._json_body
 
     def raise_for_status(self) -> None:
@@ -182,6 +194,88 @@ def test_request_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch)
     def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
         calls["n"] += 1
         return _FakeResponse(400, {"status": 400, "error": "Bad Request"})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    with pytest.raises(AdpWorkforceNowError):
+        adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert calls["n"] == 1
+
+
+def test_request_retries_server_error_with_non_json_body(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A 5xx whose body is not JSON (a gateway 504 HTML page) must still retry.
+
+    Regression: the handler called ``response.json()`` before checking the
+    status code. A gateway 504 returns a non-JSON body, so ``.json()`` raised
+    ``JSONDecodeError`` — which the tenacity predicate does not match — and the
+    request failed on the first attempt instead of being retried as a 5xx.
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(504, {}, json_raises=True, text="504 Gateway Time-out")
+        return _FakeResponse(200, {"ok": True})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    response = adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_non_json_server_error_retries_as_httperror(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A persistent non-JSON 5xx is retried, then exhausts as a wrapped HTTPError.
+
+    The underlying cause across all attempts must be the retryable ``HTTPError``,
+    never the ``JSONDecodeError`` produced by parsing a non-JSON gateway body. On
+    exhaustion tenacity wraps the last failure in ``RetryError``.
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(504, {}, json_raises=True, text="504 Gateway Time-out")
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    with pytest.raises(RetryError) as exc_info:
+        adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert calls["n"] == 5
+    assert isinstance(exc_info.value.last_attempt.exception(), HTTPError)
+
+
+def test_request_non_json_client_error_raises_adp_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A non-JSON 4xx surfaces ``AdpWorkforceNowError`` without retrying.
+
+    The deterministic-4xx branch must tolerate a non-JSON body instead of
+    crashing on ``response.json()``.
+    """
+    from teamster.libraries.adp.workforce_now.api.resources import (
+        AdpWorkforceNowError,
+    )
+
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(404, {}, json_raises=True, text="404 Not Found")
 
     adp_wfn = _build_offline_resource(request_fn)
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR makes the ADP Workforce Now `_request` helper retry transient gateway 5xx errors (e.g. 504) instead of failing immediately.

The error handler called `response.json()` **before** checking the status code. A gateway 504 returns a non-JSON body, so `.json()` raised `JSONDecodeError` — which is not in the tenacity retry predicate `(RequestsConnectionError, Timeout, HTTPError)` — converting a retryable 504 into an immediate, unrecoverable step failure. ~20 `kipptaf/adp/workforce_now/workers` partitions failed overnight this way (deep-pagination 504 at `$skip=3800`), with no recovery.

Fix: check the status code first. 429/5xx re-raise the `HTTPError` so tenacity retries with backoff (logging `response.text`); deterministic 4xx guard the JSON parse and fall back to `response.text`. Adds 3 regression tests for non-JSON 5xx (retries, then `RetryError[HTTPError]`) and non-JSON 4xx (`AdpWorkforceNowError`, no retry) — the existing `_FakeResponse` always returned valid JSON, which is why the existing 5xx test missed this.

Closes #4130

## AI Assistance

AI-authored (Claude Code): systematic debugging from the failed run to root cause, then TDD (failing tests → minimal fix). Human-directed scope and review.

A related alerting gap was investigated and **deliberately deferred** as a rare event: there is no `JOB_FAILURE` policy, the deployment-wide `ASSET_HEALTH_DEGRADED` policy did not fire on a confirmed health transition, and freshness policies cannot catch partial-partition failures (most partitions, including the latest, succeed). Analysis recorded on #4130.

## Self-review

### Dagster

- [x] `uv run pytest tests/resources/test_resource_adp_workforce_now.py -k request` — 5 passed
- [ ] `uv run dagster definitions validate` — not run locally (requires 1Password-provisioned configuration unavailable to this session); the change is to a library resource method, no definition wiring changed

## CI checks

- [ ] **Trunk** — `trunk check --force` clean locally on both changed files
- [ ] **dbt Cloud** — n/a (no dbt changes)
- [ ] **Dagster Cloud** — branch deploy
