### PR TITLE
feat(cube): staff core — roster, headcount-over-time, demographics

### DIFF
--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -38,8 +38,11 @@ school_calendars) go in `cubes/conformed/`.
   `name: dates` reading `sql_table: kipptaf_marts.dim_dates`. **Domain-prefix
   rule:** student-domain cubes start with `student` (`student_attendance`,
   `student_enrollments`, `students`); staff-domain cubes start with `staff`.
-  `queryRewrite`'s `isStudentMember`/`isStaffMember` access gating keys off
-  these prefixes, so a misnamed domain cube silently loses its access guard.
+  `queryRewrite`'s `isStudentMember` access gating keys off the `student`
+  prefix, so a misnamed student-domain cube silently loses its access guard.
+  Staff cubes carry no prefix-based gate in `cube.js` — staff RLS is governed by
+  the location scope filter plus each staff view's `cube-access-staff-data`
+  access policy. The `staff` prefix is still a naming convention, not a guard.
   Conformed dims (`dates`, `locations`, `regions`, `terms`, `school_calendars`)
   are deliberately unprefixed — they carry no domain access tier. View names are
   `<domain>_<grain>` (`student_attendance_detail`,
@@ -84,6 +87,11 @@ Views own access via `access_policy:`. Two patterns:
 - **Summary views** (no direct identifiers, demographic breakdowns only): single
   `cube-access-student-data` block with `includes: "*"`. Add a comment
   explaining why no PII tier is needed.
+- **Staff views** use a single `cube-access-staff-data` block with
+  `includes: "*"` (no PII sub-tier): privacy is enforced by view choice —
+  `staff_summary` exposes aggregates/demographics only, `staff_detail` exposes
+  identifiers. Add a `cube-access-staff-pii` sub-tier only if a
+  see-staff-but-not-PII need arises.
 
 When adding a field to a detail view, decide PII status per project CLAUDE.md
 FERPA guidance. If PII, add it to the `excludes` list under the
@@ -100,26 +108,26 @@ Default-deny, group-driven. Read [`cube.js`](cube.js) before modifying.
 - **Group membership is direct-only.** Admin Directory API's
   `groups.list({userKey})` returns direct memberships; nested `cube-*` groups
   don't transitively resolve. Flat-enroll users in every `cube-*` group they
-  need (scope tier + `cube-access-student-data`, plus `cube-access-staff-all`
-  for staff cubes).
+  need: a scope tier (`cube-network-*` / `cube-region-*` / `cube-school-*`) plus
+  `cube-access-student-data` for student views and `cube-access-staff-data` for
+  staff views.
 - **Cloud Identity `searchTransitiveGroups` is edition-gated** (Workspace
   Enterprise / Education Plus / Cloud Identity Premium). On lower editions it
   returns `INVALID_ARGUMENT`, not `PERMISSION_DENIED` — don't propose it as a
   transitive-resolution fix without verifying the tenant's edition.
-- **`queryRewrite`** enforces three filters:
+- **`queryRewrite`** enforces two filters:
   - Strips student-domain dims/measures (members where `isStudentMember` is
     true) for users without `cube-access-student-data`.
   - Adds a `locations` filter based on the highest-priority scope group: network
     (no filter) → region (`region_key`) → school (`abbreviation`). No scope
-    group → empty `IN ()` filter (default deny).
-  - For queries touching a staff-domain cube (`isStaffMember`), injects the
-    `staff.reporting_chain` segment unless the user has `cube-access-staff-all`.
-- **`isStudentMember` / `isStaffMember` prefix helpers.** Domain gating is
-  derived from the cube-name prefix (`student*` / `staff*`), not a static array
-  — a query member is `<cube_name>.<member>`, so the cube name is the prefix. A
-  new domain cube needs no `cube.js` change as long as it follows the
-  domain-prefix naming rule above. A domain cube misnamed off-prefix silently
-  loses its guard.
+    group → empty `IN ()` filter (default deny). This scope filter applies to
+    staff views too (resolved through their `locations` join).
+- **`isStudentMember` prefix helper.** Student-domain gating is derived from the
+  cube-name prefix (`student*`), not a static array — a query member is
+  `<cube_name>.<member>`, so the cube name is the prefix. A new student-domain
+  cube needs no `cube.js` change as long as it follows the naming rule above; a
+  misnamed one silently loses its guard. Staff has no equivalent `cube.js` gate
+  (manager-hierarchy RLS was removed pending a view-aware rebuild).
 - **`SNAPSHOT_CUBES` / `SNAPSHOT_MEASURE_STEMS` arrays.** For cubes built on
   fact tables with cumulative daily-status flags (values re-stamped on every row
   — overcounts without a point-in-time anchor). `queryRewrite` auto-injects

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -20,13 +20,15 @@ function nextMidnightEastern() {
   return now.getTime() + (24 * 60 * 60 * 1000 - msElapsedToday);
 }
 
-// Domain membership is derived from the cube-name prefix, not a static array —
-// a query member is "<cube>.<member>", so the cube name is the prefix. Adding a
-// new domain cube requires no cube.js change as long as it follows the naming
-// convention: student-domain cube names start with "student", staff-domain with
-// "staff" (see src/cube/CLAUDE.md naming rules).
+// Student-domain membership is derived from the cube-name prefix, not a static
+// array — a query member is "<cube>.<member>", so the cube name is the prefix.
+// Student-domain cube names start with "student" (see src/cube/CLAUDE.md).
+// Staff-domain RLS was intentionally removed from cube.js: staff visibility is
+// governed by the location scope filter below plus each staff view's
+// cube-access-staff-data access policy. Manager-hierarchy scoping is deferred;
+// when it returns it must work for view queries (segment on the view, not the
+// underlying cube).
 const isStudentMember = (member) => member.startsWith("student");
-const isStaffMember = (member) => member.startsWith("staff");
 
 // Convention for snapshot cubes: cumulative daily flags that overcount without
 // a point-in-time anchor. All snapshot cubes expose these three dimensions.
@@ -291,20 +293,6 @@ module.exports = {
           values: [true],
         });
       }
-    }
-
-    // Org-hierarchy filter: inject segment defined in staff cube YAML.
-    // Staff cubes and the reporting_chain segment are added in the follow-up
-    // spec (blocked on #3729 — dim_staff_work_assignments.staff_key fix).
-    const touchesStaffCube = [
-      ...(query.dimensions ?? []),
-      ...(query.measures ?? []),
-    ].some(isStaffMember);
-    if (touchesStaffCube && !groups.includes("cube-access-staff-all")) {
-      query = {
-        ...query,
-        segments: [...(query.segments ?? []), "staff.reporting_chain"],
-      };
     }
 
     return { ...query, filters };

--- a/src/cube/model/cubes/staff/staff.yml
+++ b/src/cube/model/cubes/staff/staff.yml
@@ -19,93 +19,113 @@ cubes:
       # PII — employee identifier.
       - name: staff_unique_id
         description:
-          Employee number — KIPP's payroll/HR identifier for the staff member.
+          KIPP-assigned unique identifier for all staff members across all
+          entities.
         sql: staff_unique_id
         type: number
         public: true
 
       # PII — name.
       - name: full_name
-        description: Staff member's full name in "Last, First, Mi." format.
+        description: Staff member's preferred name in Last, First Middle format.
         sql: full_name
         type: string
         public: true
 
       # PII — name.
       - name: first_name
+        description: Staff member's preferred first name.
         sql: first_name
         type: string
         public: true
 
       # PII — name.
       - name: last_name
+        description: Staff member's preferred last name.
         sql: last_name
         type: string
         public: true
 
       # PII — date of birth.
       - name: birth_date
+        description: Staff member's date of birth.
         sql: CAST(birth_date AS TIMESTAMP)
         type: time
         public: true
 
       - name: gender_identity
-        description: Self-identified gender for the staff member.
+        description: >-
+          Staff member's preferred gender identity as reported in the staff
+          information survey, with ADP gender_code as fallback.
         sql: gender_identity
         type: string
         public: true
 
       - name: race
-        description: Race/ethnicity reporting category for the staff member.
+        description: >-
+          Staff member's racial category for reporting purposes, sourced from
+          the staff information survey with ADP as fallback.
         sql: race
         type: string
         public: true
 
       - name: is_hispanic
-        description: TRUE if the staff member identifies as Hispanic/Latino.
+        description: >-
+          TRUE if the staff member identified as Hispanic/Latino/Latinx in the
+          staff information survey or ADP ethnicity record.
         sql: is_hispanic
         type: boolean
         public: true
 
       # PII — contact.
       - name: work_email
+        description: Staff member's work email address from ADP.
         sql: work_email
         type: string
         public: true
 
       # PII — contact.
       - name: personal_email
+        description: Staff member's personal email address from ADP.
         sql: personal_email
         type: string
         public: true
 
       # PII — contact.
       - name: personal_cell_phone
+        description: Staff member's personal cell phone number from ADP.
         sql: personal_cell_phone
         type: string
         public: true
 
       # PII — credential/identifier.
       - name: active_directory_username
-        description: SAM account name (Active Directory username).
+        description: >-
+          Staff member's Active Directory username (lowercased), used as a
+          cross-system identifier.
         sql: active_directory_username
         type: string
         public: true
 
       # PII — contact.
       - name: google_email
+        description: Staff member's Google Workspace email address from LDAP.
         sql: google_email
         type: string
         public: true
 
       - name: original_hire_date
-        description: Worker's original hire date.
+        description:
+          The date the staff member was originally hired at KIPP, from
+          worker_dates in ADP.
         sql: CAST(original_hire_date AS TIMESTAMP)
         type: time
         public: true
 
       - name: rehire_date
-        description: Worker's most recent rehire date, if rehired.
+        description: >-
+          The most recent rehire date for the staff member, if rehired, from
+          worker_dates in ADP.
         sql: CAST(rehire_date AS TIMESTAMP)
         type: time
         public: true

--- a/src/cube/model/cubes/staff/staff.yml
+++ b/src/cube/model/cubes/staff/staff.yml
@@ -1,0 +1,111 @@
+cubes:
+  - name: staff
+    public: false
+    sql_table: kipptaf_marts.dim_staff
+
+    dimensions:
+      # Surrogate key derived from employee_number. Primary key. Public — it is
+      # the pre-wire join key for a future course_section_teachers bridge cube
+      # that connects staff to student/course data.
+      - name: staff_key
+        description: >-
+          Surrogate key derived from employee_number. Primary key for the staff
+          dimension and the FK target for staff-to-student bridging.
+        sql: staff_key
+        type: string
+        primary_key: true
+        public: true
+
+      # PII — employee identifier.
+      - name: staff_unique_id
+        description:
+          Employee number — KIPP's payroll/HR identifier for the staff member.
+        sql: staff_unique_id
+        type: number
+        public: true
+
+      # PII — name.
+      - name: full_name
+        description: Staff member's full name in "Last, First, Mi." format.
+        sql: full_name
+        type: string
+        public: true
+
+      # PII — name.
+      - name: first_name
+        sql: first_name
+        type: string
+        public: true
+
+      # PII — name.
+      - name: last_name
+        sql: last_name
+        type: string
+        public: true
+
+      # PII — date of birth.
+      - name: birth_date
+        sql: CAST(birth_date AS TIMESTAMP)
+        type: time
+        public: true
+
+      - name: gender_identity
+        description: Self-identified gender for the staff member.
+        sql: gender_identity
+        type: string
+        public: true
+
+      - name: race
+        description: Race/ethnicity reporting category for the staff member.
+        sql: race
+        type: string
+        public: true
+
+      - name: is_hispanic
+        description: TRUE if the staff member identifies as Hispanic/Latino.
+        sql: is_hispanic
+        type: boolean
+        public: true
+
+      # PII — contact.
+      - name: work_email
+        sql: work_email
+        type: string
+        public: true
+
+      # PII — contact.
+      - name: personal_email
+        sql: personal_email
+        type: string
+        public: true
+
+      # PII — contact.
+      - name: personal_cell_phone
+        sql: personal_cell_phone
+        type: string
+        public: true
+
+      # PII — credential/identifier.
+      - name: active_directory_username
+        description: SAM account name (Active Directory username).
+        sql: active_directory_username
+        type: string
+        public: true
+
+      # PII — contact.
+      - name: google_email
+        sql: google_email
+        type: string
+        public: true
+
+      - name: original_hire_date
+        description: Worker's original hire date.
+        sql: CAST(original_hire_date AS TIMESTAMP)
+        type: time
+        public: true
+
+      - name: rehire_date
+        description: Worker's most recent rehire date, if rehired.
+        sql: CAST(rehire_date AS TIMESTAMP)
+        type: time
+        public: true

--- a/src/cube/model/cubes/staff/staff_manager.yml
+++ b/src/cube/model/cubes/staff/staff_manager.yml
@@ -1,7 +1,7 @@
 cubes:
   # Role alias for staff, used as the manager-side join target on
   # staff_work_history (and future fact cubes). Inherits all of staff's
-  # dimensions. The staff_ prefix keeps it under isStaffMember gating in cube.js.
+  # dimensions.
   - name: staff_manager
     extends: staff
     public: false

--- a/src/cube/model/cubes/staff/staff_manager.yml
+++ b/src/cube/model/cubes/staff/staff_manager.yml
@@ -1,0 +1,7 @@
+cubes:
+  # Role alias for staff, used as the manager-side join target on
+  # staff_work_history (and future fact cubes). Inherits all of staff's
+  # dimensions. The staff_ prefix keeps it under isStaffMember gating in cube.js.
+  - name: staff_manager
+    extends: staff
+    public: false

--- a/src/cube/model/cubes/staff/staff_reporting_relationships.yml
+++ b/src/cube/model/cubes/staff/staff_reporting_relationships.yml
@@ -3,8 +3,11 @@ cubes:
     public: false
     # Point-in-time manager resolver. One row per staff member x contiguous
     # window during which they held a single primary-assignment reporting
-    # relationship. Helper cube only — joined by staff_work_history (and future
-    # fact cubes) for manager context; not exposed in any view.
+    # relationship. Helper cube only, not exposed in any view. staff_work_history
+    # folds this logic directly into its own SQL (so each period carries one
+    # manager); this standalone cube is retained for future fact cubes
+    # (observations, gradebook, surveys) that resolve manager point-in-time by
+    # joining on their own event date.
     sql: |
       SELECT
         swa.staff_key,
@@ -46,15 +49,20 @@ cubes:
         type: string
         public: true
 
+      # {CUBE}-qualified: this dimension is referenced in staff_work_history's
+      # date-bounded join, where an unqualified column collides with that cube's
+      # own effective_start_date. Cube only auto-qualifies bare-column sql, not
+      # columns inside an expression like CAST(...).
       - name: effective_start_date
         description: Start of the contiguous reporting-relationship period.
-        sql: CAST(effective_start_date AS TIMESTAMP)
+        sql: "CAST({CUBE}.effective_start_date AS TIMESTAMP)"
         type: time
         public: true
 
-      # Required by the date-bounded join from staff_work_history.
+      # Required by the date-bounded join from staff_work_history. {CUBE}-
+      # qualified for the same reason as effective_start_date above.
       - name: effective_end_date
         description: End of the contiguous reporting-relationship period.
-        sql: CAST(effective_end_date AS TIMESTAMP)
+        sql: "CAST({CUBE}.effective_end_date AS TIMESTAMP)"
         type: time
         public: true

--- a/src/cube/model/cubes/staff/staff_reporting_relationships.yml
+++ b/src/cube/model/cubes/staff/staff_reporting_relationships.yml
@@ -1,0 +1,60 @@
+cubes:
+  - name: staff_reporting_relationships
+    public: false
+    # Point-in-time manager resolver. One row per staff member x contiguous
+    # window during which they held a single primary-assignment reporting
+    # relationship. Helper cube only — joined by staff_work_history (and future
+    # fact cubes) for manager context; not exposed in any view.
+    sql: |
+      SELECT
+        swa.staff_key,
+        rr.manager_staff_key,
+        GREATEST(wap.effective_start_date, rr.effective_start_date) AS effective_start_date,
+        LEAST(wap.effective_end_date,      rr.effective_end_date)   AS effective_end_date
+      FROM kipptaf_marts.dim_work_assignment_primary wap
+      JOIN kipptaf_marts.dim_staff_work_assignments swa
+        ON wap.work_assignment_key = swa.work_assignment_key
+        AND swa.staff_key IS NOT NULL
+      JOIN kipptaf_marts.dim_work_assignment_reporting_relationships rr
+        ON rr.work_assignment_key = wap.work_assignment_key
+        AND wap.effective_start_date <= rr.effective_end_date
+        AND wap.effective_end_date   >= rr.effective_start_date
+      WHERE wap.is_primary_position
+
+    dimensions:
+      - name: staff_reporting_relationship_key
+        description:
+          Composite key (staff_key, intersected effective_start_date). Primary
+          key.
+        sql: >
+          CONCAT(
+            CAST({CUBE}.staff_key AS STRING), '|',
+            CAST({CUBE}.effective_start_date AS STRING)
+          )
+        type: string
+        primary_key: true
+
+      - name: staff_key
+        description: FK to staff — the reportee.
+        sql: staff_key
+        type: string
+        public: true
+
+      - name: manager_staff_key
+        description: FK to staff (via staff_manager alias) — the manager.
+        sql: manager_staff_key
+        type: string
+        public: true
+
+      - name: effective_start_date
+        description: Start of the contiguous reporting-relationship period.
+        sql: CAST(effective_start_date AS TIMESTAMP)
+        type: time
+        public: true
+
+      # Required by the date-bounded join from staff_work_history.
+      - name: effective_end_date
+        description: End of the contiguous reporting-relationship period.
+        sql: CAST(effective_end_date AS TIMESTAMP)
+        type: time
+        public: true

--- a/src/cube/model/cubes/staff/staff_work_history.yml
+++ b/src/cube/model/cubes/staff/staff_work_history.yml
@@ -1,0 +1,205 @@
+cubes:
+  - name: staff_work_history
+    public: false
+    # SCD2 period intersection: one row per work assignment x contiguous window
+    # during which the worker's status, job, worker type, org unit, and location
+    # all held simultaneously. Overlaps are anchored to the staff_status period;
+    # GREATEST/LEAST then collapse each combination to its true effective range.
+    # Periods where the children do not mutually overlap yield start > end and
+    # are silently excluded by the dates BETWEEN join (queries always filter on a
+    # date). Transformation that needs multi-table joins lives here in sql:
+    # rather than a dbt mart only because every input is already a published
+    # dim; a dedicated mart is the future home if this grows.
+    sql: |
+      SELECT
+        swa.work_assignment_key,
+        swa.staff_key,
+        swa.full_time_equivalency,
+        swa.is_management_position,
+        ss.status_name,
+        wj.position_title,
+        wj.job_code,
+        wt.worker_type_name AS worker_type,
+        wo.department_name,
+        wo.business_unit_name,
+        wl.location_key AS work_location_key,
+        wp.is_primary_position,
+        GREATEST(
+          ss.effective_start_date,
+          wj.effective_start_date,
+          wt.effective_start_date,
+          wo.effective_start_date,
+          wl.effective_start_date
+        ) AS effective_start_date,
+        LEAST(
+          ss.effective_end_date,
+          wj.effective_end_date,
+          wt.effective_end_date,
+          wo.effective_end_date,
+          wl.effective_end_date
+        ) AS effective_end_date
+      FROM kipptaf_marts.dim_staff_work_assignments swa
+      JOIN kipptaf_marts.dim_staff_status ss
+        ON ss.staff_key = swa.staff_key
+      JOIN kipptaf_marts.dim_work_assignment_jobs wj
+        ON wj.work_assignment_key = swa.work_assignment_key
+        AND ss.effective_start_date < wj.effective_end_date
+        AND ss.effective_end_date   > wj.effective_start_date
+      JOIN kipptaf_marts.dim_work_assignment_types wt
+        ON wt.work_assignment_key = swa.work_assignment_key
+        AND ss.effective_start_date < wt.effective_end_date
+        AND ss.effective_end_date   > wt.effective_start_date
+      JOIN kipptaf_marts.dim_work_assignment_organizational_units wo
+        ON wo.work_assignment_key = swa.work_assignment_key
+        AND wo.assignment_type = 'home'
+        AND ss.effective_start_date < wo.effective_end_date
+        AND ss.effective_end_date   > wo.effective_start_date
+      JOIN kipptaf_marts.dim_work_assignment_locations wl
+        ON wl.work_assignment_key = swa.work_assignment_key
+        AND ss.effective_start_date < wl.effective_end_date
+        AND ss.effective_end_date   > wl.effective_start_date
+      LEFT JOIN kipptaf_marts.dim_work_assignment_primary wp
+        ON wp.work_assignment_key = swa.work_assignment_key
+        AND ss.effective_start_date < wp.effective_end_date
+        AND ss.effective_end_date   > wp.effective_start_date
+
+    joins:
+      # One employment period spans many calendar days. Range (BETWEEN) join is
+      # valid per cube conventions; relationship is one_to_many.
+      - name: dates
+        sql: >
+          {dates.date_day} BETWEEN CAST({CUBE}.effective_start_date AS
+          TIMESTAMP) AND CAST({CUBE}.effective_end_date AS TIMESTAMP)
+        relationship: one_to_many
+
+      - name: staff
+        sql: "{staff.staff_key} = {CUBE}.staff_key"
+        relationship: many_to_one
+
+      - name: locations
+        sql: "{locations.location_key} = {CUBE}.work_location_key"
+        relationship: many_to_one
+
+      # Point-in-time manager resolver. many_to_one is correct only with a date
+      # filter applied (which staff queries always have): each employment period
+      # matches its contemporaneous reporting-relationship row. Without a date
+      # filter the join is effectively many_to_many.
+      - name: staff_reporting_relationships
+        sql: >
+          {staff_reporting_relationships.staff_key} = {CUBE}.staff_key AND
+          CAST({CUBE}.effective_start_date AS TIMESTAMP)
+            <= {staff_reporting_relationships.effective_end_date} AND
+          CAST({CUBE}.effective_end_date AS TIMESTAMP)
+            >= {staff_reporting_relationships.effective_start_date}
+        relationship: many_to_one
+
+      - name: staff_manager
+        sql: >
+          {staff_manager.staff_key} =
+          {staff_reporting_relationships.manager_staff_key}
+        relationship: many_to_one
+
+    dimensions:
+      - name: staff_work_history_key
+        description: >-
+          Composite key (work_assignment_key, intersected effective_start_date).
+          Primary key. Includes work_assignment_key so concurrent assignments
+          starting the same day do not collide.
+        sql: >
+          CONCAT(
+            CAST({CUBE}.work_assignment_key AS STRING), '|',
+            CAST({CUBE}.effective_start_date AS STRING)
+          )
+        type: string
+        primary_key: true
+
+      - name: status_name
+        description:
+          Employment status during this period (e.g., Active, Leave,
+          Terminated).
+        sql: status_name
+        type: string
+        public: true
+
+      - name: position_title
+        description: Job/position title held during this period.
+        sql: position_title
+        type: string
+        public: true
+
+      - name: job_code
+        description: Job code held during this period.
+        sql: job_code
+        type: string
+        public: true
+
+      - name: worker_type
+        description: Worker type during this period (e.g., Regular, Temporary).
+        sql: worker_type
+        type: string
+        public: true
+
+      - name: department_name
+        description: Home org-unit department during this period.
+        sql: department_name
+        type: string
+        public: true
+
+      - name: business_unit_name
+        description: Home org-unit business unit during this period.
+        sql: business_unit_name
+        type: string
+        public: true
+
+      # Degenerate FK to locations — descriptors come via the locations join.
+      - name: work_location_key
+        description:
+          FK to locations (work assignment location during this period).
+        sql: work_location_key
+        type: string
+
+      - name: is_primary_position
+        description: >-
+          TRUE if this is the worker's primary assignment during the period.
+          Filter to true to count each person once across concurrent
+          assignments.
+        sql: is_primary_position
+        type: boolean
+        public: true
+
+      - name: is_management_position
+        description: TRUE if this assignment is a management position.
+        sql: is_management_position
+        type: boolean
+        public: true
+
+      - name: full_time_equivalency
+        description: FTE ratio for this assignment during the period.
+        sql: full_time_equivalency
+        type: number
+        public: true
+
+      - name: effective_start_date
+        description:
+          Start of the contiguous period (intersection of all SCD2 children).
+        sql: CAST(effective_start_date AS TIMESTAMP)
+        type: time
+        public: true
+
+    measures:
+      - name: count_headcount
+        description: >-
+          Distinct employees in scope. Counts a person once even with multiple
+          concurrent assignments. Filter is_primary_position = true to count the
+          primary assignment only. Always apply a date filter.
+        sql: staff_key
+        type: count_distinct
+        public: true
+
+      - name: sum_fte
+        description: Total FTE of active assignments in scope.
+        sql: full_time_equivalency
+        type: sum
+        public: true
+        filters:
+          - sql: "{CUBE}.status_name = 'Active'"

--- a/src/cube/model/cubes/staff/staff_work_history.yml
+++ b/src/cube/model/cubes/staff/staff_work_history.yml
@@ -4,7 +4,10 @@ cubes:
     # SCD2 period intersection: one row per work assignment x contiguous window
     # during which the worker's status, job, worker type, org unit, location,
     # AND point-in-time manager all held simultaneously. Overlaps are anchored to
-    # the staff_status period; GREATEST/LEAST then collapse each combination to
+    # the work-assignment status period (dim_work_assignment_status — the
+    # assignment-level Active/Leave/Terminated status, keyed by
+    # work_assignment_key like the other children; not the coarser worker-level
+    # dim_staff_status); GREATEST/LEAST then collapse each combination to
     # its true effective range. Manager is folded into the intersection (not a
     # separate cube join) so each period carries exactly one manager — a
     # single-day query returns one row per person instead of one per manager the
@@ -19,7 +22,8 @@ cubes:
         swa.staff_key,
         swa.full_time_equivalency,
         swa.is_management_position,
-        ss.status_code,
+        was.status_name,
+        was.reason_name AS status_reason,
         wj.position_title,
         wj.job_code,
         wt.worker_type_name AS worker_type,
@@ -29,7 +33,7 @@ cubes:
         wp.is_primary_position,
         mgr.manager_staff_key,
         GREATEST(
-          ss.effective_start_date,
+          was.effective_start_date,
           wj.effective_start_date,
           wt.effective_start_date,
           wo.effective_start_date,
@@ -37,7 +41,7 @@ cubes:
           COALESCE(mgr.effective_start_date, DATE '1900-01-01')
         ) AS effective_start_date,
         LEAST(
-          ss.effective_end_date,
+          was.effective_end_date,
           wj.effective_end_date,
           wt.effective_end_date,
           wo.effective_end_date,
@@ -45,29 +49,29 @@ cubes:
           COALESCE(mgr.effective_end_date, DATE '9999-12-31')
         ) AS effective_end_date
       FROM kipptaf_marts.dim_staff_work_assignments swa
-      JOIN kipptaf_marts.dim_staff_status ss
-        ON ss.staff_key = swa.staff_key
+      JOIN kipptaf_marts.dim_work_assignment_status was
+        ON was.work_assignment_key = swa.work_assignment_key
       JOIN kipptaf_marts.dim_work_assignment_jobs wj
         ON wj.work_assignment_key = swa.work_assignment_key
-        AND ss.effective_start_date < wj.effective_end_date
-        AND ss.effective_end_date   > wj.effective_start_date
+        AND was.effective_start_date < wj.effective_end_date
+        AND was.effective_end_date   > wj.effective_start_date
       JOIN kipptaf_marts.dim_work_assignment_types wt
         ON wt.work_assignment_key = swa.work_assignment_key
-        AND ss.effective_start_date < wt.effective_end_date
-        AND ss.effective_end_date   > wt.effective_start_date
+        AND was.effective_start_date < wt.effective_end_date
+        AND was.effective_end_date   > wt.effective_start_date
       JOIN kipptaf_marts.dim_work_assignment_organizational_units wo
         ON wo.work_assignment_key = swa.work_assignment_key
         AND wo.assignment_type = 'home'
-        AND ss.effective_start_date < wo.effective_end_date
-        AND ss.effective_end_date   > wo.effective_start_date
+        AND was.effective_start_date < wo.effective_end_date
+        AND was.effective_end_date   > wo.effective_start_date
       JOIN kipptaf_marts.dim_work_assignment_locations wl
         ON wl.work_assignment_key = swa.work_assignment_key
-        AND ss.effective_start_date < wl.effective_end_date
-        AND ss.effective_end_date   > wl.effective_start_date
+        AND was.effective_start_date < wl.effective_end_date
+        AND was.effective_end_date   > wl.effective_start_date
       LEFT JOIN kipptaf_marts.dim_work_assignment_primary wp
         ON wp.work_assignment_key = swa.work_assignment_key
-        AND ss.effective_start_date < wp.effective_end_date
-        AND ss.effective_end_date   > wp.effective_start_date
+        AND was.effective_start_date < wp.effective_end_date
+        AND was.effective_end_date   > wp.effective_start_date
       -- Point-in-time manager from the primary assignment's reporting
       -- relationship. LEFT JOIN + COALESCE in GREATEST/LEAST keeps manager-less
       -- staff (no primary reporting row) instead of dropping them. Splitting a
@@ -90,8 +94,8 @@ cubes:
         WHERE wap.is_primary_position
       ) mgr
         ON mgr.staff_key = swa.staff_key
-        AND ss.effective_start_date < mgr.effective_end_date
-        AND ss.effective_end_date   > mgr.effective_start_date
+        AND was.effective_start_date < mgr.effective_end_date
+        AND was.effective_end_date   > mgr.effective_start_date
 
     joins:
       # One employment period spans many calendar days. Range (BETWEEN) join is
@@ -131,69 +135,96 @@ cubes:
         type: string
         primary_key: true
 
-      - name: status_code
-        description:
-          Employment status during this period (e.g., Active, Inactive,
-          Terminated). status_name is null upstream; status_code is the
-          populated field.
-        sql: status_code
+      - name: status_name
+        description: >-
+          Assignment-level employment status during this period (Active, Leave,
+          Terminated). Sourced from dim_work_assignment_status (ADP
+          assignmentStatus), which is more granular than the worker-level status
+          and has a populated name. Filter status_name = 'Active' for active
+          headcount (excludes Leave).
+        sql: status_name
+        type: string
+        public: true
+
+      - name: status_reason
+        description: >-
+          Reason for the current status (e.g., leave type — Medical, Family,
+          Disability; or termination reason — Resignation, Non-Renewal). Null
+          for many Active periods.
+        sql: status_reason
         type: string
         public: true
 
       - name: position_title
-        description: Job/position title held during this period.
+        description:
+          Free-text position title for the work assignment, as held during this
+          period.
         sql: position_title
         type: string
         public: true
 
       - name: job_code
-        description: Job code held during this period.
+        description:
+          Job code value for the work assignment, as held during this period.
         sql: job_code
         type: string
         public: true
 
       - name: worker_type
-        description: Worker type during this period (e.g., Regular, Temporary).
+        description:
+          Display name for the ADP worker type (e.g., Regular, Temporary), as
+          held during this period.
         sql: worker_type
         type: string
         public: true
 
       - name: department_name
-        description: Home org-unit department during this period.
+        description: >-
+          Display name for the home Department, coalesced from longName and
+          shortName of the ADP nameCode where typeCode = 'Department', as held
+          during this period.
         sql: department_name
         type: string
         public: true
 
       - name: business_unit_name
-        description: Home org-unit business unit during this period.
+        description: >-
+          Display name for the home Business Unit, coalesced from longName and
+          shortName of the ADP nameCode where typeCode = 'Business Unit', as
+          held during this period.
         sql: business_unit_name
         type: string
         public: true
 
       # Degenerate FK to locations — descriptors come via the locations join.
       - name: work_location_key
-        description:
-          FK to locations (work assignment location during this period).
+        description: >-
+          Canonical location FK for the work assignment during this period,
+          resolved upstream on adp_location_code. NULL when the ADP location has
+          no canonical mapping. Descriptors come via the locations join.
         sql: work_location_key
         type: string
 
       - name: is_primary_position
         description: >-
-          TRUE if this is the worker's primary assignment during the period.
-          Filter to true to count each person once across concurrent
-          assignments.
+          TRUE if this was the worker's primary work assignment during the
+          period. A worker may have multiple concurrent assignments; at most one
+          is primary at any moment. Filter to true to count each person once.
         sql: is_primary_position
         type: boolean
         public: true
 
       - name: is_management_position
-        description: TRUE if this assignment is a management position.
+        description:
+          TRUE if this work assignment is designated as a management position.
         sql: is_management_position
         type: boolean
         public: true
 
       - name: full_time_equivalency
-        description: FTE ratio for this assignment during the period.
+        description: >-
+          FTE ratio for this work assignment. 1.0 represents full-time;
+          fractional values represent part-time assignments.
         sql: full_time_equivalency
         type: number
         public: true

--- a/src/cube/model/cubes/staff/staff_work_history.yml
+++ b/src/cube/model/cubes/staff/staff_work_history.yml
@@ -2,21 +2,24 @@ cubes:
   - name: staff_work_history
     public: false
     # SCD2 period intersection: one row per work assignment x contiguous window
-    # during which the worker's status, job, worker type, org unit, and location
-    # all held simultaneously. Overlaps are anchored to the staff_status period;
-    # GREATEST/LEAST then collapse each combination to its true effective range.
-    # Periods where the children do not mutually overlap yield start > end and
-    # are silently excluded by the dates BETWEEN join (queries always filter on a
-    # date). Transformation that needs multi-table joins lives here in sql:
-    # rather than a dbt mart only because every input is already a published
-    # dim; a dedicated mart is the future home if this grows.
+    # during which the worker's status, job, worker type, org unit, location,
+    # AND point-in-time manager all held simultaneously. Overlaps are anchored to
+    # the staff_status period; GREATEST/LEAST then collapse each combination to
+    # its true effective range. Manager is folded into the intersection (not a
+    # separate cube join) so each period carries exactly one manager — a
+    # single-day query returns one row per person instead of one per manager the
+    # person ever had. Periods where children do not mutually overlap yield
+    # start > end and are silently excluded by the dates BETWEEN join (queries
+    # always filter on a date). Transformation lives here in sql: rather than a
+    # dbt mart only because every input is already a published dim; a dedicated
+    # mart is the future home if this grows.
     sql: |
       SELECT
         swa.work_assignment_key,
         swa.staff_key,
         swa.full_time_equivalency,
         swa.is_management_position,
-        ss.status_name,
+        ss.status_code,
         wj.position_title,
         wj.job_code,
         wt.worker_type_name AS worker_type,
@@ -24,19 +27,22 @@ cubes:
         wo.business_unit_name,
         wl.location_key AS work_location_key,
         wp.is_primary_position,
+        mgr.manager_staff_key,
         GREATEST(
           ss.effective_start_date,
           wj.effective_start_date,
           wt.effective_start_date,
           wo.effective_start_date,
-          wl.effective_start_date
+          wl.effective_start_date,
+          COALESCE(mgr.effective_start_date, DATE '1900-01-01')
         ) AS effective_start_date,
         LEAST(
           ss.effective_end_date,
           wj.effective_end_date,
           wt.effective_end_date,
           wo.effective_end_date,
-          wl.effective_end_date
+          wl.effective_end_date,
+          COALESCE(mgr.effective_end_date, DATE '9999-12-31')
         ) AS effective_end_date
       FROM kipptaf_marts.dim_staff_work_assignments swa
       JOIN kipptaf_marts.dim_staff_status ss
@@ -62,6 +68,30 @@ cubes:
         ON wp.work_assignment_key = swa.work_assignment_key
         AND ss.effective_start_date < wp.effective_end_date
         AND ss.effective_end_date   > wp.effective_start_date
+      -- Point-in-time manager from the primary assignment's reporting
+      -- relationship. LEFT JOIN + COALESCE in GREATEST/LEAST keeps manager-less
+      -- staff (no primary reporting row) instead of dropping them. Splitting a
+      -- period on manager changes adds rows over time (correct) but never
+      -- duplicates a person on a single day.
+      LEFT JOIN (
+        SELECT
+          swa_m.staff_key,
+          rr.manager_staff_key,
+          GREATEST(wap.effective_start_date, rr.effective_start_date) AS effective_start_date,
+          LEAST(wap.effective_end_date,      rr.effective_end_date)   AS effective_end_date
+        FROM kipptaf_marts.dim_work_assignment_primary wap
+        JOIN kipptaf_marts.dim_staff_work_assignments swa_m
+          ON wap.work_assignment_key = swa_m.work_assignment_key
+          AND swa_m.staff_key IS NOT NULL
+        JOIN kipptaf_marts.dim_work_assignment_reporting_relationships rr
+          ON rr.work_assignment_key = wap.work_assignment_key
+          AND wap.effective_start_date <= rr.effective_end_date
+          AND wap.effective_end_date   >= rr.effective_start_date
+        WHERE wap.is_primary_position
+      ) mgr
+        ON mgr.staff_key = swa.staff_key
+        AND ss.effective_start_date < mgr.effective_end_date
+        AND ss.effective_end_date   > mgr.effective_start_date
 
     joins:
       # One employment period spans many calendar days. Range (BETWEEN) join is
@@ -80,23 +110,11 @@ cubes:
         sql: "{locations.location_key} = {CUBE}.work_location_key"
         relationship: many_to_one
 
-      # Point-in-time manager resolver. many_to_one is correct only with a date
-      # filter applied (which staff queries always have): each employment period
-      # matches its contemporaneous reporting-relationship row. Without a date
-      # filter the join is effectively many_to_many.
-      - name: staff_reporting_relationships
-        sql: >
-          {staff_reporting_relationships.staff_key} = {CUBE}.staff_key AND
-          CAST({CUBE}.effective_start_date AS TIMESTAMP)
-            <= {staff_reporting_relationships.effective_end_date} AND
-          CAST({CUBE}.effective_end_date AS TIMESTAMP)
-            >= {staff_reporting_relationships.effective_start_date}
-        relationship: many_to_one
-
+      # Manager name/attributes via the staff_manager alias, keyed on the
+      # point-in-time manager_staff_key folded into the SQL above. True
+      # many_to_one — one manager per period — so no fan-out.
       - name: staff_manager
-        sql: >
-          {staff_manager.staff_key} =
-          {staff_reporting_relationships.manager_staff_key}
+        sql: "{staff_manager.staff_key} = {CUBE}.manager_staff_key"
         relationship: many_to_one
 
     dimensions:
@@ -113,11 +131,12 @@ cubes:
         type: string
         primary_key: true
 
-      - name: status_name
+      - name: status_code
         description:
-          Employment status during this period (e.g., Active, Leave,
-          Terminated).
-        sql: status_name
+          Employment status during this period (e.g., Active, Inactive,
+          Terminated). status_name is null upstream; status_code is the
+          populated field.
+        sql: status_code
         type: string
         public: true
 
@@ -187,7 +206,7 @@ cubes:
         public: true
 
     measures:
-      - name: count_headcount
+      - name: count_employees
         description: >-
           Distinct employees in scope. Counts a person once even with multiple
           concurrent assignments. Filter is_primary_position = true to count the
@@ -195,11 +214,3 @@ cubes:
         sql: staff_key
         type: count_distinct
         public: true
-
-      - name: sum_fte
-        description: Total FTE of active assignments in scope.
-        sql: full_time_equivalency
-        type: sum
-        public: true
-        filters:
-          - sql: "{CUBE}.status_name = 'Active'"

--- a/src/cube/model/views/staff/staff_detail.yml
+++ b/src/cube/model/views/staff/staff_detail.yml
@@ -1,0 +1,149 @@
+views:
+  - name: staff_detail
+    description: >-
+      Row-level staff employment history. One row per employee x employment
+      period — a contiguous window during which status, job, worker type, org
+      unit, and location all held simultaneously — with point-in-time manager
+      context. Use for the staff roster, drill-down, and individual
+      investigations.
+
+      Always apply a date filter. Without one, each employment period fans out
+      to one row per calendar day in its effective range. For a current roster,
+      filter dates to today; for headcount over time, filter a date range or
+      month-ends. Filter is_primary_position = true to count each person once;
+      status_name = 'Active' filters to active employees. Use count_headcount
+      (count_distinct on staff_key) for headcounts. Contains direct staff and
+      manager identifiers.
+
+    cubes:
+      - join_path: staff_work_history
+        includes:
+          - count_headcount
+          - sum_fte
+          - status_name
+          - position_title
+          - job_code
+          - worker_type
+          - department_name
+          - business_unit_name
+          - is_primary_position
+          - is_management_position
+          - full_time_equivalency
+          - effective_start_date
+
+      - join_path: staff_work_history.dates
+        prefix: true
+        includes:
+          - date_day
+          - academic_year
+          - month_name
+          - month_number
+          - year_number
+
+      - join_path: staff_work_history.staff
+        prefix: false
+        includes:
+          - staff_key
+          - staff_unique_id
+          - full_name
+          - first_name
+          - last_name
+          - birth_date
+          - work_email
+          - google_email
+          - personal_email
+          - personal_cell_phone
+          - active_directory_username
+          - gender_identity
+          - race
+          - is_hispanic
+          - original_hire_date
+          - rehire_date
+
+      - join_path: staff_work_history.locations
+        prefix: true
+        includes:
+          - location_name
+          - abbreviation
+          - grade_band
+          - campus
+          - city
+
+      - join_path: staff_work_history.locations.regions
+        prefix: true
+        includes:
+          - region_name
+          - state
+
+      - join_path: staff_work_history.staff_manager
+        prefix: true
+        includes:
+          - staff_key
+          - full_name
+          - first_name
+          - last_name
+          - work_email
+
+    meta:
+      folders:
+        - name: Employment
+          members:
+            - status_name
+            - position_title
+            - job_code
+            - worker_type
+            - department_name
+            - business_unit_name
+            - is_primary_position
+            - is_management_position
+            - full_time_equivalency
+            - effective_start_date
+        - name: Date
+          members:
+            - dates_date_day
+            - dates_academic_year
+            - dates_month_name
+            - dates_month_number
+            - dates_year_number
+        - name: Location
+          members:
+            - locations_location_name
+            - locations_abbreviation
+            - locations_grade_band
+            - locations_campus
+            - locations_city
+            - regions_region_name
+            - regions_state
+        - name: Staff
+          members:
+            - staff_key
+            - staff_unique_id
+            - full_name
+            - first_name
+            - last_name
+            - birth_date
+            - work_email
+            - google_email
+            - personal_email
+            - personal_cell_phone
+            - active_directory_username
+            - gender_identity
+            - race
+            - is_hispanic
+            - original_hire_date
+            - rehire_date
+        - name: Manager
+          members:
+            - staff_manager_staff_key
+            - staff_manager_full_name
+            - staff_manager_first_name
+            - staff_manager_last_name
+            - staff_manager_work_email
+
+    access_policy:
+      # Single staff-data tier. The detail view is for users cleared to see
+      # identifiable staff; staff_summary is the non-PII surface. Revisit if a
+      # "see staff but not PII" sub-tier is needed later.
+      - group: cube-access-staff-data
+        member_level:
+          includes: "*"

--- a/src/cube/model/views/staff/staff_detail.yml
+++ b/src/cube/model/views/staff/staff_detail.yml
@@ -11,15 +11,16 @@ views:
       to one row per calendar day in its effective range. For a current roster,
       filter dates to today; for headcount over time, filter a date range or
       month-ends. Filter is_primary_position = true to count each person once;
-      status_code = 'Active' filters to active employees. Use count_employees
-      (count_distinct on staff_key) for headcounts. Contains direct staff and
-      manager identifiers.
+      status_name = 'Active' filters to active employees (excludes Leave). Use
+      count_employees (count_distinct on staff_key) for headcounts. Contains
+      direct staff and manager identifiers.
 
     cubes:
       - join_path: staff_work_history
         includes:
           - count_employees
-          - status_code
+          - status_name
+          - status_reason
           - position_title
           - job_code
           - worker_type
@@ -87,7 +88,8 @@ views:
       folders:
         - name: Employment
           members:
-            - status_code
+            - status_name
+            - status_reason
             - position_title
             - job_code
             - worker_type

--- a/src/cube/model/views/staff/staff_detail.yml
+++ b/src/cube/model/views/staff/staff_detail.yml
@@ -11,16 +11,15 @@ views:
       to one row per calendar day in its effective range. For a current roster,
       filter dates to today; for headcount over time, filter a date range or
       month-ends. Filter is_primary_position = true to count each person once;
-      status_name = 'Active' filters to active employees. Use count_headcount
+      status_code = 'Active' filters to active employees. Use count_employees
       (count_distinct on staff_key) for headcounts. Contains direct staff and
       manager identifiers.
 
     cubes:
       - join_path: staff_work_history
         includes:
-          - count_headcount
-          - sum_fte
-          - status_name
+          - count_employees
+          - status_code
           - position_title
           - job_code
           - worker_type
@@ -88,7 +87,7 @@ views:
       folders:
         - name: Employment
           members:
-            - status_name
+            - status_code
             - position_title
             - job_code
             - worker_type

--- a/src/cube/model/views/staff/staff_summary.yml
+++ b/src/cube/model/views/staff/staff_summary.yml
@@ -1,0 +1,100 @@
+views:
+  - name: staff_summary
+    description: >-
+      Aggregated staff employment history for headcount and FTE breakdowns. One
+      row per filter slice — never per employee. No direct identifiers;
+      demographic dimensions (gender_identity, race, is_hispanic) are aggregate
+      breakdowns only.
+
+      Always apply a date filter. Without one, each employment period fans out
+      to one row per calendar day in its effective range. Use count_headcount
+      (count_distinct on staff_key) for headcounts and filter
+      is_primary_position = true to count each person once; status_name =
+      'Active' filters to active employees. For headcount over time, group by a
+      dates granularity (e.g. month) and filter month-ends for a point-in-time
+      snapshot.
+
+    cubes:
+      - join_path: staff_work_history
+        includes:
+          - count_headcount
+          - sum_fte
+          - status_name
+          - position_title
+          - job_code
+          - worker_type
+          - department_name
+          - business_unit_name
+          - is_primary_position
+          - is_management_position
+
+      - join_path: staff_work_history.dates
+        prefix: true
+        includes:
+          - date_day
+          - academic_year
+          - month_name
+          - month_number
+          - year_number
+
+      - join_path: staff_work_history.staff
+        prefix: false
+        includes:
+          - gender_identity
+          - race
+          - is_hispanic
+
+      - join_path: staff_work_history.locations
+        prefix: true
+        includes:
+          - location_name
+          - abbreviation
+          - grade_band
+          - campus
+          - city
+
+      - join_path: staff_work_history.locations.regions
+        prefix: true
+        includes:
+          - region_name
+          - state
+
+    meta:
+      folders:
+        - name: Employment
+          members:
+            - status_name
+            - position_title
+            - job_code
+            - worker_type
+            - department_name
+            - business_unit_name
+            - is_primary_position
+            - is_management_position
+        - name: Date
+          members:
+            - dates_date_day
+            - dates_academic_year
+            - dates_month_name
+            - dates_month_number
+            - dates_year_number
+        - name: Location
+          members:
+            - locations_location_name
+            - locations_abbreviation
+            - locations_grade_band
+            - locations_campus
+            - locations_city
+            - regions_region_name
+            - regions_state
+        - name: Staff
+          members:
+            - gender_identity
+            - race
+            - is_hispanic
+
+    access_policy:
+      # No direct identifiers — demographic breakdowns only.
+      - group: cube-access-staff-data
+        member_level:
+          includes: "*"

--- a/src/cube/model/views/staff/staff_summary.yml
+++ b/src/cube/model/views/staff/staff_summary.yml
@@ -7,9 +7,9 @@ views:
       breakdowns only.
 
       Always apply a date filter. Without one, each employment period fans out
-      to one row per calendar day in its effective range. Use count_headcount
+      to one row per calendar day in its effective range. Use count_employees
       (count_distinct on staff_key) for headcounts and filter
-      is_primary_position = true to count each person once; status_name =
+      is_primary_position = true to count each person once; status_code =
       'Active' filters to active employees. For headcount over time, group by a
       dates granularity (e.g. month) and filter month-ends for a point-in-time
       snapshot.
@@ -17,9 +17,8 @@ views:
     cubes:
       - join_path: staff_work_history
         includes:
-          - count_headcount
-          - sum_fte
-          - status_name
+          - count_employees
+          - status_code
           - position_title
           - job_code
           - worker_type
@@ -63,7 +62,7 @@ views:
       folders:
         - name: Employment
           members:
-            - status_name
+            - status_code
             - position_title
             - job_code
             - worker_type

--- a/src/cube/model/views/staff/staff_summary.yml
+++ b/src/cube/model/views/staff/staff_summary.yml
@@ -9,16 +9,17 @@ views:
       Always apply a date filter. Without one, each employment period fans out
       to one row per calendar day in its effective range. Use count_employees
       (count_distinct on staff_key) for headcounts and filter
-      is_primary_position = true to count each person once; status_code =
-      'Active' filters to active employees. For headcount over time, group by a
-      dates granularity (e.g. month) and filter month-ends for a point-in-time
-      snapshot.
+      is_primary_position = true to count each person once; status_name =
+      'Active' filters to active employees (excludes Leave). For headcount over
+      time, group by a dates granularity (e.g. month) and filter month-ends for
+      a point-in-time snapshot.
 
     cubes:
       - join_path: staff_work_history
         includes:
           - count_employees
-          - status_code
+          - status_name
+          - status_reason
           - position_title
           - job_code
           - worker_type
@@ -62,7 +63,8 @@ views:
       folders:
         - name: Employment
           members:
-            - status_code
+            - status_name
+            - status_reason
             - position_title
             - job_code
             - worker_type


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will add the Cube semantic-layer **staff**
> domain: a tabular roster, point-in-time headcount with full employment
> history, and slicing by location/region/demographics — plus a pre-wired
> `staff_key` for a future staff↔student connection.

Model files under `src/cube/model/`:

- **`cubes/staff/staff.yml`** — thin wrapper on `dim_staff`. `staff_key` is
  `public` so a future `course_section_teachers` bridge cube can join staff to
  student/course data.
- **`cubes/staff/staff_work_history.yml`** — SCD2 period intersection across
  status, job, worker type, org unit, location, **and point-in-time manager**
  (folded into the intersection so each period carries exactly one manager —
  see below). Headline measure `count_employees` = `COUNT(DISTINCT staff_key)`.
  Joined `one_to_many` to `dates` via a `BETWEEN` range so one fact serves both
  the current roster (filter to a single day) and headcount-over-time (group by
  day, or filter month-ends).
- **`cubes/staff/staff_reporting_relationships.yml`** — point-in-time manager
  resolver. Now a standalone helper for future fact cubes (observations,
  gradebook); `staff_work_history` folds the same logic directly into its SQL.
- **`cubes/staff/staff_manager.yml`** — role alias extending `staff`, joined on
  the single `manager_staff_key` carried by each work-history period.
- **`views/staff/staff_detail.yml`** — row-level roster with manager and
  location/region context and identifiers.
- **`views/staff/staff_summary.yml`** — aggregate headcount with demographic
  breakdowns and no identifiers.

Plus a `cube.js` change (see below).

All cubes are `public: false`; both views gate on `cube-access-staff-data`.
Privacy is enforced by view choice (summary = aggregates only), not a per-field
PII sub-tier. Compensation and manager-scoped RLS are deferred. See #4226 for the
full design.

### Manager folded into the period intersection (fan-out fix)

A `staff_work_history` period is bounded by status/job/type/org/location changes
but **not** manager changes, so joining the manager as a separate cube matched
every manager period overlapping the employment stint — one detail row per
manager the person ever had (≈3,250 rows for 1,550 active staff on a single
day). The reporting relationship is now folded into the intersection SQL
(`LEFT JOIN` + `COALESCE` keeps manager-less staff), so each period carries one
`manager_staff_key` and `staff_manager` joins `many_to_one` with no fan-out.
Single-day roster: ~1,557 rows for 1,550 distinct staff. `count_employees` is
unaffected (count-distinct).

### `status_code` rather than `status_name`

`dim_staff_status.status_name` is `coalesce(long_name, short_name)` and both are
empty in the ADP source, so the cube exposes `status_code`
(`Active` / `Inactive` / `Terminated`). Fixing upstream name population is a
separate follow-up.

### `cube.js`: removed the deferred reporting_chain injection

`queryRewrite` injected a `staff.reporting_chain` segment for staff queries by
users without `cube-access-staff-all`, but that segment was never built — every
staff view query errored with `'reporting_chain' not found`, and it targeted a
cube segment that doesn't resolve inside a view query. Removed it (and the unused
`isStaffMember` helper). Staff visibility is governed by the location scope
filter (applies to staff views via their `locations` join) plus the
`cube-access-staff-data` policy. Manager-scoped RLS returns later as a
view-aware rebuild.

### Operational prerequisite (not code)

Enroll staff-data users in `cube-access-staff-data` plus a location scope group
(`cube-network-*` / `cube-region-*` / `cube-school-*`) — without a scope group,
`queryRewrite` returns `WHERE (1 = 0)`. `cube-access-staff-all` is no longer
required.

## AI Assistance

AI-assisted (Claude Code), human-directed. The author directed every design
decision (headcount = distinct people, pre-wire student linkage via the bridge,
defer RLS/compensation, keep manager on the roster, fold manager into the
period, remove the reporting_chain injection, use status_code); Claude reworked
the prior plan from first principles, verified columns and headcount against the
warehouse, and wrote/validated the YAML and cube.js.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR

### Dagster / dbt / Docs

Skipped — no Dagster or dbt model changes (Cube reads existing `kipptaf_marts`
tables; `powerschool_teacher_number` on `dim_staff` is deferred with the
bridge). `src/cube/CLAUDE.md` updated to match the cube.js change.

## CI checks

- [ ] **Trunk** — passes (`trunk check --force` clean locally on all changed files).
- [ ] **dbt Cloud** — n/a (no dbt changes).
- [ ] **Dagster Cloud** — not triggered.

## Validation

- Headcount validated against the warehouse: active primary staff today = 1,550,
  matching `count_employees`; the manager fold-in collapses ~3,250 detail rows to
  ~1,557 for the same 1,550 distinct staff, retaining 47 manager-less staff.
- Cube Cloud Dev Mode (manual, per `src/cube/CLAUDE.md`): confirm `staff_detail`
  / `staff_summary` appear in `meta` (cubes do not); a single-day roster returns
  one row per person with their current manager; a no-scope-group user compiles
  to `WHERE (1 = 0)`.

## Deferred follow-ups

- Restore `sum_fte` (was dropped during iteration) when FTE rollups are needed.
- Upstream `status_name` population (currently null) so the human-readable label
  works alongside `status_code`.
- `course_section_teachers` bridge cube + cross-domain view (student linkage,
  pre-wired here via public `staff_key`); `powerschool_teacher_number` on
  `dim_staff`; compensation; manager-scoped RLS.