### PR TITLE
feat(career_launch): add helper columns to appsheet and tableau extracts

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__kfwd_career_launch_survey.yml
@@ -40,7 +40,14 @@ models:
         data_type: timestamp
       - name: contact_owner
         data_type: string
+        description: Name of the Salesforce contact owner for the alumnus.
       - name: postsec_advisor
         data_type: string
+        description:
+          Postsecondary advisor assigned to the alumnus on their Salesforce
+          contact record.
       - name: advisor
         data_type: string
+        description:
+          Effective advisor for the alumnus — the postsecondary advisor when the
+          advising provider is KIPP NYC, otherwise the Salesforce contact owner.

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/properties/rpt_appsheet__kfwd_career_launch_survey.yml
@@ -38,3 +38,9 @@ models:
         data_type: int64
       - name: latest_survey_date
         data_type: timestamp
+      - name: contact_owner
+        data_type: string
+      - name: postsec_advisor
+        data_type: string
+      - name: advisor
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__kfwd_career_launch_survey.sql
@@ -18,6 +18,8 @@ with
             r.contact_home_phone as secondary_phone,
             r.contact_advising_provider as advising_provider,
             r.contact_expected_college_graduation as expected_college_grad_date,
+            r.contact_owner_name as contact_owner,
+            r.contact_postsec_advisor as postsec_advisor,
 
             sr.survey_response_id as reconciliation_response_id,
 
@@ -62,6 +64,8 @@ select
     r.secondary_phone,
     r.advising_provider,
     r.expected_college_grad_date,
+    r.contact_owner,
+    r.postsec_advisor,
 
     ce.pursuing_degree_type,
     ce.major,
@@ -69,6 +73,8 @@ select
     ss.latest_survey_date,
 
     coalesce(ss.survey_response_count, 0) as survey_response_count,
+
+    if(r.advising_provider = 'KIPP NYC', r.postsec_advisor, r.contact_owner) as advisor,
 from roster as r
 left join current_enrollment as ce on r.contact_id = ce.student
 left join survey_stats as ss on r.contact_id = ss.contact_id

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
@@ -160,9 +160,17 @@ models:
         data_type: string
       - name: advising_provider
         data_type: string
-      - name: contact_owner
+      - name: contact_owner_name
         data_type: string
       - name: postsec_advisor
         data_type: string
       - name: advisor
         data_type: string
+      - name: high_school_graduated_from
+        data_type: string
+      - name: is_special_education
+        data_type: boolean
+      - name: middle_school_attended
+        data_type: string
+      - name: most_recent_iep_date
+        data_type: date

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
@@ -160,3 +160,9 @@ models:
         data_type: string
       - name: advising_provider
         data_type: string
+      - name: contact_owner
+        data_type: string
+      - name: postsec_advisor
+        data_type: string
+      - name: advisor
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
@@ -160,17 +160,33 @@ models:
         data_type: string
       - name: advising_provider
         data_type: string
-      - name: contact_owner_name
-        data_type: string
       - name: postsec_advisor
         data_type: string
+        description:
+          Postsecondary advisor assigned to the alumnus on their Salesforce
+          contact record.
       - name: advisor
         data_type: string
+        description:
+          Effective advisor for the alumnus — the postsecondary advisor when the
+          advising provider is KIPP NYC, otherwise the Salesforce contact owner.
       - name: high_school_graduated_from
         data_type: string
+        description:
+          High school the alumnus graduated from, from their Salesforce contact
+          record.
       - name: is_special_education
         data_type: boolean
+        description:
+          Whether the alumnus has a recorded IEP date, used as a
+          special-education indicator.
       - name: middle_school_attended
         data_type: string
+        description:
+          Middle school the alumnus attended, from their Salesforce contact
+          record.
       - name: most_recent_iep_date
         data_type: date
+        description:
+          Date of the alumnus's most recent IEP on their Salesforce contact
+          record.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -54,9 +54,13 @@ with
             r.contact_actual_college_graduation_date as actual_college_grad_date,
             r.contact_current_kipp_student as current_kipp_student,
             r.contact_owner_name,
+            r.contact_postsec_advisor as postsec_advisor,
             r.es_graduated,
             r.tier,
             r.contact_advising_provider as advising_provider,
+            r.contact_most_recent_iep_date as most_recent_iep_date,
+            r.contact_middle_school_attended as middle_school_attended,
+            r.contact_high_school_graduated_from as high_school_graduated_from,
 
             e.pursuing_degree_type,
             e.type,
@@ -257,6 +261,10 @@ select
     r.es_graduated,
     r.tier,
     r.advising_provider,
+    r.postsec_advisor,
+    r.most_recent_iep_date,
+    r.middle_school_attended,
+    r.high_school_graduated_from,
 
     sp.survey_id,
     sp.survey_title,
@@ -302,6 +310,12 @@ select
     ) as season_label,
 
     if(r.contact_id is null, true, false) as is_unmatched_response,
+
+    if(r.most_recent_iep_date is not null, true, false) as is_special_education,
+
+    if(
+        r.advising_provider = 'KIPP NYC', r.postsec_advisor, r.contact_owner_name
+    ) as advisor,
 
     if(
         r.contact_id is not null,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -298,7 +298,7 @@ select
     sp.annual_income_clean,
 
     if(
-        r.actual_end_date_month < 7,
+        r.expected_grad_date_month < 7,
         concat('Spring ', r.expected_grad_date_year),
         concat('Fall ', r.expected_grad_date_year)
     ) as season_label_expected,


### PR DESCRIPTION
- **add required fields**
- **add tooltip columns requested by BS**

# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [ ] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
