### PR TITLE
feat(extracts): filter finalsite log to latest status for same-day multi-status applicants

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__finalsite__log.yml
@@ -1,18 +1,23 @@
 models:
   - name: rpt_gsheets__finalsite__log
     description: >
-      Latest Finalsite enrollment status per applicant for the current academic
-      year, one row per finalsite_enrollment_id. Feeds the SRE team's Finalsite
-      Log Google Sheet.
+      All status rows sharing the same date as each applicant's latest status,
+      limited to dates where two or more statuses occurred. latest_status
+      repeats the most recent status across all rows for a given applicant.
+      Feeds the SRE team's Finalsite Log Google Sheet.
     config:
       meta:
         contains_pii: true
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - finalsite_enrollment_id
+              - detailed_status
     columns:
       - name: finalsite_enrollment_id
         data_type: string
         description: Unique identifier for a Finalsite enrollment record.
-        data_tests:
-          - unique
       - name: enrollment_academic_year_display
         data_type: string
         description:
@@ -39,15 +44,14 @@ models:
         data_type: string
         description:
           Finalsite enrollment type (e.g. New Student, Re-Enrollment).
-      - name: gender
-        data_type: string
-        description: Applicant gender as recorded in Finalsite.
-      - name: birthdate
-        data_type: date
-        description: Applicant date of birth.
       - name: status_start_date
         data_type: date
-        description: Date the applicant entered their latest enrollment status.
+        description: Date the applicant entered this enrollment status.
       - name: detailed_status
         data_type: string
-        description: Human-readable label of the latest enrollment status stage.
+        description: Enrollment status for this specific status row.
+      - name: latest_status
+        data_type: string
+        description: >
+          Most recent enrollment status for this applicant — the same value
+          across all rows for a given finalsite_enrollment_id.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__finalsite__log.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__finalsite__log.sql
@@ -1,5 +1,5 @@
 with
-    ranked as (
+    all_rows as (
         select
             enrollment_academic_year_display,
             region,
@@ -10,15 +10,21 @@ with
             last_name,
             grade_level,
             enrollment_type,
-            gender,
-            birthdate,
             status_start_date,
             detailed_status,
 
-            row_number() over (
+            first_value(detailed_status) over (
                 partition by finalsite_enrollment_id
                 order by status_start_date desc, status_order desc
-            ) as rn,
+            ) as latest_status,
+
+            max(status_start_date) over (
+                partition by finalsite_enrollment_id
+            ) as latest_status_date,
+
+            count(*) over (
+                partition by finalsite_enrollment_id, status_start_date
+            ) as status_count_for_day,
 
         from {{ ref("int_finalsite__status_report_unpivot") }}
         where
@@ -27,18 +33,18 @@ with
     )
 
 select
-    enrollment_academic_year_display,
-    region,
-    assigned_school,
-    finalsite_enrollment_id,
-    powerschool_student_number,
-    first_name,
-    last_name,
-    grade_level,
-    enrollment_type,
-    gender,
-    birthdate,
-    status_start_date,
-    detailed_status,
-from ranked
-where rn = 1
+    a.enrollment_academic_year_display,
+    a.region,
+    a.assigned_school,
+    a.finalsite_enrollment_id,
+    a.powerschool_student_number,
+    a.first_name,
+    a.last_name,
+    a.grade_level,
+    a.enrollment_type,
+    a.status_start_date,
+    a.detailed_status,
+    a.latest_status,
+
+from all_rows as a
+where a.status_start_date = a.latest_status_date and a.status_count_for_day >= 2


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will update `rpt_gsheets__finalsite__log` to:

1. Show only the **latest status** per applicant (one row per `finalsite_enrollment_id`)
2. Restrict to applicants who had **two or more status changes on the same calendar day** in the current academic year

This surfaces the same-day status churn that the SRE team needs to act on, and eliminates the noise of showing every historical status row per applicant.

AI-assisted: SQL logic and YAML description drafted by Claude Code; requirements and direction from the human.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

_No Dagster changes._

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — existing model, properties file description updated
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.

### Docs _(skip if no schedule, sensor, or integration changes)_

_No schedule, sensor, or integration changes._

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)