### PR TITLE
ci(kippmiami): add src/dbt/focus to deploy push-paths

### DIFF
--- a/.github/workflows/deploy-prod-kippmiami.yaml
+++ b/.github/workflows/deploy-prod-kippmiami.yaml
@@ -17,6 +17,7 @@ on:
       - uv.lock
       - src/dbt/deanslist/**
       - src/dbt/finalsite/**
+      - src/dbt/focus/**
       - src/dbt/iready/**
       - src/dbt/kippmiami/**
       - src/dbt/powerschool/**


### PR DESCRIPTION
## Summary & Motivation

When merged, this adds `src/dbt/focus/**` to the `deploy-prod-kippmiami` push-paths. `kippmiami` imports the `focus` dbt package (`src/dbt/kippmiami/packages.yml`), but the deploy workflow did not watch `src/dbt/focus/**` — so the Focus Phase B staging merges (#4244–#4248) changed only `src/dbt/focus/models/staging/**` and **never triggered a kippmiami redeploy**. Dagster's kippmiami location is stranded on `51c65c9f` (6/19); the 35 new `stg_focus__*` assets aren't deployed.

This is the push-paths drift documented in `.github/CLAUDE.md`. Merging this PR is itself the fix-and-trigger: the workflow file is in its own push-paths, so the merge fires a kippmiami deploy that builds from current `main` (all focus models present) → the location reloads → the new assets register and auto-materialize.

Refs #4213.

### AI Assistance

AI-authored under human direction; root cause confirmed against `packages.yml`, the workflow paths, and Dagster's location load history.

## CI checks

- [ ] **Trunk** — passes (actionlint/yamllint checked locally, no issues)
