### PR TITLE
feat(dbt): decode Focus SIS custom-field values and reshape log fields

### DIFF
--- a/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
+++ b/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
@@ -815,12 +815,17 @@ with
         group by users.staff_id
     )
 
+-- drive from the full staff list: the active UNPIVOT drops staff with null
+-- active, which would lose education_label for staff who have education but no
+-- active. (Pure-select pivots don't need this — dropped all-null rows have
+-- nothing to decode.)
 select
-    select_pivot.staff_id,
+    users.staff_id,
     select_pivot.active_label,
     education.education_label,
-from select_pivot
-left join education on select_pivot.staff_id = education.staff_id
+from {{ ref("stg_focus__users") }} as users
+left join select_pivot on users.staff_id = select_pivot.staff_id
+left join education on users.staff_id = education.staff_id
 ```
 
 - [ ] **Step 2: Write the properties yml**

--- a/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
+++ b/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
@@ -30,18 +30,20 @@ from the design spec
 - **No staging changes.** All new files live under
   `src/dbt/focus/models/intermediate/`. The `stg_focus__*` models and their
   contracts are not touched.
-- **Decode join.** The entity stores the select-option **id**
-  (`select_options.id`), NOT its `code`. Join `int_focus__custom_field_options`
-  on `(source_class, column_name, option_id)` where `option_id` is the stored
-  value. The crosswalk exposes `option_id = cast(select_options.id as string)`
-  and joins `select_options.source_id = custom_fields.id` **with**
-  `select_options.source_class = 'CustomField'`. Never match the entity class
-  against `select_options.source_class`. (`code` is the Focus import/export
-  value and `label` the human name; decode returns `label`.)
-- **Storage formats.** `select` = a single option id (int; cast to string for
-  the unpivot). `multiple` = JSON-array string of option ids (`["2795"]`) —
-  parse with `json_value_array`, explode, map each id to its label, re-aggregate
-  to `array<string>`. The only in-scope `multiple` field is `users.education`.
+- **Decode join.** What the entity stores varies by field: the select-option
+  **id** (e.g. `sex` → `2789`) for some, the **`code`** (e.g. `prior_state` →
+  `FL`) for others. So each pivot matches its stored value against **either**:
+  `unpivoted.stored_value in (options.option_id, options.code)`, filtered by
+  `(source_class, column_name)`. The crosswalk exposes both
+  `option_id = cast(select_options.id as string)` and `code`, built by joining
+  `select_options.source_id = custom_fields.id` **with**
+  `select_options.source_class = 'CustomField'` (never the entity class). Decode
+  returns `label`.
+- **Storage formats.** `select` = a single stored value (an option id like
+  `5538`, or a code like `FL` — varies by field; cast to string for the
+  unpivot). `multiple` = JSON-array string of those values (`["2795"]`) — parse
+  with `json_value_array`, explode, match each to its label, re-aggregate to
+  `array<string>`. The only in-scope `multiple` field is `users.education`.
 - **`column_name` join keys.** The catalog stores `column_name` UPPERCASE
   (`CUSTOM_FIELD_3`); the crosswalk lowercases it. All decode joins use
   lowercase literals (e.g. `'custom_100000004'`), which grep back to the staging
@@ -144,11 +146,11 @@ touched.
 - Consumes: `stg_focus__custom_fields` (`id`, `source_class`, `column_name`),
   `stg_focus__custom_field_select_options` (`source_id`, `source_class`, `code`,
   `label`).
-- Produces: a table with columns `option_id string` (the stored select-option id
-  — the decode join key), `source_class string`, `column_name string`
-  (lowercased), `code string`, `label string`. Grain `option_id` (globally
-  unique). Consumed by every `__pivot` model, which joins
-  `entity_value = option_id`.
+- Produces: a table with columns `option_id string` (the select-option id),
+  `source_class string`, `column_name string` (lowercased), `code string`,
+  `label string`. Grain `option_id` (globally unique). Consumed by every
+  `__pivot` model, which matches its stored value against `option_id` OR `code`
+  (storage varies by field).
 
 - [ ] **Step 1: Write the failing guard test**
 
@@ -351,9 +353,9 @@ with
     ),
 
     unpivoted as (
-        select student_id, column_name, option_id
+        select student_id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_100000105,
                 custom_100000104,
                 custom_100000102,
@@ -375,7 +377,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'SISStudent'
     )
 
@@ -531,9 +533,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, option_id
+        select id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_100000004, custom_200000326, custom_50000002
             )
         )
@@ -547,7 +549,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'SISSchool'
     )
 
@@ -649,9 +651,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, option_id
+        select id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_1, custom_2, custom_3, custom_4, custom_6
             )
         )
@@ -665,7 +667,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'StudentEnrollment'
     )
 
@@ -772,8 +774,8 @@ with
     ),
 
     unpivoted as (
-        select staff_id, column_name, option_id
-        from encoded unpivot (option_id for column_name in (custom_319000004))
+        select staff_id, column_name, stored_value
+        from encoded unpivot (stored_value for column_name in (custom_319000004))
     ),
 
     decoded as (
@@ -784,7 +786,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'FocusUser'
     ),
 
@@ -807,7 +809,7 @@ with
         from {{ ref("stg_focus__users") }} as users
         cross join unnest(json_value_array(users.education)) as element_id
         left join {{ ref("int_focus__custom_field_options") }} as options
-            on element_id = options.option_id
+            on element_id in (options.option_id, options.code)
             and options.column_name = 'custom_2'
             and options.source_class = 'FocusUser'
         group by users.staff_id
@@ -924,9 +926,9 @@ with
     ),
 
     unpivoted as (
-        select course_period_id, column_name, option_id
+        select course_period_id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_2,
                 custom_4,
                 custom_6,
@@ -948,7 +950,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'CoursePeriod'
     )
 
@@ -1067,9 +1069,9 @@ with
     ),
 
     unpivoted as (
-        select course_id, column_name, option_id
+        select course_id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_field_5, custom_field_6, custom_field_13
             )
         )
@@ -1083,7 +1085,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'CourseCatalog'
     )
 
@@ -1181,8 +1183,8 @@ with
     ),
 
     unpivoted as (
-        select course_id, column_name, option_id
-        from encoded unpivot (option_id for column_name in (custom_4, custom_3))
+        select course_id, column_name, stored_value
+        from encoded unpivot (stored_value for column_name in (custom_4, custom_3))
     ),
 
     decoded as (
@@ -1193,7 +1195,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.option_id = options.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
             and options.source_class = 'Course'
     )
 
@@ -1374,6 +1376,7 @@ with
         select
             cast(id as string) as option_id,
             source_id,
+            code,
             label,
         from {{ ref("stg_focus__custom_field_select_options") }}
         where source_class = 'CustomFieldLogColumn'
@@ -1402,7 +1405,7 @@ inner join columns_meta
 left join fields_meta on unpivoted.field_id = fields_meta.field_id
 left join options
     on columns_meta.log_column_id = options.source_id
-    and unpivoted.value = options.option_id
+    and unpivoted.value in (options.option_id, options.code)
 ```
 
 - [ ] **Step 2: Write the properties yml**

--- a/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
+++ b/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
@@ -30,15 +30,18 @@ from the design spec
 - **No staging changes.** All new files live under
   `src/dbt/focus/models/intermediate/`. The `stg_focus__*` models and their
   contracts are not touched.
-- **Decode join.** Join `int_focus__custom_field_options` on
-  `(source_class, column_name, code)`. The crosswalk itself joins
-  `select_options.source_id = custom_fields.id` **with**
+- **Decode join.** The entity stores the select-option **id**
+  (`select_options.id`), NOT its `code`. Join `int_focus__custom_field_options`
+  on `(source_class, column_name, option_id)` where `option_id` is the stored
+  value. The crosswalk exposes `option_id = cast(select_options.id as string)`
+  and joins `select_options.source_id = custom_fields.id` **with**
   `select_options.source_class = 'CustomField'`. Never match the entity class
-  against `select_options.source_class`.
-- **Storage formats.** `select` = bare code (string after cast). `multiple` =
-  JSON-array string (`["2795"]`) — parse with `json_value_array`, explode, map
-  each element, re-aggregate to `array<string>`. The only in-scope `multiple`
-  field is `users.education`.
+  against `select_options.source_class`. (`code` is the Focus import/export
+  value and `label` the human name; decode returns `label`.)
+- **Storage formats.** `select` = a single option id (int; cast to string for
+  the unpivot). `multiple` = JSON-array string of option ids (`["2795"]`) —
+  parse with `json_value_array`, explode, map each id to its label, re-aggregate
+  to `array<string>`. The only in-scope `multiple` field is `users.education`.
 - **`column_name` join keys.** The catalog stores `column_name` UPPERCASE
   (`CUSTOM_FIELD_3`); the crosswalk lowercases it. All decode joins use
   lowercase literals (e.g. `'custom_100000004'`), which grep back to the staging
@@ -50,8 +53,8 @@ from the design spec
   wide-to-long log model = `int_focus__custom_field_log__unpivot`; the crosswalk
   = `int_focus__custom_field_options`.
 - **Tests.** Every intermediate model needs a uniqueness test (repo convention).
-  Crosswalk grain `(source_class, column_name, code)` at `severity: error`. Each
-  pivot: PK `unique` + `not_null`. Log: `unique_combination_of_columns` on
+  Crosswalk grain `option_id` (`unique` at `severity: error`). Each pivot: PK
+  `unique` + `not_null`. Log: `unique_combination_of_columns` on
   `(log_entry_id, slot_column_name)`.
 - **Descriptions.** Every new model and every column needs a `description:` in
   `properties/`.
@@ -141,9 +144,11 @@ touched.
 - Consumes: `stg_focus__custom_fields` (`id`, `source_class`, `column_name`),
   `stg_focus__custom_field_select_options` (`source_id`, `source_class`, `code`,
   `label`).
-- Produces: a table with columns `source_class string`, `column_name string`
-  (lowercased), `code string`, `label string`. Grain
-  `(source_class, column_name, code)`. Consumed by every `__pivot` model.
+- Produces: a table with columns `option_id string` (the stored select-option id
+  — the decode join key), `source_class string`, `column_name string`
+  (lowercased), `code string`, `label string`. Grain `option_id` (globally
+  unique). Consumed by every `__pivot` model, which joins
+  `entity_value = option_id`.
 
 - [ ] **Step 1: Write the failing guard test**
 
@@ -164,7 +169,7 @@ from expected
 left join {{ ref("int_focus__custom_field_options") }} as o
     on o.source_class = expected.source_class
     and o.column_name = expected.column_name
-where o.code is null
+where o.option_id is null
 ```
 
 - [ ] **Step 2: Run it to verify it fails**
@@ -188,6 +193,7 @@ with
 
     opt as (
         select
+            cast(id as string) as option_id,
             source_id,
             code,
             label,
@@ -196,6 +202,7 @@ with
     )
 
 select
+    opt.option_id,
     cf.source_class,
     cf.column_name,
     opt.code,
@@ -212,24 +219,27 @@ inner join cf on opt.source_id = cf.id
 models:
   - name: int_focus__custom_field_options
     description: >-
-      Code-to-label crosswalk for Focus select/multiple custom fields. Joins the
-      custom-field catalog to its stored select options on
-      select_options.source_id = custom_fields.id with source_class
-      'CustomField' (the owner-type literal, never the entity class). One row
-      per field option; inactive options are retained so historical stored codes
-      still decode.
+      Crosswalk for Focus select/multiple custom fields, keyed by option_id (the
+      value the entity stores). Joins the custom-field catalog to its stored
+      select options on select_options.source_id = custom_fields.id with
+      source_class 'CustomField' (the owner-type literal, never the entity
+      class). One row per option; inactive options are retained so historical
+      stored ids still decode. label is the human name; code is the Focus
+      import/export value.
     config:
       materialized: table
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - source_class
-              - column_name
-              - code
-          config:
-            severity: error
     columns:
+      - name: option_id
+        description: >-
+          Stored select-option id — the value persisted on the entity record and
+          the decode join key.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
       - name: source_class
         description: Owning entity class of the custom field (e.g. SISStudent).
         data_tests:
@@ -244,17 +254,10 @@ models:
               config:
                 severity: error
       - name: code
-        description: Stored option code persisted on the entity record.
-        data_tests:
-          - not_null:
-              config:
-                severity: error
+        description:
+          Focus import/export code for the option (not the stored value).
       - name: label
-        description: Human-readable label for the option code.
-        data_tests:
-          - not_null:
-              config:
-                severity: error
+        description: Human-readable label for the option.
 ```
 
 - [ ] **Step 5: Clarify the decode join in `src/dbt/focus/CLAUDE.md`**
@@ -263,17 +266,14 @@ In the "Focus field value codes" section, after the sentence ending "`label` is
 the human name.", add:
 
 ```text
-The join is `source_id` only — also filter `custom_field_select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space doesn't collide across owner types. `source_class` on the options table is the owner-type literal, never the entity class (`SISSchool`, etc.); matching the entity class returns zero rows.
+The join is `source_id` only — also filter `custom_field_select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space doesn't collide across owner types. `source_class` on the options table is the owner-type literal, never the entity class (`SISSchool`, etc.); matching the entity class returns zero rows. To DECODE a stored entity value: the entity stores the select-option `id` (`custom_field_select_options.id`), NOT its `code` — join the stored value to `id` and read `label`. (`code` is the Focus import/export value, used for the Finalsite→Focus direction.)
 ```
 
 - [ ] **Step 6: Build and run tests against real data**
 
 Run: `dbtb int_focus__custom_field_options` Expected: PASS — model builds; the
-`unique_combination_of_columns` test and the `known_fields` guard pass. If the
-uniqueness test fails on `(source_class, column_name, code)`, wrap `opt`
-selection in
-`dbt_utils.deduplicate(partition_by="source_id, code", order_by="updated_at desc")`
-(add `updated_at` to the `opt` select), then rebuild.
+`unique` test on `option_id` and the `known_fields` guard pass. `option_id` is
+the select-option PK (globally unique, non-null), so no dedupe is needed.
 
 - [ ] **Step 7: Spot-check decode correctness**
 
@@ -281,13 +281,13 @@ Run via BigQuery MCP (`mcp__bigquery__execute_sql`), substituting your dev
 schema:
 
 ```sql
-select code, label
+select option_id, code, label
 from `teamster-332318`.<your_dev_schema>.int_focus__custom_field_options
 where source_class = 'SISSchool' and column_name = 'custom_100000004'
-order by code
+order by option_id
 ```
 
-Expected: 5 rows, e.g. `E` → `E - Elementary`, `H` → `H - High`.
+Expected: 5 rows mapping `option_id` (e.g. `5538`) → `label` (`E - Elementary`).
 
 - [ ] **Step 8: Lint and commit**
 
@@ -351,9 +351,9 @@ with
     ),
 
     unpivoted as (
-        select student_id, column_name, code
+        select student_id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_100000105,
                 custom_100000104,
                 custom_100000102,
@@ -375,7 +375,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'SISStudent'
     )
 
@@ -531,9 +531,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, code
+        select id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_100000004, custom_200000326, custom_50000002
             )
         )
@@ -547,7 +547,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'SISSchool'
     )
 
@@ -649,9 +649,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, code
+        select id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_1, custom_2, custom_3, custom_4, custom_6
             )
         )
@@ -665,7 +665,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'StudentEnrollment'
     )
 
@@ -772,8 +772,8 @@ with
     ),
 
     unpivoted as (
-        select staff_id, column_name, code
-        from encoded unpivot (code for column_name in (custom_319000004))
+        select staff_id, column_name, option_id
+        from encoded unpivot (option_id for column_name in (custom_319000004))
     ),
 
     decoded as (
@@ -784,7 +784,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'FocusUser'
     ),
 
@@ -797,18 +797,18 @@ with
         )
     ),
 
-    -- multiple: education is a JSON-array string like '["2795"]'; explode, map
-    -- each element, re-aggregate. CTE form avoids a correlated subquery.
+    -- multiple: education is a JSON array of option ids like '["2795"]'; explode,
+    -- map each id to its label, re-aggregate. CTE form avoids a correlated subquery.
     education as (
         select
             users.staff_id,
             array_agg(options.label ignore nulls order by options.label)
                 as education_label,
         from {{ ref("stg_focus__users") }} as users
-        cross join unnest(json_value_array(users.education)) as code
+        cross join unnest(json_value_array(users.education)) as element_id
         left join {{ ref("int_focus__custom_field_options") }} as options
-            on options.column_name = 'custom_2'
-            and options.code = code
+            on element_id = options.option_id
+            and options.column_name = 'custom_2'
             and options.source_class = 'FocusUser'
         group by users.staff_id
     )
@@ -924,9 +924,9 @@ with
     ),
 
     unpivoted as (
-        select course_period_id, column_name, code
+        select course_period_id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_2,
                 custom_4,
                 custom_6,
@@ -948,7 +948,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'CoursePeriod'
     )
 
@@ -1067,9 +1067,9 @@ with
     ),
 
     unpivoted as (
-        select course_id, column_name, code
+        select course_id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_field_5, custom_field_6, custom_field_13
             )
         )
@@ -1083,7 +1083,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'CourseCatalog'
     )
 
@@ -1181,8 +1181,8 @@ with
     ),
 
     unpivoted as (
-        select course_id, column_name, code
-        from encoded unpivot (code for column_name in (custom_4, custom_3))
+        select course_id, column_name, option_id
+        from encoded unpivot (option_id for column_name in (custom_4, custom_3))
     ),
 
     decoded as (
@@ -1193,7 +1193,7 @@ with
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on unpivoted.column_name = options.column_name
-            and unpivoted.code = options.code
+            and unpivoted.option_id = options.option_id
             and options.source_class = 'Course'
     )
 
@@ -1372,8 +1372,8 @@ with
 
     options as (
         select
+            cast(id as string) as option_id,
             source_id,
-            code,
             label,
         from {{ ref("stg_focus__custom_field_select_options") }}
         where source_class = 'CustomFieldLogColumn'
@@ -1402,7 +1402,7 @@ inner join columns_meta
 left join fields_meta on unpivoted.field_id = fields_meta.field_id
 left join options
     on columns_meta.log_column_id = options.source_id
-    and unpivoted.value = options.code
+    and unpivoted.value = options.option_id
 ```
 
 - [ ] **Step 2: Write the properties yml**

--- a/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
+++ b/docs/superpowers/plans/2026-06-24-focus-custom-field-decode.md
@@ -1,0 +1,1512 @@
+# Focus Custom-Field Decode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decode Focus SIS `select` / `multiple` custom-field codes to labels
+and reshape the `log`-type fields into a long model, as additive `int_focus__*`
+intermediate models.
+
+**Architecture:** A shared `int_focus__custom_field_options` crosswalk resolves
+codes to labels. One `int_focus__<entity>__pivot` per entity decodes that
+entity's `select` (and, for users, `multiple`) fields via UNPIVOT → join
+crosswalk → PIVOT, emitting labels-only keyed by the entity PK.
+`int_focus__custom_field_log__unpivot` reshapes the two populated log fields
+wide→long. No staging changes; codes stay in staging and consumers join
+staging + pivot on the PK.
+
+**Tech Stack:** dbt (BigQuery dialect), the `focus` source-system dbt package
+built inside the `kippmiami` district project, `dbt_utils`. Source data in
+`dagster_kippmiami_dlt_focus`.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are verbatim
+from the design spec
+(`docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md`).
+
+- **No staging changes.** All new files live under
+  `src/dbt/focus/models/intermediate/`. The `stg_focus__*` models and their
+  contracts are not touched.
+- **Decode join.** Join `int_focus__custom_field_options` on
+  `(source_class, column_name, code)`. The crosswalk itself joins
+  `select_options.source_id = custom_fields.id` **with**
+  `select_options.source_class = 'CustomField'`. Never match the entity class
+  against `select_options.source_class`.
+- **Storage formats.** `select` = bare code (string after cast). `multiple` =
+  JSON-array string (`["2795"]`) — parse with `json_value_array`, explode, map
+  each element, re-aggregate to `array<string>`. The only in-scope `multiple`
+  field is `users.education`.
+- **`column_name` join keys.** The catalog stores `column_name` UPPERCASE
+  (`CUSTOM_FIELD_3`); the crosswalk lowercases it. All decode joins use
+  lowercase literals (e.g. `'custom_100000004'`), which grep back to the staging
+  alias.
+- **Labels-only.** Each `__pivot` model emits the entity PK + `<slug>_label`
+  columns (and `education_label array<string>` for users). No code columns;
+  codes remain in staging.
+- **Naming.** Decode-to-wide models = `int_focus__<entity>__pivot`; the
+  wide-to-long log model = `int_focus__custom_field_log__unpivot`; the crosswalk
+  = `int_focus__custom_field_options`.
+- **Tests.** Every intermediate model needs a uniqueness test (repo convention).
+  Crosswalk grain `(source_class, column_name, code)` at `severity: error`. Each
+  pivot: PK `unique` + `not_null`. Log: `unique_combination_of_columns` on
+  `(log_entry_id, slot_column_name)`.
+- **Descriptions.** Every new model and every column needs a `description:` in
+  `properties/`.
+- **PII.** Person-keyed models (`students`, `student_enrollment`, `users`, log)
+  carry `config.meta.contains_pii: true`. Tag sensitive decoded columns
+  (`sex_label`, `race_*_label`, `language_label`) at the column level too
+  (FERPA-aligned broad stance, pending People Operations confirmation). School-
+  and course-domain models are not PII.
+- **`option_query` exclusion.** `users.profile_on_non_production_sites`
+  (`custom_l790`) is `option_query`-backed and is **not** decoded (skipped as
+  low-value); its code stays in staging.
+- **SQL style** (`.trunk/config/.sqlfluff`): BigQuery, trailing commas in
+  `SELECT`, single quotes, max line length 88, ST06 column ordering, no
+  `GROUP BY ALL`, no `ORDER BY` in models. Reserved words backtick-quoted.
+- **dbt execution** (run from the worktree; never `--target prod`):
+
+  ```bash
+  # one-time setup
+  wt=/workspaces/teamster/.worktrees/cbini/feat/claude-focus-custom-field-decode
+  uv run dbt deps --project-dir "$wt/src/dbt/kippmiami"
+  # refresh the prod manifest if stale (post-merge hook usually keeps it fresh):
+  uv run dbt parse --target prod --project-dir src/dbt/kippmiami --target-path target/prod
+
+  # build/test a model against real data (prod staging via --defer; writes to your dev schema):
+  dbtb () { uv run dbt build --select "$1" \
+    --project-dir "$wt/src/dbt/kippmiami" \
+    --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod \
+    --target dev ; }
+  ```
+
+  `DBT_PROFILES_DIR` must point at the repo `.dbt` (developer profile + ADC).
+  Build Task 1 (crosswalk) first — later models pick it up from your dev schema
+  via `--defer`.
+
+- **Lint** (per file, from inside the worktree):
+
+  ```bash
+  cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force <files>
+  ```
+
+- **Commit** (lowercase shell vars only — uppercase trips the secret hook):
+
+  ```bash
+  git -C "$wt" add <files>
+  git -C "$wt" commit -m "<type>(dbt): <subject>" -m "Refs #4258" \
+    -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+  ```
+
+---
+
+## File Structure
+
+All under `src/dbt/focus/models/intermediate/` (and its `properties/`):
+
+| File                                                      | Responsibility                                   |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| `int_focus__custom_field_options.sql` + yml               | Code→label crosswalk (table)                     |
+| `int_focus__students__pivot.sql` + yml                    | Decode 9 SISStudent selects                      |
+| `int_focus__schools__pivot.sql` + yml                     | Decode 3 SISSchool selects                       |
+| `int_focus__student_enrollment__pivot.sql` + yml          | Decode 5 StudentEnrollment selects               |
+| `int_focus__users__pivot.sql` + yml                       | Decode 1 FocusUser select + `education` multiple |
+| `int_focus__course_periods__pivot.sql` + yml              | Decode 9 CoursePeriod selects                    |
+| `int_focus__master_courses__pivot.sql` + yml              | Decode 3 CourseCatalog selects                   |
+| `int_focus__courses__pivot.sql` + yml                     | Decode 2 Course selects                          |
+| `int_focus__custom_field_log__unpivot.sql` + yml          | Wide→long reshape of 2 log fields                |
+| `tests/test_focus__custom_field_options_known_fields.sql` | Guard: corrected join resolves known fields      |
+
+The existing `int_focus__student_enrollment.sql` (title enrichment) is **not**
+touched.
+
+---
+
+## Task 1: Crosswalk `int_focus__custom_field_options`
+
+**Files:**
+
+- Create:
+  `src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml`
+- Create:
+  `src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql`
+- Modify: `src/dbt/focus/CLAUDE.md` (clarify the decode join)
+
+**Interfaces:**
+
+- Consumes: `stg_focus__custom_fields` (`id`, `source_class`, `column_name`),
+  `stg_focus__custom_field_select_options` (`source_id`, `source_class`, `code`,
+  `label`).
+- Produces: a table with columns `source_class string`, `column_name string`
+  (lowercased), `code string`, `label string`. Grain
+  `(source_class, column_name, code)`. Consumed by every `__pivot` model.
+
+- [ ] **Step 1: Write the failing guard test**
+
+`src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql`:
+
+```sql
+-- Guards the corrected decode join: known in-scope fields must resolve to
+-- options. Returns offending (source_class, column_name) rows -> any row fails.
+with expected as (
+    select 'SISSchool' as source_class, 'custom_100000004' as column_name
+    union all
+    select 'SISStudent', 'custom_200000000'
+    union all
+    select 'StudentEnrollment', 'custom_4'
+)
+select expected.source_class, expected.column_name
+from expected
+left join {{ ref("int_focus__custom_field_options") }} as o
+    on o.source_class = expected.source_class
+    and o.column_name = expected.column_name
+where o.code is null
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `dbtb int_focus__custom_field_options` Expected: FAIL at parse/compile —
+`int_focus__custom_field_options` does not exist yet.
+
+- [ ] **Step 3: Write the crosswalk model**
+
+`src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql`:
+
+```sql
+with
+    cf as (
+        select
+            id,
+            source_class,
+            lower(column_name) as column_name,
+        from {{ ref("stg_focus__custom_fields") }}
+    ),
+
+    opt as (
+        select
+            source_id,
+            code,
+            label,
+        from {{ ref("stg_focus__custom_field_select_options") }}
+        where source_class = 'CustomField'  -- owner-type filter; keep inactive
+    )
+
+select
+    cf.source_class,
+    cf.column_name,
+    opt.code,
+    opt.label,
+from opt
+inner join cf on opt.source_id = cf.id
+```
+
+- [ ] **Step 4: Write the properties yml**
+
+`src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml`:
+
+```yaml
+models:
+  - name: int_focus__custom_field_options
+    description: >-
+      Code-to-label crosswalk for Focus select/multiple custom fields. Joins the
+      custom-field catalog to its stored select options on
+      select_options.source_id = custom_fields.id with source_class
+      'CustomField' (the owner-type literal, never the entity class). One row
+      per field option; inactive options are retained so historical stored codes
+      still decode.
+    config:
+      materialized: table
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - source_class
+              - column_name
+              - code
+          config:
+            severity: error
+    columns:
+      - name: source_class
+        description: Owning entity class of the custom field (e.g. SISStudent).
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: column_name
+        description:
+          Lowercased catalog column_name of the field (e.g. custom_100000004).
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: code
+        description: Stored option code persisted on the entity record.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: label
+        description: Human-readable label for the option code.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+```
+
+- [ ] **Step 5: Clarify the decode join in `src/dbt/focus/CLAUDE.md`**
+
+In the "Focus field value codes" section, after the sentence ending "`label` is
+the human name.", add:
+
+```text
+The join is `source_id` only — also filter `custom_field_select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space doesn't collide across owner types. `source_class` on the options table is the owner-type literal, never the entity class (`SISSchool`, etc.); matching the entity class returns zero rows.
+```
+
+- [ ] **Step 6: Build and run tests against real data**
+
+Run: `dbtb int_focus__custom_field_options` Expected: PASS — model builds; the
+`unique_combination_of_columns` test and the `known_fields` guard pass. If the
+uniqueness test fails on `(source_class, column_name, code)`, wrap `opt`
+selection in
+`dbt_utils.deduplicate(partition_by="source_id, code", order_by="updated_at desc")`
+(add `updated_at` to the `opt` select), then rebuild.
+
+- [ ] **Step 7: Spot-check decode correctness**
+
+Run via BigQuery MCP (`mcp__bigquery__execute_sql`), substituting your dev
+schema:
+
+```sql
+select code, label
+from `teamster-332318`.<your_dev_schema>.int_focus__custom_field_options
+where source_class = 'SISSchool' and column_name = 'custom_100000004'
+order by code
+```
+
+Expected: 5 rows, e.g. `E` → `E - Elementary`, `H` → `H - High`.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml \
+  src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql \
+  src/dbt/focus/CLAUDE.md
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql src/dbt/focus/CLAUDE.md
+git -C "$wt" commit -m "feat(dbt): add Focus custom-field code-to-label crosswalk" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `int_focus__students__pivot`
+
+**Files:**
+
+- Create: `src/dbt/focus/models/intermediate/int_focus__students__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__students` (`student_id` + the 9 select slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per `student_id` with 9 `<slug>_label` columns. PK
+  `student_id`.
+
+Decode map (`source_class = 'SISStudent'`):
+`ethnicity_hispanic_or_latino`→`custom_100000105`,
+`race_white`→`custom_100000104`,
+`race_black_or_african_american`→`custom_100000102`,
+`race_asian`→`custom_100000101`, `sex`→`custom_200000000`,
+`race_american_indian_or_alaska_native`→`custom_100000100`,
+`race_native_hawaiian_or_other_pacific_islander`→`custom_100000103`,
+`residence_county`→`custom_837`, `language`→`custom_200000005`.
+
+- [ ] **Step 1: Write the model**
+
+`src/dbt/focus/models/intermediate/int_focus__students__pivot.sql`:
+
+```sql
+with
+    encoded as (
+        select
+            student_id,
+            cast(ethnicity_hispanic_or_latino as string) as custom_100000105,
+            cast(race_white as string) as custom_100000104,
+            cast(race_black_or_african_american as string) as custom_100000102,
+            cast(race_asian as string) as custom_100000101,
+            cast(sex as string) as custom_200000000,
+            cast(race_american_indian_or_alaska_native as string)
+                as custom_100000100,
+            cast(race_native_hawaiian_or_other_pacific_islander as string)
+                as custom_100000103,
+            cast(residence_county as string) as custom_837,
+            cast(`language` as string) as custom_200000005,
+        from {{ ref("stg_focus__students") }}
+    ),
+
+    unpivoted as (
+        select student_id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_100000105,
+                custom_100000104,
+                custom_100000102,
+                custom_100000101,
+                custom_200000000,
+                custom_100000100,
+                custom_100000103,
+                custom_837,
+                custom_200000005
+            )
+        )
+    ),
+
+    decoded as (
+        select
+            unpivoted.student_id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'SISStudent'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_100000105' as ethnicity_hispanic_or_latino_label,
+        'custom_100000104' as race_white_label,
+        'custom_100000102' as race_black_or_african_american_label,
+        'custom_100000101' as race_asian_label,
+        'custom_200000000' as sex_label,
+        'custom_100000100' as race_american_indian_or_alaska_native_label,
+        'custom_100000103' as race_native_hawaiian_or_other_pacific_islander_label,
+        'custom_837' as residence_county_label,
+        'custom_200000005' as language_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+`src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml`:
+
+```yaml
+models:
+  - name: int_focus__students__pivot
+    description: >-
+      Decoded labels for the SISStudent select custom fields, one row per
+      student_id. Join to stg_focus__students on student_id for the codes. A
+      null label means the student had no code for that field.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: student_id
+        description: Primary key — Focus local student id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: ethnicity_hispanic_or_latino_label
+        description:
+          Decoded label for the ethnicity_hispanic_or_latino select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_white_label
+        description: Decoded label for the race_white select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_black_or_african_american_label
+        description:
+          Decoded label for the race_black_or_african_american select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_asian_label
+        description: Decoded label for the race_asian select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: sex_label
+        description: Decoded label for the sex select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_american_indian_or_alaska_native_label
+        description:
+          Decoded label for the race_american_indian_or_alaska_native field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_native_hawaiian_or_other_pacific_islander_label
+        description:
+          Decoded label for the race_native_hawaiian_or_other_pacific_islander
+          field.
+        config:
+          meta:
+            contains_pii: true
+      - name: residence_county_label
+        description: Decoded label for the residence_county select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: language_label
+        description: Decoded label for the language select field.
+        config:
+          meta:
+            contains_pii: true
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__students__pivot` Expected: PASS — builds; `unique` +
+`not_null` on `student_id` pass.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select count(*) as n, countif(sex_label is not null) as n_sex_label
+from `teamster-332318`.<your_dev_schema>.int_focus__students__pivot
+```
+
+Expected: `n_sex_label` > 0 and labels look human-readable (join a few rows back
+to `stg_focus__students.sex` to confirm code→label).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__students__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__students__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode SISStudent custom fields in int_focus__students__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `int_focus__schools__pivot`
+
+**Files:**
+
+- Create: `src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__schools__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__schools` (PK `id` + slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per `id` with 3 `<slug>_label` columns. PK `id`. Not PII.
+
+Decode map (`source_class = 'SISSchool'`): `school_level`→`custom_100000004`,
+`school_type`→`custom_200000326`, `technical_center`→`custom_50000002`.
+
+- [ ] **Step 1: Write the model**
+
+`src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql`:
+
+```sql
+with
+    encoded as (
+        select
+            id,
+            cast(school_level as string) as custom_100000004,
+            cast(school_type as string) as custom_200000326,
+            cast(technical_center as string) as custom_50000002,
+        from {{ ref("stg_focus__schools") }}
+    ),
+
+    unpivoted as (
+        select id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_100000004, custom_200000326, custom_50000002
+            )
+        )
+    ),
+
+    decoded as (
+        select
+            unpivoted.id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'SISSchool'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_100000004' as school_level_label,
+        'custom_200000326' as school_type_label,
+        'custom_50000002' as technical_center_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__schools__pivot
+    description: >-
+      Decoded labels for the SISSchool select custom fields, one row per Focus
+      school id. Join to stg_focus__schools on id for the codes.
+    columns:
+      - name: id
+        description: Primary key — Focus school id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: school_level_label
+        description: Decoded label for the school_level select field.
+      - name: school_type_label
+        description: Decoded label for the school_type select field.
+      - name: technical_center_label
+        description: Decoded label for the technical_center select field.
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__schools__pivot` Expected: PASS.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select id, school_level_label, school_type_label
+from `teamster-332318`.<your_dev_schema>.int_focus__schools__pivot
+order by id
+```
+
+Expected: `school_level_label` values like `E - Elementary` / `H - High`.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__schools__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__schools__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode SISSchool custom fields in int_focus__schools__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `int_focus__student_enrollment__pivot`
+
+**Files:**
+
+- Create:
+  `src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__student_enrollment` (PK `id` + slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per enrollment `id` with 5 `<slug>_label` columns. PK `id`.
+  PII (student-linked).
+
+Decode map (`source_class = 'StudentEnrollment'`): `prior_district`→`custom_1`,
+`prior_state`→`custom_2`, `prior_country`→`custom_3`,
+`educational_choice`→`custom_4`, `student_offender_transfer`→`custom_6`.
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    encoded as (
+        select
+            id,
+            cast(prior_district as string) as custom_1,
+            cast(prior_state as string) as custom_2,
+            cast(prior_country as string) as custom_3,
+            cast(educational_choice as string) as custom_4,
+            cast(student_offender_transfer as string) as custom_6,
+        from {{ ref("stg_focus__student_enrollment") }}
+    ),
+
+    unpivoted as (
+        select id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_1, custom_2, custom_3, custom_4, custom_6
+            )
+        )
+    ),
+
+    decoded as (
+        select
+            unpivoted.id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'StudentEnrollment'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_1' as prior_district_label,
+        'custom_2' as prior_state_label,
+        'custom_3' as prior_country_label,
+        'custom_4' as educational_choice_label,
+        'custom_6' as student_offender_transfer_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__student_enrollment__pivot
+    description: >-
+      Decoded labels for the StudentEnrollment select custom fields, one row per
+      Focus enrollment id. Join to stg_focus__student_enrollment on id for
+      codes.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: id
+        description: Primary key — Focus student enrollment id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: prior_district_label
+        description: Decoded label for the prior_district select field.
+      - name: prior_state_label
+        description: Decoded label for the prior_state select field.
+      - name: prior_country_label
+        description: Decoded label for the prior_country select field.
+      - name: educational_choice_label
+        description: Decoded label for the educational_choice select field.
+      - name: student_offender_transfer_label
+        description:
+          Decoded label for the student_offender_transfer select field.
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__student_enrollment__pivot` Expected: PASS.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select count(*) as n, countif(prior_state_label is not null) as n_state
+from `teamster-332318`.<your_dev_schema>.int_focus__student_enrollment__pivot
+```
+
+Expected: `n_state` > 0 with readable state labels.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode StudentEnrollment custom fields in int_focus__student_enrollment__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `int_focus__users__pivot`
+
+**Files:**
+
+- Create: `src/dbt/focus/models/intermediate/int_focus__users__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__users` (PK `staff_id`, `active`, `education`),
+  `int_focus__custom_field_options`.
+- Produces: one row per `staff_id` with `active_label string` and
+  `education_label array<string>`. PK `staff_id`. PII (staff).
+  `profile_on_non_production_sites` is intentionally not decoded.
+
+Decode map (`source_class = 'FocusUser'`): `active`→`custom_319000004` (select),
+`education`→`custom_2` (multiple, JSON-array string).
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    encoded as (
+        select
+            staff_id,
+            cast(active as string) as custom_319000004,
+        from {{ ref("stg_focus__users") }}
+    ),
+
+    unpivoted as (
+        select staff_id, column_name, code
+        from encoded unpivot (code for column_name in (custom_319000004))
+    ),
+
+    decoded as (
+        select
+            unpivoted.staff_id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'FocusUser'
+    ),
+
+    select_pivot as (
+        select *
+        from decoded pivot (
+            any_value(label) for column_name in (
+                'custom_319000004' as active_label
+            )
+        )
+    ),
+
+    -- multiple: education is a JSON-array string like '["2795"]'; explode, map
+    -- each element, re-aggregate. CTE form avoids a correlated subquery.
+    education as (
+        select
+            users.staff_id,
+            array_agg(options.label ignore nulls order by options.label)
+                as education_label,
+        from {{ ref("stg_focus__users") }} as users
+        cross join unnest(json_value_array(users.education)) as code
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on options.column_name = 'custom_2'
+            and options.code = code
+            and options.source_class = 'FocusUser'
+        group by users.staff_id
+    )
+
+select
+    select_pivot.staff_id,
+    select_pivot.active_label,
+    education.education_label,
+from select_pivot
+left join education on select_pivot.staff_id = education.staff_id
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__users__pivot
+    description: >-
+      Decoded labels for the FocusUser custom fields, one row per staff_id. Join
+      to stg_focus__users on staff_id for the codes.
+      profile_on_non_production_sites is option_query-backed and intentionally
+      not decoded (its code stays in staging).
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: staff_id
+        description: Primary key — Focus staff id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: active_label
+        description: Decoded label for the active select field.
+      - name: education_label
+        description: >-
+          Decoded labels for the education multiple-select field, as an array
+          (the stored value is a JSON array of option codes).
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__users__pivot` Expected: PASS — `unique` + `not_null` on
+`staff_id` pass.
+
+- [ ] **Step 4: Spot-check the multiple decode**
+
+```sql
+select staff_id, active_label, education_label
+from `teamster-332318`.<your_dev_schema>.int_focus__users__pivot
+where array_length(education_label) > 0
+limit 20
+```
+
+Expected: `education_label` holds readable labels (e.g. a degree name) for staff
+whose `stg_focus__users.education` is populated; non-populated staff have an
+empty/null array.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__users__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__users__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode FocusUser custom fields in int_focus__users__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `int_focus__course_periods__pivot`
+
+**Files:**
+
+- Create:
+  `src/dbt/focus/models/intermediate/int_focus__course_periods__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__course_periods__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__course_periods` (PK `course_period_id` + slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per `course_period_id` with 9 `<slug>_label` columns. PK
+  `course_period_id`. Not PII.
+
+Decode map (`source_class = 'CoursePeriod'`): `fefp_number`→`custom_2`,
+`scheduling_method`→`custom_4`, `facility_type`→`custom_6`,
+`cert_licensure_qual_status`→`custom_28`, `highly_qualified`→`custom_5`,
+`reading_intervention_component`→`custom_25`, `location_of_student`→`custom_33`,
+`eoc_exam_term`→`custom_34`, `basic_skills_exam`→`custom_22`.
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    encoded as (
+        select
+            course_period_id,
+            cast(fefp_number as string) as custom_2,
+            cast(scheduling_method as string) as custom_4,
+            cast(facility_type as string) as custom_6,
+            cast(cert_licensure_qual_status as string) as custom_28,
+            cast(highly_qualified as string) as custom_5,
+            cast(reading_intervention_component as string) as custom_25,
+            cast(location_of_student as string) as custom_33,
+            cast(eoc_exam_term as string) as custom_34,
+            cast(basic_skills_exam as string) as custom_22,
+        from {{ ref("stg_focus__course_periods") }}
+    ),
+
+    unpivoted as (
+        select course_period_id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_2,
+                custom_4,
+                custom_6,
+                custom_28,
+                custom_5,
+                custom_25,
+                custom_33,
+                custom_34,
+                custom_22
+            )
+        )
+    ),
+
+    decoded as (
+        select
+            unpivoted.course_period_id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'CoursePeriod'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_2' as fefp_number_label,
+        'custom_4' as scheduling_method_label,
+        'custom_6' as facility_type_label,
+        'custom_28' as cert_licensure_qual_status_label,
+        'custom_5' as highly_qualified_label,
+        'custom_25' as reading_intervention_component_label,
+        'custom_33' as location_of_student_label,
+        'custom_34' as eoc_exam_term_label,
+        'custom_22' as basic_skills_exam_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__course_periods__pivot
+    description: >-
+      Decoded labels for the CoursePeriod select custom fields, one row per
+      Focus course_period_id. Join to stg_focus__course_periods on
+      course_period_id.
+    columns:
+      - name: course_period_id
+        description: Primary key — Focus course period (section) id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: fefp_number_label
+        description: Decoded label for the fefp_number select field.
+      - name: scheduling_method_label
+        description: Decoded label for the scheduling_method select field.
+      - name: facility_type_label
+        description: Decoded label for the facility_type select field.
+      - name: cert_licensure_qual_status_label
+        description:
+          Decoded label for the cert_licensure_qual_status select field.
+      - name: highly_qualified_label
+        description: Decoded label for the highly_qualified select field.
+      - name: reading_intervention_component_label
+        description:
+          Decoded label for the reading_intervention_component select field.
+      - name: location_of_student_label
+        description: Decoded label for the location_of_student select field.
+      - name: eoc_exam_term_label
+        description: Decoded label for the eoc_exam_term select field.
+      - name: basic_skills_exam_label
+        description: Decoded label for the basic_skills_exam select field.
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__course_periods__pivot` Expected: PASS.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select count(*) as n, countif(facility_type_label is not null) as n_facility
+from `teamster-332318`.<your_dev_schema>.int_focus__course_periods__pivot
+```
+
+Expected: `n_facility` > 0 with readable labels.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__course_periods__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__course_periods__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__course_periods__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__course_periods__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode CoursePeriod custom fields in int_focus__course_periods__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `int_focus__master_courses__pivot`
+
+**Files:**
+
+- Create:
+  `src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__master_courses__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__master_courses` (PK `course_id` + slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per `course_id` with 3 `<slug>_label` columns. PK
+  `course_id`. Not PII.
+
+Decode map (`source_class = 'CourseCatalog'`): `fefp`→`custom_field_5`,
+`course_flag_1`→`custom_field_6`, `dual_enrollment_indicator`→`custom_field_13`.
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    encoded as (
+        select
+            course_id,
+            cast(fefp as string) as custom_field_5,
+            cast(course_flag_1 as string) as custom_field_6,
+            cast(dual_enrollment_indicator as string) as custom_field_13,
+        from {{ ref("stg_focus__master_courses") }}
+    ),
+
+    unpivoted as (
+        select course_id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_field_5, custom_field_6, custom_field_13
+            )
+        )
+    ),
+
+    decoded as (
+        select
+            unpivoted.course_id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'CourseCatalog'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_field_5' as fefp_label,
+        'custom_field_6' as course_flag_1_label,
+        'custom_field_13' as dual_enrollment_indicator_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__master_courses__pivot
+    description: >-
+      Decoded labels for the CourseCatalog (master course) select custom fields,
+      one row per Focus course_id. Join to stg_focus__master_courses on
+      course_id.
+    columns:
+      - name: course_id
+        description: Primary key — Focus master course id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: fefp_label
+        description: Decoded label for the fefp select field.
+      - name: course_flag_1_label
+        description: Decoded label for the course_flag_1 select field.
+      - name: dual_enrollment_indicator_label
+        description:
+          Decoded label for the dual_enrollment_indicator select field.
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__master_courses__pivot` Expected: PASS.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select count(*) as n, countif(fefp_label is not null) as n_fefp
+from `teamster-332318`.<your_dev_schema>.int_focus__master_courses__pivot
+```
+
+Expected: `n_fefp` > 0 with readable labels.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__master_courses__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__master_courses__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode CourseCatalog custom fields in int_focus__master_courses__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `int_focus__courses__pivot`
+
+**Files:**
+
+- Create: `src/dbt/focus/models/intermediate/int_focus__courses__pivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__courses__pivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__courses` (PK `course_id` + slugs below),
+  `int_focus__custom_field_options`.
+- Produces: one row per `course_id` with 2 `<slug>_label` columns. PK
+  `course_id`. Not PII.
+
+Decode map (`source_class = 'Course'`): `course_sequence`→`custom_4`,
+`ocp`→`custom_3`.
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    encoded as (
+        select
+            course_id,
+            cast(course_sequence as string) as custom_4,
+            cast(ocp as string) as custom_3,
+        from {{ ref("stg_focus__courses") }}
+    ),
+
+    unpivoted as (
+        select course_id, column_name, code
+        from encoded unpivot (code for column_name in (custom_4, custom_3))
+    ),
+
+    decoded as (
+        select
+            unpivoted.course_id,
+            unpivoted.column_name,
+            options.label,
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on unpivoted.column_name = options.column_name
+            and unpivoted.code = options.code
+            and options.source_class = 'Course'
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_4' as course_sequence_label,
+        'custom_3' as ocp_label
+    )
+)
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__courses__pivot
+    description: >-
+      Decoded labels for the Course select custom fields, one row per Focus
+      course_id. Join to stg_focus__courses on course_id for the codes.
+    columns:
+      - name: course_id
+        description: Primary key — Focus course id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: course_sequence_label
+        description: Decoded label for the course_sequence select field.
+      - name: ocp_label
+        description: Decoded label for the ocp select field.
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__courses__pivot` Expected: PASS.
+
+- [ ] **Step 4: Spot-check**
+
+```sql
+select count(*) as n, countif(ocp_label is not null) as n_ocp
+from `teamster-332318`.<your_dev_schema>.int_focus__courses__pivot
+```
+
+Expected: `n_ocp` > 0 with readable labels.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__courses__pivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__courses__pivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__courses__pivot.sql src/dbt/focus/models/intermediate/properties/int_focus__courses__pivot.yml
+git -C "$wt" commit -m "feat(dbt): decode Course custom fields in int_focus__courses__pivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `int_focus__custom_field_log__unpivot`
+
+**Files:**
+
+- Create:
+  `src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql`
+- Create:
+  `src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_focus__custom_field_log_entries` (`id`, `source_id`,
+  `school_id`, `field_id`, `syear`, `created_at`, `updated_at`,
+  `log_field1`..`log_field30`), `stg_focus__custom_field_log_columns` (`id`,
+  `field_id`, `column_name`, `type`, `title`, `sort_order`),
+  `stg_focus__custom_fields` (`id`, `title`),
+  `stg_focus__custom_field_select_options` (`source_class`, `source_id`, `code`,
+  `label`).
+- Produces: long rows, grain `(log_entry_id, slot_column_name)`. PII
+  (student-linked).
+
+Notes: log slots decode via `select_options` keyed on
+`source_class = 'CustomFieldLogColumn'`,
+`source_id = custom_field_log_columns.id`. `completed_at` is omitted (always
+null). Catalog `column_name` is UPPERCASE (`LOG_FIELD1`); lowercase it to match
+the entry column names. Unpivot all 30 slots; the inner join to `log_columns`
+drops slots a field does not define.
+
+- [ ] **Step 1: Write the model**
+
+```sql
+with
+    entries as (
+        select
+            id as log_entry_id,
+            source_id as student_id,
+            school_id,
+            field_id,
+            syear,
+            created_at,
+            updated_at,
+            cast(log_field1 as string) as log_field1,
+            cast(log_field2 as string) as log_field2,
+            cast(log_field3 as string) as log_field3,
+            cast(log_field4 as string) as log_field4,
+            cast(log_field5 as string) as log_field5,
+            cast(log_field6 as string) as log_field6,
+            cast(log_field7 as string) as log_field7,
+            cast(log_field8 as string) as log_field8,
+            cast(log_field9 as string) as log_field9,
+            cast(log_field10 as string) as log_field10,
+            cast(log_field11 as string) as log_field11,
+            cast(log_field12 as string) as log_field12,
+            cast(log_field13 as string) as log_field13,
+            cast(log_field14 as string) as log_field14,
+            cast(log_field15 as string) as log_field15,
+            cast(log_field16 as string) as log_field16,
+            cast(log_field17 as string) as log_field17,
+            cast(log_field18 as string) as log_field18,
+            cast(log_field19 as string) as log_field19,
+            cast(log_field20 as string) as log_field20,
+            cast(log_field21 as string) as log_field21,
+            cast(log_field22 as string) as log_field22,
+            cast(log_field23 as string) as log_field23,
+            cast(log_field24 as string) as log_field24,
+            cast(log_field25 as string) as log_field25,
+            cast(log_field26 as string) as log_field26,
+            cast(log_field27 as string) as log_field27,
+            cast(log_field28 as string) as log_field28,
+            cast(log_field29 as string) as log_field29,
+            cast(log_field30 as string) as log_field30,
+        from {{ ref("stg_focus__custom_field_log_entries") }}
+    ),
+
+    unpivoted as (
+        select
+            log_entry_id,
+            student_id,
+            school_id,
+            field_id,
+            syear,
+            created_at,
+            updated_at,
+            slot_column_name,
+            value,
+        from entries unpivot (
+            value for slot_column_name in (
+                log_field1, log_field2, log_field3, log_field4, log_field5,
+                log_field6, log_field7, log_field8, log_field9, log_field10,
+                log_field11, log_field12, log_field13, log_field14, log_field15,
+                log_field16, log_field17, log_field18, log_field19, log_field20,
+                log_field21, log_field22, log_field23, log_field24, log_field25,
+                log_field26, log_field27, log_field28, log_field29, log_field30
+            )
+        )
+    ),
+
+    columns_meta as (
+        select
+            id as log_column_id,
+            field_id,
+            lower(column_name) as slot_column_name,
+            type as slot_type,
+            title as slot_title,
+            sort_order as slot_sort_order,
+        from {{ ref("stg_focus__custom_field_log_columns") }}
+    ),
+
+    fields_meta as (
+        select
+            id as field_id,
+            title as field_title,
+        from {{ ref("stg_focus__custom_fields") }}
+    ),
+
+    options as (
+        select
+            source_id,
+            code,
+            label,
+        from {{ ref("stg_focus__custom_field_select_options") }}
+        where source_class = 'CustomFieldLogColumn'
+    )
+
+select
+    unpivoted.log_entry_id,
+    unpivoted.student_id,
+    unpivoted.school_id,
+    unpivoted.field_id,
+    columns_meta.log_column_id,
+    columns_meta.slot_column_name,
+    columns_meta.slot_type,
+    columns_meta.slot_title,
+    columns_meta.slot_sort_order,
+    fields_meta.field_title,
+    unpivoted.value,
+    unpivoted.syear,
+    unpivoted.created_at,
+    unpivoted.updated_at,
+    options.label as value_label,
+from unpivoted
+inner join columns_meta
+    on unpivoted.field_id = columns_meta.field_id
+    and unpivoted.slot_column_name = columns_meta.slot_column_name
+left join fields_meta on unpivoted.field_id = fields_meta.field_id
+left join options
+    on columns_meta.log_column_id = options.source_id
+    and unpivoted.value = options.code
+```
+
+- [ ] **Step 2: Write the properties yml**
+
+```yaml
+models:
+  - name: int_focus__custom_field_log__unpivot
+    description: >-
+      Long reshape of Focus log-type custom fields. One row per log entry per
+      populated slot: the entry keys, the slot's metadata (title/type/sort order
+      from custom_field_log_columns), the stored value, and a decoded
+      value_label for select-type slots. Currently covers the two populated
+      student log fields (Immunization Compliance, ARMS Student Field Tracker).
+    config:
+      meta:
+        contains_pii: true
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - log_entry_id
+              - slot_column_name
+          config:
+            severity: error
+    columns:
+      - name: log_entry_id
+        description: Focus custom_field_log_entries id.
+      - name: student_id
+        description: Owning student id (custom_field_log_entries.source_id).
+      - name: school_id
+        description: School id the log entry is attached to.
+      - name: field_id
+        description: Owning log custom field id (custom_fields.id).
+      - name: log_column_id
+        description: Log column id for the slot (custom_field_log_columns.id).
+      - name: slot_column_name
+        description: Lowercased slot storage column (log_fieldN).
+      - name: slot_type
+        description: Input type of the slot (select, checkbox, text, date).
+      - name: slot_title
+        description: Human-readable slot name from custom_field_log_columns.
+      - name: slot_sort_order
+        description: Display order of the slot within the field.
+      - name: field_title
+        description:
+          Human-readable log field name (e.g. Immunization Compliance).
+      - name: value
+        description: Raw stored slot value.
+      - name: syear
+        description: Focus school year of the entry (populated for ARMS only).
+      - name: created_at
+        description: Log entry creation timestamp.
+      - name: updated_at
+        description: Log entry last-update timestamp.
+      - name: value_label
+        description: >-
+          Decoded label for select-type slots; null for non-select slots (the
+          raw value carries the readable content).
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `dbtb int_focus__custom_field_log__unpivot` Expected: PASS —
+`unique_combination_of_columns` on `(log_entry_id, slot_column_name)` passes.
+
+- [ ] **Step 4: Spot-check the decode + grain**
+
+```sql
+select field_title, slot_title, slot_type,
+  count(*) as n, countif(value_label is not null) as n_decoded
+from `teamster-332318`.<your_dev_schema>.int_focus__custom_field_log__unpivot
+group by 1, 2, 3
+order by 1, 2
+```
+
+Expected: rows for both fields; `value_label` populated for the `select`-type
+slots (`Vaccination`, `ARMS Student Field`) and null for `text` / `checkbox` /
+`date` slots.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql \
+  src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+git -C "$wt" add src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+git -C "$wt" commit -m "feat(dbt): reshape Focus log custom fields in int_focus__custom_field_log__unpivot" -m "Refs #4258" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Build the full new graph together**
+
+Run: `dbtb int_focus__custom_field_options+` Expected: all 9 new models build
+and all tests pass in one run.
+
+- [ ] **Confirm no staging drift**
+
+Run: `git -C "$wt" status` — only files under `models/intermediate/`, `tests/`,
+`docs/superpowers/`, and `src/dbt/focus/CLAUDE.md` changed. No `staging/`
+changes.
+
+- [ ] **Open the PR** using `.github/pull_request_template.md`, body referencing
+      `Closes #4258`. Flag in the PR description that column-level PII tags
+      follow the FERPA-broad stance pending People Operations confirmation.

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -1,0 +1,323 @@
+# Focus SIS Wave 2 — decode encoded custom values + reshape log fields
+
+Design spec for [#4258](https://github.com/TEAMSchools/teamster/issues/4258).
+Deferred follow-up from Focus SIS Phase B (#4213).
+
+## Context
+
+The Phase B staging models project `select` / `multiple` custom-field values
+inline but leave them as their stored Focus **option codes** (decode was out of
+scope to keep staging contracts stable). This work decodes those codes to
+human-readable labels, and reshapes the `log`-type custom fields into a usable
+long shape.
+
+All work is **additive intermediate models** under
+`src/dbt/focus/models/intermediate/`. There are **no staging changes** — staging
+stays encoded, and the H custom-field metadata staging is already merged. Models
+build in `kippmiami` (the only district wired for Focus); district-internal, so
+there is no prod-materialization gate.
+
+## Findings from data profiling (Miami pull)
+
+These reframe the issue and `focus/CLAUDE.md`, and are load-bearing for the
+design:
+
+1. **The documented decode join is wrong.**
+   `custom_field_select_options.source_class` is the literal polymorphic value
+   `CustomField` (for entity fields) or `CustomFieldLogColumn` (for log-column
+   slots) — **not** the entity class (`SISSchool`, etc.). Joining on the entity
+   class returns zero matches. The correct join is
+   `select_options.source_id = custom_fields.id` alone, with
+   `select_options.source_class = 'CustomField'`.
+
+2. **`select` and `multiple` store differently.** `select` stores a **bare
+   code** (`5539`, `E`). `multiple` stores a **JSON-array string** (`["2795"]`).
+   Decode for `multiple` means parse-JSON + map each element, not split on a
+   delimiter. In the current pull every `multiple` value is single-element, but
+   the format is a real JSON array, so decode handles N elements generically.
+
+3. **A minority of fields decode only via a dynamic `option_query`** (no rows in
+   `custom_field_select_options`). Among the in-scope projected fields, exactly
+   **one** is `option_query`-only: `FocusUser.profile_on_non_production_sites`
+   (`custom_l790`). It is excluded from decode and documented; all other
+   in-scope fields resolve via stored options.
+
+4. **The `log` reshape is narrow.** All 24,224 `custom_field_log_entries` rows
+   are `SISStudent`, across just **two** fields — `Immunization Compliance`
+   (`field_id` 541) and `ARMS Student Field Tracker` (`field_id` 1119) — and
+   1,514 students. Each entry has up to four typed slots (`LOG_FIELD1..4`) named
+   by `custom_field_log_columns`. `created_at` / `updated_at` are fully
+   populated; `completed_at` is always null; `syear` is populated only on ARMS.
+
+## Goals
+
+- Decode every in-scope projected `select` / `multiple` custom value to its
+  label.
+- Reshape the two populated `log`-type fields into a long, typed, decoded model.
+- Provide a single reusable code-to-label crosswalk.
+- Fix the wrong decode-join documentation in `focus/CLAUDE.md`.
+
+## Non-goals (YAGNI)
+
+- No `rpt_` / mart / extract layer — this pass builds the reusable intermediate
+  foundation only. (Repo convention: an `rpt_` must sit between an intermediate
+  model and any external consumer; one gets added when a concrete consumer
+  appears.)
+- No decode of `option_query`-only fields (would require running the live Focus
+  query).
+- No decode of non-`select`/`multiple` customs (`checkbox` Y/N, `text`,
+  `numeric`, `date` are already human-readable).
+- No staging changes.
+
+## Architecture
+
+Nine intermediate models:
+
+| Model                                  | Role                                                  |
+| -------------------------------------- | ----------------------------------------------------- |
+| `int_focus__custom_field_options`      | Shared code-to-label crosswalk                        |
+| `int_focus__students__pivot`           | Decoded labels for SISStudent select fields           |
+| `int_focus__schools__pivot`            | Decoded labels for SISSchool select fields            |
+| `int_focus__student_enrollment__pivot` | Decoded labels for StudentEnrollment select fields    |
+| `int_focus__users__pivot`              | Decoded labels for FocusUser select + multiple fields |
+| `int_focus__course_periods__pivot`     | Decoded labels for CoursePeriod select fields         |
+| `int_focus__master_courses__pivot`     | Decoded labels for CourseCatalog select fields        |
+| `int_focus__courses__pivot`            | Decoded labels for Course select fields               |
+| `int_focus__custom_field_log`          | Long reshape of the two populated log-type fields     |
+
+The existing `int_focus__student_enrollment` (title enrichment) is unchanged;
+the new `int_focus__student_enrollment__pivot` is a separate decode-only model.
+
+Each `__pivot` model is **labels-only**, keyed by the entity primary key. Codes
+remain in staging untouched; a downstream consumer joins staging (codes) and the
+pivot model (labels) on the PK.
+
+### `int_focus__custom_field_options` (crosswalk)
+
+```sql
+with
+    cf as (
+        select id, source_class, lower(column_name) as column_name
+        from {{ ref("stg_focus__custom_fields") }}
+    ),
+
+    opt as (
+        select source_id, code, label
+        from {{ ref("stg_focus__custom_field_select_options") }}
+        where source_class = 'CustomField'  -- keep inactive: decode historical values
+    )
+
+select
+    cf.source_class,
+    cf.column_name,
+    opt.code,
+    opt.label,
+from opt
+inner join cf on opt.source_id = cf.id
+```
+
+- Grain / uniqueness: `(source_class, column_name, code)`.
+- `inactive` options are kept — a stored value can reference an option later
+  marked inactive.
+- If a field carries duplicate `code` rows (e.g. across `min_syear` /
+  `max_syear`), dedupe with `dbt_utils.deduplicate` (`partition_by` the grain,
+  `order_by updated_at desc`). Verify whether duplicates exist during
+  implementation; only add the dedupe if the uniqueness test fails.
+
+### `int_focus__<entity>__pivot` (decode via UNPIVOT then join then PIVOT)
+
+Pattern, shown for `int_focus__schools__pivot`:
+
+```sql
+with
+    encoded as (
+        select
+            school_id,
+            cast(school_level as string) as custom_100000004,
+            cast(school_type as string) as custom_200000326,
+            cast(technical_center as string) as custom_50000002,
+        from {{ ref("stg_focus__schools") }}
+    ),
+
+    unpivoted as (
+        select school_id, column_name, code
+        from encoded unpivot (
+            code for column_name in (
+                custom_100000004, custom_200000326, custom_50000002
+            )
+        )
+    ),
+
+    decoded as (
+        select unpivoted.school_id, unpivoted.column_name, options.label
+        from unpivoted
+        left join {{ ref("int_focus__custom_field_options") }} as options
+            on options.source_class = 'SISSchool'
+            and options.column_name = unpivoted.column_name
+            and options.code = unpivoted.code
+    )
+
+select *
+from decoded pivot (
+    any_value(label) for column_name in (
+        'custom_100000004' as school_level_label,
+        'custom_200000326' as school_type_label,
+        'custom_50000002' as technical_center_label
+    )
+)
+```
+
+Mechanics and rationale:
+
+- The slug to catalog-`column_name` mapping lives once, in the `encoded` CTE
+  aliases — `custom_100000004` greps straight back to staging's
+  `custom_100000004 as school_level`. No magic field-id integers in the model.
+- All encoded columns are cast to `string` in `encoded` so the mixed-type
+  `select` columns share a type for `UNPIVOT` (codes compare as strings against
+  the crosswalk).
+- `UNPIVOT` excludes nulls by default, so an unset field yields no row and a
+  null pivot column.
+- `any_value(label)` is safe: each `(pk, column_name)` has exactly one row after
+  the join. An unresolved code (none, given the inventory below) would yield a
+  null label.
+- Output label columns use the `<slug>_label` suffix.
+- Uniqueness test on the entity PK (one row per entity).
+
+#### `multiple` wrinkle — `int_focus__users__pivot`
+
+A single `PIVOT` applies one aggregate to all fields, and `multiple` needs a
+JSON-array explode plus `array_agg`. So `int_focus__users__pivot` PIVOTs its one
+decodable `select` field (`active`), then left-joins an `education_label`
+`array<string>` built with the CTE pattern (cross join `unnest` then join then
+`array_agg`) — not a correlated subquery, per the BigQuery no-correlated-
+subquery rule in `dbt/CLAUDE.md`:
+
+```sql
+education as (
+    select
+        users.staff_id,
+        array_agg(options.label ignore nulls order by options.label)
+            as education_label,
+    from {{ ref("stg_focus__users") }} as users
+    cross join unnest(json_value_array(users.education)) as code
+    left join {{ ref("int_focus__custom_field_options") }} as options
+        on options.source_class = 'FocusUser'
+        and options.column_name = 'custom_2'
+        and options.code = code
+    group by users.staff_id
+)
+```
+
+`profile_on_non_production_sites` (`custom_l790`) is `option_query`-only and is
+**omitted** from the pivot (it cannot decode from the static table). Its code
+remains available in staging; a SQL comment documents why it is excluded.
+
+#### In-scope decode inventory
+
+Authoritative map (catalog-confirmed; `field_id` shown for reference only — the
+models join on `column_name`, not the id):
+
+| Pivot model                            | source_class      | staging slug                                     | column_name        | field_id | type     | options |
+| -------------------------------------- | ----------------- | ------------------------------------------------ | ------------------ | -------- | -------- | ------- |
+| `int_focus__students__pivot`           | SISStudent        | `ethnicity_hispanic_or_latino`                   | `custom_100000105` | 73       | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `race_white`                                     | `custom_100000104` | 74       | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `race_black_or_african_american`                 | `custom_100000102` | 75       | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `race_asian`                                     | `custom_100000101` | 141      | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `sex`                                            | `custom_200000000` | 310      | select   | 3       |
+| `int_focus__students__pivot`           | SISStudent        | `race_american_indian_or_alaska_native`          | `custom_100000100` | 368      | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `race_native_hawaiian_or_other_pacific_islander` | `custom_100000103` | 369      | select   | 2       |
+| `int_focus__students__pivot`           | SISStudent        | `residence_county`                               | `custom_837`       | 374      | select   | 75      |
+| `int_focus__students__pivot`           | SISStudent        | `language`                                       | `custom_200000005` | 434      | select   | 3       |
+| `int_focus__schools__pivot`            | SISSchool         | `technical_center`                               | `custom_50000002`  | 678      | select   | 3       |
+| `int_focus__schools__pivot`            | SISSchool         | `school_level`                                   | `custom_100000004` | 681      | select   | 5       |
+| `int_focus__schools__pivot`            | SISSchool         | `school_type`                                    | `custom_200000326` | 682      | select   | 12      |
+| `int_focus__student_enrollment__pivot` | StudentEnrollment | `prior_district`                                 | `custom_1`         | 1486     | select   | 82      |
+| `int_focus__student_enrollment__pivot` | StudentEnrollment | `prior_state`                                    | `custom_2`         | 1487     | select   | 72      |
+| `int_focus__student_enrollment__pivot` | StudentEnrollment | `prior_country`                                  | `custom_3`         | 1488     | select   | 288     |
+| `int_focus__student_enrollment__pivot` | StudentEnrollment | `educational_choice`                             | `custom_4`         | 1489     | select   | 8       |
+| `int_focus__student_enrollment__pivot` | StudentEnrollment | `student_offender_transfer`                      | `custom_6`         | 1491     | select   | 2       |
+| `int_focus__users__pivot`              | FocusUser         | `active`                                         | `custom_319000004` | 513      | select   | 2       |
+| `int_focus__users__pivot`              | FocusUser         | `education`                                      | `custom_2`         | 508      | multiple | 5       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `fefp_number`                                    | `custom_2`         | 1508     | select   | 11      |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `scheduling_method`                              | `custom_4`         | 1513     | select   | 9       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `facility_type`                                  | `custom_6`         | 1516     | select   | 21      |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `cert_licensure_qual_status`                     | `custom_28`        | 1530     | select   | 13      |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `highly_qualified`                               | `custom_5`         | 1531     | select   | 9       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `reading_intervention_component`                 | `custom_25`        | 1534     | select   | 4       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `location_of_student`                            | `custom_33`        | 1554     | select   | 4       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `eoc_exam_term`                                  | `custom_34`        | 1560     | select   | 4       |
+| `int_focus__course_periods__pivot`     | CoursePeriod      | `basic_skills_exam`                              | `custom_22`        | 1544     | select   | 14      |
+| `int_focus__master_courses__pivot`     | CourseCatalog     | `fefp`                                           | `custom_field_5`   | 1738     | select   | 11      |
+| `int_focus__master_courses__pivot`     | CourseCatalog     | `course_flag_1`                                  | `custom_field_6`   | 1739     | select   | 18      |
+| `int_focus__master_courses__pivot`     | CourseCatalog     | `dual_enrollment_indicator`                      | `custom_field_13`  | 1731     | select   | 5       |
+| `int_focus__courses__pivot`            | Course            | `course_sequence`                                | `custom_4`         | 1724     | select   | 12      |
+| `int_focus__courses__pivot`            | Course            | `ocp`                                            | `custom_3`         | 1723     | select   | 78      |
+
+Excluded (in-scope entity, but not decodable): `FocusUser`
+`profile_on_non_production_sites` (`custom_l790`, field 790) —
+`option_query`-only.
+
+### `int_focus__custom_field_log` (long reshape)
+
+`UNPIVOT` `log_field1..log_field30` (nulls dropped), inner-join
+`stg_focus__custom_field_log_columns` on `(field_id, LOG_FIELDn)` to label and
+type each slot, then decode `select`-type slots via
+`stg_focus__custom_field_select_options` keyed on
+`source_class = 'CustomFieldLogColumn'`,
+`source_id = custom_field_log_columns.id`.
+
+- Columns: `log_entry_id`, `student_id` (`source_id`), `school_id`, `field_id`,
+  `field_title`, `slot_sort_order`, `slot_column_name`, `slot_title`,
+  `slot_type`, `value`, `value_label`, `syear`, `created_at`, `updated_at`.
+- Grain / uniqueness: `(log_entry_id, slot_column_name)`.
+- `completed_at` is omitted (always null). `created_at` / `updated_at` are the
+  recorded-at timestamps.
+- Unpivot all 30 slots for forward-safety; the inner join to
+  `custom_field_log_columns` drops slots a field does not define (current data
+  uses slots 1–4 only).
+- `value_label` is the decoded label for `select` slots; for non-`select` slots
+  it is null (the raw `value` carries the readable content).
+
+## Cross-cutting
+
+- **Naming.** Decode models use the `int_focus__<entity>__pivot` convention.
+  Label columns use the `<slug>_label` suffix.
+- **Tests.** Uniqueness test on every model (intermediate-layer requirement):
+  entity PK on each `__pivot`, `(source_class, column_name, code)` on the
+  crosswalk, `(log_entry_id, slot_column_name)` on the log model. Tests are
+  warn-level unless a stronger signal is warranted; the crosswalk grain is
+  `error` (a duplicate there silently corrupts every decode).
+- **PII.** Student- and staff-level pivot models and the log model carry PII via
+  their entity keys and some decoded values (e.g. `sex`, `race_*`, `language`,
+  residence/birth-linked attributes). Tag `config.meta.contains_pii: true`
+  consistent with the existing Focus staging precedent; confirm direct-only vs
+  direct+indirect scope with the field owner before finalizing tags.
+- **Descriptions.** Every new model and every column gets a `description:` in
+  `properties/`. Describe decoded columns by their logic (decoded label for the
+  named field). Data/column semantics go in descriptions, not CLAUDE.md.
+- **Docs fix.** Correct the "Focus field value codes" section of
+  `src/dbt/focus/CLAUDE.md`: the join is
+  `select_options.source_id = custom_fields.id` with
+  `select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'` for
+  log slots), **not** a match on the entity `source_class`.
+
+## Out of scope / follow-ups
+
+- `option_query`-backed dynamic option lists (one in-scope field today).
+- Any `rpt_` / mart / extract consuming these models.
+- Other districts (only `kippmiami` ingests Focus).
+
+## Open implementation checks
+
+1. **Crosswalk duplicates.** Build the crosswalk, run its uniqueness test; add
+   `dbt_utils.deduplicate` only if `(source_class, column_name, code)` is not
+   already unique.
+2. **`multiple` multi-element.** Current data is single-element; the `array_agg`
+   decode handles N elements regardless. No additional work unless a
+   multi-element value needs ordering guarantees beyond `order by label`.
+3. **Log-slot select decode coverage.** Confirm the `select`-type log slots
+   (`Vaccination`, `ARMS Student Field`) resolve via the
+   `CustomFieldLogColumn`-keyed options before relying on `value_label`.
+4. **Build order.** Crosswalk first, then the pivots and log model. Run
+   `dbt deps` in the worktree before any build (fresh worktree has no
+   `dbt_packages/`).

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -36,11 +36,15 @@ design:
    delimiter. In the current pull every `multiple` value is single-element, but
    the format is a real JSON array, so decode handles N elements generically.
 
-3. **A minority of fields decode only via a dynamic `option_query`** (no rows in
-   `custom_field_select_options`). Among the in-scope projected fields, exactly
-   **one** is `option_query`-only: `FocusUser.profile_on_non_production_sites`
-   (`custom_l790`). It is excluded from decode and documented; all other
-   in-scope fields resolve via stored options.
+3. **A minority of fields back their option list with a dynamic `option_query`**
+   (no rows in `custom_field_select_options`; Focus builds the list at render
+   time from other tables). Among the in-scope projected fields, exactly **one**
+   is `option_query`-backed: `FocusUser.profile_on_non_production_sites`
+   (`custom_l790`). It is decodable — its query is
+   `select id, title as label from user_profiles`, and `user_profiles` is staged
+   — but skipped as low-value (12 of 181 users, one distinct code). All other
+   in-scope fields resolve via stored options. See _Out of scope_ for the full
+   `option_query` inventory.
 
 4. **The `log` reshape is narrow.** All 24,224 `custom_field_log_entries` rows
    are `SISStudent`, across just **two** fields — `Immunization Compliance`
@@ -63,8 +67,8 @@ design:
   foundation only. (Repo convention: an `rpt_` must sit between an intermediate
   model and any external consumer; one gets added when a concrete consumer
   appears.)
-- No decode of `option_query`-only fields (would require running the live Focus
-  query).
+- No decode of `option_query`-backed fields (inventoried under _Out of scope_;
+  the one in-scope field is skipped as low-value).
 - No decode of non-`select`/`multiple` customs (`checkbox` Y/N, `text`,
   `numeric`, `date` are already human-readable).
 - No staging changes.
@@ -208,9 +212,12 @@ education as (
 )
 ```
 
-`profile_on_non_production_sites` (`custom_l790`) is `option_query`-only and is
-**omitted** from the pivot (it cannot decode from the static table). Its code
-remains available in staging; a SQL comment documents why it is excluded.
+`profile_on_non_production_sites` (`custom_l790`) is `option_query`-backed and
+is **omitted** from the pivot. It is decodable via a join to
+`stg_focus__user_profiles` (`custom_l790 = user_profiles.id`, then `title`), but
+skipped as low-value (12 of 181 users, one distinct code). Its code remains in
+staging; a SQL comment documents the skip. See _Out of scope_ for the full
+`option_query` inventory.
 
 #### In-scope decode inventory
 
@@ -303,9 +310,58 @@ type each slot, then decode `select`-type slots via
 
 ## Out of scope / follow-ups
 
-- `option_query`-backed dynamic option lists (one in-scope field today).
+- `option_query`-backed dynamic option lists (inventoried below).
 - Any `rpt_` / mart / extract consuming these models.
 - Other districts (only `kippmiami` ingests Focus).
+
+### `option_query`-backed fields (not decoded)
+
+These `select` fields generate their option list from a live Focus query against
+other tables instead of `custom_field_select_options`, so they do not decode via
+the crosswalk. Only `FocusUser.profile_on_non_production_sites` (`custom_l790`)
+is projected in staging today, and it is skipped as low-value; the rest are not
+projected. Recorded here so the set is captured if a future consumer needs one.
+
+| source_class  | column_name                             | title                              | label source                                   |
+| ------------- | --------------------------------------- | ---------------------------------- | ---------------------------------------------- |
+| FocusUser     | `custom_l790`                           | Profile On Non-Production Sites    | `user_profiles` (projected; skipped)           |
+| FocusUser     | `check_location`                        | Check Location                     | `gl_facilities`                                |
+| FocusUser     | `charter_final_eval`                    | Final Evaluation Code              | `gl_pr_personnel_evaluation_codes`             |
+| FocusUser     | `charter_eval_msp`                      | MSP                                | `gl_pr_measures_of_student_learning_growth`    |
+| FocusUser     | `charter_mid_eval`                      | Midpoint Evaluation (new teachers) | `gl_pr_personnel_evaluation_codes`             |
+| FocusUser     | `charter_prim_job`                      | Primary Job Code                   | `gl_pr_jobs_state`                             |
+| FocusUser     | `charter_prim_schl`                     | Primary School                     | `gl_facilities`                                |
+| FocusUser     | `custom_l1472`                          | Site Assignment (Primary)          | `schools`                                      |
+| SISStudent    | `custom_fl_biliteracy_aappl`            | ACTFL AAPPL                        | options table (syear-scoped)                   |
+| SISStudent    | `custom_fl_biliteracy_opi`              | ACTFL OPI                          | options table (syear-scoped)                   |
+| SISStudent    | `custom_fl_biliteracy_asl`              | SLPI:ASL                           | options table (syear-scoped)                   |
+| SISStudent    | `custom_fl_biliteracy_stamp4s`          | STAMP4S (Grade 7-Adult)            | options table (syear-scoped)                   |
+| SISStudent    | `custom_fl_biliteracy_bcpo`             | Biliteracy Seal Portfolio Option   | options table (syear-scoped)                   |
+| SISStudent    | `application_courses_selected_course_1` | Application Courses Selected 1     | `course_periods` + `courses` (syear-scoped)    |
+| SISStudent    | `application_courses_selected_course_2` | Application Courses Selected 2     | `course_periods` + `courses` (syear-scoped)    |
+| SISStudent    | `application_courses_selected_course_3` | Application Courses Selected 3     | `course_periods` + `courses` (syear-scoped)    |
+| SISStudent    | `custom_992012001`                      | Bus Driver Name AM                 | `custom_field_log_entries`                     |
+| SISStudent    | `custom_992012002`                      | Bus Driver Name PM                 | `custom_field_log_entries`                     |
+| SISStudent    | `custom_l1216`                          | Future ESE Model Choice            | `custom_field_select_options` (source_id 1042) |
+| CourseCatalog | `custom_field_15`                       | Industry Certification ID          | `florida_industry_certifications` (syear)      |
+| CourseCatalog | `custom_field_16`                       | 2nd Industry Certification ID      | `florida_industry_certifications` (syear)      |
+| CourseCatalog | `custom_field_18`                       | 3rd Industry Certification ID      | `florida_industry_certifications` (syear)      |
+
+`SISSchool`, `StudentEnrollment`, `CoursePeriod`, and `Course` have none. The
+catalog is the live source of truth — regenerate the current set with:
+
+```sql
+select cf.source_class, cf.column_name, cf.title, cf.option_query
+from {{ ref("stg_focus__custom_fields") }} as cf
+left join (
+    select distinct source_id
+    from {{ ref("stg_focus__custom_field_select_options") }}
+    where source_class = 'CustomField'
+) as o on cf.id = o.source_id
+where cf.type in ('select', 'multiple')
+    and cf.option_query is not null
+    and o.source_id is null
+```
 
 ## Open implementation checks
 

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -32,12 +32,13 @@ design:
    entity class (`SISSchool`, etc.) — `source_class` is never the entity class,
    so that filter returns zero rows (the trap that surfaced this).
 
-2. **The entity stores the option `id`, not the `code`.** A `select` value is a
-   single select-option **id** (e.g. `5538` → label `E - Elementary`), stored as
-   an int. A `multiple` value is a **JSON-array string of option ids**
-   (`["2795"]`). Decode joins the stored id to `select_options.id` and reads
-   `label` (the `code` — `E`, `M` — is the Focus import/export value, never the
-   stored value). `multiple` means parse-JSON + map each id, not split on a
+2. **The stored value is the option `id` OR its `code` — it varies by field.**
+   `school_level`/`sex` store the select-option **id** (`5538`, `2789`);
+   `prior_state` stores the **`code`** (`FL`). So decode matches the stored
+   value against **either** `select_options.id` or `select_options.code`
+   (`unpivoted.stored_value in (options.option_id, options.code)`), filtered to
+   the field; it reads `label`. A `multiple` value is a JSON-array string of
+   those values (`["2795"]`) — parse-JSON + match each, not split on a
    delimiter. Every current `multiple` value is single-element, but the format
    is a real JSON array, so decode handles N elements generically.
 
@@ -128,9 +129,9 @@ inner join cf on opt.source_id = cf.id
 
 - Grain / uniqueness: `option_id` (the select-option PK — globally unique,
   non-null, so no dedupe needed).
-- The entity stores the option **id**, not its `code`; pivots join the stored
-  value to `option_id`. `code` is the Focus import/export value and `label` the
-  human name (the decode output).
+- The stored value is the option `id` for some fields, the `code` for others;
+  pivots match it against `option_id` OR `code`. `code` is the Focus
+  import/export value and `label` the human name (the decode output).
 - `inactive` options are kept — a stored value can reference an option later
   marked inactive.
 
@@ -150,9 +151,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, option_id
+        select id, column_name, stored_value
         from encoded unpivot (
-            option_id for column_name in (
+            stored_value for column_name in (
                 custom_100000004, custom_200000326, custom_50000002
             )
         )
@@ -164,7 +165,7 @@ with
         left join {{ ref("int_focus__custom_field_options") }} as options
             on options.source_class = 'SISSchool'
             and options.column_name = unpivoted.column_name
-            and options.option_id = unpivoted.option_id
+            and unpivoted.stored_value in (options.option_id, options.code)
     )
 
 select *
@@ -211,7 +212,7 @@ education as (
     from {{ ref("stg_focus__users") }} as users
     cross join unnest(json_value_array(users.education)) as element_id
     left join {{ ref("int_focus__custom_field_options") }} as options
-        on element_id = options.option_id
+        on element_id in (options.option_id, options.code)
         and options.source_class = 'FocusUser'
         and options.column_name = 'custom_2'
     group by users.staff_id
@@ -378,11 +379,12 @@ where cf.type in ('select', 'multiple')
 
 ## Open implementation checks
 
-1. **Decode key is the option id.** Entities store `select_options.id`, not
-   `code`; the crosswalk keys on `option_id` (the option PK), so it is naturally
-   unique and needs no dedupe. Spot-check that each pivot decodes (non-null
-   labels where the entity value is set) — a regression to code-keying shows up
-   as all-null labels.
+1. **Decode matches id OR code.** The stored value is the option id for some
+   fields, the code for others, so pivots match
+   `stored_value in (option_id, code)`. The crosswalk keys on `option_id` (the
+   option PK — unique, no dedupe). Spot-check that each pivot decodes (non-null
+   labels where the entity value is set); all-null labels signal a match-key
+   mismatch for that entity.
 2. **`multiple` multi-element.** Current data is single-element; the `array_agg`
    decode handles N elements regardless. No additional work unless a
    multi-element value needs ordering guarantees beyond `order by label`.

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -32,11 +32,14 @@ design:
    entity class (`SISSchool`, etc.) — `source_class` is never the entity class,
    so that filter returns zero rows (the trap that surfaced this).
 
-2. **`select` and `multiple` store differently.** `select` stores a **bare
-   code** (`5539`, `E`). `multiple` stores a **JSON-array string** (`["2795"]`).
-   Decode for `multiple` means parse-JSON + map each element, not split on a
-   delimiter. In the current pull every `multiple` value is single-element, but
-   the format is a real JSON array, so decode handles N elements generically.
+2. **The entity stores the option `id`, not the `code`.** A `select` value is a
+   single select-option **id** (e.g. `5538` → label `E - Elementary`), stored as
+   an int. A `multiple` value is a **JSON-array string of option ids**
+   (`["2795"]`). Decode joins the stored id to `select_options.id` and reads
+   `label` (the `code` — `E`, `M` — is the Focus import/export value, never the
+   stored value). `multiple` means parse-JSON + map each id, not split on a
+   delimiter. Every current `multiple` value is single-element, but the format
+   is a real JSON array, so decode handles N elements generically.
 
 3. **A minority of fields back their option list with a dynamic `option_query`**
    (no rows in `custom_field_select_options`; Focus builds the list at render
@@ -108,12 +111,13 @@ with
     ),
 
     opt as (
-        select source_id, code, label
+        select cast(id as string) as option_id, source_id, code, label
         from {{ ref("stg_focus__custom_field_select_options") }}
         where source_class = 'CustomField'  -- keep inactive: decode historical values
     )
 
 select
+    opt.option_id,
     cf.source_class,
     cf.column_name,
     opt.code,
@@ -122,13 +126,13 @@ from opt
 inner join cf on opt.source_id = cf.id
 ```
 
-- Grain / uniqueness: `(source_class, column_name, code)`.
+- Grain / uniqueness: `option_id` (the select-option PK — globally unique,
+  non-null, so no dedupe needed).
+- The entity stores the option **id**, not its `code`; pivots join the stored
+  value to `option_id`. `code` is the Focus import/export value and `label` the
+  human name (the decode output).
 - `inactive` options are kept — a stored value can reference an option later
   marked inactive.
-- If a field carries duplicate `code` rows (e.g. across `min_syear` /
-  `max_syear`), dedupe with `dbt_utils.deduplicate` (`partition_by` the grain,
-  `order_by updated_at desc`). Verify whether duplicates exist during
-  implementation; only add the dedupe if the uniqueness test fails.
 
 ### `int_focus__<entity>__pivot` (decode via UNPIVOT then join then PIVOT)
 
@@ -146,9 +150,9 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, code
+        select id, column_name, option_id
         from encoded unpivot (
-            code for column_name in (
+            option_id for column_name in (
                 custom_100000004, custom_200000326, custom_50000002
             )
         )
@@ -160,7 +164,7 @@ with
         left join {{ ref("int_focus__custom_field_options") }} as options
             on options.source_class = 'SISSchool'
             and options.column_name = unpivoted.column_name
-            and options.code = unpivoted.code
+            and options.option_id = unpivoted.option_id
     )
 
 select *
@@ -205,11 +209,11 @@ education as (
         array_agg(options.label ignore nulls order by options.label)
             as education_label,
     from {{ ref("stg_focus__users") }} as users
-    cross join unnest(json_value_array(users.education)) as code
+    cross join unnest(json_value_array(users.education)) as element_id
     left join {{ ref("int_focus__custom_field_options") }} as options
-        on options.source_class = 'FocusUser'
+        on element_id = options.option_id
+        and options.source_class = 'FocusUser'
         and options.column_name = 'custom_2'
-        and options.code = code
     group by users.staff_id
 )
 ```
@@ -293,10 +297,10 @@ type each slot, then decode `select`-type slots via
   convention with `<slug>_label` columns; the wide-to-long log model uses the
   `__unpivot` suffix.
 - **Tests.** Uniqueness test on every model (intermediate-layer requirement):
-  entity PK on each `__pivot`, `(source_class, column_name, code)` on the
-  crosswalk, `(log_entry_id, slot_column_name)` on the log model. Tests are
-  warn-level unless a stronger signal is warranted; the crosswalk grain is
-  `error` (a duplicate there silently corrupts every decode).
+  entity PK on each `__pivot`, `option_id` on the crosswalk,
+  `(log_entry_id, slot_column_name)` on the log model. Tests are warn-level
+  unless a stronger signal is warranted; the crosswalk `option_id` is `error` (a
+  duplicate there silently corrupts every decode).
 - **PII.** Every pivot model and the log model is keyed by a student/staff
   identifier (a FERPA direct identifier), so each carries
   `config.meta.contains_pii: true` at the model level regardless of which
@@ -374,9 +378,11 @@ where cf.type in ('select', 'multiple')
 
 ## Open implementation checks
 
-1. **Crosswalk duplicates.** Build the crosswalk, run its uniqueness test; add
-   `dbt_utils.deduplicate` only if `(source_class, column_name, code)` is not
-   already unique.
+1. **Decode key is the option id.** Entities store `select_options.id`, not
+   `code`; the crosswalk keys on `option_id` (the option PK), so it is naturally
+   unique and needs no dedupe. Spot-check that each pivot decodes (non-null
+   labels where the entity value is set) — a regression to code-keying shows up
+   as all-null labels.
 2. **`multiple` multi-element.** Current data is single-element; the `array_agg`
    decode handles N elements regardless. No additional work unless a
    multi-element value needs ordering guarantees beyond `order by label`.

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -87,7 +87,7 @@ Nine intermediate models:
 | `int_focus__course_periods__pivot`     | Decoded labels for CoursePeriod select fields         |
 | `int_focus__master_courses__pivot`     | Decoded labels for CourseCatalog select fields        |
 | `int_focus__courses__pivot`            | Decoded labels for Course select fields               |
-| `int_focus__custom_field_log`          | Long reshape of the two populated log-type fields     |
+| `int_focus__custom_field_log__unpivot` | Wide-to-long reshape of the two log-type fields       |
 
 The existing `int_focus__student_enrollment` (title enrichment) is unchanged;
 the new `int_focus__student_enrollment__pivot` is a separate decode-only model.
@@ -264,7 +264,7 @@ Excluded (in-scope entity, but not decodable): `FocusUser`
 `profile_on_non_production_sites` (`custom_l790`, field 790) —
 `option_query`-only.
 
-### `int_focus__custom_field_log` (long reshape)
+### `int_focus__custom_field_log__unpivot` (wide-to-long reshape)
 
 `UNPIVOT` `log_field1..log_field30` (nulls dropped), inner-join
 `stg_focus__custom_field_log_columns` on `(field_id, LOG_FIELDn)` to label and
@@ -287,18 +287,25 @@ type each slot, then decode `select`-type slots via
 
 ## Cross-cutting
 
-- **Naming.** Decode models use the `int_focus__<entity>__pivot` convention.
-  Label columns use the `<slug>_label` suffix.
+- **Naming.** Decode-to-wide models use the `int_focus__<entity>__pivot`
+  convention with `<slug>_label` columns; the wide-to-long log model uses the
+  `__unpivot` suffix.
 - **Tests.** Uniqueness test on every model (intermediate-layer requirement):
   entity PK on each `__pivot`, `(source_class, column_name, code)` on the
   crosswalk, `(log_entry_id, slot_column_name)` on the log model. Tests are
   warn-level unless a stronger signal is warranted; the crosswalk grain is
   `error` (a duplicate there silently corrupts every decode).
-- **PII.** Student- and staff-level pivot models and the log model carry PII via
-  their entity keys and some decoded values (e.g. `sex`, `race_*`, `language`,
-  residence/birth-linked attributes). Tag `config.meta.contains_pii: true`
-  consistent with the existing Focus staging precedent; confirm direct-only vs
-  direct+indirect scope with the field owner before finalizing tags.
+- **PII.** Every pivot model and the log model is keyed by a student/staff
+  identifier (a FERPA direct identifier), so each carries
+  `config.meta.contains_pii: true` at the model level regardless of which
+  columns are tagged. Decoded attributes — `sex`, `race_*`, `language`,
+  residence/birth-linked values — are FERPA _indirect_ identifiers (PII under
+  the "linked or linkable" standard, which applies here because they sit
+  alongside the student key). FERPA-aligned tagging is therefore **broad** (tag
+  these columns). The existing Focus staging precedent is narrower (omits
+  gender/race/IDs); reconcile the two and confirm direct-only vs direct+indirect
+  scope with People Operations before finalizing tags — this is a compliance
+  call, not settled by this spec.
 - **Descriptions.** Every new model and every column gets a `description:` in
   `properties/`. Describe decoded columns by their logic (decoded label for the
   named field). Data/column semantics go in descriptions, not CLAUDE.md.

--- a/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
+++ b/docs/superpowers/specs/2026-06-24-focus-custom-field-decode-design.md
@@ -22,13 +22,15 @@ there is no prod-materialization gate.
 These reframe the issue and `focus/CLAUDE.md`, and are load-bearing for the
 design:
 
-1. **The documented decode join is wrong.**
-   `custom_field_select_options.source_class` is the literal polymorphic value
-   `CustomField` (for entity fields) or `CustomFieldLogColumn` (for log-column
-   slots) — **not** the entity class (`SISSchool`, etc.). Joining on the entity
-   class returns zero matches. The correct join is
-   `select_options.source_id = custom_fields.id` alone, with
-   `select_options.source_class = 'CustomField'`.
+1. **The decode join needs the owner-type filter.** The documented join
+   (`custom_field_select_options.source_id = custom_fields.id`) is correct but
+   under-specified: `select_options.source_class` is a polymorphic owner type —
+   the literal `CustomField` for entity fields, `CustomFieldLogColumn` for
+   log-column slots — and the same numeric `source_id` occurs under both. Add
+   `select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'`
+   for log slots) so the two owner types don't collide. Do **not** match the
+   entity class (`SISSchool`, etc.) — `source_class` is never the entity class,
+   so that filter returns zero rows (the trap that surfaced this).
 
 2. **`select` and `multiple` store differently.** `select` stores a **bare
    code** (`5539`, `E`). `multiple` stores a **JSON-array string** (`["2795"]`).
@@ -136,7 +138,7 @@ Pattern, shown for `int_focus__schools__pivot`:
 with
     encoded as (
         select
-            school_id,
+            id,
             cast(school_level as string) as custom_100000004,
             cast(school_type as string) as custom_200000326,
             cast(technical_center as string) as custom_50000002,
@@ -144,7 +146,7 @@ with
     ),
 
     unpivoted as (
-        select school_id, column_name, code
+        select id, column_name, code
         from encoded unpivot (
             code for column_name in (
                 custom_100000004, custom_200000326, custom_50000002
@@ -153,7 +155,7 @@ with
     ),
 
     decoded as (
-        select unpivoted.school_id, unpivoted.column_name, options.label
+        select unpivoted.id, unpivoted.column_name, options.label
         from unpivoted
         left join {{ ref("int_focus__custom_field_options") }} as options
             on options.source_class = 'SISSchool'
@@ -309,11 +311,11 @@ type each slot, then decode `select`-type slots via
 - **Descriptions.** Every new model and every column gets a `description:` in
   `properties/`. Describe decoded columns by their logic (decoded label for the
   named field). Data/column semantics go in descriptions, not CLAUDE.md.
-- **Docs fix.** Correct the "Focus field value codes" section of
-  `src/dbt/focus/CLAUDE.md`: the join is
-  `select_options.source_id = custom_fields.id` with
-  `select_options.source_class = 'CustomField'` (or `'CustomFieldLogColumn'` for
-  log slots), **not** a match on the entity `source_class`.
+- **Docs clarification.** Augment the "Focus field value codes" section of
+  `src/dbt/focus/CLAUDE.md`: keep `select_options.source_id = custom_fields.id`,
+  but add `select_options.source_class = 'CustomField'` (or
+  `'CustomFieldLogColumn'` for log slots) to prevent `source_id` collisions
+  across owner types, and note that `source_class` is never the entity class.
 
 ## Out of scope / follow-ups
 

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -245,6 +245,13 @@ A newly-created worktree has no `dbt_packages/`. Run
 `dbt build` / `test` / `clone` there — otherwise it errors with "N package(s)
 specified in packages.yml, but only 0 package(s) installed".
 
+## Building a source-system package model locally
+
+Source-system package models (`focus`, `amplify`, etc.) have no resolvable vars
+standalone — build/test them via a **consuming district** project-dir with that
+district's prod manifest for `--defer` (e.g. focus → kippmiami):
+`uv run dbt build --select <model> --project-dir src/dbt/kippmiami --defer --state src/dbt/kippmiami/target/prod --target dev`.
+
 ## Dev `--defer` for unstaged externals
 
 Dev builds depending on GCS externals (`stg_google_sheets__*` etc.) fail with
@@ -747,6 +754,12 @@ the same partition.
   columns are `{agg_alias}_{value}`; a SINGLE-aggregate pivot names them by the
   bare value (`'x'` → column `x`). `max()` can't aggregate ARRAY — use
   `any_value()` for array fields.
+- **BigQuery `UNPIVOT` excludes null rows** — an entity whose unpivoted columns
+  are all null drops out of the result. Harmless for a pure decode companion (a
+  left join from staging yields null labels anyway), but when the model also
+  LEFT JOINs a separately-computed field (e.g. a `multiple`/array decode), drive
+  the final `SELECT` from the full entity list or that field is lost for
+  all-null-unpivoted entities.
 - **AL09 on struct subfields**: `value.string_value as string_value` trips AL09
   (alias equals the leaf name). Rename to a distinct alias (`as value_string`)
   rather than dropping it when a downstream PIVOT/ref needs the column named.

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -20,20 +20,23 @@ filter `custom_field_select_options.source_class = 'CustomField'` (or
 `'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space
 doesn't collide across owner types. `source_class` on the options table is the
 owner-type literal, never the entity class (`SISSchool`, etc.); matching the
-entity class returns zero rows. Use this to build Finalsite→Focus value
-crosswalks.
+entity class returns zero rows. To DECODE a stored value, note the entity stores
+the select-option `id` (`custom_field_select_options.id`), NOT its `code` — join
+the stored value to `id` and read `label`. (`code` is the Focus import/export
+value; use it to build Finalsite→Focus value crosswalks.)
 
 **Custom-field storage.** Values live inline on the entity table's wide
 `custom_NNN` columns (e.g. `students.custom_100000105`), NOT in `custom_fields`
 — that is the _definition_ catalog. Join definition→entity column on
 `custom_fields.column_name` + `source_class`. `title` is the readable name (slug
-it for the staging alias); `select`/`multiple` values are codes (decode via the
-crosswalk above); `log`-type values live in `custom_field_log_entries`;
-`computed`/`holder` are not stored. Custom fields are NOT always named
-`custom_NNN` — some use semantic `column_name`s (e.g. `users.birth_date`,
-`charter_*`); when profiling an entity's populated custom fields, scan the FULL
-table and join the whole catalog on `lower(column_name)`, since filtering to
-`custom_*`-prefixed columns silently misses the semantic-named ones.
+it for the staging alias); `select`/`multiple` values are stored option `id`s
+(decode to `label` via the crosswalk above); `log`-type values live in
+`custom_field_log_entries`; `computed`/`holder` are not stored. Custom fields
+are NOT always named `custom_NNN` — some use semantic `column_name`s (e.g.
+`users.birth_date`, `charter_*`); when profiling an entity's populated custom
+fields, scan the FULL table and join the whole catalog on `lower(column_name)`,
+since filtering to `custom_*`-prefixed columns silently misses the
+semantic-named ones.
 
 `source_class`→entity-table map (use the catalog's own spelling, NOT the
 entity's): `SISStudent`→students, `FocusUser`→users, `SISSchool`→schools,

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -15,8 +15,13 @@ A Focus custom field's allowed value codes live in
 `dagster_<district>_dlt_focus.custom_fields` (find the field by `title` /
 `column_name`) joined to `custom_field_select_options` on
 `custom_field_select_options.source_id = custom_fields.id` — `code` is the value
-Focus expects, `label` is the human name. Use this to build Finalsite→Focus
-value crosswalks.
+Focus expects, `label` is the human name. The join is `source_id` only — also
+filter `custom_field_select_options.source_class = 'CustomField'` (or
+`'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space
+doesn't collide across owner types. `source_class` on the options table is the
+owner-type literal, never the entity class (`SISSchool`, etc.); matching the
+entity class returns zero rows. Use this to build Finalsite→Focus value
+crosswalks.
 
 **Custom-field storage.** Values live inline on the entity table's wide
 `custom_NNN` columns (e.g. `students.custom_100000105`), NOT in `custom_fields`

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -20,23 +20,25 @@ filter `custom_field_select_options.source_class = 'CustomField'` (or
 `'CustomFieldLogColumn'` for log-column slots) so the shared `source_id` space
 doesn't collide across owner types. `source_class` on the options table is the
 owner-type literal, never the entity class (`SISSchool`, etc.); matching the
-entity class returns zero rows. To DECODE a stored value, note the entity stores
-the select-option `id` (`custom_field_select_options.id`), NOT its `code` — join
-the stored value to `id` and read `label`. (`code` is the Focus import/export
-value; use it to build Finalsite→Focus value crosswalks.)
+entity class returns zero rows. To DECODE a stored value: the entity stores the
+select-option `id` (`custom_field_select_options.id`) for some fields and the
+`code` (e.g. `prior_state`=`FL`) for others, so match the stored value against
+BOTH `id` and `code`, then read `label`. Verify by spot-checking decoded values
+— a wrong match key returns all-null labels but still passes build, grain, and
+lint. (`code` also drives Finalsite→Focus import crosswalks.)
 
 **Custom-field storage.** Values live inline on the entity table's wide
 `custom_NNN` columns (e.g. `students.custom_100000105`), NOT in `custom_fields`
 — that is the _definition_ catalog. Join definition→entity column on
 `custom_fields.column_name` + `source_class`. `title` is the readable name (slug
-it for the staging alias); `select`/`multiple` values are stored option `id`s
-(decode to `label` via the crosswalk above); `log`-type values live in
-`custom_field_log_entries`; `computed`/`holder` are not stored. Custom fields
-are NOT always named `custom_NNN` — some use semantic `column_name`s (e.g.
-`users.birth_date`, `charter_*`); when profiling an entity's populated custom
-fields, scan the FULL table and join the whole catalog on `lower(column_name)`,
-since filtering to `custom_*`-prefixed columns silently misses the
-semantic-named ones.
+it for the staging alias); `select`/`multiple` values are stored option `id`s or
+`code`s (varies by field; decode to `label` via the crosswalk above); `log`-type
+values live in `custom_field_log_entries`; `computed`/`holder` are not stored.
+Custom fields are NOT always named `custom_NNN` — some use semantic
+`column_name`s (e.g. `users.birth_date`, `charter_*`); when profiling an
+entity's populated custom fields, scan the FULL table and join the whole catalog
+on `lower(column_name)`, since filtering to `custom_*`-prefixed columns silently
+misses the semantic-named ones.
 
 `source_class`→entity-table map (use the catalog's own spelling, NOT the
 entity's): `SISStudent`→students, `FocusUser`→users, `SISSchool`→schools,

--- a/src/dbt/focus/models/intermediate/int_focus__course_periods__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__course_periods__pivot.sql
@@ -1,0 +1,59 @@
+with
+    encoded as (
+        select
+            course_period_id,
+            cast(fefp_number as string) as custom_2,
+            cast(scheduling_method as string) as custom_4,
+            cast(facility_type as string) as custom_6,
+            cast(cert_licensure_qual_status as string) as custom_28,
+            cast(highly_qualified as string) as custom_5,
+            cast(reading_intervention_component as string) as custom_25,
+            cast(location_of_student as string) as custom_33,
+            cast(eoc_exam_term as string) as custom_34,
+            cast(basic_skills_exam as string) as custom_22,
+        from {{ ref("stg_focus__course_periods") }}
+    ),
+
+    unpivoted as (
+        select course_period_id, column_name, stored_value,
+        from
+            encoded unpivot (
+                stored_value for column_name in (
+                    custom_2,
+                    custom_4,
+                    custom_6,
+                    custom_28,
+                    custom_5,
+                    custom_25,
+                    custom_33,
+                    custom_34,
+                    custom_22
+                )
+            )
+    ),
+
+    decoded as (
+        select unpivoted.course_period_id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
+            and `options`.source_class = 'CoursePeriod'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name in (
+            'custom_2' as fefp_number_label,
+            'custom_4' as scheduling_method_label,
+            'custom_6' as facility_type_label,
+            'custom_28' as cert_licensure_qual_status_label,
+            'custom_5' as highly_qualified_label,
+            'custom_25' as reading_intervention_component_label,
+            'custom_33' as location_of_student_label,
+            'custom_34' as eoc_exam_term_label,
+            'custom_22' as basic_skills_exam_label
+        )
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__courses__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__courses__pivot.sql
@@ -1,0 +1,30 @@
+with
+    encoded as (
+        select
+            course_id,
+            cast(course_sequence as string) as custom_4,
+            cast(ocp as string) as custom_3,
+        from {{ ref("stg_focus__courses") }}
+    ),
+
+    unpivoted as (
+        select course_id, column_name, stored_value,
+        from encoded unpivot (stored_value for column_name in (custom_4, custom_3))
+    ),
+
+    decoded as (
+        select unpivoted.course_id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
+            and `options`.source_class = 'Course'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name
+        in ('custom_4' as course_sequence_label, 'custom_3' as ocp_label)
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql
@@ -1,0 +1,139 @@
+with
+    entries as (
+        select
+            id as log_entry_id,
+            source_id as student_id,
+            school_id,
+            field_id,
+            syear,
+            created_at,
+            updated_at,
+            cast(log_field1 as string) as log_field1,
+            cast(log_field2 as string) as log_field2,
+            cast(log_field3 as string) as log_field3,
+            cast(log_field4 as string) as log_field4,
+            cast(log_field5 as string) as log_field5,
+            cast(log_field6 as string) as log_field6,
+            cast(log_field7 as string) as log_field7,
+            cast(log_field8 as string) as log_field8,
+            cast(log_field9 as string) as log_field9,
+            cast(log_field10 as string) as log_field10,
+            cast(log_field11 as string) as log_field11,
+            cast(log_field12 as string) as log_field12,
+            cast(log_field13 as string) as log_field13,
+            cast(log_field14 as string) as log_field14,
+            cast(log_field15 as string) as log_field15,
+            cast(log_field16 as string) as log_field16,
+            cast(log_field17 as string) as log_field17,
+            cast(log_field18 as string) as log_field18,
+            cast(log_field19 as string) as log_field19,
+            cast(log_field20 as string) as log_field20,
+            cast(log_field21 as string) as log_field21,
+            cast(log_field22 as string) as log_field22,
+            cast(log_field23 as string) as log_field23,
+            cast(log_field24 as string) as log_field24,
+            cast(log_field25 as string) as log_field25,
+            cast(log_field26 as string) as log_field26,
+            cast(log_field27 as string) as log_field27,
+            cast(log_field28 as string) as log_field28,
+            cast(log_field29 as string) as log_field29,
+            cast(log_field30 as string) as log_field30,
+        from {{ ref("stg_focus__custom_field_log_entries") }}
+    ),
+
+    unpivoted as (
+        select
+            log_entry_id,
+            student_id,
+            school_id,
+            field_id,
+            syear,
+            created_at,
+            updated_at,
+            slot_column_name,
+            value,
+        from
+            entries unpivot (
+                value for slot_column_name in (
+                    log_field1,
+                    log_field2,
+                    log_field3,
+                    log_field4,
+                    log_field5,
+                    log_field6,
+                    log_field7,
+                    log_field8,
+                    log_field9,
+                    log_field10,
+                    log_field11,
+                    log_field12,
+                    log_field13,
+                    log_field14,
+                    log_field15,
+                    log_field16,
+                    log_field17,
+                    log_field18,
+                    log_field19,
+                    log_field20,
+                    log_field21,
+                    log_field22,
+                    log_field23,
+                    log_field24,
+                    log_field25,
+                    log_field26,
+                    log_field27,
+                    log_field28,
+                    log_field29,
+                    log_field30
+                )
+            )
+    ),
+
+    columns_meta as (
+        select
+            id as log_column_id,
+            field_id,
+            type as slot_type,
+            title as slot_title,
+            sort_order as slot_sort_order,
+            lower(column_name) as slot_column_name,
+        from {{ ref("stg_focus__custom_field_log_columns") }}
+    ),
+
+    fields_meta as (
+        select id as field_id, title as field_title,
+        from {{ ref("stg_focus__custom_fields") }}
+    ),
+
+    options as (
+        select cast(id as string) as option_id, source_id, code, label,
+        from {{ ref("stg_focus__custom_field_select_options") }}
+        where source_class = 'CustomFieldLogColumn'
+    )
+
+select
+    unpivoted.log_entry_id,
+    unpivoted.student_id,
+    unpivoted.school_id,
+    unpivoted.field_id,
+    columns_meta.log_column_id,
+    columns_meta.slot_column_name,
+    columns_meta.slot_type,
+    columns_meta.slot_title,
+    columns_meta.slot_sort_order,
+    fields_meta.field_title,
+    unpivoted.value,
+    unpivoted.syear,
+    unpivoted.created_at,
+    unpivoted.updated_at,
+    options.label as value_label,
+from unpivoted
+inner join
+    columns_meta
+    on unpivoted.field_id = columns_meta.field_id
+    and unpivoted.slot_column_name = columns_meta.slot_column_name
+left join fields_meta on unpivoted.field_id = fields_meta.field_id
+left join
+    options
+    on columns_meta.log_column_id = options.source_id
+    and unpivoted.value in (options.option_id, options.code)

--- a/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
@@ -1,0 +1,15 @@
+with
+    cf as (
+        select id, source_class, lower(column_name) as column_name,
+        from {{ ref("stg_focus__custom_fields") }}
+    ),
+
+    opt as (
+        select source_id, code, label,
+        from {{ ref("stg_focus__custom_field_select_options") }}
+        where source_class = 'CustomField'  -- owner-type filter; keep inactive
+    )
+
+select cf.source_class, cf.column_name, opt.code, opt.label,
+from opt
+inner join cf on opt.source_id = cf.id

--- a/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
@@ -4,12 +4,23 @@ with
         from {{ ref("stg_focus__custom_fields") }}
     ),
 
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     opt as (
-        select source_id, code, label,
+        select source_id, code, label, updated_at,
         from {{ ref("stg_focus__custom_field_select_options") }}
-        where source_class = 'CustomField'  -- owner-type filter; keep inactive
+        where source_class = 'CustomField' and code is not null
+    ),
+
+    opt_deduped as (
+        {{
+            dbt_utils.deduplicate(
+                relation="opt",
+                partition_by="source_id, code",
+                order_by="updated_at desc",
+            )
+        }}
     )
 
-select cf.source_class, cf.column_name, opt.code, opt.label,
-from opt
-inner join cf on opt.source_id = cf.id
+select cf.source_class, cf.column_name, opt_deduped.code, opt_deduped.label,
+from opt_deduped
+inner join cf on opt_deduped.source_id = cf.id

--- a/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__custom_field_options.sql
@@ -4,23 +4,12 @@ with
         from {{ ref("stg_focus__custom_fields") }}
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     opt as (
-        select source_id, code, label, updated_at,
+        select cast(id as string) as option_id, source_id, code, label,
         from {{ ref("stg_focus__custom_field_select_options") }}
-        where source_class = 'CustomField' and code is not null
-    ),
-
-    opt_deduped as (
-        {{
-            dbt_utils.deduplicate(
-                relation="opt",
-                partition_by="source_id, code",
-                order_by="updated_at desc",
-            )
-        }}
+        where source_class = 'CustomField'  -- owner-type filter; keep inactive
     )
 
-select cf.source_class, cf.column_name, opt_deduped.code, opt_deduped.label,
-from opt_deduped
-inner join cf on opt_deduped.source_id = cf.id
+select opt.option_id, cf.source_class, cf.column_name, opt.code, opt.label,
+from opt
+inner join cf on opt.source_id = cf.id

--- a/src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql
@@ -1,0 +1,38 @@
+with
+    encoded as (
+        select
+            course_id,
+            cast(fefp as string) as custom_field_5,
+            cast(course_flag_1 as string) as custom_field_6,
+            cast(dual_enrollment_indicator as string) as custom_field_13,
+        from {{ ref("stg_focus__master_courses") }}
+    ),
+
+    unpivoted as (
+        select course_id, column_name, stored_value,
+        from
+            encoded unpivot (
+                stored_value for column_name
+                in (custom_field_5, custom_field_6, custom_field_13)
+            )
+    ),
+
+    decoded as (
+        select unpivoted.course_id, unpivoted.column_name, options.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
+            and `options`.source_class = 'CourseCatalog'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name in (
+            'custom_field_5' as fefp_label,
+            'custom_field_6' as course_flag_1_label,
+            'custom_field_13' as dual_enrollment_indicator_label
+        )
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__master_courses__pivot.sql
@@ -18,7 +18,7 @@ with
     ),
 
     decoded as (
-        select unpivoted.course_id, unpivoted.column_name, options.label,
+        select unpivoted.course_id, unpivoted.column_name, `options`.label,
         from unpivoted
         left join
             {{ ref("int_focus__custom_field_options") }} as `options`

--- a/src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql
@@ -9,10 +9,10 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, option_id,
+        select id, column_name, stored_value,
         from
             encoded unpivot (
-                option_id for column_name
+                stored_value for column_name
                 in (custom_100000004, custom_200000326, custom_50000002)
             )
     ),
@@ -23,7 +23,7 @@ with
         left join
             {{ ref("int_focus__custom_field_options") }} as `options`
             on unpivoted.column_name = `options`.column_name
-            and unpivoted.option_id = `options`.option_id
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
             and `options`.source_class = 'SISSchool'
     )
 

--- a/src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__schools__pivot.sql
@@ -1,0 +1,38 @@
+with
+    encoded as (
+        select
+            id,
+            cast(school_level as string) as custom_100000004,
+            cast(school_type as string) as custom_200000326,
+            cast(technical_center as string) as custom_50000002,
+        from {{ ref("stg_focus__schools") }}
+    ),
+
+    unpivoted as (
+        select id, column_name, option_id,
+        from
+            encoded unpivot (
+                option_id for column_name
+                in (custom_100000004, custom_200000326, custom_50000002)
+            )
+    ),
+
+    decoded as (
+        select unpivoted.id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.option_id = `options`.option_id
+            and `options`.source_class = 'SISSchool'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name in (
+            'custom_100000004' as school_level_label,
+            'custom_200000326' as school_type_label,
+            'custom_50000002' as technical_center_label
+        )
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql
@@ -1,0 +1,42 @@
+with
+    encoded as (
+        select
+            id,
+            cast(prior_district as string) as custom_1,
+            cast(prior_state as string) as custom_2,
+            cast(prior_country as string) as custom_3,
+            cast(educational_choice as string) as custom_4,
+            cast(student_offender_transfer as string) as custom_6,
+        from {{ ref("stg_focus__student_enrollment") }}
+    ),
+
+    unpivoted as (
+        select id, column_name, option_id,
+        from
+            encoded unpivot (
+                option_id for column_name
+                in (custom_1, custom_2, custom_3, custom_4, custom_6)
+            )
+    ),
+
+    decoded as (
+        select unpivoted.id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.option_id = `options`.option_id
+            and `options`.source_class = 'StudentEnrollment'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name in (
+            'custom_1' as prior_district_label,
+            'custom_2' as prior_state_label,
+            'custom_3' as prior_country_label,
+            'custom_4' as educational_choice_label,
+            'custom_6' as student_offender_transfer_label
+        )
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_enrollment__pivot.sql
@@ -11,10 +11,10 @@ with
     ),
 
     unpivoted as (
-        select id, column_name, option_id,
+        select id, column_name, stored_value,
         from
             encoded unpivot (
-                option_id for column_name
+                stored_value for column_name
                 in (custom_1, custom_2, custom_3, custom_4, custom_6)
             )
     ),
@@ -25,7 +25,7 @@ with
         left join
             {{ ref("int_focus__custom_field_options") }} as `options`
             on unpivoted.column_name = `options`.column_name
-            and unpivoted.option_id = `options`.option_id
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
             and `options`.source_class = 'StudentEnrollment'
     )
 

--- a/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
@@ -17,10 +17,10 @@ with
     ),
 
     unpivoted as (
-        select student_id, column_name, code,
+        select student_id, column_name, option_id,
         from
             encoded unpivot (
-                code for column_name in (
+                option_id for column_name in (
                     custom_100000105,
                     custom_100000104,
                     custom_100000102,
@@ -40,7 +40,7 @@ with
         left join
             {{ ref("int_focus__custom_field_options") }} as `options`
             on unpivoted.column_name = `options`.column_name
-            and unpivoted.code = `options`.code
+            and unpivoted.option_id = `options`.option_id
             and `options`.source_class = 'SISStudent'
     )
 

--- a/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
@@ -1,0 +1,61 @@
+with
+    encoded as (
+        select
+            student_id,
+            cast(ethnicity_hispanic_or_latino as string) as custom_100000105,
+            cast(race_white as string) as custom_100000104,
+            cast(race_black_or_african_american as string) as custom_100000102,
+            cast(race_asian as string) as custom_100000101,
+            cast(sex as string) as custom_200000000,
+            cast(race_american_indian_or_alaska_native as string) as custom_100000100,
+            cast(
+                race_native_hawaiian_or_other_pacific_islander as string
+            ) as custom_100000103,
+            cast(residence_county as string) as custom_837,
+            cast(`language` as string) as custom_200000005,
+        from {{ ref("stg_focus__students") }}
+    ),
+
+    unpivoted as (
+        select student_id, column_name, code,
+        from
+            encoded unpivot (
+                code for column_name in (
+                    custom_100000105,
+                    custom_100000104,
+                    custom_100000102,
+                    custom_100000101,
+                    custom_200000000,
+                    custom_100000100,
+                    custom_100000103,
+                    custom_837,
+                    custom_200000005
+                )
+            )
+    ),
+
+    decoded as (
+        select unpivoted.student_id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.code = `options`.code
+            and `options`.source_class = 'SISStudent'
+    )
+
+select *,
+from
+    decoded pivot (
+        any_value(label) for column_name in (
+            'custom_100000105' as ethnicity_hispanic_or_latino_label,
+            'custom_100000104' as race_white_label,
+            'custom_100000102' as race_black_or_african_american_label,
+            'custom_100000101' as race_asian_label,
+            'custom_200000000' as sex_label,
+            'custom_100000100' as race_american_indian_or_alaska_native_label,
+            'custom_100000103' as race_native_hawaiian_or_other_pacific_islander_label,
+            'custom_837' as residence_county_label,
+            'custom_200000005' as language_label
+        )
+    )

--- a/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students__pivot.sql
@@ -17,10 +17,10 @@ with
     ),
 
     unpivoted as (
-        select student_id, column_name, option_id,
+        select student_id, column_name, stored_value,
         from
             encoded unpivot (
-                option_id for column_name in (
+                stored_value for column_name in (
                     custom_100000105,
                     custom_100000104,
                     custom_100000102,
@@ -40,7 +40,7 @@ with
         left join
             {{ ref("int_focus__custom_field_options") }} as `options`
             on unpivoted.column_name = `options`.column_name
-            and unpivoted.option_id = `options`.option_id
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
             and `options`.source_class = 'SISStudent'
     )
 

--- a/src/dbt/focus/models/intermediate/int_focus__users__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__users__pivot.sql
@@ -45,6 +45,7 @@ with
         group by users.staff_id
     )
 
-select select_pivot.staff_id, select_pivot.active_label, education.education_label,
-from select_pivot
-left join education on select_pivot.staff_id = education.staff_id
+select users.staff_id, select_pivot.active_label, education.education_label,
+from {{ ref("stg_focus__users") }} as users
+left join select_pivot on users.staff_id = select_pivot.staff_id
+left join education on users.staff_id = education.staff_id

--- a/src/dbt/focus/models/intermediate/int_focus__users__pivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__users__pivot.sql
@@ -1,0 +1,50 @@
+with
+    encoded as (
+        select staff_id, cast(active as string) as custom_319000004,
+        from {{ ref("stg_focus__users") }}
+    ),
+
+    unpivoted as (
+        select staff_id, column_name, stored_value,
+        from encoded unpivot (stored_value for column_name in (custom_319000004))
+    ),
+
+    decoded as (
+        select unpivoted.staff_id, unpivoted.column_name, `options`.label,
+        from unpivoted
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on unpivoted.column_name = `options`.column_name
+            and unpivoted.stored_value in (`options`.option_id, `options`.code)
+            and `options`.source_class = 'FocusUser'
+    ),
+
+    select_pivot as (
+        select *,
+        from
+            decoded pivot (
+                any_value(label) for column_name in ('custom_319000004' as active_label)
+            )
+    ),
+
+    -- multiple: education is a JSON array of option ids like '["2795"]'; explode,
+    -- map each id to its label, re-aggregate. CTE form avoids a correlated subquery.
+    education as (
+        select
+            users.staff_id,
+            array_agg(
+                `options`.label ignore nulls order by `options`.label
+            ) as education_label,
+        from {{ ref("stg_focus__users") }} as users
+        cross join unnest(json_value_array(users.education)) as element_id
+        left join
+            {{ ref("int_focus__custom_field_options") }} as `options`
+            on element_id in (`options`.option_id, `options`.code)
+            and `options`.column_name = 'custom_2'
+            and `options`.source_class = 'FocusUser'
+        group by users.staff_id
+    )
+
+select select_pivot.staff_id, select_pivot.active_label, education.education_label,
+from select_pivot
+left join education on select_pivot.staff_id = education.staff_id

--- a/src/dbt/focus/models/intermediate/properties/int_focus__course_periods__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__course_periods__pivot.yml
@@ -1,0 +1,36 @@
+models:
+  - name: int_focus__course_periods__pivot
+    description: >-
+      Decoded labels for the CoursePeriod select custom fields, one row per
+      Focus course_period_id. Join to stg_focus__course_periods on
+      course_period_id.
+    columns:
+      - name: course_period_id
+        description: Primary key — Focus course period (section) id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: fefp_number_label
+        description: Decoded label for the fefp_number select field.
+      - name: scheduling_method_label
+        description: Decoded label for the scheduling_method select field.
+      - name: facility_type_label
+        description: Decoded label for the facility_type select field.
+      - name: cert_licensure_qual_status_label
+        description:
+          Decoded label for the cert_licensure_qual_status select field.
+      - name: highly_qualified_label
+        description: Decoded label for the highly_qualified select field.
+      - name: reading_intervention_component_label
+        description:
+          Decoded label for the reading_intervention_component select field.
+      - name: location_of_student_label
+        description: Decoded label for the location_of_student select field.
+      - name: eoc_exam_term_label
+        description: Decoded label for the eoc_exam_term select field.
+      - name: basic_skills_exam_label
+        description: Decoded label for the basic_skills_exam select field.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__courses__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__courses__pivot.yml
@@ -1,0 +1,19 @@
+models:
+  - name: int_focus__courses__pivot
+    description: >-
+      Decoded labels for the Course select custom fields, one row per Focus
+      course_id. Join to stg_focus__courses on course_id for the codes.
+    columns:
+      - name: course_id
+        description: Primary key — Focus course id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: course_sequence_label
+        description: Decoded label for the course_sequence select field.
+      - name: ocp_label
+        description: Decoded label for the ocp select field.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
@@ -49,5 +49,7 @@ models:
         description: Log entry last-update timestamp.
       - name: value_label
         description: >-
-          Decoded label for select-type slots; null for non-select slots (the
-          raw value carries the readable content).
+          Decoded label for select-type slots whose options are stored; null for
+          non-select slots and for option_query-backed select slots (e.g. the
+          Immunization "Vaccination" slot), where the raw value carries the
+          content.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
@@ -20,6 +20,10 @@ models:
     columns:
       - name: log_entry_id
         description: Focus custom_field_log_entries id.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
       - name: student_id
         description: Owning student id (custom_field_log_entries.source_id).
       - name: school_id
@@ -30,6 +34,10 @@ models:
         description: Log column id for the slot (custom_field_log_columns.id).
       - name: slot_column_name
         description: Lowercased slot storage column (log_fieldN).
+        data_tests:
+          - not_null:
+              config:
+                severity: error
       - name: slot_type
         description: Input type of the slot (select, checkbox, text, date).
       - name: slot_title

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
@@ -1,0 +1,53 @@
+models:
+  - name: int_focus__custom_field_log__unpivot
+    description: >-
+      Long reshape of Focus log-type custom fields. One row per log entry per
+      populated slot: the entry keys, the slot's metadata (title/type/sort order
+      from custom_field_log_columns), the stored value, and a decoded
+      value_label for select-type slots. Currently covers the two populated
+      student log fields (Immunization Compliance, ARMS Student Field Tracker).
+    config:
+      meta:
+        contains_pii: true
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - log_entry_id
+              - slot_column_name
+          config:
+            severity: error
+    columns:
+      - name: log_entry_id
+        description: Focus custom_field_log_entries id.
+      - name: student_id
+        description: Owning student id (custom_field_log_entries.source_id).
+      - name: school_id
+        description: School id the log entry is attached to.
+      - name: field_id
+        description: Owning log custom field id (custom_fields.id).
+      - name: log_column_id
+        description: Log column id for the slot (custom_field_log_columns.id).
+      - name: slot_column_name
+        description: Lowercased slot storage column (log_fieldN).
+      - name: slot_type
+        description: Input type of the slot (select, checkbox, text, date).
+      - name: slot_title
+        description: Human-readable slot name from custom_field_log_columns.
+      - name: slot_sort_order
+        description: Display order of the slot within the field.
+      - name: field_title
+        description:
+          Human-readable log field name (e.g. Immunization Compliance).
+      - name: value
+        description: Raw stored slot value.
+      - name: syear
+        description: Focus school year of the entry (populated for ARMS only).
+      - name: created_at
+        description: Log entry creation timestamp.
+      - name: updated_at
+        description: Log entry last-update timestamp.
+      - name: value_label
+        description: >-
+          Decoded label for select-type slots; null for non-select slots (the
+          raw value carries the readable content).

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
@@ -1,13 +1,16 @@
 models:
   - name: int_focus__custom_field_options
     description: >-
-      Crosswalk for Focus select/multiple custom fields, keyed by option_id (the
-      value the entity stores). Joins the custom-field catalog to its stored
-      select options on select_options.source_id = custom_fields.id with
-      source_class 'CustomField' (the owner-type literal, never the entity
-      class). One row per option; inactive options are retained so historical
-      stored ids still decode. label is the human name; code is the Focus
-      import/export value.
+      Crosswalk for Focus select/multiple custom fields, one row per option
+      keyed by option_id. Joins the custom-field catalog to its stored select
+      options on select_options.source_id = custom_fields.id with source_class
+      'CustomField' (the owner-type literal, never the entity class). inactive
+      options are retained so historical stored values still decode. label is
+      the human name; code is the Focus import/export value. To decode, match
+      the stored entity value against option_id OR code within a (source_class,
+      column_name) scope — the stored value is the id for some fields and the
+      code for others; this assumes an option's code never equals another
+      option's id within the same field.
     config:
       materialized: table
     columns:

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
@@ -1,24 +1,27 @@
 models:
   - name: int_focus__custom_field_options
     description: >-
-      Code-to-label crosswalk for Focus select/multiple custom fields. Joins the
-      custom-field catalog to its stored select options on
-      select_options.source_id = custom_fields.id with source_class
-      'CustomField' (the owner-type literal, never the entity class). One row
-      per field option; inactive options are retained so historical stored codes
-      still decode.
+      Crosswalk for Focus select/multiple custom fields, keyed by option_id (the
+      value the entity stores). Joins the custom-field catalog to its stored
+      select options on select_options.source_id = custom_fields.id with
+      source_class 'CustomField' (the owner-type literal, never the entity
+      class). One row per option; inactive options are retained so historical
+      stored ids still decode. label is the human name; code is the Focus
+      import/export value.
     config:
       materialized: table
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - source_class
-              - column_name
-              - code
-          config:
-            severity: error
     columns:
+      - name: option_id
+        description: >-
+          Stored select-option id — the value persisted on the entity record and
+          the decode join key.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
       - name: source_class
         description: Owning entity class of the custom field (e.g. SISStudent).
         data_tests:
@@ -33,14 +36,7 @@ models:
               config:
                 severity: error
       - name: code
-        description: Stored option code persisted on the entity record.
-        data_tests:
-          - not_null:
-              config:
-                severity: error
+        description:
+          Focus import/export code for the option (not the stored value).
       - name: label
-        description: Human-readable label for the option code.
-        data_tests:
-          - not_null:
-              config:
-                severity: error
+        description: Human-readable label for the option.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_options.yml
@@ -1,0 +1,46 @@
+models:
+  - name: int_focus__custom_field_options
+    description: >-
+      Code-to-label crosswalk for Focus select/multiple custom fields. Joins the
+      custom-field catalog to its stored select options on
+      select_options.source_id = custom_fields.id with source_class
+      'CustomField' (the owner-type literal, never the entity class). One row
+      per field option; inactive options are retained so historical stored codes
+      still decode.
+    config:
+      materialized: table
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - source_class
+              - column_name
+              - code
+          config:
+            severity: error
+    columns:
+      - name: source_class
+        description: Owning entity class of the custom field (e.g. SISStudent).
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: column_name
+        description:
+          Lowercased catalog column_name of the field (e.g. custom_100000004).
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: code
+        description: Stored option code persisted on the entity record.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: label
+        description: Human-readable label for the option code.
+        data_tests:
+          - not_null:
+              config:
+                severity: error

--- a/src/dbt/focus/models/intermediate/properties/int_focus__master_courses__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__master_courses__pivot.yml
@@ -1,0 +1,23 @@
+models:
+  - name: int_focus__master_courses__pivot
+    description: >-
+      Decoded labels for the CourseCatalog (master course) select custom fields,
+      one row per Focus course_id. Join to stg_focus__master_courses on
+      course_id.
+    columns:
+      - name: course_id
+        description: Primary key — Focus master course id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: fefp_label
+        description: Decoded label for the fefp select field.
+      - name: course_flag_1_label
+        description: Decoded label for the course_flag_1 select field.
+      - name: dual_enrollment_indicator_label
+        description:
+          Decoded label for the dual_enrollment_indicator select field.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__schools__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__schools__pivot.yml
@@ -1,0 +1,21 @@
+models:
+  - name: int_focus__schools__pivot
+    description: >-
+      Decoded labels for the SISSchool select custom fields, one row per Focus
+      school id. Join to stg_focus__schools on id for the codes.
+    columns:
+      - name: id
+        description: Primary key — Focus school id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: school_level_label
+        description: Decoded label for the school_level select field.
+      - name: school_type_label
+        description: Decoded label for the school_type select field.
+      - name: technical_center_label
+        description: Decoded label for the technical_center select field.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment__pivot.yml
@@ -1,0 +1,30 @@
+models:
+  - name: int_focus__student_enrollment__pivot
+    description: >-
+      Decoded labels for the StudentEnrollment select custom fields, one row per
+      Focus enrollment id. Join to stg_focus__student_enrollment on id for
+      codes.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: id
+        description: Primary key — Focus student enrollment id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: prior_district_label
+        description: Decoded label for the prior_district select field.
+      - name: prior_state_label
+        description: Decoded label for the prior_state select field.
+      - name: prior_country_label
+        description: Decoded label for the prior_country select field.
+      - name: educational_choice_label
+        description: Decoded label for the educational_choice select field.
+      - name: student_offender_transfer_label
+        description:
+          Decoded label for the student_offender_transfer select field.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__students__pivot.yml
@@ -1,0 +1,69 @@
+models:
+  - name: int_focus__students__pivot
+    description: >-
+      Decoded labels for the SISStudent select custom fields, one row per
+      student_id. Join to stg_focus__students on student_id for the codes. A
+      null label means the student had no code for that field.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: student_id
+        description: Primary key — Focus local student id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: ethnicity_hispanic_or_latino_label
+        description:
+          Decoded label for the ethnicity_hispanic_or_latino select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_white_label
+        description: Decoded label for the race_white select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_black_or_african_american_label
+        description:
+          Decoded label for the race_black_or_african_american select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_asian_label
+        description: Decoded label for the race_asian select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: sex_label
+        description: Decoded label for the sex select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_american_indian_or_alaska_native_label
+        description:
+          Decoded label for the race_american_indian_or_alaska_native field.
+        config:
+          meta:
+            contains_pii: true
+      - name: race_native_hawaiian_or_other_pacific_islander_label
+        description:
+          Decoded label for the race_native_hawaiian_or_other_pacific_islander
+          field.
+        config:
+          meta:
+            contains_pii: true
+      - name: residence_county_label
+        description: Decoded label for the residence_county select field.
+        config:
+          meta:
+            contains_pii: true
+      - name: language_label
+        description: Decoded label for the language select field.
+        config:
+          meta:
+            contains_pii: true

--- a/src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
@@ -23,4 +23,4 @@ models:
       - name: education_label
         description: >-
           Decoded labels for the education multiple-select field, as an array
-          (the stored value is a JSON array of option codes).
+          (the stored value is a JSON array of option ids).

--- a/src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__users__pivot.yml
@@ -1,0 +1,26 @@
+models:
+  - name: int_focus__users__pivot
+    description: >-
+      Decoded labels for the FocusUser custom fields, one row per staff_id. Join
+      to stg_focus__users on staff_id for the codes.
+      profile_on_non_production_sites is option_query-backed and intentionally
+      not decoded (its code stays in staging).
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: staff_id
+        description: Primary key — Focus staff id.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: active_label
+        description: Decoded label for the active select field.
+      - name: education_label
+        description: >-
+          Decoded labels for the education multiple-select field, as an array
+          (the stored value is a JSON array of option codes).

--- a/src/dbt/focus/tests/properties.yml
+++ b/src/dbt/focus/tests/properties.yml
@@ -1,0 +1,12 @@
+data_tests:
+  - name: test_focus__custom_field_options_known_fields
+    description: >-
+      Guards the decode join: the three sentinel (source_class, column_name)
+      pairs must each resolve to at least one option in
+      int_focus__custom_field_options. Any returned row is a failure.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: int_focus__custom_field_options
+            package: focus

--- a/src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql
+++ b/src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql
@@ -14,4 +14,4 @@ left join
     {{ ref("int_focus__custom_field_options") }} as o
     on expected.source_class = o.source_class
     and expected.column_name = o.column_name
-where o.code is null
+where o.option_id is null

--- a/src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql
+++ b/src/dbt/focus/tests/test_focus__custom_field_options_known_fields.sql
@@ -1,0 +1,17 @@
+-- Guards the corrected decode join: known in-scope fields must resolve to
+-- options. Returns offending (source_class, column_name) rows -> any row fails.
+with
+    expected as (
+        select 'SISSchool' as source_class, 'custom_100000004' as column_name,
+        union all
+        select 'SISStudent' as source_class, 'custom_200000000' as column_name,
+        union all
+        select 'StudentEnrollment' as source_class, 'custom_4' as column_name,
+    )
+select expected.source_class, expected.column_name,
+from expected
+left join
+    {{ ref("int_focus__custom_field_options") }} as o
+    on expected.source_class = o.source_class
+    and expected.column_name = o.column_name
+where o.code is null


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR decodes Focus SIS `select` / `multiple` custom-field values
to human-readable labels and reshapes the `log`-type custom fields, as additive
`int_focus__*` intermediate models (builds in `kippmiami`; **no staging
changes**). Closes #4258.

New models:

- `int_focus__custom_field_options` — shared code/label crosswalk.
- Seven `int_focus__{entity}__pivot` models (students, schools,
  student_enrollment, users, course_periods, master_courses, courses) — decoded
  `{slug}_label` columns keyed by the entity PK, labels-only (codes stay in
  staging; consumers join staging + pivot on the PK). `users` also decodes the
  `education` multiple field into an array.
- `int_focus__custom_field_log__unpivot` — the two populated log-type fields
  reshaped wide-to-long with per-slot decode.
- A singular guard test, plus decode-join clarifications in `focus/CLAUDE.md`.

Decode design: the entity stores the select-option **id** for some fields and
the **code** for others, so each pivot matches the stored value
`in (option_id, code)` filtered by `(source_class, column_name)` and returns
`label`. `option_query`-backed fields (e.g. `users.profile_on_non_production_sites`
and the log "Vaccination" slot) are intentionally not decoded and are
inventoried in the design spec.

Each model was built against dev and its decode spot-checked (e.g. `sex` ->
`Male[M]`, `school_level` -> `E - Elementary`, `prior_state` -> `FL - Florida`,
ARMS log field 10,598/10,598). Design spec and plan live under
`docs/superpowers/`.

**Follow-up for People Operations:** column-level PII tagging on the decoded
demographic labels follows a FERPA-broad stance and should be confirmed /
reconciled with People Ops before it is treated as final (flagged in the spec).

## AI Assistance

Brainstormed, planned, and implemented with Claude Code (subagent-driven),
human-directed throughout: the author chose the design decisions (labels-only,
per-entity pivots without a shared macro, log scope, PII posture) and the review
cadence; Claude authored the spec, plan, and models and verified each model's
decode against dev data.

## Self-review

### dbt

- [x] `{model}.yml` properties file included for all new models
- [ ] Exposures — N/A: foundation layer, no dashboard/analysis/app consumer yet
- [x] Not a breaking change — additive only; no renames/removals on contracted
      (`stg_`/`rpt_`/mart) models
- [x] No external sources added or modified — `stage_external_sources` not needed

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — not triggered (no Dagster code paths changed)
