### PR TITLE
fix(cube): join dates on raw date_key to survive non-UTC query timezone

### DIFF
--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -62,8 +62,12 @@ school_calendars) go in `cubes/conformed/`.
   resolutions: a compound join on the canonical path (see
   `student_attendance.yml` → `school_calendars`), or a degenerate FK with no
   declared join. Comment the choice.
-- **Time dimensions** must cast to `TIMESTAMP` in the dim's `sql:`; joins from
-  facts cast through (`CAST({CUBE}.date_key AS TIMESTAMP)`).
+- **Time dimensions** must cast to `TIMESTAMP` in the dim's `sql:` — but never
+  reference a time dimension in a join `sql:`. Cube substitutes the
+  query-timezone conversion (`convertTz`) into join predicates, so
+  `{dates.date_day} = CAST({CUBE}.date_key AS TIMESTAMP)` matches zero rows
+  under any non-UTC query timezone (#4298). Join on raw DATE keys instead
+  (`{dates.date_key} = {CUBE}.date_key`).
 - **Hidden helper measures** prefix with `_` and set `public: false` (see
   `_sum_attendance_value` building blocks).
 - **`meta.folders` is the only Cube-rendered `meta.*` key.** Put guidance in

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -52,6 +52,11 @@ META_CACHE_DIR = Path.home() / ".cache" / "teamster"
 META_CACHE_TTL_SECONDS = 60 * 60
 TIMEOUT_SECONDS = 55
 TOKEN_TTL_SECONDS = 5 * 60
+# All mart date columns are date-grain midnight-UTC; a non-UTC query timezone
+# makes Cube's convertTz shift dates-join predicates and day-granularity
+# results off by one day (#4298). Default queries to UTC unless the caller
+# explicitly asks for another timezone.
+DEFAULT_QUERY_TIMEZONE = "UTC"
 
 TRANSPORT_STDIO = "stdio"
 TRANSPORT_HTTP = "http"
@@ -308,6 +313,15 @@ async def _request(
         return body
 
 
+def _with_default_timezone(query: dict[str, Any]) -> dict[str, Any]:
+    """Return the query with timezone defaulted to UTC when the caller omits
+    it, so a deployment-level CUBEJS_DEFAULT_TIMEZONE can't silently shift
+    date-grain results (#4298). Caller-provided timezones pass through."""
+    if query.get("timezone"):
+        return query
+    return {**query, "timezone": DEFAULT_QUERY_TIMEZONE}
+
+
 def _meta_cache_path(email: str) -> Path:
     digest = hashlib.sha256(email.encode("utf-8")).hexdigest()[:16]
     return META_CACHE_DIR / f"cube-meta-{digest}.json"
@@ -372,10 +386,17 @@ async def load(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
 
     PII: `*_detail` view results carry row-level student identifiers — keep
     those values in the local conversation only.
+
+    Queries default to timezone UTC (mart dates are date-grain UTC); pass an
+    explicit `timezone` only when wall-clock conversion is intended.
     """
     email = await _get_user_email(ctx)
     return await _request(
-        "POST", "/load", json={"query": query}, email=email, poll=True
+        "POST",
+        "/load",
+        json={"query": _with_default_timezone(query)},
+        email=email,
+        poll=True,
     )
 
 
@@ -386,10 +407,16 @@ async def sql(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
     verifying access policies, or reviewing the compiled SQL before `load`.
 
     Response is wrapped: {"sql": {"status", "sql": [query-string, [params]], "query_type"}}.
+
+    Queries default to timezone UTC (mart dates are date-grain UTC); pass an
+    explicit `timezone` only when wall-clock conversion is intended.
     """
     email = await _get_user_email(ctx)
     return await _request(
-        "GET", "/sql", params={"query": json.dumps(query)}, email=email
+        "GET",
+        "/sql",
+        params={"query": json.dumps(_with_default_timezone(query))},
+        email=email,
     )
 
 

--- a/src/cube/model/cubes/staff/staff_work_history.yml
+++ b/src/cube/model/cubes/staff/staff_work_history.yml
@@ -100,10 +100,16 @@ cubes:
     joins:
       # One employment period spans many calendar days. Range (BETWEEN) join is
       # valid per cube conventions; relationship is one_to_many.
+      # Join on the raw DATE key, not the date_day time dimension — Cube wraps
+      # time dimensions in the query-timezone conversion (convertTz) inside
+      # join predicates, which shifts the dates side by the query timezone
+      # offset and matches dates one day off under any non-UTC timezone
+      # (#4298). Both effective_* columns are DATE, so this compares
+      # DATE BETWEEN DATE AND DATE with no cast.
       - name: dates
         sql: >
-          {dates.date_day} BETWEEN CAST({CUBE}.effective_start_date AS
-          TIMESTAMP) AND CAST({CUBE}.effective_end_date AS TIMESTAMP)
+          {dates.date_key} BETWEEN {CUBE}.effective_start_date AND
+          {CUBE}.effective_end_date
         relationship: one_to_many
 
       - name: staff

--- a/src/cube/model/cubes/student_assessments/student_assessment_administrations.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_administrations.yml
@@ -7,9 +7,12 @@ cubes:
       # administration date -> the conformed dates cube (no role-play); the fact
       # surfaces the completion date (date_taken) as an unjoined degenerate dim,
       # so dates is reached by a single path and there is no diamond.
+      # Join on the raw DATE key, not the date_day time dimension — Cube wraps
+      # time dimensions in the query-timezone conversion (convertTz) inside
+      # join predicates, which breaks the equality against the unconverted
+      # fact-side date under any non-UTC timezone (#4298).
       - name: dates
-        sql: >
-          {dates.date_day} = CAST({CUBE}.administered_date_key AS TIMESTAMP)
+        sql: "{dates.date_key} = {CUBE}.administered_date_key"
         relationship: many_to_one
 
       - name: student_assessments

--- a/src/cube/model/cubes/student_attendance/student_attendance.yml
+++ b/src/cube/model/cubes/student_attendance/student_attendance.yml
@@ -4,8 +4,12 @@ cubes:
     sql_table: kipptaf_marts.fct_student_attendance_daily
 
     joins:
+      # Join on the raw DATE key, not the date_day time dimension — Cube wraps
+      # time dimensions in the query-timezone conversion (convertTz) inside
+      # join predicates, which breaks the equality against the unconverted
+      # fact-side date under any non-UTC timezone (#4298).
       - name: dates
-        sql: "{dates.date_day} = CAST({CUBE}.date_key AS TIMESTAMP)"
+        sql: "{dates.date_key} = {CUBE}.date_key"
         relationship: many_to_one
 
       - name: student_school_enrollments

--- a/src/cube/model/cubes/students/student_enrollments.yml
+++ b/src/cube/model/cubes/students/student_enrollments.yml
@@ -4,8 +4,12 @@ cubes:
     sql_table: kipptaf_marts.fct_student_attendance_daily
 
     joins:
+      # Join on the raw DATE key, not the date_day time dimension — Cube wraps
+      # time dimensions in the query-timezone conversion (convertTz) inside
+      # join predicates, which breaks the equality against the unconverted
+      # fact-side date under any non-UTC timezone (#4298).
       - name: dates
-        sql: "{dates.date_day} = CAST({CUBE}.date_key AS TIMESTAMP)"
+        sql: "{dates.date_key} = {CUBE}.date_key"
         relationship: many_to_one
 
       # Location, student identity, grade, and status are all reached via

--- a/tests/cube/test_mcp_server.py
+++ b/tests/cube/test_mcp_server.py
@@ -271,3 +271,52 @@ def test_meta_in_memory_cache_skips_disk_read_on_repeat_calls(
     third = asyncio.run(server.meta(ctx))
     assert third == {"cubes": [{"name": "x"}]}
     assert call_count == 1
+
+
+def test_with_default_timezone_injects_utc_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _load_server(monkeypatch)
+    query = {"measures": ["student_attendance_summary.avg_daily_attendance"]}
+    result = server._with_default_timezone(query)
+    assert result["timezone"] == "UTC"
+    # Original query object is not mutated.
+    assert "timezone" not in query
+
+
+def test_with_default_timezone_preserves_caller_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _load_server(monkeypatch)
+    query = {"measures": ["x.count"], "timezone": "America/New_York"}
+    assert server._with_default_timezone(query) is query
+
+
+def test_load_and_sql_send_utc_timezone_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    server = _load_server(monkeypatch)
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+
+    sent: list[dict[str, Any]] = []
+
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args
+        sent.append(dict(kwargs))
+        return {"data": []}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+    ctx = MagicMock()
+
+    asyncio.run(server.load(ctx, {"measures": ["x.count"]}))
+    assert sent[0]["json"]["query"]["timezone"] == "UTC"
+
+    asyncio.run(server.sql(ctx, {"measures": ["x.count"]}))
+    assert json.loads(sent[1]["params"]["query"])["timezone"] == "UTC"
+
+    # Caller-provided timezone passes through untouched on both tools.
+    asyncio.run(
+        server.load(ctx, {"measures": ["x.count"], "timezone": "America/New_York"})
+    )
+    assert sent[2]["json"]["query"]["timezone"] == "America/New_York"


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix the dead `dates` joins behind the NULL `academic_year` / zero-row year-filter failures documented in #4298 (Refs #4298 — the Cube Cloud `CUBEJS_DEFAULT_TIMEZONE` deployment setting still needs a human change, so this PR does not close the issue).

Cube substitutes its query-timezone conversion (`convertTz`) into any join predicate that references a time dimension. Under the deployment default `America/New_York` timezone, every `{dates.date_day} = CAST(... AS TIMESTAMP)` join compiled to a predicate that matches **0 of 4,018 calendar dates** — all `dates`-sourced view members (`academic_year`, `academic_year_label`, `month_name`, ...) returned NULL and any year filter returned 0 rows, across the assessment, attendance, and enrollment views. The staff_work_history `BETWEEN` variant matched dates one day off instead.

Changes:

- **Four `dates` joins** (`student_assessment_administrations`, `student_attendance`, `student_enrollments`, `staff_work_history`) rewritten to raw DATE-key predicates (`{dates.date_key} = {CUBE}.date_key`, and DATE `BETWEEN` for the SCD2 range join) — timezone-immune regardless of what timezone a client passes. Same pattern the `school_calendars` join already uses.
- **Cube MCP server** (`src/cube/mcp/server.py`): `load`/`sql` now default `timezone` to UTC when the caller omits it (caller-provided timezones pass through). All mart date columns are date-grain midnight-UTC, so a wall-clock default also mis-dates day-granularity results by one day.
- **`src/cube/CLAUDE.md`**: join convention updated — never reference a time dimension in a join `sql:`.
- **Tests**: 3 new tests in `tests/cube/test_mcp_server.py` (18 pass).

Verified: the identical `/load` query that returns all-NULL `academic_year` under the deployment default returns correct years 2017–2025 with `timezone: UTC` (QA1 AY2025 = 236,100, matching the warehouse), and the raw DATE-key join predicate is what my direct BigQuery validation used (0 null `academic_year` across 489,751 rows).

Remaining (deployment, not in this PR): set `CUBEJS_DEFAULT_TIMEZONE` to UTC (or unset) in Cube Cloud per #4298.

## AI Assistance

Claude Code diagnosed the root cause (compiled-SQL comparison via the Cube `/sql` endpoint + BigQuery verification) and authored this PR end-to-end; human-directed scope decisions (branch strategy, timezone-fix-only scope, issue-first workflow).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip — no Dagster changes)_

### dbt _(skip — no dbt changes)_

### Docs _(skip — no schedule, sensor, or integration changes)_

## CI checks

- [ ] **Trunk** — passes. (Ran `.trunk/tools/trunk check --force` on all changed files locally: no issues.)
- [ ] **dbt Cloud** — expected no-op (no dbt models modified).
- [ ] **Dagster Cloud** — expected not triggered (no Dagster paths changed).

## Post-merge validation

Cube Cloud redeploys the model on merge to `main`; the MCP server redeploys via `deploy-cube-mcp.yaml` (`src/cube/mcp/**` changed). After both: re-run the #4298 repro query (`student_assessment_scores_summary` grouped by `academic_year`, filter `module_code = QA1`) with no explicit timezone — expect years 2017–2025, no null bucket, even before the deployment timezone variable is changed.
