### PR TITLE
fix(finalsite): normalize Focus extract addresses, floor enrollment start dates, pull calendar dates

### DIFF
--- a/docs/superpowers/specs/references/focus-db-erd.md
+++ b/docs/superpowers/specs/references/focus-db-erd.md
@@ -16,8 +16,8 @@
 - **PK / FK** — Crow's Foot notation; a PK holds one distinct value, an FK may
   repeat (many-to-one).
 - **`syear`** — school-year start year (e.g. `2026` = SY2026-27), matching
-  Finalsite `school_year_start` and the `focus_enrollment_start_date_floor` var
-  convention.
+  Finalsite `school_year_start` and the `int_focus__school_year_first_day`
+  derivation grain.
 - **`school_id`** joins to `schools.id`; the district-facing school number is
   `schools.custom_327`. **`district_id`** joins to `districts.id`.
 - **Soft delete** — `deleted` is `NULL` for live rows and `1` for deleted, never

--- a/docs/superpowers/specs/references/focus-db-erd.md
+++ b/docs/superpowers/specs/references/focus-db-erd.md
@@ -1,0 +1,243 @@
+# Focus SIS database (Postgres) — ERD reference
+
+> Source: "Focus DB Diagram.pdf" (2024 User Conference FOCUS Database, ERD
+> Diagram; Focus School Software). A partial ERD in Crow's Foot notation
+> covering the most-queried tables. Errors/omissions →
+> `smooth@focusschoolsoftware.com`.
+>
+> This is the **database** schema (what the `dlt/focus` pull loads from the
+> Focus Postgres `public` schema into `dagster_kippmiami_dlt_focus`). For the
+> REST API surface, see `focus-api-spec.md`. For warehouse-query gotchas
+> (soft-delete sentinel, `custom_NNN` decode, join pitfalls), see
+> `src/dbt/focus/CLAUDE.md`.
+
+## Conventions
+
+- **PK / FK** — Crow's Foot notation; a PK holds one distinct value, an FK may
+  repeat (many-to-one).
+- **`syear`** — school-year start year (e.g. `2026` = SY2026-27), matching
+  Finalsite `school_year_start` and the `focus_enrollment_start_date_floor` var
+  convention.
+- **`school_id`** joins to `schools.id`; the district-facing school number is
+  `schools.custom_327`. **`district_id`** joins to `districts.id`.
+- **Soft delete** — `deleted` is `NULL` for live rows and `1` for deleted, never
+  `0` (see `src/dbt/focus/CLAUDE.md`).
+
+## Attendance calendar — singular vs plural (the trap)
+
+Two distinct tables, easy to confuse:
+
+| Table                  | Grain                         | Key columns                                                            |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------- |
+| `attendance_calendars` | one row per calendar (header) | PK `calendar_id`, FK `school_id`, `syear`, `title`, `default_calendar` |
+| `attendance_calendar`  | **one row per calendar day**  | PK `id`, FK `calendar_id`, FK `school_id`, `syear`, **`school_date`**  |
+
+`student_enrollment.calendar_id` → `attendance_calendars.calendar_id` (the
+header). The **actual in-session dates** live in the singular
+`attendance_calendar`, keyed back to the header by `calendar_id`.
+
+**First day of school** for a school year = `min(school_date)` in
+`attendance_calendar` for that `syear` (scope to the school's default calendar
+via `attendance_calendars.default_calendar`). This is the authoritative,
+registrar-maintained source for the enrollment start-date floor — independent of
+the Finalsite feed.
+
+Ingestion note: the `dlt/focus` pull historically loaded only
+`attendance_calendars` (header); `attendance_calendar` (dates) was added to
+`src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml` so the dates
+land in the warehouse.
+
+## Students, people, contacts
+
+| Table                    | PK           | Key FKs / columns                                                                                           |
+| ------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `students`               | `student_id` | `first_name`, `middle_name`, `last_name`, `custom_fields` (jsonb), `custom_*`                               |
+| `students_join_users`    | `id`         | FK `student_id`, `person_id`, `staff_id`                                                                    |
+| `students_join_people`   | `id`         | FK `student_id`, `person_id`; `student_relation`, `sort_order`, `pickup`, `custody`, `emergency`, `deleted` |
+| `students_join_students` | `id`         | FK `primary_student_id`, `secondary_student_id`                                                             |
+| `students_join_groups`   | `id`         | FK `group_id`, `student_id` (→ `student_groups.id`)                                                         |
+| `students_join_address`  | `id`         | FK `student_id`, `address_id`                                                                               |
+| `address`                | `address_id` | `address`, `address2`, `city`, `state`, `zipcode`                                                           |
+| `people`                 | `person_id`  | `first_name`, `middle_name`, `last_name`, `title`, `deleted`                                                |
+| `people_join_contacts`   | `id`         | FK `person_id`; `title`, `value`, `callout`, `sms`                                                          |
+
+`students` is the hub: `student_id` fans out to enrollment, attendance,
+schedule, grades, discipline, SSS. Guardian/contact chain: `students` →
+`students_join_people` → `people` → `people_join_contacts`.
+
+## Student enrollment
+
+`student_enrollment` (PK `id`) is the enrollment stint. Key FKs:
+
+- `student_id` → `students.student_id`
+- `school_id` → `schools.id`; `district_id` → `districts.id`
+- `grade_id` → `school_gradelevels.id`
+- `enrollment_code` → `student_enrollment_codes.id` (rows of `type` = Add)
+- `drop_code` → `student_enrollment_codes.id` (rows of `type` = Drop)
+- `calendar_id` → `attendance_calendars.calendar_id`
+- `team_id` → `scheduling_teams.id`
+- `graduation_requirement_program` → `grad_subject_programs.id`
+- plus `start_date`, `end_date`, `syear`
+
+Supporting: `student_enrollment_codes` (PK `id`, `short_name`, `title`, `type`),
+`school_gradelevels` (PK `id`, FK `school_id`, `short_name`, `title`),
+`scheduling_teams`, `grad_subject_programs`.
+
+## Attendance (day and period)
+
+| Table                  | PK                  | Key FKs / columns                                                                                                                  |
+| ---------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `attendance_day`       | `id`                | FK `student_id`, `marking_period_id`; `syear`, `school_date`, `daily_code`, `state_value`                                          |
+| `attendance_notes`     | `id`                | FK `attendance_day_id`, `student_id`                                                                                               |
+| `attendance_period`    | `id`                | FK `period_id`, `course_period_id`, `student_id`, `attendance_code`, `attendance_teacher_code`, `marking_period_id`; `school_date` |
+| `attendance_completed` | `id`                | FK `staff_id`, `school_id`, `period_id`, `course_period_id`; `school_date`, `syear`                                                |
+| `attendance_codes`     | `id`                | FK `school_id`; `syear`, `short_name`, `title`                                                                                     |
+| `marking_periods`      | `marking_period_id` | FK `school_id`; `syear`, `short_name`, `title`, `start_date`, `end_date`                                                           |
+
+`attendance_day` = daily attendance per student; `attendance_period` = per
+class-period attendance. `attendance_code` / `attendance_teacher_code` →
+`attendance_codes.id`.
+
+## Courses, course periods, schedule
+
+| Table             | PK                 | Key FKs / columns                                                                                                                                                                                                                                           |
+| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `master_courses`  | `course_id`        | FK `district_id`; `syear`, `short_name`                                                                                                                                                                                                                     |
+| `courses`         | `course_id`        | FK `school_id`, `grad_subject_id`(`_2`,`_3`), `subject_id`, `store_category_id`; `syear`, `short_name`, `title`                                                                                                                                             |
+| `course_subjects` | `subject_id`       | FK `school_id`; `short_name`, `title`                                                                                                                                                                                                                       |
+| `course_periods`  | `course_period_id` | FK `school_id`, `course_id`, `teacher_id`, `co_teacher_id1`–`10`, `marking_period_id`, `period_id`, `end_period_id`, `room`, `calendar_id`, `team_id`, `bell_schedule_id`, `grade_posting_scheme_id`, `grade_scale_id`, `standards_grade_scale_id`; `syear` |
+| `schedule`        | `id`               | FK `school_id`, `student_id`, `course_id`, `course_period_id`, `marking_period_id`; `syear`, `start_date`, `end_date`                                                                                                                                       |
+| `school_periods`  | `period_id`        | FK `school_id`                                                                                                                                                                                                                                              |
+| `co_teachers`     | —                  | FK `staff_id`, `course_period_id`, `school_id`                                                                                                                                                                                                              |
+| `co_teacher_days` | `id`               | FK `teacher_id`                                                                                                                                                                                                                                             |
+
+`course_periods` is the section (a course taught in a period by a teacher);
+`schedule` links a `student_id` to a `course_period_id`.
+
+## Grades, standards, gradebook
+
+- `student_report_card_grades` (PK `id`) — FK `school_id`, `student_id`,
+  `report_card_comment_id`, `report_card_grade_id`, `grade_scale_id`,
+  `marking_period_id`; `percent_grade`, `grade_title`, `credits`,
+  `credits_earned`, `course_num`, `course_title`, `syear`, FK `course_id`,
+  `grad_subject_id`.
+- `report_card_grades` (PK `id`) — FK `scale_id`, `school_id`; `grade_title`.
+- `report_card_grade_scales` (PK `id`) — `syear`, FK `school_id`,
+  `default_scale`.
+- `report_card_comments`, `student_report_card_grades_change_requests`,
+  `grade_change_request_reasons`.
+- `grad_subjects` / `grad_subject_credits` / `grad_subject_programs` /
+  `grad_subject_credit_course` / `grad_subject_credit_assessment` — graduation
+  requirement structure.
+- Standards: `student_standard_grades` (PK `id`; FK `standard_id`, `course_id`,
+  `course_period_id`, `student_id`, `marking_period_id`, `grade_scale_id`,
+  `report_card_grade_id`), `standards` (FK `category_1_id`..`category_4_id`),
+  `standard_categories_1`..`_4` (FK `rollover_id`), `standards_join_courses`.
+- Gradebook: `gradebook_grades` (FK `student_id`, `assignment_id`,
+  `standard_id`, `letter_grade`, `comment_codes`), `gradebook_assignments` (PK
+  `assignment_id`; FK `template_id`, `rubric_id`, `assignment_type_id`),
+  `gradebook_assignment_types`, `gradebook_templates` (FK `staff_id`, `schools`
+  delimited), `gradebook_*_join_course_periods`, `gradebook_comment_codes`.
+
+## Discipline
+
+`discipline_incidents` (PK `id`, FK `school_id`, `syear`) and
+`discipline_referrals` (PK `referral_id`; FK `attendance_code`,
+`attendance_period_id`, `school_id`, `student_id`, `merged_referral_id`,
+`tardy_threshold_id`; `referral_date`, `suspension_begin`, `suspension_end`)
+link via `discipline_incidents_join_referrals`. Codes/actions: `referral_codes`,
+`referral_code_offenses`, `referral_actions`, `referral_teacher_codes`,
+`tardy_threshold` (+ `_attendance_code`, `_school_period`), `letters` /
+`letter_queue` / `letter_triggers`.
+
+Note: `discipline_referrals` and `discipline_incidents` are custom-field
+`source_class` targets (see below).
+
+## Test history
+
+`test_history_administrations` (PK `id`; FK `test_id`, `student_id`,
+`fas_assignment_id`; `administration_date`) → `test_history_scores` (FK
+`administration_id`, `test_id`, `part_id`, `score_type_id`, `fas_section_id`,
+`student_id`; `test_code`, `score`). Reference: `test_history_tests`,
+`test_history_test_types`, `test_history_parts`, `test_history_score_types`,
+`test_history_score_ranges` (+ `_sublevels`), `eoc_scale` / `eoc_scale_sets`.
+
+## Users
+
+`users` (PK `staff_id`; `username`, `last_name`, `first_name`, `middle_name`,
+`ein`, FK `profiles`, `school_id`). Related: `user_enrollment` (FK `staff_id`,
+`profiles`, `erp_profiles`, `schools`; `start_date`, `end_date`),
+`user_profiles`, `permission` (FK `profile_id`, `key`), `user_permission`,
+`user_join_groups`, `login_history`, `teacher_student_flags`, `saved_reports`,
+`user_page_favorite`, `email_verification`, `email_notifications`.
+
+## Custom fields (critical for querying)
+
+The custom-field system spans several tables:
+
+- `custom_fields` (PK `id`) — the field **definition** catalog: `source_id`,
+  `source_class`, `type`, `code`, `column_name`, `alias`, `json`, `required`,
+  `deleted`, `computed_query`, `default_value`, `fallback_value`, `system`.
+- `custom_field_select_options` (PK `id`) — allowed values for `select` /
+  `multiple` fields: `source_id`, `source_class`, `code`, `label`.
+- `custom_field_log_columns` / `custom_field_log_entries` — `log`-type field
+  values.
+- `custom_fields_join_categories`, `custom_field_categories`,
+  `custom_field_categories_join_schools`,
+  `custom_field_categories_join_profiles`.
+
+**`source_class` → entity table + key** (join `custom_fields.source_id` to):
+
+| `source_class`          | Table                  | Key          |
+| ----------------------- | ---------------------- | ------------ |
+| `SISStudent`            | `students`             | `student_id` |
+| `FocusUser`             | `users`                | `staff_id`   |
+| `SISSchool`             | `schools`              | `id`         |
+| `SISDistrict`           | `districts`            | `id`         |
+| `SISDisciplineReferral` | `discipline_referrals` | `id`         |
+| `SISDisciplineIncident` | `discipline_incidents` | `id`         |
+
+**Value storage by field `type`:**
+
+| Type                          | Stored as                                                                                      |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `checkbox`                    | char — `null`, `N`, or `Y`                                                                     |
+| `date`                        | timestamp                                                                                      |
+| `select`                      | `bigint` → `custom_field_select_options.id`                                                    |
+| `multiple`                    | delimited list of `custom_field_select_options.id`                                             |
+| `numeric`                     | numeric                                                                                        |
+| `text` / `textarea`           | text                                                                                           |
+| `signature` / `time`          | varchar                                                                                        |
+| `json`                        | key/value pairs in `students.custom_fields` (jsonb); key = `column_name`                       |
+| `computed` / `computed_table` | not materialized — query lives in `custom_fields.computed_query`, resolvable only inside Focus |
+| `file`                        | pointer to `focus_files.source_id`                                                             |
+| `holder`                      | UI layout placeholder (no data)                                                                |
+| `log`                         | pointer to `custom_field_log_entries`                                                          |
+
+Values live inline on the entity's wide `custom_NNN` columns (e.g.
+`students.custom_327` = school number on `schools`). See
+`src/dbt/focus/CLAUDE.md` for the decode mechanics (match stored value against
+both `id` and `code`; `column_name` is uppercase in the catalog but lowercase on
+the entity table; filter `custom_field_select_options.source_class`).
+
+## Other domains (table inventories)
+
+- **School choice** — `school_choice_applications`, `_application_status`,
+  `_application_notes`, `_status`, `_programs`, `_program_categories`,
+  `_program_continuities`, `_program_seats`, `_zones`, `_tours_auditions` (+
+  `_types`).
+- **SSS (student support services)** — events/forms (`sss_events`,
+  `sss_event_instances`, `sss_forms`, `sss_form_instances`, `sss_event_steps` /
+  `_step_instances`, `sss_accommodations` (+ options / categories),
+  `sss_meeting_minutes`, `sss_tasks`, `sss_programs`, `sss_permissions`) and
+  goals/caseload (`sss_goals`, `sss_pmp_goals`, `sss_pmp_setup` /
+  `_data_points`, `sss_services`, `sss_service_code` (+ `_provider`),
+  `sss_caseload` / `_group` / `_service` (+ `_icd10`), `sss_progress_codes` /
+  `_updates`).
+- **Communication** — `communication_messages`, `_announcements`,
+  `_message_schools` / `_profiles` / `_recipients`, `_attendance_messages`,
+  `_schedules`, `_templates`, `_text`, `_audio`, `_queue`, `languages`.
+- **Formbuilder** — `formbuilder_forms`, `_components`, `_data`, `_instances`,
+  `_drafts`, `_revisions`, `_translations`, `_headers` / `_header_instances`,
+  `_collections`, `_objects`, `_actions`, `_tags` / `_join_tags`,
+  `_join_profiles`, `_form_fees`, `form_requests`.

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -132,19 +132,29 @@ models:
         description: Contact's date of birth, cast from the source string.
       - name: address_1
         data_type: string
-        description: Line 1 of the primary household address.
+        description:
+          Line 1 of the primary household address; blank values normalized to
+          null.
       - name: address_2
         data_type: string
-        description: Line 2 of the primary household address.
+        description:
+          Line 2 of the primary household address; blank values normalized to
+          null.
       - name: city
         data_type: string
-        description: City of the primary household address.
+        description:
+          City of the primary household address; blank values normalized to
+          null.
       - name: state
         data_type: string
-        description: State of the primary household address.
+        description:
+          State of the primary household address, uppercased; blank values
+          normalized to null.
       - name: zip
         data_type: string
-        description: ZIP code of the primary household address.
+        description:
+          ZIP code of the primary household address; blank values normalized to
+          null.
       - name: country
         data_type: string
         description: Country of the primary household address.

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -37,10 +37,13 @@ select
 
     safe_cast(birth_date as date) as birth_date,
 
-    households[safe_offset(0)].address_1 as address_1,
-    households[safe_offset(0)].address_2 as address_2,
-    households[safe_offset(0)].city as city,
-    households[safe_offset(0)].state as state,
-    households[safe_offset(0)].zip as zip,
+    -- normalize the household address: Finalsite emits empty strings (not null)
+    -- and mixed-case states, which flow unchanged into the Focus ADDRESS and
+    -- CONTACTS feeds. Blank -> null; uppercase the state code.
+    nullif(trim(households[safe_offset(0)].address_1), '') as address_1,
+    nullif(trim(households[safe_offset(0)].address_2), '') as address_2,
+    nullif(trim(households[safe_offset(0)].city), '') as city,
+    nullif(upper(trim(households[safe_offset(0)].state)), '') as state,
+    nullif(trim(households[safe_offset(0)].zip), '') as zip,
     households[safe_offset(0)].country as country,
 from {{ source("finalsite", "contacts") }}

--- a/src/dbt/focus/CLAUDE.md
+++ b/src/dbt/focus/CLAUDE.md
@@ -4,6 +4,19 @@ Source-system staging project for **Focus SIS** data (PostgreSQL). Provides the
 BigQuery source definitions for Focus dlt loads, consumed by district-specific
 dbt projects (currently `kippmiami`).
 
+## Schema reference
+
+Full Focus DB ERD reference: `docs/superpowers/specs/references/focus-db-erd.md`
+— table groups, PK/FK join keys, custom-field storage, and the
+`attendance_calendar` (per-day school dates) vs `attendance_calendars` (calendar
+headers) distinction. First day of school = `min(school_date)` per `syear` over
+`default_calendar = 'Y'` calendars (`int_focus__school_year_first_day`).
+
+The kipptaf `rpt_focus__*` SFTP extracts keep a `trunk-ignore(sqlfluff/ST06)` —
+the Focus import column order is contract-fixed. ST06 firing is
+expression-shape-dependent, so keep the ignore even when a diff makes it look
+vestigial.
+
 ## Data Flow
 
 Focus Postgres → dlt `sql_database` → BigQuery (`dagster_<project>_dlt_focus`) →
@@ -106,3 +119,9 @@ This project is never run standalone in production. District projects reference
 it as a dbt package and override variables. `{{ project_name }}` in source
 definitions resolves to the consuming district project name, enabling correct
 Dagster asset key lineage.
+
+To add a NEW kipptaf dependency on Focus data in a single PR, declare the dlt
+landing dataset (`dagster_kippmiami_dlt_focus`) as a BQ-native
+`sources-bigquery.yml` source (hardcoded schema, no target branch) — it reads
+prod in all targets, so kipptaf CI resolves it without seeding `zz_stg`. Only
+the raw dlt tables exist in prod pre-merge; district `stg_focus__*` do not.

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -31,6 +31,13 @@ vars:
   current_academic_year: 2025
   current_fiscal_year: 2026
 
+  # First attendance calendar date (first day of school) for the active
+  # Finalsite -> Focus enrollment feed year. Finalsite emits pre-first-day
+  # enrolled_dates (contract/registration dates); Focus matches enrollment on
+  # this date. Authoritative, human-maintained — bump each July with the year's
+  # first day of school. See rpt_focus__student_enrollment.
+  focus_enrollment_start_date_floor: "2026-08-11"
+
 models:
   kipptaf:
     act:

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -31,13 +31,6 @@ vars:
   current_academic_year: 2025
   current_fiscal_year: 2026
 
-  # First attendance calendar date (first day of school) for the active
-  # Finalsite -> Focus enrollment feed year. Finalsite emits pre-first-day
-  # enrolled_dates (contract/registration dates); Focus matches enrollment on
-  # this date. Authoritative, human-maintained — bump each July with the year's
-  # first day of school. See rpt_focus__student_enrollment.
-  focus_enrollment_start_date_floor: "2026-08-11"
-
 models:
   kipptaf:
     act:
@@ -124,6 +117,8 @@ models:
       +schema: finance
     fldoe:
       +schema: fldoe
+    focus:
+      +schema: focus
     google:
       appsheet:
         +schema: google_appsheet

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -257,6 +257,10 @@ unit_tests:
           select
             'e4' as finalsite_enrollment_id,
             '84003003004' as focus_student_id_prefixed
+      - input: ref('int_focus__school_year_first_day')
+        format: sql
+        rows: |
+          select 2025 as syear, date '2025-08-11' as first_day_of_school
     expect:
       rows:
         - {
@@ -360,6 +364,10 @@ unit_tests:
           select
             'e2' as finalsite_enrollment_id,
             '84003003002' as focus_student_id_prefixed
+      - input: ref('int_focus__school_year_first_day')
+        format: sql
+        rows: |
+          select 2025 as syear, date '2025-08-11' as first_day_of_school
     expect:
       rows:
         - {
@@ -394,12 +402,11 @@ unit_tests:
           }
   - name: test_student_enrollment_start_date_floor
     description:
-      Verifies the active-year start-date floor — a current-year enrollment that
-      starts before the school year's first day (var
-      focus_enrollment_start_date_floor) is raised to that date, a current-year
-      enrollment starting after it is left unchanged, and a prior-year
-      enrollment before the floor date is not touched (the floor is gated to the
-      var's school year).
+      Verifies the per-school-year start-date floor derived from
+      int_focus__school_year_first_day — an enrollment starting before its
+      school year's first day is raised to that date, one starting on/after it
+      is left unchanged, each year uses its own first day, and a year with no
+      calendar row leaves the start date unchanged.
     model: rpt_focus__student_enrollment
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -434,6 +441,16 @@ unit_tests:
             date '2025-07-10',
             cast(null as date),
             false
+          union all
+          select
+            'ef4',
+            2099,
+            '4th',
+            cast(null as string),
+            'KIPP Royalty Academy',
+            date '2099-05-01',
+            cast(null as date),
+            false
       - input: ref('int_finalsite__contact_custom_attributes')
         format: sql
         rows: |
@@ -445,6 +462,8 @@ unit_tests:
           select 'ef2', cast(null as string), cast(null as string)
           union all
           select 'ef3', cast(null as string), cast(null as string)
+          union all
+          select 'ef4', cast(null as string), cast(null as string)
       - input: ref('int_people__location_crosswalk')
         format: sql
         rows: |
@@ -461,6 +480,14 @@ unit_tests:
           select 'ef2', '84009009002'
           union all
           select 'ef3', '84009009003'
+          union all
+          select 'ef4', '84009009004'
+      - input: ref('int_focus__school_year_first_day')
+        format: sql
+        rows: |
+          select 2026 as syear, date '2026-08-11' as first_day_of_school
+          union all
+          select 2025, date '2025-08-11'
     expect:
       rows:
         - {
@@ -528,7 +555,37 @@ unit_tests:
             school_id: "0001",
             student_id: "84009009003",
             grade_id: "03",
-            start_date: "20250710",
+            start_date: "20250811",
+            enrollment_code: E01,
+            end_date: null,
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2099,
+            school_id: "0001",
+            student_id: "84009009004",
+            grade_id: "04",
+            start_date: "20990501",
             enrollment_code: E01,
             end_date: null,
             drop_code: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -392,3 +392,164 @@ unit_tests:
             fl_days_present: null,
             fl_days_absent: null,
           }
+  - name: test_student_enrollment_start_date_floor
+    description:
+      Verifies the active-year start-date floor — a current-year enrollment that
+      starts before the school year's first day (var
+      focus_enrollment_start_date_floor) is raised to that date, a current-year
+      enrollment starting after it is left unchanged, and a prior-year
+      enrollment before the floor date is not touched (the floor is gated to the
+      var's school year).
+    model: rpt_focus__student_enrollment
+    given:
+      - input: ref('int_finalsite__enrollment_lifecycle')
+        format: sql
+        rows: |
+          select
+            'ef1' as finalsite_enrollment_id,
+            2026 as school_year_start,
+            '1st' as grade_canonical_name,
+            cast(null as string) as promotion_status,
+            'KIPP Royalty Academy' as assigned_school,
+            date '2026-07-15' as enrollment_start_date,
+            cast(null as date) as enrollment_end_date,
+            false as is_transfer_out
+          union all
+          select
+            'ef2',
+            2026,
+            '2nd',
+            cast(null as string),
+            'KIPP Royalty Academy',
+            date '2026-09-02',
+            cast(null as date),
+            false
+          union all
+          select
+            'ef3',
+            2025,
+            '3rd',
+            cast(null as string),
+            'KIPP Royalty Academy',
+            date '2025-07-10',
+            cast(null as date),
+            false
+      - input: ref('int_finalsite__contact_custom_attributes')
+        format: sql
+        rows: |
+          select
+            'ef1' as finalsite_enrollment_id,
+            cast(null as string) as withdrawal_school_txt,
+            cast(null as string) as fl_state_withdraw_codes_ss
+          union all
+          select 'ef2', cast(null as string), cast(null as string)
+          union all
+          select 'ef3', cast(null as string), cast(null as string)
+      - input: ref('int_people__location_crosswalk')
+        format: sql
+        rows: |
+          select
+            'KIPP Royalty Academy' as location_name,
+            '0001' as location_focus_school_id
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'ef1' as finalsite_enrollment_id,
+            '84009009001' as focus_student_id_prefixed
+          union all
+          select 'ef2', '84009009002'
+          union all
+          select 'ef3', '84009009003'
+    expect:
+      rows:
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84009009001",
+            grade_id: "01",
+            start_date: "20260811",
+            enrollment_code: E01,
+            end_date: null,
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84009009002",
+            grade_id: "02",
+            start_date: "20260902",
+            enrollment_code: E01,
+            end_date: null,
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2025,
+            school_id: "0001",
+            student_id: "84009009003",
+            grade_id: "03",
+            start_date: "20250710",
+            enrollment_code: E01,
+            end_date: null,
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -1,4 +1,3 @@
--- trunk-ignore(sqlfluff/ST06): column order fixed by Focus STUDENT_ENROLLMENT contract
 select
     l.school_year_start as syear,
 
@@ -13,7 +12,22 @@ select
         lpad(regexp_extract(l.grade_canonical_name, r'\d+'), 2, '0')
     ) as grade_id,
 
-    format_date('%Y%m%d', l.enrollment_start_date) as start_date,
+    -- Finalsite emits pre-first-day enrolled_dates (contract/registration
+    -- dates); Focus matches enrollment on the first attendance calendar date, so
+    -- floor the start date up to the school year's first day for the active feed
+    -- year. Gated to the var's school year so prior-year rows (which can carry
+    -- legitimate summer start dates) are untouched.
+    format_date(
+        '%Y%m%d',
+        if(
+            l.school_year_start = {{ var("focus_enrollment_start_date_floor")[:4] }},
+            greatest(
+                l.enrollment_start_date,
+                date('{{ var("focus_enrollment_start_date_floor") }}')
+            ),
+            l.enrollment_start_date
+        )
+    ) as start_date,
 
     -- enrollment_code is the entry action and does not change on transfer_out;
     -- a withdrawal is expressed by drop_code + end_date, not by clearing the

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -1,3 +1,4 @@
+-- trunk-ignore(sqlfluff/ST06): column order fixed by Focus STUDENT_ENROLLMENT contract
 select
     l.school_year_start as syear,
 
@@ -14,18 +15,14 @@ select
 
     -- Finalsite emits pre-first-day enrolled_dates (contract/registration
     -- dates); Focus matches enrollment on the first attendance calendar date, so
-    -- floor the start date up to the school year's first day for the active feed
-    -- year. Gated to the var's school year so prior-year rows (which can carry
-    -- legitimate summer start dates) are untouched.
+    -- floor the start date up to the school year's first day (derived per school
+    -- year from the Focus attendance calendar). Rows already on/after the first
+    -- day, and years with no calendar, are left unchanged.
     format_date(
         '%Y%m%d',
-        if(
-            l.school_year_start = {{ var("focus_enrollment_start_date_floor")[:4] }},
-            greatest(
-                l.enrollment_start_date,
-                date('{{ var("focus_enrollment_start_date_floor") }}')
-            ),
-            l.enrollment_start_date
+        greatest(
+            l.enrollment_start_date,
+            coalesce(fd.first_day_of_school, l.enrollment_start_date)
         )
     ) as start_date,
 
@@ -83,6 +80,9 @@ left join
 left join
     {{ ref("int_people__location_crosswalk") }} as sch
     on l.assigned_school = sch.location_name
+left join
+    {{ ref("int_focus__school_year_first_day") }} as fd
+    on l.school_year_start = fd.syear
 -- enrolled-only: pre-enrollment statuses (enrollment_in_progress, assigned_school)
 -- carry no enrolled_date; Focus enrollment records require an entry date, so
 -- defer these students until Finalsite mints enrollment_start_date. See #4291.

--- a/src/dbt/kipptaf/models/focus/intermediate/int_focus__school_year_first_day.sql
+++ b/src/dbt/kipptaf/models/focus/intermediate/int_focus__school_year_first_day.sql
@@ -1,0 +1,17 @@
+with
+    default_calendars as (
+        select calendar_id, syear,
+        from {{ source("kippmiami_dlt_focus", "attendance_calendars") }}
+        where default_calendar = 'Y'
+    ),
+
+    calendar_days as (
+        select calendar_id, school_date,
+        from {{ source("kippmiami_dlt_focus", "attendance_calendar") }}
+        where minutes > 0
+    )
+
+select dc.syear, min(cd.school_date) as first_day_of_school,
+from default_calendars as dc
+inner join calendar_days as cd on dc.calendar_id = cd.calendar_id
+group by dc.syear

--- a/src/dbt/kipptaf/models/focus/intermediate/properties/int_focus__school_year_first_day.yml
+++ b/src/dbt/kipptaf/models/focus/intermediate/properties/int_focus__school_year_first_day.yml
@@ -1,0 +1,22 @@
+models:
+  - name: int_focus__school_year_first_day
+    description: >-
+      First day of school per Focus school year, derived as the earliest
+      instructional date (minutes greater than zero) across that year's default
+      attendance calendars. Sourced from the Focus dlt landing tables
+      attendance_calendar (per-day dates) and attendance_calendars (headers).
+      Used to floor Finalsite-sourced enrollment start dates to the first day of
+      school so they match Focus enrollment records.
+    columns:
+      - name: syear
+        description: Focus school year start year (e.g. 2026 = 2026-27).
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: first_day_of_school
+        description:
+          Earliest instructional date across the year's default calendars.

--- a/src/dbt/kipptaf/models/focus/intermediate/properties/int_focus__school_year_first_day.yml
+++ b/src/dbt/kipptaf/models/focus/intermediate/properties/int_focus__school_year_first_day.yml
@@ -3,10 +3,13 @@ models:
     description: >-
       First day of school per Focus school year, derived as the earliest
       instructional date (minutes greater than zero) across that year's default
-      attendance calendars. Sourced from the Focus dlt landing tables
-      attendance_calendar (per-day dates) and attendance_calendars (headers).
-      Used to floor Finalsite-sourced enrollment start dates to the first day of
-      school so they match Focus enrollment records.
+      attendance calendars. This is the network-earliest first day across all
+      schools' default calendars (Miami schools currently share a single first
+      day); the value is joined on school year alone, so it is not per-school.
+      Sourced from the Focus dlt landing tables attendance_calendar (per-day
+      dates) and attendance_calendars (headers). Used to floor Finalsite-sourced
+      enrollment start dates to the first day of school so they match Focus
+      enrollment records.
     columns:
       - name: syear
         description: Focus school year start year (e.g. 2026 = 2026-27).

--- a/src/dbt/kipptaf/models/focus/sources-bigquery.yml
+++ b/src/dbt/kipptaf/models/focus/sources-bigquery.yml
@@ -1,0 +1,29 @@
+sources:
+  - name: kippmiami_dlt_focus
+    description: >-
+      Focus SIS tables landed directly to BigQuery by the kippmiami Focus dlt
+      pull (dagster_kippmiami_dlt_focus). Read here pre-staging for the school
+      calendar lookup; the dlt dataset is a stable production location with no
+      branch-deployment redirect.
+    schema: dagster_kippmiami_dlt_focus
+    tables:
+      - name: attendance_calendar
+        description: Per-day school calendar dates, one row per calendar day.
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kippmiami
+                - dlt
+                - focus
+                - attendance_calendar
+      - name: attendance_calendars
+        description: Attendance calendar headers, one row per calendar.
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kippmiami
+                - dlt
+                - focus
+                - attendance_calendars

--- a/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
@@ -18,6 +18,7 @@ assets:
   - table_name: districts
   - table_name: scheduling_teams
   - table_name: attendance_calendars
+  - table_name: attendance_calendar
   - table_name: grad_subject_programs
   # Attendance Day
   - table_name: attendance_day

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -44,3 +44,9 @@ asset materialization metadata before investigating.
 
 Focus uses an IP allowlist. Codespace cannot reach the database. Connection
 verification requires a branch deployment (GKE has static egress IP).
+
+Branch-deployment dlt runs write to the **prod** BQ dataset
+(`dagster_<district>_dlt_focus`) — dlt has no branch-deployment redirect (unlike
+the GCS IO managers). A newly-configured table can be materialized in the branch
+deployment and then queried directly via BigQuery MCP to verify the load; note
+it is not isolated from prod for that source.


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will fix two data-quality issues in the Focus SFTP extract views (surfaced by profiling `kipptaf_extracts.rpt_focus__*`, tracked in #4302), pull the Focus attendance-calendar dates, derive the enrollment start-date floor from them, and add a reusable Focus DB schema reference.

1. **Normalize household address values** — `stg_finalsite__contacts` passed `households[0]` fields through raw, so Finalsite empty strings (not null) and mixed-case states (`Fl`) flowed into the Focus `ADDRESS` and `CONTACTS` feeds. Now blank becomes null and state is uppercased. Value-only change in the `finalsite` package staging model; flows up through the `union_relations` view to both extracts. Verified against prod data: 0 empty/lowercase residuals after the transform.

2. **Floor enrollment start dates to the first day of school** — `rpt_focus__student_enrollment.start_date` carried the Finalsite `enrolled_date` (a contract/registration date before the school year starts), so SY26-27 rows failed to match Focus enrollment records (which key on the first attendance calendar date). Now floored up to each school year's first day via `greatest(start, coalesce(first_day, start))`. Verified against prod: 1,585 active-year rows raised to `2026-08-11`, prior-year mid-year enrollees (Nov / Feb) untouched.

3. **Derive the first day of school from the Focus calendar** — added the `attendance_calendar` (per-day dates) table to the kippmiami Focus dlt pull, and a new `int_focus__school_year_first_day` (kipptaf) that computes `min(school_date)` over each year's default calendars (instructional days only), read via a BQ-native source over `dagster_kippmiami_dlt_focus`. This replaces an earlier hardcoded var — the floor is now data-driven and self-maintaining. Confirmed the derived date matches the registrar calendar exactly (SY2026 = `2026-08-11` across all 10 default calendars).

4. **Focus DB ERD reference** — added `docs/superpowers/specs/references/focus-db-erd.md`, a reusable schema reference distilled from the Focus DB ERD (table groups, PK/FK connecting keys, custom-field storage and `source_class` map, and the `attendance_calendar` vs `attendance_calendars` distinction). Complements the existing `focus-api-spec.md`.

**Deploy note:** address normalization lands in the `finalsite` package (builds into kippmiami); the floor, `int_focus__school_year_first_day`, and rpt change land in `kipptaf`; the calendar pull is a kippmiami Dagster asset. The kipptaf source reads the `dagster_kippmiami_dlt_focus` dlt dataset directly (stable prod location, no branch redirect), so kipptaf CI resolves it. After merge, `stg_finalsite__contacts` must rebuild in kippmiami prod for the normalization to reach the feed. Confirm `deploy-prod-kippmiami.yaml` push-paths include `src/dbt/finalsite/**` and `src/teamster/code_locations/kippmiami/**`.

## AI Assistance

Authored by Claude Code. Human-directed: the profiling scope, the call to pull `attendance_calendar` and derive the floor from it (rather than a maintained var), and the branch/issue workflow. Claude did the profiling, root-cause tracing, ERD internalization, implementation, unit tests, and verification.

## Self-review

### Dagster

- [x] `attendance_calendar` wires into the asset factory and daily schedule from the config list (verified the YAML parses; new key `kippmiami/dlt/focus/attendance_calendar`). Materialized via the branch deployment; confirmed 15,227 rows land in `dagster_kippmiami_dlt_focus`.

### dbt

- [x] `int_focus__school_year_first_day` has a `unique` + `not_null` PK test on `syear`; builds locally and returns one row per year with the correct first day.
- [x] `rpt_focus__student_enrollment` unit tests updated to mock the derived model (per-syear floor + no-calendar guard); all focus-extract unit tests pass.
- [x] Not a breaking change — no column renames or removals; contracts unchanged.
- [x] No external source add/modify — the address change is a value-only staging edit; the kipptaf focus source is BQ-native (dlt dataset).

## CI checks

- [x] **Trunk** — passes locally on all changed files.
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — expected to run (kippmiami dlt asset added).

Closes #4302