### PR TITLE
feat(cube): add cube-access-staff-pii sub-tier to staff_detail

### DIFF
--- a/docs/superpowers/plans/2026-06-22-staff-pii-gate.md
+++ b/docs/superpowers/plans/2026-06-22-staff-pii-gate.md
@@ -1,0 +1,303 @@
+# Staff PII Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restrict six personal/sensitive staff fields in the `staff_detail`
+Cube view to a new `cube-access-staff-pii` group, mirroring the existing student
+two-tier access pattern.
+
+**Architecture:** Add a second `access_policy` block to the `staff_detail` view:
+the base `cube-access-staff-data` block keeps `includes: "*"` but adds an
+`excludes:` list for the six fields; a new `cube-access-staff-pii` block grants
+`includes: "*"`. Re-comment the backing `staff` cube dimensions to reflect the
+real tiers, and update the cube CLAUDE.md note. No `cube.js` change — group
+membership resolves dynamically.
+
+**Tech Stack:** Cube semantic layer (YAML data models), BigQuery driver, Cube
+Cloud. Lint via trunk (yamllint). Spec:
+[docs/superpowers/specs/2026-06-22-staff-pii-gate-design.md](2026-06-22-staff-pii-gate-design.md),
+issue [#4236](https://github.com/TEAMSchools/teamster/issues/4236).
+
+## Global Constraints
+
+- **No automated test harness exists for Cube access policies.** Per-task
+  verification is `trunk check` (YAML lint) + a manual Cube Cloud Dev Mode
+  validation at the end (Task 4). Do not invent a pytest cycle.
+- **One cube/view per file; filename matches `name:`.** Do not rename files.
+- **Never use the Cube Playground Models tab** — it overwrites hand-authored
+  YAML.
+- **Gated fields (exact set, do not add or remove):** `personal_email`,
+  `personal_cell_phone`, `birth_date`, `gender_identity`, `race`, `is_hispanic`.
+- **Not gated (stay in base tier):** `full_name`, `first_name`, `last_name`,
+  `staff_unique_id`, `work_email`, `google_email`, `active_directory_username`,
+  all `staff_manager_*`, `original_hire_date`, `rehire_date`, `staff_key`.
+- **trunk runs at commit (fmt) and pre-push (check).** Run
+  `/workspaces/teamster/.trunk/tools/trunk check --force <file>` from the repo
+  root (cwd `/workspaces/teamster`) before declaring a file clean.
+- **Working branch:** `cristinabaldor/feat/claude-staff-pii-gate` (already
+  checked out; not a worktree). All edits target files under
+  `/workspaces/teamster/`.
+
+---
+
+### Task 1: Add the PII sub-tier to `staff_detail`
+
+**Files:**
+
+- Modify: `src/cube/model/views/staff/staff_detail.yml` (the `access_policy:`
+  block, currently the last block in the file)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: the `cube-access-staff-pii` group name, referenced by the docs in
+  Task 3.
+
+- [ ] **Step 1: Replace the `access_policy` block**
+
+Find the current block (single `cube-access-staff-data` group with
+`includes: "*"`) and replace the entire `access_policy:` section with:
+
+```yaml
+access_policy:
+  # Non-PII staff tier: roster/employment structure without personal or
+  # sensitive data. Personal contact, DOB, and demographics are gated to
+  # cube-access-staff-pii. Work-directory info (names, work/google email,
+  # AD username, manager contacts) stays visible — already internally public.
+  - group: cube-access-staff-data
+    member_level:
+      includes: "*"
+      excludes:
+        - personal_email
+        - personal_cell_phone
+        - birth_date
+        - gender_identity
+        - race
+        - is_hispanic
+  - group: cube-access-staff-pii
+    member_level:
+      includes: "*"
+```
+
+- [ ] **Step 2: Lint the file**
+
+Run:
+`cd /workspaces/teamster && .trunk/tools/trunk check --force src/cube/model/views/staff/staff_detail.yml`
+Expected: `✔ No issues`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cube/model/views/staff/staff_detail.yml
+git commit -m "feat(cube): gate personal staff fields behind cube-access-staff-pii
+
+Refs #4236"
+```
+
+---
+
+### Task 2: Re-comment the `staff` cube dimensions
+
+**Files:**
+
+- Modify: `src/cube/model/cubes/staff/staff.yml` (dimension comment lines)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing (comments only — no member names change).
+
+The current comments are inconsistent: demographics are uncommented; directory
+identifiers are mislabeled `# PII —`. There are several identical
+`# PII — name.` and `# PII — contact.` lines — disambiguate each edit by the
+dimension `- name:` immediately below the comment.
+
+- [ ] **Step 1: Update gated-field comments**
+
+For `birth_date` (currently `# PII — date of birth.`):
+
+```yaml
+# Gated to cube-access-staff-pii — date of birth.
+- name: birth_date
+```
+
+For `personal_email` (currently `# PII — contact.` directly above
+`- name: personal_email`):
+
+```yaml
+# Gated to cube-access-staff-pii — personal contact.
+- name: personal_email
+```
+
+For `personal_cell_phone` (currently `# PII — contact.` directly above
+`- name: personal_cell_phone`):
+
+```yaml
+# Gated to cube-access-staff-pii — personal contact.
+- name: personal_cell_phone
+```
+
+- [ ] **Step 2: Add comments to the demographic dimensions**
+
+`gender_identity`, `race`, and `is_hispanic` currently have **no** comment line.
+Add this line immediately above each `- name:`:
+
+```yaml
+# Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.
+```
+
+So, for example:
+
+```yaml
+# Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.
+- name: gender_identity
+```
+
+Repeat verbatim above `- name: race` and `- name: is_hispanic`.
+
+- [ ] **Step 3: Update directory-identifier comments**
+
+These five dimensions stay in the base tier. Replace each one's comment
+(`# PII — employee identifier.` / `# PII — name.` / `# PII — contact.` /
+`# PII — credential/identifier.`) with the same line, disambiguating by the
+`- name:` below:
+
+```yaml
+# Staff-directory identifier — visible to all cube-access-staff-data (internally public).
+```
+
+Apply above: `- name: staff_unique_id`, `- name: full_name`,
+`- name: first_name`, `- name: last_name`, `- name: work_email`,
+`- name: google_email`, `- name: active_directory_username`.
+
+- [ ] **Step 4: Lint the file**
+
+Run:
+`cd /workspaces/teamster && .trunk/tools/trunk check --force src/cube/model/cubes/staff/staff.yml`
+Expected: `✔ No issues`
+
+- [ ] **Step 5: Sanity-check the comment count**
+
+Run: `grep -c "cube-access-staff" src/cube/model/cubes/staff/staff.yml`
+Expected: `13` — one per re-commented dimension: 3 gated contact/DOB
+(`personal_email`, `personal_cell_phone`, `birth_date`) + 3 demographic
+(`gender_identity`, `race`, `is_hispanic`) + 7 directory (`staff_unique_id`,
+`full_name`, `first_name`, `last_name`, `work_email`, `google_email`,
+`active_directory_username`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cube/model/cubes/staff/staff.yml
+git commit -m "docs(cube): re-comment staff dimensions to reflect PII tiers
+
+Refs #4236"
+```
+
+---
+
+### Task 3: Update the cube CLAUDE.md "Staff views" note
+
+**Files:**
+
+- Modify: `src/cube/CLAUDE.md` (the "Staff views" bullet under "## View access
+  policies")
+
+**Interfaces:**
+
+- Consumes: the `cube-access-staff-pii` group name from Task 1.
+- Produces: nothing.
+
+- [ ] **Step 1: Replace the "Staff views" bullet**
+
+Find the bullet that begins `- **Staff views** use a single` and ends with
+`see-staff-but-not-PII need arises.` Replace the whole bullet with:
+
+```markdown
+- **Staff views**: `staff_summary` uses a single `cube-access-staff-data` block
+  with `includes: "*"` — aggregate demographics only, no direct identifiers.
+  `staff_detail` uses two blocks: `cube-access-staff-data` with `includes: "*"`
+  and `excludes:` the personal/sensitive fields (`personal_email`,
+  `personal_cell_phone`, `birth_date`, `gender_identity`, `race`,
+  `is_hispanic`), plus `cube-access-staff-pii` with `includes: "*"`.
+  Work-directory info (names, work/google email, AD username, `staff_unique_id`,
+  manager contacts) stays in the base tier — internally public. Demographics are
+  gated row-level in `staff_detail` but remain valid aggregate breakdowns in
+  `staff_summary` (low-n suppression is tracked separately, #4237).
+```
+
+- [ ] **Step 2: Lint the file**
+
+Run:
+`cd /workspaces/teamster && .trunk/tools/trunk check --force src/cube/CLAUDE.md`
+Expected: `✔ No issues`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cube/CLAUDE.md
+git commit -m "docs(cube): document staff_detail two-tier access policy
+
+Refs #4236"
+```
+
+---
+
+### Task 4: Validate in Cube Cloud Dev Mode (manual)
+
+**Files:** none.
+
+**Interfaces:**
+
+- Consumes: the deployed branch.
+
+This task is **manual and requires the user** — Claude cannot run the long-lived
+Cube dev server, and branch staging envs are not auto-created from pushes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin cristinabaldor/feat/claude-staff-pii-gate
+```
+
+- [ ] **Step 2: Spin up the branch staging env**
+
+In Cube Cloud → Data Model → Dev Mode → add the branch
+`cristinabaldor/feat/claude-staff-pii-gate` by name. Confirm
+`GOOGLE_DIRECTORY_SA_KEY` / `GOOGLE_DIRECTORY_SA_SUBJECT` are set on that
+environment (branch staging does not fully inherit production secrets).
+
+- [ ] **Step 3: Verify the model compiles**
+
+Compile a `staff_detail` query via `/sql`. Expected: it compiles (this confirms
+the YAML is structurally valid and the view is present). `/sql` compiles even
+against hidden members, so this is a presence/syntax check, not an enforcement
+check.
+
+- [ ] **Step 4: Verify enforcement with `/load`**
+
+Using a test account in `cube-access-staff-data` but NOT in
+`cube-access-staff-pii`, run a `/load` query selecting `personal_email` (or any
+of the six gated fields). Expected: a 500 "You requested hidden member" /
+`rlsAccessDenied` — the field is hidden. With a `cube-access-staff-pii` account,
+the same query succeeds. (`/load` enforces hiding; `/sql` does not.)
+
+- [ ] **Step 5: Confirm `staff_summary` is unaffected**
+
+Run a `staff_summary` query grouping by `race` for a
+`cube-access-staff-data`-only account. Expected: succeeds (demographics remain
+aggregate breakdowns there).
+
+---
+
+## Post-implementation
+
+- Open the PR using `.github/pull_request_template.md`; body references
+  `Closes #4236`.
+- **Rollout prerequisite (admin, outside repo):** the `cube-access-staff-pii`
+  Workspace group must be created and members enrolled before/with merge. On
+  merge, any `cube-access-staff-data` user not also in the new group loses the
+  six fields. Coordinate before merging.

--- a/docs/superpowers/specs/2026-06-22-staff-pii-gate-design.md
+++ b/docs/superpowers/specs/2026-06-22-staff-pii-gate-design.md
@@ -1,0 +1,138 @@
+# Staff PII gate on `staff_detail` — design
+
+Issue: [#4236](https://github.com/TEAMSchools/teamster/issues/4236)
+
+## Problem
+
+The `staff_detail` Cube view exposes identifiable, row-level staff data behind a
+single `cube-access-staff-data` access tier. Anyone cleared to see the staff
+roster sees every field, including personal contact details, date of birth, and
+demographics. We need a "see staff but not their personal/sensitive data" tier
+so that those fields are restricted to a smaller, explicitly-provisioned group.
+
+## Goal
+
+Add a `cube-access-staff-pii` sub-tier to `staff_detail`, mirroring the existing
+student two-tier `access_policy` pattern, so six personal/sensitive fields are
+visible only to members of that group.
+
+## Non-goals
+
+- **Small-cell / low-n suppression** of aggregate demographic breakdowns. That
+  is a value-dependent, post-aggregation problem that Cube `access_policy`
+  cannot express, and it spans far more than this view (survey, performance, and
+  compensation breakdowns). Tracked separately in
+  [#4237](https://github.com/TEAMSchools/teamster/issues/4237).
+- **Gating staff-directory info.** Names, `staff_unique_id`, work/Google email,
+  Active Directory username, and manager identifiers stay visible to all
+  `cube-access-staff-data` users. They are already internally visible (Outlook
+  profiles) and seen by no outside party.
+- **`staff_summary`** changes. Its `gender_identity` / `race` / `is_hispanic`
+  are deidentified aggregate breakdowns, not row-level identifiers.
+
+## Gated fields
+
+These six move behind `cube-access-staff-pii` (excluded from
+`cube-access-staff-data`):
+
+| Field                 | Why                     |
+| --------------------- | ----------------------- |
+| `personal_email`      | Personal contact        |
+| `personal_cell_phone` | Personal contact        |
+| `birth_date`          | Date of birth           |
+| `gender_identity`     | Demographic (row-level) |
+| `race`                | Demographic (row-level) |
+| `is_hispanic`         | Demographic (row-level) |
+
+## Approach
+
+Follow the established student two-tier pattern (see
+`student_enrollments_detail.yml`): one `cube-access-staff-data` block with
+`includes: "*"` and an `excludes:` list, plus a `cube-access-staff-pii` block
+with `includes: "*"`. A user in both groups gets the union (full access).
+
+A rejected alternative was splitting `staff_detail` into two separate views (PII
+/ non-PII). That duplicates the entire view definition and diverges from the
+student convention; the two-block policy is simpler and consistent.
+
+### Access-policy behavior
+
+- `cube-access-staff-pii` member → sees all fields.
+- `cube-access-staff-data` member (not PII) → sees all fields except the six.
+- Member of both → union → all fields.
+- The existing `locations` scope filter in `cube.js` `queryRewrite` is unchanged
+  and continues to apply to both tiers.
+
+## Change set
+
+### 1. `src/cube/model/views/staff/staff_detail.yml`
+
+Replace the single `access_policy` block with two:
+
+```yaml
+access_policy:
+  # Non-PII staff tier: roster/employment structure without personal or
+  # sensitive data. Personal contact, DOB, and demographics are gated to
+  # cube-access-staff-pii. Work-directory info (names, work/google email,
+  # AD username, manager contacts) stays visible — already internally public.
+  - group: cube-access-staff-data
+    member_level:
+      includes: "*"
+      excludes:
+        - personal_email
+        - personal_cell_phone
+        - birth_date
+        - gender_identity
+        - race
+        - is_hispanic
+  - group: cube-access-staff-pii
+    member_level:
+      includes: "*"
+```
+
+### 2. `src/cube/model/cubes/staff/staff.yml`
+
+Re-comment the dimensions to reflect the actual tiers. Current comments are
+inconsistent: the demographic dimensions are uncommented, while directory
+identifiers are mislabeled `# PII —`.
+
+| Fields                                                                                                               | New comment                                                                                                  |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `personal_email`, `personal_cell_phone`                                                                              | `# Gated to cube-access-staff-pii — personal contact.`                                                       |
+| `birth_date`                                                                                                         | `# Gated to cube-access-staff-pii — date of birth.`                                                          |
+| `gender_identity`, `race`, `is_hispanic`                                                                             | `# Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.` |
+| `staff_unique_id`, `full_name`, `first_name`, `last_name`, `work_email`, `google_email`, `active_directory_username` | `# Staff-directory identifier — visible to all cube-access-staff-data (internally public).`                  |
+
+`staff_work_history.yml` has no PII comments and needs no change.
+
+### 3. `src/cube/CLAUDE.md`
+
+Update the "Staff views" access-policy note (currently says to add a
+`cube-access-staff-pii` sub-tier "only if a see-staff-but-not-PII need arises")
+to document the now-implemented two-tier pattern, matching how the student
+detail/summary split is described.
+
+### No `cube.js` change
+
+`contextToGroups` resolves a requester's `cube-*` group membership dynamically,
+so the new group name is picked up automatically. PII sub-tiers are enforced
+entirely in view YAML — confirmed that `cube.js` references no PII-tier group in
+code (only a comment).
+
+## Rollout prerequisite
+
+The `cube-access-staff-pii` Google Workspace group must be created and members
+enrolled before or with this deploy. Group membership is direct-only (Admin
+Directory API; no transitive resolution). **On merge, any
+`cube-access-staff-data` user not also in the new group loses the six fields.**
+Group provisioning is an admin task outside this repo and must be coordinated.
+
+## Testing / verification
+
+- Validate the branch in Cube Cloud Dev Mode (Data Model → Dev Mode → add branch
+  by name) — branch staging envs are not auto-created from pushes.
+- Confirm via `/sql` (or `meta` + `load`) that a `cube-access-staff-pii` context
+  resolves all members and a `cube-access-staff-data`-only context excludes the
+  six fields. `/sql` compiles even against hidden members; `/load` enforces
+  hiding, so verify with `load`.
+- Confirm `staff_summary` is unaffected.

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -103,8 +103,9 @@ Views own access via `access_policy:`. Two patterns:
   [#4237](https://github.com/TEAMSchools/teamster/issues/4237)).
 
 When adding a field to a detail view, decide PII status per project CLAUDE.md
-FERPA guidance. If PII, add it to the `excludes` list under the
-`cube-access-student-data` policy block.
+FERPA guidance. If PII, add it to the `excludes` list under the base-tier policy
+block — `cube-access-student-data` for student views, `cube-access-staff-data`
+for `staff_detail`.
 
 ## `cube.js` security model
 

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -90,11 +90,17 @@ Views own access via `access_policy:`. Two patterns:
 - **Summary views** (no direct identifiers, demographic breakdowns only): single
   `cube-access-student-data` block with `includes: "*"`. Add a comment
   explaining why no PII tier is needed.
-- **Staff views** use a single `cube-access-staff-data` block with
-  `includes: "*"` (no PII sub-tier): privacy is enforced by view choice —
-  `staff_summary` exposes aggregates/demographics only, `staff_detail` exposes
-  identifiers. Add a `cube-access-staff-pii` sub-tier only if a
-  see-staff-but-not-PII need arises.
+- **Staff views**: `staff_summary` uses a single `cube-access-staff-data` block
+  with `includes: "*"` — aggregate demographics only, no direct identifiers.
+  `staff_detail` uses two blocks: `cube-access-staff-data` with `includes: "*"`
+  and `excludes:` the personal/sensitive fields (`personal_email`,
+  `personal_cell_phone`, `birth_date`, `gender_identity`, `race`,
+  `is_hispanic`), plus `cube-access-staff-pii` with `includes: "*"`.
+  Work-directory info (names, work/google email, AD username, `staff_unique_id`,
+  manager contacts) stays in the base tier — already internally public.
+  Demographics are gated row-level in `staff_detail` but remain valid aggregate
+  breakdowns in `staff_summary` (low-n suppression tracked separately in
+  [#4237](https://github.com/TEAMSchools/teamster/issues/4237)).
 
 When adding a field to a detail view, decide PII status per project CLAUDE.md
 FERPA guidance. If PII, add it to the `excludes` list under the

--- a/src/cube/model/cubes/staff/staff.yml
+++ b/src/cube/model/cubes/staff/staff.yml
@@ -16,7 +16,7 @@ cubes:
         primary_key: true
         public: true
 
-      # PII — employee identifier.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: staff_unique_id
         description:
           KIPP-assigned unique identifier for all staff members across all
@@ -25,34 +25,35 @@ cubes:
         type: number
         public: true
 
-      # PII — name.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: full_name
         description: Staff member's preferred name in Last, First Middle format.
         sql: full_name
         type: string
         public: true
 
-      # PII — name.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: first_name
         description: Staff member's preferred first name.
         sql: first_name
         type: string
         public: true
 
-      # PII — name.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: last_name
         description: Staff member's preferred last name.
         sql: last_name
         type: string
         public: true
 
-      # PII — date of birth.
+      # Gated to cube-access-staff-pii — date of birth.
       - name: birth_date
         description: Staff member's date of birth.
         sql: CAST(birth_date AS TIMESTAMP)
         type: time
         public: true
 
+      # Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.
       - name: gender_identity
         description: >-
           Staff member's preferred gender identity as reported in the staff
@@ -61,6 +62,7 @@ cubes:
         type: string
         public: true
 
+      # Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.
       - name: race
         description: >-
           Staff member's racial category for reporting purposes, sourced from
@@ -69,6 +71,7 @@ cubes:
         type: string
         public: true
 
+      # Demographic — gated to cube-access-staff-pii in staff_detail; aggregate-only breakdown in staff_summary.
       - name: is_hispanic
         description: >-
           TRUE if the staff member identified as Hispanic/Latino/Latinx in the
@@ -77,28 +80,28 @@ cubes:
         type: boolean
         public: true
 
-      # PII — contact.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: work_email
         description: Staff member's work email address from ADP.
         sql: work_email
         type: string
         public: true
 
-      # PII — contact.
+      # Gated to cube-access-staff-pii — personal contact.
       - name: personal_email
         description: Staff member's personal email address from ADP.
         sql: personal_email
         type: string
         public: true
 
-      # PII — contact.
+      # Gated to cube-access-staff-pii — personal contact.
       - name: personal_cell_phone
         description: Staff member's personal cell phone number from ADP.
         sql: personal_cell_phone
         type: string
         public: true
 
-      # PII — credential/identifier.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: active_directory_username
         description: >-
           Staff member's Active Directory username (lowercased), used as a
@@ -107,7 +110,7 @@ cubes:
         type: string
         public: true
 
-      # PII — contact.
+      # Staff-directory identifier — visible to all cube-access-staff-data (internally public).
       - name: google_email
         description: Staff member's Google Workspace email address from LDAP.
         sql: google_email

--- a/src/cube/model/views/staff/staff_detail.yml
+++ b/src/cube/model/views/staff/staff_detail.yml
@@ -142,9 +142,20 @@ views:
             - staff_manager_work_email
 
     access_policy:
-      # Single staff-data tier. The detail view is for users cleared to see
-      # identifiable staff; staff_summary is the non-PII surface. Revisit if a
-      # "see staff but not PII" sub-tier is needed later.
+      # Non-PII staff tier: roster/employment structure without personal or
+      # sensitive data. Personal contact, DOB, and demographics are gated to
+      # cube-access-staff-pii. Work-directory info (names, work/google email,
+      # AD username, manager contacts) stays visible — already internally public.
       - group: cube-access-staff-data
+        member_level:
+          includes: "*"
+          excludes:
+            - personal_email
+            - personal_cell_phone
+            - birth_date
+            - gender_identity
+            - race
+            - is_hispanic
+      - group: cube-access-staff-pii
         member_level:
           includes: "*"


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request gates six personal/sensitive staff fields in the `staff_detail` Cube view behind a new `cube-access-staff-pii` group, mirroring the existing student two-tier `access_policy` pattern. Users with `cube-access-staff-data` but **not** `cube-access-staff-pii` lose access to: `personal_email`, `personal_cell_phone`, `birth_date`, `gender_identity`, `race`, `is_hispanic`.

Work-directory info (names, work/Google email, AD username, `staff_unique_id`, manager contacts) stays in the base tier — already internally visible (Outlook profiles).

Also re-comments the backing `staff` cube dimensions to reflect the real tiers (the prior comments were inconsistent — demographics were uncommented, directory identifiers were mislabeled as PII), and updates the cube `CLAUDE.md` note.

No `cube.js` change: group membership resolves dynamically via `contextToGroups`, and PII tiers are enforced entirely in view YAML. Verified locally that a `cube-access-staff-data`-only context cannot read the six fields while a `cube-access-staff-pii` context can.

Closes #4236. Small-cell / low-n suppression of aggregate demographic breakdowns is tracked separately in #4237.

**Rollout prerequisite (admin, outside this repo):** the `cube-access-staff-pii` Google Workspace group must be created and members enrolled before/with merge. Group membership is direct-only. On merge, any `cube-access-staff-data` user not also in the new group loses the six fields. Coordinate before merging.

## AI Assistance

AI-assisted (Claude Code): brainstormed the design, wrote the spec and implementation plan, and made the edits. Human-directed: the exact gated-field list, the decision to keep work-directory info open, the hard-fail (vs. silent-strip) behavior on gated columns, and the scope split that moved small-cell suppression to #4237.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

_Dagster, dbt, and Docs (schedule/sensor) sections: not applicable — this PR changes only Cube YAML and markdown._

## CI checks

- [x] **Trunk** — passes locally (`trunk check` clean on all changed files).
- [ ] **dbt Cloud** — not applicable (no dbt changes).
- [ ] **Dagster Cloud** — not applicable (no Dagster path changes).