### PR TITLE
feat(dagster): add nightly schedule for lattice user extract

### DIFF
--- a/src/teamster/code_locations/kipptaf/extracts/jobs.py
+++ b/src/teamster/code_locations/kipptaf/extracts/jobs.py
@@ -9,6 +9,7 @@ from teamster.code_locations.kipptaf.extracts.assets import (
     egencia_extract,
     idauto_extract,
     illuminate_extract_assets,
+    lattice_extract,
     littlesis_extract,
 )
 
@@ -30,6 +31,11 @@ egencia_extract_asset_job = define_asset_job(
 idauto_extract_asset_job = define_asset_job(
     name=f"{idauto_extract.key.to_python_identifier()}__asset_job",
     selection=[idauto_extract],
+)
+
+lattice_extract_asset_job = define_asset_job(
+    name=f"{lattice_extract.key.to_python_identifier()}__asset_job",
+    selection=[lattice_extract],
 )
 
 littlesis_extract_asset_job = define_asset_job(

--- a/src/teamster/code_locations/kipptaf/extracts/schedules.py
+++ b/src/teamster/code_locations/kipptaf/extracts/schedules.py
@@ -9,6 +9,7 @@ from teamster.code_locations.kipptaf.extracts.jobs import (
     egencia_extract_asset_job,
     idauto_extract_asset_job,
     illuminate_extract_asset_job,
+    lattice_extract_asset_job,
     littlesis_extract_asset_job,
 )
 
@@ -54,6 +55,12 @@ illuminate_extract_assets_schedule = ScheduleDefinition(
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 
+lattice_extract_assets_schedule = ScheduleDefinition(
+    job=lattice_extract_asset_job,
+    cron_schedule="0 3 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+)
+
 littlesis_extract_assets_schedule = ScheduleDefinition(
     job=littlesis_extract_asset_job,
     cron_schedule="0 3 * * *",
@@ -68,5 +75,6 @@ schedules = [
     egencia_extract_assets_schedule,
     idauto_extract_assets_schedule,
     illuminate_extract_assets_schedule,
+    lattice_extract_assets_schedule,
     littlesis_extract_assets_schedule,
 ]


### PR DESCRIPTION
## Summary & Motivation

> When merged, this pull request will schedule the existing Lattice user extract to refresh nightly.

The `lattice_extract` asset (`kipptaf/extracts/lattice/users_today_csv`) already queries `rpt_lattice__users` and uploads `users_{today}.csv` to the Lattice SFTP, but it had no automation. This adds a daily asset job and a `ScheduleDefinition` running at **3:00 AM America/New_York**, matching the existing daily-extract schedule pattern (coupa, egencia, illuminate, littlesis).

Two-file change following the established pattern:

- `extracts/jobs.py` — define `lattice_extract_asset_job`
- `extracts/schedules.py` — define `lattice_extract_assets_schedule` (`0 3 * * *`) and add it to the `schedules` list

No `assets.py`/`definitions.py` changes needed — `*extracts.schedules` is already spread into the location `Definitions`, and schedules auto-carry their jobs.

**Go-live note:** Dagster schedules ship stopped by default (no sibling extract schedule sets `default_status=RUNNING`). After deploy, toggle `lattice_extract_assets_schedule` **on** in the Dagster UI or it will not fire.

## AI Assistance

AI-assisted (Claude Code), human-directed. Claude located the asset, wrote the job/schedule following existing conventions, and verified wiring; the schedule time and go-live decision were human-directed.

## Self-review

### Dagster

- [x] Definitions import cleanly (`uv run python -c` import check — `definitions validate` errors locally on missing environment variables). Verified: schedule count 8→9, cron `0 3 * * *`, timezone `America/New_York`, job name `kipptaf__extracts__lattice__users_today_csv__asset_job`.
- [x] Follows the Library + Config extract pattern with correct asset key format.

### Docs

- [ ] **Automations catalog NOT regenerated in this PR.** `uv run scripts/gen-automations-doc.py` runs locally with only `kipppaterson` loadable (missing code-location environment variables), which would drop the other 4 locations from `docs/reference/automations.md`. Needs regeneration in a fully-loaded environment.

## CI checks

- [ ] Trunk — `trunk check` clean locally on both files.
- [ ] dbt Cloud — n/a (no dbt changes).
- [ ] Dagster Cloud — should pass; verify branch deployment loads the new schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)