### PR TITLE
fix(dbt): declare drifted aimline columns in pm_student_summary contract

### DIFF
--- a/src/dbt/amplify/models/mclass/sftp/staging/properties/stg_amplify__mclass__sftp__pm_student_summary.yml
+++ b/src/dbt/amplify/models/mclass/sftp/staging/properties/stg_amplify__mclass__sftp__pm_student_summary.yml
@@ -111,5 +111,11 @@ models:
         data_type: int64
       - name: additional_student_id_sisid
         data_type: string
+      - name: aimline_status
+        data_type: string
+      - name: aimline_value_by_date
+        data_type: string
+      - name: growth_goal_set
+        data_type: string
       - name: source_file_name
         data_type: string


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will fix the failed materialization of `stg_amplify__mclass__sftp__pm_student_summary` on the **kippnewark** and **kipppaterson** code locations.

PR #4271 added `aimline_status`, `aimline_value_by_date`, and `growth_goal_set` to the `PMStudentSummary` avro schema (to capture vendor columns and silence the `avro_schema_valid` drift warning). Once the SFTP source re-materialized, the staging model's `select *` surfaced those three columns, but the enforced contract did not declare them, so `dbt build` failed on both locations:

```text
This model has an enforced contract that failed.
| column_name           | definition_type | contract_type | mismatch_reason     |
| aimline_status        | STRING          |               | missing in contract |
| aimline_value_by_date | STRING          |               | missing in contract |
| growth_goal_set       | STRING          |               | missing in contract |
```

This declares the three columns (`string`) in the package contract so it matches the model output. The staging model passes them through `select *` uncast, and the fields are `str | None` in the Pydantic schema, so `string` is the correct type.

### Scope notes (investigated, no change needed)

- **kipptaf** `stg_amplify__mclass__sftp__pm_student_summary` is a non-contracted view (the kipptaf `amplify` staging block sets no contract enforcement), so it absorbs the new columns without failing — no cascade. The columns are also dropped at the downstream `union_relations` with the API source.
- The same PR's LDAP `extensionAttribute1` addition is safe: `stg_ldap__user_person` uses an explicit column list, not `select *`.

## AI Assistance

Root-caused and authored by Claude Code (Opus 4.8) via the systematic-debugging workflow. Human-directed decisions: declaring the columns (vs. excepting them out) and confirming no kipptaf change was required.

## Self-review

### dbt

- [x] Properties file updated for the modified model (additive only)
- Breaking change? No — additive contract columns, no rename/removal.
- External source not modified here (the avro schema change shipped in #4271).

## CI checks

- [ ] Trunk — validated locally (`trunk check` clean on the modified YAML)
- [ ] dbt Cloud — the only CI is kipptaf-scoped and no-ops for this package-only change; correctness is verified by the Dagster prod rebuild post-merge (the actual failing path)