### PR TITLE
fix(dbt): update njgpa_season_11th accountability date to June 30

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__graduation_path_codes.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__graduation_path_codes.sql
@@ -30,7 +30,7 @@ with
             fulfilling the NJGPA test requirement */
             if(
                 current_date('{{ var("local_timezone") }}')
-                < date({{ var("current_academic_year") + 1 }}, 06, 05),
+                < date({{ var("current_academic_year") + 1 }}, 06, 30),
                 false,
                 true
             ) as njgpa_season_11th,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
@@ -58,8 +58,14 @@ models:
       - name: has_fafsa
       - name: njgpa_season_11th
         data_type: boolean
+        description: >-
+          True on or after June 30 of the current academic year end; gates
+          11th-grade NJGPA test accountability.
       - name: fafsa_season_12th
         data_type: boolean
+        description: >-
+          True on or after January 1 of the current academic year end; gates
+          12th-grade FAFSA accountability.
       - name: pathway_option
         data_type: string
       - name: score_type


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR will update the date threshold after which 11th graders are held accountable for completing the NJGPA test requirement, from June 5 to June 30.

**Context**: Stakeholder requested the change because NJDOE score reporting is delayed. The dashboard stops refreshing on 06/23 and data will be frozen for the rest of the year — so June 30 is intentionally after that freeze date, meaning `njgpa_season_11th` will remain `false` and the accountability window will never open before the data is locked.

Change is a one-line update to `njgpa_season_11th` in `int_students__graduation_path_codes.sql`.

_Human-directed date change; worktree setup and PR creation AI-assisted via Claude Code._

## AI Assistance

Date value set by the analyst; branch/commit/PR scaffolding handled by Claude Code.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with affected teams before merging and document your rollback plan in the summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** so the dbt Cloud CI job can find the table.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.