### PR TITLE
feat(cube): assessment-scores semantic layer — design spec

### DIFF
--- a/docs/superpowers/plans/2026-06-11-assessment-scores-dbt-enrichments.md
+++ b/docs/superpowers/plans/2026-06-11-assessment-scores-dbt-enrichments.md
@@ -1,0 +1,238 @@
+# Assessment-scores dbt dim enrichments — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three DDI-parity dimension columns that are clean passthroughs of
+values already present upstream: `is_foundations` on `dim_courses`, and `is_504`
+
+- `year_in_network` on `dim_student_enrollments`.
+
+**Architecture:** Additive-only dbt mart changes in `kipptaf`. Each column
+already exists on a model the target dim already reads (or already joins), so
+these are projections — no new joins, no surrogate-key hash changes.
+
+**Tech Stack:** dbt (BigQuery), `src/dbt/kipptaf`. Work in the worktree
+`/workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube`.
+
+**Prerequisite:** Plan 1 (`2026-06-11-assessment-scores-dbt-foundation.md`)
+applied on this branch. Run Task 0 of Plan 1 (dbt deps) if not already done.
+
+**Scope guardrails:**
+
+- Additive only. No `generate_surrogate_key(...)` input changes, no new joins.
+- Follow `src/dbt/kipptaf/models/marts/CLAUDE.md` (R1–R10, ST06, reserved
+  words).
+- `git -C <worktree>` for git; name exact files in `git add` (never
+  `-u`/`-A`/`.`).
+- `--project-dir <worktree>/src/dbt/kipptaf` for dbt;
+  `--target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod`.
+
+**Deferred (NOT in this plan — need sourcing work, tracked separately):**
+
+- `head_of_school` — `dim_locations` is a single-sheet passthrough; adding it
+  needs a leadership-crosswalk join, and the obvious column
+  (`head_of_school_preferred_name_lastfirst`) is NULL on 18/19 schools, so the
+  real HoS-name source must be found first.
+- `is_self_contained` — no clean dim/intermediate derivation (every occurrence
+  is a `false`/`null` literal or a finalsite-roster passthrough).
+- `is_sipps` — derived flag (enrolled in course `SEM01099G1`), not a
+  passthrough.
+
+---
+
+## Task 1: Add `is_foundations` to `dim_courses`
+
+`dim_courses` already left-joins
+`stg_google_sheets__assessments__course_subject_crosswalk as csc` on
+`c.course_number = csc.powerschool_course_number` (it reads
+`csc.discipline as academic_subject`). `is_foundations` is on that same
+crosswalk — add one projection.
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql`
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml`
+
+- [ ] **Step 1: Confirm the crosswalk key is unique (no fan-out)**
+
+The join already exists, but confirm `dim_courses` will not fan out:
+
+```bash
+uv run dbt show --inline "select powerschool_course_number, count(*) as n from {{ ref('stg_google_sheets__assessments__course_subject_crosswalk') }} group by 1 having count(*) > 1" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+Expected: zero rows. (If any row returns, STOP — the existing join would already
+be fanning; raise it, do not dedupe.)
+
+- [ ] **Step 2: Add the column to `dim_courses.sql`**
+
+Add `csc.is_foundations,` to the SELECT, grouped with the other `csc.` column
+(`csc.discipline as academic_subject`) so ST06 keeps the `csc` enumerations
+together. Resulting SELECT body:
+
+```sql
+    c.course_number as course_code,
+    c.course_name as course_title,
+    c.credittype as credit_type,
+    c.credit_hours as credits,
+
+    csc.discipline as academic_subject,
+    csc.is_foundations,
+```
+
+(Reorder `credits` above the `csc` group if needed so the `c.` and `csc.`
+enumerations are not interleaved — run trunk check in Task 3 to confirm ST06.)
+
+- [ ] **Step 3: Add the column to the contract YAML**
+
+In `properties/dim_courses.yml`, add (read the file first, match formatting):
+
+```yaml
+- name: is_foundations
+  data_type: boolean
+  description: >-
+    TRUE if this course is a Foundations (intervention) course, per the
+    course-subject crosswalk.
+```
+
+- [ ] **Step 4: Build and verify row count unchanged**
+
+```bash
+uv run dbt build --select dim_courses --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS including the PK uniqueness test (row count unchanged — the join
+already existed and Step 1 confirmed it is 1:1).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube add src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube commit -m "feat(dbt): add is_foundations to dim_courses
+
+Refs #4163"
+```
+
+---
+
+## Task 2: Add `is_504` and `year_in_network` to `dim_student_enrollments`
+
+`dim_student_enrollments` reads
+`int_powerschool__student_enrollment_union as enr`. That union carries `is_504`
+(passed through its `select * except(...)`, originally
+`base_powerschool__student_enrollments.is_504`) and `year_in_network` (re-added
+at the union's final select). Both are plain projections.
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml`
+
+- [ ] **Step 1: Confirm both columns resolve on the union**
+
+```bash
+uv run dbt show --inline "select is_504, year_in_network from {{ ref('int_powerschool__student_enrollment_union') }}" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+(No trailing `limit` — dbt 1.11/BigQuery rejects it on `--inline`.) Expected:
+the columns resolve. If either errors, STOP and report.
+
+- [ ] **Step 2: Add the columns to `dim_student_enrollments.sql`**
+
+Add to the `enr.` enumeration group (with `enr.is_retained_year`, etc.):
+
+```sql
+    enr.is_504,
+    enr.year_in_network,
+```
+
+- [ ] **Step 3: Add the columns to the contract YAML**
+
+In `properties/dim_student_enrollments.yml` (read first, match formatting):
+
+```yaml
+- name: is_504
+  data_type: boolean
+  description: >-
+    TRUE if the student has an active 504 plan for this enrollment.
+
+- name: year_in_network
+  data_type: int64
+  description: >-
+    Count of years the student has been enrolled in the network. Populated on
+    the student's primary enrollment stint per academic year; null on additional
+    same-year stints (multi-stint students).
+```
+
+- [ ] **Step 4: Build, verify row count unchanged, and check `year_in_network`
+      population**
+
+```bash
+uv run dbt build --select dim_student_enrollments --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS (row count unchanged — pure projection). Then check the
+`year_in_network` null share (expected: some nulls on multi-stint rows, but the
+majority populated):
+
+```bash
+uv run dbt show --inline "select countif(year_in_network is null) as n_null, count(*) as n_total from {{ ref('dim_student_enrollments') }}" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+If `n_null` is a large majority (e.g. >60% of rows), STOP and report — the
+`rn_year = 1` nulling in the union may make this column too sparse to expose,
+and we should source it differently instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube add src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube commit -m "feat(dbt): add is_504 and year_in_network to dim_student_enrollments
+
+Refs #4163"
+```
+
+---
+
+## Task 3: Trunk-check and push
+
+**Files:** none (validation).
+
+- [ ] **Step 1: Trunk-check the four changed files**
+
+Run from inside the worktree:
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk check --force src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+```
+
+Expected: `No issues`. Fix any ST06 ordering and rebuild before pushing.
+
+- [ ] **Step 2: Push (confirm dbt Cloud CI is idle first)**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube push origin cristinabaldor/feat/claude-assessment-scores-cube
+```
+
+- [ ] **Step 3: After CI passes, pull warnings**
+
+`mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)`. Expect only
+the pre-existing/known warns (#4173 college-Practice, #4174 bridge orphans) plus
+stale-dev drift — triage anything new per `marts/CLAUDE.md`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `is_foundations`, `is_504`, `year_in_network` — Tasks 1–2.
+  `head_of_school`, `is_self_contained`, `is_sipps` are explicitly deferred (see
+  header).
+- **No hash changes, no new joins** — every column is a projection of a value
+  already on a model the dim reads/joins.
+- **Fan-out guards:** Task 1 Step 1 (crosswalk uniqueness) and Step 4 / Task 2
+  Step 4 (row-count unchanged) protect grain; Task 2 Step 4 also gates on
+  `year_in_network` not being too sparse.

--- a/docs/superpowers/plans/2026-06-11-assessment-scores-dbt-foundation.md
+++ b/docs/superpowers/plans/2026-06-11-assessment-scores-dbt-foundation.md
@@ -1,0 +1,399 @@
+# Assessment-scores dbt mart foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the response/standard columns to
+`fct_assessment_scores_enrollment_scoped` and an `assessment_key` FK to
+`dim_assessment_administrations`, so the Cube semantic layer can break scores
+down by standard/skill and read canonical assessment descriptors from
+`dim_assessments`.
+
+**Architecture:** Two additive dbt mart changes in the `kipptaf` project. Both
+are pure projections of values already computed upstream — no surrogate-key hash
+changes. The fact gains response-grain columns from
+`int_assessments__response_rollup` plus a `standard_domain` lookup; the
+administration dim gains a single surrogate-key FK that resolves to the
+canonical-representative `dim_assessments` row.
+
+**Tech Stack:** dbt (BigQuery dialect), `src/dbt/kipptaf`. All work happens in
+the worktree at
+`/workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube`.
+
+**Scope guardrails:**
+
+- Additive only. Do **not** change any `generate_surrogate_key(...)` input list.
+- Follow `src/dbt/kipptaf/models/marts/CLAUDE.md` (column-naming R1–R10, ST06
+  ordering, reserved-word backticks).
+- Do **not** use `select distinct` / `qualify row_number() = 1` /
+  `dbt_utils.deduplicate` to paper over the `standard_domains` lookup — instead
+  verify the lookup key is unique (Task 1, Step 2).
+
+---
+
+## Task 0: Worktree dbt setup
+
+**Files:** none (environment only).
+
+- [ ] **Step 1: Install dbt packages in the worktree**
+
+A fresh worktree has no `dbt_packages/`.
+
+Run:
+
+```bash
+uv run dbt deps --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf
+```
+
+Expected: `Installed from ...` / `Up to date` with no error.
+
+- [ ] **Step 2: Confirm the prod manifest exists for `--defer`**
+
+Run:
+
+```bash
+ls /workspaces/teamster/src/dbt/kipptaf/target/prod/manifest.json
+```
+
+Expected: the file exists. If missing, regenerate:
+`uv run dbt parse --target prod --project-dir /workspaces/teamster/src/dbt/kipptaf --target-path target/prod`.
+
+---
+
+## Task 1: Project response/standard columns onto the fact
+
+Add `response_type`, `response_type_code`, `response_type_description`,
+`response_type_root_description`, `is_replacement`,
+`performance_band_label_number`, and `standard_domain` to
+`fct_assessment_scores_enrollment_scoped`. Internal (Illuminate) rows get real
+values from `int_assessments__response_rollup`; state rows get typed NULLs
+(state scores have no response-type breakdown).
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`
+
+- [ ] **Step 1: Confirm the source columns exist in the rollup**
+
+Run:
+
+```bash
+uv run dbt show --inline "select response_type, response_type_code, response_type_description, response_type_root_description, is_replacement, performance_band_label_number from {{ ref('int_assessments__response_rollup') }} limit 1" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+Expected: returns one row (columns resolve). If any column errors, stop and
+re-trace before editing.
+
+- [ ] **Step 2: Verify the `standard_domains` lookup key is unique**
+
+The fact will left-join `stg_google_sheets__assessments__standard_domains` on
+`response_type_code = standard_code`. A duplicate `standard_code` would fan out
+the fact. Confirm uniqueness:
+
+```bash
+uv run dbt show --inline "select standard_code, count(*) as n from {{ ref('stg_google_sheets__assessments__standard_domains') }} group by 1 having count(*) > 1" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+Expected: **zero rows**. If any row returns, the join would fan out — stop and
+raise it with the data team (do not add a defensive dedupe).
+
+- [ ] **Step 3: Add the source columns + lookup join to the
+      `internal_assessments` CTE**
+
+In `fct_assessment_scores_enrollment_scoped.sql`, the `internal_assessments` CTE
+selects from `int_assessments__response_rollup as rr`. Add the new `rr.*`
+columns and a left join to the standard-domain lookup. The CTE's column list
+gains (placed with the other `rr.` enumerations, before the constant/aliased
+columns per ST06):
+
+```sql
+            rr.response_type,
+            rr.response_type_code,
+            rr.response_type_description,
+            rr.response_type_root_description,
+            rr.is_replacement,
+            rr.performance_band_label_number,
+
+            sd.standard_domain,
+```
+
+And add the join after the existing `inner join ... as c ...` joins in that CTE:
+
+```sql
+        left join
+            {{ ref("stg_google_sheets__assessments__standard_domains") }} as sd
+            on rr.response_type_code = sd.standard_code
+```
+
+(`response_type` and `response_type_code` may already be selected for the hash —
+if so, do not duplicate them; keep one copy each.)
+
+- [ ] **Step 4: Project the columns in the internal `SELECT` branch**
+
+In the `/* internal assessments */` final `SELECT` (the branch reading
+`internal_assessments as ia`), add, grouped with the other `ia.` columns:
+
+```sql
+    ia.response_type,
+    ia.response_type_code,
+    ia.response_type_description,
+    ia.response_type_root_description,
+    ia.is_replacement,
+    ia.performance_band_label_number,
+    ia.standard_domain,
+```
+
+- [ ] **Step 5: Project typed NULLs in the state `SELECT` branch**
+
+In the `/* state assessments */` final `SELECT` (reading `state_union as su`),
+add the same column names as typed NULLs so the `UNION ALL` aligns. Place them
+with the constants group per ST06:
+
+```sql
+    cast(null as string) as response_type,
+    cast(null as string) as response_type_code,
+    cast(null as string) as response_type_description,
+    cast(null as string) as response_type_root_description,
+    cast(null as bool) as is_replacement,
+    cast(null as int) as performance_band_label_number,
+    cast(null as string) as standard_domain,
+```
+
+- [ ] **Step 6: Add the columns to the contract YAML**
+
+In `properties/fct_assessment_scores_enrollment_scoped.yml`, add column entries
+(no per-column data_tests; descriptions required). Match `data_type` to the
+casts above (`string`, `string`, `string`, `string`, `boolean`, `int64`,
+`string`):
+
+```yaml
+- name: response_type
+  data_type: string
+  description: >-
+    The standard/skill breakdown level of this scored response (e.g. overall vs
+    a specific standard). Null for state assessments, which have no
+    response-type breakdown.
+
+- name: response_type_code
+  data_type: string
+  description: >-
+    Standard code for this response type (joins the standard-domain lookup).
+    Null for state assessments.
+
+- name: response_type_description
+  data_type: string
+  description: Human-readable description of the response type. Null for state.
+
+- name: response_type_root_description
+  data_type: string
+  description: >-
+    Root/parent description of the response type's standard hierarchy. Null for
+    state.
+
+- name: is_replacement
+  data_type: boolean
+  description: >-
+    TRUE if this Illuminate score replaced a prior attempt for the same student
+    and canonical assessment. Null for state.
+
+- name: performance_band_label_number
+  data_type: int64
+  description: >-
+    Numeric rank of the performance band (pairs with proficiency_level). Null
+    for state.
+
+- name: standard_domain
+  data_type: string
+  description: >-
+    Domain grouping for the response type's standard, from the standard-domains
+    reference sheet. Null when the standard code has no mapping or for state
+    assessments.
+```
+
+- [ ] **Step 7: Build the fact and its downstream, verify success + no new
+      warnings**
+
+Run:
+
+```bash
+uv run dbt build --select fct_assessment_scores_enrollment_scoped --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: `PASS`/`Completed successfully`. The PK `unique`/`not_null` tests
+still pass (row count unchanged — the `standard_domains` join is verified 1:1 in
+Step 2). If the row count changed, the join fanned out — revert and recheck
+Step 2.
+
+- [ ] **Step 8: Confirm row count is unchanged vs prod**
+
+Run:
+
+```bash
+uv run dbt show --inline "select count(*) as n from {{ ref('fct_assessment_scores_enrollment_scoped') }}" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+Expected: equals the prod row count (~14.19M, the figure from the spec's
+verified findings). A higher count means fan-out.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube add src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube commit -m "feat(dbt): add response/standard columns to assessment-scores fact
+
+Refs #4163"
+```
+
+---
+
+## Task 2: Add `assessment_key` FK to `dim_assessment_administrations`
+
+Add one column, `assessment_key`, computed from the four inputs already present
+in the model's `all_administrations` CTE. It resolves to the
+canonical-representative `dim_assessments` row (Illuminate) or the 1:1 state
+row.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml`
+
+- [ ] **Step 1: Add the FK column to the final `SELECT`**
+
+In `dim_assessment_administrations.sql`, the final `SELECT` reads from
+`all_administrations`, which carries `assessment_type`, `module_code`,
+`source_assessment_id`, and `test_type`. Add, immediately after the existing
+`assessment_administration_key` surrogate-key block:
+
+```sql
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "assessment_type",
+                "module_code",
+                "source_assessment_id",
+                "test_type",
+            ]
+        )
+    }} as assessment_key,
+```
+
+Do not alter the existing `assessment_administration_key` inputs.
+
+- [ ] **Step 2: Add the FK column + relationships test to the contract YAML**
+
+In `properties/dim_assessment_administrations.yml`, add the column with a
+`foreign_key` constraint and a `relationships` test to `dim_assessments`:
+
+```yaml
+- name: assessment_key
+  data_type: string
+  description: >-
+    FK to dim_assessments. Resolves to the canonical-representative member row
+    for Illuminate (the canonical id is itself the representative member id) and
+    the 1:1 row for state assessments. Lets consumers read canonical descriptors
+    (title, academic_subject, type, grade_level_tested, module_type) without
+    denormalizing them onto this dim.
+  constraints:
+    - type: foreign_key
+      to: ref('dim_assessments')
+      to_columns: [assessment_key]
+      warn_unsupported: false
+  data_tests:
+    - relationships:
+        arguments:
+          to: ref('dim_assessments')
+          field: assessment_key
+```
+
+- [ ] **Step 3: Build the dim + run the relationships test**
+
+Run:
+
+```bash
+uv run dbt build --select dim_assessment_administrations --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: `PASS`. The new `relationships` test passes for the Illuminate branch
+(verified 4748/4748 in the spec).
+
+- [ ] **Step 4: Verify the state-branch FK populates (the spec's open validation
+      item)**
+
+The spec flagged that only Illuminate was empirically proven. Confirm state rows
+resolve (no NULL/orphan `assessment_key` for state administrations):
+
+```bash
+uv run dbt show --inline "select countif(a.assessment_key is null) as n_unmatched, count(*) as n_total from {{ ref('dim_assessment_administrations') }} adm left join {{ ref('dim_assessments') }} a on adm.assessment_key = a.assessment_key where adm._dbt_source_project is not null" --project-dir /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube/src/dbt/kipptaf --target dev
+```
+
+Expected: `n_unmatched = 0`. (`_dbt_source_project is not null` scopes to
+region-scoped administrations, which is where state assessments live.) If
+`n_unmatched > 0`, capture the unmatched `assessment_type`/`module_code` and
+raise before proceeding — the state key composition needs reconciliation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube add src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube commit -m "feat(dbt): add assessment_key FK from administrations to dim_assessments
+
+Refs #4163"
+```
+
+---
+
+## Task 3: Trunk-check and push
+
+**Files:** none (validation).
+
+- [ ] **Step 1: Trunk-check the changed SQL/YAML**
+
+sqlfluff/yamllint fire at pre-push, not pre-commit. Verify from inside the
+worktree:
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk check --force src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+```
+
+Run with cwd set to the worktree. Expected: `No issues`. Fix any ST06 ordering /
+RF04 reserved-word findings and rebuild before pushing.
+
+- [ ] **Step 2: Push (confirm dbt Cloud CI is idle first)**
+
+Pushing triggers dbt Cloud CI. Push the branch:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cristinabaldor/feat/claude-assessment-scores-cube push origin cristinabaldor/feat/claude-assessment-scores-cube
+```
+
+- [ ] **Step 3: After CI passes, pull warnings**
+
+Use `mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)`. New
+marts-model warnings must be triaged per `marts/CLAUDE.md` (search open issues
+by model + FK target before filing). Pre-existing warnings unchanged from `main`
+are ignorable.
+
+---
+
+## Self-review notes
+
+- **Spec coverage (this plan only):** fact response/standard columns → Task 1;
+  administration `assessment_key` FK → Task 2. The dim enrichments
+  (`is_foundations`, `year_in_network`, `head_of_school`, `status_504`,
+  `is_sipps`, `is_self_contained`) and the entire Cube layer are **out of scope
+  for this plan** — they are Plan 2 (dbt dim enrichments) and Plan 3 (Cube),
+  respectively.
+- **No hash changes:** neither task touches a `generate_surrogate_key` input
+  list; the new `assessment_key` is a _new_ surrogate, not a change to an
+  existing one.
+- **Fan-out guards:** Task 1 Step 2 (standard_domains uniqueness) and Step 8
+  (row-count equality) protect the fact's grain; Task 2 Step 4 confirms the FK
+  is not silently NULL.

--- a/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
+++ b/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
@@ -1,0 +1,241 @@
+# Assessment-scores semantic layer — design
+
+Anchor issue: [#4163](https://github.com/TEAMSchools/teamster/issues/4163).
+Follow-ups: [#4164](https://github.com/TEAMSchools/teamster/issues/4164)
+(normalized canonical dim),
+[#4165](https://github.com/TEAMSchools/teamster/issues/4165) (section teacher).
+
+## Purpose
+
+A broad, all-source assessment-score explorer in the Cube semantic layer over
+`fct_assessment_scores_enrollment_scoped`, covering internal Illuminate interims
+and NJ/FL state assessments (NJSLA, NJGPA, FAST). The headline metric is
+proficiency/mastery rate, which is the only score measure that is meaningful
+across the incompatible score scales of the different sources. Analysts slice by
+subject, score source, testing season, school/region, grade level, and student
+demographics, and can drill from aggregates to row-level scores and to the
+individual member assessments behind a score.
+
+## Source fact
+
+`fct_assessment_scores_enrollment_scoped` — grain: one row per student x
+assessment x administration. PK `assessment_score_key`. The fact is thin: its
+only measures are `scale_score` (null for internal), `percent_correct` (null for
+state), `proficiency_level`, and `is_mastery`. Everything an analyst slices by
+lives on parent dims. The fact FKs to `dim_assessment_administrations`
+(`assessment_administration_key`), `dim_student_section_enrollments`
+(`student_section_enrollment_key`), and `dim_dates` (`test_date_key`), and
+carries `enrollment_resolution` (`subject_section` / `homeroom`).
+
+This is event-grained (one row per test event), not a cumulative daily-status
+fact, so it is **not** a snapshot cube — no `SNAPSHOT_CUBES` entry and no
+`is_latest_record` / `_month_end` / `_week_end` machinery.
+
+## Verified findings (drove the design)
+
+All confirmed against prod (`kipptaf_marts`, `kipptaf_assessments`) during
+brainstorming:
+
+- **Location never diverges.** Across 14,189,742 fact rows, the student's
+  enrollment `location_key` and the course-section `location_key` never differ
+  (0 divergent rows); the student path is null on 13,878 rows (0.1%, grade-99 /
+  placeholder schools) where the course path is populated. Decision: single
+  canonical location join via the student enrollment; `course_sections`
+  `location_key` is unused in the cube.
+- **`dim_assessments` is member-grain for Illuminate.** Joining it directly to
+  the fact fans out up to 30x on 19% (2,268 / 12,209) of Illuminate
+  administrations. Within an administration, `academic_subject` and
+  `is_internal_assessment` are constant (0 varying); `title` varies (2,135
+  administrations), so the canonical title must be used, not a member title.
+- **Member is multi-valued per score; canonical is single.** Of 14.16M internal
+  score rows, 96.5% map to exactly one member assessment, 2.8% to two, and 0.7%
+  to three or more (max 23). The rollup `array_agg`s members into
+  `assessment_ids`. So canonical can be a clean single parent; member requires a
+  bridge.
+
+## Architecture
+
+### Cube inventory
+
+Six new cubes, reusing six existing (`student_enrollments`, `students`,
+`locations`, `regions`, `dates`, `terms`):
+
+| New cube                            | Reads                                       | Folder                      | Student-gated |
+| ----------------------------------- | ------------------------------------------- | --------------------------- | ------------- |
+| `student_assessment_scores` (fact)  | `fct_assessment_scores_enrollment_scoped`   | `cubes/student_assessment/` | yes           |
+| `student_section_enrollments`       | `dim_student_section_enrollments`           | `cubes/students/`           | yes           |
+| `assessment_administrations`        | `dim_assessment_administrations` (enriched) | `cubes/assessments/`        | no            |
+| `assessments`                       | `dim_assessments` (member-grain)            | `cubes/assessments/`        | no            |
+| `course_sections`                   | `dim_course_sections`                       | `cubes/conformed/`          | no            |
+| `courses`                           | `dim_courses`                               | `cubes/conformed/`          | no            |
+| `assessment_score_members` (bridge) | `bridge_assessment_score_members`           | `cubes/student_assessment/` | no            |
+
+Student-domain cubes are `student`-prefixed so `cube.js`'s `isStudentMember`
+gating and location scoping auto-apply; curriculum and assessment-reference dims
+are unprefixed (no student data, no domain tier).
+
+### Join graph
+
+```text
+student_assessment_scores (fct)
+  - dates                      test_date_key                       (only date join; avoids diamond)
+  - assessment_administrations assessment_administration_key       (canonical + occurrence/season)
+  - student_section_enrollments student_section_enrollment_key
+      - student_enrollments    student_enrollment_key
+          - students           student_key                         (identity / demographics)
+          - locations          location_key  (canonical location)
+              - regions        region_key
+      - course_sections        course_section_key
+          - courses            course_key    (enrolled-course subject/title)
+      - terms                  term_key
+  - (bridge) assessment_score_members assessment_score_key
+      - assessments            assessment_key (member-grain; drill-down only)
+```
+
+### Diamond / role-play resolutions
+
+1. **`dates`** — two routes exist (fact `test_date_key`; administration
+   `administered_date_key`). Only the fact joins `dates` (the score's
+   `test_date`). `assessment_administrations` exposes `administered_date` as a
+   degenerate `CAST(... AS TIMESTAMP)` with no `dates` join.
+2. **`locations`** — only `student_enrollments` to `locations`. The
+   `course_sections` `location_key` is not joined (verified never divergent).
+3. **`academic_year`** — present on `student_section_enrollments`,
+   `student_enrollments`, and `terms`. Exposed canonically from
+   `student_section_enrollments` only, to avoid multi-cube ambiguity in views.
+4. **canonical assessment** — reached through `assessment_administrations` (the
+   administration determines the canonical). The fact deliberately has no direct
+   canonical FK, which would diamond against the administration.
+
+## dbt changes (additive only)
+
+### Enrich `dim_assessment_administrations`
+
+Project descriptors that already exist in the model's `all_administrations`
+union but are dropped in the final SELECT: `title` (the **canonical** title for
+Illuminate — sourced from `int_assessments__assessments_canonical`),
+`academic_subject` (from `subject_area`), `type` (from `assessment_type`),
+`scope`, `grade_level_tested` (from `grade_level`), and a derived
+`is_internal_assessment` (= `assessment_type = 'illuminate'`). Surface the
+existing `source_assessment_id` as the canonical-assessment id (Illuminate).
+This is the canonical-assessment anchor and the sole source of
+`administration_period` (testing season / window). No surrogate-key hash change
+(none of these are hash inputs). Update the contract YAML and any `select *`
+consumers.
+
+### New `bridge_assessment_score_members`
+
+Factless bridge: `assessment_score_key` to member `assessment_key`. Internal:
+reconstruct `assessment_score_key` from the same inputs the fact uses and unnest
+the rollup `assessment_ids` to member ids, hashing each to the member
+`assessment_key`
+(`surrogate('illuminate', module_code, member_assessment_id, null)`). State: map
+the single state `assessment_key`
+(`surrogate(assessment_type, module_code, null, null)`). Properties + tests
+(`unique_combination_of_columns` on the two keys; `relationships` to the fact
+and to `dim_assessments`).
+
+### No change
+
+`fct_assessment_scores_enrollment_scoped` itself (canonical reached via the
+administration; no degenerate columns) and `dim_assessments` (already has every
+member column).
+
+## Cube measures
+
+Defined on `student_assessment_scores`; used in the detail and summary views
+only (never the member-detail view, where the bridge fan-out would
+double-count):
+
+| Measure               | Definition                                          | Notes                                                                                                                        |
+| --------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `count_scores`        | `count_distinct assessment_score_key`               | score-record count                                                                                                           |
+| `count_students`      | `count_distinct student_enrollment_key` (via chain) | per student-year, matching the attendance convention                                                                         |
+| `pct_proficient`      | `_count_proficient / count_scores`, percent         | headline; `is_mastery`-based, source-agnostic                                                                                |
+| `avg_percent_correct` | `avg(percent_correct)`                              | internal-effective; filter by subject/module                                                                                 |
+| `avg_scale_score`     | `avg(scale_score)`                                  | guardrail docs: meaningful only filtered to a single assessment + subject + grade + source; steers users to `pct_proficient` |
+
+`_count_proficient` is a private helper (count where `is_mastery`).
+
+## Cube dimensions
+
+On the fact: `assessment_score_key` (PK), `test_date`, `enrollment_resolution`
+(load-bearing filter — subject is only meaningful on `subject_section` rows),
+`proficiency_level`, `is_mastery`, `scale_score`, `percent_correct`.
+
+From joined cubes (subject appears twice, prefix-disambiguated):
+
+- `assessment_administrations`: `academic_subject` (the assessment's subject),
+  `title`, `type`, `scope`, `grade_level_tested`, `is_internal_assessment`
+  (score source), `administration_period` (season/window), `test_type`,
+  `administered_date`, `source_assessment_id` (canonical id).
+- `courses`: `academic_subject` (enrolled-course subject), `course_title`,
+  `course_code`.
+- `course_sections`: `identifier`, `period`.
+- `assessments` (member, drill-down view only): `title`, `academic_subject`,
+  `module_code`, `module_type`, `grade_level_tested`, `is_internal_assessment`.
+- `student_section_enrollments`: `academic_year` (canonical), `entry_date`,
+  `exit_date`, `is_dropped_section`, `is_dropped_course`.
+- `student_enrollments`: `grade_level`, `graduation_year`, `is_retained_year`.
+- `students`: `full_name` + identifiers (PII), `race`, `gender_identity`,
+  `is_gifted`, `enrollment_status`.
+- `locations`: `location_name`, `abbreviation`, `grade_band`, `campus`, `city`;
+  `regions`: `region_name`, `state`.
+- `terms`: `semester`, `term_name`, `term_code`, `term_type`.
+
+## Views
+
+Three analyst-facing views:
+
+- **`student_assessment_scores_detail`** — row-level scores; carries `full_name`
+  / identifiers. Two-policy access: `cube-access-student-data` with PII fields
+  in `excludes`, plus `cube-access-student-pii` with `includes: "*"`. Does
+  **not** join the member bridge (keeps measures clean). Canonical and the
+  assessment descriptors come from `assessment_administrations`.
+- **`student_assessment_scores_summary`** — aggregates and demographic
+  breakdowns only; no direct identifiers. Single `cube-access-student-data`
+  policy.
+- **`student_assessment_scores_members_detail`** — member-level drill-down via
+  the bridge to `assessments`: one row per score x member. **No aggregate
+  measures**, so the 3.5% multi-member fan-out never double-counts. Each row
+  shows the member (from `assessments`), its canonical and season (from
+  `assessment_administrations`), and the student context. PII-gated like the
+  detail view.
+
+## Access gating
+
+No `cube.js` change. Student-prefixed cubes inherit `isStudentMember` member
+stripping and the location scope filter (resolved through the existing
+`student_enrollments` to `locations` chain, as in `student_attendance`). The
+assessment-reference and curriculum dims are unprefixed and carry no student
+data. Not a snapshot cube, so no `SNAPSHOT_CUBES` / `SNAPSHOT_MEASURE_STEMS`
+entry.
+
+## Exposures
+
+Add every new mart (`fct_assessment_scores_enrollment_scoped` if not already
+present, `dim_assessment_administrations`, `dim_student_section_enrollments`,
+`dim_course_sections`, `dim_courses`, `dim_assessments`,
+`bridge_assessment_score_members`) to `cube.yml`'s
+`cube_semantic_layer.depends_on`.
+
+## Out of scope (tracked)
+
+- Normalized `dim_canonical_assessments` with canonical + member as first-class
+  linked dims — [#4164](https://github.com/TEAMSchools/teamster/issues/4164).
+- Section teacher (all teachers incl. co-teachers via bridge + `dim_staff` +
+  staff-domain access decision) —
+  [#4165](https://github.com/TEAMSchools/teamster/issues/4165).
+
+## Validation approach
+
+- Build the enriched administration dim and the bridge in a dev schema; confirm
+  uniqueness/relationships tests pass and the bridge row counts reconcile with
+  the rollup `assessment_ids` cardinality.
+- Verify each cube FK populates in prod (sample non-null share; treat 99%+ null
+  as a broken join).
+- Compile each view via the Cube `/sql` endpoint and validate a representative
+  query (`pct_proficient` by `academic_subject` x `region` x `academic_year`)
+  against direct warehouse SQL.
+- Confirm the member-detail view never inflates `count_scores` (the bridge is
+  absent from measure paths).

--- a/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
+++ b/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
@@ -6,7 +6,9 @@ Follow-ups: [#4164](https://github.com/TEAMSchools/teamster/issues/4164)
 [#4165](https://github.com/TEAMSchools/teamster/issues/4165) (section teacher),
 [#4167](https://github.com/TEAMSchools/teamster/issues/4167) (academic-goals
 dim), [#4168](https://github.com/TEAMSchools/teamster/issues/4168)
-(student-subject intervention-status dim).
+(student-subject intervention-status dim),
+[#4170](https://github.com/TEAMSchools/teamster/issues/4170) (score-to-member
+drill-down).
 
 ## Purpose
 
@@ -16,10 +18,9 @@ and NJ/FL state assessments (NJSLA, NJGPA, FAST). The headline metric is
 proficiency/mastery rate, which is the only score measure meaningful across the
 incompatible score scales of the different sources. Analysts slice by
 standard/skill, subject, score source, testing season, administration date,
-school/region, grade level, course, and student demographics, and can drill from
-aggregates to row-level scores and to the individual member assessments behind a
-score. Dimension parity is benchmarked against the existing
-`rpt_tableau__ddi_dashboard` Tableau extract.
+school/region, grade level, course, and student demographics, and drill from
+aggregates to row-level scores. Dimension parity is benchmarked against the
+existing `rpt_tableau__ddi_dashboard` Tableau extract.
 
 ## Source fact
 
@@ -38,8 +39,8 @@ parent dims. The fact FKs to `dim_assessment_administrations`
 `date_taken` / completion date), and carries `enrollment_resolution`
 (`subject_section` / `homeroom`).
 
-Event-grained (one row per scored response), not a cumulative daily-status fact,
-so it is **not** a snapshot cube.
+Event-grained, not a cumulative daily-status fact, so it is **not** a snapshot
+cube.
 
 ## Verified findings (drove the design)
 
@@ -56,39 +57,85 @@ All confirmed against prod (`kipptaf_marts`, `kipptaf_assessments`):
   member. Across all 4,748 Illuminate canonicals,
   `surrogate(assessment_type, module_code, canonical_id, null)` matches a
   `dim_assessments` row 100% of the time, with **0** `title` and **0**
-  `academic_subject` mismatches vs. the canonical. This join is
-  many-administrations-to-one-assessment — **no fan-out**. (The 30x fan-out risk
-  applies only to joining the _fact_ to all members, which is the bridge path.)
-- **Member is multi-valued per score; canonical is single.** Of 14.16M internal
+  `academic_subject` mismatches. This is many-administrations-to-one-assessment
+  — **no fan-out** — so canonical descriptors are read from `dim_assessments`
+  via a single FK.
+- **Actual member is multi-valued per score; deferred.** Of 14.16M internal
   score rows, 96.5% map to one member, 2.8% to two, 0.7% to three or more (max
-  23). The actual member(s) a score rolled up are reached via the bridge.
+  23). Drilling to the actual member form(s) a score rolled up requires a
+  score-grain bridge; it is deferred to #4170 because the canonical FK covers
+  reporting needs.
 
 ## Architecture
 
 ### Cube inventory
 
-Nine new cubes, reusing six existing (`student_enrollments`, `students`,
-`locations`, `regions`, `dates`, `terms`). Two pairs are role-played (same
-table, two cube instances): `dim_dates` (`dates` + `administration_dates`) and
-`dim_assessments` (`assessments` + `assessment_members`).
+Seven new cubes; seven reused (three extended additively):
 
-| New cube                            | Reads                                                   | Role                                          |
-| ----------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
-| `student_assessment_scores` (fact)  | `fct_assessment_scores_enrollment_scoped`               | scores                                        |
-| `student_section_enrollments`       | `dim_student_section_enrollments`                       | enrollment bridge to student/course           |
-| `assessment_administrations`        | `dim_assessment_administrations` (+`assessment_key` FK) | occurrence: season, admin date                |
-| `assessments`                       | `dim_assessments`                                       | canonical descriptors (via administration FK) |
-| `assessment_members`                | `dim_assessments`                                       | actual member(s) (via score bridge)           |
-| `course_sections`                   | `dim_course_sections`                                   | section context                               |
-| `courses`                           | `dim_courses` (+`is_foundations`)                       | course subject/title/code                     |
-| `assessment_score_members` (bridge) | `bridge_assessment_score_members`                       | score to member(s)                            |
-| `administration_dates`              | `dim_dates`                                             | administration-date calendar                  |
+| New cube                           | Reads                                                   | Role                                          |
+| ---------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
+| `student_assessment_scores` (fact) | `fct_assessment_scores_enrollment_scoped`               | scores                                        |
+| `student_section_enrollments`      | `dim_student_section_enrollments`                       | enrollment bridge to student/course           |
+| `assessment_administrations`       | `dim_assessment_administrations` (+`assessment_key` FK) | occurrence: season, admin date                |
+| `assessments`                      | `dim_assessments`                                       | canonical descriptors (via administration FK) |
+| `course_sections`                  | `dim_course_sections`                                   | section context                               |
+| `courses`                          | `dim_courses` (+`is_foundations`)                       | course subject/title/code                     |
+| `administration_dates`             | `dim_dates`                                             | administration-date calendar (role-played)    |
+
+| Reused cube                 | Change                                                |
+| --------------------------- | ----------------------------------------------------- |
+| `dates`                     | as-is (role-played with `administration_dates`)       |
+| `student_enrollments`       | extend: `year_in_network`                             |
+| `students`                  | as-is                                                 |
+| `student_enrollment_status` | extend: `status_504`, `is_self_contained`, `is_sipps` |
+| `locations`                 | extend: `head_of_school`                              |
+| `regions`                   | as-is                                                 |
+| `terms`                     | as-is                                                 |
 
 Student-domain cubes are `student`-prefixed for `cube.js` gating; assessment,
 curriculum, and date dims are unprefixed. `standard_domain` is a degenerate
-column on the fact (1:1 on `response_type_code`), not a cube.
+column on the fact (1:1 on `response_type_code`), not a cube. Only `dim_dates`
+is role-played (`dates` + `administration_dates`); `dim_assessments` is a single
+instance reached via the administration FK.
 
-### Cube join graph
+### Relationship diagram
+
+```mermaid
+graph TD
+  FCT["student_assessment_scores (fct)"]
+  DATE[dates]
+  ADM[assessment_administrations]
+  ADATE[administration_dates]
+  ASM[assessments]
+  SSE[student_section_enrollments]
+  SE[student_enrollments]
+  STU[students]
+  SES[student_enrollment_status]
+  LOC[locations]
+  REG[regions]
+  CS[course_sections]
+  CRS[courses]
+  TRM[terms]
+
+  FCT -->|test_date_key| DATE
+  FCT -->|assessment_administration_key| ADM
+  ADM -->|administered_date_key| ADATE
+  ADM -->|assessment_key| ASM
+  FCT -->|student_section_enrollment_key| SSE
+  SSE -->|student_enrollment_key| SE
+  SE -->|student_key| STU
+  SE -->|student_enrollment_key one_to_one| SES
+  SE -->|location_key| LOC
+  LOC -->|region_key| REG
+  SSE -->|course_section_key| CS
+  CS -->|course_key| CRS
+  SSE -->|term_key| TRM
+```
+
+`dates` and `administration_dates` both read `dim_dates` (role-played). Edge
+labels are the join keys.
+
+### Cube join graph (text)
 
 ```text
 student_assessment_scores (fct)
@@ -99,19 +146,18 @@ student_assessment_scores (fct)
   - student_section_enrollments student_section_enrollment_key
       - student_enrollments     student_enrollment_key
           - students            student_key
+          - student_enrollment_status  student_enrollment_key (one_to_one: ELL/IEP/504/SpEd/meal)
           - locations           location_key
               - regions         region_key
       - course_sections         course_section_key
           - courses             course_key
       - terms                   term_key
-  - (bridge) assessment_score_members assessment_score_key
-      - assessment_members      assessment_key  (actual member(s); drill-down only)
 ```
 
 ### dbt model references (FK graph)
 
 Arrows point from child to the parent it references (`*` marks a model touched
-by this spec; `[NEW]` is created by it).
+by this spec; `[NEW FK]` is a column added by it).
 
 ```text
 fct_assessment_scores_enrollment_scoped *
@@ -121,23 +167,18 @@ fct_assessment_scores_enrollment_scoped *
   |-- student_section_enrollment_key --> dim_student_section_enrollments
   |                                        |-- student_enrollment_key --> dim_student_enrollments *
   |                                        |                                |-- student_key --> dim_students
+  |                                        |                                |-- student_enrollment_key --> dim_student_enrollment_status *
   |                                        |                                '-- location_key --> dim_locations *
   |                                        |                                                      '-- region_key --> dim_regions
   |                                        |-- course_section_key --> dim_course_sections
   |                                        |                            '-- course_key --> dim_courses *
   |                                        '-- term_key --> dim_terms
   '-- test_date_key --> dim_dates
-
-bridge_assessment_score_members [NEW]
-  |-- assessment_score_key --> fct_assessment_scores_enrollment_scoped *
-  '-- assessment_key --------> dim_assessments
-
-dim_student_enrollment_status *   (joined to dim_student_enrollments via student_enrollment_key)
 ```
 
-`dim_assessments` itself is unchanged (it already carries `title`,
-`academic_subject`, `type`, `scope`, `grade_level_tested`, `module_type`,
-`module_code`, `is_internal_assessment`).
+`dim_assessments` is unchanged (it already carries `title`, `academic_subject`,
+`type`, `scope`, `grade_level_tested`, `module_type`, `module_code`,
+`is_internal_assessment`).
 
 ### Diamond / role-play resolutions
 
@@ -145,14 +186,10 @@ dim_student_enrollment_status *   (joined to dim_student_enrollments via student
    `dates`; administration `administered_date_key` (administered_at, primary
    reporting date; null for state) joins a second instance
    `administration_dates`. Two instances, two single-path joins — no diamond.
-2. **`dim_assessments` (role-played).** Canonical descriptors reached via
-   `assessment_administrations → assessments` (FK on `assessment_key`, the
-   canonical-representative row, single, no fan-out). Actual member(s) reached
-   via `bridge → assessment_members`. Two instances avoid a diamond.
-3. **`locations`** — single join via `student_enrollments`; `course_sections`
-   `location_key` unused.
-4. **`academic_year`** — exposed canonically from `student_section_enrollments`.
-5. **canonical assessment** — reached through the administration FK, not a
+2. **`locations`** — single join via `student_enrollments`; `course_sections`
+   `location_key` unused (verified never divergent).
+3. **`academic_year`** — exposed canonically from `student_section_enrollments`.
+4. **canonical assessment** — reached through the administration FK, not a
    direct fact FK (which would diamond against the administration).
 
 ## dbt changes (additive only)
@@ -172,11 +209,9 @@ and any `select *` consumers.
 Add **one** column: `assessment_key` =
 `generate_surrogate_key([assessment_type, module_code, source_assessment_id, test_type])`
 (all four already in the `all_administrations` CTE). For Illuminate this
-resolves to the canonical-representative `dim_assessments` row; for state it's
+resolves to the canonical-representative `dim_assessments` row; for state it is
 the 1:1 state row. Add a `relationships` test to `dim_assessments`. No
-descriptor denormalization, no hash change. (Existing columns —
-`administered_date_key`, `_dbt_source_project`, `administration_period`,
-`source_assessment_id`, `test_type` — stay.)
+descriptor denormalization, no hash change. Existing columns stay.
 
 ### Other dims (additive)
 
@@ -190,22 +225,12 @@ descriptor denormalization, no hash change. (Existing columns —
   `graduation_year`.)
 - `dim_locations`: add `head_of_school`.
 
-No change to `int_assessments__assessments_canonical` — `module_type` comes from
-`dim_assessments` via the administration FK.
-
-### New `bridge_assessment_score_members`
-
-Factless bridge: `assessment_score_key` to member `assessment_key`. Internal:
-reconstruct `assessment_score_key` from the fact's inputs and unnest the rollup
-`assessment_ids` to member ids, hashing each to
-`surrogate('illuminate', module_code, member_assessment_id, null)`. State: the
-single state `assessment_key`. Tests: `unique_combination_of_columns` on the two
-keys; `relationships` to the fact and to `dim_assessments`.
+No change to `int_assessments__assessments_canonical` (`module_type` comes from
+`dim_assessments` via the administration FK) and none to `dim_assessments`.
 
 ## Cube measures
 
-On `student_assessment_scores`; detail + summary views only (never the member
-view — bridge fan-out):
+On `student_assessment_scores`:
 
 | Measure               | Definition                                  | Notes                                                        |
 | --------------------- | ------------------------------------------- | ------------------------------------------------------------ |
@@ -230,10 +255,8 @@ From joined cubes:
   `module_code`, `is_internal_assessment`.
 - `assessment_administrations`: `administration_period`, `test_type`,
   `source_assessment_id` (canonical id).
-- `administration_dates`: administration-date calendar attributes (primary
-  reporting date). `dates`: completion-date attributes.
-- `assessment_members` (member view only): `title`, `academic_subject`,
-  `module_code`, `module_type`, `grade_level_tested`.
+- `administration_dates`: administration-date calendar (primary reporting date).
+  `dates`: completion-date calendar.
 - `courses`: `academic_subject`, `course_title`, `course_code`, `credit_type`,
   `is_foundations`. `course_sections`: `identifier`, `period`.
 - `student_section_enrollments`: `academic_year`, `entry_date`, `exit_date`,
@@ -253,12 +276,11 @@ From joined cubes:
 
 - **`student_assessment_scores_detail`** — row-level; `full_name` / identifiers;
   two-policy access (PII fields in `excludes` + a `cube-access-student-pii`
-  `includes: "*"`). Reads `assessments` (canonical) via the administration; does
-  not join the member bridge.
+  `includes: "*"`).
 - **`student_assessment_scores_summary`** — aggregates + demographic breakdowns;
   single `cube-access-student-data` policy.
-- **`student_assessment_scores_members_detail`** — member drill-down via bridge
-  to `assessment_members`; one row per score x member; no aggregate measures.
+
+(A member-level drill-down view is deferred with the bridge — #4170.)
 
 ## Access gating
 
@@ -272,7 +294,7 @@ Add every new/touched mart to `cube.yml`'s `cube_semantic_layer.depends_on`:
 `fct_assessment_scores_enrollment_scoped`, `dim_assessment_administrations`,
 `dim_assessments`, `dim_student_section_enrollments`, `dim_course_sections`,
 `dim_courses`, `dim_student_enrollment_status`, `dim_student_enrollments`,
-`dim_locations`, `dim_dates`, `bridge_assessment_score_members`.
+`dim_locations`, `dim_dates`.
 
 ## DDI dimension parity
 
@@ -283,7 +305,8 @@ module_code/type via the `dim_assessments` FK, administered_at), the
 response/standard family, course fields (incl. `is_foundations`), and enrollment
 extras (`year_in_network`, `head_of_school`). Intentionally **not** in this cube
 (separate facts/domains): iReady lessons, walkthrough/observation data,
-microgoals. Teacher fields deferred (#4165).
+microgoals. Teacher fields deferred (#4165); actual-member drill-down deferred
+(#4170).
 
 ## Out of scope (tracked)
 
@@ -295,13 +318,14 @@ microgoals. Teacher fields deferred (#4165).
   [#4167](https://github.com/TEAMSchools/teamster/issues/4167).
 - Student-subject intervention-status dim —
   [#4168](https://github.com/TEAMSchools/teamster/issues/4168).
+- Score-to-member drill-down (bridge + `assessment_members` + members view) —
+  [#4170](https://github.com/TEAMSchools/teamster/issues/4170).
 - QBL / power-standard flags — not currently tracked.
 
 ## Validation approach
 
-- Build the enriched dims + bridge in a dev schema; confirm uniqueness /
-  relationships tests pass; reconcile bridge row counts with the rollup
-  `assessment_ids` cardinality.
+- Build the enriched dims in a dev schema; confirm uniqueness / relationships
+  tests pass.
 - **Confirm the `assessment_key` FK on `dim_assessment_administrations`
   populates for the state branches** (Illuminate proven 100%; state is
   structurally 1:1 but unverified empirically).
@@ -310,4 +334,3 @@ microgoals. Teacher fields deferred (#4165).
 - Compile each view via Cube `/sql`; validate `pct_proficient` by
   `response_type_code` x `region` x `academic_year` and by administration season
   against direct warehouse SQL.
-- Confirm the member view never inflates `count_scores`.

--- a/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
+++ b/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
@@ -3,7 +3,10 @@
 Anchor issue: [#4163](https://github.com/TEAMSchools/teamster/issues/4163).
 Follow-ups: [#4164](https://github.com/TEAMSchools/teamster/issues/4164)
 (normalized canonical dim),
-[#4165](https://github.com/TEAMSchools/teamster/issues/4165) (section teacher).
+[#4165](https://github.com/TEAMSchools/teamster/issues/4165) (section teacher),
+[#4167](https://github.com/TEAMSchools/teamster/issues/4167) (academic-goals
+dim), [#4168](https://github.com/TEAMSchools/teamster/issues/4168)
+(student-subject intervention-status dim).
 
 ## Purpose
 
@@ -12,24 +15,32 @@ A broad, all-source assessment-score explorer in the Cube semantic layer over
 and NJ/FL state assessments (NJSLA, NJGPA, FAST). The headline metric is
 proficiency/mastery rate, which is the only score measure that is meaningful
 across the incompatible score scales of the different sources. Analysts slice by
-subject, score source, testing season, school/region, grade level, and student
-demographics, and can drill from aggregates to row-level scores and to the
-individual member assessments behind a score.
+standard/skill, subject, score source, testing season, administration date,
+school/region, grade level, course, and student demographics, and can drill from
+aggregates to row-level scores and to the individual member assessments behind a
+score. Dimension parity is benchmarked against the existing
+`rpt_tableau__ddi_dashboard` Tableau extract.
 
 ## Source fact
 
 `fct_assessment_scores_enrollment_scoped` — grain: one row per student x
-assessment x administration. PK `assessment_score_key`. The fact is thin: its
-only measures are `scale_score` (null for internal), `percent_correct` (null for
-state), `proficiency_level`, and `is_mastery`. Everything an analyst slices by
-lives on parent dims. The fact FKs to `dim_assessment_administrations`
-(`assessment_administration_key`), `dim_student_section_enrollments`
-(`student_section_enrollment_key`), and `dim_dates` (`test_date_key`), and
-carries `enrollment_resolution` (`subject_section` / `homeroom`).
+assessment x administration x **response type**. The response type
+(`response_type` / `response_type_id` / `response_type_code`) is part of the
+surrogate key but is currently dropped from the output; it is the standard /
+skill / overall breakdown that mastery-by-standard reporting depends on, so this
+spec projects it (additive — see dbt changes). PK `assessment_score_key`.
 
-This is event-grained (one row per test event), not a cumulative daily-status
-fact, so it is **not** a snapshot cube — no `SNAPSHOT_CUBES` entry and no
-`is_latest_record` / `_month_end` / `_week_end` machinery.
+The fact's intrinsic measures are `scale_score` (null for internal),
+`percent_correct` (null for state), `proficiency_level`, and `is_mastery`.
+Descriptive attributes live on parent dims. The fact FKs to
+`dim_assessment_administrations` (`assessment_administration_key`),
+`dim_student_section_enrollments` (`student_section_enrollment_key`), and
+`dim_dates` (`test_date_key` = the student's `date_taken` / completion date),
+and carries `enrollment_resolution` (`subject_section` / `homeroom`).
+
+Event-grained (one row per scored response), not a cumulative daily-status fact,
+so it is **not** a snapshot cube — no `SNAPSHOT_CUBES` entry and no
+`is_latest_record` machinery.
 
 ## Verified findings (drove the design)
 
@@ -39,54 +50,57 @@ brainstorming:
 - **Location never diverges.** Across 14,189,742 fact rows, the student's
   enrollment `location_key` and the course-section `location_key` never differ
   (0 divergent rows); the student path is null on 13,878 rows (0.1%, grade-99 /
-  placeholder schools) where the course path is populated. Decision: single
-  canonical location join via the student enrollment; `course_sections`
-  `location_key` is unused in the cube.
+  placeholder schools). Decision: single canonical location join via the student
+  enrollment; `course_sections` `location_key` is unused in the cube.
 - **`dim_assessments` is member-grain for Illuminate.** Joining it directly to
-  the fact fans out up to 30x on 19% (2,268 / 12,209) of Illuminate
-  administrations. Within an administration, `academic_subject` and
-  `is_internal_assessment` are constant (0 varying); `title` varies (2,135
-  administrations), so the canonical title must be used, not a member title.
+  the fact fans out up to 30x on 19% (2,268 / 12,209) of administrations. Within
+  an administration, `academic_subject` and `is_internal_assessment` are
+  constant (0 varying); `title` varies (member-level), so the canonical title is
+  used. The administration does **not** FK to `dim_assessments` and cannot — its
+  key uses the canonical id, `dim_assessments`' uses the member id.
 - **Member is multi-valued per score; canonical is single.** Of 14.16M internal
-  score rows, 96.5% map to exactly one member assessment, 2.8% to two, and 0.7%
-  to three or more (max 23). The rollup `array_agg`s members into
-  `assessment_ids`. So canonical can be a clean single parent; member requires a
-  bridge.
+  score rows, 96.5% map to one member, 2.8% to two, 0.7% to three or more (max
+  23). Canonical can be a clean single parent (via the administration); member
+  needs a bridge.
 
 ## Architecture
 
 ### Cube inventory
 
-Six new cubes, reusing six existing (`student_enrollments`, `students`,
+Eight new cubes, reusing six existing (`student_enrollments`, `students`,
 `locations`, `regions`, `dates`, `terms`):
 
-| New cube                            | Reads                                       | Folder                      | Student-gated |
-| ----------------------------------- | ------------------------------------------- | --------------------------- | ------------- |
-| `student_assessment_scores` (fact)  | `fct_assessment_scores_enrollment_scoped`   | `cubes/student_assessment/` | yes           |
-| `student_section_enrollments`       | `dim_student_section_enrollments`           | `cubes/students/`           | yes           |
-| `assessment_administrations`        | `dim_assessment_administrations` (enriched) | `cubes/assessments/`        | no            |
-| `assessments`                       | `dim_assessments` (member-grain)            | `cubes/assessments/`        | no            |
-| `course_sections`                   | `dim_course_sections`                       | `cubes/conformed/`          | no            |
-| `courses`                           | `dim_courses`                               | `cubes/conformed/`          | no            |
-| `assessment_score_members` (bridge) | `bridge_assessment_score_members`           | `cubes/student_assessment/` | no            |
+| New cube                             | Reads                                       | Folder                      | Student-gated |
+| ------------------------------------ | ------------------------------------------- | --------------------------- | ------------- |
+| `student_assessment_scores` (fact)   | `fct_assessment_scores_enrollment_scoped`   | `cubes/student_assessment/` | yes           |
+| `student_section_enrollments`        | `dim_student_section_enrollments`           | `cubes/students/`           | yes           |
+| `assessment_administrations`         | `dim_assessment_administrations` (enriched) | `cubes/assessments/`        | no            |
+| `assessments`                        | `dim_assessments` (member-grain)            | `cubes/assessments/`        | no            |
+| `course_sections`                    | `dim_course_sections`                       | `cubes/conformed/`          | no            |
+| `courses`                            | `dim_courses` (enriched)                    | `cubes/conformed/`          | no            |
+| `assessment_score_members` (bridge)  | `bridge_assessment_score_members`           | `cubes/student_assessment/` | no            |
+| `administration_dates` (role-played) | `dim_dates`                                 | `cubes/conformed/`          | no            |
 
 Student-domain cubes are `student`-prefixed so `cube.js`'s `isStudentMember`
-gating and location scoping auto-apply; curriculum and assessment-reference dims
-are unprefixed (no student data, no domain tier).
+gating and location scoping auto-apply; curriculum, assessment-reference, and
+date dims are unprefixed (no student data, no domain tier). `standard_domain` is
+carried as a degenerate column on the fact (1:1 lookup on `response_type_code`),
+not a separate cube.
 
 ### Join graph
 
 ```text
 student_assessment_scores (fct)
-  - dates                      test_date_key                       (only date join; avoids diamond)
-  - assessment_administrations assessment_administration_key       (canonical + occurrence/season)
+  - dates                      test_date_key (date_taken / completion date)
+  - assessment_administrations assessment_administration_key (canonical + occurrence/season)
+      - administration_dates   administered_date_key (administered_at; primary reporting date)
   - student_section_enrollments student_section_enrollment_key
       - student_enrollments    student_enrollment_key
-          - students           student_key                         (identity / demographics)
+          - students           student_key                  (identity / demographics)
           - locations          location_key  (canonical location)
               - regions        region_key
       - course_sections        course_section_key
-          - courses            course_key    (enrolled-course subject/title)
+          - courses            course_key    (course title/code/subject/is_foundations)
       - terms                  term_key
   - (bridge) assessment_score_members assessment_score_key
       - assessments            assessment_key (member-grain; drill-down only)
@@ -94,34 +108,60 @@ student_assessment_scores (fct)
 
 ### Diamond / role-play resolutions
 
-1. **`dates`** — two routes exist (fact `test_date_key`; administration
-   `administered_date_key`). Only the fact joins `dates` (the score's
-   `test_date`). `assessment_administrations` exposes `administered_date` as a
-   degenerate `CAST(... AS TIMESTAMP)` with no `dates` join.
+1. **`dates` (role-played, not collapsed).** Two genuinely different dates: the
+   fact's `test_date_key` (= `date_taken`, completion) and the administration's
+   `administered_date_key` (= `administered_at`, the primary reporting date,
+   populated for Illuminate, null for state). These are role-playing dimensions,
+   not a diamond: the fact joins the conformed `dates` cube on `test_date_key`,
+   and a second cube instance `administration_dates` (same `dim_dates` table) is
+   joined from `assessment_administrations` on `administered_date_key`. Two
+   single-path joins to two distinct cube instances — no shared target row.
+   Views prefix-disambiguate (`dates_*` vs `administration_dates_*`).
 2. **`locations`** — only `student_enrollments` to `locations`. The
    `course_sections` `location_key` is not joined (verified never divergent).
 3. **`academic_year`** — present on `student_section_enrollments`,
    `student_enrollments`, and `terms`. Exposed canonically from
-   `student_section_enrollments` only, to avoid multi-cube ambiguity in views.
-4. **canonical assessment** — reached through `assessment_administrations` (the
-   administration determines the canonical). The fact deliberately has no direct
-   canonical FK, which would diamond against the administration.
+   `student_section_enrollments` only.
+4. **canonical assessment** — reached through `assessment_administrations`. The
+   fact has no direct canonical FK (would diamond against the administration).
 
 ## dbt changes (additive only)
 
+### `fct_assessment_scores_enrollment_scoped` (additive columns)
+
+Project response-grain and band attributes already available in
+`int_assessments__response_rollup` but currently dropped: `response_type`,
+`response_type_code`, `response_type_description`,
+`response_type_root_description`, `is_replacement`,
+`performance_band_label_number`. Add `standard_domain` as a degenerate column
+via the existing `stg_google_sheets__assessments__standard_domains` lookup on
+`response_type_code`. **No surrogate-key hash change** — `response_type` is
+already a hash input; these are pure additive projections. Update the contract
+YAML and any `select *` consumers.
+
 ### Enrich `dim_assessment_administrations`
 
-Project descriptors that already exist in the model's `all_administrations`
-union but are dropped in the final SELECT: `title` (the **canonical** title for
-Illuminate — sourced from `int_assessments__assessments_canonical`),
+Project descriptors already in the model's `all_administrations` union but
+dropped in the final SELECT: `title` (the canonical title for Illuminate),
 `academic_subject` (from `subject_area`), `type` (from `assessment_type`),
-`scope`, `grade_level_tested` (from `grade_level`), and a derived
-`is_internal_assessment` (= `assessment_type = 'illuminate'`). Surface the
-existing `source_assessment_id` as the canonical-assessment id (Illuminate).
-This is the canonical-assessment anchor and the sole source of
-`administration_period` (testing season / window). No surrogate-key hash change
-(none of these are hash inputs). Update the contract YAML and any `select *`
-consumers.
+`scope`, `grade_level_tested` (from `grade_level`), `module_code`, and a derived
+`is_internal_assessment` (= `assessment_type = 'illuminate'`). Also add
+`module_type` (source onto the canonical grain) and surface
+`source_assessment_id` as the canonical-assessment id. No hash change. This is
+the canonical-assessment anchor and the sole source of `administration_period`
+(season/window).
+
+### Enrich other dims (additive)
+
+- `dim_courses`: add `is_foundations` (derived today in
+  `int_assessments__course_enrollments`). `course_number` is already exposed as
+  `course_code`.
+- `dim_student_enrollment_status`: add `status_504`, `is_self_contained`,
+  `is_sipps`. (`ml_status` is already covered by `is_ell`; `iep_status` by
+  `is_iep` / `iep_classification`.)
+- `dim_student_enrollments`: add `year_in_network`. (`cohort` is already covered
+  by `graduation_year`.)
+- `dim_locations`: add `head_of_school`.
 
 ### New `bridge_assessment_score_members`
 
@@ -135,52 +175,56 @@ the single state `assessment_key`
 (`unique_combination_of_columns` on the two keys; `relationships` to the fact
 and to `dim_assessments`).
 
-### No change
-
-`fct_assessment_scores_enrollment_scoped` itself (canonical reached via the
-administration; no degenerate columns) and `dim_assessments` (already has every
-member column).
-
 ## Cube measures
 
 Defined on `student_assessment_scores`; used in the detail and summary views
 only (never the member-detail view, where the bridge fan-out would
-double-count):
+double-count). With `response_type` projected, these aggregate at the
+standard/skill grain when filtered by `response_type` / `response_type_code`:
 
-| Measure               | Definition                                          | Notes                                                                                                                        |
-| --------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `count_scores`        | `count_distinct assessment_score_key`               | score-record count                                                                                                           |
-| `count_students`      | `count_distinct student_enrollment_key` (via chain) | per student-year, matching the attendance convention                                                                         |
-| `pct_proficient`      | `_count_proficient / count_scores`, percent         | headline; `is_mastery`-based, source-agnostic                                                                                |
-| `avg_percent_correct` | `avg(percent_correct)`                              | internal-effective; filter by subject/module                                                                                 |
-| `avg_scale_score`     | `avg(scale_score)`                                  | guardrail docs: meaningful only filtered to a single assessment + subject + grade + source; steers users to `pct_proficient` |
+| Measure               | Definition                                          | Notes                                                                                 |
+| --------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `count_scores`        | `count_distinct assessment_score_key`               | scored-response count                                                                 |
+| `count_students`      | `count_distinct student_enrollment_key` (via chain) | per student-year, matching the attendance convention                                  |
+| `pct_proficient`      | `_count_proficient / count_scores`, percent         | headline; `is_mastery`-based, source-agnostic                                         |
+| `avg_percent_correct` | `avg(percent_correct)`                              | internal-effective; filter by subject/standard                                        |
+| `avg_scale_score`     | `avg(scale_score)`                                  | guardrail docs — meaningful only filtered to a single assessment/subject/grade/source |
 
 `_count_proficient` is a private helper (count where `is_mastery`).
 
 ## Cube dimensions
 
 On the fact: `assessment_score_key` (PK), `test_date`, `enrollment_resolution`
-(load-bearing filter — subject is only meaningful on `subject_section` rows),
-`proficiency_level`, `is_mastery`, `scale_score`, `percent_correct`.
+(load-bearing — subject is only meaningful on `subject_section` rows),
+`proficiency_level`, `performance_band_label_number`, `is_mastery`,
+`scale_score`, `percent_correct`, `response_type`, `response_type_code`,
+`response_type_description`, `response_type_root_description`,
+`standard_domain`, `is_replacement`.
 
 From joined cubes (subject appears twice, prefix-disambiguated):
 
-- `assessment_administrations`: `academic_subject` (the assessment's subject),
-  `title`, `type`, `scope`, `grade_level_tested`, `is_internal_assessment`
-  (score source), `administration_period` (season/window), `test_type`,
-  `administered_date`, `source_assessment_id` (canonical id).
-- `courses`: `academic_subject` (enrolled-course subject), `course_title`,
-  `course_code`.
+- `assessment_administrations`: `academic_subject`, `title`, `type`, `scope`,
+  `grade_level_tested`, `is_internal_assessment`, `module_code`, `module_type`,
+  `administration_period`, `test_type`, `source_assessment_id`.
+- `administration_dates`: `date_day`, `month_name`, `quarter_number`,
+  `academic_year`, etc. (primary reporting date).
+- `dates`: completion-date calendar attributes.
+- `courses`: `academic_subject`, `course_title`, `course_code`, `credit_type`,
+  `is_foundations`.
 - `course_sections`: `identifier`, `period`.
 - `assessments` (member, drill-down view only): `title`, `academic_subject`,
   `module_code`, `module_type`, `grade_level_tested`, `is_internal_assessment`.
 - `student_section_enrollments`: `academic_year` (canonical), `entry_date`,
   `exit_date`, `is_dropped_section`, `is_dropped_course`.
-- `student_enrollments`: `grade_level`, `graduation_year`, `is_retained_year`.
+- `student_enrollments`: `grade_level`, `graduation_year`, `year_in_network`,
+  `is_retained_year`.
+- `student_enrollment_status`: `is_ell`, `is_iep`, `iep_classification`,
+  `special_education_code`/`_name`/`_placement`, `status_504`,
+  `is_self_contained`, `is_sipps`, `is_meal_eligible`, `meal_eligibility`.
 - `students`: `full_name` + identifiers (PII), `race`, `gender_identity`,
   `is_gifted`, `enrollment_status`.
-- `locations`: `location_name`, `abbreviation`, `grade_band`, `campus`, `city`;
-  `regions`: `region_name`, `state`.
+- `locations`: `location_name`, `abbreviation`, `grade_band`, `campus`, `city`,
+  `head_of_school`; `regions`: `region_name`, `state`.
 - `terms`: `semester`, `term_name`, `term_code`, `term_type`.
 
 ## Views
@@ -189,53 +233,69 @@ Three analyst-facing views:
 
 - **`student_assessment_scores_detail`** — row-level scores; carries `full_name`
   / identifiers. Two-policy access: `cube-access-student-data` with PII fields
-  in `excludes`, plus `cube-access-student-pii` with `includes: "*"`. Does
-  **not** join the member bridge (keeps measures clean). Canonical and the
-  assessment descriptors come from `assessment_administrations`.
+  in `excludes`, plus `cube-access-student-pii` with `includes: "*"`. Does not
+  join the member bridge.
 - **`student_assessment_scores_summary`** — aggregates and demographic
   breakdowns only; no direct identifiers. Single `cube-access-student-data`
   policy.
 - **`student_assessment_scores_members_detail`** — member-level drill-down via
-  the bridge to `assessments`: one row per score x member. **No aggregate
-  measures**, so the 3.5% multi-member fan-out never double-counts. Each row
-  shows the member (from `assessments`), its canonical and season (from
-  `assessment_administrations`), and the student context. PII-gated like the
+  the bridge to `assessments`: one row per score x member. No aggregate
+  measures, so the multi-member fan-out never double-counts. PII-gated like the
   detail view.
 
 ## Access gating
 
 No `cube.js` change. Student-prefixed cubes inherit `isStudentMember` member
 stripping and the location scope filter (resolved through the existing
-`student_enrollments` to `locations` chain, as in `student_attendance`). The
-assessment-reference and curriculum dims are unprefixed and carry no student
-data. Not a snapshot cube, so no `SNAPSHOT_CUBES` / `SNAPSHOT_MEASURE_STEMS`
-entry.
+`student_enrollments` to `locations` chain). Assessment-reference, curriculum,
+and date dims are unprefixed. Not a snapshot cube.
 
 ## Exposures
 
-Add every new mart (`fct_assessment_scores_enrollment_scoped` if not already
-present, `dim_assessment_administrations`, `dim_student_section_enrollments`,
-`dim_course_sections`, `dim_courses`, `dim_assessments`,
-`bridge_assessment_score_members`) to `cube.yml`'s
-`cube_semantic_layer.depends_on`.
+Add every new/enriched mart to `cube.yml`'s `cube_semantic_layer.depends_on`:
+`fct_assessment_scores_enrollment_scoped`, `dim_assessment_administrations`,
+`dim_student_section_enrollments`, `dim_course_sections`, `dim_courses`,
+`dim_assessments`, `dim_student_enrollment_status`, `dim_student_enrollments`,
+`dim_locations`, `dim_dates`, `bridge_assessment_score_members`.
+
+## DDI dimension parity
+
+Benchmarked against `rpt_tableau__ddi_dashboard`. Covered after this spec: all
+student demographics, enrollment, school/region, status (incl. 504 /
+self-contained / SIPPS), term, assessment descriptors (title, subject,
+module*code/type, administered_at), the response/standard family
+(`response_type*`, `standard_domain`, `is_replacement`, band number), course fields (`course\*\*`, `is_foundations`), and enrollment extras (`year_in_network`, `head_of_school`).
+Intentionally **not** in this cube (separate facts/domains): iReady lessons,
+walkthrough/observation data, microgoals — these belong to their own cubes.
+Teacher fields are deferred (#4165).
 
 ## Out of scope (tracked)
 
-- Normalized `dim_canonical_assessments` with canonical + member as first-class
-  linked dims — [#4164](https://github.com/TEAMSchools/teamster/issues/4164).
+- Normalized `dim_canonical_assessments` (canonical + member as first-class
+  linked dims) — [#4164](https://github.com/TEAMSchools/teamster/issues/4164).
 - Section teacher (all teachers incl. co-teachers via bridge + `dim_staff` +
   staff-domain access decision) —
   [#4165](https://github.com/TEAMSchools/teamster/issues/4165).
+- Academic-goals dim (`grade`/`school`/`region`/`organization` goals via
+  `dim_assessment_goals`) —
+  [#4167](https://github.com/TEAMSchools/teamster/issues/4167).
+- Student-subject intervention-status dim (DIBELS, state-test proficiency, NJ
+  tier, FL low-25, iReady-exempt) —
+  [#4168](https://github.com/TEAMSchools/teamster/issues/4168).
+- QBL / power-standard flags (Google Sheet) — not currently tracked; raise if
+  needed.
 
 ## Validation approach
 
-- Build the enriched administration dim and the bridge in a dev schema; confirm
+- Build the enriched dims and the bridge in a dev schema; confirm
   uniqueness/relationships tests pass and the bridge row counts reconcile with
   the rollup `assessment_ids` cardinality.
-- Verify each cube FK populates in prod (sample non-null share; treat 99%+ null
-  as a broken join).
+- Confirm each enrichment is functionally determined by its host grain (no new
+  duplicate keys) — especially `module_type` on the administration and the
+  response/standard columns on the fact.
+- Verify each cube FK populates in prod (treat 99%+ null as a broken join);
+  expect `administration_dates` to be null for state rows by design.
 - Compile each view via the Cube `/sql` endpoint and validate a representative
-  query (`pct_proficient` by `academic_subject` x `region` x `academic_year`)
-  against direct warehouse SQL.
-- Confirm the member-detail view never inflates `count_scores` (the bridge is
-  absent from measure paths).
+  query (`pct_proficient` by `response_type_code` x `region` x `academic_year`,
+  and by `administration_dates` season) against direct warehouse SQL.
+- Confirm the member-detail view never inflates `count_scores`.

--- a/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
+++ b/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md
@@ -13,8 +13,8 @@ dim), [#4168](https://github.com/TEAMSchools/teamster/issues/4168)
 A broad, all-source assessment-score explorer in the Cube semantic layer over
 `fct_assessment_scores_enrollment_scoped`, covering internal Illuminate interims
 and NJ/FL state assessments (NJSLA, NJGPA, FAST). The headline metric is
-proficiency/mastery rate, which is the only score measure that is meaningful
-across the incompatible score scales of the different sources. Analysts slice by
+proficiency/mastery rate, which is the only score measure meaningful across the
+incompatible score scales of the different sources. Analysts slice by
 standard/skill, subject, score source, testing season, administration date,
 school/region, grade level, course, and student demographics, and can drill from
 aggregates to row-level scores and to the individual member assessments behind a
@@ -26,196 +26,218 @@ score. Dimension parity is benchmarked against the existing
 `fct_assessment_scores_enrollment_scoped` — grain: one row per student x
 assessment x administration x **response type**. The response type
 (`response_type` / `response_type_id` / `response_type_code`) is part of the
-surrogate key but is currently dropped from the output; it is the standard /
-skill / overall breakdown that mastery-by-standard reporting depends on, so this
-spec projects it (additive — see dbt changes). PK `assessment_score_key`.
+surrogate key but currently dropped from the output; it is the standard / skill
+/ overall breakdown that mastery-by-standard reporting depends on, so this spec
+projects it (additive). PK `assessment_score_key`.
 
-The fact's intrinsic measures are `scale_score` (null for internal),
-`percent_correct` (null for state), `proficiency_level`, and `is_mastery`.
-Descriptive attributes live on parent dims. The fact FKs to
-`dim_assessment_administrations` (`assessment_administration_key`),
-`dim_student_section_enrollments` (`student_section_enrollment_key`), and
-`dim_dates` (`test_date_key` = the student's `date_taken` / completion date),
-and carries `enrollment_resolution` (`subject_section` / `homeroom`).
+Intrinsic measures: `scale_score` (null for internal), `percent_correct` (null
+for state), `proficiency_level`, `is_mastery`. Descriptive attributes live on
+parent dims. The fact FKs to `dim_assessment_administrations`
+(`assessment_administration_key`), `dim_student_section_enrollments`
+(`student_section_enrollment_key`), and `dim_dates` (`test_date_key` =
+`date_taken` / completion date), and carries `enrollment_resolution`
+(`subject_section` / `homeroom`).
 
 Event-grained (one row per scored response), not a cumulative daily-status fact,
-so it is **not** a snapshot cube — no `SNAPSHOT_CUBES` entry and no
-`is_latest_record` machinery.
+so it is **not** a snapshot cube.
 
 ## Verified findings (drove the design)
 
-All confirmed against prod (`kipptaf_marts`, `kipptaf_assessments`) during
-brainstorming:
+All confirmed against prod (`kipptaf_marts`, `kipptaf_assessments`):
 
-- **Location never diverges.** Across 14,189,742 fact rows, the student's
-  enrollment `location_key` and the course-section `location_key` never differ
-  (0 divergent rows); the student path is null on 13,878 rows (0.1%, grade-99 /
-  placeholder schools). Decision: single canonical location join via the student
-  enrollment; `course_sections` `location_key` is unused in the cube.
-- **`dim_assessments` is member-grain for Illuminate.** Joining it directly to
-  the fact fans out up to 30x on 19% (2,268 / 12,209) of administrations. Within
-  an administration, `academic_subject` and `is_internal_assessment` are
-  constant (0 varying); `title` varies (member-level), so the canonical title is
-  used. The administration does **not** FK to `dim_assessments` and cannot — its
-  key uses the canonical id, `dim_assessments`' uses the member id.
+- **Location never diverges.** Across 14,189,742 fact rows, student-enrollment
+  `location_key` and course-section `location_key` never differ (0 rows);
+  student path null on 13,878 rows (0.1%). Single canonical location join via
+  the student enrollment.
+- **`dim_assessment_administrations` CAN FK to `dim_assessments` on the
+  canonical id.** The canonical model sets
+  `canonical_assessment_id = first_value(assessment_id)` — the canonical id is
+  itself the representative member's id, and `dim_assessments` has a row per
+  member. Across all 4,748 Illuminate canonicals,
+  `surrogate(assessment_type, module_code, canonical_id, null)` matches a
+  `dim_assessments` row 100% of the time, with **0** `title` and **0**
+  `academic_subject` mismatches vs. the canonical. This join is
+  many-administrations-to-one-assessment — **no fan-out**. (The 30x fan-out risk
+  applies only to joining the _fact_ to all members, which is the bridge path.)
 - **Member is multi-valued per score; canonical is single.** Of 14.16M internal
   score rows, 96.5% map to one member, 2.8% to two, 0.7% to three or more (max
-  23). Canonical can be a clean single parent (via the administration); member
-  needs a bridge.
+  23). The actual member(s) a score rolled up are reached via the bridge.
 
 ## Architecture
 
 ### Cube inventory
 
-Eight new cubes, reusing six existing (`student_enrollments`, `students`,
-`locations`, `regions`, `dates`, `terms`):
+Nine new cubes, reusing six existing (`student_enrollments`, `students`,
+`locations`, `regions`, `dates`, `terms`). Two pairs are role-played (same
+table, two cube instances): `dim_dates` (`dates` + `administration_dates`) and
+`dim_assessments` (`assessments` + `assessment_members`).
 
-| New cube                             | Reads                                       | Folder                      | Student-gated |
-| ------------------------------------ | ------------------------------------------- | --------------------------- | ------------- |
-| `student_assessment_scores` (fact)   | `fct_assessment_scores_enrollment_scoped`   | `cubes/student_assessment/` | yes           |
-| `student_section_enrollments`        | `dim_student_section_enrollments`           | `cubes/students/`           | yes           |
-| `assessment_administrations`         | `dim_assessment_administrations` (enriched) | `cubes/assessments/`        | no            |
-| `assessments`                        | `dim_assessments` (member-grain)            | `cubes/assessments/`        | no            |
-| `course_sections`                    | `dim_course_sections`                       | `cubes/conformed/`          | no            |
-| `courses`                            | `dim_courses` (enriched)                    | `cubes/conformed/`          | no            |
-| `assessment_score_members` (bridge)  | `bridge_assessment_score_members`           | `cubes/student_assessment/` | no            |
-| `administration_dates` (role-played) | `dim_dates`                                 | `cubes/conformed/`          | no            |
+| New cube                            | Reads                                                   | Role                                          |
+| ----------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
+| `student_assessment_scores` (fact)  | `fct_assessment_scores_enrollment_scoped`               | scores                                        |
+| `student_section_enrollments`       | `dim_student_section_enrollments`                       | enrollment bridge to student/course           |
+| `assessment_administrations`        | `dim_assessment_administrations` (+`assessment_key` FK) | occurrence: season, admin date                |
+| `assessments`                       | `dim_assessments`                                       | canonical descriptors (via administration FK) |
+| `assessment_members`                | `dim_assessments`                                       | actual member(s) (via score bridge)           |
+| `course_sections`                   | `dim_course_sections`                                   | section context                               |
+| `courses`                           | `dim_courses` (+`is_foundations`)                       | course subject/title/code                     |
+| `assessment_score_members` (bridge) | `bridge_assessment_score_members`                       | score to member(s)                            |
+| `administration_dates`              | `dim_dates`                                             | administration-date calendar                  |
 
-Student-domain cubes are `student`-prefixed so `cube.js`'s `isStudentMember`
-gating and location scoping auto-apply; curriculum, assessment-reference, and
-date dims are unprefixed (no student data, no domain tier). `standard_domain` is
-carried as a degenerate column on the fact (1:1 lookup on `response_type_code`),
-not a separate cube.
+Student-domain cubes are `student`-prefixed for `cube.js` gating; assessment,
+curriculum, and date dims are unprefixed. `standard_domain` is a degenerate
+column on the fact (1:1 on `response_type_code`), not a cube.
 
-### Join graph
+### Cube join graph
 
 ```text
 student_assessment_scores (fct)
-  - dates                      test_date_key (date_taken / completion date)
-  - assessment_administrations assessment_administration_key (canonical + occurrence/season)
-      - administration_dates   administered_date_key (administered_at; primary reporting date)
+  - dates                       test_date_key (completion date)
+  - assessment_administrations  assessment_administration_key
+      - administration_dates    administered_date_key (administered_at; primary reporting date)
+      - assessments             assessment_key  (canonical descriptors; many-to-one, no fan-out)
   - student_section_enrollments student_section_enrollment_key
-      - student_enrollments    student_enrollment_key
-          - students           student_key                  (identity / demographics)
-          - locations          location_key  (canonical location)
-              - regions        region_key
-      - course_sections        course_section_key
-          - courses            course_key    (course title/code/subject/is_foundations)
-      - terms                  term_key
+      - student_enrollments     student_enrollment_key
+          - students            student_key
+          - locations           location_key
+              - regions         region_key
+      - course_sections         course_section_key
+          - courses             course_key
+      - terms                   term_key
   - (bridge) assessment_score_members assessment_score_key
-      - assessments            assessment_key (member-grain; drill-down only)
+      - assessment_members      assessment_key  (actual member(s); drill-down only)
 ```
+
+### dbt model references (FK graph)
+
+Arrows point from child to the parent it references (`*` marks a model touched
+by this spec; `[NEW]` is created by it).
+
+```text
+fct_assessment_scores_enrollment_scoped *
+  |-- assessment_administration_key --> dim_assessment_administrations *
+  |                                        |-- assessment_key [NEW FK] --> dim_assessments
+  |                                        '-- administered_date_key ----> dim_dates
+  |-- student_section_enrollment_key --> dim_student_section_enrollments
+  |                                        |-- student_enrollment_key --> dim_student_enrollments *
+  |                                        |                                |-- student_key --> dim_students
+  |                                        |                                '-- location_key --> dim_locations *
+  |                                        |                                                      '-- region_key --> dim_regions
+  |                                        |-- course_section_key --> dim_course_sections
+  |                                        |                            '-- course_key --> dim_courses *
+  |                                        '-- term_key --> dim_terms
+  '-- test_date_key --> dim_dates
+
+bridge_assessment_score_members [NEW]
+  |-- assessment_score_key --> fct_assessment_scores_enrollment_scoped *
+  '-- assessment_key --------> dim_assessments
+
+dim_student_enrollment_status *   (joined to dim_student_enrollments via student_enrollment_key)
+```
+
+`dim_assessments` itself is unchanged (it already carries `title`,
+`academic_subject`, `type`, `scope`, `grade_level_tested`, `module_type`,
+`module_code`, `is_internal_assessment`).
 
 ### Diamond / role-play resolutions
 
-1. **`dates` (role-played, not collapsed).** Two genuinely different dates: the
-   fact's `test_date_key` (= `date_taken`, completion) and the administration's
-   `administered_date_key` (= `administered_at`, the primary reporting date,
-   populated for Illuminate, null for state). These are role-playing dimensions,
-   not a diamond: the fact joins the conformed `dates` cube on `test_date_key`,
-   and a second cube instance `administration_dates` (same `dim_dates` table) is
-   joined from `assessment_administrations` on `administered_date_key`. Two
-   single-path joins to two distinct cube instances — no shared target row.
-   Views prefix-disambiguate (`dates_*` vs `administration_dates_*`).
-2. **`locations`** — only `student_enrollments` to `locations`. The
-   `course_sections` `location_key` is not joined (verified never divergent).
-3. **`academic_year`** — present on `student_section_enrollments`,
-   `student_enrollments`, and `terms`. Exposed canonically from
-   `student_section_enrollments` only.
-4. **canonical assessment** — reached through `assessment_administrations`. The
-   fact has no direct canonical FK (would diamond against the administration).
+1. **`dim_dates` (role-played).** Fact `test_date_key` (completion) joins
+   `dates`; administration `administered_date_key` (administered_at, primary
+   reporting date; null for state) joins a second instance
+   `administration_dates`. Two instances, two single-path joins — no diamond.
+2. **`dim_assessments` (role-played).** Canonical descriptors reached via
+   `assessment_administrations → assessments` (FK on `assessment_key`, the
+   canonical-representative row, single, no fan-out). Actual member(s) reached
+   via `bridge → assessment_members`. Two instances avoid a diamond.
+3. **`locations`** — single join via `student_enrollments`; `course_sections`
+   `location_key` unused.
+4. **`academic_year`** — exposed canonically from `student_section_enrollments`.
+5. **canonical assessment** — reached through the administration FK, not a
+   direct fact FK (which would diamond against the administration).
 
 ## dbt changes (additive only)
 
-### `fct_assessment_scores_enrollment_scoped` (additive columns)
+### `fct_assessment_scores_enrollment_scoped`
 
-Project response-grain and band attributes already available in
-`int_assessments__response_rollup` but currently dropped: `response_type`,
-`response_type_code`, `response_type_description`,
+Project response-grain attributes already in `int_assessments__response_rollup`
+but dropped: `response_type`, `response_type_code`, `response_type_description`,
 `response_type_root_description`, `is_replacement`,
-`performance_band_label_number`. Add `standard_domain` as a degenerate column
-via the existing `stg_google_sheets__assessments__standard_domains` lookup on
-`response_type_code`. **No surrogate-key hash change** — `response_type` is
-already a hash input; these are pure additive projections. Update the contract
-YAML and any `select *` consumers.
+`performance_band_label_number`. Add `standard_domain` (degenerate, via
+`stg_google_sheets__assessments__standard_domains` on `response_type_code`). No
+hash change (`response_type` is already a hash input). Update the contract YAML
+and any `select *` consumers.
 
-### Enrich `dim_assessment_administrations`
+### `dim_assessment_administrations`
 
-Project descriptors already in the model's `all_administrations` union but
-dropped in the final SELECT: `title` (the canonical title for Illuminate),
-`academic_subject` (from `subject_area`), `type` (from `assessment_type`),
-`scope`, `grade_level_tested` (from `grade_level`), `module_code`, and a derived
-`is_internal_assessment` (= `assessment_type = 'illuminate'`). Also add
-`module_type` (source onto the canonical grain) and surface
-`source_assessment_id` as the canonical-assessment id. No hash change. This is
-the canonical-assessment anchor and the sole source of `administration_period`
-(season/window).
+Add **one** column: `assessment_key` =
+`generate_surrogate_key([assessment_type, module_code, source_assessment_id, test_type])`
+(all four already in the `all_administrations` CTE). For Illuminate this
+resolves to the canonical-representative `dim_assessments` row; for state it's
+the 1:1 state row. Add a `relationships` test to `dim_assessments`. No
+descriptor denormalization, no hash change. (Existing columns —
+`administered_date_key`, `_dbt_source_project`, `administration_period`,
+`source_assessment_id`, `test_type` — stay.)
 
-### Enrich other dims (additive)
+### Other dims (additive)
 
 - `dim_courses`: add `is_foundations` (derived today in
-  `int_assessments__course_enrollments`). `course_number` is already exposed as
+  `int_assessments__course_enrollments`). `course_number` already exposed as
   `course_code`.
 - `dim_student_enrollment_status`: add `status_504`, `is_self_contained`,
-  `is_sipps`. (`ml_status` is already covered by `is_ell`; `iep_status` by
-  `is_iep` / `iep_classification`.)
-- `dim_student_enrollments`: add `year_in_network`. (`cohort` is already covered
-  by `graduation_year`.)
+  `is_sipps`. (`ml_status` covered by `is_ell`; `iep_status` by `is_iep` /
+  `iep_classification`.)
+- `dim_student_enrollments`: add `year_in_network`. (`cohort` covered by
+  `graduation_year`.)
 - `dim_locations`: add `head_of_school`.
+
+No change to `int_assessments__assessments_canonical` — `module_type` comes from
+`dim_assessments` via the administration FK.
 
 ### New `bridge_assessment_score_members`
 
 Factless bridge: `assessment_score_key` to member `assessment_key`. Internal:
-reconstruct `assessment_score_key` from the same inputs the fact uses and unnest
-the rollup `assessment_ids` to member ids, hashing each to the member
-`assessment_key`
-(`surrogate('illuminate', module_code, member_assessment_id, null)`). State: map
-the single state `assessment_key`
-(`surrogate(assessment_type, module_code, null, null)`). Properties + tests
-(`unique_combination_of_columns` on the two keys; `relationships` to the fact
-and to `dim_assessments`).
+reconstruct `assessment_score_key` from the fact's inputs and unnest the rollup
+`assessment_ids` to member ids, hashing each to
+`surrogate('illuminate', module_code, member_assessment_id, null)`. State: the
+single state `assessment_key`. Tests: `unique_combination_of_columns` on the two
+keys; `relationships` to the fact and to `dim_assessments`.
 
 ## Cube measures
 
-Defined on `student_assessment_scores`; used in the detail and summary views
-only (never the member-detail view, where the bridge fan-out would
-double-count). With `response_type` projected, these aggregate at the
-standard/skill grain when filtered by `response_type` / `response_type_code`:
+On `student_assessment_scores`; detail + summary views only (never the member
+view — bridge fan-out):
 
-| Measure               | Definition                                          | Notes                                                                                 |
-| --------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `count_scores`        | `count_distinct assessment_score_key`               | scored-response count                                                                 |
-| `count_students`      | `count_distinct student_enrollment_key` (via chain) | per student-year, matching the attendance convention                                  |
-| `pct_proficient`      | `_count_proficient / count_scores`, percent         | headline; `is_mastery`-based, source-agnostic                                         |
-| `avg_percent_correct` | `avg(percent_correct)`                              | internal-effective; filter by subject/standard                                        |
-| `avg_scale_score`     | `avg(scale_score)`                                  | guardrail docs — meaningful only filtered to a single assessment/subject/grade/source |
-
-`_count_proficient` is a private helper (count where `is_mastery`).
+| Measure               | Definition                                  | Notes                                                        |
+| --------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `count_scores`        | `count_distinct assessment_score_key`       | scored-response count                                        |
+| `count_students`      | `count_distinct student_enrollment_key`     | per student-year                                             |
+| `pct_proficient`      | `_count_proficient / count_scores`, percent | headline, source-agnostic                                    |
+| `avg_percent_correct` | `avg(percent_correct)`                      | internal-effective; filter by subject/standard               |
+| `avg_scale_score`     | `avg(scale_score)`                          | guardrail docs — single assessment/subject/grade/source only |
 
 ## Cube dimensions
 
-On the fact: `assessment_score_key` (PK), `test_date`, `enrollment_resolution`
-(load-bearing — subject is only meaningful on `subject_section` rows),
+On the fact: `assessment_score_key` (PK), `test_date`, `enrollment_resolution`,
 `proficiency_level`, `performance_band_label_number`, `is_mastery`,
 `scale_score`, `percent_correct`, `response_type`, `response_type_code`,
 `response_type_description`, `response_type_root_description`,
 `standard_domain`, `is_replacement`.
 
-From joined cubes (subject appears twice, prefix-disambiguated):
+From joined cubes:
 
-- `assessment_administrations`: `academic_subject`, `title`, `type`, `scope`,
-  `grade_level_tested`, `is_internal_assessment`, `module_code`, `module_type`,
-  `administration_period`, `test_type`, `source_assessment_id`.
-- `administration_dates`: `date_day`, `month_name`, `quarter_number`,
-  `academic_year`, etc. (primary reporting date).
-- `dates`: completion-date calendar attributes.
+- `assessments` (canonical descriptors, via administration): `title`,
+  `academic_subject`, `type`, `scope`, `grade_level_tested`, `module_type`,
+  `module_code`, `is_internal_assessment`.
+- `assessment_administrations`: `administration_period`, `test_type`,
+  `source_assessment_id` (canonical id).
+- `administration_dates`: administration-date calendar attributes (primary
+  reporting date). `dates`: completion-date attributes.
+- `assessment_members` (member view only): `title`, `academic_subject`,
+  `module_code`, `module_type`, `grade_level_tested`.
 - `courses`: `academic_subject`, `course_title`, `course_code`, `credit_type`,
-  `is_foundations`.
-- `course_sections`: `identifier`, `period`.
-- `assessments` (member, drill-down view only): `title`, `academic_subject`,
-  `module_code`, `module_type`, `grade_level_tested`, `is_internal_assessment`.
-- `student_section_enrollments`: `academic_year` (canonical), `entry_date`,
-  `exit_date`, `is_dropped_section`, `is_dropped_course`.
+  `is_foundations`. `course_sections`: `identifier`, `period`.
+- `student_section_enrollments`: `academic_year`, `entry_date`, `exit_date`,
+  `is_dropped_section`, `is_dropped_course`.
 - `student_enrollments`: `grade_level`, `graduation_year`, `year_in_network`,
   `is_retained_year`.
 - `student_enrollment_status`: `is_ell`, `is_iep`, `iep_classification`,
@@ -229,33 +251,27 @@ From joined cubes (subject appears twice, prefix-disambiguated):
 
 ## Views
 
-Three analyst-facing views:
-
-- **`student_assessment_scores_detail`** — row-level scores; carries `full_name`
-  / identifiers. Two-policy access: `cube-access-student-data` with PII fields
-  in `excludes`, plus `cube-access-student-pii` with `includes: "*"`. Does not
-  join the member bridge.
-- **`student_assessment_scores_summary`** — aggregates and demographic
-  breakdowns only; no direct identifiers. Single `cube-access-student-data`
-  policy.
-- **`student_assessment_scores_members_detail`** — member-level drill-down via
-  the bridge to `assessments`: one row per score x member. No aggregate
-  measures, so the multi-member fan-out never double-counts. PII-gated like the
-  detail view.
+- **`student_assessment_scores_detail`** — row-level; `full_name` / identifiers;
+  two-policy access (PII fields in `excludes` + a `cube-access-student-pii`
+  `includes: "*"`). Reads `assessments` (canonical) via the administration; does
+  not join the member bridge.
+- **`student_assessment_scores_summary`** — aggregates + demographic breakdowns;
+  single `cube-access-student-data` policy.
+- **`student_assessment_scores_members_detail`** — member drill-down via bridge
+  to `assessment_members`; one row per score x member; no aggregate measures.
 
 ## Access gating
 
-No `cube.js` change. Student-prefixed cubes inherit `isStudentMember` member
-stripping and the location scope filter (resolved through the existing
-`student_enrollments` to `locations` chain). Assessment-reference, curriculum,
-and date dims are unprefixed. Not a snapshot cube.
+No `cube.js` change. Student-prefixed cubes inherit `isStudentMember` gating and
+location scoping. Assessment/curriculum/date dims unprefixed. Not a snapshot
+cube.
 
 ## Exposures
 
-Add every new/enriched mart to `cube.yml`'s `cube_semantic_layer.depends_on`:
+Add every new/touched mart to `cube.yml`'s `cube_semantic_layer.depends_on`:
 `fct_assessment_scores_enrollment_scoped`, `dim_assessment_administrations`,
-`dim_student_section_enrollments`, `dim_course_sections`, `dim_courses`,
-`dim_assessments`, `dim_student_enrollment_status`, `dim_student_enrollments`,
+`dim_assessments`, `dim_student_section_enrollments`, `dim_course_sections`,
+`dim_courses`, `dim_student_enrollment_status`, `dim_student_enrollments`,
 `dim_locations`, `dim_dates`, `bridge_assessment_score_members`.
 
 ## DDI dimension parity
@@ -263,39 +279,35 @@ Add every new/enriched mart to `cube.yml`'s `cube_semantic_layer.depends_on`:
 Benchmarked against `rpt_tableau__ddi_dashboard`. Covered after this spec: all
 student demographics, enrollment, school/region, status (incl. 504 /
 self-contained / SIPPS), term, assessment descriptors (title, subject,
-module*code/type, administered_at), the response/standard family
-(`response_type*`, `standard_domain`, `is_replacement`, band number), course fields (`course\*\*`, `is_foundations`), and enrollment extras (`year_in_network`, `head_of_school`).
-Intentionally **not** in this cube (separate facts/domains): iReady lessons,
-walkthrough/observation data, microgoals — these belong to their own cubes.
-Teacher fields are deferred (#4165).
+module_code/type via the `dim_assessments` FK, administered_at), the
+response/standard family, course fields (incl. `is_foundations`), and enrollment
+extras (`year_in_network`, `head_of_school`). Intentionally **not** in this cube
+(separate facts/domains): iReady lessons, walkthrough/observation data,
+microgoals. Teacher fields deferred (#4165).
 
 ## Out of scope (tracked)
 
-- Normalized `dim_canonical_assessments` (canonical + member as first-class
-  linked dims) — [#4164](https://github.com/TEAMSchools/teamster/issues/4164).
-- Section teacher (all teachers incl. co-teachers via bridge + `dim_staff` +
-  staff-domain access decision) —
+- Normalized `dim_canonical_assessments` —
+  [#4164](https://github.com/TEAMSchools/teamster/issues/4164).
+- Section teacher —
   [#4165](https://github.com/TEAMSchools/teamster/issues/4165).
-- Academic-goals dim (`grade`/`school`/`region`/`organization` goals via
-  `dim_assessment_goals`) —
+- Academic-goals dim —
   [#4167](https://github.com/TEAMSchools/teamster/issues/4167).
-- Student-subject intervention-status dim (DIBELS, state-test proficiency, NJ
-  tier, FL low-25, iReady-exempt) —
+- Student-subject intervention-status dim —
   [#4168](https://github.com/TEAMSchools/teamster/issues/4168).
-- QBL / power-standard flags (Google Sheet) — not currently tracked; raise if
-  needed.
+- QBL / power-standard flags — not currently tracked.
 
 ## Validation approach
 
-- Build the enriched dims and the bridge in a dev schema; confirm
-  uniqueness/relationships tests pass and the bridge row counts reconcile with
-  the rollup `assessment_ids` cardinality.
-- Confirm each enrichment is functionally determined by its host grain (no new
-  duplicate keys) — especially `module_type` on the administration and the
-  response/standard columns on the fact.
-- Verify each cube FK populates in prod (treat 99%+ null as a broken join);
-  expect `administration_dates` to be null for state rows by design.
-- Compile each view via the Cube `/sql` endpoint and validate a representative
-  query (`pct_proficient` by `response_type_code` x `region` x `academic_year`,
-  and by `administration_dates` season) against direct warehouse SQL.
-- Confirm the member-detail view never inflates `count_scores`.
+- Build the enriched dims + bridge in a dev schema; confirm uniqueness /
+  relationships tests pass; reconcile bridge row counts with the rollup
+  `assessment_ids` cardinality.
+- **Confirm the `assessment_key` FK on `dim_assessment_administrations`
+  populates for the state branches** (Illuminate proven 100%; state is
+  structurally 1:1 but unverified empirically).
+- Verify each cube FK populates in prod; expect `administration_dates` null for
+  state rows by design.
+- Compile each view via Cube `/sql`; validate `pct_proficient` by
+  `response_type_code` x `region` x `academic_year` and by administration season
+  against direct warehouse SQL.
+- Confirm the member view never inflates `count_scores`.

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -349,6 +349,17 @@ select
         )
     }} as assessment_administration_key,
 
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "assessment_type",
+                "module_code",
+                "source_assessment_id",
+                "test_type",
+            ]
+        )
+    }} as assessment_key,
+
     -- `academic_year` is intentionally not exposed in the final SELECT —
     -- it's a hash input only. The canonical-grain dim represents an
     -- administration scoped by `_dbt_source_project` + `administered_date_key`

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_courses.sql
@@ -5,8 +5,10 @@ select
     c.course_number as course_code,
     c.course_name as course_title,
     c.credittype as credit_type,
-    csc.discipline as academic_subject,
     c.credit_hours as credits,
+
+    csc.discipline as academic_subject,
+    csc.is_foundations,
 
 from {{ ref("stg_powerschool__courses") }} as c
 left join

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql
@@ -21,6 +21,7 @@ select
     enr.grade_level,
     enr.cohort_primary as graduation_year,
     enr.is_retained_year,
+    enr.year_in_network,
 
 from {{ ref("int_powerschool__student_enrollment_union") }} as enr
 left join

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -27,6 +27,26 @@ models:
           - unique
           - not_null
 
+      - name: assessment_key
+        data_type: string
+        description: >-
+          FK to dim_assessments. Resolves to the canonical-representative member
+          row for Illuminate (the canonical id is itself the representative
+          member id) and the 1:1 row for state assessments. Lets consumers read
+          canonical descriptors (title, academic_subject, type,
+          grade_level_tested, module_type) without denormalizing them onto this
+          dim.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_assessments')
+            to_columns: [assessment_key]
+            warn_unsupported: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_assessments')
+                field: assessment_key
+
       - name: administered_date_key
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -65,6 +65,18 @@ models:
             source_model: stg_google_sheets__assessments__course_subject_crosswalk
             source_column: discipline
 
+      - name: is_foundations
+        data_type: boolean
+        description: >-
+          TRUE if this course is a Foundations (intervention) course, per the
+          course-subject crosswalk.
+
+        config:
+          meta:
+            source_system: Google Sheets
+            source_model: stg_google_sheets__assessments__course_subject_crosswalk
+            source_column: is_foundations
+
       - name: credits
         data_type: float64
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -130,3 +130,10 @@ models:
         description: >-
           TRUE if the student repeated this grade level in the same school
           compared to the prior academic year.
+
+      - name: year_in_network
+        data_type: int64
+        description: >-
+          Count of years the student has been enrolled in the network. Populated
+          on the student's primary enrollment stint per academic year; null on
+          additional same-year stints (multi-stint students).

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -10,7 +10,11 @@ with
             rr.response_type,
             rr.response_type_id,
             rr.response_type_code,
+            rr.response_type_description,
+            rr.response_type_root_description,
+            rr.is_replacement,
             rr.performance_band_label,
+            rr.performance_band_label_number,
             rr.is_mastery,
             rr.n_assessments,
             rr.percent_correct,
@@ -201,6 +205,12 @@ select
     ia.percent_correct,
     ia.proficiency_level,
     ia.is_mastery,
+    ia.response_type,
+    ia.response_type_code,
+    ia.response_type_description,
+    ia.response_type_root_description,
+    ia.is_replacement,
+    ia.performance_band_label_number,
 
     sr.resolution_type as enrollment_resolution,
 from internal_assessments as ia
@@ -253,8 +263,14 @@ select
     su.scale_score,
     su.percent_correct,
     su.performance_band as proficiency_level,
-
     su.is_proficient as is_mastery,
+
+    cast(null as string) as response_type,
+    cast(null as string) as response_type_code,
+    cast(null as string) as response_type_description,
+    cast(null as string) as response_type_root_description,
+    cast(null as bool) as is_replacement,
+    cast(null as numeric) as performance_band_label_number,
 
     sr.resolution_type as enrollment_resolution,
 from state_union as su

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -107,3 +107,38 @@ models:
         description: >-
           TRUE if the student met the mastery or proficiency threshold for this
           assessment.
+
+      - name: response_type
+        data_type: string
+        description: >-
+          The response type associated with the assessment score (e.g., overall,
+          strand, standard). Null for state assessments.
+
+      - name: response_type_code
+        data_type: string
+        description: >-
+          Short code identifying the response type. Null for state assessments.
+
+      - name: response_type_description
+        data_type: string
+        description: >-
+          Human-readable description of the response type. Null for state
+          assessments.
+
+      - name: response_type_root_description
+        data_type: string
+        description: >-
+          Description of the root (top-level) response type in the hierarchy.
+          Null for state assessments.
+
+      - name: is_replacement
+        data_type: boolean
+        description: >-
+          TRUE if this score is a replacement score superseding an earlier
+          attempt. Null for state assessments.
+
+      - name: performance_band_label_number
+        data_type: numeric
+        description: >-
+          Numeric ordering of the performance band label within the assessment's
+          band scale. Null for state assessments.


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

Add the **design spec** for an assessment-scores semantic layer over `fct_assessment_scores_enrollment_scoped` — a broad, all-source explorer (internal Illuminate + NJ/FL state) with proficiency/mastery rate as the headline metric. This PR is **docs only** (the spec under `docs/superpowers/specs/`); the dbt + Cube implementation follows on this same branch.

Spec: [docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md](https://github.com/TEAMSchools/teamster/blob/cristinabaldor/feat/claude-assessment-scores-cube/docs/superpowers/specs/2026-06-11-assessment-scores-cube-design.md)

Refs #4163. Follow-ups tracked in #4164 (normalized canonical dim) and #4165 (section teacher).

## AI Assistance

Spec was brainstormed and authored with Claude Code (human-directed throughout: every scope, grain, and modeling decision was made by the author via Q&A; Claude verified claims against BigQuery and drafted the document).

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment (note: the auto-review workflow excludes markdown, so it will not run on this docs-only PR)

### dbt _(skip if no dbt changes)_

Not in this PR — design spec only. The implementation PR (same branch) will add the enriched `dim_assessment_administrations`, the new `bridge_assessment_score_members`, properties/tests, and the `cube.yml` exposure update, and will flag the contract `select *` consumers per the spec.

## CI checks

- [ ] **Trunk** — passes (spec is trunk-clean locally incl. markdownlint).
- [ ] **dbt Cloud** — no-op (no models modified).
- [ ] **Dagster Cloud** — not triggered (no relevant paths changed).
