### PR TITLE
feat(kipptaf): add alum_name + school_name audit helpers to NSC rpt views

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
@@ -55,3 +55,13 @@ models:
       - name: nsc_verified__c
         data_type: boolean
         description: Flag indicating this enrollment has been verified by NSC.
+      - name: alum_name
+        data_type: string
+        description: >
+          Audit helper — alum name in `Last, First` form from the kippadb
+          roster. Delete before Salesforce upload.
+      - name: school_name
+        data_type: string
+        description: >
+          Audit helper — school name from the kippadb account. Delete before
+          Salesforce upload.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
@@ -60,6 +60,17 @@ models:
         description: >
           Audit helper — alum name in `Last, First` form from the kippadb
           roster. Delete before Salesforce upload.
+      - name: contact_advising_provider
+        data_type: string
+        description: >
+          Audit helper — alum's post-secondary advising provider from the
+          kippadb roster. Delete before Salesforce upload.
+      - name: ktc_status
+        data_type: string
+        description: >
+          Audit helper — alum's KIPP Through College status from the kippadb
+          roster (e.g. HSG, TAF, TAFHS, or current school-level + grade). Delete
+          before Salesforce upload.
       - name: school_name
         data_type: string
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_updates.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_updates.yml
@@ -33,6 +33,17 @@ models:
         description: >
           Audit helper — alum name in `Last, First` form from the kippadb
           roster. Delete before Salesforce upload.
+      - name: contact_advising_provider
+        data_type: string
+        description: >
+          Audit helper — alum's post-secondary advising provider from the
+          kippadb roster. Delete before Salesforce upload.
+      - name: ktc_status
+        data_type: string
+        description: >
+          Audit helper — alum's KIPP Through College status from the kippadb
+          roster (e.g. HSG, TAF, TAFHS, or current school-level + grade). Delete
+          before Salesforce upload.
       - name: school_name
         data_type: string
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_updates.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_updates.yml
@@ -28,3 +28,13 @@ models:
       - name: date_last_verified__c
         data_type: date
         description: Date this record was last verified against NSC data.
+      - name: alum_name
+        data_type: string
+        description: >
+          Audit helper — alum name in `Last, First` form from the kippadb
+          roster. Delete before Salesforce upload.
+      - name: school_name
+        data_type: string
+        description: >
+          Audit helper — school name from the kippadb account. Delete before
+          Salesforce upload.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_terms_new.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_terms_new.yml
@@ -44,6 +44,17 @@ models:
         description: >
           Audit helper — alum name in `Last, First` form from the kippadb
           roster. Delete before Salesforce upload.
+      - name: contact_advising_provider
+        data_type: string
+        description: >
+          Audit helper — alum's post-secondary advising provider from the
+          kippadb roster. Delete before Salesforce upload.
+      - name: ktc_status
+        data_type: string
+        description: >
+          Audit helper — alum's KIPP Through College status from the kippadb
+          roster (e.g. HSG, TAF, TAFHS, or current school-level + grade). Delete
+          before Salesforce upload.
       - name: school_name
         data_type: string
         description: >

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_terms_new.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_terms_new.yml
@@ -39,3 +39,13 @@ models:
       - name: verified_by_nsc__c
         data_type: boolean
         description: Flag indicating this term record was verified by NSC.
+      - name: alum_name
+        data_type: string
+        description: >
+          Audit helper — alum name in `Last, First` form from the kippadb
+          roster. Delete before Salesforce upload.
+      - name: school_name
+        data_type: string
+        description: >
+          Audit helper — school name from the kippadb account. Delete before
+          Salesforce upload.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
@@ -17,6 +17,9 @@ with
             and coalesce(n.stint_end, date(9999, 12, 31)) >= e.`start_date`
     )
 
+/* Audit helpers (alum_name, school_name) intentionally last so the upload
+   columns sit contiguously on the left of the sheet. */
+-- trunk-ignore(sqlfluff/ST06): audit helpers placed last for sheet-deletion
 select
     n.contact_id as student__c,
     n.account_id as school__c,
@@ -36,10 +39,16 @@ select
         when '2-year'
         then "Associate's (2 year)"
     end as pursuing_degree_type__c,
+
+    /* Audit-only helper columns — delete before Salesforce upload. */
+    r.lastfirst as alum_name,
+    a.`name` as school_name,
 from {{ ref("int_nsc__enrollment_stints") }} as n
 left join
     covered_stints as c
     on n.contact_id = c.contact_id
     and n.account_id = c.account_id
     and n.stint_num = c.stint_num
+left join {{ ref("int_kippadb__roster") }} as r on n.contact_id = r.contact_id
+left join {{ ref("stg_kippadb__account") }} as a on n.account_id = a.id
 where c.contact_id is null

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
@@ -42,6 +42,8 @@ select
 
     /* Audit-only helper columns — delete before Salesforce upload. */
     r.lastfirst as alum_name,
+    r.contact_advising_provider,
+    r.ktc_status,
     a.`name` as school_name,
 from {{ ref("int_nsc__enrollment_stints") }} as n
 left join

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_updates.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_updates.sql
@@ -6,6 +6,8 @@ with
     enrollment_stint_match as (
         select
             e.id as enrollment_id,
+            e.student,
+            e.school,
             e.actual_end_date,
             e.attending_status,
             e.`status`,
@@ -35,18 +37,24 @@ with
     )
 
 select
-    enrollment_id as id,
-    stint_end as actual_end_date__c,
-    derived_status as status__c,
-    current_enrollment_status as attending_status__c,
+    n.enrollment_id as id,
+    n.stint_end as actual_end_date__c,
+    n.derived_status as status__c,
+    n.current_enrollment_status as attending_status__c,
 
     true as nsc_verified__c,
     current_date('{{ var("local_timezone") }}') as date_last_verified__c,
-from enrollment_latest_stint
+
+    /* Audit-only helper columns — delete before Salesforce upload. */
+    r.lastfirst as alum_name,
+    a.`name` as school_name,
+from enrollment_latest_stint as n
+left join {{ ref("int_kippadb__roster") }} as r on n.student = r.contact_id
+left join {{ ref("stg_kippadb__account") }} as a on n.school = a.id
 where
-    not do_not_overwrite_with_nsc_data
+    not n.do_not_overwrite_with_nsc_data
     and (
-        stint_end is distinct from actual_end_date
-        or derived_status is distinct from `status`
-        or current_enrollment_status is distinct from attending_status
+        n.stint_end is distinct from n.actual_end_date
+        or n.derived_status is distinct from n.`status`
+        or n.current_enrollment_status is distinct from n.attending_status
     )

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_updates.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_updates.sql
@@ -47,6 +47,8 @@ select
 
     /* Audit-only helper columns — delete before Salesforce upload. */
     r.lastfirst as alum_name,
+    r.contact_advising_provider,
+    r.ktc_status,
     a.`name` as school_name,
 from enrollment_latest_stint as n
 left join {{ ref("int_kippadb__roster") }} as r on n.student = r.contact_id

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_terms_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_terms_new.sql
@@ -90,6 +90,8 @@ select
 
     /* Audit-only helper columns — delete before Salesforce upload. */
     r.lastfirst as alum_name,
+    r.contact_advising_provider,
+    r.ktc_status,
     a.`name` as school_name,
 from term_with_parent as n
 left join

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_terms_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_terms_new.sql
@@ -87,9 +87,15 @@ select
             date_field="n.enrollment_begin", start_month=7, year_source="start"
         )
     }} as year__c,
+
+    /* Audit-only helper columns — delete before Salesforce upload. */
+    r.lastfirst as alum_name,
+    a.`name` as school_name,
 from term_with_parent as n
 left join
     {{ ref("stg_kippadb__term") }} as t
     on n.enrollment_id = t.enrollment
     and n.enrollment_begin = t.term_start_date
+left join {{ ref("int_kippadb__roster") }} as r on n.contact_id = r.contact_id
+left join {{ ref("stg_kippadb__account") }} as a on n.account_id = a.id
 where t.id is null


### PR DESCRIPTION
## Summary

Adds two trailing audit-only columns to each of the three NSC rpt views so the intern doing hand-reconciliation against Salesforce can read alum + school names directly from each sheet row:

- `alum_name` — from `int_kippadb__roster.lastfirst` (`Last, First` form)
- `school_name` — from `stg_kippadb__account.name`

Affected views:
- `rpt_gsheets__nsc_enrollment_new`
- `rpt_gsheets__nsc_enrollment_updates`
- `rpt_gsheets__nsc_terms_new`

Both columns sit to the right of the upload payload so they can be deleted as a contiguous block before Salesforce import.

Follow-up to #4072.

## Test plan

- [x] `dbt build` of all three views passes in dev
- [x] All three uniqueness tests pass
- [x] Trunk clean
- [x] Spot-checked helper columns populate non-null on each view

🤖 Generated with [Claude Code](https://claude.com/claude-code)