### PR TITLE
feat(dbt): de-identify assessment roster extract with pseudonymous student_token

### DIFF
--- a/docs/superpowers/specs/2026-06-15-assessment-roster-extract-design.md
+++ b/docs/superpowers/specs/2026-06-15-assessment-roster-extract-design.md
@@ -17,12 +17,12 @@ It unifies five assessment sources (i-Ready, Miami FAST, DIBELS, NJSLA, internal
 assessments) into one schema and ties each result to the student's ELA/Math
 course enrollment (teacher, course, section) and core demographics.
 
-**PII / access basis:** the sheet carries the raw `student_number` (no in-model
-anonymization). Anonymization is handled downstream by the owner before any
-external sharing. The destination Google Sheet is access-restricted to the
-owner/team, and the owner has confirmed permission and a legitimate need. The
-sheet output therefore contains directly-identifiable student data and must be
-treated as PII (restricted access; not shared with outside researchers as-is).
+**PII / access basis:** the extract does not emit the raw `student_number`.
+Students are identified by a pseudonymous `student_token` (a stable hash of
+`student_number`), so the data is de-identified at the source. It is shared with
+outside researchers under a signed research data-sharing agreement (the FERPA
+studies exception), which is the primary control; the token is defense-in-depth.
+The raw-number → token map is not part of the extract.
 
 ## Decisions
 
@@ -31,10 +31,11 @@ treated as PII (restricted access; not shared with outside researchers as-is).
   initially built as a separate `int_assessments__roster_union` intermediate —
   Approach B — but was folded into the reporting view during PR review since it
   had exactly one consumer.)
-- **Student identifier:** the sheet carries the raw `student_number` directly.
-  In-model anonymization (salted-hash + crosswalk) was scrapped — anonymization
-  is handled downstream by the owner before external sharing. See the PII /
-  access basis in Context.
+- **Student identifier:** the extract emits a pseudonymous `student_token`
+  (`generate_surrogate_key(['student_number'])`) and never the raw number. A
+  deterministic hash is acceptable here because sharing is governed by a signed
+  research agreement (the studies exception) rather than relying on the
+  de-identification alone. See the PII / access basis in Context.
 - **Performance columns:** two columns — `performance_band_label` (string, e.g.
   "Mid or Above Grade Level") and `performance_band_int` (integer, e.g. 5). Both
   are native to each source; no new standardized scale is invented.
@@ -121,7 +122,7 @@ present in the demographics model within the two-year window.
 
 | Column                               | Source                              |
 | ------------------------------------ | ----------------------------------- |
-| `student_number`                     | union (raw PowerSchool id; PII)     |
+| `student_token`                      | hash of `student_number` (no raw)   |
 | `academic_year`                      | union                               |
 | `region`                             | demographics                        |
 | `school_abbreviation`                | demographics (`school`, aliased)    |

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__assessment_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__assessment_roster.yml
@@ -5,27 +5,29 @@ models:
       year, assessment source, subject, administration round, and assessment.
       Scoped to enrolled K-8 students in ELA and Math for the current and prior
       academic year. Joins the assessment union to a single demographic row per
-      student/year and to the student's ENG/MATH course teacher and section.
-      Carries the raw student_number (PII; the destination sheet is
-      access-restricted and anonymization is handled downstream).
+      student/year and to the student's ENG/MATH course teacher and section. The
+      raw student_number is never emitted: students are identified by a
+      pseudonymous student_token (a stable hash of student_number), so the
+      extract is de-identified at the source and shared under the research
+      data-sharing agreement.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - student_number
+              - student_token
               - academic_year
               - assessment_source
               - subject
               - administration_round
               - assessment_id
     columns:
-      - name: student_number
-        data_type: int64
+      - name: student_token
+        data_type: string
         description: >
-          The raw PowerSchool student number (PII), carried through from the
-          assessment union.
-        data_tests:
-          - not_null
+          Pseudonymous student identifier — a stable hash of the PowerSchool
+          student number. The same student resolves to the same token across
+          rounds and years, so longitudinal joins hold; the raw number is not
+          emitted.
       - name: academic_year
         data_type: int64
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__assessment_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__assessment_roster.sql
@@ -270,10 +270,20 @@ with
             rn_credittype_year = 1
             and not is_dropped_section
             and courses_credittype in ('ENG', 'MATH')
+    ),
+
+    -- pseudonymous, stable per-student token (hash of student_number). The raw
+    -- number is used for the joins below but never emitted; the extract is
+    -- de-identified at the source and shared under the research agreement.
+    roster as (
+        select
+            *,
+            {{ dbt_utils.generate_surrogate_key(["student_number"]) }} as student_token,
+        from unioned
     )
 
 select
-    ru.student_number,
+    ru.student_token,
     ru.academic_year,
     ru.assessment_source,
     ru.`subject`,
@@ -296,7 +306,7 @@ select
     c.teacher_powerschool_teacher_number,
     c.course_number,
     c.section_number,
-from unioned as ru
+from roster as ru
 -- demographics is the enrollment gate: the grade 0-8 (K-8) scope is enforced
 -- here, so this join is INNER. Assessment rows for a student with no
 -- enrollment record for that year are intentionally dropped.


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

Replace the raw `student_number` in `rpt_gsheets__assessment_roster` with a stable pseudonymous `student_token` (`generate_surrogate_key(['student_number'])`). The raw number is still used internally for the demographics and ENG/MATH course joins, but it is **never emitted** — the extract is de-identified at the source.

Fast-follow to #4192, which squash-merged the raw-`student_number` version before this change was ready. No external consumer is wired yet (the Sheets/file exposure was deferred), so this lands the de-identification before anything leaves the warehouse.

**Why a deterministic hash is acceptable here:** the research share is governed by a signed data-sharing agreement (the FERPA studies exception), which is the primary control; the token is defense-in-depth. The same student resolves to the same token across rounds and years, so the researchers' longitudinal joins still hold.

Closes #4203.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude Code authored the SQL/YAML/spec edits. The token approach (deterministic hash vs. a random crosswalk) and the governance basis were human-directed after a data-engineering review.

## Self-review

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — `student_token` column documented; grain test moved to `student_token`.
- [x] Include (or update) an exposure for all models consumed by an application — still no external consumer wired (deferred, tracked from #4192).
- [x] No external sources added.

## CI checks

- [x] Trunk — passes.
- [ ] dbt Cloud — will run on this PR; built clean locally (377,539 rows, 11,276 distinct tokens, grain test passes, no `student_number` column in the output).
