### PR TITLE
feat(dbt): add _dbt_source_project to kipptaf models and replace union_dataset_join_clause

### DIFF
--- a/src/dbt/kipptaf/macros/utils.sql
+++ b/src/dbt/kipptaf/macros/utils.sql
@@ -5,3 +5,7 @@
 {% macro union_dataset_join_clause(left_alias, right_alias) %}
     {{ extract_code_location(left_alias) }} = {{ extract_code_location(right_alias) }}
 {% endmacro %}
+
+{% macro extract_region(table) %}
+    initcap(regexp_extract({{ table }}._dbt_source_project, r'kipp(\w+)'))
+{% endmacro %}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
@@ -17,6 +17,5 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
 select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
@@ -18,6 +18,5 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04)
-select
-    ur.*, regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
@@ -1,9 +1,23 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", "int_deanslist__roster_assignments"),
-            source("kippcamden_deanslist", "int_deanslist__roster_assignments"),
-            source("kippmiami_deanslist", "int_deanslist__roster_assignments"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_deanslist", "int_deanslist__roster_assignments"
+                    ),
+                    source(
+                        "kippcamden_deanslist", "int_deanslist__roster_assignments"
+                    ),
+                    source(
+                        "kippmiami_deanslist", "int_deanslist__roster_assignments"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04)
+select
+    ur.*, regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -174,7 +174,7 @@ with
 
     tardies_weekly as (
         select
-            _dbt_source_project
+            _dbt_source_project,
             student_number,
             academic_year,
             week_number_academic_year,
@@ -409,6 +409,7 @@ select
             order by dli.is_suspension desc
         )
     ) as rn_incident,
+
 from {{ ref("int_extracts__student_enrollments_weeks") }} as co
 left join
     {{ ref("int_deanslist__incidents__penalties") }} as dli

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -135,7 +135,7 @@ with
             and co.academic_year = dli.create_ts_academic_year
             and extract(date from dli.create_ts_date)
             between co.week_start_monday and co.week_end_sunday
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="dli") }}
+            and co._dbt_source_project = dli._dbt_source_project
         group by co.student_number, co.academic_year, co.schoolid
     ),
 
@@ -165,7 +165,7 @@ with
         -- model; every column is functionally determined by the partition key,
         -- not a mask for upstream duplicates
         select distinct
-            _dbt_source_relation,
+            _dbt_source_project,
             student_number,
             academic_year,
             week_number_academic_year,
@@ -209,7 +209,7 @@ with
             on sw.student_number = tw.student_number
             and sw.academic_year = tw.academic_year
             and sw.week_number_academic_year = tw.week_number_academic_year
-            and {{ union_dataset_join_clause(left_alias="sw", right_alias="tw") }}
+            and sw._dbt_source_project = tw._dbt_source_project
     )
 
 select

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -174,7 +174,7 @@ with
 
     tardies_weekly as (
         select
-            _dbt_source_relation,
+            _dbt_source_project
             student_number,
             academic_year,
             week_number_academic_year,
@@ -182,7 +182,7 @@ with
             sum(is_tardy) as n_tardies_week,
         from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }}
         group by
-            _dbt_source_relation,
+            _dbt_source_project,
             student_number,
             academic_year,
             week_number_academic_year
@@ -190,20 +190,18 @@ with
 
     tardies_ytd as (
         select
-            sw._dbt_source_relation,
+            sw._dbt_source_project,
             sw.student_number,
             sw.academic_year,
             sw.week_number_academic_year,
 
             sum(coalesce(tw.n_tardies_week, 0)) over (
-                partition by
-                    sw._dbt_source_relation, sw.student_number, sw.academic_year
+                partition by sw._dbt_source_project, sw.student_number, sw.academic_year
                 order by sw.week_number_academic_year
             ) as total_tardies_ytd,
 
             sum(coalesce(tw.n_tardies_week, 0)) over (
-                partition by
-                    sw._dbt_source_relation, sw.student_number, sw.academic_year
+                partition by sw._dbt_source_project, sw.student_number, sw.academic_year
             ) as total_tardies,
         from student_weeks as sw
         left join
@@ -427,7 +425,7 @@ left join
     on co.studentid = gpa.studentid
     and co.yearid = gpa.yearid
     and gpa.is_current
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
 left join
     {{ ref("int_deanslist__roster_assignments") }} as tr
     on co.student_number = tr.student_school_id
@@ -462,5 +460,5 @@ left join
     on co.student_number = tar.student_number
     and co.academic_year = tar.academic_year
     and co.week_number_academic_year = tar.week_number_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="tar") }}
+    and co._dbt_source_project = tar._dbt_source_project
 where co.academic_year >= {{ var("current_academic_year") - 1 }}

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -418,7 +418,7 @@ left join
     and co.academic_year = dli.create_ts_academic_year
     and extract(date from dli.create_ts_date)
     between co.week_start_monday and co.week_end_sunday
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="dli") }}
+    and co._dbt_source_project = dli._dbt_source_project
 left join
     ssds_period as s
     on dli.create_ts_date between s.period_start_date and s.period_end_date

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fte_pivot.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fte_pivot.sql
@@ -1,5 +1,11 @@
-{{
-    dbt_utils.union_relations(
-        relations=[source("kippmiami_fldoe", "int_fldoe__fte_pivot")]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[source("kippmiami_fldoe", "int_fldoe__fte_pivot")]
+            )
+        }}
     )
-}}
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_school_calendars.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_school_calendars.sql
@@ -9,6 +9,6 @@ from {{ ref("stg_powerschool__calendar_day") }} as cd
 inner join
     {{ ref("stg_powerschool__schools") }} as sch
     on cd.schoolid = sch.school_number
-    and {{ union_dataset_join_clause(left_alias="cd", right_alias="sch") }}
+    and cd._dbt_source_project = sch._dbt_source_project
     and sch.location_key is not null
 where cd.date_value is not null

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_assignments.sql
@@ -1,7 +1,6 @@
 with
     course_enrollments as (
         select
-            _dbt_source_relation,
             _dbt_source_project,
             cc_studentid,
             cc_academic_year,
@@ -19,7 +18,6 @@ with
 
     student_enrollments as (
         select
-            _dbt_source_relation,
             _dbt_source_project,
             studentid,
             schoolid,
@@ -100,7 +98,7 @@ inner join
     and asg.students_dcid = ce.students_dcid
     and asg.duedate >= ce.cc_dateenrolled
     and asg.duedate < ce.cc_dateleft
-    and {{ union_dataset_join_clause(left_alias="asg", right_alias="ce") }}
+    and asg._dbt_source_project = ce._dbt_source_project
 -- retained as a row-population filter (assignment must fall within a covering
 -- school enrollment); enrollment linkage now flows via
 -- student_section_enrollment_key -> dim_student_section_enrollments

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_category.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_category.sql
@@ -1,7 +1,6 @@
 with
     course_enrollments as (
         select
-            _dbt_source_relation,
             _dbt_source_project,
             cc_studentid,
             cc_abs_sectionid,
@@ -78,7 +77,7 @@ inner join
     on cg.studentid = ce.cc_studentid
     and cg.sectionid = ce.cc_abs_sectionid
     and cg.yearid = ce.cc_yearid
-    and {{ union_dataset_join_clause(left_alias="cg", right_alias="ce") }}
+    and cg._dbt_source_project = ce._dbt_source_project
 left join
     reporting_terms as rt
     on cg.storecode = rt.name

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_gpa.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_gpa.sql
@@ -1,7 +1,6 @@
 with
     student_enrollments as (
         select
-            _dbt_source_relation,
             _dbt_source_project,
             studentid,
             schoolid,
@@ -29,7 +28,7 @@ with
 
     gpa_term as (
         select
-            gt._dbt_source_relation,
+            gt._dbt_source_project,
             gt.studentid,
             gt.schoolid,
             gt.yearid,
@@ -52,10 +51,8 @@ with
             gc.earned_credits_cum,
             gc.potential_credits_cum,
 
-            initcap(regexp_extract(gt._dbt_source_relation, r'kipp(\w+)_')) as region,
-
             row_number() over (
-                partition by gt._dbt_source_relation, gt.studentid, gt.schoolid
+                partition by gt._dbt_source_project, gt.studentid, gt.schoolid
                 order by
                     gt.yearid desc,
                     case
@@ -71,12 +68,13 @@ with
                         else 0
                     end desc
             ) as rn_current,
+
         from {{ ref("int_powerschool__gpa_term") }} as gt
         left join
             {{ ref("int_powerschool__gpa_cumulative") }} as gc
             on gt.studentid = gc.studentid
             and gt.schoolid = gc.schoolid
-            and {{ union_dataset_join_clause(left_alias="gt", right_alias="gc") }}
+            and gt._dbt_source_project = gc._dbt_source_project
     )
 
 select
@@ -148,7 +146,7 @@ inner join
     on gt.studentid = enr.studentid
     and gt.schoolid = enr.schoolid
     and gt.yearid = enr.yearid
-    and {{ union_dataset_join_clause(left_alias="gt", right_alias="enr") }}
+    and gt._dbt_source_project = enr._dbt_source_project
 left join
     reporting_terms as rt
     on gt.term_name = rt.`name`

--- a/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
@@ -31,7 +31,6 @@ with
             )
     )
 
--- trunk-ignore(sqlfluff/AM04)
 select
     ur.*,
 

--- a/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
@@ -39,7 +39,7 @@ select
     c.second_choice_school,
     c.third_choice_school,
 
-    regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("ur") }} as _dbt_source_project,
 
 from union_relations as ur
 left join choices_pivot as c on ur.id = c.student__id

--- a/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
@@ -32,6 +32,14 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04)
-select ur.*, c.first_choice_school, c.second_choice_school, c.third_choice_school,
+select
+    ur.*,
+
+    c.first_choice_school,
+    c.second_choice_school,
+    c.third_choice_school,
+
+    regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+
 from union_relations as ur
 left join choices_pivot as c on ur.id = c.student__id

--- a/src/dbt/kipptaf/models/overgrad/intermediate/properties/int_overgrad__students.yml
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/properties/int_overgrad__students.yml
@@ -6,7 +6,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - _dbt_source_relation
+              - _dbt_source_project
               - id
           config:
             severity: error

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -24,9 +24,14 @@ with
         }}
     ),
 
+    add_dbt_field as (
+        select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+        from union_relations as ur
+    ),
+
     course_joins as (
         select
-            ur.* except (courses_credittype),
+            a.* except (courses_credittype),
 
             cx.ap_course_subject,
             cx.block_schedule_session,
@@ -47,29 +52,27 @@ with
             cx.school_code_override,
             cx.sla_include_tf,
 
-            initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
-
-            {{ extract_code_location("ur") }} as _dbt_source_project,
+            initcap(regexp_extract(a._dbt_source_relation, r'kipp(\w+)_')) as region,
 
             case
-                when ur.courses_credittype in ('ENG', 'ELA')
+                when a.courses_credittype in ('ENG', 'ELA')
                 then 'ENG'
-                when ur.courses_credittype in ('MATH', 'Math')
+                when a.courses_credittype in ('MATH', 'Math')
                 then 'MATH'
-                when ur.courses_credittype in ('SCI', 'Science')
+                when a.courses_credittype in ('SCI', 'Science')
                 then 'SCI'
-                when ur.courses_credittype in ('HR', 'Homeroom')
+                when a.courses_credittype in ('HR', 'Homeroom')
                 then 'HR'
-                else ur.courses_credittype
+                else a.courses_credittype
             end as courses_credittype,
 
             if(cx.ap_course_subject is not null, true, false) as is_ap_course,
 
-        from union_relations as ur
+        from add_dbt_field as a
         left join
             {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
-            on ur.courses_dcid = cx.coursesdcid
-            and {{ extract_code_location("ur") }} = cx._dbt_source_project
+            on a.courses_dcid = cx.coursesdcid
+            and a._dbt_source_project = cx._dbt_source_project
 
     )
 

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -52,7 +52,7 @@ with
             cx.school_code_override,
             cx.sla_include_tf,
 
-            initcap(regexp_extract(a._dbt_source_relation, r'kipp(\w+)_')) as region,
+            {{ extract_region("a") }} as region,
 
             case
                 when a.courses_credittype in ('ENG', 'ELA')

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -83,7 +83,7 @@ from union_relations as ur
 left join
     {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
     on ur.courses_dcid = cx.coursesdcid
-    and {{ union_dataset_join_clause(left_alias="ur", right_alias="cx") }}
+    and {{ extract_code_location("ur") }} = cx._dbt_source_project
 left join
     {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
     on ur.cc_course_number = csc.powerschool_course_number

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -53,7 +53,7 @@ select
 
     -- materialized region-prefix discriminator for downstream surrogate-key
     -- composition; replaces per-consumer extract_code_location() per #3142
-    regexp_extract(ur._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("ur") }} as _dbt_source_project,
 
     initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
 

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -73,7 +73,6 @@ with
             {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
             on a.courses_dcid = cx.coursesdcid
             and a._dbt_source_project = cx._dbt_source_project
-
     )
 
 select

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -22,68 +22,74 @@ with
                 ]
             )
         }}
+    ),
+
+    course_joins as (
+        select
+            ur.* except (courses_credittype),
+
+            cx.ap_course_subject,
+            cx.block_schedule_session,
+            cx.county_code_override,
+            cx.course_level,
+            cx.course_sequence_code,
+            cx.course_span,
+            cx.course_type,
+            cx.cte_test_name_code,
+            cx.ctecollegecredits as cte_college_credits,
+            cx.ctetestdevelopercode as cte_test_developer_code,
+            cx.ctetestname as cte_test_name,
+            cx.district_code_override,
+            cx.dual_institution,
+            cx.exclude_course_submission_tf,
+            cx.nces_course_id,
+            cx.nces_subject_area,
+            cx.school_code_override,
+            cx.sla_include_tf,
+
+            initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
+
+            {{ extract_code_location("ur") }} as _dbt_source_project,
+
+            case
+                when ur.courses_credittype in ('ENG', 'ELA')
+                then 'ENG'
+                when ur.courses_credittype in ('MATH', 'Math')
+                then 'MATH'
+                when ur.courses_credittype in ('SCI', 'Science')
+                then 'SCI'
+                when ur.courses_credittype in ('HR', 'Homeroom')
+                then 'HR'
+                else ur.courses_credittype
+            end as courses_credittype,
+
+            if(cx.ap_course_subject is not null, true, false) as is_ap_course,
+
+        from union_relations as ur
+        left join
+            {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
+            on ur.courses_dcid = cx.coursesdcid
+            and {{ extract_code_location("ur") }} = cx._dbt_source_project
+
     )
 
 select
-    ur.* except (courses_credittype),
-
-    cx.ap_course_subject,
-    cx.block_schedule_session,
-    cx.county_code_override,
-    cx.course_level,
-    cx.course_sequence_code,
-    cx.course_span,
-    cx.course_type,
-    cx.cte_test_name_code,
-    cx.ctecollegecredits as cte_college_credits,
-    cx.ctetestdevelopercode as cte_test_developer_code,
-    cx.ctetestname as cte_test_name,
-    cx.district_code_override,
-    cx.dual_institution,
-    cx.exclude_course_submission_tf,
-    cx.nces_course_id,
-    cx.nces_subject_area,
-    cx.school_code_override,
-    cx.sla_include_tf,
+    cj.*,
 
     csc.illuminate_subject_area,
     csc.is_foundations,
     csc.is_advanced_math,
     csc.discipline,
 
-    -- materialized region-prefix discriminator for downstream surrogate-key
-    -- composition; replaces per-consumer extract_code_location() per #3142
-    {{ extract_code_location("ur") }} as _dbt_source_project,
-
-    initcap(regexp_extract(ur._dbt_source_relation, r'kipp(\w+)_')) as region,
-
-    if(cx.ap_course_subject is not null, true, false) as is_ap_course,
-
-    case
-        when ur.courses_credittype in ('ENG', 'ELA')
-        then 'ENG'
-        when ur.courses_credittype in ('MATH', 'Math')
-        then 'MATH'
-        when ur.courses_credittype in ('SCI', 'Science')
-        then 'SCI'
-        when ur.courses_credittype in ('HR', 'Homeroom')
-        then 'HR'
-        else ur.courses_credittype
-    end as courses_credittype,
-
     if(csc.discipline = 'SOC', 'Civics', csc.discipline) as standardized_discipline,
 
     row_number() over (
         partition by
-            ur._dbt_source_relation, ur.cc_studyear, csc.illuminate_subject_area
-        order by ur.cc_termid desc, ur.cc_dateenrolled desc, ur.cc_dateleft desc
+            cj._dbt_source_relation, cj.cc_studyear, csc.illuminate_subject_area
+        order by cj.cc_termid desc, cj.cc_dateenrolled desc, cj.cc_dateleft desc
     ) as rn_student_year_illuminate_subject_desc,
 
-from union_relations as ur
-left join
-    {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
-    on ur.courses_dcid = cx.coursesdcid
-    and {{ extract_code_location("ur") }} = cx._dbt_source_project
+from course_joins as cj
 left join
     {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
-    on ur.cc_course_number = csc.powerschool_course_number
+    on cj.cc_course_number = csc.powerschool_course_number

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -27,71 +27,63 @@ with
     add_dbt_field as (
         select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
         from union_relations as ur
-    ),
-
-    course_joins as (
-        select
-            a.* except (courses_credittype),
-
-            cx.ap_course_subject,
-            cx.block_schedule_session,
-            cx.county_code_override,
-            cx.course_level,
-            cx.course_sequence_code,
-            cx.course_span,
-            cx.course_type,
-            cx.cte_test_name_code,
-            cx.ctecollegecredits as cte_college_credits,
-            cx.ctetestdevelopercode as cte_test_developer_code,
-            cx.ctetestname as cte_test_name,
-            cx.district_code_override,
-            cx.dual_institution,
-            cx.exclude_course_submission_tf,
-            cx.nces_course_id,
-            cx.nces_subject_area,
-            cx.school_code_override,
-            cx.sla_include_tf,
-
-            {{ extract_region("a") }} as region,
-
-            case
-                when a.courses_credittype in ('ENG', 'ELA')
-                then 'ENG'
-                when a.courses_credittype in ('MATH', 'Math')
-                then 'MATH'
-                when a.courses_credittype in ('SCI', 'Science')
-                then 'SCI'
-                when a.courses_credittype in ('HR', 'Homeroom')
-                then 'HR'
-                else a.courses_credittype
-            end as courses_credittype,
-
-            if(cx.ap_course_subject is not null, true, false) as is_ap_course,
-
-        from add_dbt_field as a
-        left join
-            {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
-            on a.courses_dcid = cx.coursesdcid
-            and a._dbt_source_project = cx._dbt_source_project
     )
 
 select
-    cj.*,
+    a.* except (courses_credittype),
+
+    cx.ap_course_subject,
+    cx.block_schedule_session,
+    cx.county_code_override,
+    cx.course_level,
+    cx.course_sequence_code,
+    cx.course_span,
+    cx.course_type,
+    cx.cte_test_name_code,
+    cx.ctecollegecredits as cte_college_credits,
+    cx.ctetestdevelopercode as cte_test_developer_code,
+    cx.ctetestname as cte_test_name,
+    cx.district_code_override,
+    cx.dual_institution,
+    cx.exclude_course_submission_tf,
+    cx.nces_course_id,
+    cx.nces_subject_area,
+    cx.school_code_override,
+    cx.sla_include_tf,
 
     csc.illuminate_subject_area,
     csc.is_foundations,
     csc.is_advanced_math,
     csc.discipline,
 
+    {{ extract_region("a") }} as region,
+
+    case
+        when a.courses_credittype in ('ENG', 'ELA')
+        then 'ENG'
+        when a.courses_credittype in ('MATH', 'Math')
+        then 'MATH'
+        when a.courses_credittype in ('SCI', 'Science')
+        then 'SCI'
+        when a.courses_credittype in ('HR', 'Homeroom')
+        then 'HR'
+        else a.courses_credittype
+    end as courses_credittype,
+
+    if(cx.ap_course_subject is not null, true, false) as is_ap_course,
+
     if(csc.discipline = 'SOC', 'Civics', csc.discipline) as standardized_discipline,
 
     row_number() over (
-        partition by
-            cj._dbt_source_relation, cj.cc_studyear, csc.illuminate_subject_area
-        order by cj.cc_termid desc, cj.cc_dateenrolled desc, cj.cc_dateleft desc
+        partition by a._dbt_source_relation, a.cc_studyear, csc.illuminate_subject_area
+        order by a.cc_termid desc, a.cc_dateenrolled desc, a.cc_dateleft desc
     ) as rn_student_year_illuminate_subject_desc,
 
-from course_joins as cj
+from add_dbt_field as a
+left join
+    {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
+    on a.courses_dcid = cx.coursesdcid
+    and a._dbt_source_project = cx._dbt_source_project
 left join
     {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
-    on cj.cc_course_number = csc.powerschool_course_number
+    on a.cc_course_number = csc.powerschool_course_number

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -31,9 +31,6 @@ with
         select
             *,
 
-            -- materialized region-prefix discriminator for downstream surrogate-key
-            -- composition; replaces per-consumer extract_code_location() per #3142.
-            -- code_location is the prior name; both will collapse when #3142 ships.
             regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
             regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as code_location,
 
@@ -182,6 +179,7 @@ select
         then '<2.00'
         else 'No GPA'
     end as salesforce_contact_college_match_gpa_band,
+
     if(
         extract(
             month
@@ -203,15 +201,15 @@ from with_region as ar
 left join
     {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
     on ar.students_dcid = suf.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="suf") }}
+    and ar._dbt_source_project = suf._dbt_source_project
 left join
     {{ ref("stg_powerschool__s_nj_stu_x") }} as njs
     on ar.students_dcid = njs.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="njs") }}
+    and ar._dbt_source_project = njs._dbt_source_project
 left join
     {{ ref("stg_powerschool__s_nj_ren_x") }} as njr
     on ar.reenrollments_dcid = njr.reenrollmentsdcid
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="njr") }}
+    and ar._dbt_source_project = njr._dbt_source_project
 left join
     {{ ref("stg_powerschool__student_email") }} as se
     on ar.student_number = se.student_number
@@ -225,18 +223,18 @@ left join
     {{ ref("int_edplan__njsmart_powerschool_union") }} as sped
     on ar.student_number = sped.student_number
     and ar.academic_year = sped.academic_year
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="sped") }}
+    and ar._dbt_source_project = sped._dbt_source_project
     and sped.rn_student_year_desc = 1
 left join
     {{ ref("stg_titan__person_data") }} as tpd
     on ar.student_number = tpd.person_identifier
     and ar.academic_year = tpd.academic_year
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="tpd") }}
+    and ar._dbt_source_project = tpd._dbt_source_project
 left join
     {{ ref("int_fldoe__fte_pivot") }} as fte
     on ar.state_studentnumber = fte.student_id
     and ar.academic_year = fte.academic_year
-    and {{ union_dataset_join_clause(left_alias="ar", right_alias="fte") }}
+    and ar._dbt_source_project = fte._dbt_source_project
 left join
     {{ ref("stg_kippadb__contact") }} as adb
     on ar.student_number = adb.school_specific_id

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__course_enrollments.yml
@@ -435,6 +435,13 @@ models:
         data_type: int64
       - name: rn_course_number_year
         data_type: int64
+      - name: _dbt_source_project
+        data_type: string
+        description: |
+          Region prefix extracted from `_dbt_source_relation` via
+          `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
+          in downstream surrogate keys, consistent across all upstream union
+          tables.
       - name: ap_course_subject
         data_type: string
       - name: block_schedule_session
@@ -479,13 +486,6 @@ models:
         data_type: boolean
       - name: discipline
         data_type: string
-      - name: _dbt_source_project
-        data_type: string
-        description: |
-          Region prefix extracted from `_dbt_source_relation` via
-          `regexp_extract(..., r'(kipp\w+)_')`. Used as a region discriminator
-          in downstream surrogate keys, consistent across all upstream union
-          tables.
       - name: region
         data_type: string
         description: Derived from _dbt_source_relation.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term.sql
@@ -1,7 +1,7 @@
 with
     ada_by_term as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             academic_year,
             semester,
@@ -16,16 +16,17 @@ with
             avg(attendancevalue) as ada_term,
 
             sum(abs(attendancevalue - 1)) as sum_absences_term,
+
         from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }}
         where
             membershipvalue = 1
             and attendancevalue is not null
             and calendardate <= current_date('{{ var("local_timezone") }}')
-        group by _dbt_source_relation, studentid, academic_year, semester, term
+        group by _dbt_source_project, studentid, academic_year, semester, term
     )
 
 select
-    _dbt_source_relation,
+    _dbt_source_project,
     studentid,
     academic_year,
     term,
@@ -40,10 +41,10 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year, semester
+                partition by _dbt_source_project, studentid, academic_year, semester
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year, semester
+                partition by _dbt_source_project, studentid, academic_year, semester
             )
         ),
         3
@@ -52,10 +53,10 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
             )
         ),
         3
@@ -64,11 +65,11 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
                 order by term asc
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
                 order by term asc
             )
         ),
@@ -80,10 +81,10 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_weighted_term) over (
-                partition by _dbt_source_relation, studentid, academic_year, semester
+                partition by _dbt_source_project, studentid, academic_year, semester
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year, semester
+                partition by _dbt_source_project, studentid, academic_year, semester
             )
         ),
         3
@@ -92,10 +93,10 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_weighted_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
             )
         ),
         3
@@ -104,11 +105,11 @@ select
     round(
         safe_divide(
             sum(sum_attendance_value_weighted_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
                 order by term asc
             ),
             sum(count_attendance_value_term) over (
-                partition by _dbt_source_relation, studentid, academic_year
+                partition by _dbt_source_project, studentid, academic_year
                 order by term asc
             )
         ),

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
@@ -1,5 +1,4 @@
 select
-    _dbt_source_relation,
     studentid,
     academic_year,
 
@@ -39,6 +38,8 @@ select
     + coalesce(sum_absences_term_q2, 0)
     + coalesce(sum_absences_term_q3, 0)
     + coalesce(sum_absences_term_q4, 0) as sum_absences_year,
+
+    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
 
 from
     {{ ref("int_powerschool__ada_term") }} pivot (

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
@@ -1,4 +1,5 @@
 select
+    _dbt_source_project,
     studentid,
     academic_year,
 
@@ -39,8 +40,6 @@ select
     + coalesce(sum_absences_term_q3, 0)
     + coalesce(sum_absences_term_q4, 0) as sum_absences_year,
 
-    {{ extract_code_location("src") }} as _dbt_source_project,
-
 from
     {{ ref("int_powerschool__ada_term") }} pivot (
         max(ada_term) as ada_term,
@@ -57,4 +56,4 @@ from
         max(sum_absences_term) as sum_absences_term,
         max(count_attendance_value_term) as count_attendance_value_term
         for term in ('Q1', 'Q2', 'Q3', 'Q4')
-    ) as src
+    )

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term_pivot.sql
@@ -39,7 +39,7 @@ select
     + coalesce(sum_absences_term_q3, 0)
     + coalesce(sum_absences_term_q4, 0) as sum_absences_year,
 
-    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("src") }} as _dbt_source_project,
 
 from
     {{ ref("int_powerschool__ada_term") }} pivot (
@@ -57,4 +57,4 @@ from
         max(sum_absences_term) as sum_absences_term,
         max(count_attendance_value_term) as count_attendance_value_term
         for term in ('Q1', 'Q2', 'Q3', 'Q4')
-    )
+    ) as src

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
@@ -25,11 +25,11 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
 select
-    *,
+    ur.*,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
-    yearid + 1990 as academic_year,
+    {{ extract_code_location("ur") }} as _dbt_source_project,
 
-from union_relations
+    ur.yearid + 1990 as academic_year,
+
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
@@ -1,9 +1,35 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__category_grades"),
-            source("kippcamden_powerschool", "int_powerschool__category_grades"),
-            source("kippmiami_powerschool", "int_powerschool__category_grades"),
-        ]
+/*
+ * kipppaterson_powerschool is intentionally absent —
+ * Paterson lacks the GradeBook plugin deployment required to
+ * populate category grades. Paterson rows flow through the
+ * gradebook audit scaffold but will have null
+ * category_quarter_percent_grade until the plugin is deployed.
+ * Tracked: https://github.com/TEAMSchools/teamster/issues/3908
+ */
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "int_powerschool__category_grades"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "int_powerschool__category_grades"
+                    ),
+                    source(
+                        "kippmiami_powerschool", "int_powerschool__category_grades"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04)
+select
+    *,
+
+    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    yearid + 1990 as academic_year,
+
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
@@ -29,7 +29,7 @@ with
 select
     *,
 
-    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
     yearid + 1990 as academic_year,
 
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative.sql
@@ -1,9 +1,41 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+select
+    ur.*,
+
+    {{ extract_code_location("ur") }} as _dbt_source_project,
+
+    case
+        when ur.cumulative_y1_gpa_unweighted >= 3.00
+        then 4
+        when ur.cumulative_y1_gpa_unweighted >= 2.50
+        then 3
+        when ur.cumulative_y1_gpa_unweighted >= 2.00
+        then 2
+        when ur.cumulative_y1_gpa_unweighted < 2.00
+        then 1
+    end as cumulative_y1_gpa_unweighted_band,
+
+    case
+        when ur.cumulative_y1_gpa_projected_unweighted >= 3.00
+        then 4
+        when ur.cumulative_y1_gpa_projected_unweighted >= 2.50
+        then 3
+        when ur.cumulative_y1_gpa_projected_unweighted >= 2.00
+        then 2
+        when ur.cumulative_y1_gpa_projected_unweighted < 2.00
+        then 1
+    end as cumulative_y1_gpa_projected_unweighted_band,
+
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term.sql
@@ -1,9 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__gpa_term"),
-            source("kippcamden_powerschool", "int_powerschool__gpa_term"),
-            source("kippmiami_powerschool", "int_powerschool__gpa_term"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "int_powerschool__gpa_term"),
+                    source("kippcamden_powerschool", "int_powerschool__gpa_term"),
+                    source("kippmiami_powerschool", "int_powerschool__gpa_term"),
+                ]
+            )
+        }}
     )
-}}
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
@@ -28,7 +28,6 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
 
-from union_relations
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
@@ -1,13 +1,34 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source(
-                "kippnewark_powerschool", "int_powerschool__gradebook_assignments"
-            ),
-            source(
-                "kippcamden_powerschool", "int_powerschool__gradebook_assignments"
-            ),
-            source("kippmiami_powerschool", "int_powerschool__gradebook_assignments"),
-        ]
+/*
+ * kipppaterson_powerschool is intentionally absent —
+ * Paterson lacks the GradeBook plugin deployment required to
+ * populate assignment data. Paterson teacher rows flow through
+ * the gradebook audit scaffold but will have zero assignment
+ * counts and null max score flags until the plugin is deployed.
+ * Tracked: https://github.com/TEAMSchools/teamster/issues/3908
+ */
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "int_powerschool__gradebook_assignments",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "int_powerschool__gradebook_assignments",
+                    ),
+                    source(
+                        "kippmiami_powerschool",
+                        "int_powerschool__gradebook_assignments",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04)
+select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
@@ -29,6 +29,6 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04)
-select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
 
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
@@ -13,5 +13,6 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04)
-select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__terms"),
-            source("kippcamden_powerschool", "int_powerschool__terms"),
-            source("kippmiami_powerschool", "int_powerschool__terms"),
-            source("kipppaterson_powerschool", "int_powerschool__terms"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "int_powerschool__terms"),
+                    source("kippcamden_powerschool", "int_powerschool__terms"),
+                    source("kippmiami_powerschool", "int_powerschool__terms"),
+                    source("kipppaterson_powerschool", "int_powerschool__terms"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04)
+select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
@@ -12,7 +12,6 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
 
-from union_relations
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term.yml
@@ -1,8 +1,9 @@
 models:
   - name: int_powerschool__ada_term
     columns:
-      - name: _dbt_source_relation
+      - name: _dbt_source_project
         data_type: string
+        description: District code location derived from `_dbt_source_project`.
       - name: studentid
         data_type: int64
         description:
@@ -24,19 +25,19 @@ models:
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           semester, studentid, sum_attendance_value_term.
       - name: ada_year
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           studentid, sum_attendance_value_term.
       - name: ada_year_running
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           studentid, sum_attendance_value_term, term.
       - name: ada_weighted_term
         data_type: float64
@@ -45,17 +46,17 @@ models:
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           semester, studentid, sum_attendance_value_weighted_term.
       - name: ada_weighted_year
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           studentid, sum_attendance_value_weighted_term.
       - name: ada_weighted_year_running
         data_type: float64
         description:
           The internal number and ID of the associated Students record. Derived
-          from _dbt_source_relation, academic_year, count_attendance_value_term,
+          from _dbt_source_project, academic_year, count_attendance_value_term,
           studentid, sum_attendance_value_weighted_term, term.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
@@ -12,6 +12,9 @@ models:
           config:
             severity: error
     columns:
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
         description:
@@ -94,6 +97,6 @@ models:
         data_type: float64
         description:
           Derived from ada_year_q1, ada_year_q2, ada_year_q3, ada_year_q4.
-      - name: _dbt_source_project
-        data_type: string
-        description: District code location derived from `_dbt_source_relation`.
+      - name: sum_absences_year
+        data_type: int64
+        description: Sum of unexcused absences across all four quarters.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
@@ -96,3 +96,4 @@ models:
           Derived from ada_year_q1, ada_year_q2, ada_year_q3, ada_year_q4.
       - name: _dbt_source_project
         data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ada_term_pivot.yml
@@ -6,14 +6,12 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - _dbt_source_relation
+              - _dbt_source_project
               - studentid
               - academic_year
           config:
             severity: error
     columns:
-      - name: _dbt_source_relation
-        data_type: string
       - name: studentid
         data_type: int64
         description:
@@ -96,3 +94,5 @@ models:
         data_type: float64
         description:
           Derived from ada_year_q1, ada_year_q2, ada_year_q3, ada_year_q4.
+      - name: _dbt_source_project
+        data_type: string

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades.yml
@@ -92,3 +92,10 @@ models:
         data_type: string
       - name: percent_grade_y1_running
         data_type: float64
+      - name: _dbt_source_project
+        data_type: string
+      - name: academic_year
+        data_type: int64
+        description:
+          The academic year in which the grade was recorded, derived as yearid +
+          1990.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades.yml
@@ -94,6 +94,7 @@ models:
         data_type: float64
       - name: _dbt_source_project
         data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: academic_year
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
@@ -45,3 +45,16 @@ models:
         data_type: float64
       - name: core_cumulative_y1_gpa
         data_type: float64
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
+      - name: cumulative_y1_gpa_unweighted_band
+        data_type: int64
+        description: >
+          KTAF GPA band for cumulative_y1_gpa_unweighted (4 = ≥3.00, 3 =
+          2.50–2.99, 2 = 2.00–2.49, 1 = <2.00).
+      - name: cumulative_y1_gpa_projected_unweighted_band
+        data_type: int64
+        description: >
+          KTAF GPA band for cumulative_y1_gpa_projected_unweighted (4 = ≥3.00, 3
+          = 2.50–2.99, 2 = 2.00–2.49, 1 = <2.00).

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term.yml
@@ -3,6 +3,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments.yml
@@ -113,3 +113,4 @@ models:
         data_type: string
       - name: _dbt_source_project
         data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments.yml
@@ -111,3 +111,5 @@ models:
         data_type: string
       - name: category_code
         data_type: string
+      - name: _dbt_source_project
+        data_type: string

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__assignmentscore.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__assignmentscore.yml
@@ -1,2 +1,6 @@
 models:
   - name: stg_powerschool__assignmentscore
+    columns:
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__calendar_day.yml
@@ -7,3 +7,7 @@ models:
               date_value is null or date_value >= '2000-01-01'
           config:
             severity: warn
+    columns:
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__s_nj_crs_x.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__s_nj_crs_x.yml
@@ -2,3 +2,7 @@ models:
   - name: stg_powerschool__s_nj_crs_x
     config:
       materialized: table
+    columns:
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
@@ -146,3 +146,5 @@ models:
         data_type: string
       - name: is_transfer_grade
         data_type: boolean
+      - name: _dbt_source_project
+        data_type: string

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__storedgrades.yml
@@ -7,7 +7,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - _dbt_source_relation
+              - _dbt_source_project
               - dcid
           config:
             severity: error
@@ -148,3 +148,4 @@ models:
         data_type: boolean
       - name: _dbt_source_project
         data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
@@ -11,6 +11,5 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
-from union_relations
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
@@ -12,5 +12,5 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04)
-select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04)
+select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
@@ -19,4 +19,5 @@ select
     * except (date_value),
 
     if(date_value < date '2000-01-01', null, date_value) as date_value,
+    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
@@ -14,10 +14,11 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04): union_relations expands at compile time
 select
-    * except (date_value),
+    ur.* except (date_value),
 
-    if(date_value < date '2000-01-01', null, date_value) as date_value,
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
-from union_relations
+    {{ extract_code_location("ur") }} as _dbt_source_project,
+
+    if(ur.date_value < date '2000-01-01', null, ur.date_value) as date_value,
+
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
@@ -19,5 +19,5 @@ select
     * except (date_value),
 
     if(date_value < date '2000-01-01', null, date_value) as date_value,
-    regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_crs_x.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_crs_x.sql
@@ -1,9 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__s_nj_crs_x"),
-            source("kippcamden_powerschool", "stg_powerschool__s_nj_crs_x"),
-            source("kipppaterson_powerschool", "stg_powerschool__s_nj_crs_x"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__s_nj_crs_x"),
+                    source("kippcamden_powerschool", "stg_powerschool__s_nj_crs_x"),
+                    source("kipppaterson_powerschool", "stg_powerschool__s_nj_crs_x"),
+                ]
+            )
+        }}
     )
-}}
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_ren_x.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_ren_x.sql
@@ -1,9 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__s_nj_ren_x"),
-            source("kippcamden_powerschool", "stg_powerschool__s_nj_ren_x"),
-            source("kipppaterson_powerschool", "stg_powerschool__s_nj_ren_x"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__s_nj_ren_x"),
+                    source("kippcamden_powerschool", "stg_powerschool__s_nj_ren_x"),
+                    source("kipppaterson_powerschool", "stg_powerschool__s_nj_ren_x"),
+                ]
+            )
+        }}
     )
-}}
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
@@ -31,7 +31,7 @@ select
 
     if(l.location_name is null, true, false) as is_transfer_grade,
 
-    regexp_extract(u._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+    {{ extract_code_location("u") }} as _dbt_source_project,
 
 from union_relations as u
 left join

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
@@ -31,6 +31,8 @@ select
 
     if(l.location_name is null, true, false) as is_transfer_grade,
 
+    regexp_extract(u._dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
+
 from union_relations as u
 left join
     {{ ref("int_people__location_crosswalk") }} as l on u.schoolname = l.location_name

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_studentsuserfields.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_studentsuserfields.sql
@@ -1,12 +1,28 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__u_studentsuserfields"),
-            source("kippcamden_powerschool", "stg_powerschool__u_studentsuserfields"),
-            source("kippmiami_powerschool", "stg_powerschool__u_studentsuserfields"),
-            source(
-                "kipppaterson_powerschool", "stg_powerschool__u_studentsuserfields"
-            ),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "stg_powerschool__u_studentsuserfields",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "stg_powerschool__u_studentsuserfields",
+                    ),
+                    source(
+                        "kippmiami_powerschool",
+                        "stg_powerschool__u_studentsuserfields",
+                    ),
+                    source(
+                        "kipppaterson_powerschool",
+                        "stg_powerschool__u_studentsuserfields",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -1,7 +1,13 @@
 with
+    school_year_start as (
+        select distinct
+            _dbt_source_project, academic_year, schoolid, first_day_school_year,
+        from {{ ref("int_powerschool__calendar_week") }}
+    ),
+
     esms_attend as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             student_number,
             school_level,
             school_abbreviation,
@@ -20,6 +26,7 @@ with
             row_number() over (
                 partition by student_number order by exitdate desc
             ) as rn,
+
         from {{ ref("base_powerschool__student_enrollments") }}
         where
             grade_level = 4
@@ -39,13 +46,14 @@ with
             lead(schoolid, 1) over (
                 partition by student_number order by academic_year asc
             ) as next_year_schoolid,
+
         from {{ ref("base_powerschool__student_enrollments") }}
         where rn_year = 1
     ),
 
     mia_territory as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             roster_name as territory,
             student_school_id,
 
@@ -59,7 +67,7 @@ with
 
     graduation_pathway_m as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             studentsdcid,
 
             case
@@ -77,7 +85,7 @@ with
 
     finalsite_enrollment_type_calc as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             student_number,
 
@@ -89,49 +97,7 @@ with
 
         from {{ ref("base_powerschool__student_enrollments") }}
         where grade_level != 99
-        group by _dbt_source_relation, academic_year, student_number
-    ),
-
-    gpa_bands as (
-        select
-            _dbt_source_relation,
-            schoolid,
-            studentid,
-
-            cumulative_y1_gpa,
-            cumulative_y1_gpa_unweighted,
-            cumulative_y1_gpa_projected,
-            cumulative_y1_gpa_projected_s1,
-            cumulative_y1_gpa_projected_s1_unweighted,
-            cumulative_y1_gpa_projected_unweighted,
-            core_cumulative_y1_gpa,
-            earned_credits_cum,
-            earned_credits_cum_projected,
-            potential_credits_cum,
-
-            case
-                when cumulative_y1_gpa_unweighted >= 3.00
-                then 4
-                when cumulative_y1_gpa_unweighted >= 2.50
-                then 3
-                when cumulative_y1_gpa_unweighted >= 2.00
-                then 2
-                when cumulative_y1_gpa_unweighted < 2.00
-                then 1
-            end as cumulative_y1_gpa_unweighted_band,
-
-            case
-                when cumulative_y1_gpa_projected_unweighted >= 3.00
-                then 4
-                when cumulative_y1_gpa_projected_unweighted >= 2.50
-                then 3
-                when cumulative_y1_gpa_projected_unweighted >= 2.00
-                then 2
-                when cumulative_y1_gpa_projected_unweighted < 2.00
-                then 1
-            end as cumulative_y1_gpa_projected_unweighted_band,
-
-        from {{ ref("int_powerschool__gpa_cumulative") }}
+        group by _dbt_source_project, academic_year, student_number
     )
 
 select
@@ -289,6 +255,22 @@ select
         false
     ) as student_slideback,
 
+    if(
+        (
+            (
+                e.school_level = 'HS'
+                and e.academic_year >= 2025
+                and ada.ada_weighted_year >= 0.80
+            )
+            or ada.ada_year >= 0.80
+        )
+        and gc.cumulative_y1_gpa < 2.0,
+        true,
+        false
+    ) as is_ada_above_or_at_80_cum_gpa_less_2,
+
+    if(e.exitdate < cal.first_day_school_year, true, false) as is_pre_year_withdrawal,
+
     case
         e.gender when 'F' then 'Female' when 'M' then 'Male' when 'X' then 'Non-Binary'
     end as aligned_gender,
@@ -317,7 +299,7 @@ select
 
     case
         when
-            e.academic_year = 2025
+            e.academic_year >= 2025
             and e.school_abbreviation = 'Sumner'
             and e.grade_level = 5
         then 'MS'
@@ -363,51 +345,56 @@ select
 
 from {{ ref("base_powerschool__student_enrollments") }} as e
 left join
+    school_year_start as cal
+    on e.schoolid = cal.schoolid
+    and e.academic_year = cal.academic_year
+    and e._dbt_source_project = cal._dbt_source_project
+left join
     {{ ref("int_people__location_crosswalk") }} as lc
     on e.school_name = lc.location_name
 left join
     esms_attend as m
     on e.student_number = m.student_number
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="m") }}
+    and e._dbt_source_project = m._dbt_source_project
     and m.school_level = 'MS'
     and m.rn = 1
 left join
     esms_attend as es
     on e.student_number = es.student_number
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="es") }}
+    and e._dbt_source_project = es._dbt_source_project
     and es.school_level = 'ES'
     and es.rn = 1
 left join
     mia_territory as mt
     on e.student_number = mt.student_school_id
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="mt") }}
+    and e._dbt_source_project = mt._dbt_source_project
     and mt.rn_territory = 1
 left join
     {{ ref("int_powerschool__spenrollments") }} as cs
     on e.studentid = cs.studentid
     and e.academic_year = cs.academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="cs") }}
+    and e._dbt_source_project = cs._dbt_source_project
     and cs.specprog_name = 'Counseling Services'
     and cs.rn_student_program_year_desc = 1
 left join
     {{ ref("int_powerschool__spenrollments") }} as ath
     on e.studentid = ath.studentid
     and e.academic_year = ath.academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="ath") }}
+    and e._dbt_source_project = ath._dbt_source_project
     and ath.specprog_name = 'Student Athlete'
     and ath.rn_student_program_year_desc = 1
 left join
     {{ ref("int_powerschool__spenrollments") }} as tut
     on e.studentid = tut.studentid
     and e.academic_year = tut.academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="tut") }}
+    and e._dbt_source_project = tut._dbt_source_project
     and tut.specprog_name = 'Tutoring'
     and tut.rn_student_program_year_desc = 1
 left join
     {{ ref("int_powerschool__spenrollments") }} as hi
     on e.studentid = hi.studentid
     and e.academic_year = hi.academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="hi") }}
+    and e._dbt_source_project = hi._dbt_source_project
     and hi.specprog_name = 'Home Instruction'
     and hi.rn_student_program_year_desc = 1
 left join
@@ -416,7 +403,7 @@ left join
 left join
     {{ ref("int_overgrad__students") }} as ovg
     on e.salesforce_contact_id = ovg.external_student_id
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="ovg") }}
+    and e._dbt_source_project = ovg._dbt_source_project
 left join
     {{ ref("int_powerschool__ada_term_pivot") }} as ada
     on e.studentid = ada.studentid
@@ -428,10 +415,10 @@ left join
     and e.academic_year = (adapy.academic_year + 1)
     and e._dbt_source_project = adapy._dbt_source_project
 left join
-    gpa_bands as gc
+    {{ ref("int_powerschool__gpa_cumulative") }} as gc
     on e.studentid = gc.studentid
     and e.schoolid = gc.schoolid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="gc") }}
+    and e._dbt_source_project = gc._dbt_source_project
 left join
     next_year_school as ny
     on e.student_number = ny.student_number
@@ -439,17 +426,17 @@ left join
 left join
     graduation_pathway_m as mc
     on e.students_dcid = mc.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="mc") }}
+    and e._dbt_source_project = mc._dbt_source_project
 left join
     finalsite_enrollment_type_calc as fs
     on e.academic_year = fs.academic_year
     and e.student_number = fs.student_number
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="fs") }}
+    and e._dbt_source_project = fs._dbt_source_project
 left join
     {{ ref("base_powerschool__course_enrollments") }} as sip
     on e.student_number = sip.students_student_number
     and e.academic_year = sip.cc_academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="sip") }}
+    and e._dbt_source_project = sip._dbt_source_project
     and sip.courses_course_number = 'SEM01099G1'
     and sip.rn_course_number_year = 1
     and not sip.is_dropped_section

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -421,12 +421,12 @@ left join
     {{ ref("int_powerschool__ada_term_pivot") }} as ada
     on e.studentid = ada.studentid
     and e.academic_year = ada.academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="ada") }}
+    and e._dbt_source_project = ada._dbt_source_project
 left join
     {{ ref("int_powerschool__ada_term_pivot") }} as adapy
     on e.studentid = adapy.studentid
     and e.academic_year = (adapy.academic_year + 1)
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="adapy") }}
+    and e._dbt_source_project = adapy._dbt_source_project
 left join
     gpa_bands as gc
     on e.studentid = gc.studentid

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
@@ -7,14 +7,14 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - _dbt_source_relation
+              - _dbt_source_project
               - student_number
               - academic_year
               - entrydate
           config:
             severity: error
     columns:
-      - name: _dbt_source_relation
+      - name: _dbt_source_project
         data_type: string
       - name: studentid
         data_type: int64
@@ -863,6 +863,19 @@ models:
           GPA band than their current unweighted GPA
           (cumulative_y1_gpa_unweighted). False if bands are equal, improving,
           or either GPA value is null.
+      - name: is_ada_above_or_at_80_cum_gpa_less_2
+        data_type: boolean
+        description: >
+          True when the student's ADA is at or above 80% (using weighted ADA for
+          HS starting AY 2025) and their cumulative year-to-date GPA
+          (cumulative_y1_gpa) is below 2.0. False otherwise.
+      - name: is_pre_year_withdrawal
+        data_type: boolean
+        description: >
+          True when the student's exitdate falls before August 1st of the
+          academic year — a registration that was cancelled before the school
+          year began (summer melt or pre-year transfer). These stints have no
+          course enrollments and should be excluded from course-level reporting.
       - name: aligned_gender
         data_type: string
         description: >


### PR DESCRIPTION
## Summary

Adds `_dbt_source_project` to kipptaf union models and replaces `union_dataset_join_clause` macro calls with direct equality joins on `_dbt_source_project`. Also adds `extract_region()` macro to `macros/utils.sql` for deriving region from `_dbt_source_project`.

- Wraps bare `dbt_utils.union_relations` calls in a CTE and exposes `_dbt_source_project` via `{{ extract_code_location("ur") }}` on 20 models across staging, intermediate, and mart layers
- Replaces all `union_dataset_join_clause` macro calls with `a._dbt_source_project = b._dbt_source_project` equality joins
- Adds GPA band columns (`cumulative_y1_gpa_unweighted_band`, `cumulative_y1_gpa_projected_unweighted_band`) to `int_powerschool__gpa_cumulative`
- Ports `gpa_bands` CTE, `is_ada_above_or_at_80_cum_gpa_less_2`, and `is_pre_year_withdrawal` into `int_extracts__student_enrollments`; removes dependency on `union_dataset_join_clause` throughout
- Adds `extract_region(table)` macro: `initcap(regexp_extract({table}._dbt_source_project, r'kipp(\w+)'))`

**Models updated (kipptaf):**

_Staging:_ `stg_powerschool__assignmentscore`, `stg_powerschool__calendar_day`, `stg_powerschool__s_nj_crs_x`, `stg_powerschool__s_nj_ren_x`, `stg_powerschool__storedgrades`, `stg_powerschool__u_studentsuserfields`

_Intermediate:_ `base_powerschool__course_enrollments`, `base_powerschool__student_enrollments`, `int_deanslist__roster_assignments`, `int_fldoe__fte_pivot`, `int_overgrad__students`, `int_powerschool__ada_term`, `int_powerschool__ada_term_pivot`, `int_powerschool__category_grades`, `int_powerschool__gpa_cumulative`, `int_powerschool__gpa_term`, `int_powerschool__gradebook_assignments`, `int_powerschool__terms`, `int_extracts__student_enrollments`

_Marts:_ `dim_school_calendars`, `fct_grades_assignments`, `fct_grades_category`, `fct_grades_gpa`

_Extracts:_ `rpt_tableau__okrts_referrals`

Extracted from #3908 to keep that PR focused on the gradebook audit pipeline redesign.

## AI Assistance

Claude co-authored the majority of the SQL and YAML changes under human direction. Model structure decisions (CTE wrapper pattern, GPA band placement, macro design) were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [ ] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with affected teams before merging and document your rollback plan in the summary above.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216010582913838