### PR TITLE
fix(dbt): exclude null-focus-id and pre-enrollment rows from rpt_focus exports

### DIFF
--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -82,6 +82,18 @@ date and drop code only when Focus does not already have a withdrawal on that
 enrollment. If Focus already shows the student as withdrawn, the pipeline leaves
 it alone — a later change to the code or date must be made in Focus directly.
 
+### Enrollment feed — enrolled students only
+
+A student appears in the **Student Enrollment** file only once Finalsite has an
+enrollment **start date** for them — that is, once they are actually enrolled.
+Students who are still accepted, in progress, or only assigned a school (with no
+start date yet) are held back and not sent until they enroll.
+
+> **A student can be in Demographics, Address, and Contacts but not yet in
+> Student Enrollment.** Those three files are sent as soon as the student has a
+> minted ID; the enrollment record waits for the start date. This is expected —
+> the enrollment flows to Focus once Finalsite records the start date.
+
 ### What gets sent
 
 Every feed follows the same import-once rule — a record is sent only when Focus
@@ -89,8 +101,9 @@ does not already have it, and nothing is ever overwritten:
 
 - **Demographics** — a student's demographics are sent only if the student is
   not yet in Focus.
-- **Student enrollment** — an enrollment is sent when it is new to Focus; a
-  withdrawal (end date + drop code) is filled in once when Focus has none yet.
+- **Student enrollment** — an enrollment is sent when it is new to Focus **and
+  the student is enrolled** (has a start date); a withdrawal (end date + drop
+  code) is filled in once when Focus has none yet.
 - **Addresses and Contacts** — a student's address / contacts are sent only if
   Focus does not already have them for that student.
 
@@ -145,6 +158,10 @@ pipeline will not reconcile them for you.
 
 - **Mint the Finalsite student ID** before expecting a student in Focus —
   records without one are skipped.
+- **An enrollment needs a start date.** A student reaches Focus's Student
+  Enrollment file only once Finalsite has an enrollment start date; accepted or
+  in-progress students wait until they enroll (they can still appear in
+  Demographics, Address, and Contacts in the meantime).
 - **Set the last-attended date** in Finalsite when a student withdraws — it is
   what triggers the end date and drop code being sent.
 - **Corrections after the first import are manual.** A wrong entry code, drop

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__addresses.yml
@@ -7,10 +7,11 @@ models:
       One row per in-scope Finalsite student reshaped into the Focus `ADDRESS`
       SFTP template layout. Joins `stg_finalsite__contacts` to
       `int_finalsite__enrollment_lifecycle` (the in-scope filter; grain =
-      `finalsite_enrollment_id`), then left joins
-      `int_finalsite__contact_id_attributes` for the Focus student ID. Produces
-      12 columns in `ADDRESS_LAYOUT` order. Focus column header casing
-      (`STUDENT_ID`, `ADDRESS`, etc.) is applied at transport time via
+      `finalsite_enrollment_id`), then inner joins
+      `int_finalsite__contact_id_attributes` for the Focus student ID, excluding
+      contacts without a minted Focus id. Produces 12 columns in
+      `ADDRESS_LAYOUT` order. Focus column header casing (`STUDENT_ID`,
+      `ADDRESS`, etc.) is applied at transport time via
       `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case. Mailing address columns are always null — Focus does
       not receive a separate mailing address from Finalsite.
@@ -19,11 +20,13 @@ models:
         data_type: string
         description:
           Focus student id (Focus `STDT_ID`) from
-          `int_finalsite__contact_id_attributes.focus_student_id`; null for
-          contacts where Finalsite has not minted the id.
+          `int_finalsite__contact_id_attributes.focus_student_id_prefixed`. Rows
+          for contacts without a minted Focus id are excluded from this extract.
         data_tests:
           - unique
-          - not_null
+          - not_null:
+              config:
+                severity: error
       - name: address
         data_type: string
         description: Primary street address line 1 from Finalsite (`address_1`).

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -7,12 +7,13 @@ models:
       guardian, grandparent, stepparent, relative, aunt/uncle) inner-joined to
       `stg_finalsite__contacts` for guardian attributes, gated to in-scope
       students via `int_finalsite__enrollment_lifecycle`. The student's Focus id
-      (`student_id`) is left-joined from `int_finalsite__contact_id_attributes`.
-      Produces 50 columns in `CONTACTS_LAYOUT` order. `SORT_ORDER` ranks
-      guardians per student by `is_primary desc` so the primary contact sorts
-      first. Phone slots `CONTACT1_*` and `CONTACT2_*` map the guardian's two
-      phones; `CONTACT3` through `CONTACT7` are always null. Focus column header
-      casing is applied at transport time via
+      (`student_id`) is inner-joined from
+      `int_finalsite__contact_id_attributes`, excluding students without a
+      minted Focus id. Produces 50 columns in `CONTACTS_LAYOUT` order.
+      `SORT_ORDER` ranks guardians per student by `is_primary desc` so the
+      primary contact sorts first. Phone slots `CONTACT1_*` and `CONTACT2_*` map
+      the guardian's two phones; `CONTACT3` through `CONTACT7` are always null.
+      Focus column header casing is applied at transport time via
       `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case.
     data_tests:
@@ -26,10 +27,12 @@ models:
         data_type: string
         description:
           Focus student id of the student this guardian belongs to, from
-          `int_finalsite__contact_id_attributes.focus_student_id`; null where
-          Finalsite has not minted the id.
+          `int_finalsite__contact_id_attributes.focus_student_id_prefixed`. Rows
+          for students without a minted Focus id are excluded from this extract.
         data_tests:
-          - not_null
+          - not_null:
+              config:
+                severity: error
       - name: sort_order
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__demographics.yml
@@ -4,11 +4,12 @@ models:
       One row per in-scope Finalsite student reshaped into the Focus
       `DEMOGRAPHICS` SFTP template layout. Joins `stg_finalsite__contacts` to
       `int_finalsite__enrollment_lifecycle` (the in-scope filter; grain =
-      `finalsite_enrollment_id`), then left joins
+      `finalsite_enrollment_id`), then inner joins
       `int_finalsite__contact_id_attributes` for the Focus student id
-      (`stdt_id`) and `int_finalsite__contact_custom_attributes` for race,
-      language, media-release, and Hispanic/Latino fields. Produces 42 columns
-      in `DEMOGRAPHICS_LAYOUT` order. Focus column header casing (`STDT_ID`,
+      (`stdt_id`), excluding contacts without a minted Focus id, and left joins
+      `int_finalsite__contact_custom_attributes` for race, language,
+      media-release, and Hispanic/Latino fields. Produces 42 columns in
+      `DEMOGRAPHICS_LAYOUT` order. Focus column header casing (`STDT_ID`,
       `LAST_NAME`, etc.) is applied at transport time via
       `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case. Race flags, language, photo permission, and
@@ -20,11 +21,13 @@ models:
         data_type: string
         description:
           Focus student id (Focus `STDT_ID`) from
-          `int_finalsite__contact_id_attributes.focus_student_id`; null for
-          contacts where Finalsite has not minted the id.
+          `int_finalsite__contact_id_attributes.focus_student_id_prefixed`. Rows
+          for contacts without a minted Focus id are excluded from this extract.
         data_tests:
           - unique
-          - not_null
+          - not_null:
+              config:
+                severity: error
       - name: last_name
         data_type: string
         description: Student last name from Finalsite.
@@ -202,15 +205,15 @@ unit_tests:
   - name: test_demographics_shape
     description:
       Verifies the 42-column DEMOGRAPHICS layout — STDT_ID is sourced from
-      int_finalsite__contact_id_attributes (null for a contact with no minted
-      id), DT_BIRTH is formatted as YYYYMMDD, GENDER is mapped to single-letter
-      code, ETHNIC_HL derives from
+      int_finalsite__contact_id_attributes, DT_BIRTH is formatted as YYYYMMDD,
+      GENDER is mapped to single-letter code, ETHNIC_HL derives from
       int_finalsite__contact_custom_attributes.latino_hispanic_yn. The second
       student has no custom-attributes row, confirming ETHNIC_HL is null (not
       'N') for an unknown while PHOTO_VID_PERM defaults to 'N'. The third
       student has a custom-attributes row whose lang_parent_ss has no crosswalk
       entry, confirming the language columns fall through to null (not the raw
-      label).
+      label). The fourth student has no int_finalsite__contact_id_attributes row
+      (no minted Focus id) and is excluded from the extract.
     model: rpt_focus__demographics
     given:
       - input: ref('stg_finalsite__contacts')
@@ -237,11 +240,18 @@ unit_tests:
               first_name: Worf,
               birth_date: 2011-01-10,
             }
+          - {
+              finalsite_enrollment_id: enr-004,
+              last_name: Kim,
+              first_name: Harry,
+              birth_date: 2010-07-04,
+            }
       - input: ref('int_finalsite__enrollment_lifecycle')
         rows:
           - { finalsite_enrollment_id: enr-001 }
           - { finalsite_enrollment_id: enr-002 }
           - { finalsite_enrollment_id: enr-003 }
+          - { finalsite_enrollment_id: enr-004 }
       - input: ref('int_finalsite__contact_custom_attributes')
         format: sql
         rows: |
@@ -268,6 +278,10 @@ unit_tests:
           select
             'enr-001' as finalsite_enrollment_id,
             '84001001001' as focus_student_id_prefixed
+          union all
+          select 'enr-002', '84001001002'
+          union all
+          select 'enr-003', '84001001003'
     expect:
       rows:
         - {
@@ -315,7 +329,7 @@ unit_tests:
             lcp_cont_stdt: null,
           }
         - {
-            stdt_id: null,
+            stdt_id: "84001001002",
             last_name: Doe,
             first_name: John,
             name_suffix: null,
@@ -359,7 +373,7 @@ unit_tests:
             lcp_cont_stdt: null,
           }
         - {
-            stdt_id: null,
+            stdt_id: "84001001003",
             last_name: Mara,
             first_name: Worf,
             name_suffix: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__linked_students.yml
@@ -25,7 +25,9 @@ models:
           Focus student ID of the student whose ID sorts first in the pair
           (least of the two IDs). From `int_finalsite__contact_id_attributes`.
         data_tests:
-          - not_null
+          - not_null:
+              config:
+                severity: error
       - name: secondary_student_id
         data_type: string
         description:
@@ -33,7 +35,9 @@ models:
           From the sibling contact's `int_finalsite__contact_id_attributes` row
           via `rel_id`.
         data_tests:
-          - not_null
+          - not_null:
+              config:
+                severity: error
 unit_tests:
   - name: test_linked_students_normalizes_pair
     description:

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -3,11 +3,13 @@ models:
     description:
       One row per in-scope Finalsite enrollment reshaped into the Focus
       `STUDENT_ENROLLMENT` SFTP template layout, built from
-      `int_finalsite__enrollment_lifecycle`. Grade is translated inline
-      (`k`→`KG`, else zero-padded number); enrollment_code is derived from grade
-      (`E05` for KG, `E01` otherwise) and does not change on transfer-out;
-      school maps via `int_people__location_crosswalk`; Focus student id
-      (`student_id`) via
+      `int_finalsite__enrollment_lifecycle`. Filtered to enrollments with a
+      minted Focus id and a start date — pre-enrollment students
+      (`enrollment_in_progress`, `assigned_school`) carry no `enrolled_date` and
+      are excluded until they enroll. Grade is translated inline (`k`→`KG`, else
+      zero-padded number); enrollment_code is derived from grade (`E05` for KG,
+      `E01` otherwise) and does not change on transfer-out; school maps via
+      `int_people__location_crosswalk`; Focus student id (`student_id`) via
       `int_finalsite__contact_id_attributes.focus_student_id_prefixed`; and the
       raw Florida state withdrawal label (carried as `drop_code`) from
       `int_finalsite__contact_custom_attributes` — together producing the
@@ -28,10 +30,13 @@ models:
         data_type: string
         description:
           Focus student id (Focus `STDT_ID`) from
-          `int_finalsite__contact_id_attributes.focus_student_id_prefixed`; null
-          for enrollments where Finalsite has not minted the id.
+          `int_finalsite__contact_id_attributes.focus_student_id_prefixed`. Rows
+          for enrollments without a minted Focus id are excluded from this
+          extract.
         data_tests:
-          - not_null
+          - not_null:
+              config:
+                severity: error
       - name: syear
         data_type: int64
         description: School year start year (e.g. 2025 for the 2025-26 year).
@@ -47,7 +52,7 @@ models:
         data_tests:
           - not_null:
               config:
-                severity: warn
+                severity: error
       - name: grade_id
         data_type: string
         description:
@@ -60,12 +65,13 @@ models:
       - name: start_date
         data_type: string
         description:
-          Enrollment start date formatted as `YYYYMMDD` for Focus. Null until
-          the student reaches enrolled status.
+          Enrollment start date formatted as `YYYYMMDD` for Focus. This extract
+          is filtered to enrollments that have a start date (pre-enrollment
+          students without an `enrolled_date` are excluded).
         data_tests:
           - not_null:
               config:
-                severity: warn
+                severity: error
       - name: enrollment_code
         data_type: string
         description:
@@ -180,7 +186,9 @@ unit_tests:
       kindergarten (`k`→`KG`); enrollment_code is E05 for KG and E01 otherwise;
       student_id is sourced from
       int_finalsite__contact_id_attributes.focus_student_id_prefixed; and
-      end_date/drop_code are null for non-transfer rows.
+      end_date/drop_code are null for non-transfer rows. A third enrollment with
+      a minted Focus id but no enrollment_start_date (pre-enrollment) is
+      excluded by the enrolled-only filter.
     model: rpt_focus__student_enrollment
     given:
       # format: sql (not dict) — is_transfer_out is added in this PR, so the
@@ -205,6 +213,16 @@ unit_tests:
             cast(null as string),
             'KIPP Royalty Academy',
             date '2025-08-12',
+            cast(null as date),
+            false
+          union all
+          select
+            'e4',
+            2025,
+            '6th',
+            cast(null as string),
+            'KIPP Royalty Academy',
+            cast(null as date),
             cast(null as date),
             false
       - input: ref('int_finalsite__contact_custom_attributes')
@@ -235,6 +253,10 @@ unit_tests:
           select
             'e3' as finalsite_enrollment_id,
             '84003003003' as focus_student_id_prefixed
+          union all
+          select
+            'e4' as finalsite_enrollment_id,
+            '84003003004' as focus_student_id_prefixed
     expect:
       rows:
         - {

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
@@ -18,6 +18,7 @@ from {{ ref("stg_finalsite__contacts") }} as c
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on c.finalsite_enrollment_id = l.finalsite_enrollment_id
-left join
+inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
     on c.finalsite_enrollment_id = ida.finalsite_enrollment_id
+    and ida.focus_student_id_prefixed is not null

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
@@ -67,9 +67,10 @@ inner join
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on rel.finalsite_enrollment_id = l.finalsite_enrollment_id
-left join
+inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
     on rel.finalsite_enrollment_id = ida.finalsite_enrollment_id
+    and ida.focus_student_id_prefixed is not null
 where
     rel.rel_type
     in ('parent', 'guardian', 'grandparent', 'stepparent', 'relative', 'aunt/uncle')

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__demographics.sql
@@ -77,9 +77,10 @@ from {{ ref("stg_finalsite__contacts") }} as c
 inner join
     {{ ref("int_finalsite__enrollment_lifecycle") }} as l
     on c.finalsite_enrollment_id = l.finalsite_enrollment_id
-left join
+inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
     on c.finalsite_enrollment_id = ida.finalsite_enrollment_id
+    and ida.focus_student_id_prefixed is not null
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
     on c.finalsite_enrollment_id = cca.finalsite_enrollment_id

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -59,12 +59,17 @@ select
     cast(null as int64) as fl_days_present,
     cast(null as int64) as fl_days_absent,
 from {{ ref("int_finalsite__enrollment_lifecycle") }} as l
-left join
+inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
     on l.finalsite_enrollment_id = ida.finalsite_enrollment_id
+    and ida.focus_student_id_prefixed is not null
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
     on l.finalsite_enrollment_id = cca.finalsite_enrollment_id
 left join
     {{ ref("int_people__location_crosswalk") }} as sch
     on l.assigned_school = sch.location_name
+-- enrolled-only: pre-enrollment statuses (enrollment_in_progress, assigned_school)
+-- carry no enrolled_date; Focus enrollment records require an entry date, so
+-- defer these students until Finalsite mints enrollment_start_date. See #4291.
+where l.enrollment_start_date is not null


### PR DESCRIPTION
## Summary and Motivation

When merged, this pull request will stop the `rpt_focus__*` Focus SFTP exports from emitting rows that should not ship to Focus — the warn-level test failures seen on run `da0535c5`.

Two fixes:

- **Null Focus student id.** `demographics`, `addresses`, `contacts`, and `student_enrollment` left-joined `int_finalsite__contact_id_attributes`, so contacts without a minted Focus id produced null-keyed rows (and collided on the uniqueness checks). Switched to an inner join filtering `focus_student_id_prefixed is not null`, matching the existing `rpt_focus__linked_students` idiom.
- **Pre-enrollment rows in STUDENT_ENROLLMENT.** The enrollment feed included `enrollment_in_progress` / `assigned_school` students with no `enrolled_date` (null `start_date` / `school_id`). Filtered to `enrollment_start_date is not null` (enrolled-only); those students remain in demographics / contacts / addresses.

Tightened `not_null` from warn to error on `student_id` / `stdt_id` (all exports) and on `student_enrollment` `start_date` and `school_id`. Updated unit-test fixtures to cover both exclusions.

All 3 affected students were SY2026-27 incoming; current-year exports are unchanged in shape.

### AI Assistance

Claude Code (systematic-debugging skill) diagnosed the warnings, verified the root cause against prod data, and authored the model / test / fixture changes. Human-directed: the enrolled-only scope decision and the choice to tighten tests to error.

## Self-review

### dbt

- [x] Properties files updated for all changed models (descriptions + tightened tests)
- [x] **Breaking change?** No columns renamed/removed. This filters rows OUT of the four export views (drops null-keyed and pre-enrollment rows) — a row-count reduction, not a schema break. Focus receives students once they have a minted id and an enrollment start date.
- [x] No external source changes
- [x] `dbt parse`, the 6 `extracts.focus` unit tests, and a `dbt build` of all 5 models + 18 data tests pass locally against prod-deferred upstreams (`--favor-state`)

## CI checks

- [ ] **Trunk** — passes (ran `trunk check` locally, clean)
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — not triggered (dbt-only change)

Closes #4291
Refs #4290
