### PR TITLE
fix(kipptaf): derive pursuing_degree_type__c from NSC class_level + Account.type

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nsc_enrollment_new.yml
@@ -43,8 +43,16 @@ models:
       - name: pursuing_degree_type__c
         data_type: string
         description: >
-          Degree type mapped from NSC two-year/four-year classification:
-          "Bachelor's (4-year)" or "Associate's (2 year)".
+          Salesforce picklist value for the credential the alum is pursuing at
+          this institution. Resolved with precedence — the credential implied by
+          the NSC class_level code from the stint's most-recent term (see
+          int_nsc__enrollment_stints.current_class_level for the full code
+          mapping), then a fallback to the Salesforce Account.type ("Public 2
+          yr" / "Private 4 yr" / etc.) for year-in-school codes (F/S/J/R) and
+          NULL class_level. NULL when no signal is available. Specific degree
+          titles (MBA, JD, etc.) are not resolved here — NSC only emits
+          degree_title on its graduation-summary row, which is not the term row
+          that current_class_level is sourced from.
       - name: source__c
         data_type: string
         description: Data source identifier; always 'NSC' for this model.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
@@ -15,6 +15,58 @@ with
             and n.account_id = e.school
             and n.stint_begin <= coalesce(e.actual_end_date, date(9999, 12, 31))
             and coalesce(n.stint_end, date(9999, 12, 31)) >= e.`start_date`
+    ),
+
+    /* Two independent credential signals per stint, combined in the final
+       SELECT via coalesce. Kept separate so each branch is a flat lookup:
+         credential_from_class_level — NSC's reported credential, when the
+           class_level code is explicit (A, B, C, N, M, D, L, P, G). See
+           int_nsc__enrollment_stints.current_class_level for code meanings.
+         credential_from_institution — fallback for year-in-school codes
+           (F, S, J, R) and NULL class_level, derived from the Salesforce
+           Account.type ("Public 2 yr", "Private 4 yr", etc.). */
+    stints_with_credentials as (
+        select
+            n.contact_id,
+            n.account_id,
+            n.stint_num,
+            n.stint_begin,
+            n.stint_end,
+            n.current_enrollment_status,
+            n.current_class_level,
+            n.derived_status,
+
+            a.`name` as school_name,
+
+            case
+                n.current_class_level
+                when 'A'
+                then "Associate's (2 year)"
+                when 'B'
+                then "Bachelor's (4-year)"
+                when 'C'
+                then 'Certificate'
+                when 'N'
+                then 'Course Credit (Non-Degree Seeking)'
+                when 'M'
+                then "Master's"
+                when 'D'
+                then 'Graduate Degree'
+                when 'L'
+                then 'Graduate Degree'
+                when 'P'
+                then 'Graduate Degree'
+                when 'G'
+                then 'Graduate Degree'
+            end as credential_from_class_level,
+            case
+                when a.type like '%2 yr%'
+                then "Associate's (2 year)"
+                when a.type like '%4 yr%'
+                then "Bachelor's (4-year)"
+            end as credential_from_institution,
+        from {{ ref("int_nsc__enrollment_stints") }} as n
+        left join {{ ref("stg_kippadb__account") }} as a on n.account_id = a.id
     )
 
 /* Audit helpers (alum_name, school_name) intentionally last so the upload
@@ -32,25 +84,26 @@ select
     true as created_for_nsc_data__c,
     true as nsc_verified__c,
 
-    case
-        n.current_two_year_four_year
-        when '4-year'
-        then "Bachelor's (4-year)"
-        when '2-year'
-        then "Associate's (2 year)"
-    end as pursuing_degree_type__c,
+    /* Precedence: NSC's explicit class_level credential first, then
+       institution-type fallback for year-in-school codes (F/S/J/R) and NULL
+       class_level. NULL out means no signal at all (rare; intern reviews
+       and infers). Specific degree titles (MBA, JD, etc.) are not resolved
+       here — NSC only emits degree_title on its graduation-summary row,
+       which is not the term row that current_class_level is sourced from. */
+    coalesce(
+        n.credential_from_class_level, n.credential_from_institution
+    ) as pursuing_degree_type__c,
 
     /* Audit-only helper columns — delete before Salesforce upload. */
     r.lastfirst as alum_name,
     r.contact_advising_provider,
     r.ktc_status,
-    a.`name` as school_name,
-from {{ ref("int_nsc__enrollment_stints") }} as n
+    n.school_name,
+from stints_with_credentials as n
 left join
     covered_stints as c
     on n.contact_id = c.contact_id
     and n.account_id = c.account_id
     and n.stint_num = c.stint_num
 left join {{ ref("int_kippadb__roster") }} as r on n.contact_id = r.contact_id
-left join {{ ref("stg_kippadb__account") }} as a on n.account_id = a.id
 where c.contact_id is null

--- a/src/dbt/kipptaf/models/nsc/intermediate/int_nsc__enrollment_stints.sql
+++ b/src/dbt/kipptaf/models/nsc/intermediate/int_nsc__enrollment_stints.sql
@@ -7,7 +7,7 @@ with
             n.enrollment_status,
             n.graduated,
             n.graduation_date,
-            n.two_year_four_year,
+            n.class_level,
             n.search_date,
 
             x.account_id,
@@ -38,7 +38,7 @@ with
             enrollment_begin,
             enrollment_end,
             enrollment_status,
-            two_year_four_year,
+            class_level,
 
             date_diff(
                 enrollment_begin,
@@ -61,7 +61,7 @@ with
             enrollment_begin,
             enrollment_end,
             enrollment_status,
-            two_year_four_year,
+            class_level,
 
             countif(gap_months is null or gap_months > 6) over (
                 partition by contact_id, account_id
@@ -88,7 +88,7 @@ with
             account_id,
             stint_num,
             enrollment_status as current_enrollment_status,
-            two_year_four_year as current_two_year_four_year,
+            class_level as current_class_level,
         from stint_latest_term_raw
     ),
 
@@ -171,7 +171,7 @@ select
     a.stint_end,
     a.any_withdrawn,
     l.current_enrollment_status,
-    l.current_two_year_four_year,
+    l.current_class_level,
 
     a.any_graduated,
 

--- a/src/dbt/kipptaf/models/nsc/intermediate/properties/int_nsc__enrollment_stints.yml
+++ b/src/dbt/kipptaf/models/nsc/intermediate/properties/int_nsc__enrollment_stints.yml
@@ -51,11 +51,16 @@ models:
         description: >
           NSC enrollment_status from the most recent term in the stint (e.g. F =
           Full-time, H = Half-time, W = Withdrew).
-      - name: current_two_year_four_year
+      - name: current_class_level
         data_type: string
         description: >
-          NSC two_year_four_year classification from the most recent term in the
-          stint ('2-year' or '4-year').
+          NSC class_level from the most recent term in the stint. Per the
+          StudentTracker Detail Report spec, undergraduate codes are F
+          (Freshman), S (Sophomore), J (Junior), R (Senior), C (Certificate), N
+          (Unspecified); graduate codes are M (Master's), D (Doctoral), L (First
+          Professional), P (Postdoctorate), G (Unspecified graduate). Some
+          institutions emit non-spec codes A and B as shorthand for Associate's-
+          and Bachelor's-seeking, which NSC passes through unchanged.
       - name: derived_status
         data_type: string
         description: >


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR will populate `pursuing_degree_type__c` on `rpt_gsheets__nsc_enrollment_new` for every row that has any usable signal — today, that column resolves to NULL on every row because the previous derivation keyed off NSC's `two_year_four_year` field, which is 100% NULL at the source (NSC isn't emitting it for our SFTP feed).

Replaces the dead derivation with a two-step resolution:

1. **NSC `class_level`** (most-recent term in the stint) maps to its credential equivalent — A/B/C/N/M/D/L/P/G per the StudentTracker Detail Report spec, plus institution-emitted non-spec codes A (Associate's-seeking) and B (Bachelor's-seeking) that NSC passes through unchanged.
2. **Fallback to Salesforce `Account.type`** (Public/Private 2 yr/4 yr) for year-in-school codes (F/S/J/R) and NULL `class_level`.

Drops the now-unused `current_two_year_four_year` carrier from `int_nsc__enrollment_stints` and adds `current_class_level` in its place. Code mapping and resolution precedence documented inline in the rpt view and on `current_class_level` in the intermediate's YAML.

Verified output in dev: 215 Associate's, 192 Bachelor's, 17 Master's, 6 Certificate, 6 Course Credit, 3 Graduate Degree (previously: all 439 rows NULL).

## AI Assistance

Claude-assisted: investigated the NULL root cause via BigQuery, confirmed the NSC `class_level` code mapping against the official StudentTracker Detail Report spec, drafted the two-step CTE design, and wrote the implementation. Human-directed on the derivation shape (rejected an inline-CASE-only design in favor of the two-signal CTE + coalesce structure for readability) and on dropping a dead MBA carve-out that the data flow couldn't fire.

## Self-review

### dbt

- [x] Properties YAML updated for both modified models
- [x] No breaking change: `current_two_year_four_year` drop has zero remaining consumers (verified via grep); replaced by `current_class_level` in `int_nsc__enrollment_stints`
- [x] No external source changes
- [x] `dbt build --select int_nsc__enrollment_stints+` passes in dev (6 PASS / 0 WARN / 0 ERROR)

## CI checks

- [x] Trunk — clean
- [ ] dbt Cloud
- [ ] Dagster Cloud (not applicable; dbt-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)