### PR TITLE
feat(kipptaf): add NSC request gap audit (qa_kippadb__nsc_gaps)

### DIFF
--- a/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
+++ b/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
@@ -14,16 +14,15 @@ permanent audit model (candidate: `qa_kippadb__nsc_gaps`).
 
 ## Sources
 
-| Model                        | Role                                          | Key fields used                                                                                                                             |
-| ---------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `int_kippadb__roster`        | Alum universe (KTC-tracked)                   | `contact_id`, `contact_graduation_year`, `contact_advising_provider`, `contact_actual_hs_graduation_date`, `contact_expected_hs_graduation` |
-| `stg_nsc__student_tracker`   | Existing NSC pull records                     | `contact_id`, `record_found_y_n`                                                                                                            |
-| `stg_kippadb__term`          | Salesforce postsecondary terms                | `student` (contact FK), `verified_by_nsc`, `term_end_date`, `nsc_enrollment_end`                                                            |
-| `int_nsc__enrollment_stints` | Derived NSC stints (for completion flag only) | `contact_id`, `derived_status`                                                                                                              |
+| Model                        | Role                                      | Key fields used                                                                                                                             |
+| ---------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `int_kippadb__roster`        | Alum universe (KTC-tracked)               | `contact_id`, `contact_graduation_year`, `contact_advising_provider`, `contact_actual_hs_graduation_date`, `contact_expected_hs_graduation` |
+| `stg_nsc__student_tracker`   | Existing NSC pull records                 | `contact_id`, `record_found_y_n`                                                                                                            |
+| `stg_kippadb__term`          | Salesforce postsecondary terms            | `enrollment` (FK to enrollment), `verified_by_nsc` (date), `term_end_date`, `nsc_enrollment_end`                                            |
+| `stg_kippadb__enrollment`    | Bridges term to contact                   | `id` (term FK target), `student` (contact id)                                                                                               |
+| `int_nsc__enrollment_stints` | Derived NSC stints (completion flag only) | `contact_id`, `derived_status`                                                                                                              |
 
-Note `stg_kippadb__term.student` is the contact id FK (joins to
-`int_kippadb__roster.contact_id`). `stg_nsc__student_tracker.contact_id` is the
-canonical mixed-case Salesforce contact id recovered in staging.
+### Join paths and grains
 
 `int_kippadb__roster` is grained one row per `student_number` (its `unique` key)
 — the KTC-tracked roster (`ktc_status is not null`, grades 8–12, most recent
@@ -33,22 +32,38 @@ undergrad enrollment), with `contact_*` fields left-joined from
 contact). Sourcing the roster instead of raw `base_kippadb__contact` scopes the
 universe to KTC-tracked alumni from the start.
 
+`stg_kippadb__term` has **no** direct contact FK. A term reaches its contact
+through its enrollment: `term.enrollment = enrollment.id`, and
+`enrollment.student` is the contact id. `stg_nsc__student_tracker.contact_id` is
+the canonical mixed-case Salesforce contact id recovered in staging, and joins
+directly to `int_kippadb__roster.contact_id`.
+
 ## Universe
 
-Include an alum when either branch holds:
+Include an alum when all of these hold:
 
 ```text
-contact_graduation_year <= 2022
-OR (contact_graduation_year > 2022 AND contact_advising_provider IS NULL)
+contact_actual_hs_graduation_date IS NOT NULL   -- actually graduated HS
+AND contact_graduation_year <= 2026             -- current_academic_year + 1
+AND (
+  contact_graduation_year <= 2022
+  OR (contact_graduation_year > 2022 AND contact_advising_provider IS NULL)
+)
 ```
 
 Rationale: alumni who graduated high school in 2022 or earlier are tracked by
 KTAF directly via NSC; alumni who graduated after 2022 are tracked by an
 external advising provider unless none is assigned (then KTAF tracks them).
 
-Alumni with a NULL `contact_graduation_year` satisfy neither branch and are
-excluded. The analysis reports that excluded count separately so we can confirm
-the exclusion is intended before acting on the list.
+The two leading guards scope the universe to **actual HS graduates** through the
+class of 2026. Without them, the `> 2022 when advising_provider IS NULL` branch
+sweeps in the entire current grade 8–12 roster that has no provider assigned
+(~4,100 current students, HS classes 2027–2030), for whom an NSC postsecondary
+request is premature. `contact_actual_hs_graduation_date IS NOT NULL` is the
+substantive filter; the year cap is a redundant guard.
+
+Alumni with a NULL `contact_graduation_year` satisfy neither inner branch and
+are excluded (empty in current data).
 
 ## Per-alum signals
 
@@ -56,32 +71,43 @@ Computed once per `contact_id`:
 
 - `has_nsc_record` — the contact appears in `stg_nsc__student_tracker` with
   `record_found_y_n = 'Y'`.
+- `has_verified_terms` — the contact has at least one `stg_kippadb__term` row
+  (via its enrollment) where `verified_by_nsc IS NOT NULL`. `verified_by_nsc` is
+  a **date** (the NSC verification date), not a boolean — a non-null value means
+  the term was NSC-verified.
 - `latest_verified_term_end` —
-  `max(coalesce(term_end_date, nsc_enrollment_end))` over the contact's
-  `stg_kippadb__term` rows where `verified_by_nsc = true`. This is the anchor
-  for the suggested NSC search start.
+  `max(coalesce(term_end_date, safe.parse_date('%Y%m%d', substr(nsc_enrollment_end, 1, 8))))`
+  over the contact's NSC-verified terms. `term_end_date` is a DATE and is the
+  primary anchor; `nsc_enrollment_end` is a `%Y%m%d` STRING (some values carry a
+  trailing `.0` float artifact, hence `substr(..., 1, 8)`) used only as a
+  fallback. This is the anchor for the suggested NSC search start.
 - `completed_college` —
   `int_nsc__enrollment_stints.derived_status = 'Graduated'` for the contact (or
   a Salesforce terminal status). Used as a flag, never a filter.
 
-The "NSC verified column" referenced in the request is `term.verified_by_nsc`.
-The end-date anchor prefers `term_end_date` and falls back to
-`nsc_enrollment_end`.
+These two presences come from **different sources** — `stg_nsc__student_tracker`
+(the raw NSC pull echo) and Salesforce verified terms — and a contact can have
+one without the other. The gap classification below resolves the overlap with
+explicit precedence.
 
 ## Gap classification (alum grain — one row per alum)
 
-| `gap_type`        | Condition                                                       | `suggested_search_from`    |
-| ----------------- | --------------------------------------------------------------- | -------------------------- |
-| `no_nsc_record`   | not in `stg_nsc__student_tracker` (no `record_found_y_n = 'Y'`) | HS graduation date         |
-| `unverified_only` | in the tracker, but no `verified_by_nsc` terms                  | HS graduation date         |
-| `forward_gap`     | has `verified_by_nsc` terms, latest verified term has ended     | `latest_verified_term_end` |
+Each universe alum is assigned exactly one `gap_type` by precedence (verified
+terms first, then tracker presence):
+
+| Precedence | `gap_type`        | Condition                                                                       | `suggested_search_from`    |
+| ---------- | ----------------- | ------------------------------------------------------------------------------- | -------------------------- |
+| 1          | `forward_gap`     | `has_verified_terms` and the latest verified term has ended                     | `latest_verified_term_end` |
+| 2          | `unverified_only` | no verified terms, but in `stg_nsc__student_tracker` (`record_found_y_n = 'Y'`) | HS graduation date         |
+| 3          | `no_nsc_record`   | no verified terms and not in the tracker                                        | HS graduation date         |
 
 HS graduation date =
 `coalesce(contact_actual_hs_graduation_date, contact_expected_hs_graduation)`.
 
-An alum matches exactly one `gap_type`. An alum with verified terms whose latest
-term has **not** ended (currently enrolled per the verified record) is not a gap
-and is excluded from the output.
+A `forward_gap` alum whose latest verified term has **not** ended (currently
+enrolled per the verified record) is not a gap and is excluded. In the current
+data every verified-terms alum in the universe has already ended their latest
+verified term, so none are excluded on this basis.
 
 ## Output columns
 
@@ -93,10 +119,10 @@ One row per gap alum:
 - `gap_type`
 - `suggested_search_from`
 - `is_stale_6mo` — `latest_verified_term_end` more than 6 months before
-  `current_date('America/New_York')`. NULL/false for non-`forward_gap` rows.
+  `current_date('America/New_York')`. NULL for non-`forward_gap` rows.
 - `is_stale_prior_ay` — `latest_verified_term_end` before the start of the
-  current academic year (`var('current_academic_year')`). NULL/false for
-  non-`forward_gap` rows.
+  current academic year (`var('current_academic_year')`, July 1 of that year).
+  NULL for non-`forward_gap` rows.
 - `completed_college_flag` — NSC/SF shows degree completion.
 
 Both staleness flags are reported side by side and labeled, per request — they
@@ -104,16 +130,34 @@ are informational, not filters.
 
 ## Edge cases and confirmations
 
-- **NULL `contact_graduation_year`** — excluded; count reported separately.
+- **NULL `contact_graduation_year`** — excluded; count reported separately
+  (empty in current data).
+- **`forward_gap` with no parseable term end** — a small number of verified-term
+  alumni have neither a `term_end_date` nor a parseable `nsc_enrollment_end`.
+  They are still `forward_gap` but cannot anchor a search-from; fall back to the
+  HS graduation date and flag them.
 - **`unverified_only`** — alum searched but nothing verified into Salesforce
   terms; treated as its own gap type rather than dropped, since it represents a
   real follow-up need.
 - **`completed_college`** — kept in the output (flagged), not filtered, so the
   user decides per row whether further searching is warranted.
-- **Verified-term source assumption** — `term.verified_by_nsc` is the
-  authoritative "NSC verified" flag and `term_end_date` (fallback
-  `nsc_enrollment_end`) is the term end. To be confirmed against profiled data
-  before the query is finalized.
+
+## Validation (observed against prod, 2026-06-24)
+
+Universe = 2,406 actual HS graduates (classes through 2025; no class-of-2026
+contact has a recorded HS graduation date yet). Buckets (mutually exclusive, by
+precedence):
+
+- `forward_gap` — 1,552 (1,502 stale > 6 months, 1,470 before AY2025 start; none
+  currently enrolled)
+- `no_nsc_record` — 740
+- `unverified_only` — 114
+
+`completed_college` flagged: 268. Grad-year split: ≤2022 = 2,161; 2023–2026
+= 245.
+
+(Before the HS-graduate guards, the literal rule returned 7,359 contacts, of
+which ~4,100 were current grade 8–12 students — see Universe.)
 
 ## PII handling
 

--- a/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
+++ b/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
@@ -1,0 +1,128 @@
+# NSC Request Gap Audit — Design
+
+Refs: [#4261](https://github.com/TEAMSchools/teamster/issues/4261)
+
+## Goal
+
+Identify alumni for whom we need to submit further NSC (National Student
+Clearinghouse) requests to fill postsecondary tracking gaps, and for each one
+suggest a date to start the NSC search from.
+
+Immediate deliverable: a one-off ad-hoc query, results written to local scratch.
+This document captures the full logic so the analysis can later be promoted to a
+permanent audit model (candidate: `qa_kippadb__nsc_gaps`).
+
+## Sources
+
+| Model                        | Role                                          | Key fields used                                                                                                             |
+| ---------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `base_kippadb__contact`      | Alum universe                                 | `contact_id`, `contact_graduation_year`, `contact_advising_provider`, `actual_hs_graduation_date`, `expected_hs_graduation` |
+| `stg_nsc__student_tracker`   | Existing NSC pull records                     | `contact_id`, `record_found_y_n`                                                                                            |
+| `stg_kippadb__term`          | Salesforce postsecondary terms                | `student` (contact FK), `verified_by_nsc`, `term_end_date`, `nsc_enrollment_end`                                            |
+| `int_nsc__enrollment_stints` | Derived NSC stints (for completion flag only) | `contact_id`, `derived_status`                                                                                              |
+
+Note `stg_kippadb__term.student` is the contact id FK (joins to
+`base_kippadb__contact.contact_id`). `stg_nsc__student_tracker.contact_id` is
+the canonical mixed-case Salesforce contact id recovered in staging.
+
+## Universe
+
+Include an alum when either branch holds:
+
+```text
+contact_graduation_year <= 2022
+OR (contact_graduation_year > 2022 AND contact_advising_provider IS NULL)
+```
+
+Rationale: alumni who graduated high school in 2022 or earlier are tracked by
+KTAF directly via NSC; alumni who graduated after 2022 are tracked by an
+external advising provider unless none is assigned (then KTAF tracks them).
+
+Alumni with a NULL `contact_graduation_year` satisfy neither branch and are
+excluded. The analysis reports that excluded count separately so we can confirm
+the exclusion is intended before acting on the list.
+
+## Per-alum signals
+
+Computed once per `contact_id`:
+
+- `has_nsc_record` — the contact appears in `stg_nsc__student_tracker` with
+  `record_found_y_n = 'Y'`.
+- `latest_verified_term_end` —
+  `max(coalesce(term_end_date, nsc_enrollment_end))` over the contact's
+  `stg_kippadb__term` rows where `verified_by_nsc = true`. This is the anchor
+  for the suggested NSC search start.
+- `completed_college` —
+  `int_nsc__enrollment_stints.derived_status = 'Graduated'` for the contact (or
+  a Salesforce terminal status). Used as a flag, never a filter.
+
+The "NSC verified column" referenced in the request is `term.verified_by_nsc`.
+The end-date anchor prefers `term_end_date` and falls back to
+`nsc_enrollment_end`.
+
+## Gap classification (alum grain — one row per alum)
+
+| `gap_type`        | Condition                                                       | `suggested_search_from`    |
+| ----------------- | --------------------------------------------------------------- | -------------------------- |
+| `no_nsc_record`   | not in `stg_nsc__student_tracker` (no `record_found_y_n = 'Y'`) | HS graduation date         |
+| `unverified_only` | in the tracker, but no `verified_by_nsc` terms                  | HS graduation date         |
+| `forward_gap`     | has `verified_by_nsc` terms, latest verified term has ended     | `latest_verified_term_end` |
+
+HS graduation date =
+`coalesce(actual_hs_graduation_date, expected_hs_graduation)`.
+
+An alum matches exactly one `gap_type`. An alum with verified terms whose latest
+term has **not** ended (currently enrolled per the verified record) is not a gap
+and is excluded from the output.
+
+## Output columns
+
+One row per gap alum:
+
+- `contact_id`
+- `contact_graduation_year`
+- `contact_advising_provider`
+- `gap_type`
+- `suggested_search_from`
+- `is_stale_6mo` — `latest_verified_term_end` more than 6 months before
+  `current_date('America/New_York')`. NULL/false for non-`forward_gap` rows.
+- `is_stale_prior_ay` — `latest_verified_term_end` before the start of the
+  current academic year (`var('current_academic_year')`). NULL/false for
+  non-`forward_gap` rows.
+- `completed_college_flag` — NSC/SF shows degree completion.
+
+Both staleness flags are reported side by side and labeled, per request — they
+are informational, not filters.
+
+## Edge cases and confirmations
+
+- **NULL `contact_graduation_year`** — excluded; count reported separately.
+- **`unverified_only`** — alum searched but nothing verified into Salesforce
+  terms; treated as its own gap type rather than dropped, since it represents a
+  real follow-up need.
+- **`completed_college`** — kept in the output (flagged), not filtered, so the
+  user decides per row whether further searching is warranted.
+- **Verified-term source assumption** — `term.verified_by_nsc` is the
+  authoritative "NSC verified" flag and `term_end_date` (fallback
+  `nsc_enrollment_end`) is the term end. To be confirmed against profiled data
+  before the query is finalized.
+
+## PII handling
+
+The query touches alum names, contact ids, and graduation dates (PII). Results
+stay in `.claude/scratch/` and the terminal. No alum-identifying values go into
+the issue, PR, commits, or any external surface — only aggregate counts and
+column-name references.
+
+## Productionization notes (future)
+
+If promoted to `qa_kippadb__nsc_gaps`:
+
+- Lives under `src/dbt/kipptaf/models/kippadb/qa/` alongside
+  `qa_kippadb__duplicate_enrollments`.
+- Needs a uniqueness test on `contact_id`.
+- The staleness comparisons (`current_date`, `current_academic_year`) make it
+  time-varying; anchor to a table materialization if a refreshing asset check is
+  wanted.
+- A reporting view (`rpt_gsheets__*`) would sit between the QA model and any
+  Google Sheet Ops uses to drive submissions.

--- a/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
+++ b/docs/superpowers/specs/2026-06-24-nsc-request-gap-audit-design.md
@@ -14,16 +14,24 @@ permanent audit model (candidate: `qa_kippadb__nsc_gaps`).
 
 ## Sources
 
-| Model                        | Role                                          | Key fields used                                                                                                             |
-| ---------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `base_kippadb__contact`      | Alum universe                                 | `contact_id`, `contact_graduation_year`, `contact_advising_provider`, `actual_hs_graduation_date`, `expected_hs_graduation` |
-| `stg_nsc__student_tracker`   | Existing NSC pull records                     | `contact_id`, `record_found_y_n`                                                                                            |
-| `stg_kippadb__term`          | Salesforce postsecondary terms                | `student` (contact FK), `verified_by_nsc`, `term_end_date`, `nsc_enrollment_end`                                            |
-| `int_nsc__enrollment_stints` | Derived NSC stints (for completion flag only) | `contact_id`, `derived_status`                                                                                              |
+| Model                        | Role                                          | Key fields used                                                                                                                             |
+| ---------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `int_kippadb__roster`        | Alum universe (KTC-tracked)                   | `contact_id`, `contact_graduation_year`, `contact_advising_provider`, `contact_actual_hs_graduation_date`, `contact_expected_hs_graduation` |
+| `stg_nsc__student_tracker`   | Existing NSC pull records                     | `contact_id`, `record_found_y_n`                                                                                                            |
+| `stg_kippadb__term`          | Salesforce postsecondary terms                | `student` (contact FK), `verified_by_nsc`, `term_end_date`, `nsc_enrollment_end`                                                            |
+| `int_nsc__enrollment_stints` | Derived NSC stints (for completion flag only) | `contact_id`, `derived_status`                                                                                                              |
 
 Note `stg_kippadb__term.student` is the contact id FK (joins to
-`base_kippadb__contact.contact_id`). `stg_nsc__student_tracker.contact_id` is
-the canonical mixed-case Salesforce contact id recovered in staging.
+`int_kippadb__roster.contact_id`). `stg_nsc__student_tracker.contact_id` is the
+canonical mixed-case Salesforce contact id recovered in staging.
+
+`int_kippadb__roster` is grained one row per `student_number` (its `unique` key)
+— the KTC-tracked roster (`ktc_status is not null`, grades 8–12, most recent
+undergrad enrollment), with `contact_*` fields left-joined from
+`base_kippadb__contact`. The audit aggregates the roster to one row per
+`contact_id`, dropping rows with a NULL `contact_id` (non-alumni / no Salesforce
+contact). Sourcing the roster instead of raw `base_kippadb__contact` scopes the
+universe to KTC-tracked alumni from the start.
 
 ## Universe
 
@@ -69,7 +77,7 @@ The end-date anchor prefers `term_end_date` and falls back to
 | `forward_gap`     | has `verified_by_nsc` terms, latest verified term has ended     | `latest_verified_term_end` |
 
 HS graduation date =
-`coalesce(actual_hs_graduation_date, expected_hs_graduation)`.
+`coalesce(contact_actual_hs_graduation_date, contact_expected_hs_graduation)`.
 
 An alum matches exactly one `gap_type`. An alum with verified terms whose latest
 term has **not** ended (currently enrolled per the verified record) is not a gap

--- a/src/dbt/kipptaf/models/kippadb/qa/properties/qa_kippadb__nsc_gaps.yml
+++ b/src/dbt/kipptaf/models/kippadb/qa/properties/qa_kippadb__nsc_gaps.yml
@@ -1,0 +1,54 @@
+models:
+  - name: qa_kippadb__nsc_gaps
+    description: >
+      Audit of KTC-tracked alumni who need a further NSC (National Student
+      Clearinghouse) request to fill postsecondary tracking gaps. One row per
+      alum. The universe is actual HS graduates (a recorded HS graduation date)
+      through the class of current_academic_year + 1 who either graduated in
+      2022 or earlier, or graduated later but have no advising provider
+      assigned. Each alum is classified into exactly one gap type by precedence
+      and given a suggested date to start the next NSC search from.
+    columns:
+      - name: contact_id
+        data_type: string
+        description: Salesforce contact id of the alum. Grain of the model.
+        data_tests:
+          - unique
+          - not_null
+      - name: contact_graduation_year
+        data_type: int64
+        description: HS graduation year of the alum, from the KTC roster.
+      - name: contact_advising_provider
+        data_type: string
+        description: >
+          External advising provider assigned to the alum, if any. Null for
+          alumni KTAF tracks directly via NSC.
+      - name: gap_type
+        data_type: string
+        description: >
+          The single gap classification, by precedence. forward_gap — has NSC
+          verified Salesforce terms whose latest term has ended. unverified_only
+          — present in the NSC tracker but with no verified terms to anchor.
+          no_nsc_record — no verified terms and not present in the NSC tracker.
+      - name: completed_college_flag
+        data_type: boolean
+        description: >
+          The alum has an NSC enrollment stint with a derived status of
+          Graduated. Informational — completed alumni are flagged, not excluded.
+      - name: is_stale_6mo
+        data_type: boolean
+        description: >
+          For forward_gap alumni, whether the latest verified term ended more
+          than six months before today. Null for other gap types.
+      - name: is_stale_prior_ay
+        data_type: boolean
+        description: >
+          For forward_gap alumni, whether the latest verified term ended before
+          the start of the current academic year (July 1). Null for other gap
+          types.
+      - name: suggested_search_from
+        data_type: date
+        description: >
+          Suggested date to begin the next NSC search. For forward_gap alumni,
+          the latest verified term end date (falling back to HS graduation date
+          when no term end can be parsed); otherwise the HS graduation date.

--- a/src/dbt/kipptaf/models/kippadb/qa/qa_kippadb__nsc_gaps.sql
+++ b/src/dbt/kipptaf/models/kippadb/qa/qa_kippadb__nsc_gaps.sql
@@ -1,0 +1,116 @@
+with
+    roster as (
+        select distinct
+            contact_id,
+            contact_graduation_year,
+            contact_advising_provider,
+
+            coalesce(
+                contact_actual_hs_graduation_date, contact_expected_hs_graduation
+            ) as hs_grad_date,
+        from {{ ref("int_kippadb__roster") }}
+        where
+            contact_id is not null
+            /* scope to actual HS graduates through class of current_academic_year
+               + 1; without these guards the post-2022 advising-null branch sweeps
+               in the current grade 8-12 roster, for whom an NSC postsecondary
+               request is premature */
+            and contact_actual_hs_graduation_date is not null
+            and contact_graduation_year <= {{ var("current_academic_year") + 1 }}
+            and (
+                contact_graduation_year <= 2022
+                or (
+                    contact_graduation_year > 2022 and contact_advising_provider is null
+                )
+            )
+    ),
+
+    nsc_found as (
+        select distinct contact_id,
+        from {{ ref("stg_nsc__student_tracker") }}
+        where record_found_y_n = 'Y'
+    ),
+
+    /* a term reaches its contact only through its enrollment; verified_by_nsc is
+       a date (the NSC verification date), so non-null means NSC-verified */
+    verified_terms as (
+        select
+            e.student as contact_id,
+
+            max(
+                coalesce(
+                    t.term_end_date,
+                    safe.parse_date('%Y%m%d', substr(t.nsc_enrollment_end, 1, 8))
+                )
+            ) as latest_verified_term_end,
+        from {{ ref("stg_kippadb__term") }} as t
+        inner join {{ ref("stg_kippadb__enrollment") }} as e on t.enrollment = e.id
+        where t.verified_by_nsc is not null
+        group by e.student
+    ),
+
+    completed as (
+        select distinct contact_id,
+        from {{ ref("int_nsc__enrollment_stints") }}
+        where derived_status = 'Graduated'
+    ),
+
+    classified as (
+        select
+            r.contact_id,
+            r.contact_graduation_year,
+            r.contact_advising_provider,
+            r.hs_grad_date,
+
+            vt.latest_verified_term_end,
+
+            cp.contact_id is not null as completed_college_flag,
+
+            case
+                when vt.contact_id is not null
+                then 'forward_gap'
+                when nf.contact_id is not null
+                then 'unverified_only'
+                else 'no_nsc_record'
+            end as gap_type,
+        from roster as r
+        left join nsc_found as nf on r.contact_id = nf.contact_id
+        left join verified_terms as vt on r.contact_id = vt.contact_id
+        left join completed as cp on r.contact_id = cp.contact_id
+    )
+
+select
+    contact_id,
+    contact_graduation_year,
+    contact_advising_provider,
+    gap_type,
+    completed_college_flag,
+
+    if(
+        gap_type = 'forward_gap',
+        latest_verified_term_end
+        < date_sub(current_date('{{ var("local_timezone") }}'), interval 6 month),
+        cast(null as bool)
+    ) as is_stale_6mo,
+
+    if(
+        gap_type = 'forward_gap',
+        latest_verified_term_end < date({{ var("current_academic_year") }}, 7, 1),
+        cast(null as bool)
+    ) as is_stale_prior_ay,
+
+    case
+        when gap_type = 'forward_gap'
+        then coalesce(latest_verified_term_end, hs_grad_date)
+        else hs_grad_date
+    end as suggested_search_from,
+from classified
+/* exclude forward_gap alumni still currently enrolled per the verified record;
+   guard on is not null so a null end date falls through rather than being
+   silently filtered by the null comparison */
+where
+    not (
+        gap_type = 'forward_gap'
+        and latest_verified_term_end is not null
+        and latest_verified_term_end >= current_date('{{ var("local_timezone") }}')
+    )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will add `qa_kippadb__nsc_gaps`, an audit of
> KTC-tracked alumni who need a further NSC (National Student Clearinghouse)
> request to fill postsecondary tracking gaps, plus the design doc capturing the
> logic.

One row per alum, classified into exactly one gap type by precedence:

- `forward_gap` — has NSC-verified Salesforce terms whose latest term has ended;
  search from that term end date.
- `unverified_only` — present in the NSC tracker but with no verified terms.
- `no_nsc_record` — no verified terms and absent from the tracker.

Each row carries a `suggested_search_from` date, two staleness flags
(`is_stale_6mo`, `is_stale_prior_ay`), and a `completed_college_flag`. The
universe is actual HS graduates (a recorded HS graduation date) through the
class of `current_academic_year + 1` who graduated in 2022 or earlier, or later
with no advising provider assigned.

Observed against prod: 2,406 contacts (1,552 forward_gap / 740 no_nsc_record /
114 unverified_only; 268 flagged completed_college).

The model is left **enabled** (a standing Dagster asset), unlike the sibling
on-demand QA models. Closes #4261.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude-authored (design, profiling, model, tests) under human direction on the
universe scope, gap definitions, and the source model.

## Self-review

### dbt

- [x] Includes a `qa_kippadb__nsc_gaps.yml` properties file with model and
      column descriptions and a `unique` + `not_null` test on `contact_id`.
- [x] Not a breaking change — new model only, no contracted columns renamed or
      removed; no exposure needed (no dashboard consumer yet).
- [x] No external sources added or modified.
- Built and tested locally with deferral to prod (view created; `unique` and
      `not_null` on `contact_id` PASS). Output grain verified against prod.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
