### PR TITLE
docs(claude): capture Workflow-orchestrator reliability + run-hygiene gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,25 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   partway through. Scope dispatches to one file / one commit; inspect the file
   diff and `git log` before marking complete — don't trust the self-report.
 
+- **The `Workflow`-tool orchestrator is unreliable for long fan-outs in this
+  Codespace** — it stalled/died mid-run repeatedly (not OOM; 11Gi free), and a
+  window reload left a prior run orphaned-but-alive that kept spawning
+  branches/worktrees and collided with the relaunch. Prefer discrete main-loop
+  `Agent` dispatches for multi-batch work (one unit lost on failure, resumable);
+  if you must run a Workflow, after any reload/relaunch check for and kill a
+  leftover prior run BEFORE relaunching.
+
+- **Workflow run hygiene**: a dead run = its journal
+  (`~/.claude/projects/<proj>/subagents/workflows/wf_<id>/journal.jsonl`) stops
+  growing for ~2min with no live `dbt`/agent procs. Its `isolation:'worktree'`
+  dirs are `.claude/worktrees/wf_<id>-N` (NOT the repo `.worktrees/`; left
+  `locked` when orphaned — `git worktree unlock` then `remove --force`).
+  `TaskStop` only sees tasks launched in the CURRENT session — a Workflow from a
+  prior (reloaded) session isn't in the registry; clean it at the
+  process/worktree level. Concurrency cap = `min(16, cpu_cores-2)` (4-core
+  Codespace → 2; raising it needs a larger machine, whose restart kills
+  in-flight runs).
+
 - **Git resuming**: Before resuming work on an existing branch, merge `main`:
   `git fetch origin main && git merge origin/main`.
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this adds two bullets to the root `CLAUDE.md` (Working Conventions) capturing hard-won lessons from a Phase B fan-out session where the `Workflow` tool's orchestrator repeatedly stalled/died and a reload-orphaned run collided with a relaunch:

- **Orchestration choice**: the long-lived Workflow orchestrator is unreliable for long fan-outs in this Codespace (stalled/died mid-run with no OOM; a reload left a prior run orphaned-but-alive that spawned colliding branches/worktrees). Prefer discrete main-loop `Agent` dispatches for multi-batch work; if running a Workflow, check for and kill a leftover prior run after any reload before relaunching.
- **Run hygiene**: how to detect a dead run (journal stops growing + no live procs), where its worktrees live (`.claude/worktrees/wf_<id>-N`, locked when orphaned), that `TaskStop` can't see a prior-session Workflow, and the `min(16, cpu_cores-2)` concurrency cap.

Docs-only; safe to merge anytime.

### AI Assistance

AI-authored under human direction, distilled from the session that produced the Focus Phase B staging PRs.

## CI checks

- [ ] **Trunk** — passes (markdownlint checked locally, no issues)
