### PR TITLE
feat(dbt): add referral rank, percentile, and tardy counts to rpt_tableau__okrts_referrals

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
@@ -173,3 +173,7 @@ models:
         data_type: int64
       - name: referral_percentile
         data_type: float64
+      - name: total_tardies_ytd
+        data_type: float64
+      - name: total_tardies
+        data_type: float64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
@@ -167,3 +167,9 @@ models:
         data_type: string
       - name: state_studentnumber
         data_type: string
+      - name: total_referrals
+        data_type: int64
+      - name: referral_rank
+        data_type: int64
+      - name: referral_percentile
+        data_type: float64

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -119,6 +119,45 @@ with
         from {{ ref("int_deanslist__incidents__attachments") }}
         where attachment_type = 'UPLOAD'
         group by incident_id
+    ),
+
+    referral_counts as (
+        select
+            co.student_number,
+            co.academic_year,
+            co.schoolid,
+
+            count(distinct dli.incident_id) as total_referrals,
+        from {{ ref("int_extracts__student_enrollments_weeks") }} as co
+        inner join
+            {{ ref("int_deanslist__incidents__penalties") }} as dli
+            on co.student_number = dli.student_school_id
+            and co.academic_year = dli.create_ts_academic_year
+            and extract(date from dli.create_ts_date)
+            between co.week_start_monday and co.week_end_sunday
+            and {{ union_dataset_join_clause(left_alias="co", right_alias="dli") }}
+        group by co.student_number, co.academic_year, co.schoolid
+    ),
+
+    referral_ranks as (
+        select
+            student_number,
+            academic_year,
+            schoolid,
+            total_referrals,
+
+            rank() over (
+                partition by academic_year, schoolid order by total_referrals desc
+            ) as referral_rank,
+
+            round(
+                cume_dist() over (
+                    partition by academic_year, schoolid order by total_referrals asc
+                )
+                * 100,
+                2
+            ) as referral_percentile,
+        from referral_counts
     )
 
 select
@@ -191,6 +230,10 @@ select
 
     ats.attachments,
     atr.attachments as attachments_uploaded,
+
+    rr.total_referrals,
+    rr.referral_rank,
+    rr.referral_percentile,
 
     coalesce(s.ssds_period, 'Outside SSDS Period') as ssds_period,
 
@@ -352,4 +395,9 @@ left join
     attachments as atr
     on dli.incident_id = atr.incident_id
     and atr.incident_type = 'Upload'
+left join
+    referral_ranks as rr
+    on co.student_number = rr.student_number
+    and co.academic_year = rr.academic_year
+    and co.schoolid = rr.schoolid
 where co.academic_year >= {{ var("current_academic_year") - 1 }}

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -158,6 +158,60 @@ with
                 2
             ) as referral_percentile,
         from referral_counts
+    ),
+
+    student_weeks as (
+        -- grain projection: distinct student-week spine from the enrollment-weeks
+        -- model; every column is functionally determined by the partition key,
+        -- not a mask for upstream duplicates
+        select distinct
+            _dbt_source_relation,
+            student_number,
+            academic_year,
+            week_number_academic_year,
+        from {{ ref("int_extracts__student_enrollments_weeks") }}
+    ),
+
+    tardies_weekly as (
+        select
+            _dbt_source_relation,
+            student_number,
+            academic_year,
+            week_number_academic_year,
+
+            sum(is_tardy) as n_tardies_week,
+        from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }}
+        group by
+            _dbt_source_relation,
+            student_number,
+            academic_year,
+            week_number_academic_year
+    ),
+
+    tardies_ytd as (
+        select
+            sw._dbt_source_relation,
+            sw.student_number,
+            sw.academic_year,
+            sw.week_number_academic_year,
+
+            sum(coalesce(tw.n_tardies_week, 0)) over (
+                partition by
+                    sw._dbt_source_relation, sw.student_number, sw.academic_year
+                order by sw.week_number_academic_year
+            ) as total_tardies_ytd,
+
+            sum(coalesce(tw.n_tardies_week, 0)) over (
+                partition by
+                    sw._dbt_source_relation, sw.student_number, sw.academic_year
+            ) as total_tardies,
+        from student_weeks as sw
+        left join
+            tardies_weekly as tw
+            on sw.student_number = tw.student_number
+            and sw.academic_year = tw.academic_year
+            and sw.week_number_academic_year = tw.week_number_academic_year
+            and {{ union_dataset_join_clause(left_alias="sw", right_alias="tw") }}
     )
 
 select
@@ -234,6 +288,9 @@ select
     rr.total_referrals,
     rr.referral_rank,
     rr.referral_percentile,
+
+    tar.total_tardies_ytd,
+    tar.total_tardies,
 
     coalesce(s.ssds_period, 'Outside SSDS Period') as ssds_period,
 
@@ -400,4 +457,10 @@ left join
     on co.student_number = rr.student_number
     and co.academic_year = rr.academic_year
     and co.schoolid = rr.schoolid
+left join
+    tardies_ytd as tar
+    on co.student_number = tar.student_number
+    and co.academic_year = tar.academic_year
+    and co.week_number_academic_year = tar.week_number_academic_year
+    and {{ union_dataset_join_clause(left_alias="co", right_alias="tar") }}
 where co.academic_year >= {{ var("current_academic_year") - 1 }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add five per-student columns to
`rpt_tableau__okrts_referrals`, all scoped within an academic year and school:

- `total_referrals` — distinct DeansList incidents per student.
- `referral_rank` — rank within academic year + school; rank 1 = most referrals, ties share a rank.
- `referral_percentile` — `cume_dist * 100` (0–100), limited to students with at least one referral.
- `total_tardies_ytd` — running per-week cumulative tardies, carried forward across weeks with no attendance record.
- `total_tardies` — latest full-year tardy total, broadcast to every row for the student.

Referral metrics are computed at student grain in CTEs (`referral_counts`,
`referral_ranks`) and joined back, because `count(distinct ...)` and
student-grain percentile cannot be windowed over the view's student-week grain.
Tardies are rolled up from `int_powerschool__ps_adaadm_daily_ctod` via a
`student_weeks` spine so the cumulative carries forward across gap/future weeks.

Refs #4157

## AI Assistance

AI-assisted (Claude Code) for the SQL, properties YAML, and validation;
human-directed on the metric definitions (referral = distinct incident, rank
direction, percentile method, population, and tardy window/carry-forward
semantics).

## Self-review

### dbt

- [x] Properties file updated with the five new columns and their types
- [x] No exposure change needed — existing Tableau view, no new model
- [x] Not a breaking change — only additive columns to the contracted view

## CI checks

- [x] **Trunk** — passes locally (`trunk check` clean on both files)
- [ ] **dbt Cloud** — pending CI
- [ ] **Dagster Cloud** — passes or not triggered

## Notes

- Local validation: `dbt build --select rpt_tableau__okrts_referrals` against prod-deferred upstreams passes (`PASS=1`, contract enforced); referral rank/percentile and the tardy running total spot-checked against prod data.
- Restored a `int_deanslist__roster_assignments` (`tr`) join that had been dropped from the working tree while the `is_tier3_4` column still referenced it.