### PR TITLE
docs: align superpowers overrides with plugin v6.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,8 @@ alone may be safe; combinations may not. When unsure, consult the
 
 - **Branch creation always goes through the issue-and-branch flow in _Working
   Conventions_** — no exceptions for `superpowers:brainstorming`'s "Write design
-  doc" step or `superpowers:writing-plans`' "Save plans to:" step. Pause those
+  doc" step, `superpowers:writing-plans`' "Save plans to:" step, or
+  `superpowers:using-git-worktrees`' worktree-consent prompt. Pause those
   skills, run the flow, then write specs to `docs/superpowers/specs/...` or
   plans to `docs/superpowers/plans/...` on the new branch. Default to
   `gh issue develop` so the branch is linked to an issue; only create a branch
@@ -273,10 +274,27 @@ alone may be safe; combinations may not. When unsure, consult the
   pre-commit `fmt` hook; checking only the code files misses a doc-only Trunk
   failure.
 
+- **`finishing-a-development-branch` / `using-git-worktrees` tooling**: This repo
+  is `uv`-only — skip both skills' `npm test / cargo test / pytest / go test`
+  heuristics, plus `using-git-worktrees` Step 2 setup (`poetry install` /
+  `pip install`) and Step 3 baseline. Verify dbt changes with
+  `uv run dbt build --select <model>+` against the relevant project, Python with
+  `uv run pytest` where tests exist. At `finishing-a-development-branch`'s menu
+  pick Option 2 (push + PR) — never Option 1 (local merge to `main`;
+  `git push origin main` is hard-blocked and we squash-merge via PR). PR body
+  uses `.github/pull_request_template.md`.
+
 - **Before brainstorming a fix for a GitHub issue**: verify the issue's claims
   (row counts, bucket sizes, reproduce queries, named files/columns) against
   current code and data. Issue bodies drift — code moves, data changes, prior
   PRs land. Re-run the diagnostic before designing.
+
+- **Continuous execution exceptions**: `superpowers:subagent-driven-development`
+  and `superpowers:executing-plans` push you to execute every task without
+  pausing to check in. Pause anyway to ask the user before (a) opening a
+  tracking issue, (b) creating a
+  branch or worktree, (c) modifying protected files (hook scripts,
+  `.devcontainer/scripts/`, `.claude/settings*.json`).
 
 ## CLAUDE.md Editing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ alone may be safe; combinations may not. When unsure, consult the
 
 - **Branch creation always goes through the issue-and-branch flow in _Working
   Conventions_** — no exceptions for `superpowers:brainstorming`'s "Write design
-  doc" step, `superpowers:writing-plans`' "Save plan" step, or
+  doc" step, `superpowers:writing-plans`' "Save plans to:" step, or
   `superpowers:using-git-worktrees`' worktree-consent prompt. Pause those
   skills, run the flow, then write specs to `docs/superpowers/specs/...` or
   plans to `docs/superpowers/plans/...` on the new branch. Default to
@@ -274,11 +274,15 @@ alone may be safe; combinations may not. When unsure, consult the
   pre-commit `fmt` hook; checking only the code files misses a doc-only Trunk
   failure.
 
-- **`finishing-a-development-branch` verification gate**: Skip the skill's
-  `npm test / pytest / ...` heuristic. For dbt changes,
-  `uv run dbt build --select <model>+` against the relevant project. For Python
-  changes, `uv run pytest` where tests exist. PR body uses
-  `.github/pull_request_template.md`.
+- **`finishing-a-development-branch` / `using-git-worktrees` tooling**: This repo
+  is `uv`-only — skip both skills' `npm test / cargo test / pytest / go test`
+  heuristics, plus `using-git-worktrees` Step 2 setup (`poetry install` /
+  `pip install`) and Step 3 baseline. Verify dbt changes with
+  `uv run dbt build --select <model>+` against the relevant project, Python with
+  `uv run pytest` where tests exist. At `finishing-a-development-branch`'s menu
+  pick Option 2 (push + PR) — never Option 1 (local merge to `main`;
+  `git push origin main` is hard-blocked and we squash-merge via PR). PR body
+  uses `.github/pull_request_template.md`.
 
 - **Before brainstorming a fix for a GitHub issue**: verify the issue's claims
   (row counts, bucket sizes, reproduce queries, named files/columns) against
@@ -286,8 +290,9 @@ alone may be safe; combinations may not. When unsure, consult the
   PRs land. Re-run the diagnostic before designing.
 
 - **Continuous execution exceptions**: `superpowers:subagent-driven-development`
-  and `superpowers:executing-plans` say "do not pause between tasks." Pause
-  anyway to ask the user before (a) opening a tracking issue, (b) creating a
+  and `superpowers:executing-plans` push you to execute every task without
+  pausing to check in. Pause anyway to ask the user before (a) opening a
+  tracking issue, (b) creating a
   branch or worktree, (c) modifying protected files (hook scripts,
   `.devcontainer/scripts/`, `.claude/settings*.json`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,15 +274,10 @@ alone may be safe; combinations may not. When unsure, consult the
   pre-commit `fmt` hook; checking only the code files misses a doc-only Trunk
   failure.
 
-- **`finishing-a-development-branch` / `using-git-worktrees` tooling**: This repo
-  is `uv`-only — skip both skills' `npm test / cargo test / pytest / go test`
-  heuristics, plus `using-git-worktrees` Step 2 setup (`poetry install` /
-  `pip install`) and Step 3 baseline. Verify dbt changes with
-  `uv run dbt build --select <model>+` against the relevant project, Python with
-  `uv run pytest` where tests exist. At `finishing-a-development-branch`'s menu
-  pick Option 2 (push + PR) — never Option 1 (local merge to `main`;
-  `git push origin main` is hard-blocked and we squash-merge via PR). PR body
-  uses `.github/pull_request_template.md`.
+- **`finishing-a-development-branch` / `using-git-worktrees` tests & setup**:
+  this repo uses `uv`, not `poetry`/`pip`, and
+  `uv run dbt build --select <model>+` should run alongside the skills' other
+  tests.
 
 - **Before brainstorming a fix for a GitHub issue**: verify the issue's claims
   (row counts, bucket sizes, reproduce queries, named files/columns) against
@@ -292,9 +287,8 @@ alone may be safe; combinations may not. When unsure, consult the
 - **Continuous execution exceptions**: `superpowers:subagent-driven-development`
   and `superpowers:executing-plans` push you to execute every task without
   pausing to check in. Pause anyway to ask the user before (a) opening a
-  tracking issue, (b) creating a
-  branch or worktree, (c) modifying protected files (hook scripts,
-  `.devcontainer/scripts/`, `.claude/settings*.json`).
+  tracking issue, (b) creating a branch or worktree, (c) modifying protected
+  files (hook scripts, `.devcontainer/scripts/`, `.claude/settings*.json`).
 
 ## CLAUDE.md Editing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,8 +260,7 @@ alone may be safe; combinations may not. When unsure, consult the
 
 - **Branch creation always goes through the issue-and-branch flow in _Working
   Conventions_** — no exceptions for `superpowers:brainstorming`'s "Write design
-  doc" step, `superpowers:writing-plans`' "Save plans to:" step, or
-  `superpowers:using-git-worktrees`' worktree-consent prompt. Pause those
+  doc" step or `superpowers:writing-plans`' "Save plans to:" step. Pause those
   skills, run the flow, then write specs to `docs/superpowers/specs/...` or
   plans to `docs/superpowers/plans/...` on the new branch. Default to
   `gh issue develop` so the branch is linked to an issue; only create a branch
@@ -274,27 +273,10 @@ alone may be safe; combinations may not. When unsure, consult the
   pre-commit `fmt` hook; checking only the code files misses a doc-only Trunk
   failure.
 
-- **`finishing-a-development-branch` / `using-git-worktrees` tooling**: This repo
-  is `uv`-only — skip both skills' `npm test / cargo test / pytest / go test`
-  heuristics, plus `using-git-worktrees` Step 2 setup (`poetry install` /
-  `pip install`) and Step 3 baseline. Verify dbt changes with
-  `uv run dbt build --select <model>+` against the relevant project, Python with
-  `uv run pytest` where tests exist. At `finishing-a-development-branch`'s menu
-  pick Option 2 (push + PR) — never Option 1 (local merge to `main`;
-  `git push origin main` is hard-blocked and we squash-merge via PR). PR body
-  uses `.github/pull_request_template.md`.
-
 - **Before brainstorming a fix for a GitHub issue**: verify the issue's claims
   (row counts, bucket sizes, reproduce queries, named files/columns) against
   current code and data. Issue bodies drift — code moves, data changes, prior
   PRs land. Re-run the diagnostic before designing.
-
-- **Continuous execution exceptions**: `superpowers:subagent-driven-development`
-  and `superpowers:executing-plans` push you to execute every task without
-  pausing to check in. Pause anyway to ask the user before (a) opening a
-  tracking issue, (b) creating a
-  branch or worktree, (c) modifying protected files (hook scripts,
-  `.devcontainer/scripts/`, `.claude/settings*.json`).
 
 ## CLAUDE.md Editing Rules
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will update the `## Superpowers skill overrides`
> section of the root `CLAUDE.md` so it matches the superpowers plugin **v6.0.0**.

Compared our overrides against the v6.0.0 skill files and reconciled the drift:

- Refreshed stale skill-step quotes: `writing-plans`' "Save plans to:" step, and
  dropped the no-longer-literal "do not pause between tasks" phrasing in the
  continuous-execution exceptions bullet.
- Minimized the `finishing-a-development-branch` / `using-git-worktrees` note to
  the two points that actually differ for this repo: we use `uv` (not
  `poetry`/`pip`), and `uv run dbt build --select {model}+` should run alongside
  the skills' other tests.

Docs-only change — touches only the root `CLAUDE.md`. No issue was opened (quick
docs fix).

## AI Assistance

> Authored by Claude Code, human-directed: the user reviewed each edit and
> directed the scope (which overrides to keep, drop, and minimize).

## Self-review

> Docs-only — Dagster / dbt / Docs-site sections are not applicable.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment (the review workflow excludes
      markdown, so it will not post on this docs-only PR).

## CI checks

- [x] **Trunk** — passes locally (`trunk check` clean on `CLAUDE.md`).
- [ ] **dbt Cloud** — not triggered (markdown-only; `pull_request` paths exclude docs).
- [ ] **Dagster Cloud** — not triggered (no relevant paths changed).
