### PR TITLE
fix(dagster): harden in-step retry for ADP/Coupa/KnowBe4 API resources

### DIFF
--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -90,8 +90,22 @@ class AdpWorkforceNowResource(ConfigurableResource):
             # a 504 HTML page) are not JSON, and JSONDecodeError is not in the
             # retry predicate, so parsing here would convert a retryable error
             # into a non-retryable one.
-            if response.status_code == 429 or response.status_code >= 500:
-                self._log.warning(msg=response.text)
+            #
+            # ADP's gateway also returns a transient "default backend - 404" when
+            # it briefly has no healthy backend (a load-balancer signature, seen
+            # mid-pagination). That is distinct from a genuine resource 404 —
+            # treat only the gateway variant as retryable so a real 404 still
+            # fails fast.
+            body = response.text
+            is_transient_gateway_404 = (
+                response.status_code == 404 and "default backend" in body.lower()
+            )
+            if (
+                response.status_code == 429
+                or response.status_code >= 500
+                or is_transient_gateway_404
+            ):
+                self._log.warning(msg=body)
                 raise
 
             # other 4xx are deterministic client errors — surface a specific

--- a/src/teamster/libraries/coupa/resources.py
+++ b/src/teamster/libraries/coupa/resources.py
@@ -4,8 +4,19 @@ from oauthlib.oauth2 import BackendApplicationClient
 from pydantic import PrivateAttr
 from requests import Response
 from requests.auth import HTTPBasicAuth
-from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, JSONDecodeError, Timeout
 from requests_oauthlib import OAuth2Session
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+
+class CoupaError(Exception):
+    """Non-retryable Coupa API error (deterministic 4xx response)."""
 
 
 class CoupaResource(ConfigurableResource):
@@ -29,17 +40,30 @@ class CoupaResource(ConfigurableResource):
         )
 
         # authorize client
-        token_dict = self._session.fetch_token(
-            token_url=f"{self._service_root}/oauth2/token",
-            auth=HTTPBasicAuth(username=self.client_id, password=self.client_secret),
-        )
+        token_dict = self._fetch_access_token()
 
         self._session.headers["Authorization"] = "Bearer " + token_dict["access_token"]
         self._session.headers["Accept"] = "application/json"
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=10, max=60),
+        retry=retry_if_exception_type((RequestsConnectionError, Timeout, HTTPError)),
+    )
+    def _fetch_access_token(self) -> dict:
+        return self._session.fetch_token(
+            token_url=f"{self._service_root}/oauth2/token",
+            auth=HTTPBasicAuth(username=self.client_id, password=self.client_secret),
+        )
+
     def _get_url(self, resource: str, id: int | None) -> str:
         return f"{self._service_root}/api/{resource}" + (f"/{id}" if id else "")
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=10, max=60),
+        retry=retry_if_exception_type((RequestsConnectionError, Timeout, HTTPError)),
+    )
     def _request(
         self, method: str, resource: str, id: int | None, **kwargs
     ) -> Response:
@@ -52,8 +76,22 @@ class CoupaResource(ConfigurableResource):
             response.raise_for_status()
             return response
         except HTTPError as e:
-            self._log.error(response.text)
-            raise e
+            # 429 (rate limited) and 5xx (server-side) errors are transient;
+            # re-raise the HTTPError so tenacity retries with backoff.
+            if response.status_code == 429 or response.status_code >= 500:
+                self._log.warning(msg=response.text)
+                raise
+
+            # other 4xx are deterministic client errors — surface a specific
+            # exception (never a bare Exception) and do not retry. Guard the JSON
+            # parse: a 4xx body may not be JSON.
+            try:
+                detail = response.json()
+            except JSONDecodeError:
+                detail = response.text
+
+            self._log.error(msg=detail)
+            raise CoupaError(detail) from e
 
     def get(self, resource: str, id: int | None = None, **kwargs) -> Response:
         return self._request(method="GET", resource=resource, id=id, **kwargs)

--- a/src/teamster/libraries/knowbe4/resources.py
+++ b/src/teamster/libraries/knowbe4/resources.py
@@ -3,7 +3,19 @@ import time
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster_shared import check
 from pydantic import PrivateAttr
-from requests import HTTPError, Response, Session
+from requests import Response, Session
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, JSONDecodeError, Timeout
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+
+class KnowBe4Error(Exception):
+    """Non-retryable KnowBe4 API error (deterministic 4xx response)."""
 
 
 class KnowBe4Resource(ConfigurableResource):
@@ -25,6 +37,11 @@ class KnowBe4Resource(ConfigurableResource):
             f"/{id}" if id else ""
         )
 
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=10, max=60),
+        retry=retry_if_exception_type((RequestsConnectionError, Timeout, HTTPError)),
+    )
     def _request(
         self, method: str, resource: str, id: int | None, **kwargs
     ) -> Response:
@@ -37,8 +54,22 @@ class KnowBe4Resource(ConfigurableResource):
             response.raise_for_status()
             return response
         except HTTPError as e:
-            self._log.error(response.text)
-            raise e
+            # 429 (rate limited) and 5xx (server-side) errors are transient;
+            # re-raise the HTTPError so tenacity retries with backoff.
+            if response.status_code == 429 or response.status_code >= 500:
+                self._log.warning(msg=response.text)
+                raise
+
+            # other 4xx are deterministic client errors — surface a specific
+            # exception (never a bare Exception) and do not retry. Guard the JSON
+            # parse: a 4xx body may not be JSON.
+            try:
+                detail = response.json()
+            except JSONDecodeError:
+                detail = response.text
+
+            self._log.error(msg=detail)
+            raise KnowBe4Error(detail) from e
 
     def get(self, resource: str, id: int | None = None, **kwargs) -> Response:
         return self._request(method="GET", resource=resource, id=id, **kwargs)

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -278,3 +278,55 @@ def test_request_non_json_client_error_raises_adp_error(
         adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
 
     assert calls["n"] == 1
+
+
+def test_request_retries_on_transient_gateway_404(monkeypatch: pytest.MonkeyPatch):
+    """ADP's gateway returns a transient ``default backend - 404`` mid-pagination.
+
+    Regression: this load-balancer 404 was classified as a deterministic 4xx and
+    raised ``AdpWorkforceNowError`` without retrying. It must be re-raised as the
+    retryable ``HTTPError`` so tenacity retries with backoff (the genuine-404
+    case above must still fail fast).
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(404, {}, text="default backend - 404")
+        return _FakeResponse(200, {"ok": True})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    response = adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_persistent_gateway_404_retries_as_httperror(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A persistent gateway 404 is retried, then exhausts as a wrapped HTTPError.
+
+    Confirms the transient-gateway-404 branch routes through the retryable
+    ``HTTPError`` path end-to-end rather than the non-retryable
+    ``AdpWorkforceNowError`` path.
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(404, {}, text="default backend - 404")
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    with pytest.raises(RetryError) as exc_info:
+        adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert calls["n"] == 5
+    assert isinstance(exc_info.value.last_attempt.exception(), HTTPError)

--- a/tests/resources/test_resource_coupa.py
+++ b/tests/resources/test_resource_coupa.py
@@ -1,0 +1,108 @@
+import logging
+import types
+
+import pytest
+from requests.exceptions import HTTPError, JSONDecodeError, ReadTimeout
+from tenacity import wait_none
+
+from teamster.libraries.coupa.resources import CoupaError, CoupaResource
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        json_body,
+        *,
+        text: str = "",
+        json_raises: bool = False,
+    ) -> None:
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+        self._json_raises = json_raises
+
+    def json(self):
+        if self._json_raises:
+            raise JSONDecodeError("Expecting value", "", 0)
+
+        return self._json_body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} Server Error", response=self)  # pyright: ignore[reportArgumentType]
+
+
+def _build_offline_resource(request_fn) -> CoupaResource:
+    """Instantiate the resource without the network setup_for_execution path."""
+    coupa = CoupaResource(
+        instance_url="example.test", client_id="x", client_secret="x", scope=["x"]
+    )
+
+    object.__setattr__(coupa, "_session", types.SimpleNamespace(request=request_fn))
+    object.__setattr__(coupa, "_log", logging.getLogger("test_coupa"))
+    object.__setattr__(coupa, "_service_root", "https://example.test")
+
+    return coupa
+
+
+def test_request_retries_on_read_timeout(monkeypatch: pytest.MonkeyPatch):
+    """A ``ReadTimeout`` is transient and must be retried.
+
+    Regression: ``CoupaResource`` had no retry, so a single read timeout (the
+    actual 2026-06 prod failure) failed the step immediately.
+    """
+    monkeypatch.setattr(CoupaResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ReadTimeout("Read timed out. (read timeout=30)")
+        return _FakeResponse(200, [{"ok": True}])
+
+    coupa = _build_offline_resource(request_fn)
+
+    response = coupa._request(method="GET", resource="users", id=None)
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx response is transient and must be retried."""
+    monkeypatch.setattr(CoupaResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(500, {}, text="500 Internal Server Error")
+        return _FakeResponse(200, [{"ok": True}])
+
+    coupa = _build_offline_resource(request_fn)
+
+    response = coupa._request(method="GET", resource="users", id=None)
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch):
+    """A non-429 4xx is deterministic: raise CoupaError without retrying."""
+    monkeypatch.setattr(CoupaResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(400, {"error": "Bad Request"})
+
+    coupa = _build_offline_resource(request_fn)
+
+    with pytest.raises(CoupaError):
+        coupa._request(method="GET", resource="users", id=None)
+
+    assert calls["n"] == 1

--- a/tests/resources/test_resource_knowbe4.py
+++ b/tests/resources/test_resource_knowbe4.py
@@ -1,6 +1,12 @@
-from dagster import EnvVar, build_resources
+import logging
+import types
 
-from teamster.libraries.knowbe4.resources import KnowBe4Resource
+import pytest
+from dagster import EnvVar, build_resources
+from requests.exceptions import HTTPError, JSONDecodeError, ReadTimeout
+from tenacity import wait_none
+
+from teamster.libraries.knowbe4.resources import KnowBe4Error, KnowBe4Resource
 
 
 def test_knowbe4_resource():
@@ -14,3 +20,102 @@ def test_knowbe4_resource():
         knowbe4: KnowBe4Resource = resources.knowbe4
 
     assert knowbe4 is not None
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        json_body,
+        *,
+        text: str = "",
+        json_raises: bool = False,
+    ) -> None:
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+        self._json_raises = json_raises
+
+    def json(self):
+        if self._json_raises:
+            raise JSONDecodeError("Expecting value", "", 0)
+
+        return self._json_body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} Server Error", response=self)  # pyright: ignore[reportArgumentType]
+
+
+def _build_offline_resource(request_fn) -> KnowBe4Resource:
+    """Instantiate the resource without the network setup_for_execution path."""
+    knowbe4 = KnowBe4Resource(api_key="x", server="us")
+
+    object.__setattr__(knowbe4, "_session", types.SimpleNamespace(request=request_fn))
+    object.__setattr__(knowbe4, "_log", logging.getLogger("test_knowbe4"))
+    object.__setattr__(knowbe4, "_service_root", "https://us.api.knowbe4.com")
+
+    return knowbe4
+
+
+def test_request_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx response is transient and must be retried.
+
+    Regression: ``KnowBe4Resource`` had no retry, so a single 500 (the actual
+    2026-06 prod failure on ``training/enrollments``) failed the step
+    immediately.
+    """
+    monkeypatch.setattr(KnowBe4Resource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(500, {}, text="500 Internal Server Error")
+        return _FakeResponse(200, [{"ok": True}])
+
+    knowbe4 = _build_offline_resource(request_fn)
+
+    response = knowbe4._request(method="GET", resource="training/enrollments", id=None)
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_retries_on_read_timeout(monkeypatch: pytest.MonkeyPatch):
+    """A ``ReadTimeout`` is transient and must be retried."""
+    monkeypatch.setattr(KnowBe4Resource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ReadTimeout("Read timed out")
+        return _FakeResponse(200, [{"ok": True}])
+
+    knowbe4 = _build_offline_resource(request_fn)
+
+    response = knowbe4._request(method="GET", resource="training/enrollments", id=None)
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch):
+    """A non-429 4xx is deterministic: raise KnowBe4Error without retrying."""
+    monkeypatch.setattr(KnowBe4Resource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(400, {"error": "Bad Request"})
+
+    knowbe4 = _build_offline_resource(request_fn)
+
+    with pytest.raises(KnowBe4Error):
+        knowbe4._request(method="GET", resource="training/enrollments", id=None)
+
+    assert calls["n"] == 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR stops three vendor-API resources from failing a step on a single transient blip and relying on Dagster run-retry to recover. Closes #4136.

Root causes were confirmed from the actual step tracebacks for the 2026-06-05/08 day-2 window:

- **ADP Workforce Now** — 21 worker-pull runs failed with `AdpWorkforceNowError: default backend - 404` mid-pagination. `default backend - 404` is a load-balancer signature (transient — all 21 recovered on run-retry), but the resource classified any non-429/non-5xx as a deterministic error, so the 404 bypassed tenacity entirely. Now the gateway 404 is re-raised as a retryable `HTTPError`; a genuine 404 still fails fast.
- **Coupa** — failed on a `ReadTimeout (30s)`; the resource had no request-layer retry at all.
- **KnowBe4** — failed on a `500` on `training/enrollments?page=60`; also no retry.

Coupa and KnowBe4 now use the house tenacity pattern (`src/teamster/CLAUDE.md` "Retry pattern"): 5× exponential-jitter backoff, retry on `(ConnectionError, Timeout, HTTPError)`, 429/5xx re-raised, other 4xx → a named non-retryable error (`CoupaError` / `KnowBe4Error`), and the OAuth token fetch wrapped (Coupa). Run-retry remains the backstop for true outages (e.g. the ADP case where an outage outlasts the in-step budget).

Broader cross-resource retry consolidation is tracked separately in #3390; this is the narrow operational fix. Overgrad is intentionally out of scope — its weekend failure was `DagsterK8sAPIRetryLimitExceeded` (K8s control-plane), not a vendor error.

## AI Assistance

AI-assisted (Claude Code), human-directed. Claude diagnosed the failures from `get_run_logs` tracebacks, implemented the three resource changes, and wrote the offline unit tests; the scope decision (exclude Overgrad), the gateway-404 discriminator approach, and review are human-directed.

## Self-review

### Dagster

- [ ] `uv run dagster definitions validate` — not run locally (requires 1Password secrets unavailable in this session); resource-internal change adds no assets/keys. CI covers.
- [x] Offline unit tests added and passing for every retry path (`tests/resources/test_resource_{adp_workforce_now,coupa,knowbe4}.py`): gateway-404 retry + genuine-404 fast-fail, 5xx/ReadTimeout retry, 4xx no-retry.
- [x] No new integration — existing Library + Config pattern unchanged.

## CI checks

- [x] **Trunk** — passes locally (`trunk check` clean on all 6 changed files, run from the worktree).
- [ ] **dbt Cloud** — not applicable (Python-only change, no dbt models touched).
- [ ] **Dagster Cloud** — may run on `src/teamster/**` change; expected to pass.
