### PR TITLE
feat(kipptaf): add KIPP Aid award columns to kfwd dashboard

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -610,3 +610,37 @@ models:
           Overgrad. False if the student has no Overgrad top-choice data.
       - name: es_attended
         data_type: string
+      - name: id
+        data_type: string
+        description:
+          KIPP Aid award record ID (Salesforce) joined from
+          rpt_tableau__kfwd_aid_report on contact and academic year.
+      - name: aid_name
+        data_type: string
+        description: KIPP Aid record name / auto-number (e.g. KA-016473).
+      - name: amount
+        data_type: numeric
+        description: KIPP Aid award amount in dollars.
+      - name: award_date
+        data_type: date
+        description: Date the KIPP Aid award was recorded.
+      - name: created_date
+        data_type: timestamp
+        description: Timestamp the KIPP Aid record was created in Salesforce.
+      - name: fund_type
+        data_type: string
+        description:
+          Maher funding type parsed from the MAHER_FUND tag (Emergency,
+          Enrichment, or Unclassified); null when untagged.
+      - name: kipp_aid_count
+        data_type: numeric
+        description: KIPP Aid count value from the source record.
+      - name: notes
+        data_type: string
+        description:
+          Raw KIPP Aid award note, including any appended MAHER_FUND marker tag.
+      - name: notes_clean
+        data_type: string
+        description:
+          KIPP Aid award note with the MAHER_FUND tag and surrounding whitespace
+          removed; null when the note is null.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -610,37 +610,51 @@ models:
           Overgrad. False if the student has no Overgrad top-choice data.
       - name: es_attended
         data_type: string
+      - name: amount
+        data_type: numeric
+        description:
+          Total KIPP Aid award amount in dollars for the student in the academic
+          year, summed across all awards from rpt_tableau__kfwd_aid_report.
+      - name: aid_award_count
+        data_type: int64
+        description:
+          Number of KIPP Aid awards the student received in the academic year.
       - name: id
         data_type: string
         description:
-          KIPP Aid award record ID (Salesforce) joined from
-          rpt_tableau__kfwd_aid_report on contact and academic year.
+          KIPP Aid award record ID (Salesforce) of the student's most recent
+          award in the academic year (ordered by award_date, then created_date).
       - name: aid_name
         data_type: string
-        description: KIPP Aid record name / auto-number (e.g. KA-016473).
-      - name: amount
-        data_type: numeric
-        description: KIPP Aid award amount in dollars.
+        description:
+          KIPP Aid record name / auto-number (e.g. KA-016473) of the most recent
+          award in the academic year.
       - name: award_date
         data_type: date
-        description: Date the KIPP Aid award was recorded.
+        description:
+          Date the most recent KIPP Aid award in the academic year was recorded.
       - name: created_date
         data_type: timestamp
-        description: Timestamp the KIPP Aid record was created in Salesforce.
+        description:
+          Timestamp the most recent KIPP Aid award in the year was created in
+          Salesforce.
       - name: fund_type
         data_type: string
         description:
-          Maher funding type parsed from the MAHER_FUND tag (Emergency,
-          Enrichment, or Unclassified); null when untagged.
+          Maher funding type of the most recent award, parsed from the
+          MAHER_FUND tag (Emergency, Enrichment, or Unclassified); null when
+          untagged.
       - name: kipp_aid_count
         data_type: numeric
-        description: KIPP Aid count value from the source record.
+        description:
+          KIPP Aid count value from the most recent award's source record.
       - name: notes
         data_type: string
         description:
-          Raw KIPP Aid award note, including any appended MAHER_FUND marker tag.
+          Raw note from the most recent KIPP Aid award, including any appended
+          MAHER_FUND marker tag.
       - name: notes_clean
         data_type: string
         description:
-          KIPP Aid award note with the MAHER_FUND tag and surrounding whitespace
-          removed; null when the note is null.
+          Most recent KIPP Aid award note with the MAHER_FUND tag and
+          surrounding whitespace removed; null when the note is null.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -610,51 +610,132 @@ models:
           Overgrad. False if the student has no Overgrad top-choice data.
       - name: es_attended
         data_type: string
-      - name: amount
+      - name: total_aid_amount
         data_type: numeric
         description:
-          Total KIPP Aid award amount in dollars for the student in the academic
-          year, summed across all awards from rpt_tableau__kfwd_aid_report.
+          Total KIPP Aid award amount in dollars, summed across all of the
+          student's awards in the academic year.
       - name: aid_award_count
         data_type: int64
         description:
           Number of KIPP Aid awards the student received in the academic year.
-      - name: id
+      - name: award_1_name
         data_type: string
         description:
-          KIPP Aid award record ID (Salesforce) of the student's most recent
-          award in the academic year (ordered by award_date, then created_date).
-      - name: aid_name
-        data_type: string
-        description:
-          KIPP Aid record name / auto-number (e.g. KA-016473) of the most recent
-          award in the academic year.
-      - name: award_date
-        data_type: date
-        description:
-          Date the most recent KIPP Aid award in the academic year was recorded.
-      - name: created_date
-        data_type: timestamp
-        description:
-          Timestamp the most recent KIPP Aid award in the year was created in
-          Salesforce.
-      - name: fund_type
-        data_type: string
-        description:
-          Maher funding type of the most recent award, parsed from the
-          MAHER_FUND tag (Emergency, Enrichment, or Unclassified); null when
-          untagged.
-      - name: kipp_aid_count
+          Record name / auto-number of the student's award number 1 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 1 award(s).
+      - name: award_1_amount
         data_type: numeric
         description:
-          KIPP Aid count value from the most recent award's source record.
-      - name: notes
+          Amount in dollars of the student's award number 1 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 1 award(s).
+      - name: award_2_name
         data_type: string
         description:
-          Raw note from the most recent KIPP Aid award, including any appended
-          MAHER_FUND marker tag.
-      - name: notes_clean
+          Record name / auto-number of the student's award number 2 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 2 award(s).
+      - name: award_2_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 2 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 2 award(s).
+      - name: award_3_name
         data_type: string
         description:
-          Most recent KIPP Aid award note with the MAHER_FUND tag and
-          surrounding whitespace removed; null when the note is null.
+          Record name / auto-number of the student's award number 3 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 3 award(s).
+      - name: award_3_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 3 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 3 award(s).
+      - name: award_4_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 4 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 4 award(s).
+      - name: award_4_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 4 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 4 award(s).
+      - name: award_5_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 5 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 5 award(s).
+      - name: award_5_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 5 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 5 award(s).
+      - name: award_6_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 6 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 6 award(s).
+      - name: award_6_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 6 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 6 award(s).
+      - name: award_7_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 7 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 7 award(s).
+      - name: award_7_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 7 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 7 award(s).
+      - name: award_8_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 8 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 8 award(s).
+      - name: award_8_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 8 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 8 award(s).
+      - name: award_9_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 9 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 9 award(s).
+      - name: award_9_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 9 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 9 award(s).
+      - name: award_10_name
+        data_type: string
+        description:
+          Record name / auto-number of the student's award number 10 in the
+          academic year (awards ordered earliest first); null when the student
+          had fewer than 10 award(s).
+      - name: award_10_amount
+        data_type: numeric
+        description:
+          Amount in dollars of the student's award number 10 in the academic
+          year (awards ordered earliest first); null when the student had fewer
+          than 10 award(s).

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -619,6 +619,8 @@ models:
         data_type: int64
         description:
           Number of KIPP Aid awards the student received in the academic year.
+          May exceed the number of populated award_N_* slots when the count of
+          awards exceeds the pivot's fixed slot limit.
       - name: award_1_name
         data_type: string
         description:
@@ -628,9 +630,9 @@ models:
       - name: award_1_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 1 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 1 award(s).
+          Amount in dollars of the student's award number 1 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          1 award(s).
       - name: award_2_name
         data_type: string
         description:
@@ -640,9 +642,9 @@ models:
       - name: award_2_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 2 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 2 award(s).
+          Amount in dollars of the student's award number 2 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          2 award(s).
       - name: award_3_name
         data_type: string
         description:
@@ -652,9 +654,9 @@ models:
       - name: award_3_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 3 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 3 award(s).
+          Amount in dollars of the student's award number 3 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          3 award(s).
       - name: award_4_name
         data_type: string
         description:
@@ -664,9 +666,9 @@ models:
       - name: award_4_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 4 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 4 award(s).
+          Amount in dollars of the student's award number 4 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          4 award(s).
       - name: award_5_name
         data_type: string
         description:
@@ -676,9 +678,9 @@ models:
       - name: award_5_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 5 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 5 award(s).
+          Amount in dollars of the student's award number 5 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          5 award(s).
       - name: award_6_name
         data_type: string
         description:
@@ -688,9 +690,9 @@ models:
       - name: award_6_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 6 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 6 award(s).
+          Amount in dollars of the student's award number 6 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          6 award(s).
       - name: award_7_name
         data_type: string
         description:
@@ -700,9 +702,9 @@ models:
       - name: award_7_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 7 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 7 award(s).
+          Amount in dollars of the student's award number 7 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          7 award(s).
       - name: award_8_name
         data_type: string
         description:
@@ -712,9 +714,9 @@ models:
       - name: award_8_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 8 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 8 award(s).
+          Amount in dollars of the student's award number 8 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          8 award(s).
       - name: award_9_name
         data_type: string
         description:
@@ -724,9 +726,9 @@ models:
       - name: award_9_amount
         data_type: numeric
         description:
-          Amount in dollars of the student's award number 9 in the academic
-          year (awards ordered earliest first); null when the student had fewer
-          than 9 award(s).
+          Amount in dollars of the student's award number 9 in the academic year
+          (awards ordered earliest first); null when the student had fewer than
+          9 award(s).
       - name: award_10_name
         data_type: string
         description:

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -217,16 +217,16 @@ with
 
     aid_awards as (
         select
-            sf_contact_id,
+            student as sf_contact_id,
             academic_year,
-            aid_name,
+            `name` as aid_name,
             amount,
 
             row_number() over (
-                partition by sf_contact_id, academic_year
-                order by award_date asc, created_date asc
+                partition by student, academic_year
+                order by `date` asc, created_date asc, id asc
             ) as rn_award,
-        from {{ ref("rpt_tableau__kfwd_aid_report") }}
+        from {{ ref("stg_kippadb__kipp_aid") }}
     ),
 
     aid_pivot as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -1,3 +1,4 @@
+{%- set max_awards = 10 -%}
 with
     year_scaffold as (
         select {{ var("current_academic_year") }} as academic_year
@@ -218,28 +219,30 @@ with
         select
             sf_contact_id,
             academic_year,
-            id,
             aid_name,
-            award_date,
-            created_date,
-            fund_type,
-            kipp_aid_count,
-            notes,
-            notes_clean,
-
-            sum(amount) over (
-                partition by sf_contact_id, academic_year
-            ) as total_aid_amount,
-
-            count(*) over (
-                partition by sf_contact_id, academic_year
-            ) as aid_award_count,
+            amount,
 
             row_number() over (
                 partition by sf_contact_id, academic_year
-                order by award_date desc, created_date desc
+                order by award_date asc, created_date asc
             ) as rn_award,
         from {{ ref("rpt_tableau__kfwd_aid_report") }}
+    ),
+
+    aid_pivot as (
+        select
+            sf_contact_id,
+            academic_year,
+
+            sum(amount) as total_aid_amount,
+
+            count(*) as aid_award_count,
+            {%- for i in range(1, max_awards + 1) %}
+            max(if(rn_award = {{ i }}, aid_name, null)) as award_{{ i }}_name,
+            max(if(rn_award = {{ i }}, amount, null)) as award_{{ i }}_amount,
+            {%- endfor %}
+        from aid_awards
+        group by sf_contact_id, academic_year
     )
 
 select
@@ -548,16 +551,12 @@ select
 
     ba.n_ba_enrolled_semesters,
 
-    kar.id,
-    kar.aid_name,
-    kar.award_date,
-    kar.created_date,
-    kar.fund_type,
-    kar.kipp_aid_count,
-    kar.notes,
-    kar.notes_clean,
+    kar.total_aid_amount,
     kar.aid_award_count,
-    kar.total_aid_amount as amount,
+    {%- for i in range(1, max_awards + 1) %}
+    kar.award_{{ i }}_name,
+    kar.award_{{ i }}_amount,
+    {%- endfor %}
 
     if(
         c.contact_kipp_region_name = 'KIPP Miami' and c.ktc_status like 'TAF%',
@@ -782,10 +781,9 @@ left join
     {{ ref("int_overgrad__choice_counts") }} as ogc on c.contact_id = ogc.contact_id
 left join {{ ref("int_overgrad__top_choices") }} as otc on c.contact_id = otc.contact_id
 left join
-    aid_awards as kar
+    aid_pivot as kar
     on c.contact_id = kar.sf_contact_id
     and ay.academic_year = kar.academic_year
-    and kar.rn_award = 1
 where
     c.ktc_status in ('HS9', 'HS10', 'HS11', 'HS12', 'HSG', 'TAF', 'TAFHS')
     and c.contact_id is not null

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -238,8 +238,8 @@ with
 
             count(*) as aid_award_count,
             {%- for i in range(1, max_awards + 1) %}
-            max(if(rn_award = {{ i }}, aid_name, null)) as award_{{ i }}_name,
-            max(if(rn_award = {{ i }}, amount, null)) as award_{{ i }}_amount,
+                max(if(rn_award = {{ i }}, aid_name, null)) as award_{{ i }}_name,
+                max(if(rn_award = {{ i }}, amount, null)) as award_{{ i }}_amount,
             {%- endfor %}
         from aid_awards
         group by sf_contact_id, academic_year
@@ -554,8 +554,7 @@ select
     kar.total_aid_amount,
     kar.aid_award_count,
     {%- for i in range(1, max_awards + 1) %}
-    kar.award_{{ i }}_name,
-    kar.award_{{ i }}_amount,
+        kar.award_{{ i }}_name, kar.award_{{ i }}_amount,
     {%- endfor %}
 
     if(

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -520,6 +520,16 @@ select
 
     ba.n_ba_enrolled_semesters,
 
+    kar.id,
+    kar.aid_name,
+    kar.amount,
+    kar.award_date,
+    kar.created_date,
+    kar.fund_type,
+    kar.kipp_aid_count,
+    kar.notes,
+    kar.notes_clean,
+
     if(
         c.contact_kipp_region_name = 'KIPP Miami' and c.ktc_status like 'TAF%',
         'Miami TAF',
@@ -742,6 +752,10 @@ left join ba_semesters_enrolled as ba on c.contact_id = ba.sf_contact_id
 left join
     {{ ref("int_overgrad__choice_counts") }} as ogc on c.contact_id = ogc.contact_id
 left join {{ ref("int_overgrad__top_choices") }} as otc on c.contact_id = otc.contact_id
+left join
+    {{ ref("rpt_tableau__kfwd_aid_report") }} as kar
+    on c.contact_id = kar.sf_contact_id
+    and ay.academic_year = kar.academic_year
 where
     c.ktc_status in ('HS9', 'HS10', 'HS11', 'HS12', 'HSG', 'TAF', 'TAFHS')
     and c.contact_id is not null

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -212,6 +212,34 @@ with
         from {{ ref("int_kippadb__persistence") }}
         where rn_enrollment_year = 1 and pursuing_degree_type = "Bachelor's (4-year)"
         group by sf_contact_id
+    ),
+
+    aid_awards as (
+        select
+            sf_contact_id,
+            academic_year,
+            id,
+            aid_name,
+            award_date,
+            created_date,
+            fund_type,
+            kipp_aid_count,
+            notes,
+            notes_clean,
+
+            sum(amount) over (
+                partition by sf_contact_id, academic_year
+            ) as total_aid_amount,
+
+            count(*) over (
+                partition by sf_contact_id, academic_year
+            ) as aid_award_count,
+
+            row_number() over (
+                partition by sf_contact_id, academic_year
+                order by award_date desc, created_date desc
+            ) as rn_award,
+        from {{ ref("rpt_tableau__kfwd_aid_report") }}
     )
 
 select
@@ -522,13 +550,14 @@ select
 
     kar.id,
     kar.aid_name,
-    kar.amount,
     kar.award_date,
     kar.created_date,
     kar.fund_type,
     kar.kipp_aid_count,
     kar.notes,
     kar.notes_clean,
+    kar.aid_award_count,
+    kar.total_aid_amount as amount,
 
     if(
         c.contact_kipp_region_name = 'KIPP Miami' and c.ktc_status like 'TAF%',
@@ -753,9 +782,10 @@ left join
     {{ ref("int_overgrad__choice_counts") }} as ogc on c.contact_id = ogc.contact_id
 left join {{ ref("int_overgrad__top_choices") }} as otc on c.contact_id = otc.contact_id
 left join
-    {{ ref("rpt_tableau__kfwd_aid_report") }} as kar
+    aid_awards as kar
     on c.contact_id = kar.sf_contact_id
     and ay.academic_year = kar.academic_year
+    and kar.rn_award = 1
 where
     c.ktc_status in ('HS9', 'HS10', 'HS11', 'HS12', 'HSG', 'TAF', 'TAFHS')
     and c.contact_id is not null


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will surface each student's KIPP Aid awards on
`rpt_tableau__kfwd_dashboard`, joined from `rpt_tableau__kfwd_aid_report` on
`sf_contact_id` and `academic_year` (matching the dashboard's existing
per-student/per-year grain).

Awards are pivoted to **wide format** so the dashboard's one-row-per-student-per-year
grain is preserved (no fan-out). New columns:

- `total_aid_amount` — sum of all the student's awards that academic year
- `aid_award_count` — count of all awards that year
- `award_1_name` / `award_1_amount` … `award_10_name` / `award_10_amount` — each
  award in its own columns, ordered earliest-first

The slot count is a single tunable Jinja var (`{%- set max_awards = 10 -%}` at
the top of the model). Awards beyond the cap still contribute to
`total_aid_amount` and `aid_award_count`.

**AI Assistance:** Pivot structure, Jinja loop, and YAML contract entries were
Claude-authored; the join keys, aggregate-then-pivot approach, and the slot cap
were human-directed across iteration.

### Open items for reviewer

- **`max_awards = 10` is provisional.** It was not possible to query the
  warehouse during development to confirm the true max awards-per-student-per-year.
  Please run `select max(c) from (select count(*) c from
  rpt_tableau__kfwd_aid_report group by sf_contact_id, academic_year)` and bump
  the var if any student exceeds 10 (otherwise their extra awards drop from the
  `award_N_*` slots, though totals remain correct).
- Local `dbt build` / `trunk` could not run in the dev environment (package
  registry egress blocked); the Jinja was rendered to confirm it compiles to 20
  award columns matching the 22 YAML contract entries. **dbt Cloud CI is the
  validation gate.**

## Self-review

### dbt

- [x] Properties file updated — `rpt_tableau__kfwd_dashboard.yml` carries
      contract types + descriptions for all new columns
- [ ] Exposure — `rpt_tableau__kfwd_dashboard` already has its Tableau exposure;
      no new consumer added
- [x] **Breaking change?** Additive only — new columns, no renames/removals on
      existing dashboard columns

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)