### PR TITLE
feat(dbt): add last_day_school_year; fix is_current_week_mon_sun double-flag in int_powerschool__calendar_week

### DIFF
--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__calendar_week.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__calendar_week.sql
@@ -55,6 +55,10 @@ with
                 partition by schoolid, yearid
             ) as last_week_start_school_year,
 
+            max(school_week_end_date) over (
+                partition by schoolid, yearid
+            ) as last_day_school_year,
+
             lead(school_week_start_date) over (
                 partition by schoolid, yearid order by week_start_date asc
             ) as school_week_start_date_lead,
@@ -65,6 +69,7 @@ with
             row_number() over (
                 partition by schoolid, yearid, `quarter` order by week_start_date asc
             ) as week_number_quarter,
+
         from week_rollup
     )
 
@@ -77,8 +82,13 @@ select
             and current_date('{{ var("local_timezone") }}')
             between week_start_monday and week_end_sunday
         then true
-        when week_start_monday = last_week_start_school_year
+        when
+            academic_year = {{ var("current_academic_year") }}
+            and current_date('{{ var("local_timezone") }}')
+            > date_add(last_week_start_school_year, interval 6 day)
+            and week_start_monday = last_week_start_school_year
         then true
         else false
     end as is_current_week_mon_sun,
+
 from window_calcs

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__calendar_week.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__calendar_week.yml
@@ -29,6 +29,10 @@ models:
         data_type: date
       - name: school_week_end_date
         data_type: date
+      - name: last_day_school_year
+        data_type: date
+        description:
+          Last actual instructional day of the school year for this school.
       - name: date_count
         data_type: int64
       - name: week_number_academic_year

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__calendar_week.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__calendar_week.yml
@@ -29,6 +29,12 @@ models:
         data_type: date
       - name: school_week_end_date
         data_type: date
+      - name: first_day_school_year
+        data_type: date
+        description: Calendar Monday of the first school week of the year.
+      - name: last_week_start_school_year
+        data_type: date
+        description: Calendar Monday of the last school week of the year.
       - name: last_day_school_year
         data_type: date
         description:
@@ -45,3 +51,8 @@ models:
         data_type: date
       - name: school_week_start_date_lead
         data_type: date
+      - name: is_current_week_mon_sun
+        data_type: boolean
+        description:
+          True if this is the current school week (Mon–Sun window), or the last
+          school week of the year once its Sunday has passed.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will:

- Add `last_day_school_year` to `int_powerschool__calendar_week` — the max `school_week_end_date` per school/year partition, giving downstream enrollment models a clean last-instructional-day anchor (e.g., for deduplicating multi-stint enrollments to the most recent active stint).
- Fix `is_current_week_mon_sun` incorrectly flagging two weeks as `true` simultaneously. The bug: condition 2 (post-year fallback) fired unconditionally once `current_date` passed the last school week start, regardless of whether that week had ended, and also lacked an `academic_year` guard so all prior years' last weeks were also flagged `true`. Fixed by (a) adding `academic_year = current_academic_year` to condition 2 and (b) gating it on `current_date > date_add(last_week_start_school_year, interval 6 day)` (i.e., the Sunday of the last school week must have passed).

**AI Assistance:** Claude Code identified the double-flag root cause, proposed and implemented the fix, verified against kippnewark dev data across all academic years and school levels, and authored this PR. Human-directed: diagnosis trigger and final sign-off.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — `int_powerschool__calendar_week.yml` updated with `last_day_school_year` column entry.
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — no new exposure needed; this is a package intermediate.
- [ ] **Breaking change?** — `last_day_school_year` is additive; no existing columns removed or renamed.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes. Note: this PR touches only the `powerschool` package (not `kipptaf`), so the kipptaf CI run will be a no-op. Verify via local `uv run dbt build` against a district project.
- [ ] **Dagster Cloud** — not triggered (no Python changes).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215641106327045