### PR TITLE
feat(dbt): repoint Focus student id to minted focus_student_id

### DIFF
--- a/src/dbt/finalsite/CLAUDE.md
+++ b/src/dbt/finalsite/CLAUDE.md
@@ -31,9 +31,9 @@ models/
   receivers).
 - `int_finalsite__contact_id_attributes` — pivots every `id_attributes` field to
   its own column, aliased to the original field name (`power_school_contact_id`,
-  `powerschool_student_number`). The PIVOT enumerates fields explicitly — add a
-  new `id_attributes` field (e.g. the Finalsite-minted Focus `STDT_ID`) to the
-  PIVOT list in the model SQL; it does not surface automatically.
+  `powerschool_student_number`, `focus_student_id`). The PIVOT enumerates fields
+  explicitly — add a new `id_attributes` field to the PIVOT list in the model
+  SQL; it does not surface automatically.
 - `int_finalsite__contact_custom_attributes` — pivots every `custom_attributes`
   field to its own column, aliased to the original field name and typed by the
   populated value subtype (`_yn`/`_opt_in` booleans, `_ms` string arrays, else

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_id_attributes.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_id_attributes.sql
@@ -8,9 +8,14 @@ with
         cross join unnest(c.id_attributes) as a
     )
 
-select finalsite_enrollment_id, power_school_contact_id, powerschool_student_number,
+select
+    finalsite_enrollment_id,
+    power_school_contact_id,
+    powerschool_student_number,
+    focus_student_id,
 from
     attributes pivot (
         max(value_string)
-        for field_name in ('power_school_contact_id', 'powerschool_student_number')
+        for field_name
+        in ('power_school_contact_id', 'powerschool_student_number', 'focus_student_id')
     )

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_id_attributes.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_id_attributes.yml
@@ -5,10 +5,8 @@ models:
       key-value array into one column per identifier field, each aliased to its
       original Finalsite field name. Contacts with no `id_attributes` are absent
       (resolve via a left join). The PIVOT enumerates fields explicitly, so a
-      new `id_attributes` field does not surface automatically — when the
-      Finalsite-minted student number (the future Focus `STDT_ID`) lands, add it
-      to the PIVOT field list in the model SQL, then repoint downstream
-      extracts.
+      new `id_attributes` field must be added to the PIVOT field list in the
+      model SQL to surface — it does not appear automatically.
     columns:
       - name: finalsite_enrollment_id
         data_type: string
@@ -22,3 +20,8 @@ models:
       - name: powerschool_student_number
         data_type: string
         description: PowerSchool student number from the `id_attributes` array.
+      - name: focus_student_id
+        data_type: string
+        description:
+          Finalsite-minted Focus student id (the Focus `STDT_ID`) from the
+          `id_attributes` array.

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
@@ -18,8 +18,9 @@ models:
       - name: student_id
         data_type: string
         description:
-          Focus student ID. Null until Finalsite mints the student id into
-          `int_finalsite__contact_id_attributes`, then sourced from there.
+          Focus student id (Focus `STDT_ID`) from
+          `int_finalsite__contact_id_attributes.focus_student_id`; null for
+          contacts where Finalsite has not minted the id.
         data_tests:
           - unique
           - not_null
@@ -69,8 +70,8 @@ unit_tests:
   - name: test_addresses_shape
     description:
       Verifies the 13-column ADDRESS layout for a single student — STUDENT_ID is
-      null until the Finalsite-minted student id lands, address columns map from
-      contacts, mailing columns are always null.
+      sourced from int_finalsite__contact_id_attributes, address columns map
+      from contacts, mailing columns are always null.
     model: rpt_focus__addresses
     given:
       - input: ref('stg_finalsite__contacts')
@@ -87,10 +88,16 @@ unit_tests:
       - input: ref('int_finalsite__enrollment_lifecycle')
         rows:
           - { finalsite_enrollment_id: enr-001 }
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            '4004004' as focus_student_id
     expect:
       rows:
         - {
-            student_id: null,
+            student_id: "4004004",
             address: 123 Main St,
             address2: Apt 4B,
             city: Miami,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -6,15 +6,15 @@ models:
       `stg_finalsite__contact_relationships` (adult relationship types — parent,
       guardian, grandparent, stepparent, relative, aunt/uncle) inner-joined to
       `stg_finalsite__contacts` for guardian attributes, gated to in-scope
-      students via `int_finalsite__enrollment_lifecycle`. `student_id` is
-      stubbed null until the Finalsite-minted student id lands in
-      `int_finalsite__contact_id_attributes`. Produces 51 columns in
-      `CONTACTS_LAYOUT` order. `SORT_ORDER` ranks guardians per student by
-      `is_primary desc` so the primary contact sorts first. Phone slots
-      `CONTACT1_*` and `CONTACT2_*` map the guardian's two phones; `CONTACT3`
-      through `CONTACT7` are always null. Focus column header casing is applied
-      at transport time via `file_config.format.header_replacements`; dbt column
-      names remain lowercase snake_case.
+      students via `int_finalsite__enrollment_lifecycle`. The student's Focus id
+      (`student_id`) is left-joined from `int_finalsite__contact_id_attributes`.
+      Produces 51 columns in `CONTACTS_LAYOUT` order. `SORT_ORDER` ranks
+      guardians per student by `is_primary desc` so the primary contact sorts
+      first. Phone slots `CONTACT1_*` and `CONTACT2_*` map the guardian's two
+      phones; `CONTACT3` through `CONTACT7` are always null. Focus column header
+      casing is applied at transport time via
+      `file_config.format.header_replacements`; dbt column names remain
+      lowercase snake_case.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -25,8 +25,9 @@ models:
       - name: student_id
         data_type: string
         description:
-          Focus student ID. Null until Finalsite mints the student id into
-          `int_finalsite__contact_id_attributes`, then sourced from there.
+          Focus student id of the student this guardian belongs to, from
+          `int_finalsite__contact_id_attributes.focus_student_id`; null where
+          Finalsite has not minted the id.
         data_tests:
           - not_null
       - name: sort_order
@@ -261,7 +262,8 @@ unit_tests:
       Verifies the 51-column CONTACTS layout for one student with two guardian
       relationships — primary guardian sorts to SORT_ORDER 1, non-primary to 2.
       Asserts STUDENT_RELATION, FIRST_NAME, LAST_NAME, and CONTACT1_VALUE.
-      STUDENT_ID is null until the Finalsite-minted student id lands.
+      STUDENT_ID is sourced from int_finalsite__contact_id_attributes for the
+      student and is identical across both guardian rows.
     model: rpt_focus__contacts
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -323,10 +325,16 @@ unit_tests:
               state: FL,
               zip: "33102",
             }
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-stu-001' as finalsite_enrollment_id,
+            '2002002' as focus_student_id
     expect:
       rows:
         - {
-            student_id: null,
+            student_id: "2002002",
             student_relation: parent,
             sort_order: 1,
             first_name: Alice,
@@ -379,7 +387,7 @@ unit_tests:
             contact7_callout: null,
           }
         - {
-            student_id: null,
+            student_id: "2002002",
             student_relation: guardian,
             sort_order: 2,
             first_name: Bob,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
@@ -5,11 +5,10 @@ models:
       `DEMOGRAPHICS` SFTP template layout. Joins `stg_finalsite__contacts` to
       `int_finalsite__enrollment_lifecycle` (the in-scope filter; grain =
       `finalsite_enrollment_id`), then left joins
-      `int_finalsite__contact_custom_attributes` for race, language,
-      media-release, and Hispanic/Latino fields. `stdt_id` is stubbed null until
-      the Finalsite-minted student id lands in
-      `int_finalsite__contact_id_attributes`. Produces 43 columns in
-      `DEMOGRAPHICS_LAYOUT` order. Focus column header casing (`STDT_ID`,
+      `int_finalsite__contact_id_attributes` for the Focus student id
+      (`stdt_id`) and `int_finalsite__contact_custom_attributes` for race,
+      language, media-release, and Hispanic/Latino fields. Produces 43 columns
+      in `DEMOGRAPHICS_LAYOUT` order. Focus column header casing (`STDT_ID`,
       `LAST_NAME`, etc.) is applied at transport time via
       `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case. Race flags, language, photo permission, and
@@ -20,8 +19,9 @@ models:
       - name: stdt_id
         data_type: string
         description:
-          Focus student ID. Null until Finalsite mints the student id into
-          `int_finalsite__contact_id_attributes`, then sourced from there.
+          Focus student id (Focus `STDT_ID`) from
+          `int_finalsite__contact_id_attributes.focus_student_id`; null for
+          contacts where Finalsite has not minted the id.
         data_tests:
           - unique
           - not_null
@@ -204,9 +204,10 @@ models:
 unit_tests:
   - name: test_demographics_shape
     description:
-      Verifies the 43-column DEMOGRAPHICS layout — STDT_ID is null until the
-      Finalsite-minted student id lands, DT_BIRTH is formatted as YYYYMMDD,
-      GENDER is mapped to single-letter code, ETHNIC_HL derives from
+      Verifies the 43-column DEMOGRAPHICS layout — STDT_ID is sourced from
+      int_finalsite__contact_id_attributes (null for a contact with no minted
+      id), DT_BIRTH is formatted as YYYYMMDD, GENDER is mapped to single-letter
+      code, ETHNIC_HL derives from
       int_finalsite__contact_custom_attributes.latino_hispanic_yn. The second
       student has no custom-attributes row, confirming ETHNIC_HL is null (not
       'N') for an unknown while PHOTO_VID_PERM defaults to 'N'. The third
@@ -264,10 +265,16 @@ unit_tests:
         format: sql
         rows: |
           select 'Spanish' as finalsite_language, 'SP' as focus_language_code
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            '1001001' as focus_student_id
     expect:
       rows:
         - {
-            stdt_id: null,
+            stdt_id: "1001001",
             last_name: Smith,
             first_name: Jane,
             name_suffix: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
@@ -6,9 +6,9 @@ models:
       (least/greatest dedup handles both bidirectional and one-directional
       edges). Sourced from `stg_finalsite__contact_relationships` (rel_type =
       sibling) with both sides resolved to a minted Focus student ID via
-      `int_finalsite__contact_id_attributes`. Pairs where either side is outside
-      the pulled cohort (no lifecycle row) or has no minted ID are dropped.
-      Produces 2 columns in `LINKED_STUDENTS` contract order.
+      `int_finalsite__contact_id_attributes`. Pairs where either side has no
+      minted ID are dropped. Produces 2 columns in `LINKED_STUDENTS` contract
+      order.
     config:
       contract:
         enforced: true
@@ -40,7 +40,7 @@ unit_tests:
       A bidirectional sibling edge (a->b and b->a) collapses to one row, with
       the lexicographically-smaller minted Focus id as PRIMARY_STUDENT_ID and
       the larger as SECONDARY_STUDENT_ID. Both sides resolve a minted id via
-      int_finalsite__contact_id_attributes and a lifecycle row (in-cohort).
+      int_finalsite__contact_id_attributes.
     model: rpt_focus__linked_students
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -55,10 +55,6 @@ unit_tests:
               rel_id: enr-stu-a,
               rel_type: sibling,
             }
-      - input: ref('int_finalsite__enrollment_lifecycle')
-        rows:
-          - { finalsite_enrollment_id: enr-stu-a }
-          - { finalsite_enrollment_id: enr-stu-b }
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
@@ -46,12 +46,12 @@ models:
                 values: [sibling, step_sibling, cousin, parent]
 
 unit_tests:
-  - name: test_linked_students_dormant_until_stdt_id
+  - name: test_linked_students_normalizes_pair
     description:
-      STDT_ID is null until the Finalsite-minted student id lands in
-      id_attributes, so `pairs` filters out every sibling edge and the extract
-      emits no rows. Restore the least/greatest normalization assertions (lesser
-      id = primary, greater = secondary) once the id source is repointed.
+      A bidirectional sibling edge (a->b and b->a) collapses to one row, with
+      the lexicographically-smaller minted Focus id as PRIMARY_STUDENT_ID and
+      the larger as SECONDARY_STUDENT_ID. Both sides resolve a minted id via
+      int_finalsite__contact_id_attributes and a lifecycle row (in-cohort).
     model: rpt_focus__linked_students
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -66,5 +66,20 @@ unit_tests:
               rel_id: enr-stu-a,
               rel_type: sibling,
             }
+      - input: ref('int_finalsite__enrollment_lifecycle')
+        rows:
+          - { finalsite_enrollment_id: enr-stu-a }
+          - { finalsite_enrollment_id: enr-stu-b }
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select 'enr-stu-a' as finalsite_enrollment_id, '900' as focus_student_id
+          union all
+          select 'enr-stu-b' as finalsite_enrollment_id, '100' as focus_student_id
     expect:
-      rows: []
+      rows:
+        - {
+            primary_student_id: "100",
+            secondary_student_id: "900",
+            relationship: sibling,
+          }

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -5,10 +5,11 @@ models:
       `STUDENT_ENROLLMENT` SFTP template layout, built from
       `int_finalsite__enrollment_lifecycle`. Grade is translated inline
       (`k`→`KG`, else zero-padded number); school maps via
-      `int_people__location_crosswalk` and enrollment/drop codes via Google
-      Sheets crosswalks — together producing the 29-column layout consumed by
-      the Focus SFTP transport. The Focus column header casing (`SYEAR`,
-      `SCHOOL_ID`, etc.) is applied at transport time via
+      `int_people__location_crosswalk`, the Focus student id (`student_id`) via
+      `int_finalsite__contact_id_attributes`, and enrollment/drop codes via
+      Google Sheets crosswalks — together producing the 29-column layout
+      consumed by the Focus SFTP transport. The Focus column header casing
+      (`SYEAR`, `SCHOOL_ID`, etc.) is applied at transport time via
       `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case. `end_date` and `drop_code` populate only for
       `lifecycle_action = 'transfer_out'` rows.
@@ -16,8 +17,9 @@ models:
       - name: student_id
         data_type: string
         description:
-          Focus student ID. Null until Finalsite mints the student id into
-          `int_finalsite__contact_id_attributes`, then sourced from there.
+          Focus student id (Focus `STDT_ID`) from
+          `int_finalsite__contact_id_attributes.focus_student_id`; null for
+          enrollments where Finalsite has not minted the id.
         data_tests:
           - unique
           - not_null
@@ -167,8 +169,8 @@ unit_tests:
       Verifies the 29-column STUDENT_ENROLLMENT layout for new-enrollment rows —
       grade is translated inline for both a numbered grade (`5th`→`05`) and
       kindergarten (`k`→`KG`), school/enrollment-code crosswalks resolve,
-      student_id is null (no Focus ID minted yet), and end_date/drop_code are
-      null for a non-transfer row.
+      student_id is sourced from int_finalsite__contact_id_attributes, and
+      end_date/drop_code are null for a non-transfer row.
     model: rpt_focus__student_enrollment
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -216,12 +218,22 @@ unit_tests:
               finalsite_withdrawal_reason: mid_year_withdrawal,
               focus_drop_code: W05,
             }
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'e1' as finalsite_enrollment_id,
+            '3003001' as focus_student_id
+          union all
+          select
+            'e3' as finalsite_enrollment_id,
+            '3003003' as focus_student_id
     expect:
       rows:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: null,
+            student_id: "3003001",
             grade_id: "05",
             start_date: "20250812",
             enrollment_code: EA1,
@@ -252,7 +264,7 @@ unit_tests:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: null,
+            student_id: "3003003",
             grade_id: KG,
             start_date: "20250812",
             enrollment_code: EA1,
@@ -323,12 +335,18 @@ unit_tests:
               finalsite_withdrawal_reason: mid_year_withdrawal,
               focus_drop_code: W05,
             }
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'e2' as finalsite_enrollment_id,
+            '3003002' as focus_student_id
     expect:
       rows:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: null,
+            student_id: "3003002",
             grade_id: "07",
             start_date: "20250812",
             enrollment_code: W01,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
@@ -1,8 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus ADDRESS contract
 select
-    -- STDT_ID is null until the Finalsite-minted student id lands in
-    -- id_attributes; repoint to int_finalsite__contact_id_attributes then.
-    cast(null as string) as student_id,
+    ida.focus_student_id as student_id,
 
     c.address_1 as address,
     c.address_2 as address2,
@@ -21,3 +19,6 @@ from {{ ref("stg_finalsite__contacts") }} as c
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on c.finalsite_enrollment_id = l.finalsite_enrollment_id
+left join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida
+    on c.finalsite_enrollment_id = ida.finalsite_enrollment_id

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
@@ -1,8 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus CONTACTS contract
 select
-    -- STDT_ID is null until the Finalsite-minted student id lands in
-    -- id_attributes; repoint to int_finalsite__contact_id_attributes then.
-    cast(null as string) as student_id,
+    ida.focus_student_id as student_id,
 
     rel.rel_type as student_relation,
 
@@ -70,6 +68,9 @@ inner join
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on rel.finalsite_enrollment_id = l.finalsite_enrollment_id
+left join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida
+    on rel.finalsite_enrollment_id = ida.finalsite_enrollment_id
 where
     rel.rel_type
     in ('parent', 'guardian', 'grandparent', 'stepparent', 'relative', 'aunt/uncle')

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
@@ -1,8 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus DEMOGRAPHICS contract
 select
-    -- STDT_ID is null until the Finalsite-minted student id lands in
-    -- id_attributes; repoint to int_finalsite__contact_id_attributes then.
-    cast(null as string) as stdt_id,
+    ida.focus_student_id as stdt_id,
 
     c.last_name,
     c.first_name,
@@ -80,6 +78,9 @@ from {{ ref("stg_finalsite__contacts") }} as c
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on c.finalsite_enrollment_id = l.finalsite_enrollment_id
+left join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida
+    on c.finalsite_enrollment_id = ida.finalsite_enrollment_id
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
     on c.finalsite_enrollment_id = cca.finalsite_enrollment_id

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
@@ -1,12 +1,35 @@
--- LINKED_STUDENTS pairs sibling enrollments by Focus STDT_ID. STDT_ID is null
--- until the Finalsite-minted id lands in id_attributes, so no links are emitted
--- yet (this returns no rows). When the id source exists, inner join
--- int_finalsite__contact_id_attributes on rel.finalsite_enrollment_id and
--- rel.rel_id and project least/greatest of the two student ids.
-select
-    cast(null as string) as primary_student_id,
-    cast(null as string) as secondary_student_id,
+with
+    sibling_pairs as (
+        select
+            ida_a.focus_student_id as student_id_a,
+            ida_b.focus_student_id as student_id_b,
+        from {{ ref("stg_finalsite__contact_relationships") }} as rel
+        inner join
+            {{ ref("int_finalsite__enrollment_lifecycle") }} as la
+            on rel.finalsite_enrollment_id = la.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__enrollment_lifecycle") }} as lb
+            on rel.rel_id = lb.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as ida_a
+            on rel.finalsite_enrollment_id = ida_a.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as ida_b
+            on rel.rel_id = ida_b.finalsite_enrollment_id
+        where
+            rel.rel_type = 'sibling'
+            and ida_a.focus_student_id is not null
+            and ida_b.focus_student_id is not null
+    )
+
+-- grain projection to the unordered sibling pair: least/greatest normalize each
+-- bidirectional edge (a->b and b->a) to the same (primary, secondary) tuple, so
+-- distinct collapses them; every column is determined by the pair, not a mask
+-- for upstream duplicates.
+-- trunk-ignore(sqlfluff/ST06): column order fixed by Focus LINKED_STUDENTS contract
+select distinct
+    least(student_id_a, student_id_b) as primary_student_id,
+    greatest(student_id_a, student_id_b) as secondary_student_id,
 
     'sibling' as relationship,
-from {{ ref("stg_finalsite__contact_relationships") }} as rel
-where rel.rel_type = 'sibling' and false
+from sibling_pairs

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
@@ -1,32 +1,16 @@
-with
-    sibling_pairs as (
-        select
-            ida_a.focus_student_id as student_id_a,
-            ida_b.focus_student_id as student_id_b,
-        from {{ ref("stg_finalsite__contact_relationships") }} as rel
-        inner join
-            {{ ref("int_finalsite__enrollment_lifecycle") }} as la
-            on rel.finalsite_enrollment_id = la.finalsite_enrollment_id
-        inner join
-            {{ ref("int_finalsite__enrollment_lifecycle") }} as lb
-            on rel.rel_id = lb.finalsite_enrollment_id
-        inner join
-            {{ ref("int_finalsite__contact_id_attributes") }} as ida_a
-            on rel.finalsite_enrollment_id = ida_a.finalsite_enrollment_id
-        inner join
-            {{ ref("int_finalsite__contact_id_attributes") }} as ida_b
-            on rel.rel_id = ida_b.finalsite_enrollment_id
-        where
-            rel.rel_type = 'sibling'
-            and ida_a.focus_student_id is not null
-            and ida_b.focus_student_id is not null
-    )
-
 -- grain projection to the unordered sibling pair: least/greatest normalize each
--- bidirectional edge (a->b and b->a) to the same (primary, secondary) tuple, so
--- distinct collapses them; every column is determined by the pair, not a mask
--- for upstream duplicates.
+-- bidirectional edge (a->b and b->a) to one (primary, secondary) tuple, which
+-- distinct collapses; not a mask for upstream duplicates.
 select distinct
-    least(student_id_a, student_id_b) as primary_student_id,
-    greatest(student_id_a, student_id_b) as secondary_student_id,
-from sibling_pairs
+    least(ida_a.focus_student_id, ida_b.focus_student_id) as primary_student_id,
+    greatest(ida_a.focus_student_id, ida_b.focus_student_id) as secondary_student_id,
+from {{ ref("stg_finalsite__contact_relationships") }} as rel
+inner join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida_a
+    on rel.finalsite_enrollment_id = ida_a.finalsite_enrollment_id
+    and ida_a.focus_student_id is not null
+inner join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida_b
+    on rel.rel_id = ida_b.finalsite_enrollment_id
+    and ida_b.focus_student_id is not null
+where rel.rel_type = 'sibling'

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -4,9 +4,7 @@ select
 
     sch.location_focus_school_id as school_id,
 
-    -- STDT_ID is null until the Finalsite-minted student id lands in
-    -- id_attributes; repoint to int_finalsite__contact_id_attributes then.
-    cast(null as string) as student_id,
+    ida.focus_student_id as student_id,
 
     if(
         l.grade_canonical_name = 'k',
@@ -50,6 +48,9 @@ select
     cast(null as int64) as fl_days_absent,
     cast(null as int64) as fl_days_absent_not_disc,
 from {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+left join
+    {{ ref("int_finalsite__contact_id_attributes") }} as ida
+    on l.finalsite_enrollment_id = ida.finalsite_enrollment_id
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
     on l.finalsite_enrollment_id = cca.finalsite_enrollment_id


### PR DESCRIPTION
## Summary & Motivation

When merged, this wires the Finalsite-minted Focus student id into the Focus SFTP extracts. Implements #4205 (follow-up to #4201, Component 4 of #4073).

- Adds the `focus_student_id` field to the `int_finalsite__contact_id_attributes` PIVOT (package model). The PIVOT enumerates fields explicitly, so new fields must be listed to surface.
- Repoints all five `rpt_focus__*` extracts to source the Focus student id from `int_finalsite__contact_id_attributes` instead of the `cast(null as string)` stub:
  - `rpt_focus__demographics` — `stdt_id`
  - `rpt_focus__contacts` — `student_id` (joined on the student's enrollment id, not the guardian)
  - `rpt_focus__student_enrollment` — `student_id`
  - `rpt_focus__addresses` — `student_id`
  - `rpt_focus__linked_students` — restores the least/greatest sibling-pair normalization; both sides must resolve to a minted id and an in-cohort lifecycle row, and bidirectional sibling edges dedupe to one row
- Updates unit-test expects across all five.

**Scope note:** #4205 listed three models; this PR also covers `addresses` and `linked_students`, which carry the same null stub and whose descriptions already promised this source. Five-model scope confirmed with the requester.

**No data change today.** Finalsite has not begun minting the field yet, so `focus_student_id` is all-NULL in the warehouse (verified: 0/3253 rows populated). This PR is wiring only — output values are unchanged for now. The `not_null` warns on `stdt_id` / `student_id` stay until Finalsite mints the id, then values flow through automatically with no further code change. Suggest keeping #4205 open until minting is confirmed and the warns clear.

## AI Assistance

AI-assisted (Claude Code): all SQL/YAML edits, unit-test updates, and local validation. Human-directed: the field name (`focus_student_id`), the five-model scope, and the single-PR delivery approach.

## Self-review

### dbt

- [x] Properties files updated for every modified model
- [x] Not a breaking change — no columns renamed/removed in any contracted model; only the `stdt_id` / `student_id` source changed, layouts unchanged
- [x] No external source added or modified

### CI checks

- [ ] **Trunk** — clean locally; passes on push
- [ ] **dbt Cloud** — single-PR cross-project: the unmodified kipptaf `int_finalsite__contact_id_attributes` union only exposes `focus_student_id` after `zz_stg` is seeded with the rebuilt package + union (`union_relations` is compile-time). Seeding step pending.

Local validation: `dbt parse` clean; 6 unit tests pass (incl. the `linked_students` normalization); package PIVOT dev-builds and produces the `focus_student_id` column.

Refs #4205