### PR TITLE
fix(dbt): restore NJSLA staging contract columns present network-wide

### DIFF
--- a/src/dbt/pearson/models/staging/properties/stg_pearson__njsla.yml
+++ b/src/dbt/pearson/models/staging/properties/stg_pearson__njsla.yml
@@ -406,9 +406,9 @@ models:
         description: >-
           Date the student took the assessment, derived from the earliest online
           unit start datetime, falling back to the paper attempt create date.
-      # - name: homeless_primary_nighttime_residence
-      #   data_type: string
-      # - name: multilinguallearneraccommodatedresponse
-      #   data_type: string
-      # - name: requiredhighschoolmathassessment
-      #   data_type: string
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+      - name: multilinguallearneraccommodatedresponse
+        data_type: string
+      - name: requiredhighschoolmathassessment
+        data_type: string

--- a/src/dbt/pearson/models/staging/properties/stg_pearson__njsla_science.yml
+++ b/src/dbt/pearson/models/staging/properties/stg_pearson__njsla_science.yml
@@ -408,9 +408,9 @@ models:
         description: >-
           Date the student took the assessment, derived from the earliest online
           unit start datetime, falling back to the paper attempt create date.
-      # - name: homeless_primary_nighttime_residence
-      #   data_type: string
-      # - name: multilinguallearneraccommodatedresponse
-      #   data_type: string
-      # - name: requiredhighschoolmathassessment
-      #   data_type: string
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+      - name: multilinguallearneraccommodatedresponse
+        data_type: string
+      - name: requiredhighschoolmathassessment
+        data_type: string

--- a/src/dbt/pearson/models/staging/stg_pearson__njsla.sql
+++ b/src/dbt/pearson/models/staging/stg_pearson__njsla.sql
@@ -2,6 +2,7 @@ with
     njsla as (
         select
             * except (
+                source_file_name,
                 accountabledistrictcode,
                 accountableorganizationaltype,
                 accountableschoolcode,

--- a/src/dbt/pearson/models/staging/stg_pearson__njsla_science.sql
+++ b/src/dbt/pearson/models/staging/stg_pearson__njsla_science.sql
@@ -2,6 +2,7 @@ with
     njsla_science as (
         select
             * except (
+                source_file_name,
                 accountabledistrictcode,
                 accountableorganizationaltype,
                 accountableschoolcode,


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will fix the NJSLA / NJSLA Science staging models in the shared `pearson` package so they enforce a contract that matches the columns Pearson now delivers network-wide, across all three districts (Newark, Camden, Paterson).

Two coordinated schema changes had drifted out of sync with the enforced contracts:

1. **Three Pearson columns** (`homeless_primary_nighttime_residence`, `multilinguallearneraccommodatedresponse`, `requiredhighschoolmathassessment`) were added to the NJSLA / NJSLA Science feeds network-wide; the shared `NJSLA` schema type has declared them since 2025-08-27 (`832b3589b`). They were added to the staging contracts in December (`b383d0ec0`), then commented out in February (`909f3286a`) to keep Newark/Camden green while their external tables still lacked the columns. Paterson's source carries them, so its staging assets have failed contract enforcement since (prod run `e3b136a6-6ac7-4405-9d91-ad01c641902b`). **Fix:** uncomment the three columns.

2. **`source_file_name`** — a provenance column the SFTP ingestion adds to every row (`teamster/core/utils/functions.py`), introduced after Paterson's December pull. It now appears in every freshly re-pulled NJSLA source. **Fix:** drop it via `select * except (source_file_name)`, matching the dominant staging convention, so it stays out of the contract.

## Operational steps (external Avro schema evolution)

This change requires the underlying external tables to expose the 199-column schema. Completed / required:

- [x] Re-materialized partition `25` of `njsla` + `njsla_science` source assets for **all three districts** (Newark, Camden, Paterson) so prod GCS / external tables expose the columns. Pre-FY25 partitions keep the old schema, so the new columns read NULL for older years (Avro heterogeneity) — acceptable, as they are unused downstream.
- [ ] **`stage_external_sources --target staging` (with `ext_full_refresh`) for the three districts' pearson njsla sources** so the `zz_stg_*` staging external tables dbt Cloud CI reads are refreshed to 199 columns. Without this, CI fails ("missing in contract" / EXCEPT column not found). Run serialized across districts to avoid BigQuery rate limits.

## AI Assistance

Root-cause investigation, cross-district + source-asset diagnosis, the model/contract edits, and the source re-materializations were Claude-assisted (systematic-debugging); sequencing and the network-wide-schema framing were human-directed.

## Self-review

### dbt

- [x] Contract change is name/type only. `source_file_name` dropped via EXCEPT (convention: 63 of 71 sftp staging models).
- [x] **Breaking change / coordination:** documented above — all three districts re-pulled; `zz_stg` staging externals must be refreshed before CI passes.

## CI checks

- [ ] **Trunk** — passes (verified locally on all four changed files).
- [ ] **dbt Cloud** — passes only after the `stage_external_sources --target staging` refresh above; re-run CI once that's done.
- [ ] **Dagster Cloud** — n/a (no Dagster code change).
