### PR TITLE
feat(dbt): grade-based Focus enrollment codes and 8400 student-id prefix

### DIFF
--- a/docs/superpowers/plans/2026-06-29-finalsite-focus-idempotent-imports.md
+++ b/docs/superpowers/plans/2026-06-29-finalsite-focus-idempotent-imports.md
@@ -1,0 +1,823 @@
+# Finalsite to Focus idempotent imports — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the five Finalsite-to-Focus SFTP extracts idempotent (diff
+against current Focus state, import-once where required), resolve the #4208
+enrollment and withdraw codes, and apply the Florida 8400 student-id prefix.
+
+**Architecture:** `kipptaf` `rpt_focus__*` stay the desired-state build and gain
+the 8400 prefix (req 5) and grade-based enrollment code (req 4). The `kippmiami`
+`rpt_focus__*` pass-throughs become the reconciliation layer — they join current
+Focus state (the `focus` package, available only in `kippmiami`), decode the
+withdraw code, and apply the diff / import-once filters. New `stg_focus__*`
+staging models expose the Focus linkage tables req 1 needs.
+
+**Tech Stack:** dbt (BigQuery), dbt unit tests, Dagster dlt (Focus replication).
+
+Spec:
+`docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md`.
+Issue: [#4279](https://github.com/TEAMSchools/teamster/issues/4279).
+
+## Global Constraints
+
+- Read `src/dbt/CLAUDE.md`, `src/dbt/kipptaf/CLAUDE.md`,
+  `src/dbt/kippmiami/CLAUDE.md`, `src/dbt/focus/CLAUDE.md`, and
+  `src/dbt/finalsite/CLAUDE.md` before editing those projects. Invoke `Skill`
+  with skill `dbt:using-dbt-for-analytics-engineering` before any dbt work.
+- The `rpt_focus__*` output column **names and left-to-right order must not
+  change** — the Dagster `header_replacements` in
+  `src/teamster/code_locations/kippmiami/extracts/config/focus.yaml` map them to
+  the Focus headers positionally. (Exception: `kipptaf`
+  `rpt_focus__student_enrollment` renames `drop_code` to a carrier column;
+  `kippmiami` re-emits `drop_code` in the same position.)
+- All `rpt_`/staging models are contract-enforced; update the `properties/*.yml`
+  `data_type` list whenever a column is added, removed, or renamed.
+- Match key (export to Focus):
+  `concat('8400', focus_student_id) = students.student_id`.
+- Enrollment match grain: `(student_id, start_date)` only.
+- Diff rule: a populated export column triggers re-send when it differs —
+  `export_col is not null and export_col is distinct from focus_norm`. Unmatched
+  students/enrollments are always kept.
+- Import-once codes: emit `enrollment_code`/`drop_code` only when the matched
+  Focus enrollment's value is null.
+- dbt CLI locally (build source-package models through the consuming district):
+  `DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt <cmd> --project-dir <abs worktree>/src/dbt/<project> --defer --state <abs worktree>/src/dbt/<project>/target/prod --target dev`.
+  A fresh worktree needs
+  `uv run dbt deps --project-dir <abs worktree>/src/dbt/<project>` first.
+- `--target prod` builds are classifier-blocked — hand prod runs to the user.
+- Worktree: prefix every git call with
+  `git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-focus-idempotent-imports`
+  and every dbt call with the worktree `--project-dir`. Trunk-check changed
+  files from inside the worktree with
+  `/workspaces/teamster/.trunk/tools/trunk check --force <files>`.
+
+---
+
+## Phase 1 — kipptaf desired state (reqs 4 and 5)
+
+No Focus dependency; validated entirely by dbt unit tests.
+
+### Task 1: 8400 prefix on all five kipptaf extracts
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql`
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql`
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql`
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql`
+- Modify: the matching `properties/*.yml` unit-test `expect` rows.
+
+**Interfaces:**
+
+- Produces: every emitted student id is `concat('8400', focus_student_id)`
+  (10-char string, or `NULL` when `focus_student_id` is null).
+
+- [ ] **Step 1: Update the demographics unit test.** In
+      `properties/rpt_focus__demographics.yml`, change the `unit_tests` `expect`
+      `stdt_id` from the raw id to the prefixed value (e.g. `305000` becomes
+      `'8400305000'`; quote leading-zero-safe). Add a `given` `focus_student_id`
+      of `305000` if not already present.
+
+- [ ] **Step 2: Run it to confirm it fails.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+    --select rpt_focus__demographics \
+    --project-dir <worktree>/src/dbt/kipptaf --target dev
+  ```
+
+  Expected: FAIL (model still emits the raw id).
+
+- [ ] **Step 3: Apply the prefix in each model.** Replace the id projection.
+      Demographics:
+
+  ```sql
+  concat('8400', ida.focus_student_id) as stdt_id,
+  ```
+
+  `addresses`, `contacts`, `student_enrollment`:
+  `concat('8400', ida.focus_student_id) as student_id,`. `linked_students` —
+  prefix both sides before `least`/`greatest`:
+
+  ```sql
+  least(
+      concat('8400', ida_a.focus_student_id),
+      concat('8400', ida_b.focus_student_id)
+  ) as primary_student_id,
+  greatest(
+      concat('8400', ida_a.focus_student_id),
+      concat('8400', ida_b.focus_student_id)
+  ) as secondary_student_id,
+  ```
+
+- [ ] **Step 4: Update the other four unit tests** the same way (prefix the
+      expected id values in each `properties/*.yml` `expect` block).
+
+- [ ] **Step 5: Run all five unit tests to pass.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+    --select "rpt_focus__demographics rpt_focus__addresses rpt_focus__contacts rpt_focus__student_enrollment rpt_focus__linked_students" \
+    --project-dir <worktree>/src/dbt/kipptaf --target dev
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): apply 8400 focus student-id prefix (#4279)"
+  ```
+
+### Task 2: enrollment code (E05/E01) and withdraw-label carrier
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml`
+
+**Interfaces:**
+
+- Produces: `enrollment_code` (`E05` for `grade_canonical_name = 'k'`, else
+  `E01`, `NULL` on `transfer_out`); a new carrier column `state_withdraw_label`
+  (raw `cca.fl_state_withdraw_codes_ss`) replacing the old `drop_code` crosswalk
+  output. Column position of `state_withdraw_label` is the same slot `drop_code`
+  occupied.
+
+- [ ] **Step 1: Update the unit test.** In the `properties` `unit_tests`:
+  - For a `create`/KG row assert `enrollment_code: E05`; add a non-KG `create`
+    row asserting `enrollment_code: E01`.
+  - Replace the `drop_code` assertion with `state_withdraw_label` equal to the
+    mocked `fl_state_withdraw_codes_ss` (e.g. `(W02) In District Transfer`).
+  - Remove the `enrollment_code_crosswalk` and `drop_code_crosswalk` mocked
+    `given` inputs (no longer referenced).
+
+- [ ] **Step 2: Run to confirm fail.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+    --select rpt_focus__student_enrollment \
+    --project-dir <worktree>/src/dbt/kipptaf --target dev
+  ```
+
+  Expected: FAIL.
+
+- [ ] **Step 3: Edit the model.** Replace the `enrollment_code` projection (drop
+      the `ec` crosswalk join) with:
+
+  ```sql
+  case
+      when l.lifecycle_action = 'transfer_out'
+      then cast(null as string)
+      when l.grade_canonical_name = 'k'
+      then 'E05'
+      else 'E01'
+  end as enrollment_code,
+  ```
+
+  Replace the `dc.focus_drop_code as drop_code` projection (drop the `dc`
+  crosswalk join) with the raw carrier in the same column slot:
+
+  ```sql
+  cca.fl_state_withdraw_codes_ss as state_withdraw_label,
+  ```
+
+  Delete the two `left join ... enrollment_code_crosswalk` /
+  `... drop_code_crosswalk` blocks.
+
+- [ ] **Step 4: Update the contract yml.** Rename the `drop_code` column entry
+      to `state_withdraw_label` (keep `data_type: string`, same position);
+      update its `description`. Keep all other columns/order unchanged.
+
+- [ ] **Step 5: Run unit test to pass.** (command from Step 2.) Expected: PASS.
+
+- [ ] **Step 6: Parse kipptaf to confirm no dangling crosswalk refs.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt parse \
+    --project-dir <worktree>/src/dbt/kipptaf
+  ```
+
+  Expected: parses clean. (The two `stg_google_sheets__focus__*_crosswalk`
+  models are now unused by this model; leave them in place — other refs or a
+  later cleanup handle removal.)
+
+- [ ] **Step 7: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): grade-based focus enrollment code + withdraw carrier (#4279)"
+  ```
+
+---
+
+## Phase 2 — Focus linkage staging (req 1 prerequisite)
+
+### Task 3: materialize the Focus linkage tables (dlt)
+
+**Files:**
+
+- Inspect: `src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml`
+- Inspect: `src/teamster/libraries/dlt/**` (the `sql_database` factory)
+
+**Interfaces:**
+
+- Produces: confirmation that `students_join_address`, `students_join_people`,
+  `people`, and `students_join_students` either exist in
+  `dagster_kippmiami_dlt_focus` or a documented reason they cannot, plus their
+  column lists for Task 4.
+
+- [ ] **Step 1: Confirm current absence.**
+
+  ```sql
+  select table_id, row_count
+  from `teamster-332318`.dagster_kippmiami_dlt_focus.__TABLES__
+  where table_id in (
+    'students_join_address', 'students_join_people',
+    'people', 'students_join_students'
+  )
+  ```
+
+  Expected: 0 rows (tables absent today).
+
+- [ ] **Step 2: Determine why.** Read the dlt `sql_database` resource/factory
+      used by `kippmiami/dlt/focus` to see whether empty/absent source tables
+      are skipped, errored, or filtered. Check the most recent
+      `kippmiami/dlt/focus` run logs (`mcp__dagster__get_run_logs`) for
+      per-table skip/error messages.
+
+- [ ] **Step 3: Decide the fix and record it in the plan.** Likely one of: (a)
+      the Focus source tables have rows but a config/selection bug drops them —
+      fix the config; (b) the source tables are genuinely empty and dlt does not
+      create empty relations — confirm the table will appear once Focus has its
+      first row, and note that Task 4 staging + Task 7-9 filters stay
+      **un-merged** until the relations exist (do not ship staging models on
+      absent sources — they fail to build). If (b), STOP and surface to the
+      user: req 1 cannot be validated end to end until Focus holds linkage data;
+      reqs 2-5 proceed independently.
+
+- [ ] **Step 4: If a config change was needed,** hand the prod re-pull to the
+      user (dlt asset materialization is a prod deploy). Re-run Step 1 after to
+      confirm the tables exist; capture their columns:
+
+  ```sql
+  select table_name, column_name, data_type
+  from `teamster-332318`.dagster_kippmiami_dlt_focus.INFORMATION_SCHEMA.COLUMNS
+  where table_name in (
+    'students_join_address', 'students_join_people',
+    'people', 'students_join_students'
+  )
+  and column_name not like '\\_dlt%'
+  order by table_name, ordinal_position
+  ```
+
+- [ ] **Step 5: Commit** any dlt config change.
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "fix(dlt): materialize focus student linkage tables (#4279)"
+  ```
+
+### Task 4: Focus linkage staging models
+
+**Files** (create, one `.sql` + one `properties/*.yml` each):
+
+- `src/dbt/focus/models/staging/stg_focus__people.sql`
+- `src/dbt/focus/models/staging/stg_focus__students_join_people.sql`
+- `src/dbt/focus/models/staging/stg_focus__students_join_address.sql`
+- `src/dbt/focus/models/staging/stg_focus__students_join_students.sql`
+- Modify: `src/dbt/focus/models/staging/sources-bigquery.yml` (4 source tables).
+
+**Interfaces:**
+
+- Produces: `stg_focus__students_join_address` (keyed by `student_id` +
+  `address_id`), `stg_focus__students_join_people` (`student_id` + `person_id`),
+  `stg_focus__students_join_students` (`student_id` + linked `student_id`),
+  `stg_focus__people`. Exact columns from Task 3 Step 4.
+
+- [ ] **Step 1: Add the four source tables** to `sources-bigquery.yml` under the
+      existing `focus` source `name`, mirroring an existing entry (e.g.
+      `address`).
+
+- [ ] **Step 2: Write each staging model** following the existing
+      `stg_focus__address` pattern: read through a `source` CTE
+      (`with source as (select *, from {{ source("focus", "<table>") }})`),
+      select the real columns enumerated in Task 3 Step 4, drop `_dlt_*` and the
+      audit quad, and apply `where deleted is null` only on tables that have a
+      `deleted` column (per `src/dbt/focus/CLAUDE.md`: present on `address`;
+      confirm per table).
+
+  Example skeleton (`stg_focus__students_join_address`):
+
+  ```sql
+  with source as (select *, from {{ source("focus", "students_join_address") }})
+
+  select
+      student_id,
+      address_id,
+      -- ...remaining real columns from INFORMATION_SCHEMA...
+  from source
+  ```
+
+- [ ] **Step 3: Write each `properties/*.yml`** with `data_type` per column and
+      a uniqueness test: `unique` on the single PK where one exists, else
+      `dbt_utils.unique_combination_of_columns` on the join pair, both at
+      `severity: error`.
+
+- [ ] **Step 4: Build the four models through kippmiami.**
+
+  ```bash
+  uv run dbt deps --project-dir <worktree>/src/dbt/kippmiami
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt build \
+    --select "stg_focus__people stg_focus__students_join_people stg_focus__students_join_address stg_focus__students_join_students" \
+    --project-dir <worktree>/src/dbt/kippmiami \
+    --defer --state <worktree>/src/dbt/kippmiami/target/prod --target dev
+  ```
+
+  Expected: builds + contract + uniqueness pass. (Blocked until Task 3 makes the
+  sources exist.)
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(focus): stage student linkage tables for import-once (#4279)"
+  ```
+
+---
+
+## Phase 3 — kippmiami reconciliation
+
+Each kippmiami model keeps its current output columns and order; only the
+`FROM`/filter changes. Add a `unit_tests` block to each `properties/*.yml`.
+
+### Task 5: demographics diff (req 2)
+
+**Files:**
+
+- Modify: `src/dbt/kippmiami/models/extracts/focus/rpt_focus__demographics.sql`
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__demographics.yml`
+
+**Interfaces:**
+
+- Consumes: `source("kipptaf_extracts", "rpt_focus__demographics")`
+  (8400-prefixed `stdt_id`), `ref("stg_focus__students")`,
+  `ref("int_focus__students__pivot")`.
+- Produces: same demographics columns; rows only for unmatched or changed
+  students.
+
+- [ ] **Step 1: Write the unit test** in the `properties` yml with three
+      `source('kipptaf_extracts', 'rpt_focus__demographics')` desired rows and
+      mocked Focus state:
+  - `8400000001` not in Focus -> kept.
+  - `8400000002` matching Focus on every populated field -> dropped.
+  - `8400000003` matching the Focus student but with a changed `first_name` ->
+    kept.
+
+  Mock `ref('stg_focus__students')` and `ref('int_focus__students__pivot')` with
+  rows for `student_id` `8400000002`/`8400000003`. Assert the output `stdt_id`
+  set is `{8400000001, 8400000003}`.
+
+- [ ] **Step 2: Run to confirm fail** (model has no filter yet).
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+    --select rpt_focus__demographics \
+    --project-dir <worktree>/src/dbt/kippmiami --target dev
+  ```
+
+- [ ] **Step 3: Rewrite the model** keeping the existing output column list:
+
+  ```sql
+  with
+      desired as (
+          select *
+          from {{ source("kipptaf_extracts", "rpt_focus__demographics") }}
+      ),
+
+      focus_state as (
+          select
+              s.student_id,
+              s.first_name,
+              s.last_name,
+              s.middle_name,
+              s.student_e_mail_address,
+              format_date('%Y%m%d', s.birthdate) as dt_birth_focus,
+              regexp_extract(p.sex_label, r'\[(.+)\]') as gender_focus,
+              p.language_label,
+              case p.ethnicity_hispanic_or_latino_label
+                  when 'Yes' then 'Y'
+                  when 'No' then 'N'
+              end as ethnic_hl_focus,
+              case p.race_american_indian_or_alaska_native_label
+                  when 'Yes' then 'Y'
+              end as race_am_ind_ak_nat_focus,
+              case p.race_asian_label when 'Yes' then 'Y' end as race_asian_focus,
+              case p.race_black_or_african_american_label
+                  when 'Yes' then 'Y'
+              end as race_black_focus,
+              case p.race_native_hawaiian_or_other_pacific_islander_label
+                  when 'Yes' then 'Y'
+              end as race_nat_haw_pac_isl_focus,
+              case p.race_white_label when 'Yes' then 'Y' end as race_white_focus,
+          from {{ ref("stg_focus__students") }} as s
+          left join
+              {{ ref("int_focus__students__pivot") }} as p
+              on s.student_id = p.student_id
+      ),
+
+      diffed as (
+          select d.*, f.student_id as focus_student_id,
+          from desired as d
+          left join focus_state as f on d.stdt_id = f.student_id
+          where
+              f.student_id is null
+              or (d.first_name is not null and d.first_name is distinct from f.first_name)
+              or (d.last_name is not null and d.last_name is distinct from f.last_name)
+              or (d.middle_name is not null and d.middle_name is distinct from f.middle_name)
+              or (d.stdt_email is not null and d.stdt_email is distinct from f.student_e_mail_address)
+              or (d.dt_birth is not null and d.dt_birth is distinct from f.dt_birth_focus)
+              or (d.gender is not null and d.gender is distinct from f.gender_focus)
+              or (d.lang is not null and d.lang is distinct from f.language_label)
+              or (d.ethnic_hl is not null and d.ethnic_hl is distinct from f.ethnic_hl_focus)
+              or (d.race_am_ind_ak_nat is not null and d.race_am_ind_ak_nat is distinct from f.race_am_ind_ak_nat_focus)
+              or (d.race_asian is not null and d.race_asian is distinct from f.race_asian_focus)
+              or (d.race_black is not null and d.race_black is distinct from f.race_black_focus)
+              or (d.race_nat_haw_pac_isl is not null and d.race_nat_haw_pac_isl is distinct from f.race_nat_haw_pac_isl_focus)
+              or (d.race_white is not null and d.race_white is distinct from f.race_white_focus)
+      )
+
+  select
+      stdt_id,
+      last_name,
+      first_name,
+      -- ...the full existing demographics column list, in order...
+      lcp_cont_stdt,
+  from diffed
+  ```
+
+  Keep the **exact** existing column list in the final `select` (copy it from
+  the current model). Long predicate lines exceed 88 chars — the SQL fluff line
+  length applies; reformat each disjunct onto wrapped lines or extract the
+  normalized comparison into the `desired`/`focus_state` CTEs so the `where`
+  reads plain columns. Prefer pre-computing both sides in CTEs.
+
+- [ ] **Step 4: Run unit test to pass** (command from Step 2). Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): diff focus demographics against current state (#4279)"
+  ```
+
+### Task 6: enrollment diff + drop-code decode + code import-once (req 3 and 4)
+
+**Files:**
+
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/rpt_focus__student_enrollment.sql`
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__student_enrollment.yml`
+
+**Interfaces:**
+
+- Consumes: `source("kipptaf_extracts", "rpt_focus__student_enrollment")` (has
+  `state_withdraw_label`, no `drop_code`),
+  `ref("stg_focus__student_enrollment")`,
+  `ref("stg_focus__student_enrollment_codes")`.
+- Produces: the existing enrollment column list with `drop_code` (decoded) in
+  its original position; codes nulled when Focus already has them.
+
+- [ ] **Step 1: Write the unit test** with mocked desired rows + a mocked
+      `ref('stg_focus__student_enrollment')`:
+  - new student/enrollment -> kept, `enrollment_code` (E05/E01) and decoded
+    `drop_code` populated.
+  - matched on `(student_id, start_date)`, no non-code change, Focus already has
+    `enrollment_code` -> dropped (no row).
+  - matched, `grade_id` changed, Focus has `enrollment_code` and null
+    `drop_code` -> kept, `enrollment_code` nulled, `drop_code` decoded+emitted.
+    Mock `ref('stg_focus__student_enrollment_codes')` with a `Drop` row whose
+    `title` equals the mocked `state_withdraw_label` and `short_name` `W02`.
+
+- [ ] **Step 2: Run to confirm fail** (command pattern from Task 5 Step 2,
+      selecting `rpt_focus__student_enrollment`).
+
+- [ ] **Step 3: Rewrite the model.**
+
+  ```sql
+  with
+      desired as (
+          select *
+          from {{ source("kipptaf_extracts", "rpt_focus__student_enrollment") }}
+      ),
+
+      decoded as (
+          select
+              d.*,
+              dc.short_name as drop_code_decoded,
+          from desired as d
+          left join
+              {{ ref("stg_focus__student_enrollment_codes") }} as dc
+              on d.state_withdraw_label = dc.title
+              and dc.type = 'Drop'
+      ),
+
+      matched as (
+          select
+              e.*,
+              fe.start_date as focus_start_date,
+              fe.enrollment_code as focus_enrollment_code,
+              fe.drop_code as focus_drop_code,
+              fe.grade_id as focus_grade_id,
+              fe.syear as focus_syear,
+              fe.school_id as focus_school_id,
+              fe.end_date as focus_end_date,
+          from decoded as e
+          left join
+              {{ ref("stg_focus__student_enrollment") }} as fe
+              on e.student_id = fe.student_id
+              and e.start_date = format_date('%Y%m%d', fe.start_date)
+          where
+              fe.start_date is null
+              or (e.grade_id is not null and e.grade_id is distinct from fe.grade_id)
+              or (e.syear is not null and e.syear is distinct from fe.syear)
+              or (e.school_id is not null and e.school_id is distinct from fe.school_id)
+              or (e.end_date is not null and e.end_date is distinct from format_date('%Y%m%d', fe.end_date))
+      )
+
+  select
+      syear,
+      school_id,
+      student_id,
+      grade_id,
+      start_date,
+      if(
+          focus_enrollment_code is null, enrollment_code, cast(null as string)
+      ) as enrollment_code,
+      end_date,
+      if(
+          focus_drop_code is null, drop_code_decoded, cast(null as string)
+      ) as drop_code,
+      -- ...the rest of the existing enrollment column list, in order...
+      fl_days_absent,
+  from matched
+  ```
+
+  Compare `syear`/`school_id`/`grade_id` types carefully (cast both sides to a
+  common type if the Focus columns are ints and the export emits strings). Keep
+  the **exact** existing output column list/order. Reformat long `where`
+  disjuncts to satisfy the 88-char limit (pre-compute normalized columns in CTEs
+  if cleaner).
+
+- [ ] **Step 4: Run unit test to pass.** Expected: PASS.
+
+- [ ] **Step 5: Verify school-id domain alignment** (spec open question 2):
+
+  ```sql
+  select countif(e.school_id = cast(fe.school_id as string)) aligned, count(*) n
+  from `teamster-332318`.kipptaf_extracts.rpt_focus__student_enrollment e
+  join `teamster-332318`.kippmiami_focus.stg_focus__student_enrollment fe
+    on concat('8400', e.student_id) = cast(fe.student_id as string)
+    and e.start_date = format_date('%Y%m%d', fe.start_date)
+  ```
+
+  (Adjust for the prefix state of the prod table.) If `school_id` domains
+  differ, drop `school_id` from the diff predicate and note it; do not let a
+  domain mismatch force every matched row to re-send.
+
+- [ ] **Step 6: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): diff focus enrollment + decode drop code + import-once codes (#4279)"
+  ```
+
+### Task 7: addresses import-once (req 1)
+
+**Files:**
+
+- Modify: `src/dbt/kippmiami/models/extracts/focus/rpt_focus__addresses.sql`
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__addresses.yml`
+
+**Interfaces:**
+
+- Consumes: `source("kipptaf_extracts", "rpt_focus__addresses")`,
+  `ref("stg_focus__students_join_address")`.
+- Produces: address columns; rows only for students with no Focus address link.
+
+- [ ] **Step 1: Write the unit test** — one desired student with a matching
+      `stg_focus__students_join_address` row (dropped) and one without (kept).
+      Assert only the unmatched `student_id` survives.
+
+- [ ] **Step 2: Run to confirm fail.**
+
+- [ ] **Step 3: Rewrite the model** as an anti-join, keeping the existing column
+      list:
+
+  ```sql
+  with
+      desired as (
+          select * from {{ source("kipptaf_extracts", "rpt_focus__addresses") }}
+      ),
+
+      already_in_focus as (
+          select distinct cast(student_id as string) as student_id,
+          from {{ ref("stg_focus__students_join_address") }}
+      )
+
+  select
+      d.student_id,
+      d.address,
+      -- ...existing addresses column list, in order...
+      d.mail_state,
+  from desired as d
+  left join already_in_focus as f on d.student_id = f.student_id
+  where f.student_id is null
+  ```
+
+- [ ] **Step 4: Run unit test to pass.**
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): import focus addresses once (#4279)"
+  ```
+
+### Task 8: contacts import-once (req 1)
+
+**Files:**
+
+- Modify: `src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql`
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__contacts.yml`
+
+**Interfaces:**
+
+- Consumes: `source("kipptaf_extracts", "rpt_focus__contacts")`,
+  `ref("stg_focus__students_join_people")`.
+- Produces: contacts columns; rows only for students with no Focus people link.
+
+- [ ] **Step 1: Write the unit test** — desired contact rows for two students,
+      one with a `stg_focus__students_join_people` row (all that student's
+      contact rows dropped) and one without (kept).
+
+- [ ] **Step 2: Run to confirm fail.**
+
+- [ ] **Step 3: Rewrite the model** as a per-student anti-join (same shape as
+      Task 7 Step 3, sourcing `rpt_focus__contacts` and
+      `stg_focus__students_join_people`, keeping the full contacts column
+      list/order).
+
+- [ ] **Step 4: Run unit test to pass.**
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): import focus contacts once (#4279)"
+  ```
+
+### Task 9: linked students import-once (req 1)
+
+**Files:**
+
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/rpt_focus__linked_students.sql`
+- Modify:
+  `src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__linked_students.yml`
+
+**Interfaces:**
+
+- Consumes: `source("kipptaf_extracts", "rpt_focus__linked_students")`,
+  `ref("stg_focus__students_join_students")`.
+- Produces: `(primary_student_id, secondary_student_id)` pairs not already
+  linked in Focus.
+
+- [ ] **Step 1: Write the unit test** — two desired pairs, one already present
+      in `stg_focus__students_join_students` (dropped) and one not (kept). The
+      existing pair-existence test must match regardless of pair direction
+      (normalize both sides with `least`/`greatest` before comparing).
+
+- [ ] **Step 2: Run to confirm fail.**
+
+- [ ] **Step 3: Rewrite the model** as an anti-join on the normalized pair:
+
+  ```sql
+  with
+      desired as (
+          select *
+          from {{ source("kipptaf_extracts", "rpt_focus__linked_students") }}
+      ),
+
+      focus_pairs as (
+          select distinct
+              least(cast(student_id as string), cast(linked_student_id as string))
+                  as primary_student_id,
+              greatest(cast(student_id as string), cast(linked_student_id as string))
+                  as secondary_student_id,
+          from {{ ref("stg_focus__students_join_students") }}
+      )
+
+  select d.primary_student_id, d.secondary_student_id,
+  from desired as d
+  left join
+      focus_pairs as f
+      on d.primary_student_id = f.primary_student_id
+      and d.secondary_student_id = f.secondary_student_id
+  where f.primary_student_id is null
+  ```
+
+  (Adjust `linked_student_id` to the real second-id column name from Task 3.)
+
+- [ ] **Step 4: Run unit test to pass.**
+
+- [ ] **Step 5: Commit.**
+
+  ```bash
+  git -C <worktree> add -u
+  git -C <worktree> commit -m "feat(finalsite): import focus linked students once (#4279)"
+  ```
+
+---
+
+## Phase 4 — validation and PR
+
+### Task 10: full validation and pull request
+
+**Files:** none (verification) unless a fix is needed.
+
+- [ ] **Step 1: Parse both projects.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt parse --project-dir <worktree>/src/dbt/kipptaf
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt parse --project-dir <worktree>/src/dbt/kippmiami
+  ```
+
+- [ ] **Step 2: Run every focus unit test.**
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+    --select "rpt_focus__* stg_focus__students_join_*" \
+    --project-dir <worktree>/src/dbt/kippmiami --target dev \
+    --defer --state <worktree>/src/dbt/kippmiami/target/prod
+  ```
+
+  Also run the kipptaf unit tests
+  (`--select rpt_focus__* --project-dir <worktree>/src/dbt/kipptaf`). Expected:
+  all PASS.
+
+- [ ] **Step 3: Build the kippmiami extracts end to end** (defer to prod):
+
+  ```bash
+  DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt build \
+    --select "rpt_focus__*" \
+    --project-dir <worktree>/src/dbt/kippmiami --target dev \
+    --defer --state <worktree>/src/dbt/kippmiami/target/prod
+  ```
+
+  (Req 1 models build only once Task 3 made their sources exist; if deferred,
+  build the other four and note req 1 pending.)
+
+- [ ] **Step 4: Sanity-check row reduction** in BigQuery — confirm each extract
+      now emits fewer rows than the desired-state count for already-matched
+      students, and that unmatched students still appear.
+
+- [ ] **Step 5: Trunk-check every changed file** from inside the worktree.
+
+  ```bash
+  /workspaces/teamster/.trunk/tools/trunk check --force <changed .sql/.yml/.md>
+  ```
+
+- [ ] **Step 6: Push and open the PR.** Push the branch (hand `git push` to the
+      user if the classifier blocks it), then open a PR with the
+      `.github/pull_request_template.md` body and `Closes #4279` (which chains
+      `Closes #4208`). Flag that the kipptaf source change (8400 prefix +
+      `state_withdraw_label` rename) must materialize in prod before kippmiami
+      CI can read it (two-PR / clone-seed consideration per
+      `src/dbt/CLAUDE.md`).
+
+---
+
+## Self-review notes
+
+- Spec coverage: req 1 (Tasks 3,4,7,8,9), req 2 (Task 5), req 3 (Task 6), req 4
+  (Tasks 2,6), req 5 (Task 1). All covered.
+- Cross-project ordering: Task 2 renames a kipptaf output column (`drop_code` ->
+  `state_withdraw_label`) that kippmiami Task 6 consumes; kippmiami CI reads the
+  `zz_stg`/prod kipptaf copy, so the kipptaf change must reach prod before
+  kippmiami CI passes (Task 10 Step 6).
+- Req 1 is gated on Task 3; if the Focus linkage tables cannot be materialized,
+  Tasks 4/7/8/9 stay un-merged and reqs 2-5 ship independently.

--- a/docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md
+++ b/docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md
@@ -1,0 +1,262 @@
+# Finalsite to Focus idempotent imports — design
+
+Tracking issue: [#4279](https://github.com/TEAMSchools/teamster/issues/4279)
+(closes [#4208](https://github.com/TEAMSchools/teamster/issues/4208)).
+
+## Problem
+
+The five `rpt_focus__*` SFTP extracts (Demographics, Student_Enrollment,
+Addresses, Contacts, Linked_Students) re-emit **every** in-scope Finalsite row
+on every run. Nothing compares the outbound data to what already lives in Focus,
+so Focus is asked to re-import unchanged rows continuously and entry/withdrawal
+codes risk being overwritten. We also need to resolve the #4208 enrollment-code
+gap and apply the Florida-required student-id prefix.
+
+## Current architecture
+
+```text
+Finalsite (API)  ->  kipptaf_extracts.rpt_focus__*   (desired state, all rows)
+                          |  source("kipptaf_extracts", ...)
+                          v
+                     kippmiami_extracts.rpt_focus__*  (thin pass-through)
+                          |  Dagster build_bigquery_query_sftp_asset
+                          v
+                     Focus SFTP  incoming/*.csv
+```
+
+- Desired-state logic lives in `kipptaf` and reads `stg_finalsite__*`,
+  `int_finalsite__*`, and Google-Sheets crosswalks.
+- The `kippmiami` models are pass-throughs that the Dagster extract reads.
+- The `focus` dbt package (current Focus SIS state, dlt-loaded) is a package of
+  `kippmiami` **only** — `kipptaf` cannot reach it.
+
+### Identity / match key
+
+`int_finalsite__contact_id_attributes.focus_student_id` is a 6-digit
+Finalsite-minted id (e.g. `305000`). Focus `students.student_id` is the 10-digit
+Florida id (e.g. `8400305000`). The relationship is:
+
+```text
+focus.students.student_id = 8400000000 + finalsite.focus_student_id
+                          = concat('8400', focus_student_id)
+```
+
+1,376 of 3,088 minted ids already exist in Focus; the remainder are new. After
+requirement 5 (prefix) the exported id equals `students.student_id` directly, so
+all diffs join on a single clean key.
+
+## Requirements
+
+1. **Addresses, Contacts, Linked Students — import once.** Drop a student from
+   the extract once a row exists in that extract's Focus destination table.
+2. **Demographics — diff.** Emit only unmatched students and students whose
+   populated values differ from Focus.
+3. **Student Enrollment — diff with code exception.** Emit only unmatched and
+   changed records, EXCEPT entry and withdrawal codes, which import once and are
+   never overwritten.
+4. **#4208 codes.** `ENROLLMENT_CODE` = `E05` for KG, `E01` for everyone else.
+   `DROP_CODE` comes from the Finalsite field `fl_state_withdraw_codes_ss`.
+5. **8400 id prefix.** Prefix `focus_student_id` with the constant `8400` on
+   every emitted student id. Florida-required; Finalsite autoincrement cannot
+   hold the full value.
+
+## Design
+
+Division of labor stays aligned with the existing layers:
+
+- **`kipptaf` (desired state)** — work with no Focus dependency: the 8400 prefix
+  (req 5) and the grade-based enrollment code (req 4). It also carries the raw
+  withdraw label forward for downstream decode.
+- **`kippmiami` (reconciliation)** — everything that needs current Focus state:
+  the drop-code decode, all diff/import-once filtering, and the new Focus
+  staging models. This is the only layer with both the `finalsite` and `focus`
+  packages.
+
+### Req 5 — 8400 prefix (kipptaf, all five models)
+
+Replace every `ida.focus_student_id as <id>` projection with:
+
+```sql
+concat('8400', ida.focus_student_id) as student_id
+```
+
+Applies to `rpt_focus__demographics` (`stdt_id`), `rpt_focus__addresses`,
+`rpt_focus__contacts`, `rpt_focus__student_enrollment` (`student_id`), and both
+ids in `rpt_focus__linked_students`. `concat` returns `NULL` when
+`focus_student_id` is `NULL`, preserving current null behavior. In
+`linked_students`, `least`/`greatest` over the prefixed fixed-width strings keep
+the same pair-normalization (equal prefix preserves order).
+
+### Req 4 — enrollment + withdraw codes
+
+`kipptaf/.../rpt_focus__student_enrollment.sql`:
+
+- **ENROLLMENT_CODE** — drop the `enrollment_code_crosswalk` join. Derive from
+  grade, only for entry actions:
+
+  ```sql
+  case
+      when l.lifecycle_action = 'transfer_out'
+      then cast(null as string)
+      when l.grade_canonical_name = 'k'
+      then 'E05'
+      else 'E01'
+  end as enrollment_code
+  ```
+
+  `E05` = "Entering PK or KG First Time"; `E01` = "In District Previous Year"
+  (verified against `stg_focus__student_enrollment_codes`). Assumption: req 4 is
+  purely grade-based for all entries, including re-enrollers (per the literal
+  instruction "everyone else E01").
+
+- **DROP_CODE** — drop the `drop_code_crosswalk` join. Carry the raw
+  `cca.fl_state_withdraw_codes_ss` forward as `state_withdraw_label` (a renamed
+  carrier column). The decode to a Focus short code happens in `kippmiami`
+  (needs `stg_focus__student_enrollment_codes`).
+
+The withdraw label is a human string such as `(W02) In District Transfer`. It
+matches `stg_focus__student_enrollment_codes.title` (where `type = 'Drop'`) at
+100% across the 7 distinct values present, yielding the `short_name` (`W02`,
+`W3A`, `W3D`, `OUTAPP`, ...). Decode in `kippmiami`:
+
+```sql
+left join {{ ref("stg_focus__student_enrollment_codes") }} as dc
+    on e.state_withdraw_label = dc.title
+    and dc.type = 'Drop'
+-- then: dc.short_name as drop_code
+```
+
+### Req 2 — demographics diff (kippmiami)
+
+`kippmiami/.../rpt_focus__demographics.sql` joins current Focus state and keeps
+a row when the student is **unmatched** OR any **populated** export value
+differs.
+
+Comparison set (only columns present on both sides; null-placeholder export
+columns and Focus-absent columns such as `nickname`/`photo_vid_perm` are
+excluded from the diff):
+
+| Export column                              | Focus source                                       | Normalization for comparison             |
+| ------------------------------------------ | -------------------------------------------------- | ---------------------------------------- |
+| `last_name` / `first_name` / `middle_name` | `stg_focus__students`                              | direct string                            |
+| `dt_birth` (`YYYYMMDD`)                    | `students.birthdate` (timestamp)                   | `format_date('%Y%m%d', birthdate)`       |
+| `gender` (`M`/`F`)                         | `int_focus__students__pivot.sex_label` (`Male[M]`) | `regexp_extract(sex_label, r'\[(.+)\]')` |
+| `stdt_email`                               | `students.student_e_mail_address`                  | direct string                            |
+| `ethnic_hl` (`Y`/`N`)                      | `ethnicity_hispanic_or_latino_label` (`Yes`/`No`)  | map `Yes`->`Y`, `No`->`N`                |
+| `race_*` (`Y`/null)                        | `race_*_label` (`Yes`/`No`)                        | map `Yes`->`Y`, `No`->null               |
+| `lang` (FLDOE code)                        | `language_label` (`EN`)                            | compare code to label directly           |
+
+Match key: `demographics.stdt_id = students.student_id` (both 8400-prefixed
+after req 5). A NULL-safe per-field comparison (`a is distinct from b`) over the
+normalized values drives the keep predicate; unmatched students
+(`students.student_id is null`) are always kept.
+
+### Req 3 — enrollment diff with code import-once (kippmiami)
+
+`kippmiami/.../rpt_focus__student_enrollment.sql`:
+
+- Match a desired enrollment to a Focus enrollment on
+  `(student_id, syear, school_id)`. (Open item: confirm whether `start_date`
+  must join the key for same-year re-entries; see Open questions.)
+- **Keep** a row when unmatched OR any non-code field (`grade_id`, `start_date`,
+  `end_date`) differs from the Focus enrollment.
+- **ENROLLMENT_CODE / DROP_CODE import-once:** emit the computed code only when
+  the matched Focus enrollment does not already carry one; otherwise emit `NULL`
+  so Focus never overwrites:
+
+  ```sql
+  if(fe.enrollment_code is null, e.enrollment_code, cast(null as string))
+      as enrollment_code,
+  if(fe.drop_code is null, e.decoded_drop_code, cast(null as string))
+      as drop_code,
+  ```
+
+  (`fe` = matched `stg_focus__student_enrollment` row.) For unmatched
+  enrollments `fe.*` is null, so both codes emit in full on first import.
+
+### Req 1 — import once for addresses / contacts / linked students (kippmiami)
+
+These exclude a student once the matching Focus destination row exists.
+Destinations (from the import templates and `dlt/focus/config/focus.yaml`):
+
+| Extract         | Focus destination                                            | Exclusion test                              |
+| --------------- | ------------------------------------------------------------ | ------------------------------------------- |
+| Addresses       | `students_join_address` -> `address`                         | student has any `students_join_address` row |
+| Contacts        | `students_join_people` -> `people` -> `people_join_contacts` | student has any `students_join_people` row  |
+| Linked Students | `students_join_students`                                     | the (primary, secondary) pair exists        |
+
+**Prerequisite (blocker):** `students_join_address`, `students_join_people`,
+`people`, and `students_join_students` are listed in the dlt config but were
+**never materialized** in BigQuery (Focus source has no rows yet), and have no
+`stg_focus__` models. Work:
+
+1. **dlt** — confirm why these tables do not materialize (likely the
+   `sql_database` source skips empty/absent source tables) and ensure they are
+   created (even empty) on the next pull, so dbt sources resolve.
+2. **focus staging** — add `stg_focus__students_join_address`,
+   `stg_focus__students_join_people`, `stg_focus__people`, and
+   `stg_focus__students_join_students` (contract-enforced, soft-delete filtered
+   where applicable), plus `sources-bigquery.yml` entries.
+3. **kippmiami extracts** — left join the relevant link table on
+   `student_id`/pair and keep only rows with no match (anti-join).
+
+Until the source tables exist the staging models cannot build; the dlt task
+gates the rest of req 1.
+
+## Files
+
+**Modify (`kipptaf`):**
+
+- `models/extracts/focus/rpt_focus__{demographics,addresses,contacts,student_enrollment,linked_students}.sql`
+  (+ matching `properties/*.yml`) — 8400 prefix; enrollment + carrier label
+  changes; drop the two crosswalk joins in `student_enrollment`.
+
+**Modify (`kippmiami`):**
+
+- `models/extracts/focus/rpt_focus__*.sql` (+ `properties/*.yml`) — Focus joins,
+  diff/import-once filters, drop-code decode.
+- `models/extracts/sources.yml` — any new cross-project/source wiring.
+
+**Create (`focus` package):**
+
+- `models/staging/stg_focus__students_join_address.sql` (+ yml)
+- `models/staging/stg_focus__students_join_people.sql` (+ yml)
+- `models/staging/stg_focus__people.sql` (+ yml)
+- `models/staging/stg_focus__students_join_students.sql` (+ yml)
+- `models/staging/sources-bigquery.yml` — four new source tables.
+
+**Modify (Dagster):**
+
+- `src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml` / related
+  — ensure the four link tables materialize.
+
+## Testing
+
+- dbt **unit tests** per modified extract model: mock Finalsite inputs + a
+  mocked Focus state row and assert (a) unmatched rows pass through, (b)
+  byte-identical matched rows are dropped, (c) a single changed field re-emits,
+  (d) import-once nulls codes when Focus already has them, (e) the 8400 prefix
+  is applied, (f) `E05`/`E01` by grade, (g) the withdraw-label decode.
+- `dbt build` of the focus staging additions once the dlt tables exist.
+- Full diff sanity check in BigQuery against live `kippmiami_focus` after build.
+
+## Open questions / assumptions
+
+1. **Enrollment match grain.** `(student_id, syear, school_id)` assumed; confirm
+   whether `start_date` is needed for same-year re-entries.
+2. **School-id alignment.** Export `school_id` (`location_focus_school_id`) must
+   equal `stg_focus__student_enrollment.school_id`; verify before trusting the
+   enrollment match.
+3. **Enrollment code scope.** Assumed purely grade-based for all entries
+   (re-enrollers included). Confirm with registrar if re-enrollers should keep
+   an R-code instead of `E01`.
+4. **dlt link-table materialization.** Root cause of the missing
+   `students_join_*` tables to be confirmed; may need a dlt source-config change
+   or a one-time pull.
+
+## Out of scope
+
+- Race/ethnicity value mapping beyond the confirmed `Yes`/`No` -> `Y`/`N`/null
+  normalization.
+- Any change to the SFTP transport (filenames, schedule, headers).
+- Backfilling or correcting historical Focus data.

--- a/docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md
+++ b/docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md
@@ -156,10 +156,16 @@ normalized values drives the keep predicate; unmatched students
 `kippmiami/.../rpt_focus__student_enrollment.sql`:
 
 - Match a desired enrollment to a Focus enrollment on
-  `(student_id, syear, school_id)`. (Open item: confirm whether `start_date`
-  must join the key for same-year re-entries; see Open questions.)
-- **Keep** a row when unmatched OR any non-code field (`grade_id`, `start_date`,
-  `end_date`) differs from the Focus enrollment.
+  `(student_id, start_date)`. This is the natural grain of
+  `stg_focus__student_enrollment`: verified `(student_id, start_date)` is unique
+  (9,591 of 9,591 rows), while `(student_id, syear, school_id)` collides (9,487)
+  because a student can have multiple spans in one year+school. `syear`,
+  `school_id`, and `grade_id` are enrollment attributes, not key. Focus
+  `start_date` is a `DATE` (`2024-07-01`) and the export emits `YYYYMMDD`, so
+  the join normalizes one side
+  (`format_date('%Y%m%d', fe.start_date) = e.start_date`).
+- **Keep** a row when unmatched OR any non-code field (`grade_id`, `syear`,
+  `school_id`, `end_date`) differs from the Focus enrollment.
 - **ENROLLMENT_CODE / DROP_CODE import-once:** emit the computed code only when
   the matched Focus enrollment does not already carry one; otherwise emit `NULL`
   so Focus never overwrites:
@@ -242,11 +248,13 @@ gates the rest of req 1.
 
 ## Open questions / assumptions
 
-1. **Enrollment match grain.** `(student_id, syear, school_id)` assumed; confirm
-   whether `start_date` is needed for same-year re-entries.
-2. **School-id alignment.** Export `school_id` (`location_focus_school_id`) must
-   equal `stg_focus__student_enrollment.school_id`; verify before trusting the
-   enrollment match.
+1. **Enrollment match grain — RESOLVED.** `(student_id, start_date)` is the
+   unique grain (9,591/9,591); `syear`/`school_id`/`grade_id` are attributes.
+2. **School-id alignment.** `school_id` is now a compared attribute (not a join
+   key). Export `school_id` (`location_focus_school_id`) and
+   `stg_focus__student_enrollment.school_id` must share the same value domain or
+   the diff will treat every matched row as changed; verify during
+   implementation.
 3. **Enrollment code scope.** Assumed purely grade-based for all entries
    (re-enrollers included). Confirm with registrar if re-enrollers should keep
    an R-code instead of `E01`.

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
@@ -94,7 +94,7 @@ unit_tests:
     expect:
       rows:
         - {
-            student_id: "4004004",
+            student_id: "84004004004",
             address: 123 Main St,
             address2: Apt 4B,
             city: Miami,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -329,7 +329,7 @@ unit_tests:
     expect:
       rows:
         - {
-            student_id: "2002002",
+            student_id: "84002002002",
             student_relation: parent,
             sort_order: 1,
             first_name: Alice,
@@ -381,7 +381,7 @@ unit_tests:
             contact7_unlisted: null,
           }
         - {
-            student_id: "2002002",
+            student_id: "84002002002",
             student_relation: guardian,
             sort_order: 2,
             first_name: Bob,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
@@ -271,7 +271,7 @@ unit_tests:
     expect:
       rows:
         - {
-            stdt_id: "1001001",
+            stdt_id: "84001001001",
             last_name: Smith,
             first_name: Jane,
             name_suffix: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
@@ -63,4 +63,4 @@ unit_tests:
           select 'enr-stu-b' as finalsite_enrollment_id, '100' as focus_student_id
     expect:
       rows:
-        - { primary_student_id: "100", secondary_student_id: "900" }
+        - { primary_student_id: "8400100", secondary_student_id: "8400900" }

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -4,15 +4,17 @@ models:
       One row per in-scope Finalsite enrollment reshaped into the Focus
       `STUDENT_ENROLLMENT` SFTP template layout, built from
       `int_finalsite__enrollment_lifecycle`. Grade is translated inline
-      (`k`→`KG`, else zero-padded number); school maps via
-      `int_people__location_crosswalk`, the Focus student id (`student_id`) via
-      `int_finalsite__contact_id_attributes`, and enrollment/drop codes via
-      Google Sheets crosswalks — together producing the 28-column layout
-      consumed by the Focus SFTP transport. The Focus column header casing
-      (`SYEAR`, `SCHOOL_ID`, etc.) is applied at transport time via
-      `file_config.format.header_replacements`; dbt column names remain
-      lowercase snake_case. `end_date` and `drop_code` populate only for
-      `lifecycle_action = 'transfer_out'` rows.
+      (`k`→`KG`, else zero-padded number); enrollment_code is derived from grade
+      (`E05` for KG, `E01` otherwise, null for transfer_out); school maps via
+      `int_people__location_crosswalk`; Focus student id (`student_id`) via
+      `int_finalsite__contact_id_attributes`; and the raw Florida state
+      withdrawal label from `int_finalsite__contact_custom_attributes` —
+      together producing the 28-column layout consumed by the Focus SFTP
+      transport. The Focus column header casing (`SYEAR`, `SCHOOL_ID`, etc.) is
+      applied at transport time via `file_config.format.header_replacements`;
+      dbt column names remain lowercase snake_case. `end_date` and
+      `state_withdraw_label` populate only for `lifecycle_action =
+      'transfer_out'` rows.
     columns:
       - name: student_id
         data_type: string
@@ -60,18 +62,20 @@ models:
       - name: enrollment_code
         data_type: string
         description:
-          Focus enrollment action code mapped from `lifecycle_action` via the
-          enrollment-code crosswalk (e.g. `EA1` for a new enrollment).
+          Focus enrollment action code derived from grade — `E05` for
+          kindergarten (`grade_canonical_name = 'k'`), `E01` for all other
+          grades; null for `transfer_out` rows.
       - name: end_date
         data_type: string
         description:
           Enrollment end date formatted as `YYYYMMDD`; populated only for
           `transfer_out` rows.
-      - name: drop_code
+      - name: state_withdraw_label
         data_type: string
         description:
-          Focus drop/withdrawal code mapped from `withdrawal_reason` via the
-          drop-code crosswalk; populated only for `transfer_out` rows.
+          Raw Florida state withdrawal code label from the Finalsite
+          `fl_state_withdraw_codes_ss` custom attribute (e.g. `(W02) In District
+          Transfer`); populated only for `transfer_out` rows, null otherwise.
       - name: calendar_id
         data_type: string
         description:
@@ -163,9 +167,9 @@ unit_tests:
     description:
       Verifies the 28-column STUDENT_ENROLLMENT layout for new-enrollment rows —
       grade is translated inline for both a numbered grade (`5th`→`05`) and
-      kindergarten (`k`→`KG`), school/enrollment-code crosswalks resolve,
-      student_id is sourced from int_finalsite__contact_id_attributes, and
-      end_date/drop_code are null for a non-transfer row.
+      kindergarten (`k`→`KG`); enrollment_code is E05 for KG and E01 otherwise;
+      student_id is sourced from int_finalsite__contact_id_attributes; and
+      end_date/state_withdraw_label are null for non-transfer rows.
     model: rpt_focus__student_enrollment
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -197,22 +201,19 @@ unit_tests:
         rows: |
           select
             'e1' as finalsite_enrollment_id,
-            cast(null as string) as withdrawal_school_txt
+            cast(null as string) as withdrawal_school_txt,
+            cast(null as string) as fl_state_withdraw_codes_ss
+          union all
+          select
+            'e3' as finalsite_enrollment_id,
+            cast(null as string) as withdrawal_school_txt,
+            cast(null as string) as fl_state_withdraw_codes_ss
       - input: ref('int_people__location_crosswalk')
         format: sql
         rows: |
           select
             'KIPP Royalty Academy' as location_name,
             '0001' as location_focus_school_id
-      - input: ref('stg_google_sheets__focus__enrollment_code_crosswalk')
-        rows:
-          - { finalsite_lifecycle_action: create, focus_enrollment_code: EA1 }
-      - input: ref('stg_google_sheets__focus__drop_code_crosswalk')
-        rows:
-          - {
-              finalsite_withdrawal_reason: mid_year_withdrawal,
-              focus_drop_code: W05,
-            }
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |
@@ -231,9 +232,9 @@ unit_tests:
             student_id: "84003003001",
             grade_id: "05",
             start_date: "20250812",
-            enrollment_code: EA1,
+            enrollment_code: E01,
             end_date: null,
-            drop_code: null,
+            state_withdraw_label: null,
             calendar_id: null,
             prior_dist: null,
             prior_state: null,
@@ -261,9 +262,9 @@ unit_tests:
             student_id: "84003003003",
             grade_id: KG,
             start_date: "20250812",
-            enrollment_code: EA1,
+            enrollment_code: E05,
             end_date: null,
-            drop_code: null,
+            state_withdraw_label: null,
             calendar_id: null,
             prior_dist: null,
             prior_state: null,
@@ -287,8 +288,10 @@ unit_tests:
           }
   - name: test_student_enrollment_transfer_out
     description:
-      Verifies that end_date and drop_code populate for a transfer_out row, and
-      that end_date is formatted as YYYYMMDD.
+      Verifies that end_date and state_withdraw_label populate for a
+      transfer_out row, that enrollment_code is null for transfer_out, that
+      end_date is formatted as YYYYMMDD, and that state_withdraw_label carries
+      the raw fl_state_withdraw_codes_ss value.
     model: rpt_focus__student_enrollment
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -309,25 +312,14 @@ unit_tests:
         rows: |
           select
             'e2' as finalsite_enrollment_id,
-            'Prior Elementary' as withdrawal_school_txt
+            'Prior Elementary' as withdrawal_school_txt,
+            '(W02) In District Transfer' as fl_state_withdraw_codes_ss
       - input: ref('int_people__location_crosswalk')
         format: sql
         rows: |
           select
             'KIPP Royalty Academy' as location_name,
             '0001' as location_focus_school_id
-      - input: ref('stg_google_sheets__focus__enrollment_code_crosswalk')
-        rows:
-          - {
-              finalsite_lifecycle_action: transfer_out,
-              focus_enrollment_code: W01,
-            }
-      - input: ref('stg_google_sheets__focus__drop_code_crosswalk')
-        rows:
-          - {
-              finalsite_withdrawal_reason: mid_year_withdrawal,
-              focus_drop_code: W05,
-            }
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |
@@ -342,9 +334,9 @@ unit_tests:
             student_id: "84003003002",
             grade_id: "07",
             start_date: "20250812",
-            enrollment_code: W01,
+            enrollment_code: null,
             end_date: "20260115",
-            drop_code: W05,
+            state_withdraw_label: (W02) In District Transfer,
             calendar_id: null,
             prior_dist: null,
             prior_state: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -12,9 +12,15 @@ models:
       together producing the 28-column layout consumed by the Focus SFTP
       transport. The Focus column header casing (`SYEAR`, `SCHOOL_ID`, etc.) is
       applied at transport time via `file_config.format.header_replacements`;
-      dbt column names remain lowercase snake_case. `end_date` and
-      `state_withdraw_label` populate only for `lifecycle_action =
-      'transfer_out'` rows.
+      dbt column names remain lowercase snake_case. `end_date`,
+      `state_withdraw_label`, and `moved_to` populate only for `lifecycle_action
+      = 'transfer_out'` rows.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_id
+              - start_date
     columns:
       - name: student_id
         data_type: string
@@ -23,7 +29,6 @@ models:
           `int_finalsite__contact_id_attributes.focus_student_id`; null for
           enrollments where Finalsite has not minted the id.
         data_tests:
-          - unique
           - not_null
       - name: syear
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -228,7 +228,7 @@ unit_tests:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: "3003001",
+            student_id: "84003003001",
             grade_id: "05",
             start_date: "20250812",
             enrollment_code: EA1,
@@ -258,7 +258,7 @@ unit_tests:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: "3003003",
+            student_id: "84003003003",
             grade_id: KG,
             start_date: "20250812",
             enrollment_code: EA1,
@@ -339,7 +339,7 @@ unit_tests:
         - {
             syear: 2025,
             school_id: "0001",
-            student_id: "3003002",
+            student_id: "84003003002",
             grade_id: "07",
             start_date: "20250812",
             enrollment_code: W01,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
@@ -1,6 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus ADDRESS contract
 select
-    ida.focus_student_id as student_id,
+    concat('8400', ida.focus_student_id) as student_id,
 
     c.address_1 as address,
     c.address_2 as address2,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
@@ -1,6 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus CONTACTS contract
 select
-    ida.focus_student_id as student_id,
+    concat('8400', ida.focus_student_id) as student_id,
 
     rel.rel_type as student_relation,
 

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
@@ -1,6 +1,6 @@
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus DEMOGRAPHICS contract
 select
-    ida.focus_student_id as stdt_id,
+    concat('8400', ida.focus_student_id) as stdt_id,
 
     c.last_name,
     c.first_name,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__linked_students.sql
@@ -2,8 +2,12 @@
 -- bidirectional edge (a->b and b->a) to one (primary, secondary) tuple, which
 -- distinct collapses; not a mask for upstream duplicates.
 select distinct
-    least(ida_a.focus_student_id, ida_b.focus_student_id) as primary_student_id,
-    greatest(ida_a.focus_student_id, ida_b.focus_student_id) as secondary_student_id,
+    least(
+        concat('8400', ida_a.focus_student_id), concat('8400', ida_b.focus_student_id)
+    ) as primary_student_id,
+    greatest(
+        concat('8400', ida_a.focus_student_id), concat('8400', ida_b.focus_student_id)
+    ) as secondary_student_id,
 from {{ ref("stg_finalsite__contact_relationships") }} as rel
 inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida_a

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -9,6 +9,7 @@ select
     if(
         l.grade_canonical_name = 'k',
         'KG',
+        -- non-digit grade names (e.g. pk) yield null here; Miami is K-9 today
         lpad(regexp_extract(l.grade_canonical_name, r'\d+'), 2, '0')
     ) as grade_id,
 
@@ -22,11 +23,19 @@ select
         else 'E01'
     end as enrollment_code,
 
-    -- enrollment_end_date / withdrawal_reason are already null upstream for
-    -- non-transfer rows, so no transfer_out re-gating is needed here.
+    -- enrollment_end_date is gated to transfer_out upstream in
+    -- int_finalsite__enrollment_lifecycle, so end_date needs no re-gating.
     format_date('%Y%m%d', l.enrollment_end_date) as end_date,
 
-    cca.fl_state_withdraw_codes_ss as state_withdraw_label,
+    -- fl_state_withdraw_codes_ss is a raw contact custom attribute (NOT gated
+    -- upstream), so gate it to transfer_out here — a withdraw code is only
+    -- meaningful for a withdrawal, and an ungated value would emit a drop code
+    -- for a still-enrolled student downstream.
+    if(
+        l.lifecycle_action = 'transfer_out',
+        cca.fl_state_withdraw_codes_ss,
+        cast(null as string)
+    ) as state_withdraw_label,
 
     cast(null as string) as calendar_id,
     cast(null as string) as prior_dist,
@@ -37,7 +46,11 @@ select
     cast(null as string) as offender_transfer_stdt,
     cast(null as string) as came_from,
 
-    cca.withdrawal_school_txt as moved_to,
+    if(
+        l.lifecycle_action = 'transfer_out',
+        cca.withdrawal_school_txt,
+        cast(null as string)
+    ) as moved_to,
 
     cast(null as string) as sec_sch,
 

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -4,7 +4,7 @@ select
 
     sch.location_focus_school_id as school_id,
 
-    ida.focus_student_id as student_id,
+    concat('8400', ida.focus_student_id) as student_id,
 
     if(
         l.grade_canonical_name = 'k',

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -14,13 +14,19 @@ select
 
     format_date('%Y%m%d', l.enrollment_start_date) as start_date,
 
-    ec.focus_enrollment_code as enrollment_code,
+    case
+        when l.lifecycle_action = 'transfer_out'
+        then cast(null as string)
+        when l.grade_canonical_name = 'k'
+        then 'E05'
+        else 'E01'
+    end as enrollment_code,
 
     -- enrollment_end_date / withdrawal_reason are already null upstream for
     -- non-transfer rows, so no transfer_out re-gating is needed here.
     format_date('%Y%m%d', l.enrollment_end_date) as end_date,
 
-    dc.focus_drop_code as drop_code,
+    cca.fl_state_withdraw_codes_ss as state_withdraw_label,
 
     cast(null as string) as calendar_id,
     cast(null as string) as prior_dist,
@@ -56,9 +62,3 @@ left join
 left join
     {{ ref("int_people__location_crosswalk") }} as sch
     on l.assigned_school = sch.location_name
-left join
-    {{ ref("stg_google_sheets__focus__enrollment_code_crosswalk") }} as ec
-    on l.lifecycle_action = ec.finalsite_lifecycle_action
-left join
-    {{ ref("stg_google_sheets__focus__drop_code_crosswalk") }} as dc
-    on l.withdrawal_reason = dc.finalsite_withdrawal_reason


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request updates the kipptaf Focus extracts' desired-state logic:

- **8400 student-id prefix (req 5):** every emitted student id becomes `concat('8400', focus_student_id)` across all five `rpt_focus__*` models. Florida requires the district prefix and Finalsite's autoincrement cannot hold the full 10-digit value. The prefixed id also equals Focus `students.student_id` directly, which the downstream diff relies on.
- **Grade-based enrollment code (req 4, resolves #4208):** `rpt_focus__student_enrollment.enrollment_code` is now `E05` for kindergarten, `E01` for everyone else, and `NULL` on transfer-out — replacing the lifecycle-action crosswalk that could not express E05 vs the entry codes.
- **Withdraw-code carrier (req 4):** the old `drop_code` crosswalk output is replaced by `state_withdraw_label`, carrying the raw Finalsite `fl_state_withdraw_codes_ss` value. The downstream kippmiami extract decodes it to the Focus drop-code `short_name`.

This is **part 1 of 2** for #4279 (idempotent Finalsite-to-Focus imports). Part 2 (the kippmiami diff and import-once reconciliation, reqs 2 and 3) follows in a separate PR after this lands and Dagster materializes prod `kipptaf_extracts`, because the kippmiami enrollment model reads the new `state_withdraw_label` column from this project's output. Requirement 1 (addresses/contacts/linked-students import-once) is deferred: its Focus source tables are empty, so dlt has not created them in BigQuery yet.

Full design and plan are in `docs/superpowers/specs/` and `docs/superpowers/plans/` (included in this PR).

## AI Assistance

Spec, plan, and implementation were drafted by Claude Code under human direction (issue #4279) and reviewed task-by-task. Human-directed: requirements, the E05/E01 rule, the 8400 constant, and all scope/merge decisions.

## Self-review

### dbt

- [x] Properties files updated for the renamed column (`state_withdraw_label`) and all unit-test expectations.
- [x] **Breaking change:** this renames the contracted column `drop_code` to `state_withdraw_label` in `rpt_focus__student_enrollment`. The only downstream consumer is the kippmiami `rpt_focus__student_enrollment` pass-through, updated in the part-2 PR; no exposures consume it. Rollback: revert this PR.
- No external source added or modified.

### CI checks

- [ ] Trunk passes (clean locally).
- [ ] dbt Cloud passes (kipptaf is self-contained here; no cross-project read).

## Follow-ups

- Retire the two now-orphaned crosswalk models (`stg_google_sheets__focus__enrollment_code_crosswalk`, `stg_google_sheets__focus__drop_code_crosswalk`) and their Sheets sources.

Closes #4208
Refs #4279