### PR TITLE
feat(kipptaf): surface is_maher per-slot on kfwd dashboard

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -633,6 +633,12 @@ models:
           Amount in dollars of the student's award number 1 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           1 award(s).
+      - name: award_1_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 1 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 1 award(s).
       - name: award_2_name
         data_type: string
         description:
@@ -645,6 +651,12 @@ models:
           Amount in dollars of the student's award number 2 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           2 award(s).
+      - name: award_2_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 2 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 2 award(s).
       - name: award_3_name
         data_type: string
         description:
@@ -657,6 +669,12 @@ models:
           Amount in dollars of the student's award number 3 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           3 award(s).
+      - name: award_3_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 3 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 3 award(s).
       - name: award_4_name
         data_type: string
         description:
@@ -669,6 +687,12 @@ models:
           Amount in dollars of the student's award number 4 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           4 award(s).
+      - name: award_4_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 4 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 4 award(s).
       - name: award_5_name
         data_type: string
         description:
@@ -681,6 +705,12 @@ models:
           Amount in dollars of the student's award number 5 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           5 award(s).
+      - name: award_5_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 5 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 5 award(s).
       - name: award_6_name
         data_type: string
         description:
@@ -693,6 +723,12 @@ models:
           Amount in dollars of the student's award number 6 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           6 award(s).
+      - name: award_6_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 6 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 6 award(s).
       - name: award_7_name
         data_type: string
         description:
@@ -705,6 +741,12 @@ models:
           Amount in dollars of the student's award number 7 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           7 award(s).
+      - name: award_7_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 7 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 7 award(s).
       - name: award_8_name
         data_type: string
         description:
@@ -717,6 +759,12 @@ models:
           Amount in dollars of the student's award number 8 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           8 award(s).
+      - name: award_8_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 8 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 8 award(s).
       - name: award_9_name
         data_type: string
         description:
@@ -729,6 +777,12 @@ models:
           Amount in dollars of the student's award number 9 in the academic year
           (awards ordered earliest first); null when the student had fewer than
           9 award(s).
+      - name: award_9_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 9 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 9 award(s).
       - name: award_10_name
         data_type: string
         description:
@@ -741,3 +795,9 @@ models:
           Amount in dollars of the student's award number 10 in the academic
           year (awards ordered earliest first); null when the student had fewer
           than 10 award(s).
+      - name: award_10_is_maher
+        data_type: boolean
+        description:
+          True when the student's award number 10 in the academic year (awards
+          ordered earliest first) carries the MAHER_FUND marker tag in its
+          notes; null when the student had fewer than 10 award(s).

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -221,6 +221,7 @@ with
             academic_year,
             `name` as aid_name,
             amount,
+            is_maher,
 
             row_number() over (
                 partition by student, academic_year
@@ -240,6 +241,7 @@ with
             {%- for i in range(1, max_awards + 1) %}
                 max(if(rn_award = {{ i }}, aid_name, null)) as award_{{ i }}_name,
                 max(if(rn_award = {{ i }}, amount, null)) as award_{{ i }}_amount,
+                max(if(rn_award = {{ i }}, is_maher, null)) as award_{{ i }}_is_maher,
             {%- endfor %}
         from aid_awards
         group by sf_contact_id, academic_year
@@ -554,7 +556,7 @@ select
     kar.total_aid_amount,
     kar.aid_award_count,
     {%- for i in range(1, max_awards + 1) %}
-        kar.award_{{ i }}_name, kar.award_{{ i }}_amount,
+        kar.award_{{ i }}_name, kar.award_{{ i }}_amount, kar.award_{{ i }}_is_maher,
     {%- endfor %}
 
     if(


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Surface `is_maher` per award slot on `rpt_tableau__kfwd_dashboard` so the
KIPP Forward Tableau dashboard can identify which of a student's KIPP Aid
awards in a given academic year are Maher Fund awards. The flag was added
upstream on `stg_kippadb__kipp_aid` (parsed from the `[MAHER_FUND|...]`
marker tag in the award's notes) but never propagated to the dashboard.

Adds `award_{1..10}_is_maher` (boolean) to the existing per-slot pivot,
mirroring the established `award_{i}_name` / `award_{i}_amount` pattern.

## AI Assistance

AI-assisted: drafting of the SQL pivot column, YAML column descriptions,
and trunk-fmt cleanup. Human-directed: the per-slot pivot shape (vs. an
aggregate-only rollup) and the decision to source straight from staging.

## Self-review

### General

- [x] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file updated with 10 new `award_{i}_is_maher` column entries (boolean) with descriptions mirroring the existing per-slot pattern.
- [x] Existing dashboard exposure unchanged — only adds columns to the same consumed model.
- [x] **Not a breaking change** — additive columns only; existing `award_{i}_name` / `award_{i}_amount` columns are untouched.

## CI checks

- [x] **Trunk** — passes (pre-push hook clean).
- [ ] **dbt Cloud** — pending CI run on push.
- [ ] **Dagster Cloud** — not triggered (no Dagster paths).
