### PR TITLE
fix(coupa): add coupa_navi_ai_agent_user to User schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,16 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   source systems, and `dagster`/`dbt` when applicable.
 
 - **Before creating a branch**: ask the user — worktree or branch switch? Do not
-  choose for them.
+  choose for them. When an issue isn't already required (i.e. quick fixes, not
+  specs/plans), also ask whether to anchor the branch with one, and honor a
+  decline — create the branch without an issue via the paths below.
 
 - **Before writing any file (spec, code, config)**: be on the feature branch.
 
-- **Worktree**: `gh issue develop <number> --name <branch>` (no `--checkout`),
-  then `git worktree add .worktrees/<branch> <branch>`.
+- **Worktree**: with an issue, `gh issue develop <number> --name <branch>` (no
+  `--checkout`), then `git worktree add .worktrees/<branch> <branch>`. If the
+  user explicitly declined an issue, skip `gh issue develop` and create the
+  branch directly: `git worktree add -b <branch> .worktrees/<branch>`.
 
 - **Linking an existing remote branch to an issue**:
   `mcp__github__create_branch` and GraphQL `createLinkedBranch` both no-op when
@@ -67,7 +71,9 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   main repo's `.venv` and misses worktree-only changes. Otherwise prefer
   absolute paths.
 
-- **Branch switch**: `gh issue develop <number> --name <branch> --checkout`.
+- **Branch switch**: with an issue,
+  `gh issue develop <number> --name <branch> --checkout`; if the user explicitly
+  declined an issue, `git checkout -b <branch>`.
 
 - **Git naming**: Commit messages and branch names use
   [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Branch
@@ -104,8 +110,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   out-of-band consent, re-confirm in plain text the same turn or the write will
   be denied. Common surfaces: `git worktree add -b` / `git checkout -b`,
   `git push origin main` (route through a PR or have the user push), bulk Asana
-  `create_tasks`. If the user declined tracking issues, open minimal ones anyway
-  (title + 1-2 sentences) and use `gh issue develop`.
+  `create_tasks`. If the user hasn't ruled an issue out, open a minimal one
+  (title + 1-2 sentences) and use `gh issue develop`; if the user explicitly
+  declined an issue, create the branch directly (`git worktree add -b` /
+  `git checkout -b`) and re-confirm that consent in plain text the same turn so
+  the classifier (which can't see `AskUserQuestion` answers) allows it.
   `gh issue develop --name <branch>` also fails when the branch contains trigger
   words like `log`, `auth`, `secret` — rename and retry.
 
@@ -248,9 +257,11 @@ alone may be safe; combinations may not. When unsure, consult the
   doc" step, `superpowers:writing-plans`' "Save plan" step, or
   `superpowers:using-git-worktrees`' worktree-consent prompt. Pause those
   skills, run the flow, then write specs to `docs/superpowers/specs/...` or
-  plans to `docs/superpowers/plans/...` on the new branch. Never
-  `git worktree add -b` or `git checkout -b` standalone — the branch must be
-  created via `gh issue develop` so it's linked to the issue.
+  plans to `docs/superpowers/plans/...` on the new branch. Default to
+  `gh issue develop` so the branch is linked to an issue; only create a branch
+  standalone (`git worktree add -b` / `git checkout -b`) when the user
+  explicitly declines an issue — re-confirm that consent in plain text the same
+  turn.
 
 - **`finishing-a-development-branch` verification gate**: Skip the skill's
   `npm test / pytest / ...` heuristic. For dbt changes,

--- a/src/teamster/libraries/coupa/schema.py
+++ b/src/teamster/libraries/coupa/schema.py
@@ -316,15 +316,6 @@ class LegalEntity(BaseModel):
 
 
 class User(UserBase):
-    id: int | None = None
-    login: str | None = None
-    email: str | None = None
-    firstname: str | None = None
-    lastname: str | None = None
-    fullname: str | None = None
-    employee_number: str | None = None
-    salesforce_id: str | None = None
-    avatar_thumb_url: str | None = None
     middlename: str | None = None
     active: bool | None = None
     created_at: str | None = None

--- a/src/teamster/libraries/coupa/schema.py
+++ b/src/teamster/libraries/coupa/schema.py
@@ -356,6 +356,7 @@ class User(UserBase):
     allow_employee_payment_account_creation: bool | None = None
     category_planner_user: bool | None = None
     intake_user: bool | None = None
+    coupa_navi_ai_agent_user: bool | None = None
 
     custom_fields: UserCustomFields | None = None
     default_account: Account | None = None


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

Resolve the daily `avro_schema_valid` WARN on `kipptaf/coupa/users`. Coupa added a new flag, `coupa-navi-ai-agent-user`, to its `/users` API around 2026-06-06; the asset normalizes it to `coupa_navi_ai_agent_user`, which wasn't in the `User` model, so the check flagged it as an extra field (and the field was silently dropped from the Avro output) on every run since. Adds it as `bool | None` alongside the other `*_user` access flags.

Also folds in a small `CLAUDE.md` convention change: the branch-creation flow now allows creating a branch directly (no issue) when the user explicitly declines one, instead of "open a minimal issue anyway."

Closes #4140

### AI Assistance

AI-assisted via Claude Code (systematic-debugging): root-cause diagnosis from the Dagster run + check history, the one-line schema field, and the CLAUDE.md wording. Human-directed: the decision to fix at the schema, the field type (`bool`), and the convention change.

## Self-review

### Dagster

- [x] Field type matches sibling `*_user` flags; verified by regenerating `USER_SCHEMA` locally and confirming `coupa_navi_ai_agent_user` is present and the simulated check returns no extras.
- [ ] `uv run dagster definitions validate` — env-dependent locally; relying on CI.

### Docs

- [x] `CLAUDE.md` updated for the branch-creation convention change.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — not applicable (no dbt changes).
- [ ] **Dagster Cloud** — passes or not triggered.
