### PR TITLE
fix(ci): add dlt library to kippmiami deploy paths

### DIFF
--- a/.github/workflows/deploy-prod-kippmiami.yaml
+++ b/.github/workflows/deploy-prod-kippmiami.yaml
@@ -27,6 +27,7 @@ on:
       - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/fldoe/**
       - src/teamster/libraries/google/drive/resources.py
@@ -48,6 +49,7 @@ on:
       - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/fldoe/**
       - src/teamster/libraries/iready/**


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will make changes to `src/teamster/libraries/dlt/**` trigger the kippmiami prod deploy.

kippmiami's Focus assets live in `src/teamster/libraries/dlt/focus/`, but `deploy-prod-kippmiami.yaml` omitted `src/teamster/libraries/dlt/**` from both its `push` and `pull_request` paths. As a result, #4216 (the Focus nullability fix) merged to `main` but did **not** trigger a kippmiami redeploy — only kipptaf deployed, since its workflow already lists the dlt path. This is the same push-paths drift class documented in `.github/CLAUDE.md` (PR #4175).

Added `src/teamster/libraries/dlt/**` to both path lists, in the existing alphabetical slot.

The immediate #4216 deploy is being handled out-of-band via `workflow_dispatch`; this PR prevents the drift from recurring on future dlt-library changes.

## AI Assistance

Diagnosed and authored by Claude Code; human-directed.

## CI checks

- [ ] **Trunk** — passes (fmt clean locally).
