### PR TITLE
docs: refine PR-reply guidance and add dbt show --inline note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,10 +391,12 @@ the allowlist.
   equivalents and are not on this list.
 - Editing an existing comment — `mcp__github__add_issue_comment` only creates.
   Use `gh api -X PATCH repos/<owner>/<repo>/issues/comments/<id> -f body='...'`.
-- Replying to a PR inline review comment in-thread —
-  `mcp__github__add_issue_comment` posts top-level PR comments only, not thread
-  replies. Use
-  `gh api -X POST repos/<owner>/<repo>/pulls/<pr>/comments/<id>/replies -f body='...'`.
+- Replying to a PR inline review comment in-thread — use
+  `mcp__github__add_reply_to_pull_request_comment`
+  (`mcp__github__add_issue_comment` posts top-level PR comments only, not thread
+  replies). The `gh api -X POST .../pulls/<pr>/comments/<id>/replies` fallback
+  is blocked by the classifier (read as routing around the `gh pr comment` deny)
+  — don't retry it.
 - `gh api -X POST repos/<owner>/<repo>/labels -f name=... -f color=... -f description=...`
   — no `mcp__github__*` label-create tool.
 - `gh api -X POST repos/<owner>/<repo>/issues/<n>/labels -f 'labels[]=<name>'` —

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -177,6 +177,11 @@ file before re-running the build.
 Stdout interleaves dbt log lines with JSON records. Pipe through `grep '^{'`
 before parsing.
 
+## `dbt show --inline` rejects a trailing `limit`
+
+dbt 1.11/BigQuery errors when an `--inline` query ends in `limit N`. Omit it —
+`dbt show` already caps rows with its own `--limit` flag (default 5).
+
 ## Materialization overrides go in properties yml
 
 Use `config: materialized: <kind>` in `properties/<model>.yml`, not inline


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will carry over two CLAUDE.md improvements that
were stranded on local `main` during a worktree/branch cleanup (never pushed
anywhere). Doc-only, no code changes.

- **Root `CLAUDE.md`**: prefer `mcp__github__add_reply_to_pull_request_comment`
  for in-thread PR review replies, and note that the
  `gh api ... /pulls/{pr}/comments/{id}/replies` fallback is blocked by the
  classifier (don't retry it).
- **`src/dbt/CLAUDE.md`**: document that `dbt show --inline` rejects a trailing
  `limit N` on dbt 1.11/BigQuery — omit it; `dbt show` already caps rows with
  its own `--limit` flag.

## AI Assistance

AI-assisted: Claude Code recovered the stranded edits, isolated them from
unrelated eval artifacts, and authored this PR. Human-directed: the cleanup and
decision to preserve these specific doc edits.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR.

Docs-only change — no Dagster, dbt model, or schedule/sensor changes.

## CI checks

- [ ] **Trunk** — passes (markdownlint on the two `.md` files).
- dbt Cloud / Dagster Cloud — not triggered (no `src/` or dbt model changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)