### PR TITLE
fix(deanslist): add AcademicYearID to rosters Avro schema

### DIFF
--- a/src/teamster/libraries/deanslist/schema.py
+++ b/src/teamster/libraries/deanslist/schema.py
@@ -319,6 +319,7 @@ class RosterAssignment(BaseModel):
 
 
 class Roster(BaseModel):
+    AcademicYearID: str | None = None
     Active: str | None = None
     AttScanVisible: str | None = None
     CollectHW: str | None = None


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will clear the `avro_schema_valid` WARN
> (`extras=AcademicYearID`) on the DeansList `rosters` asset for kippcamden,
> kippmiami, and kippnewark.

The DeansList `rosters` endpoint now returns an `AcademicYearID` field that the
shared `Roster` model in `libraries/deanslist/schema.py` did not declare. The
`avro_schema_valid` check warns on extra fields, so every rosters
materialization across the three districts has been flagging `AcademicYearID`
as an undeclared extra. Adding the field to the shared model resolves all three
at once.

`AcademicYearID: str | None = None` matches how `Term.AcademicYearID` and
`EnrollmentObject.AcademicYearID` are already typed. WARN-only check — no run is
currently blocked.

## AI Assistance

Surfaced during a `/dagster-day2` operations review and authored by Claude Code
(human-directed: root cause, field type, and the decision to fix the shared
model rather than per-district). Verified by generating the rosters Avro schema
from the updated model and confirming `AcademicYearID` is present as
`['null', 'string']` (field count 34 → 35).

## Self-review

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

## CI checks

- [ ] **Trunk** — passes (clean at commit time via pre-commit `fmt`).
- [ ] **Dagster Cloud** — passes or not triggered.
