### PR TITLE
feat(dbt): add Marketing, Comms, and Enrollment staff to Lattice users

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -2,10 +2,12 @@ models:
   - name: rpt_lattice__users
     description: >
       Daily staff roster for Lattice SFTP import. Includes all KIPP TEAM and
-      Family Schools Inc. employees, all KIPP Paterson employees, and
-      Director/Head/Leader-tier staff in Miami, Newark, and Camden who are
-      Active or on Leave, plus any staff who met those same business unit and
-      role criteria and were terminated within the past 30 days.
+      Family Schools Inc. employees, all KIPP Paterson employees,
+      Director/Head/Leader/Dean-tier (or Room 11) staff in Miami, and Newark and
+      Camden staff in select Operations director roles or in the Technology or
+      Marketing, Comms, and Enrollment departments. Interns are excluded. Covers
+      staff who are Active or on Leave, plus any staff who met those same
+      criteria and were terminated within the past 30 days.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -30,7 +30,8 @@ with
                 or (
                     home_business_unit_name
                     in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
-                    and home_department_name = 'Technology'
+                    and home_department_name
+                    in ('Technology', 'Marketing, Comms, and Enrollment')
                 )
             )
             and (


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will include **Marketing, Comms, and Enrollment** department staff (alongside the existing Technology department) in the Newark + Camden branch of the `rpt_lattice__users` staff filter, so those staff are provisioned in the Lattice users feed.

The starting working-tree edit added the new department as a bare `or home_department_name = '...'` outside the parentheses. Because `AND` binds tighter than `OR`, that would have pulled Marketing staff from **every** business unit, not just Newark + Camden. This PR folds both departments into a single `home_department_name in ('Technology', 'Marketing, Comms, and Enrollment')` clause so the business-unit scope stays intact.

## AI Assistance

AI-assisted: Claude Code flagged the operator-precedence bug in the original edit, applied the scoped fix, linted, and validated the build. Human-directed: the decision to scope Marketing/Comms/Enrollment to Newark + Camden only.

## Self-review

### dbt

- [x] No new models — modifies an existing `rpt_` model only; no properties/exposure changes needed.
- [x] No new or modified external sources.
- [x] Not a breaking change — no column renames or removals.

Validation: `trunk check` clean; `dbt build --select rpt_lattice__users` (dev, deferred) created the view and passed the `external_user_id` uniqueness test.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
