### PR TITLE
feat(dbt): map Finalsite language values to Focus codes in rpt_focus__demographics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,6 +552,16 @@ Hyphenated identifiers in INFORMATION_SCHEMA paths need backticks — `region-us
 as a bare token fails with "Syntax error: Expected end of input but got '-'".
 Write `` `teamster-332318`.`region-us`.INFORMATION_SCHEMA.TABLES ``.
 
+Single quotes inside a BigQuery string literal escape with a **backslash**
+(`'O\'odham'`), not by doubling (`''`) — the doubled form fails with
+"concatenated string literals must be separated by whitespace".
+
+The BigQuery MCP service account **cannot read GOOGLE_SHEETS external tables**
+("Access Denied: ... while getting Drive credentials", 403) — it lacks Drive
+scope. To inspect a sheet-backed source's rows, build the staging model via dbt
+(`dbt build --select <stg_model> --target staging`; ADC has Drive scope), then
+query the materialized `zz_stg_*` table — a native BQ table, not Drive-backed.
+
 `bq` CLI fallback for shell contexts (Monitor poll loops): binary at
 `/usr/local/share/google-cloud-sdk/bin/bq`, `--project_id=teamster-332318`. Same
 SELECT-only constraints apply.

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -9,6 +9,15 @@ dbt projects (currently `kippmiami`).
 Focus Postgres → dlt `sql_database` → BigQuery (`dagster_<project>_dlt_focus`) →
 dbt staging models → dbt intermediate models
 
+## Focus field value codes
+
+A Focus custom field's allowed value codes live in
+`dagster_<district>_dlt_focus.custom_fields` (find the field by `title` /
+`column_name`) joined to `custom_field_select_options` on
+`custom_field_select_options.source_id = custom_fields.id` — `code` is the value
+Focus expects, `label` is the human name. Use this to build Finalsite→Focus
+value crosswalks.
+
 ## Model Structure
 
 ```text

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
@@ -209,7 +209,10 @@ unit_tests:
       GENDER is mapped to single-letter code, ETHNIC_HL derives from
       int_finalsite__contact_custom_attributes.latino_hispanic_yn. The second
       student has no custom-attributes row, confirming ETHNIC_HL is null (not
-      'N') for an unknown while PHOTO_VID_PERM defaults to 'N'.
+      'N') for an unknown while PHOTO_VID_PERM defaults to 'N'. The third
+      student has a custom-attributes row whose lang_parent_ss has no crosswalk
+      entry, confirming the language columns fall through to null (not the raw
+      label).
     model: rpt_focus__demographics
     given:
       - input: ref('stg_finalsite__contacts')
@@ -230,10 +233,17 @@ unit_tests:
               first_name: John,
               birth_date: 2013-05-20,
             }
+          - {
+              finalsite_enrollment_id: enr-003,
+              last_name: Mara,
+              first_name: Worf,
+              birth_date: 2011-01-10,
+            }
       - input: ref('int_finalsite__enrollment_lifecycle')
         rows:
           - { finalsite_enrollment_id: enr-001 }
           - { finalsite_enrollment_id: enr-002 }
+          - { finalsite_enrollment_id: enr-003 }
       - input: ref('int_finalsite__contact_custom_attributes')
         format: sql
         rows: |
@@ -243,6 +253,13 @@ unit_tests:
             true as media_release_yn,
             'Spanish' as lang_parent_ss,
             ['Black', 'White'] as race_ms
+          union all
+          select
+            'enr-003',
+            false,
+            false,
+            'Klingon',
+            cast(null as array<string>)
       - input: ref('stg_google_sheets__focus__language_code_crosswalk')
         format: sql
         rows: |
@@ -306,6 +323,51 @@ unit_tests:
             lang: null,
             stdt_email: null,
             ethnic_hl: null,
+            single_ethnic: null,
+            race_am_ind_ak_nat: null,
+            race_asian: null,
+            race_black: null,
+            race_nat_haw_pac_isl: null,
+            race_white: null,
+            residence_county: null,
+            contry_birth: null,
+            homeroom_tchr: null,
+            resident_st: null,
+            birth_loc: null,
+            bdate_verif: null,
+            immun_st: null,
+            primary_home_lang: null,
+            native_parent_lang: null,
+            grde_enter_dist: null,
+            msix_id: null,
+            homeroom: null,
+            pmrn: null,
+            internt_perm: null,
+            act_perm: null,
+            direct_perm: null,
+            screen_perm: null,
+            photo_vid_perm: N,
+            survey_perm: null,
+            mckay_sch_attend: null,
+            fhsaa_el3_ind: null,
+            fhsaa_el3ch_ind: null,
+            dt_home_lang_survey: null,
+            casas_track: null,
+            lcp_cont_stdt: null,
+            tide_access_code: null,
+          }
+        - {
+            stdt_id: null,
+            last_name: Mara,
+            first_name: Worf,
+            name_suffix: null,
+            middle_name: null,
+            nickname: null,
+            dt_birth: "20110110",
+            gender: null,
+            lang: null,
+            stdt_email: null,
+            ethnic_hl: N,
             single_ethnic: null,
             race_am_ind_ak_nat: null,
             race_asian: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
@@ -54,8 +54,9 @@ models:
       - name: lang
         data_type: string
         description:
-          Primary language from the `lang_parent_ss` Finalsite custom field
-          (e.g. English/Spanish/Creole). May need a Focus language-code mapping.
+          Focus language value code mapped from the `lang_parent_ss` Finalsite
+          custom field via `stg_google_sheets__focus__language_code_crosswalk`.
+          Null when the Finalsite value has no crosswalk entry.
       - name: stdt_email
         data_type: string
         description: Student email address from Finalsite.
@@ -122,13 +123,15 @@ models:
       - name: primary_home_lang
         data_type: string
         description:
-          Primary home language from the `lang_parent_ss` Finalsite custom
-          field.
+          Primary home language as a Focus value code mapped from the
+          `lang_parent_ss` Finalsite custom field via
+          `stg_google_sheets__focus__language_code_crosswalk`.
       - name: native_parent_lang
         data_type: string
         description:
-          Native parent language from the `lang_parent_ss` Finalsite custom
-          field.
+          Native parent language as a Focus value code mapped from the
+          `lang_parent_ss` Finalsite custom field via
+          `stg_google_sheets__focus__language_code_crosswalk`.
       - name: grde_enter_dist
         data_type: string
         description:
@@ -240,6 +243,10 @@ unit_tests:
             true as media_release_yn,
             'Spanish' as lang_parent_ss,
             ['Black', 'White'] as race_ms
+      - input: ref('stg_google_sheets__focus__language_code_crosswalk')
+        format: sql
+        rows: |
+          select 'Spanish' as finalsite_language, 'SP' as focus_language_code
     expect:
       rows:
         - {
@@ -251,7 +258,7 @@ unit_tests:
             nickname: Jay,
             dt_birth: "20120315",
             gender: F,
-            lang: Spanish,
+            lang: SP,
             stdt_email: jane.smith@example.com,
             ethnic_hl: Y,
             single_ethnic: null,
@@ -267,8 +274,8 @@ unit_tests:
             birth_loc: null,
             bdate_verif: null,
             immun_st: null,
-            primary_home_lang: Spanish,
-            native_parent_lang: Spanish,
+            primary_home_lang: SP,
+            native_parent_lang: SP,
             grde_enter_dist: null,
             msix_id: null,
             homeroom: null,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
@@ -21,7 +21,12 @@ select
         then 'F'
     end as gender,
 
-    cca.lang_parent_ss as lang,
+    -- LANG, PRIMARY_HOME_LANG, and NATIVE_PARENT_LANG all draw the same Focus
+    -- value code from the language crosswalk. NOTE: the Focus LANG field
+    -- (custom_200000005) historically carried a legacy 3-option set
+    -- (EN/English/Spanish); pending registrar confirmation it is assumed to
+    -- accept the same FLDOE code as the home/native-language fields.
+    lcc.focus_language_code as lang,
 
     c.email as stdt_email,
 
@@ -49,8 +54,8 @@ select
     cast(null as string) as bdate_verif,
     cast(null as string) as immun_st,
 
-    cca.lang_parent_ss as primary_home_lang,
-    cca.lang_parent_ss as native_parent_lang,
+    lcc.focus_language_code as primary_home_lang,
+    lcc.focus_language_code as native_parent_lang,
 
     cast(null as string) as grde_enter_dist,
     cast(null as string) as msix_id,
@@ -78,3 +83,6 @@ inner join
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
     on c.finalsite_enrollment_id = cca.finalsite_enrollment_id
+left join
+    {{ ref("stg_google_sheets__focus__language_code_crosswalk") }} as lcc
+    on cca.lang_parent_ss = lcc.finalsite_language

--- a/src/dbt/kipptaf/models/google/sheets/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources-external.yml
@@ -1797,3 +1797,25 @@ sources:
                 - sheets
                 - focus
                 - drop_code_crosswalk
+      - name: src_google_sheets__focus__language_code_crosswalk
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris:
+              - https://docs.google.com/spreadsheets/d/16l2loYxWINL7MG7eE1xzO2piVdKx5vvgavxntEMRSLk
+            sheet_range: src_focus__language_code_crosswalk
+            skip_leading_rows: 1
+        columns:
+          - name: finalsite_language
+            data_type: string
+          - name: focus_language_code
+            data_type: string
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kipptaf
+                - google
+                - sheets
+                - focus
+                - language_code_crosswalk

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__focus__language_code_crosswalk.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__focus__language_code_crosswalk.yml
@@ -1,0 +1,23 @@
+models:
+  - name: stg_google_sheets__focus__language_code_crosswalk
+    description: >
+      Crosswalk mapping a Finalsite `lang_parent_ss` value to the corresponding
+      Focus language value code (the FLDOE two-letter code used by the Focus
+      `PRIMARY_HOME_LANG` / `NATIVE_PARENT_LANG` / `LANG` custom fields).
+    columns:
+      - name: finalsite_language
+        data_type: string
+        description:
+          Language value as recorded in the Finalsite `lang_parent_ss` custom
+          field.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          - unique:
+              config:
+                severity: error
+      - name: focus_language_code
+        data_type: string
+        description:
+          Focus language value code that corresponds to the Finalsite language.

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__focus__language_code_crosswalk.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__focus__language_code_crosswalk.yml
@@ -21,3 +21,7 @@ models:
         data_type: string
         description:
           Focus language value code that corresponds to the Finalsite language.
+        data_tests:
+          - not_null:
+              config:
+                severity: error

--- a/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__focus__language_code_crosswalk.sql
+++ b/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__focus__language_code_crosswalk.sql
@@ -1,0 +1,3 @@
+select *,
+from {{ source("google_sheets", "src_google_sheets__focus__language_code_crosswalk") }}
+where finalsite_language is not null

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -194,7 +194,7 @@ data_tests:
       meta:
         dagster:
           ref:
-            name: stg_google_sheets__focus__language_code_crosswalk
+            name: int_finalsite__contact_custom_attributes
 
   - name: dim_student_section_enrollments__no_multi_stint_overlap
     description: >-

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -181,6 +181,21 @@ data_tests:
           ref:
             name: int_collegeboard__ap_unpivot
 
+  - name: rpt_focus__demographics__language_crosswalk_resolves
+    description: >-
+      Returns one row per `int_finalsite__contact_custom_attributes` record
+      whose non-null `lang_parent_ss` has no matching `finalsite_language` in
+      `stg_google_sheets__focus__language_code_crosswalk`. Each row is a
+      Finalsite language value that falls through to a null Focus code in
+      `rpt_focus__demographics` (LANG / PRIMARY_HOME_LANG / NATIVE_PARENT_LANG).
+      Ops signal to add the missing value to the crosswalk sheet; failure rows
+      persist in `kipptaf_dbt_test__audit` for direct query.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: stg_google_sheets__focus__language_code_crosswalk
+
   - name: dim_student_section_enrollments__no_multi_stint_overlap
     description: >-
       Warns when a non-dropped course-enrollment (cc) record overlaps more than

--- a/src/dbt/kipptaf/tests/rpt_focus__demographics__language_crosswalk_resolves.sql
+++ b/src/dbt/kipptaf/tests/rpt_focus__demographics__language_crosswalk_resolves.sql
@@ -1,0 +1,6 @@
+select cca.lang_parent_ss,
+from {{ ref("int_finalsite__contact_custom_attributes") }} as cca
+left join
+    {{ ref("stg_google_sheets__focus__language_code_crosswalk") }} as lcc
+    on cca.lang_parent_ss = lcc.finalsite_language
+where cca.lang_parent_ss is not null and lcc.finalsite_language is null


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will translate Finalsite `lang_parent_ss` values into Focus language value codes in `rpt_focus__demographics`, so the `LANG`, `PRIMARY_HOME_LANG`, and `NATIVE_PARENT_LANG` columns emit Focus codes (e.g. `EN`, `SP`, `HC`) instead of raw Finalsite labels (`English`, `Spanish`, `Haitian Creole`).

Follow-up to #4201 (Component 4 of #4073). Implements the language half of #4206.

Changes, following the existing enrollment-code / drop-code crosswalk pattern:

- New Google-Sheets source `src_google_sheets__focus__language_code_crosswalk` (same spreadsheet as the other Focus crosswalks, tab `src_focus__language_code_crosswalk`) and staging model `stg_google_sheets__focus__language_code_crosswalk` — 94 rows, one per Finalsite picklist value.
- Left-join the crosswalk in `rpt_focus__demographics`; the three language columns now carry `focus_language_code`.
- Warn-level singular test `rpt_focus__demographics__language_crosswalk_resolves` flags any non-null `lang_parent_ss` with no crosswalk entry, so a new Finalsite picklist value surfaces (Ops signal to add it) instead of silently passing through as null.
- Updated the unit test and column descriptions.

Open registrar item (does not block this PR): the Focus `LANG` field historically carried a legacy 3-option set (`EN` / `English` / `Spanish`); this PR assumes it accepts the same FLDOE code as the home/native-language fields. An inline comment in the model flags this. If `LANG` must keep its legacy values, a second crosswalk column is a follow-up.

### Validation

- Staging crosswalk built against staging: 94 rows, `not_null` + `unique` pass; all 94 codes verified against valid Focus option codes (no typos).
- `rpt_focus__demographics` builds end-to-end; real-data output maps English to `EN`, Spanish to `SP`, Creole to `ZF`, Haitian Creole to `HC`, Farsi to `FA`, with no non-null source values falling through to null.
- Unit test and the new crosswalk-resolves test pass.

### AI Assistance

AI-assisted: warehouse exploration, mapping draft, and all model/test scaffolding were authored by Claude Code. Human-directed: the crosswalk sheet values and the worktree/PR decisions.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** — done for `src_google_sheets__focus__language_code_crosswalk`
- [ ] **Breaking change?** `rpt_focus__demographics` is contracted, but column values change (raw label to code); no column rename/removal. The extract is not yet live in Focus, so no downstream consumer breaks.

## CI checks

- [ ] **Trunk** — clean locally on all changed files
- [ ] **dbt Cloud** — pending
- [ ] **Dagster Cloud** — not expected (no Dagster code changes)

Refs #4206
