### PR TITLE
chore: update dependencies

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,12 +16,12 @@ lint:
     - gitleaks@8.30.1
     - hadolint@2.14.0
     - isort@8.0.1
-    - markdownlint@0.48.0
-    - osv-scanner@2.3.8
+    - markdownlint@0.49.0
+    - osv-scanner@2.4.0
     - oxipng@10.1.1
     - prettier@3.8.4
     - pyright@1.1.410
-    - ruff@0.15.17
+    - ruff@0.15.18
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - sqlfluff@4.2.2

--- a/src/dbt/amplify/package-lock.yml
+++ b/src/dbt/amplify/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/deanslist/package-lock.yml
+++ b/src/dbt/deanslist/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/edplan/package-lock.yml
+++ b/src/dbt/edplan/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/finalsite/package-lock.yml
+++ b/src/dbt/finalsite/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/iready/package-lock.yml
+++ b/src/dbt/iready/package-lock.yml
@@ -1,7 +1,7 @@
 packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
   - name: dbt_external_tables
     package: dbt-labs/dbt_external_tables
     version: 0.12.2

--- a/src/dbt/kippcamden/package-lock.yml
+++ b/src/dbt/kippcamden/package-lock.yml
@@ -18,5 +18,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: af574a8b35ffc4b6e887724310a907084806a0b1

--- a/src/dbt/kippmiami/package-lock.yml
+++ b/src/dbt/kippmiami/package-lock.yml
@@ -16,5 +16,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 27346872ea8ba9aecf67148b288f7c78a7429627

--- a/src/dbt/kippnewark/package-lock.yml
+++ b/src/dbt/kippnewark/package-lock.yml
@@ -24,5 +24,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 5570079e221ff852de47fdebe3ac63b255f4e667

--- a/src/dbt/kipppaterson/package-lock.yml
+++ b/src/dbt/kipppaterson/package-lock.yml
@@ -12,5 +12,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: e8986a0f1726db71d70527227388fe1d2e0eaa70

--- a/src/dbt/kipptaf/package-lock.yml
+++ b/src/dbt/kipptaf/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/overgrad/package-lock.yml
+++ b/src/dbt/overgrad/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/pearson/package-lock.yml
+++ b/src/dbt/pearson/package-lock.yml
@@ -4,5 +4,5 @@ packages:
     version: 0.12.2
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
 sha1_hash: 7bd42ade1aac7baaf975ecf69ca317572e685b2e

--- a/src/dbt/powerschool/package-lock.yml
+++ b/src/dbt/powerschool/package-lock.yml
@@ -1,7 +1,7 @@
 packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
   - name: dbt_external_tables
     package: dbt-labs/dbt_external_tables
     version: 0.12.2

--- a/src/dbt/titan/package-lock.yml
+++ b/src/dbt/titan/package-lock.yml
@@ -1,7 +1,7 @@
 packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
-    version: 1.3.3
+    version: 1.4.0
   - name: dbt_external_tables
     package: dbt-labs/dbt_external_tables
     version: 0.12.2

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "dagster"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -611,28 +611,28 @@ dependencies = [
     { name = "universal-pathlib" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/56/2b332a573916a86922d3b519dce95b931ab88002ab0e8032730fde2a336e/dagster-1.13.9.tar.gz", hash = "sha256:e17bfe66413fa585e5bd204e455ed1958a04017869c6111a55c94f3d9e48f63e", size = 3557989, upload-time = "2026-06-11T18:25:15.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/c6/745b4d571b59cd3f65ff51845c81e0e1d57235cd3f873fe2d01ca17c3a1d/dagster-1.13.10.tar.gz", hash = "sha256:1d76ca1b40250132c5913797adc7121c6de05f287cd4d4dea5d4122ea9cf5514", size = 3562689, upload-time = "2026-06-18T18:33:31.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/55/813ce10ffd342bc4af602d726bea73a5e5106f34ec2e6c10c73d8a503ed0/dagster-1.13.9-py3-none-any.whl", hash = "sha256:8d2eb51521ca8731ecb4c7a05e8e35ba9421ea6a6cddb15b80be95fe2e1555d0", size = 1998881, upload-time = "2026-06-11T18:25:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/26/c8c8e839cf79eef3911d25d8f82894ef2104cbc4d6348aaef25b36d47093/dagster-1.13.10-py3-none-any.whl", hash = "sha256:2a5f1f05979a50c82606c6b6468f2a12e5d54646c14ba4a23cd423f85b133a3a", size = 2000249, upload-time = "2026-06-18T18:33:28.765Z" },
 ]
 
 [[package]]
 name = "dagster-airbyte"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/83/a0695ea53279a005372d25fb03c1f1f4c11c0d9cb99f1b3a25646b39f9ab/dagster_airbyte-0.29.9.tar.gz", hash = "sha256:d593874842ed380fc4714ea990cc1ce419abdef49fd270e7828a613a85aa9f02", size = 325847, upload-time = "2026-06-11T18:34:07.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/8d/914c4f5ce2802335c0752c55ba897d9ab53b74e89b536fbebd8f8bb9b800/dagster_airbyte-0.29.10.tar.gz", hash = "sha256:e0ccc07ff8e27cde92331ae26bc5ebac35194f8e62e9badd2d8e702cf0844f7f", size = 325861, upload-time = "2026-06-18T18:44:22.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/f0/3ef53c3ae9abc982119fe42a43f076d296d2538194607d35757416d7e171/dagster_airbyte-0.29.9-py3-none-any.whl", hash = "sha256:d323e3464c231a5ac060ec525659ea32aeb1807970115bb1c40203eb2de17c31", size = 116540, upload-time = "2026-06-11T18:34:05.964Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/78f2e8b29e81552e32041e754a3ebd8fe2152e195b9a434acc86cc966701/dagster_airbyte-0.29.10-py3-none-any.whl", hash = "sha256:83dd98454f2e332dc1c3573145fff478bebd86379f11b373a9766b8b32841790", size = 116551, upload-time = "2026-06-18T18:44:20.733Z" },
 ]
 
 [[package]]
 name = "dagster-cloud"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
@@ -643,14 +643,14 @@ dependencies = [
     { name = "requests" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/d8/bd15f7c48b397af28f34cc8361c90c980405d10bd1664135c1879821fd16/dagster_cloud-1.13.9.tar.gz", hash = "sha256:69676f881e248ac98405761b3e3a4c20762e96a0eda18b9f678cf6aef6822630", size = 724136, upload-time = "2026-06-11T18:25:35.375Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/24/f5909d05000849c4a7d75f90ce953d80859d48d5e08b6c72869a3c127c4c/dagster_cloud-1.13.10.tar.gz", hash = "sha256:2ba665ce48ca2efa7b1c8eba850c4a3e26fc7403f372e538c10a284e5a9d1635", size = 724745, upload-time = "2026-06-18T18:33:50.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/ab/a9def6fb79cbc07141d269621533523116a291225413e17f9c95f477442b/dagster_cloud-1.13.9-py3-none-any.whl", hash = "sha256:88388155a2152df6196a061ed3fb981b041aae49f39e4fad5f57bd695b8f47dc", size = 196443, upload-time = "2026-06-11T18:25:33.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/41/0a0528f58e664942b0050e5bd344305ed998a507ba98cb50ec7c823c70af/dagster_cloud-1.13.10-py3-none-any.whl", hash = "sha256:c416366b0ee93d17cb925a5e14d9e387ab0bf09b1c6977885358c68713da633d", size = 196558, upload-time = "2026-06-18T18:33:48.799Z" },
 ]
 
 [[package]]
 name = "dagster-cloud-cli"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -665,14 +665,14 @@ dependencies = [
     { name = "typer" },
     { name = "validators" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/6a/10a1aab77ea5d503ca3a3bcd5aa664947bfd7f568ebadb4863f971959341/dagster_cloud_cli-1.13.9.tar.gz", hash = "sha256:102448b8ad61118bdd540f258c4a7780f018ae583e688177ce19da9640949b4c", size = 172889, upload-time = "2026-06-11T18:33:24.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/04/0742acc9751488225c5c43143d171289c24473ec82f9e85ab6b0ef141566/dagster_cloud_cli-1.13.10.tar.gz", hash = "sha256:1ecb2927d962e1bfebf514066fd33453a07e9bec982b9bf66ebdd908de633004", size = 172876, upload-time = "2026-06-18T18:48:19.823Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/b8/5b4eccc18032fe0dc802553d33c66e4488037c00ed97a091f87207d0beab/dagster_cloud_cli-1.13.9-py3-none-any.whl", hash = "sha256:a96ce62273e6d7d864aa573ba98fe48010a0315491eb0e095ff1474775eda6ee", size = 119690, upload-time = "2026-06-11T18:33:23.586Z" },
+    { url = "https://files.pythonhosted.org/packages/76/35/0f5a21ae4d309789ad6a9022d806d43e7db9819cfc8c8b737d87bfcd7913/dagster_cloud_cli-1.13.10-py3-none-any.whl", hash = "sha256:730fb76689a502ac5467280590233adedd2a4bdb71a248e2eaa84a4a9df89d40", size = 119704, upload-time = "2026-06-18T18:48:18.522Z" },
 ]
 
 [[package]]
 name = "dagster-dbt"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
@@ -687,27 +687,27 @@ dependencies = [
     { name = "sqlglot", extra = ["rs"] },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/a9/77a4879208b4951c10c73a76f39c5730f49e7436606ff286697ed99aa5d4/dagster_dbt-0.29.9.tar.gz", hash = "sha256:45b8f84a1d30f621436fdb0a289f6bbae8cb2af89497cafacbd93be55ccbdb0a", size = 915103, upload-time = "2026-06-11T18:32:50.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/97/8571e1ed81c2bc4b4f6b8fbe5b8c117b66e7fafddde056dfc66fa13144a7/dagster_dbt-0.29.10.tar.gz", hash = "sha256:dd68045b594acadc574b8efc9fd221a26400251546d59bbc86054f8ac704b28d", size = 917279, upload-time = "2026-06-18T18:48:09.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/a7/5dcbbdc38c56a62484480e65a14fdf42b790ad2fd5dcf3ece1b8c38b7d54/dagster_dbt-0.29.9-py3-none-any.whl", hash = "sha256:18366468fac3635a96d27ca1c5c8eb358024f9997a6fb66fa89410bddbd790ac", size = 131407, upload-time = "2026-06-11T18:32:49.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/43/b7088be156a3387da8ffeeb40af9fa3879f2e1b22b309cd449f95bf9a868/dagster_dbt-0.29.10-py3-none-any.whl", hash = "sha256:548dc7ffb361669488171a0f121748c8a85aae61842013e042eab59ed3510efb", size = 131420, upload-time = "2026-06-18T18:48:07.874Z" },
 ]
 
 [[package]]
 name = "dagster-dlt"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
     { name = "dlt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/67/7316db1183506f6cbe65a8a66ca3aceb8d53a3eab9de84138f81c8b8bad7/dagster_dlt-0.29.9.tar.gz", hash = "sha256:27354d7f4cd7af39de4b5061b2ad6d34dbb14df7ce960311b0bf36174d550f8c", size = 232663, upload-time = "2026-06-11T18:40:29.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/8d/ded5efee222f2a992d33e24b84de8adeec0edd5b9d56dcae4f7386d66cdf/dagster_dlt-0.29.10.tar.gz", hash = "sha256:b84c4c6085ef25c8d7b12881dd2593ac26f3ce2575ae2a9feedf500d6f5d6507", size = 232667, upload-time = "2026-06-18T18:42:42.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/f8/6e17a81b358ecf87644fe32777b266879f65decf26504de586cabebebad8/dagster_dlt-0.29.9-py3-none-any.whl", hash = "sha256:c4e54511a5696e9e136ed06327ad88fb4cd073d258cf3e13757f79339187de1c", size = 21157, upload-time = "2026-06-11T18:40:28.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/c13efde402388d39da22d10f8a9547e9bb587aca10b454e0f984024376e9/dagster_dlt-0.29.10-py3-none-any.whl", hash = "sha256:ed421be03e5e7c2641cf6a1eeaf289c700413c7bdf6226eaa0b2c803d8cacd83", size = 21169, upload-time = "2026-06-18T18:42:41.94Z" },
 ]
 
 [[package]]
 name = "dagster-gcp"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
@@ -718,14 +718,14 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "oauth2client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/55/c07d8b2ac5c46dce13fd35c0e74b4236ec33a56e2681467e935363160c8a/dagster_gcp-0.29.9.tar.gz", hash = "sha256:f96e954606e5ca6113fb5b336457f6d8a9d1c07de60b3602bd2a5a63fcba854b", size = 228697, upload-time = "2026-06-11T18:36:01.48Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/0e/e08ba9410ac602e6492d2ca8fb04068c00f2d119f57dce8dd03ecb74273f/dagster_gcp-0.29.10.tar.gz", hash = "sha256:2364c1df22d3e22d9eb6ebb2edc7ab6f0a0422efa6d78ea5d8ca630b125c2bd9", size = 228708, upload-time = "2026-06-18T18:43:01.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/68/dc50d450d8cc8fe019d58e7287a401dfdf8fff9ba6c0f680d1c84f7bcc5b/dagster_gcp-0.29.9-py3-none-any.whl", hash = "sha256:972440ba4f1a85a29762aa6849759dc0d7299848ac45b16623a8090f4a2ce67e", size = 68435, upload-time = "2026-06-11T18:35:59.856Z" },
+    { url = "https://files.pythonhosted.org/packages/de/03/978318f4895c6df046c6e0260ddb82494e58a140c8b271a19297072a5a6a/dagster_gcp-0.29.10-py3-none-any.whl", hash = "sha256:4c72f3a64369a814747d072c155857c7c12404b670f58dbc80644049077cbcb5", size = 68448, upload-time = "2026-06-18T18:43:00.173Z" },
 ]
 
 [[package]]
 name = "dagster-graphql"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
@@ -734,45 +734,45 @@ dependencies = [
     { name = "requests" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/58/28c433883a34c29586d34d2d52e66a110043d9d7df3fb8473e9a580ffb13/dagster_graphql-1.13.9.tar.gz", hash = "sha256:2429b448d86e10c6a8f3c17b619ef030da2f5674aea2e3ed8c776f43620b15e3", size = 677856, upload-time = "2026-06-11T18:25:54.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/e3/db2a75c06de174128b020127e605b7927d291557839e9a2b39b879496274/dagster_graphql-1.13.10.tar.gz", hash = "sha256:720763e590d7327bec7ae6d5941fcc17d70bd89344305a8876b36876fdc46e27", size = 678025, upload-time = "2026-06-18T18:34:09.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/24/c11a73dae0d28513cd08d437eaecf2592ffb1121a552d46af85d4f4bb28d/dagster_graphql-1.13.9-py3-none-any.whl", hash = "sha256:ad5126906818963f99fa9e912ff61bddd84e4ce6e62d4ab6b1a613ad5b102514", size = 222234, upload-time = "2026-06-11T18:25:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/32bf78dbd6d1de531adfb8a53500bc283edb26a33bca79d11f712f892332/dagster_graphql-1.13.10-py3-none-any.whl", hash = "sha256:a65f4d3f5efc4b26f09d669cd64caceac1096128e14227516c67c8ea9d702453", size = 222377, upload-time = "2026-06-18T18:34:08.099Z" },
 ]
 
 [[package]]
 name = "dagster-k8s"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
     { name = "google-auth" },
     { name = "kubernetes" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/3c/f9fbf923897ca414a444f0fddddfea4e5843435cc3ccf7135911ccfb5db5/dagster_k8s-0.29.9.tar.gz", hash = "sha256:3afde39847e354a2f7fe0e9ad45aa08a9acbb33ec3dd01177de1a4cec3ccd650", size = 309352, upload-time = "2026-06-11T18:41:39.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8e/efd1fb4f47f78ca7a01cfec5135c6003868924db9650843745e1cd37b030/dagster_k8s-0.29.10.tar.gz", hash = "sha256:0f9457d58a4b50d1fd2dbf887dd6a7a0548f45593519021cff470623f1430335", size = 309352, upload-time = "2026-06-18T18:51:49.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/cc/548958d8536f89515eb1d99ef4bf83f7212ca917eb90355d1a7c8a01b1e3/dagster_k8s-0.29.9-py3-none-any.whl", hash = "sha256:0d0dc46d1db71c48ba4b96b6246ceded9b10fd34775cd0768841ad1b318876ce", size = 57785, upload-time = "2026-06-11T18:41:38.292Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/18/94f9e3600af9ce9004d825b00525813b3e58f077b8ef88339da7a5ebcb9e/dagster_k8s-0.29.10-py3-none-any.whl", hash = "sha256:8c9efd33571abdea1ca49b67747996791bac8afdb2fc642bd45593f93fb1649f", size = 57793, upload-time = "2026-06-18T18:51:47.981Z" },
 ]
 
 [[package]]
 name = "dagster-pandas"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
     { name = "pandas" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/08/babb8a916a63333355de330ba606899a40e33e911f60d43beb4263eb680b/dagster_pandas-0.29.9.tar.gz", hash = "sha256:8b181876cdc4fc19aea94955ee78b9a8c208b16c3b1f8175813a94360f6ab08b", size = 325533, upload-time = "2026-06-11T18:37:28.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ae/d8c6b52b3e772c836f3c9fad83cc38dea56cc7fb6dd64b864008ee4c7987/dagster_pandas-0.29.10.tar.gz", hash = "sha256:50db7493c932bd294eff761f344fa12300e03c814b1e365380ba853fd4adb786", size = 325529, upload-time = "2026-06-18T18:51:09.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/0a/a95933dfb7142f3bef7bfe1b47cb639f89f1942e474f65a7c886046cedb0/dagster_pandas-0.29.9-py3-none-any.whl", hash = "sha256:8224d1d4f8a9ff5e9c522a318318bf9ebd132434c19d8aa82a8607ed496b88ae", size = 26880, upload-time = "2026-06-11T18:37:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8f/95d0a505dc441eb9f25ee9bea94bb815c4130acf1f576cd5027c6a0aadbe/dagster_pandas-0.29.10-py3-none-any.whl", hash = "sha256:27f39dbf97def8efc4683c37b0eb6c1248a44085a9330e37487bd5dfd82d5a9c", size = 26891, upload-time = "2026-06-18T18:51:08.106Z" },
 ]
 
 [[package]]
 name = "dagster-pipes"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/3f/4e995e5644d0a3b888000f5c28345efb78990d680795d57716f5c261ee3f/dagster_pipes-1.13.9.tar.gz", hash = "sha256:1e5f08a216a77093483857189644ad164e78e1fb9d123a703276b946804072c9", size = 149676, upload-time = "2026-06-11T18:25:44.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ac/21deab022989000da16a404a5983f78196e7a7ffac16eb63d1fffab8ec83/dagster_pipes-1.13.10.tar.gz", hash = "sha256:92bac2e89233cc0ddeee38b4b79e6d30d63c7f00b4e213a235b777caab48ecc4", size = 149680, upload-time = "2026-06-18T18:33:59.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/04/4fb6fc71489db24c9102fb93df5f4f2228301fc1a5a31fd38821792dfc75/dagster_pipes-1.13.9-py3-none-any.whl", hash = "sha256:68fb92bf8c5d9a64c40439d1a02d6bfbf5cd4e66da9290bb0dc15e3c676709c9", size = 20235, upload-time = "2026-06-11T18:25:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2b/b7b1c4bc1a5c9561412c38dd524e3106bf3921f87999ffc3660fd0a76b3a/dagster_pipes-1.13.10-py3-none-any.whl", hash = "sha256:99977d01a0e8f65e4093b9cfd48acb0ca4e2656ffc5c131f40175df5a00b26e9", size = 20244, upload-time = "2026-06-18T18:33:58.846Z" },
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "dagster-shared"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
@@ -796,28 +796,28 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/2ea6ad47f1aa1a21a0aa9957388a5108c381f910a9d192ed59d78512031f/dagster_shared-1.13.9.tar.gz", hash = "sha256:ac7e52fa1cd9888f9ecd4ec32467ae19a5739b55ba5898f09d7eda3684293514", size = 123149, upload-time = "2026-06-11T18:37:55.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/c9/3aadcd3e950d1794f05dae78dec97ba612c8d784b2c631afeb3d3be85b93/dagster_shared-1.13.10.tar.gz", hash = "sha256:4a2fcdfcd0de225f8cb95f7896afc696f895778e5c6717cc13863472d1fbd7c5", size = 123699, upload-time = "2026-06-18T18:52:16.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/ff/64b5f5d99690cb45b12df72adefc51d4a1eef0f69ad35109621e535f4469/dagster_shared-1.13.9-py3-none-any.whl", hash = "sha256:4ec4254c1e67db3c2f0250a847c0008f7fc1ad3f14acedca85462945d0fc395e", size = 95711, upload-time = "2026-06-11T18:37:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b2/1e9ab122e090f4c95dcbef2e55206b64fbd2585cb0e58e18984e7e2038d7/dagster_shared-1.13.10-py3-none-any.whl", hash = "sha256:a66dda9ec1d8373c0dfcc9d0fcb133f098677949fd8ee08443421717d8a27e2e", size = 95992, upload-time = "2026-06-18T18:52:15.89Z" },
 ]
 
 [[package]]
 name = "dagster-ssh"
-version = "0.29.9"
+version = "0.29.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dagster" },
     { name = "paramiko" },
     { name = "sshtunnel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/47/613d0fca13d2043e3c33ec42d2327c81c2172aab3b4c43734fc394d1fbf0/dagster_ssh-0.29.9.tar.gz", hash = "sha256:41ebd4436a9925428311bff7099422e27c7356a5bf5398cf001279f911787e68", size = 142754, upload-time = "2026-06-11T18:41:30.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/c8/31ee7151c558967e4d515e11904fdbb06b156e2e56b55200190b075738a0/dagster_ssh-0.29.10.tar.gz", hash = "sha256:f1188ae90390a330857e8bc09ec18062e4345e4cb63f3f7d66f2319f1e598ad4", size = 142759, upload-time = "2026-06-18T18:49:48.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/02/97cc55bf444de6d446f52b6a928c374d9834d570cd8d21a21ef52d376dc8/dagster_ssh-0.29.9-py3-none-any.whl", hash = "sha256:4508d7393ea7056a1a17d3fa75b44f09e1a00b25fd0fff000470a9ea0dbafde4", size = 9468, upload-time = "2026-06-11T18:41:29.476Z" },
+    { url = "https://files.pythonhosted.org/packages/39/48/80d4900e5d3feef62475c1ffeac6e1a27c7087e78818c2368a3611a21fbd/dagster_ssh-0.29.10-py3-none-any.whl", hash = "sha256:07c98f9c4ac5cfac6c3db2f5efd7ab94f0aed64c389f649c4448c99fe828d5b5", size = 9477, upload-time = "2026-06-18T18:49:47.383Z" },
 ]
 
 [[package]]
 name = "dagster-webserver"
-version = "1.13.9"
+version = "1.13.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -826,9 +826,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/b2/3a0e193988e69515aba593a6e5392281481c6c078ab168d7c8e2570eae0f/dagster_webserver-1.13.9.tar.gz", hash = "sha256:40fd472d33a5d1844147ea05461ed4b315614ef363aa77089456b183b5158827", size = 12349774, upload-time = "2026-06-11T18:31:55.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/3f6ac54db4b1fb895d3880a4e96bd0c0fd412a5f051824bbadc0e77bb16f/dagster_webserver-1.13.10.tar.gz", hash = "sha256:565bc620c69a7bc2678b7111929aa1907f59c90902cfc04c7958f3aed43bcea7", size = 12353236, upload-time = "2026-06-18T18:41:05.992Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/7e/2e0aaaf3d8794b5f89d5821d3b1eeaf6ece78f35d1a936b84feaec7fe771/dagster_webserver-1.13.9-py3-none-any.whl", hash = "sha256:fdabc79b58bba30930796a93023597174b616b713016b864d276b6d8ce0796b3", size = 12504829, upload-time = "2026-06-11T18:31:53.359Z" },
+    { url = "https://files.pythonhosted.org/packages/15/92/a6a66965a1163b73cb56c5971f9f05b9f9b41350c54019f1a2a30d40735b/dagster_webserver-1.13.10-py3-none-any.whl", hash = "sha256:8be7dbb68a944ffb9a347f841f58452c51a6e2d736226ca6046e0b202f98348b", size = 12505058, upload-time = "2026-06-18T18:41:03.675Z" },
 ]
 
 [[package]]
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "dbt-bigquery"
-version = "1.11.1"
+version = "1.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbt-adapters" },
@@ -880,9 +880,9 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "nbformat" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/15/8becb292fe176a730c4b92dee22a17048379cc3cbbd06b8d02fde96c5469/dbt_bigquery-1.11.1.tar.gz", hash = "sha256:e0a4b67b6670cf1a23d53cc6701d3d1192ab49ba72b0f4784b16330fdd9b3898", size = 164123, upload-time = "2026-03-03T20:43:34.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7b/2abc5f4fc9217a147f46fcc101959cc733c45990d03d957dd45cd24bc782/dbt_bigquery-1.11.2.tar.gz", hash = "sha256:66d29a760a8af2e061103615ac295ef567533390b1fae75954ef77291fd95be8", size = 165069, upload-time = "2026-06-18T09:46:52.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/e5/2f22192541ed1d1dd01f6df7574fc5d7520d60c5db8fb9db67234fca9ab3/dbt_bigquery-1.11.1-py3-none-any.whl", hash = "sha256:4f53155366b4bcf1a38bbf9247589e3e18812ed2468e56c14676c649782eae5d", size = 103321, upload-time = "2026-03-03T20:43:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/81/9a/2d241d197ca033def9a59ead33693dbc6d9bd0fcee601197b85961044036/dbt_bigquery-1.11.2-py3-none-any.whl", hash = "sha256:54f9779025f2b99b6966fd925118f83a170db0b9d75c3d6015a5f9793557cbbf", size = 103668, upload-time = "2026-06-18T09:46:51.119Z" },
 ]
 
 [[package]]
@@ -2202,43 +2202,43 @@ wheels = [
 
 [[package]]
 name = "msgpack"
-version = "1.2.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/23/6139781ca7aadf656fa8e384fa84693ffb13f299e6931b6526427fe5e297/msgpack-1.2.0.tar.gz", hash = "sha256:8e17af38197bf58e7e819041678f6178f4491493f5b8c8580414f40f7c2c3c41", size = 183017, upload-time = "2026-06-11T04:16:10.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/26/2902c6946ab5c8fe1e46e40842dfc32b8824464ad5cd4725364fd83f7a58/msgpack-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3a1d30df1f302f2b7a7404afbac2ab76d510036c34cf34dffb01f704a7288e45", size = 82621, upload-time = "2026-06-11T04:15:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/59/7e6b812629d2f919e586041bffc130e1af32079f71bb20699eed54ed6d92/msgpack-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:581e317112260d8ca488d490cad9290a5682276f309c41c7de237a85ed8799c8", size = 81866, upload-time = "2026-06-11T04:15:25.032Z" },
-    { url = "https://files.pythonhosted.org/packages/31/13/8c291196e60aafdbae38f482205d79432297749ac5d412fe638154fb6f1d/msgpack-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6827d12eacc16873eba62408a1b7bbe8ecfb4a8f7ed78a631ae9bae6ad43cf2", size = 405618, upload-time = "2026-06-11T04:15:26.235Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/63/68f5d0ea81e167db5f59ddb94dc6f837667062113feff1c73fabf8907061/msgpack-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a186027e4279efa4c8bf06ce30605498d7d0d3af0fba0b9799dce85a3fd4a93c", size = 416468, upload-time = "2026-06-11T04:15:27.732Z" },
-    { url = "https://files.pythonhosted.org/packages/73/58/567dddf5c5a2790f673bcd7d80c83466d68e5ee9a9674ebca3db8101c0c8/msgpack-1.2.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a96142c14a11cf1a509e8b9aaf72858a3b742b7613e095ce646913e88ce7bd99", size = 374464, upload-time = "2026-06-11T04:15:29.286Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/30/0c2342fc9092e4498045f5f60bca6ccbe4f4d87789778c2300e6fd6efe82/msgpack-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50c220579b68a6085b95408b2eaa486b259520f55d8e363ddc9b5d7ba5a6ac6d", size = 395879, upload-time = "2026-06-11T04:15:30.973Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/11/9565b29b58ce3c33e177b490478b7aaeb8f726ecaaeda26d815893c1db5a/msgpack-1.2.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4dcb9d12ab100ecacdfaaf37a3d72fe8392eacc7054afc1916b12d1b747c8446", size = 371749, upload-time = "2026-06-11T04:15:32.418Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/da/7bade19d60b73e2ef73fb76aaf4504c112a70cb760951b7202a0c64b5111/msgpack-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a804727188ab0ebb237fadb303b743f04925a69d8c3247292d1e33e679767c15", size = 410416, upload-time = "2026-06-11T04:15:34.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/14/c0c619571c02432208a5977a8dbdd3fc65fe1369f8226ca4b6d08cca87d8/msgpack-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1a1ac6ae1fe23298f79380e7b144c8a454e5d05616b0096584f353ba2d750114", size = 64357, upload-time = "2026-06-11T04:15:35.535Z" },
-    { url = "https://files.pythonhosted.org/packages/50/a5/de06718460909aa965737fec4cfe8a15dedc6544a8c55feeb6956fa0d6e3/msgpack-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:1c3c80949d79578f9dc85fd9fb91edfe6694e8a729cd5744634d59d8455fdde3", size = 71057, upload-time = "2026-06-11T04:15:36.83Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/52/73446b0141c94a856e22b787c56709c0815fc34f185326577e15b26d8cfe/msgpack-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:fcf8f76fa587c2395fd0057c7232dbf071241f9ad280b235adb7ab585289989e", size = 64490, upload-time = "2026-06-11T04:15:38.001Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3d/a7e3cdafa8c0cf36c81e2fa848ec4d30cf089459af45b390ad03f9ce6f49/msgpack-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f854fa1a8b55d75d82ef9a905d9cdbeffdf7897c088f6020bd221867da5e56a5", size = 83032, upload-time = "2026-06-11T04:15:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/aa/53ddfba0e347cc4b484e95f629c5850b9e800ca8390c91ffc604407acf87/msgpack-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e90df581f80f53b372d5d9d9349078d729851a3a0d0bd74f53ccb598d01e45b8", size = 82600, upload-time = "2026-06-11T04:15:40.609Z" },
-    { url = "https://files.pythonhosted.org/packages/59/fd/e64c2c776e6dbad0af3c963fe0c0dd1ee1ba09efac478b233ab1db41868f/msgpack-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b276ed50d8ac75d1f134a433ae79af8557d0fa25ee5b4737da533dfc2ce382e8", size = 404342, upload-time = "2026-06-11T04:15:41.87Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/60/fb9a08e6ccba882dfd370a5837fe3a07572938fdfe954f0f17fdf3e574b9/msgpack-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:544d972459c92aa32e63b800d07c2d9cf2734a3be29cee3a0b478a622850e9f5", size = 412351, upload-time = "2026-06-11T04:15:43.253Z" },
-    { url = "https://files.pythonhosted.org/packages/37/4d/df5c575c274fedc68ac9c6c61d045161899efad2afcdc25138efa7edde69/msgpack-1.2.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a070147cc2cf6b8a891734e0f5c8fe8f70ed8739ab30ba140b058005a6e86af4", size = 373331, upload-time = "2026-06-11T04:15:44.754Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a4/c8b98f8191e985ed2003d87664ce3c95cca41db5d0cf6bf4f54327d32ec8/msgpack-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7685e23b0f51745a751629c31713fbefdef8896b31b2bb38299dfa4ae6c0740c", size = 394654, upload-time = "2026-06-11T04:15:46.423Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/49/76f036720a602ea24428cfec5ec806f2487c0380b1bff0a2aa3094e15f87/msgpack-1.2.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b9204daeee8d91a7ae5acf2d2a8e3983be9a3025f38aa21bfaefbd7eea84a7dc", size = 370624, upload-time = "2026-06-11T04:15:48.062Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/38/40af3d29232833705a43b0fce0d07425cc280a7b92ab2b29932425b40df4/msgpack-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bfc057248609742ebbabf6bcd27fea4fd99c4980584e613c168c9b002318298f", size = 408038, upload-time = "2026-06-11T04:15:49.669Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b2/f140ca450524dff4d8d0eb81eb9ed75f8f3e0b1f12e49c5b01617cfa0b1c/msgpack-1.2.0-cp314-cp314-win32.whl", hash = "sha256:a3faa7edf2388337ae849239878e92f0298b4dab4488e4f1834062f9d0c410c9", size = 65823, upload-time = "2026-06-11T04:15:51.062Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/13/6517bf966b841c7675ded30701a068ce141f3e698a27aaa35c702d8e078b/msgpack-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:1a3effc392a57744e4681e55d05f97d5ee7b598747d718340a9b4b8a970c40e1", size = 72484, upload-time = "2026-06-11T04:15:52.289Z" },
-    { url = "https://files.pythonhosted.org/packages/45/8c/1d948420fdaa24de4efdb8012a6a5bebe09c82ee002b8c2ca745e9917f1f/msgpack-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:56a318f7df6bec7b40928d6b0519961f20a510d8baabf6baa393a70444588f0a", size = 66657, upload-time = "2026-06-11T04:15:53.583Z" },
-    { url = "https://files.pythonhosted.org/packages/39/16/1674faa1b7bddc19e79b465fd8e88e2cf4e3f7cae90723740701e8541068/msgpack-1.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:afa4a65ab2097795e771a74a3a81ea49534aaeba874eaf426a3332268e045ae6", size = 86093, upload-time = "2026-06-11T04:15:54.98Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/24/f241bcfdd9e96b2246289357c5a5e5a496189fd41c5844bee802c116aac7/msgpack-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:409550770632bb28daa70a11d0ed5763f7db38f40b06f7db9f11dd2794d01102", size = 86372, upload-time = "2026-06-11T04:15:56.381Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c9/57f8ab98a1b21808c27b6dd6029053e0a796ffbb9b371e460dbe997011a9/msgpack-1.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf47e3cd11ce044965a9736a322afdd390b31ed602d1c1b10211d1a841f1d587", size = 428207, upload-time = "2026-06-11T04:15:57.739Z" },
-    { url = "https://files.pythonhosted.org/packages/17/6b/4fd4aa739f131ded751ca7167c8ee87d2aab32506ebbeea893b60b51d343/msgpack-1.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:204bc9f5d6e59c1718c0a4a84fc8ff71b5b4562faac257c1a68bca611ecf9b72", size = 426082, upload-time = "2026-06-11T04:15:59.356Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/00/db88e9a08fcd6513decaad06cbd5c168142bc3e662fb2f1aca3a563b7aa1/msgpack-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:610154307b27267266368bc1d1c7bb8aeb71da7be9356d403cb2442d9e6399f5", size = 378355, upload-time = "2026-06-11T04:16:00.916Z" },
-    { url = "https://files.pythonhosted.org/packages/54/84/eee4dd703d7a600cf46159d621c070b0b9468cf3dbade4ea8272bf5232a4/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6799f157bb63e79f11e2e590cfdb28423fc18dd60c270c3914b5b4586ae36f7e", size = 410848, upload-time = "2026-06-11T04:16:02.745Z" },
-    { url = "https://files.pythonhosted.org/packages/12/0a/195e2c549fd4631eb7f157d016ff15a10c4c1cf82b6d0a9b1edaef5174b1/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:72bd844902cf0a5ac3af2ef742f253cd0b1e5bcd184f49b4fb9a6a1f7bf305e8", size = 376152, upload-time = "2026-06-11T04:16:04.041Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9b/bdd143fa79baec411dc658f5686fed680a18b36fcea5fccb6af1b8c7d832/msgpack-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3c0bd450f78d0d81722c80da6cdbf674a856967870a9db2f6c4debc4d8b3c67c", size = 417061, upload-time = "2026-06-11T04:16:05.63Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ce/011ffcd8b919f55196ec53f12ae162e21c879d95afba226894314ff62c07/msgpack-1.2.0-cp314-cp314t-win32.whl", hash = "sha256:378caf74c4c718dfc17590ce68a6d710ed398ff6fcf08237de23b77755730b55", size = 70782, upload-time = "2026-06-11T04:16:07.105Z" },
-    { url = "https://files.pythonhosted.org/packages/57/a8/9b8791ca96b1be6b9f659c718271e2cb7f99f73f58aad2dd0b30f750f6c0/msgpack-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:553b42598165c4dd3235994fd6e4b0dfb1ce5f3fd33d94ba9609442643015f38", size = 77899, upload-time = "2026-06-11T04:16:08.353Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/04/3fa2dffb87bf598696b86bde7cd642d0a7590520c3fa24cd19611dfebeb7/msgpack-1.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2825bb1da548d214ab8a810906b7dd69a10f3838b615a2cc46e5172d3cb44f6e", size = 71004, upload-time = "2026-06-11T04:16:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -3436,14 +3436,14 @@ wheels = [
 
 [[package]]
 name = "requirements-parser"
-version = "0.13.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
