### PR TITLE
refactor(marts): collapse fct_grades_* enrollment diamond

### DIFF
--- a/docs/superpowers/plans/2026-06-08-collapse-grades-enrollment-diamond.md
+++ b/docs/superpowers/plans/2026-06-08-collapse-grades-enrollment-diamond.md
@@ -1,0 +1,714 @@
+# Collapse `fct_grades_*` → `dim_student_enrollments` Diamond — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the diamond path by dropping the direct
+`student_enrollment_key` FK from `fct_grades_assignments` and `fct_grades_term`,
+after fixing `dim_student_section_enrollments` so its `student_enrollment_key`
+resolves for every section that overlaps a school enrollment stint.
+
+**Architecture:** Change the dim's enrollment match from a point anchor on
+`cc_dateenrolled` to an overlap match against enrollment stints, collapsing the
+rare (147) multi-stint fan-out with a covering-first deterministic pick. Then
+remove the facts' independently-computed direct FK; consumers traverse
+`student_section_enrollment_key` → `dim_student_section_enrollments` →
+`student_enrollment_key`. A `warn` test monitors multi-stint drift.
+
+**Tech Stack:** dbt (BigQuery), `dbt_utils`, the kipptaf project. Spec:
+[2026-06-08-collapse-grades-enrollment-diamond-design.md](../specs/2026-06-08-collapse-grades-enrollment-diamond-design.md).
+Issues: [#4145](https://github.com/TEAMSchools/teamster/issues/4145) (this
+work), [#4146](https://github.com/TEAMSchools/teamster/issues/4146) (separate
+DQ).
+
+---
+
+## Conventions for every task
+
+- All paths are relative to the worktree root
+  `/workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond`.
+- Run dbt from the main repo with `--project-dir` pointing at the worktree, and
+  defer to prod for unstaged externals (the `reporting__terms` Google Sheet):
+
+  ```bash
+  uv run dbt deps --project-dir \
+    /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf
+  ```
+
+  (run `dbt deps` once — a fresh worktree has no `dbt_packages/`).
+
+- Build/show commands use this prefix (the `--state` path must be absolute from
+  a worktree):
+
+  ```bash
+  uv run dbt build --project-dir \
+    /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+    --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+    --select <model>
+  ```
+
+- `git` calls use `git -C <worktree>`.
+- Commit messages use conventional commits and end with the
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+  trailer.
+- `<dev_schema>` below = the schema your dbt profile writes to locally
+  (`kipptaf_marts` mapped through your dev target). Final PR verification runs
+  against the dbt Cloud PR-branch schema `dbt_cloud_pr_<job>_<pr>_marts`.
+
+---
+
+### Task 1: Rewrite `dim_student_section_enrollments` to resolve by overlap
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml`
+
+- [ ] **Step 1: Replace the model SQL**
+
+Replace the entire contents of `dim_student_section_enrollments.sql` with:
+
+```sql
+with
+    student_enrollments as (
+        select
+            _dbt_source_project,
+            studentid,
+            schoolid,
+            yearid,
+            student_number,
+            academic_year,
+            entrydate,
+            exitdate,
+        from {{ ref("int_powerschool__student_enrollment_union") }}
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    enrollment_overlap as (
+        select
+            cc._dbt_source_project,
+            cc.cc_dcid,
+            cc.sections_dcid,
+            cc.cc_academic_year,
+            cc.cc_dateenrolled,
+            cc.cc_dateleft,
+            cc.cc_abs_termid,
+            cc.sections_schoolid,
+            cc.region,
+            cc.is_dropped_section,
+            cc.is_dropped_course,
+
+            enr._dbt_source_project as enr_source_project,
+            enr.student_number as enr_student_number,
+            enr.academic_year as enr_academic_year,
+            enr.entrydate as enr_entrydate,
+
+            (
+                cc.cc_dateenrolled >= enr.entrydate
+                and cc.cc_dateenrolled < enr.exitdate
+            ) as is_covering,
+        from {{ ref("base_powerschool__course_enrollments") }} as cc
+        left join
+            student_enrollments as enr
+            on cc.cc_studentid = enr.studentid
+            and cc.sections_schoolid = enr.schoolid
+            and cc.cc_yearid = enr.yearid
+            and cc._dbt_source_project = enr._dbt_source_project
+            and enr.entrydate < cc.cc_dateleft
+            and enr.exitdate > cc.cc_dateenrolled
+    ),
+
+    enrollment_resolved as (
+        {{
+            dbt_utils.deduplicate(
+                relation="enrollment_overlap",
+                partition_by="cc_dcid, _dbt_source_project",
+                order_by="is_covering desc, enr_entrydate asc",
+            )
+        }}
+    ),
+
+    course_enrollments_joined as (
+        select
+            er.cc_dcid,
+            er._dbt_source_project,
+            er.sections_dcid,
+            er.cc_academic_year,
+            er.cc_dateenrolled,
+            er.cc_dateleft,
+            er.is_dropped_section,
+            er.is_dropped_course,
+            er.enr_source_project,
+            er.enr_student_number,
+            er.enr_academic_year,
+            er.enr_entrydate,
+
+            rt.`type` as rt_type,
+            rt.code as rt_code,
+            rt.name as rt_name,
+            rt.start_date as rt_start_date,
+            rt.region as rt_region,
+            rt.school_id as rt_school_id,
+        from enrollment_resolved as er
+        left join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on er.cc_abs_termid = rt.powerschool_term_id
+            and er.sections_schoolid = rt.school_id
+            and er.region = rt.region
+            and rt.`type` = 'RT'
+    )
+
+select
+    cc_academic_year as academic_year,
+    cc_dateenrolled as entry_date,
+    cc_dateleft as exit_date,
+    is_dropped_section,
+    is_dropped_course,
+
+    {{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
+    as student_section_enrollment_key,
+
+    {{ dbt_utils.generate_surrogate_key(["sections_dcid", "_dbt_source_project"]) }}
+    as course_section_key,
+
+    if(
+        enr_student_number is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "enr_student_number",
+                    "enr_source_project",
+                    "enr_academic_year",
+                    "enr_entrydate",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as student_enrollment_key,
+
+    if(
+        rt_code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "rt_type",
+                    "rt_code",
+                    "rt_name",
+                    "rt_start_date",
+                    "rt_region",
+                    "rt_school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
+from course_enrollments_joined
+```
+
+- [ ] **Step 2: Update the `student_enrollment_key` column description**
+
+In `dim_student_section_enrollments.yml`, replace the `student_enrollment_key`
+column `description` text:
+
+```yaml
+- name: student_enrollment_key
+  data_type: string
+  description: >-
+    Surrogate key derived from student_number, _dbt_source_project,
+    academic_year, and entrydate. FK to dim_student_enrollments. Resolved to the
+    school enrollment stint the section enrollment overlaps (the stint covering
+    cc_dateenrolled when one exists, else the earliest overlapping stint). Null
+    only when no enrollment stint overlaps the section enrollment.
+```
+
+(Leave the constraint and `relationships` test blocks unchanged.)
+
+- [ ] **Step 3: Build the dim and its upstreams**
+
+Run:
+
+```bash
+uv run dbt build --project-dir \
+  /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select dim_student_section_enrollments
+```
+
+Expected: PASS — model builds, `unique` + `not_null` on
+`student_section_enrollment_key` pass, `relationships` on
+`student_enrollment_key` passes.
+
+- [ ] **Step 4: Verify NULL fill and PK uniqueness against the built relation**
+
+Run this against `<dev_schema>` (the schema the build wrote to). Use the
+BigQuery MCP:
+
+```sql
+select
+  count(*) as n_rows,
+  count(distinct student_section_enrollment_key) as n_distinct_pk,
+  countif(student_enrollment_key is null) as n_enrollment_null,
+from `teamster-332318.<dev_schema>.dim_student_section_enrollments`
+```
+
+Expected: `n_rows = n_distinct_pk` (PK intact). `n_enrollment_null` ≈ 2,541
+(down from ~22K under the old point match — the orphan floor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  add src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql \
+      src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  commit -m "refactor(marts): resolve dim_student_section_enrollments enrollment by overlap
+
+Refs #4145
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add the multi-stint-overlap `warn` test
+
+**Files:**
+
+- Create:
+  `src/dbt/kipptaf/tests/dim_student_section_enrollments__no_multi_stint_overlap.sql`
+- Modify: `src/dbt/kipptaf/tests/properties.yml`
+
+- [ ] **Step 1: Create the test SQL**
+
+Create `dim_student_section_enrollments__no_multi_stint_overlap.sql` with:
+
+```sql
+with
+    student_enrollments as (
+        select studentid, schoolid, yearid, entrydate, exitdate, _dbt_source_project
+        from {{ ref("int_powerschool__student_enrollment_union") }}
+        where entrydate is not null and exitdate is not null
+    )
+
+select
+    cc.cc_dcid,
+    cc._dbt_source_project,
+    count(*) as n_overlapping_stints,
+from {{ ref("base_powerschool__course_enrollments") }} as cc
+inner join
+    student_enrollments as enr
+    on cc.cc_studentid = enr.studentid
+    and cc.sections_schoolid = enr.schoolid
+    and cc.cc_yearid = enr.yearid
+    and cc._dbt_source_project = enr._dbt_source_project
+    and enr.entrydate < cc.cc_dateleft
+    and enr.exitdate > cc.cc_dateenrolled
+where not cc.is_dropped_section
+group by cc.cc_dcid, cc._dbt_source_project
+having count(*) > 1
+```
+
+- [ ] **Step 2: Register the test in `properties.yml`**
+
+Append this entry under the top-level `data_tests:` list in
+`src/dbt/kipptaf/tests/properties.yml` (no `severity:` — the project default is
+`warn`, which is intended here):
+
+```yaml
+- name: dim_student_section_enrollments__no_multi_stint_overlap
+  description: >-
+    Warns when a non-dropped course-enrollment (cc) record overlaps more than
+    one school enrollment stint. dim_student_section_enrollments resolves these
+    to a single stint (covering-first, else earliest), so a nonzero count is a
+    known, monitored condition (baseline ~147, almost all genuine mid-year
+    drop/re-enroll) rather than a failure. Growth signals new boundary-spanning
+    sections to review.
+  config:
+    meta:
+      dagster:
+        ref:
+          name: dim_student_section_enrollments
+```
+
+- [ ] **Step 3: Run the test**
+
+Run:
+
+```bash
+uv run dbt test --project-dir \
+  /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select dim_student_section_enrollments__no_multi_stint_overlap
+```
+
+Expected: WARN (not error) reporting ~147 failing rows. A warn does not fail the
+run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  add src/dbt/kipptaf/tests/dim_student_section_enrollments__no_multi_stint_overlap.sql \
+      src/dbt/kipptaf/tests/properties.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  commit -m "test(marts): warn on multi-stint section-enrollment overlap
+
+Refs #4145
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Drop the direct FK from `fct_grades_assignments`
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml`
+
+- [ ] **Step 1: Remove the `student_enrollment_key` SELECT expression**
+
+In `fct_grades_assignments.sql`, delete this block from the `select` list (the
+`student_enrollments` CTE and its inner join STAY — they filter the assignment
+row population; add the trailing comment shown to record why):
+
+Remove:
+
+```sql
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "enr.student_number",
+                "enr._dbt_source_project",
+                "asg.academic_year",
+                "enr.entrydate",
+            ]
+        )
+    }} as student_enrollment_key,
+```
+
+Then add this comment immediately above the
+`inner join student_enrollments as enr` line:
+
+```sql
+-- retained as a row-population filter (assignment must fall within a covering
+-- school enrollment); enrollment linkage now flows via
+-- student_section_enrollment_key -> dim_student_section_enrollments
+```
+
+- [ ] **Step 2: Remove the column from the contract YAML**
+
+In `fct_grades_assignments.yml`, delete the entire `student_enrollment_key`
+column entry (the column `name`, `data_type`, `description`, the `foreign_key`
+constraint block, and the `not_null` + `relationships` `data_tests`):
+
+```yaml
+- name: student_enrollment_key
+  data_type: string
+  description: >-
+    FK to dim_student_enrollments. Surrogate key derived from student_number,
+    _dbt_source_project, academic_year, and entrydate.
+  constraints:
+    - type: foreign_key
+      to: ref('dim_student_enrollments')
+      to_columns: [student_enrollment_key]
+      warn_unsupported: false
+  data_tests:
+    - not_null
+
+    - relationships:
+        arguments:
+          to: ref('dim_student_enrollments')
+          field: student_enrollment_key
+```
+
+- [ ] **Step 3: Update the model description**
+
+In `fct_grades_assignments.yml`, change the model `description` FK sentence
+from:
+
+```yaml
+FK to dim_student_section_enrollments, dim_student_enrollments, dim_terms, and
+dim_dates (role-playing via due_date_key).
+```
+
+to:
+
+```yaml
+FK to dim_student_section_enrollments, dim_terms, and dim_dates (role-playing
+via due_date_key). Reaches dim_student_enrollments by traversing
+student_section_enrollment_key.
+```
+
+- [ ] **Step 4: Build and verify row count unchanged + traversal resolves**
+
+Run:
+
+```bash
+uv run dbt build --project-dir \
+  /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select fct_grades_assignments
+```
+
+Expected: PASS — `unique` (warn, per #3915) + `not_null` on
+`grades_assignment_key`, `not_null` + `relationships` on
+`student_section_enrollment_key`, all pass. No `student_enrollment_key` column
+remains.
+
+Then verify the traversal carries the enrollment and row count held (run against
+`<dev_schema>`):
+
+```sql
+select
+  count(*) as n_rows,
+  countif(d.student_enrollment_key is null) as n_traversed_null,
+from `teamster-332318.<dev_schema>.fct_grades_assignments` as f
+left join `teamster-332318.<dev_schema>.dim_student_section_enrollments` as d
+  on f.student_section_enrollment_key = d.student_section_enrollment_key
+```
+
+Expected: `n_rows` ≈ 25,410,721 (unchanged — the enr filter join was kept).
+`n_traversed_null` ≈ 0 (down from 985,984; the leftover is the orphan floor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  add src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql \
+      src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  commit -m "refactor(marts): drop direct student_enrollment_key FK from fct_grades_assignments
+
+Refs #4145
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Drop the direct FK from `fct_grades_term`
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql`
+- Modify: `src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml`
+
+- [ ] **Step 1: Remove the `student_enrollment_key` SELECT expression**
+
+In `fct_grades_term.sql`, delete this block from the `select` list (the
+`student_enrollments` CTE and its inner join STAY):
+
+```sql
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "enr.student_number",
+                "enr._dbt_source_project",
+                "fg.academic_year",
+                "enr.entrydate",
+            ]
+        )
+    }} as student_enrollment_key,
+```
+
+Then add this comment immediately above the
+`inner join student_enrollments as enr` line:
+
+```sql
+-- retained as a row-population filter (term grade must fall within a covering
+-- school enrollment); enrollment linkage now flows via
+-- student_section_enrollment_key -> dim_student_section_enrollments
+```
+
+- [ ] **Step 2: Remove the column from the contract YAML**
+
+In `fct_grades_term.yml`, delete the entire `student_enrollment_key` column
+entry:
+
+```yaml
+- name: student_enrollment_key
+  data_type: string
+  description: >-
+    FK to dim_student_enrollments. Surrogate key derived from student_number,
+    _dbt_source_project, academic_year, and entrydate.
+  constraints:
+    - type: foreign_key
+      to: ref('dim_student_enrollments')
+      to_columns: [student_enrollment_key]
+      warn_unsupported: false
+  data_tests:
+    - not_null
+
+    - relationships:
+        arguments:
+          to: ref('dim_student_enrollments')
+          field: student_enrollment_key
+```
+
+- [ ] **Step 3: Update the model description**
+
+In `fct_grades_term.yml`, change the model `description` FK sentence from:
+
+```yaml
+FK to dim_student_section_enrollments, dim_student_enrollments, dim_terms, and
+dim_dates (role-playing via term_start_date_key and term_end_date_key).
+```
+
+to:
+
+```yaml
+FK to dim_student_section_enrollments, dim_terms, and dim_dates (role-playing
+via term_start_date_key and term_end_date_key). Reaches dim_student_enrollments
+by traversing student_section_enrollment_key.
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run:
+
+```bash
+uv run dbt build --project-dir \
+  /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select fct_grades_term
+```
+
+Expected: PASS — `unique` + `not_null` on `grades_term_key`, FK tests on
+`student_section_enrollment_key` pass; no `student_enrollment_key` column.
+
+Verify (against `<dev_schema>`):
+
+```sql
+select
+  count(*) as n_rows,
+  countif(d.student_enrollment_key is null) as n_traversed_null,
+from `teamster-332318.<dev_schema>.fct_grades_term` as f
+left join `teamster-332318.<dev_schema>.dim_student_section_enrollments` as d
+  on f.student_section_enrollment_key = d.student_section_enrollment_key
+```
+
+Expected: `n_rows` ≈ 262,188 (unchanged). `n_traversed_null` ≈ 0 (down from 974;
+the ~47 nonpositive-length term rows from #4146 may remain).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  add src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql \
+      src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  commit -m "refactor(marts): drop direct student_enrollment_key FK from fct_grades_term
+
+Refs #4145
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Lint, full-chain build, and push for CI
+
+**Files:** none (verification + push).
+
+- [ ] **Step 1: Lint the changed SQL/YAML with trunk (from inside the
+      worktree)**
+
+Run (cwd must be the worktree; the binary lives in the main repo):
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond && \
+/workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql \
+  src/dbt/kipptaf/tests/dim_student_section_enrollments__no_multi_stint_overlap.sql \
+  src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql \
+  src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
+```
+
+Expected: no issues. If sqlfluff flags ST03 on `enrollment_overlap` despite the
+`-- trunk-ignore` line, confirm the directive sits on the line immediately above
+the CTE.
+
+- [ ] **Step 2: Build the full downstream chain locally**
+
+Run:
+
+```bash
+uv run dbt build --project-dir \
+  /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond/src/dbt/kipptaf \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select dim_student_section_enrollments+ fct_grades_assignments fct_grades_term
+```
+
+Expected: PASS (the multi-stint test WARNs at ~147; everything else passes).
+
+- [ ] **Step 3: Push the branch (hand to the user if the classifier blocks)**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-grades-enrollment-diamond \
+  push -u origin cbini/refactor/claude-grades-enrollment-diamond
+```
+
+- [ ] **Step 4: Open the PR**
+
+Use the GitHub MCP `create_pull_request` with base `main`, head
+`cbini/refactor/claude-grades-enrollment-diamond`, body from
+`.github/pull_request_template.md`, and `Closes #4145` in the body.
+
+- [ ] **Step 5: After dbt Cloud CI passes, verify against the PR-branch schema**
+
+Resolve `<job>` from `mcp__dbt__get_job_run_details` and run the four spec
+verification queries against `dbt_cloud_pr_<job>_<pr>_marts`:
+
+1. NULL linkage → ~0 for both facts (divergence query, `traversal NULL` bucket).
+2. Stint-mismatch ≈ 3,363 / 895 (unchanged — accepted residual).
+3. `dim_student_section_enrollments` PK still unique.
+4. No non-null → non-null hash drift on the dim's `student_enrollment_key`
+   (compare PR-branch vs prod for rows where prod key is non-null):
+
+   ```sql
+   select count(*) as n_nonnull_drift
+   from `teamster-332318.kipptaf_marts.dim_student_section_enrollments` as prod
+   inner join
+     `teamster-332318.dbt_cloud_pr_<job>_<pr>_marts.dim_student_section_enrollments` as pr
+     using (student_section_enrollment_key)
+   where
+     prod.student_enrollment_key is not null
+     and pr.student_enrollment_key is not null
+     and prod.student_enrollment_key != pr.student_enrollment_key
+   ```
+
+   Expected: 0.
+
+- [ ] **Step 6: Fetch CI warnings**
+
+After CI is green, run
+`mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)`. Confirm the
+only new warning is the multi-stint test (~147); triage any others per the marts
+pre-merge checklist.
+
+---
+
+## Notes / risks
+
+- **Hash change is one-directional.** The dim's `student_enrollment_key` only
+  goes NULL→populated; the facts compute their own key independently today, so
+  dropping the facts' column needs no producer/consumer hash migration.
+- **No Cube/Tableau consumer** reads either grade fact, so the dropped column
+  breaks nothing downstream (verified: `grep -rn` in `src/cube/` is empty).
+- **The kept enr inner join** in both facts preserves row population. If a
+  future PR wants to remove it, that is a deliberate row-count change requiring
+  its own measurement — out of scope here.
+- **Nonpositive-length sections** (#4146) are untouched; the ~47
+  `fct_grades_term` rows on them may keep a NULL traversed enrollment until that
+  issue lands.
+
+```
+
+```

--- a/docs/superpowers/plans/2026-06-08-collapse-grades-enrollment-diamond.md
+++ b/docs/superpowers/plans/2026-06-08-collapse-grades-enrollment-diamond.md
@@ -708,7 +708,3 @@ pre-merge checklist.
 - **Nonpositive-length sections** (#4146) are untouched; the ~47
   `fct_grades_term` rows on them may keep a NULL traversed enrollment until that
   issue lands.
-
-```
-
-```

--- a/docs/superpowers/specs/2026-06-08-collapse-grades-enrollment-diamond-design.md
+++ b/docs/superpowers/specs/2026-06-08-collapse-grades-enrollment-diamond-design.md
@@ -1,0 +1,199 @@
+# Collapse the `fct_grades_*` → `dim_student_enrollments` diamond
+
+Issue: [#4145](https://github.com/TEAMSchools/teamster/issues/4145) Date:
+2026-06-08
+
+## Problem
+
+`fct_grades_assignments` and `fct_grades_term` each carry two FK routes to
+`dim_student_enrollments`:
+
+- direct: `student_enrollment_key`
+- traversed: `student_section_enrollment_key` →
+  `dim_student_section_enrollments.student_enrollment_key`
+
+This is the diamond path forbidden by `marts/CLAUDE.md` → "Strict-chain
+traversal". The goal is to drop the direct FK so the only route to the
+enrollment dim is through `dim_student_section_enrollments`.
+
+## Why this is not a clean delete today
+
+The two routes are computed by independent join logic, so the direct FK is not
+redundant with the traversed one. Measured against prod `kipptaf_marts`:
+
+```text
+fct_grades_assignments (25,410,721 rows)
+  direct == traversed         24,421,374  (96.1%)
+  different stint (mismatch)       3,363  (0.013%)
+  traversal NULL, direct set     985,984  (3.88%)   <- blocker
+  FK fails to resolve                  0
+
+fct_grades_term (262,188 rows)
+  direct == traversed            260,319  (99.3%)
+  different stint (mismatch)         895  (0.34%)
+  traversal NULL, direct set         974  (0.37%)
+  FK fails to resolve                  0
+```
+
+Dropping the direct FK today would strand the ~986K NULL-linkage assignment
+rows: their section-enrollment parent has a NULL `student_enrollment_key`, so
+traversal yields no enrollment.
+
+## Root cause
+
+A section enrollment (`cc` record) is a child of one school enrollment stint.
+`dim_student_section_enrollments` resolves that parent with a **point** match —
+`cc_dateenrolled >= entrydate and cc_dateenrolled < exitdate`. The blocker is
+that **`cc_dateenrolled` precedes the stint's `entrydate`** for ~19.5K sections
+(the section roster date is set before the official enrollment date), so the
+point match drops them even though the section clearly belongs to — and uniquely
+overlaps — that stint. The assignment/term dates fall inside the stint, so the
+facts match and the dim does not. The school key is not a factor: a `cc` record
+is tied to a single school, and `cc_schoolid == sections_schoolid` for 100% of
+non-dropped `cc` records, so the dim's `sections_schoolid` scoping is
+unambiguous and equals the fact's `cc_schoolid`.
+
+Containment across all non-dropped section enrollments (655,718, grained on
+`cc_dcid + _dbt_source_project`):
+
+```text
+fully contained in exactly one stint        624,063  (95.2%)
+overlaps exactly one stint, not contained    28,967  (4.42%)
+  - section starts before stint entrydate    19,538   <- the blocker
+  - section ends after stint exitdate          9,568   (already point-matches)
+overlaps more than one stint                    147  (0.022%)
+overlaps no stint at all                      2,541  (0.39%)
+```
+
+So a section enrollment resolves to a **unique** school stint for 99.98% of
+records (contained or single-overlap). This is not a dedup problem — it is a
+resolution problem for ~19.5K sections whose roster date predates the stint.
+
+## Design: resolve each section to its overlapping school stint
+
+Change `dim_student_section_enrollments` to match the school stint the section
+enrollment **overlaps**
+(`entrydate < cc_dateleft and exitdate > cc_dateenrolled`, half-open) instead of
+the point anchor on `cc_dateenrolled`. Keep the existing join keys
+(`sections_schoolid`, `cc_yearid`, `_dbt_source_project`) — the school key needs
+no change.
+
+For 99.98% of sections this is a single match. Only **147** sections overlap
+more than one stint, and they are overwhelmingly legitimate, not data quality:
+
+```text
+exactly one covering stint   127  genuine drop/re-enroll; cc_dateenrolled sits
+                                  in one stint -> resolved to the stint it began
+no covering stint             20  section enrolled during a withdrawal gap
+                                  (18 short gaps, 2 are 122-year garbage)
+```
+
+Resolve each to the stint it began in, in priority order:
+
+1. the stint **covering** `cc_dateenrolled`
+   (`cc_dateenrolled >= entrydate and cc_dateenrolled < exitdate`) — unambiguous
+   for the 127, else
+2. the earliest overlapping stint (`entrydate asc`) — the 20 no-covering cases.
+
+Add a `warn`-level singular test that counts non-dropped `cc` records
+overlapping more than one stint (currently 147), so multi-overlap drift stays
+visible rather than being silently resolved.
+
+### Why this is safe for existing keys
+
+A section contained in stint A overlaps only stint A (stints within a
+student/school/year do not overlap each other), so all 624,063 contained
+sections — and the 9,568 "ends-after" sections that already point-match —
+resolve to the same stint as today. Their `student_enrollment_key` does not
+change. Every key change is a **NULL → populated** transition (the ~19.5K
+starts-before sections plus the 147 boundary-spanners, which were NULL because
+the point match failed). No existing non-null key moves.
+
+### Implementation notes
+
+- Half-open intervals throughout per the date-range-join convention.
+- Resolve the stint in a CTE at `cc` grain **before** the reporting-terms join,
+  so the resolution cannot interact with term-join cardinality.
+- The overlap match fans out only for the 147 boundary-spanners; collapse them
+  with
+  `dbt_utils.deduplicate(partition_by="cc_dcid, _dbt_source_project", order_by="is_covering desc, enr_entrydate asc")`
+  — **not** `qualify row_number() = 1`. Precompute `is_covering` as a boolean
+  column in the overlap-join CTE; do not inline a CASE into the surrogate-key
+  inputs.
+- `is_covering desc` → NULLS LAST by default; entrydate is non-null here, so the
+  BigQuery `array_agg` NULLS-ordering restriction does not apply.
+- The resolved row's enr attributes are authoritative including NULL — do not
+  `coalesce` to a fallback row.
+- Add the multi-overlap monitor as a singular `warn` test under
+  `src/dbt/kipptaf/tests/` (counts non-dropped `cc` records overlapping >1
+  enrollment stint; refs default to kipptaf, no `package:` needed). Baseline is
+  147; the test exists for drift visibility, not to fail CI.
+
+## Dropping the direct FK
+
+After the dim change is verified, in both `fct_grades_assignments` and
+`fct_grades_term`:
+
+- remove the `student_enrollment_key` column from the SELECT (and its
+  `student_enrollments` CTE / join where no longer otherwise needed);
+- remove the column entry, its `foreign_key` constraint, and its `relationships`
+  test from the model's properties YAML;
+- update the model `description` (drop "FK to ... dim_student_enrollments ...").
+
+Consumers reach the enrollment dim by traversing
+`student_section_enrollment_key` → `dim_student_section_enrollments` →
+`student_enrollment_key`.
+
+## Consumer / blast radius
+
+- **Cube**: no cube or view references either grade fact (`grep -rn` in
+  `src/cube/` returns nothing). Dropping the facts' `student_enrollment_key`
+  breaks no Cube model. The grade facts remain listed in `cube.yml` `depends_on`
+  (the dependency exposure) but are not modeled.
+- **Marts**: no other mart `ref()`s the two facts.
+- **Dim hash change**: `dim_student_section_enrollments.student_enrollment_key`
+  changes only NULL→populated. No existing non-null value moves, so no consumer
+  keyed on a non-null value breaks. The dim's own `relationships` test to
+  `dim_student_enrollments` stays valid (the new keys reference real enrollment
+  rows).
+
+## Residual / accepted
+
+- **Stint-mismatch (0.013% / 0.34%)** — irreducible: a single section-grain dim
+  row cannot carry a different enrollment per assignment due date. Accepted for
+  grade reporting. The only reason to keep the direct FK would be a hard
+  requirement for grade-time-exact enrollment attribution, which is not a
+  current requirement.
+- **2,541 orphan sections** (overlap no stint) stay NULL. They carry ~0
+  assignments; ~1,400 have no enrollment record at all that year (pre-existing
+  upstream gap), and ~1,140 are nonpositive-length sections handled separately
+  in [#4146](https://github.com/TEAMSchools/teamster/issues/4146).
+
+## Verification
+
+Run against the PR-branch schema (`dbt_cloud_pr_<job>_<pr>_marts`):
+
+1. **NULL linkage → ~0** — re-run the divergence query (direct vs traversed) for
+   both facts; `traversal NULL, direct set` should drop from 985,984 / 974 to
+   ~the orphan floor.
+2. **Mismatch unchanged** — the ~0.013% / 0.34% stint-mismatch persists
+   (documented residual).
+3. **PK intact** — `dim_student_section_enrollments` stays unique on
+   `student_section_enrollment_key` (the 147-row resolution collapses the
+   overlap fan-out).
+4. **No non-null hash drift** — count dim rows whose `student_enrollment_key`
+   changed from one non-null value to a different non-null value; expect 0.
+5. `dbt build --select state:modified+` green against staging.
+
+## Out of scope
+
+- **Nonpositive-length sections** (`cc_dateenrolled >= cc_dateleft`, 1,394
+  records; 0 assignment grades, 47 term grades) and the 2 pre-2000 garbage
+  sections — tracked in
+  [#4146](https://github.com/TEAMSchools/teamster/issues/4146) as a
+  staging-layer filter. Not gating this work.
+- Aligning the assessment-scoped enrollment models (separate diamond, separate
+  issue if needed).
+- Any change to `dim_student_enrollments` itself.
+- Per-assignment enrollment attribution (would require a fact-grain enrollment
+  key, the opposite of this change).

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -1,7 +1,6 @@
 with
     student_enrollments as (
         select
-            _dbt_source_relation,
             _dbt_source_project,
             studentid,
             schoolid,
@@ -13,15 +12,18 @@ with
         from {{ ref("int_powerschool__student_enrollment_union") }}
     ),
 
-    course_enrollments_joined as (
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    enrollment_overlap as (
         select
-            cc._dbt_source_relation,
             cc._dbt_source_project,
             cc.cc_dcid,
             cc.sections_dcid,
             cc.cc_academic_year,
             cc.cc_dateenrolled,
             cc.cc_dateleft,
+            cc.cc_abs_termid,
+            cc.sections_schoolid,
+            cc.region,
             cc.is_dropped_section,
             cc.is_dropped_course,
 
@@ -30,26 +32,60 @@ with
             enr.academic_year as enr_academic_year,
             enr.entrydate as enr_entrydate,
 
+            (
+                cc.cc_dateenrolled >= enr.entrydate
+                and cc.cc_dateenrolled < enr.exitdate
+            ) as is_covering,
+        from {{ ref("base_powerschool__course_enrollments") }} as cc
+        -- alumni placeholder rows (enroll_status=3) have NULL entrydate/exitdate
+        -- and match no stint here, producing a NULL student_enrollment_key
+        left join
+            student_enrollments as enr
+            on cc.cc_studentid = enr.studentid
+            and cc.sections_schoolid = enr.schoolid
+            and cc.cc_yearid = enr.yearid
+            and cc._dbt_source_project = enr._dbt_source_project
+            and cc.cc_dateleft > enr.entrydate
+            and cc.cc_dateenrolled < enr.exitdate
+    ),
+
+    enrollment_resolved as (
+        {{
+            dbt_utils.deduplicate(
+                relation="enrollment_overlap",
+                partition_by="cc_dcid, _dbt_source_project",
+                order_by="is_covering desc, enr_entrydate asc",
+            )
+        }}
+    ),
+
+    course_enrollments_joined as (
+        select
+            er.cc_dcid,
+            er._dbt_source_project,
+            er.sections_dcid,
+            er.cc_academic_year,
+            er.cc_dateenrolled,
+            er.cc_dateleft,
+            er.is_dropped_section,
+            er.is_dropped_course,
+            er.enr_source_project,
+            er.enr_student_number,
+            er.enr_academic_year,
+            er.enr_entrydate,
+
             rt.`type` as rt_type,
             rt.code as rt_code,
             rt.name as rt_name,
             rt.start_date as rt_start_date,
             rt.region as rt_region,
             rt.school_id as rt_school_id,
-        from {{ ref("base_powerschool__course_enrollments") }} as cc
-        left join
-            student_enrollments as enr
-            on cc.cc_studentid = enr.studentid
-            and cc.sections_schoolid = enr.schoolid
-            and cc.cc_yearid = enr.yearid
-            and cc.cc_dateenrolled >= enr.entrydate
-            and cc.cc_dateenrolled < enr.exitdate
-            and cc._dbt_source_project = enr._dbt_source_project
+        from enrollment_resolved as er
         left join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
-            on cc.cc_abs_termid = rt.powerschool_term_id
-            and cc.sections_schoolid = rt.school_id
-            and cc.region = rt.region
+            on er.cc_abs_termid = rt.powerschool_term_id
+            and er.sections_schoolid = rt.school_id
+            and er.region = rt.region
             and rt.`type` = 'RT'
     )
 

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -25,9 +25,11 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from student_number, _dbt_source_project,
-          academic_year, and entrydate. FK to dim_student_enrollments. Null when
-          no matching student enrollment record covers the CC dateenrolled.
-
+          academic_year, and entrydate. FK to dim_student_enrollments. Resolved
+          to the school enrollment stint the section enrollment overlaps (the
+          stint covering cc_dateenrolled when one exists, else the earliest
+          overlapping stint). Null only when no enrollment stint overlaps the
+          section enrollment.
         constraints:
           - type: foreign_key
             to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
@@ -58,17 +58,6 @@ select
     {{ dbt_utils.generate_surrogate_key(["ce.cc_dcid", "ce._dbt_source_project"]) }}
     as student_section_enrollment_key,
 
-    {{
-        dbt_utils.generate_surrogate_key(
-            [
-                "enr.student_number",
-                "enr._dbt_source_project",
-                "asg.academic_year",
-                "enr.entrydate",
-            ]
-        )
-    }} as student_enrollment_key,
-
     if(
         rt.code is not null,
         {{
@@ -112,6 +101,9 @@ inner join
     and asg.duedate >= ce.cc_dateenrolled
     and asg.duedate < ce.cc_dateleft
     and {{ union_dataset_join_clause(left_alias="asg", right_alias="ce") }}
+-- retained as a row-population filter (assignment must fall within a covering
+-- school enrollment); enrollment linkage now flows via
+-- student_section_enrollment_key -> dim_student_section_enrollments
 inner join
     student_enrollments as enr
     on ce.cc_studentid = enr.studentid

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
@@ -35,17 +35,6 @@ select
     {{ dbt_utils.generate_surrogate_key(["fg.cc_dcid", "fg._dbt_source_project"]) }}
     as student_section_enrollment_key,
 
-    {{
-        dbt_utils.generate_surrogate_key(
-            [
-                "enr.student_number",
-                "enr._dbt_source_project",
-                "fg.academic_year",
-                "enr.entrydate",
-            ]
-        )
-    }} as student_enrollment_key,
-
     if(
         rt.code is not null,
         {{
@@ -88,6 +77,9 @@ select
 
     cast(fg.exclude_from_gpa as bool) as is_excluded_from_gpa,
 from {{ ref("base_powerschool__final_grades") }} as fg
+-- retained as a row-population filter (term grade must fall within a covering
+-- school enrollment); enrollment linkage now flows via
+-- student_section_enrollment_key -> dim_student_section_enrollments
 inner join
     student_enrollments as enr
     on fg.studentid = enr.studentid

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -5,9 +5,9 @@ models:
       (assignmentsectionid x student). Contains score, points possible,
       missing/late/exempt flags, and category information. Assignments are
       matched to student enrollments only when the due date falls within the
-      enrollment period. FK to dim_student_section_enrollments,
-      dim_student_enrollments, dim_terms, and dim_dates (role-playing via
-      due_date_key).
+      enrollment period. FK to dim_student_section_enrollments, dim_terms, and
+      dim_dates (role-playing via due_date_key). Reaches dim_student_enrollments
+      by traversing student_section_enrollment_key.
     columns:
       - name: grades_assignment_key
         data_type: string
@@ -44,23 +44,6 @@ models:
               arguments:
                 to: ref('dim_student_section_enrollments')
                 field: student_section_enrollment_key
-      - name: student_enrollment_key
-        data_type: string
-        description: >-
-          FK to dim_student_enrollments. Surrogate key derived from
-          student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
-        data_tests:
-          - not_null
-
-          - relationships:
-              arguments:
-                to: ref('dim_student_enrollments')
-                field: student_enrollment_key
       - name: term_key
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -4,9 +4,10 @@ models:
       Term-level grade fact table. One row per student x section enrollment x
       term (storecode). Contains percent and letter grades for the term and
       running year-to-date (Y1) calculations, citizenship, grade points, and
-      credit hours. FK to dim_student_section_enrollments,
-      dim_student_enrollments, dim_terms, and dim_dates (role-playing via
-      term_start_date_key and term_end_date_key).
+      credit hours. FK to dim_student_section_enrollments, dim_terms, and
+      dim_dates (role-playing via term_start_date_key and term_end_date_key).
+      Reaches dim_student_enrollments by traversing
+      student_section_enrollment_key.
     columns:
       - name: grades_term_key
         data_type: string
@@ -37,23 +38,6 @@ models:
               arguments:
                 to: ref('dim_student_section_enrollments')
                 field: student_section_enrollment_key
-      - name: student_enrollment_key
-        data_type: string
-        description: >-
-          FK to dim_student_enrollments. Surrogate key derived from
-          student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
-        data_tests:
-          - not_null
-
-          - relationships:
-              arguments:
-                to: ref('dim_student_enrollments')
-                field: student_enrollment_key
       - name: term_key
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/tests/dim_student_section_enrollments__no_multi_stint_overlap.sql
+++ b/src/dbt/kipptaf/tests/dim_student_section_enrollments__no_multi_stint_overlap.sql
@@ -1,0 +1,20 @@
+with
+    student_enrollments as (
+        select studentid, schoolid, yearid, entrydate, exitdate, _dbt_source_project,
+        from {{ ref("int_powerschool__student_enrollment_union") }}
+        where entrydate is not null and exitdate is not null
+    )
+
+select cc.cc_dcid, cc._dbt_source_project, count(*) as n_overlapping_stints,
+from {{ ref("base_powerschool__course_enrollments") }} as cc
+inner join
+    student_enrollments as enr
+    on cc.cc_studentid = enr.studentid
+    and cc.sections_schoolid = enr.schoolid
+    and cc.cc_yearid = enr.yearid
+    and cc._dbt_source_project = enr._dbt_source_project
+    and cc.cc_dateleft > enr.entrydate
+    and cc.cc_dateenrolled < enr.exitdate
+where not cc.is_dropped_section
+group by cc.cc_dcid, cc._dbt_source_project
+having count(*) > 1

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -164,3 +164,17 @@ data_tests:
         dagster:
           ref:
             name: int_collegeboard__ap_unpivot
+
+  - name: dim_student_section_enrollments__no_multi_stint_overlap
+    description: >-
+      Warns when a non-dropped course-enrollment (cc) record overlaps more than
+      one school enrollment stint. dim_student_section_enrollments resolves
+      these to a single stint (covering-first, else earliest), so a nonzero
+      count is a known, monitored condition (baseline ~147, almost all genuine
+      mid-year drop/re-enroll) rather than a failure. Growth signals new
+      boundary-spanning sections to review.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: dim_student_section_enrollments


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will remove the star-schema diamond where
`fct_grades_assignments` and `fct_grades_term` each had **two** FK routes to
`dim_student_enrollments` (a direct `student_enrollment_key` and a traversal via
`student_section_enrollment_key`), violating the `marts/CLAUDE.md` "Strict-chain
traversal" rule.

The direct FK was not redundant today because the three models resolved the
enrollment with different join logic — so simply dropping it would have stranded
~986K assignment rows whose section-enrollment parent had a NULL
`student_enrollment_key`. Root cause: `dim_student_section_enrollments` resolved
the parent stint with a **point** match on `cc_dateenrolled`, which falls
outside the stint for ~19.5K sections whose roster date precedes the official
`entrydate`.

Changes:

1. `dim_student_section_enrollments` now resolves each course-enrollment to the
   school stint it **overlaps** (unique for 99.98% of records), collapsing the
   147 genuine mid-year drop/re-enroll spanners with a covering-first
   deterministic pick via `dbt_utils.deduplicate`. This is a NULL to populated
   change only — no existing non-null `student_enrollment_key` moves.
2. New `warn`-level singular test `dim_student_section_enrollments__no_multi_stint_overlap`
   monitors multi-stint drift (baseline ~147).
3. Direct `student_enrollment_key` FK dropped from both grade facts (SELECT +
   contract YAML). The `student_enrollments` inner join is retained as a
   row-population filter, so row counts are unchanged.
4. Latent FK-correctness gain: both facts previously hashed
   `student_enrollment_key` with the fact's own `academic_year`
   (`asg.academic_year` / `fg.academic_year`) rather than the enrollment's.
   `dim_student_enrollments` — and now the traversal — hashes the enrollment's
   `academic_year`, so routing through the dim closes a silent-orphan gap for any
   row where those two diverged.

Design + analysis: `docs/superpowers/specs/2026-06-08-collapse-grades-enrollment-diamond-design.md`.

Closes #4145. Follow-up DQ (nonpositive-length `cc` sections) tracked in #4146.

## AI Assistance

Claude Code (Opus 4.8) authored this end-to-end — diagnosis, the data analysis
that drove the design, the spec/plan, and the implementation (subagent-driven,
with spec + code-quality review per task). Human-directed: the key structural
insights (section within stint containment, `cc` records tied to one school),
the fix-vs-document decision, and treating the 147 as data-quality before
profiling confirmed they are mostly legitimate.

## Self-review

### dbt

- [x] Properties file present — the new singular test has a `properties.yml`
      entry; no new models added.
- [x] Exposures: **not breaking.** Removing `student_enrollment_key` from the
      two contracted facts breaks no downstream consumer — no Cube model
      references either grade fact (`grep -rn` in `src/cube/` is empty) and no
      other mart `ref()`s them. The facts appear only in `cube.yml`
      `depends_on`.
- [x] **Breaking change?** Column removal from contracted marts, but verified
      non-breaking per above. The dim's `student_enrollment_key` hash changes
      only NULL to populated, so nothing keyed on a non-null value is affected.
- [x] No external sources added or modified.

## CI checks

- [x] **Trunk** — MD040 (a stray empty code fence in the plan doc) tripped the
      first run; fixed in `2a6c27da7` and re-running. The 8 changed SQL/YAML
      files were clean throughout.
- [x] **dbt Cloud** — passed (2m25s). Verified against the PR-branch schema:
      `fct_grades_assignments` traversed-enrollment NULL = 0 (was 985,984),
      `fct_grades_term` = 12 (was 974), no non-null hash drift, row counts
      unchanged. Remaining test warns are pre-existing (#3900 / #3915
      double-writes, #3817 assessment FK) — see the verification comment.
- [x] **Dagster Cloud** — not triggered (no Dagster code changes).
