### PR TITLE
feat(dbt): add school_abbreviation and school_level to base_powerschool__sections

### DIFF
--- a/src/dbt/powerschool/models/sis/base/base_powerschool__sections.sql
+++ b/src/dbt/powerschool/models/sis/base/base_powerschool__sections.sql
@@ -24,6 +24,8 @@ select
     }},
 
     sch.name as school_name,
+    sch.abbreviation as school_abbreviation,
+    sch.school_level,
 
     t.teachernumber,
     t.lastfirst as teacher_lastfirst,

--- a/src/dbt/powerschool/models/sis/base/properties/base_powerschool__sections.yml
+++ b/src/dbt/powerschool/models/sis/base/properties/base_powerschool__sections.yml
@@ -371,13 +371,22 @@ models:
         data_type: int64
       - name: terms_fiscal_year
         data_type: int64
+      - name: school_name
+        data_type: string
+        description:
+          Full name of the school, sourced from stg_powerschool__schools.
+      - name: school_abbreviation
+        data_type: string
+        description:
+          Short abbreviation for the school, sourced from
+          stg_powerschool__schools.
+      - name: school_level
+        data_type: string
+        description:
+          School level (ES, MS, HS), sourced from stg_powerschool__schools.
       - name: teachernumber
         data_type: string
       - name: teacher_lastfirst
-        data_type: string
-      - name: school_abbreviation
-        data_type: string
-      - name: school_level
         data_type: string
       - name: courses_gradescaleid_unweighted
         data_type: int64

--- a/src/dbt/powerschool/models/sis/base/properties/base_powerschool__sections.yml
+++ b/src/dbt/powerschool/models/sis/base/properties/base_powerschool__sections.yml
@@ -375,5 +375,9 @@ models:
         data_type: string
       - name: teacher_lastfirst
         data_type: string
+      - name: school_abbreviation
+        data_type: string
+      - name: school_level
+        data_type: string
       - name: courses_gradescaleid_unweighted
         data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR will add `school_abbreviation` and `school_level` from the existing `stg_powerschool__schools` join to `base_powerschool__sections`. Both fields are already present on `base_powerschool__student_enrollments`; the gap is the section-grain base model.

No duplication risk: the join to `stg_powerschool__schools` is already there (many-to-one on `school_number`). This is a purely additive change.

`base_powerschool__course_enrollments` uses `dbt_utils.star(from=ref("base_powerschool__sections"))`, so both new columns will automatically surface in that model at the next district rebuild — no changes needed there.

Once this merges and Dagster rebuilds district projects in prod, the `stg_powerschool__schools` re-joins in `int_tableau__gradebook_audit_teacher_scaffold` and `int_powerschool__gradebook_assignments_scores` (kipptaf) can be removed in a follow-up PR.

AI-assisted: Claude Code drafted the two-line SQL addition and YAML entries. Direction and scope were human.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — updated `base_powerschool__sections.yml` with the two new columns
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No — additive only. No columns renamed or removed.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215542145916744