### PR TITLE
chore(dagster): retime kippmiami focus/finalsite schedules off the midnight rush

### DIFF
--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -22,7 +22,7 @@ GCS bucket: `teamster-kippmiami`
 | `renlearn`    | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)     |
 | `extracts`    | BigQuery→SFTP | schedule                                  |
 | `couchdrop`   | sensor only   | sensor (Google Drive watcher)             |
-| `dlt/focus`   | dlt assets    | schedule (daily midnight ET)              |
+| `dlt/focus`   | dlt assets    | schedule (daily 04:00 ET)                 |
 
 ## Florida-Specific
 

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -12,7 +12,7 @@ asset_key_prefix = f"{CODE_LOCATION}/dlt/focus"
 
 focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__dlt__focus__daily_asset_job_schedule",
-    cron_schedule="0 0 * * *",
+    cron_schedule="0 4 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -14,7 +14,7 @@ powerschool_extract_assets_schedule = ScheduleDefinition(
 
 focus_extract_assets_schedule = ScheduleDefinition(
     job=focus_extract_asset_job,
-    cron_schedule="0 3 * * *",
+    cron_schedule="0 5 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -4,7 +4,7 @@ from teamster.code_locations.kippmiami import CODE_LOCATION, LOCAL_TIMEZONE
 
 finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    cron_schedule="0 0 * * *",
+    cron_schedule="0 4 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{CODE_LOCATION}/finalsite/contacts"],
 )


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will move the two kippmiami schedules that currently launch at midnight ET into the quiet overnight trough, avoiding the 12 AM top-of-hour fan-out that overloads the `autopilot-cluster-dagster-hybrid-1` GKE Autopilot cluster.

**Why:** Sampling per-node CPU on the cluster across several recent nights, the overnight load profile (all times ET) is:

| ET hour | load | note |
| --- | --- | --- |
| 00:00 | ~130-296 nodes / ~10-29 used cores | the midnight rush |
| 01:00 | ~27-35 nodes | midnight tail |
| 02:00 | ~118-124 nodes / ~10 cores | second sustained peak (PowerSchool ODBC + Coupa + Grow) |
| 03:00 | ~20-46 nodes | 03:00 batch |
| 04:00 | ~6-23 nodes / ~1-3 cores | deepest trough |
| 05:00 | ~9-17 nodes / ~1-2 cores | second-quietest |

So 04:00 and 05:00 are the only genuinely quiet windows before 6 AM.

**Changes (all `America/New_York`):**

- `dlt/focus` DLT: `0 0` to `0 4` (04:00)
- `finalsite` contacts: `0 0` to `0 4` (04:00) — no downstream scheduled consumer
- `extracts` **focus** extract: `0 3` to `0 5` (05:00)

The focus extract move preserves the freshness chain focus DLT to `rpt_focus__*` dbt models to the focus extract: DLT now lands at 04:00, so the extract must follow it. DLT loads run in minutes (e.g. the `students` table is ~3.5k rows in under 20s), so the 1-hour gap is ample. The PowerSchool extract stays at 03:00 (it does not depend on focus DLT).

## AI Assistance

Claude Code (human-directed): investigated the cluster load profile via GCP Monitoring, identified the focus DLT to extract dependency, proposed the retiming, and made the edits. The decision to also shift the focus extract (rather than keep focus DLT before 03:00) was made by the human.

## Self-review

### Dagster

- [ ] `uv run dagster definitions validate` — not runnable in the codespace (missing `FOCUS_DB` and other source credentials cause all locations to skip/error); deferred to the Dagster Cloud branch deploy. Locally verified via `py_compile` + module import of the finalsite/extracts schedules and AST inspection of the focus DLT schedule; all four cron values load as intended.
- [ ] `uv run pytest tests/test_dagster_definitions.py` — same local credential limitation; deferred to CI.
- Change is limited to three cron string literals; no asset key, IO manager, or integration-pattern changes.

### Docs

- [ ] `uv run scripts/gen-automations-doc.py` — **needs to be run in a credentialed environment.** In the codespace the script skips every code location (no source credentials) and rewrites `docs/reference/automations.md` with the content stripped out, so the regenerated file was reverted here rather than committed. Please regenerate on a machine with the source secrets so the catalog reflects the new times.

## CI checks

- [ ] **Trunk** — `fmt` passed at commit and pre-push check passed locally.
- [ ] **dbt Cloud** — no dbt changes; should be a no-op.
- [ ] **Dagster Cloud** — should run (touches `src/teamster/code_locations/kippmiami/**`); this is the authoritative definitions validation for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)