### PR TITLE
feat(dbt): add rpt_gsheets__finalsite__log for SRE team

### DIFF
--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -859,3 +859,16 @@ exposures:
         dagster:
           kinds:
             - googlesheets
+  - name: finalsite_log
+    label: Finalsite Log
+    type: application
+    owner:
+      name: Data Team
+    url: https://docs.google.com/spreadsheets/d/1O0LapZFC1X1JoYs8z3K3iFNeaD5hV2xpV_fdhIYx1Vo
+    depends_on:
+      - ref("rpt_gsheets__finalsite__log")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - googlesheets

--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -859,9 +859,9 @@ exposures:
         dagster:
           kinds:
             - googlesheets
-  - name: finalsite_log
+  - name: rpt_gsheets__finalsite__log
     label: Finalsite Log
-    type: application
+    type: analysis
     owner:
       name: Data Team
     url: https://docs.google.com/spreadsheets/d/1O0LapZFC1X1JoYs8z3K3iFNeaD5hV2xpV_fdhIYx1Vo

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
@@ -1,29 +1,53 @@
 models:
   - name: rpt_gsheets__finalsite__log
+    description: >
+      Latest Finalsite enrollment status per applicant for the current academic
+      year, one row per finalsite_enrollment_id. Feeds the SRE team's Finalsite
+      Log Google Sheet.
+    config:
+      meta:
+        contains_pii: true
     columns:
       - name: enrollment_academic_year_display
         data_type: string
+        description:
+          Academic year label as displayed in Finalsite (e.g. "2025-2026").
       - name: region
         data_type: string
+        description: KTAF region the applicant applied to.
       - name: assigned_school
         data_type: string
+        description: School the applicant has been assigned to in Finalsite.
       - name: finalsite_enrollment_id
         data_type: string
+        description: Unique identifier for a Finalsite enrollment record.
+        data_tests:
+          - unique
       - name: powerschool_student_number
         data_type: int64
+        description: Corresponding PowerSchool student number, if matched.
       - name: first_name
         data_type: string
+        description: Applicant first name.
       - name: last_name
         data_type: string
+        description: Applicant last name.
       - name: grade_level
         data_type: int64
+        description: Grade level the applicant is applying for.
       - name: enrollment_type
         data_type: string
+        description:
+          Finalsite enrollment type (e.g. New Student, Re-Enrollment).
       - name: gender
         data_type: string
+        description: Applicant gender as recorded in Finalsite.
       - name: birthdate
         data_type: date
+        description: Applicant date of birth.
       - name: status_start_date
         data_type: date
+        description: Date the applicant entered their latest enrollment status.
       - name: detailed_status
         data_type: string
+        description: Human-readable label of the latest enrollment status stage.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
@@ -1,0 +1,29 @@
+models:
+  - name: rpt_gsheets__finalsite__log
+    columns:
+      - name: enrollment_academic_year_display
+        data_type: string
+      - name: region
+        data_type: string
+      - name: assigned_school
+        data_type: string
+      - name: finalsite_enrollment_id
+        data_type: string
+      - name: powerschool_student_number
+        data_type: int64
+      - name: first_name
+        data_type: string
+      - name: last_name
+        data_type: string
+      - name: grade_level
+        data_type: int64
+      - name: enrollment_type
+        data_type: string
+      - name: gender
+        data_type: string
+      - name: birthdate
+        data_type: date
+      - name: status_start_date
+        data_type: date
+      - name: detailed_status
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
@@ -8,6 +8,11 @@ models:
       meta:
         contains_pii: true
     columns:
+      - name: finalsite_enrollment_id
+        data_type: string
+        description: Unique identifier for a Finalsite enrollment record.
+        data_tests:
+          - unique
       - name: enrollment_academic_year_display
         data_type: string
         description:
@@ -18,11 +23,6 @@ models:
       - name: assigned_school
         data_type: string
         description: School the applicant has been assigned to in Finalsite.
-      - name: finalsite_enrollment_id
-        data_type: string
-        description: Unique identifier for a Finalsite enrollment record.
-        data_tests:
-          - unique
       - name: powerschool_student_number
         data_type: int64
         description: Corresponding PowerSchool student number, if matched.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__finalsite__log.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__finalsite__log.sql
@@ -1,0 +1,44 @@
+with
+    ranked as (
+        select
+            enrollment_academic_year_display,
+            region,
+            assigned_school,
+            finalsite_enrollment_id,
+            powerschool_student_number,
+            first_name,
+            last_name,
+            grade_level,
+            enrollment_type,
+            gender,
+            birthdate,
+            status_start_date,
+            detailed_status,
+
+            row_number() over (
+                partition by finalsite_enrollment_id
+                order by status_start_date desc, status_order desc
+            ) as rn,
+
+        from {{ ref("int_finalsite__status_report_unpivot") }}
+        where
+            status_start_date is not null
+            and enrollment_academic_year = {{ var("current_academic_year") }}
+    )
+
+select
+    enrollment_academic_year_display,
+    region,
+    assigned_school,
+    finalsite_enrollment_id,
+    powerschool_student_number,
+    first_name,
+    last_name,
+    grade_level,
+    enrollment_type,
+    gender,
+    birthdate,
+    status_start_date,
+    detailed_status,
+from ranked
+where rn = 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add `rpt_gsheets__finalsite__log`, a Google Sheets extract for the SRE team surfacing the latest Finalsite enrollment status per applicant for the current academic year.

- Sources from `int_finalsite__status_report_unpivot`
- Filters to `status_start_date is not null` and `enrollment_academic_year = current_academic_year`
- Deduplicates to one row per `finalsite_enrollment_id` (latest `status_start_date`, tiebroken by `status_order`)
- Exposes 13 columns: year display, region, school, enrollment ID, PS student number, name, grade, enrollment type, gender, birthdate, status date, and detailed status
- Adds `finalsite_log` exposure pointing to the SRE team's Google Sheet

**AI Assistance:** Claude Code built the model and YAML, identified and fixed a variable/column name error in the WHERE clause (`current_year` → `current_academic_year`, `academic_year` → `enrollment_academic_year`), and authored this PR. Human-directed: column selection, dedup logic, and sheet URL.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file included for new model
- [x] Exposure added for Google Sheets consumer
- [ ] No breaking changes — additive only

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not triggered.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215643175786339