### PR TITLE
docs: correct Focus custom-field catalog facts (CLAUDE.md + batch-B plan)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-focus-staging-b-enrollment.md
+++ b/docs/superpowers/plans/2026-06-18-focus-staging-b-enrollment.md
@@ -1020,24 +1020,25 @@ non-custom core to: the keys (`id`, `school_id`, `student_id`, `grade_id`,
 **Populated custom fields (inline block):** the five `custom_*` columns that are
 populated in the current Miami pull, per
 `.claude/scratch/focus-student_enrollment-custom-map.md`. Each is projected
-`<raw> as <slug>` after the core, before any cast block. None resolved to a
-catalog title, so every one uses its raw `custom_N` name as the slug and the
-generic-slot fallback description. The other 15 `custom_*` columns are
-unpopulated and OUT OF SCOPE. All five are `STRING` and stored as-is (no
-decoding).
+`<raw> as <slug>` after the core, before any cast block. All five resolve to a
+catalog title under source*class `StudentEnrollment` (join on
+`lower(column_name)` — see `src/dbt/focus/CLAUDE.md`), so each is aliased to the
+slugified title. The other 15
+`custom*\*`columns are unpopulated and OUT OF SCOPE. All five are`STRING`; values are encoded `select`
+option codes left as-is (decode deferred to Wave 2).
 
 **Populated-custom map (verbatim from the scratch map file):**
 
-| raw column | slug       | bq_type | focus_type | populated_rows | title  |
-| ---------- | ---------- | ------- | ---------- | -------------- | ------ |
-| `custom_1` | `custom_1` | STRING  | None       | 1276           | (none) |
-| `custom_2` | `custom_2` | STRING  | None       | 1276           | (none) |
-| `custom_3` | `custom_3` | STRING  | None       | 1276           | (none) |
-| `custom_6` | `custom_6` | STRING  | None       | 1276           | (none) |
-| `custom_4` | `custom_4` | STRING  | None       | 158            | (none) |
+| raw column | slug                        | bq_type | focus_type | populated_rows | title                     |
+| ---------- | --------------------------- | ------- | ---------- | -------------- | ------------------------- |
+| `custom_1` | `prior_district`            | STRING  | select     | 1276           | Prior District            |
+| `custom_2` | `prior_state`               | STRING  | select     | 1276           | Prior State               |
+| `custom_3` | `prior_country`             | STRING  | select     | 1276           | Prior Country             |
+| `custom_6` | `student_offender_transfer` | STRING  | select     | 1276           | Student Offender Transfer |
+| `custom_4` | `educational_choice`        | STRING  | select     | 158            | Educational Choice        |
 
-Because slug equals the raw column name for all five, these are projected as
-plain `custom_N` (no `as` alias) — a self-alias would trip sqlfluff AL09.
+Each slug differs from its raw `custom_N` name, so each is projected with an
+explicit `as <slug>` alias (no AL09 self-alias concern).
 
 **Files:**
 
@@ -1054,8 +1055,7 @@ plain `custom_N` (no `as` alias) — a self-alias would trip sqlfluff AL09.
 - [ ] **Step 1: Write the model SQL**
 
 ST06 — the curated core (plain refs) first, then the populated-custom block
-(plain refs; slug equals raw name so no `as` alias), then audit columns. No
-casts are used.
+(each aliased `<raw> as <slug>`), then audit columns. No casts are used.
 
 ```sql
 select
@@ -1087,11 +1087,11 @@ select
     fl_days_present,
     fl_days_absent,
     fl_days_absent_not_disc,
-    custom_1,
-    custom_2,
-    custom_3,
-    custom_4,
-    custom_6,
+    custom_1 as prior_district,
+    custom_2 as prior_state,
+    custom_3 as prior_country,
+    custom_4 as educational_choice,
+    custom_6 as student_offender_transfer,
     uuid,
     created_at,
     updated_at,
@@ -1106,11 +1106,12 @@ models:
     description: >-
       Focus student enrollment spans — one row per enrollment record (a student
       at a school for a date range in a school year). Carries the curated core
-      (keys, dates, FLDOE day counts) plus every populated Focus custom field.
-      The populated customs (custom_1 through custom_6) have no catalog label
-      and are passed through as stored codes — select / multiple custom values
-      remain encoded, and code-to-label decoding is a deferred follow-up.
-      Unpopulated custom fields are out of scope for this batch.
+      (keys, dates, FLDOE day counts) plus every populated Focus custom field,
+      each aliased to its catalog title (prior_district, prior_state,
+      prior_country, educational_choice, student_offender_transfer). Those are
+      select-type custom values stored as encoded option codes — code-to-label
+      decoding is a deferred follow-up. Unpopulated custom fields are out of
+      scope for this batch.
     columns:
       - name: id
         description: Primary key — Focus student enrollment id.
@@ -1207,30 +1208,30 @@ models:
       - name: fl_days_absent_not_disc
         description: FLDOE days absent not disciplinary.
         data_type: numeric
-      - name: custom_1
+      - name: prior_district
         description: >-
-          Focus generic custom slot; label not defined in the extracted
-          custom_fields catalog.
+          Prior district — Focus custom field. Stored as an encoded select
+          option code (decode deferred).
         data_type: string
-      - name: custom_2
+      - name: prior_state
         description: >-
-          Focus generic custom slot; label not defined in the extracted
-          custom_fields catalog.
+          Prior state — Focus custom field. Stored as an encoded select option
+          code (decode deferred).
         data_type: string
-      - name: custom_3
+      - name: prior_country
         description: >-
-          Focus generic custom slot; label not defined in the extracted
-          custom_fields catalog.
+          Prior country — Focus custom field. Stored as an encoded select option
+          code (decode deferred).
         data_type: string
-      - name: custom_4
+      - name: educational_choice
         description: >-
-          Focus generic custom slot; label not defined in the extracted
-          custom_fields catalog.
+          Educational choice — Focus custom field. Stored as an encoded select
+          option code (decode deferred).
         data_type: string
-      - name: custom_6
+      - name: student_offender_transfer
         description: >-
-          Focus generic custom slot; label not defined in the extracted
-          custom_fields catalog.
+          Student offender transfer — Focus custom field. Stored as an encoded
+          select option code (decode deferred).
         data_type: string
       - name: uuid
         description: Focus global unique identifier for the row.

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -20,14 +20,28 @@ value crosswalks.
 
 **Custom-field storage.** Values live inline on the entity table's wide
 `custom_NNN` columns (e.g. `students.custom_100000105`), NOT in `custom_fields`
-— that is the _definition_ catalog. Join definition→entity column by
-`custom_fields.column_name` + `source_class` (`SISStudent`→students,
-`FocusUser`→users, `SISSchool`→schools). `title` is the readable name;
-`select`/`multiple` values are codes (decode via the crosswalk above);
-`log`-type values live in `custom_field_log_entries`; `computed`/`holder` are
-not stored. `course_periods`/`master_courses`/`student_enrollment` use generic
-positional `custom_N` / `custom_field_N` slots that are NOT in `custom_fields`
-(labels live in Focus config, not extracted).
+— that is the _definition_ catalog. Join definition→entity column on
+`custom_fields.column_name` + `source_class`. `title` is the readable name (slug
+it for the staging alias); `select`/`multiple` values are codes (decode via the
+crosswalk above); `log`-type values live in `custom_field_log_entries`;
+`computed`/`holder` are not stored.
+
+`source_class`→entity-table map (use the catalog's own spelling, NOT the
+entity's): `SISStudent`→students, `FocusUser`→users, `SISSchool`→schools,
+`StudentEnrollment`→student_enrollment, `CoursePeriod`→course_periods,
+`CourseCatalog`→master_courses, `Course`→courses.
+
+**Two join gotchas, each silently returns zero matches.** (1) `column_name` is
+UPPERCASE in the catalog (`CUSTOM_FIELD_3`, `CUSTOM_2`) but lowercase on the
+entity table (`custom_field_3`) — join on `lower(column_name)`. (2) Use the
+catalog `source_class` spelling — e.g. enrollment fields are under
+`StudentEnrollment`, not `SISStudentEnrollment`. With both handled, the
+`course_periods`, `master_courses`, `courses`, and `student_enrollment`
+positional `custom_N` / `custom_field_N` slots DO resolve to catalog titles
+(e.g. `master_courses.custom_field_3` = "Core for Class Size",
+`course_periods.custom_4` = "Scheduling Method"). Genuinely unlabeled (no
+catalog row): `course_subjects` (no `CourseSubject` class) and
+`master_courses.custom_field_11`.
 
 ## Source data conventions
 
@@ -47,14 +61,20 @@ students→`student_id`, users→`profile_id`).
 ```text
 models/
   staging/
-    sources-bigquery.yml   # BQ-native sources (dlt-loaded, not external tables)
+    sources-bigquery.yml          # BQ-native sources (dlt-loaded, not external)
+    stg_focus__<table>.sql        # one contract-enforced model per source table
+    properties/
+      stg_focus__<table>.yml      # contract columns, tests, descriptions
 ```
 
-Staging/intermediate SQL models are not yet implemented — only the source
-definitions exist. When added, staging models will be contract-enforced
-(`contract: enforced: true`, set at directory level in `dbt_project.yml`). Data
+Staging models are contract-enforced (`contract: enforced: true`, set at the
+`staging` directory level in `dbt_project.yml`): every projected column is
+declared with a `data_type` in `properties/`, with a `unique` + `not_null` PK
+test at `severity: error`. Each model selects from a
+`{{ source("focus", ...) }}` relation, drops dlt bookkeeping (`_dlt_*`) and the
+audit-quad, and applies the soft-delete filter where the table has one. Data
 comes from dlt (not external tables), so sources use `sources-bigquery.yml` with
-a plain schema var.
+a plain schema var. Intermediate (`int_focus__*`) models layer on top.
 
 ## Key Variables
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this corrects Focus custom-field documentation that was factually wrong, surfaced while reviewing the Phase B staging PRs. Two files:

**1. `src/dbt/focus/CLAUDE.md`**

- The custom-field note claimed `course_periods` / `master_courses` / `student_enrollment` positional `custom_N` / `custom_field_N` slots "are NOT in `custom_fields` (labels live in Focus config, not extracted)." They **are** catalogued — verified against `dagster_kippmiami_dlt_focus.custom_fields` (`CourseCatalog` 48 fields, `CoursePeriod` 57, `StudentEnrollment` 24, `Course` 5, `SISSchool`/`SISDistrict`, all titled). The maps missed them on two join bugs the note now documents: catalog `column_name` is UPPERCASE vs lowercase on the entity table (join on `lower(column_name)`), and catalog `source_class` differs from the entity class (`StudentEnrollment`, not `SISStudentEnrollment`). Added the full `source_class`→table map and the genuinely-unlabeled exceptions.
- "Model Structure" was stale ("staging not yet implemented") — updated to the `stg_focus__*` + `properties/` layout and conventions.

**2. `docs/superpowers/plans/2026-06-18-focus-staging-b-enrollment.md`**

- The batch-B plan baked the same defect for `student_enrollment` — self-aliased `custom_1..6` with "no catalog label" descriptions. All five **do** resolve under `StudentEnrollment`: `custom_1`→prior_district, `custom_2`→prior_state, `custom_3`→prior_country, `custom_4`→educational_choice, `custom_6`→student_offender_transfer. Corrected the map table, SQL aliases, model description, and column entries so the batch-B build (not yet started) ships descriptive aliases. (`schools` was already correct; `districts` has no populated custom columns.)

Docs-only; safe to merge anytime. Refs #4213.

### AI Assistance

AI-authored under human direction; every catalog claim verified against the warehouse via BigQuery.

## CI checks

- [ ] **Trunk** — passes (markdownlint checked locally on both files, no issues)
