### PR TITLE
refactor(dbt): rename rpt_lattice__users.region to business_unit

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -49,7 +49,7 @@ models:
         description:
           Home work location abbreviation; falls back to full location name.
         data_type: string
-      - name: region
+      - name: business_unit
         description:
           Friendly region name derived from home business unit (Newark, Camden,
           Miami, Paterson, KTAF).

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -51,6 +51,6 @@ models:
         data_type: string
       - name: business_unit
         description:
-          Friendly region name derived from home business unit (Newark, Camden,
-          Miami, Paterson, KTAF).
+          Friendly business unit name derived from the employee's home business
+          unit (Newark, Camden, Miami, Paterson, KTAF).
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -72,6 +72,6 @@ select
         then 'Newark'
         when 'KIPP Cooper Norcross Academy'
         then 'Camden'
-    end as region,
+    end as business_unit,
 from staff as s
 left join managers as m on s.reports_to_employee_number = m.employee_number


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Rename the `region` column in `rpt_lattice__users` to `business_unit` so the
outbound Lattice users CSV carries the header Lattice now expects. The value
logic is unchanged — it is still the friendly region name derived from home
business unit (Newark / Camden / Miami / Paterson / KTAF). Only the SELECT alias
and the contract column name change.

After merge + prod materialize, the `kipptaf/extracts/lattice` asset will be
manually materialized to push the renamed-header file to Lattice over SFTP.

## AI Assistance

Claude-authored under human direction (Cristina specified the column and target
name). Claude located the model + extract asset, made the rename in SQL and the
contract YAML, validated the build against dev, and opened this PR.

## Self-review

### dbt

- [x] Properties file updated alongside the model (`rpt_lattice__users.yml`)
- [x] **Breaking change?** This renames a column in a contracted `rpt_` model.
      The only consumer is the Lattice SFTP import (`kipptaf/extracts/lattice`) —
      there is no dbt exposure or downstream model referencing this column (grep
      confirmed). Lattice expects the `business_unit` header.
      **Rollback:** revert this commit; the next `lattice_extract`
      materialization restores the `region` header.

## CI checks

- [x] **Trunk** — passes locally (`trunk check --force` on both files: no issues).
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — not expected (no Dagster code change).

Refs: outbound Lattice users feed header alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)