### PR TITLE
fix(dlt): force NULLABLE columns in Focus pipeline

### DIFF
--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -24,8 +24,9 @@ database directly to BigQuery using `dlt`'s `sql_database` source with PyArrow
 backend.
 
 - Asset keys: `[code_location, "dlt", "focus", table_name]`
-- Uses `reflection_level="full_with_precision"` — no custom type or nullability
-  adapters
+- Uses `reflection_level="full_with_precision"` + `remove_nullability_adapter`
+  (forces all columns `NULLABLE` so upstream `NOT NULL` changes don't break the
+  `replace` load — see `focus/CLAUDE.md`)
 - Factory:
   `build_focus_dlt_assets(sql_database_credentials, code_location, table_name)`
 

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -8,18 +8,29 @@ using dlt's `sql_database` source with PyArrow backend.
 `build_focus_dlt_assets(sql_database_credentials, code_location, table_name)`
 
 - Asset keys: `[code_location, "dlt", "focus", table_name]`
-- Uses `reflection_level="full_with_precision"` — no custom type adapters
-- No custom callbacks — add only if Postgres-specific issues surface
+- Uses `reflection_level="full_with_precision"` + `remove_nullability_adapter`
 - All tables from the `public` schema (Focus default)
 
 ## Differences from Illuminate
 
-| Aspect              | Illuminate                              | Focus                      |
-| ------------------- | --------------------------------------- | -------------------------- |
-| Schema dimension    | Multi-schema (asset key includes it)    | Single `public` schema     |
-| Type adapters       | `unbounded_numeric_adapter`             | None (full_with_precision) |
-| Query callbacks     | `filter_date_taken_callback` (optional) | None                       |
-| Nullability adapter | `remove_nullability_adapter`            | None (full_with_precision) |
+| Aspect              | Illuminate                              | Focus                        |
+| ------------------- | --------------------------------------- | ---------------------------- |
+| Schema dimension    | Multi-schema (asset key includes it)    | Single `public` schema       |
+| Type adapters       | `unbounded_numeric_adapter`             | None (full_with_precision)   |
+| Query callbacks     | `filter_date_taken_callback` (optional) | None                         |
+| Nullability adapter | `remove_nullability_adapter`            | `remove_nullability_adapter` |
+
+## Nullability adapter (required)
+
+`full_with_precision` reflects Postgres `NOT NULL` into BigQuery `REQUIRED`
+mode. BigQuery forbids both adding a `REQUIRED` column and relaxing an existing
+`REQUIRED` column to `NULLABLE`, so any upstream nullability change breaks the
+`replace` load (it migrates schema in place, never drops the table). Passing
+`table_adapter_callback=remove_nullability_adapter` makes every column
+`NULLABLE`, so schema evolution never hits a `REQUIRED`-mode constraint — the
+same fix Illuminate uses. Adding/removing this adapter against existing tables
+that already have `REQUIRED` columns requires dropping those tables first
+(`replace` repopulates them on the next run).
 
 ## Testing Constraints
 

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -16,7 +16,7 @@ using dlt's `sql_database` source with PyArrow backend.
 | Aspect              | Illuminate                              | Focus                        |
 | ------------------- | --------------------------------------- | ---------------------------- |
 | Schema dimension    | Multi-schema (asset key includes it)    | Single `public` schema       |
-| Type adapters       | `unbounded_numeric_adapter`             | None (full_with_precision)   |
+| Type adapters       | `unbounded_numeric_adapter`             | None                         |
 | Query callbacks     | `filter_date_taken_callback` (optional) | None                         |
 | Nullability adapter | `remove_nullability_adapter`            | `remove_nullability_adapter` |
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -6,7 +6,7 @@ from dlt import pipeline
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
-from dlt.sources.sql_database import sql_database
+from dlt.sources.sql_database import remove_nullability_adapter, sql_database
 
 
 class FocusDagsterDltTranslator(DagsterDltTranslator):
@@ -50,6 +50,7 @@ def build_focus_dlt_assets(
         defer_table_reflect=True,
         backend="pyarrow",
         reflection_level="full_with_precision",
+        table_adapter_callback=remove_nullability_adapter,
     )
 
     dlt_pipeline = pipeline(


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will stop the kippmiami Focus dlt pipeline from failing on upstream schema/nullability changes.

**Root cause:** the Focus factory reflected with `reflection_level="full_with_precision"` and no `table_adapter_callback`, so Postgres `NOT NULL` constraints propagated into BigQuery `REQUIRED` column mode. BigQuery forbids both (a) adding a `REQUIRED` column and (b) relaxing an existing `REQUIRED` column to `NULLABLE` on an existing table. Because `write_disposition="replace"` uses dlt's truncate-and-insert strategy (in-place schema migration, no table drop), the load broke on:

- `gradebook_assignments` — new upstream `NOT NULL` column `allow_google_drive` (`Cannot add required fields to an existing schema`)
- `custom_field_log_columns` — upstream dropped `NOT NULL` on `alias` (`Field alias has changed mode from REQUIRED to NULLABLE`)

Diagnosed from run `2f424953-f2ed-44fc-94a3-69df468159f5` and confirmed against the live BigQuery table schemas.

**Fix:** add `table_adapter_callback=remove_nullability_adapter` so all columns load as `NULLABLE` — the same approach the Illuminate pipeline already uses. Nullability changes then never hit a `REQUIRED`-mode constraint.

### Required one-time data step (post-deploy)

The adapter wants every currently-`REQUIRED` column to become `NULLABLE`, which BigQuery rejects on existing tables. So **after this deploys**, all tables in `dagster_kippmiami_dlt_focus` must be dropped once so `replace` recreates them all-`NULLABLE`. The drop is effectively free — `replace` already re-pulls every table on each run. Order matters: deploy the adapter first, then drop, then materialize.

## AI Assistance

Diagnosis (systematic-debugging), code change, and doc updates were AI-assisted by Claude Code; root-cause path and the drop-all decision were human-directed.

## Self-review

### Dagster

- [x] Change is library-only (`remove_nullability_adapter` mirrors the Illuminate factory); import + adapter behavior verified locally. End-to-end load verifiable only via branch deployment (Focus IP allowlist blocks codespace access).

## CI checks

- [ ] **Trunk** — passes (fmt clean locally).
- [ ] **Dagster Cloud** — branch deployment is the only path to verify the Focus connection end-to-end.
