### PR TITLE
feat(finalsite): filter Focus enrollment extract to new and changed rows

### DIFF
--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -94,6 +94,41 @@ start date yet) are held back and not sent until they enroll.
 > minted ID; the enrollment record waits for the start date. This is expected —
 > the enrollment flows to Focus once Finalsite records the start date.
 
+### Enrollment start date — aligned to the first day of school
+
+Finalsite often records an enrollment's start date as the **registration or
+contract date**, which can fall weeks before school actually starts. Focus
+records enrollments as of the **first day of school**. To make the two line up,
+the pipeline raises any start date that falls before the first day up to the
+first day of school; a start date already on or after the first day is left
+unchanged (so a genuine mid-year enrollment keeps its real date).
+
+The first day of school is read from **Focus's own attendance calendar** (the
+earliest instructional day of the year), so it always matches what Focus expects
+— for 2026-27 that is August 11, 2026. A school year with no calendar in Focus
+yet leaves its start dates unchanged.
+
+> **This is what lets the enrollment feed match cleanly.** Because the start
+> date is aligned to Focus's first day, a student already enrolled in Focus is
+> recognized as the same enrollment instead of being re-sent with a date that
+> doesn't line up.
+
+### How the pipeline knows Focus already has an enrollment
+
+An enrollment counts as "already in Focus" when Focus has a record for the same
+**student, school year, and start date** — the three values that mean the same
+thing in both systems. Matched enrollments are not re-sent (see the exception
+for withdrawals below).
+
+School, grade, and entry code are **not** used to decide this. Focus stores its
+own internal codes for them and translates the imported values on load, so they
+never match on a literal comparison even when they describe the same school and
+grade — comparing them would make every record look new.
+
+The one thing that will still be sent for a matched enrollment is a **new
+withdrawal**: if the extract now has an end date or drop code and the Focus
+record has none, that exit is filled in (see Withdraw / drop codes above).
+
 ### What gets sent
 
 Every feed follows the same import-once rule — a record is sent only when Focus
@@ -114,6 +149,18 @@ Finalsite ID and moves the start date forward). The pipeline ensures a **new
 enrollment never carries a previous year's drop code or end date** — a
 last-attended date before the current enrollment's start is treated as belonging
 to the prior enrollment and is ignored.
+
+### Address and contact formatting
+
+Household address values are cleaned before they go to Focus so the imports stay
+consistent:
+
+- A blank or space-only field (street, city, state, zip) is sent as **truly
+  empty**, not as a stray space.
+- The **state is upper-cased** (e.g. `fl` becomes `FL`).
+
+This is formatting only — it does not change which addresses or contacts are
+sent, and it follows the same import-once rule as everything else.
 
 ## Where to make corrections
 

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -18,7 +18,13 @@ models:
       via `file_config.format.header_replacements`; dbt column names remain
       lowercase snake_case. `end_date`, `drop_code`, and `moved_to` populate
       only for transfer-out rows
-      (`int_finalsite__enrollment_lifecycle.is_transfer_out`).
+      (`int_finalsite__enrollment_lifecycle.is_transfer_out`). This is a delta
+      feed — enrollments already present in Focus `student_enrollment` (matched
+      on `student_id`, `syear`, and the floored `start_date`) are suppressed
+      unless the extract carries an exit (transfer-out or `end_date`) the Focus
+      row has not recorded, so only new and changed enrollments are emitted.
+      `school_id`, `grade_id`, and `enrollment_code` are Focus import codes
+      translated on load, so they are not used to detect changes.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -261,6 +267,10 @@ unit_tests:
         format: sql
         rows: |
           select 2025 as syear, date '2025-08-11' as first_day_of_school
+      # empty: none of these students exist in Focus yet, so all rows pass the
+      # delta filter as new enrollments
+      - input: source('kippmiami_dlt_focus', 'student_enrollment')
+        rows: []
     expect:
       rows:
         - {
@@ -368,6 +378,10 @@ unit_tests:
         format: sql
         rows: |
           select 2025 as syear, date '2025-08-11' as first_day_of_school
+      # empty: none of these students exist in Focus yet, so all rows pass the
+      # delta filter as new enrollments
+      - input: source('kippmiami_dlt_focus', 'student_enrollment')
+        rows: []
     expect:
       rows:
         - {
@@ -488,6 +502,10 @@ unit_tests:
           select 2026 as syear, date '2026-08-11' as first_day_of_school
           union all
           select 2025, date '2025-08-11'
+      # empty: none of these students exist in Focus yet, so all rows pass the
+      # delta filter as new enrollments
+      - input: source('kippmiami_dlt_focus', 'student_enrollment')
+        rows: []
     expect:
       rows:
         - {
@@ -598,6 +616,181 @@ unit_tests:
             offender_transfer_stdt: null,
             came_from: null,
             moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+  - name: test_student_enrollment_focus_delta
+    description:
+      Verifies the delta filter against Focus student_enrollment — an enrollment
+      absent from Focus is emitted (new); one already present with no exit and
+      no new exit in the extract is suppressed; one present with no exit whose
+      extract carries an end_date is emitted; and one present with no exit whose
+      extract is a transfer_out (drop_code) is emitted. Matching is on
+      student_id, syear, and floored start_date only.
+    model: rpt_focus__student_enrollment
+    given:
+      - input: ref('int_finalsite__enrollment_lifecycle')
+        format: sql
+        rows: |
+          select
+            'd1' as finalsite_enrollment_id,
+            2026 as school_year_start,
+            '1st' as grade_canonical_name,
+            cast(null as string) as promotion_status,
+            'KIPP Royalty Academy' as assigned_school,
+            date '2026-08-11' as enrollment_start_date,
+            cast(null as date) as enrollment_end_date,
+            false as is_transfer_out
+          union all
+          select
+            'd2', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
+            date '2026-08-11', cast(null as date), false
+          union all
+          select
+            'd3', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
+            date '2026-08-11', date '2026-10-01', false
+          union all
+          select
+            'd4', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
+            date '2026-08-11', date '2026-11-15', true
+      - input: ref('int_finalsite__contact_custom_attributes')
+        format: sql
+        rows: |
+          select
+            'd1' as finalsite_enrollment_id,
+            cast(null as string) as withdrawal_school_txt,
+            cast(null as string) as fl_state_withdraw_codes_ss
+          union all
+          select 'd2', cast(null as string), cast(null as string)
+          union all
+          select 'd3', cast(null as string), cast(null as string)
+          union all
+          select 'd4', 'Prior Elementary', '(W02) In District Transfer'
+      - input: ref('int_people__location_crosswalk')
+        format: sql
+        rows: |
+          select
+            'KIPP Royalty Academy' as location_name,
+            '0001' as location_focus_school_id
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'd1' as finalsite_enrollment_id,
+            '84003003001' as focus_student_id_prefixed
+          union all
+          select 'd2', '84003003002'
+          union all
+          select 'd3', '84003003003'
+          union all
+          select 'd4', '84003003004'
+      - input: ref('int_focus__school_year_first_day')
+        format: sql
+        rows: |
+          select 2026 as syear, date '2026-08-11' as first_day_of_school
+      # d1 absent (new); d2/d3/d4 present in Focus with no exit recorded
+      - input: source('kippmiami_dlt_focus', 'student_enrollment')
+        format: sql
+        rows: |
+          select
+            84003003002 as student_id,
+            2026 as syear,
+            date '2026-08-11' as start_date,
+            cast(null as int64) as drop_code,
+            cast(null as date) as end_date
+          union all
+          select 84003003003, 2026, date '2026-08-11', cast(null as int64), cast(null as date)
+          union all
+          select 84003003004, 2026, date '2026-08-11', cast(null as int64), cast(null as date)
+    expect:
+      rows:
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84003003001",
+            grade_id: "01",
+            start_date: "20260811",
+            enrollment_code: E01,
+            end_date: null,
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84003003003",
+            grade_id: "01",
+            start_date: "20260811",
+            enrollment_code: E01,
+            end_date: "20261001",
+            drop_code: null,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: null,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84003003004",
+            grade_id: "01",
+            start_date: "20260811",
+            enrollment_code: E01,
+            end_date: "20261115",
+            drop_code: (W02) In District Transfer,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: Prior Elementary,
             sec_sch: null,
             grde_prom_st: null,
             good_cause_exempt: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__student_enrollment.yml
@@ -633,9 +633,12 @@ unit_tests:
       Verifies the delta filter against Focus student_enrollment — an enrollment
       absent from Focus is emitted (new); one already present with no exit and
       no new exit in the extract is suppressed; one present with no exit whose
-      extract carries an end_date is emitted; and one present with no exit whose
-      extract is a transfer_out (drop_code) is emitted. Matching is on
-      student_id, syear, and floored start_date only.
+      extract carries an end_date is emitted; one present with no exit whose
+      extract is a transfer_out (drop_code) is emitted; one whose exit Focus has
+      already fully recorded is suppressed; and one where Focus has the end_date
+      but not the drop_code still emits so the drop_code syncs (end_date and
+      drop_code are gated independently). Matching is on student_id, syear, and
+      floored start_date only.
     model: rpt_focus__student_enrollment
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -662,6 +665,14 @@ unit_tests:
           select
             'd4', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
             date '2026-08-11', date '2026-11-15', true
+          union all
+          select
+            'd5', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
+            date '2026-08-11', date '2026-09-15', true
+          union all
+          select
+            'd6', 2026, '1st', cast(null as string), 'KIPP Royalty Academy',
+            date '2026-08-11', date '2026-10-20', true
       - input: ref('int_finalsite__contact_custom_attributes')
         format: sql
         rows: |
@@ -675,6 +686,10 @@ unit_tests:
           select 'd3', cast(null as string), cast(null as string)
           union all
           select 'd4', 'Prior Elementary', '(W02) In District Transfer'
+          union all
+          select 'd5', 'Somewhere', '(W02) In District Transfer'
+          union all
+          select 'd6', 'Elsewhere', '(W3A) WD to public sch distr in FL'
       - input: ref('int_people__location_crosswalk')
         format: sql
         rows: |
@@ -693,11 +708,16 @@ unit_tests:
           select 'd3', '84003003003'
           union all
           select 'd4', '84003003004'
+          union all
+          select 'd5', '84003003005'
+          union all
+          select 'd6', '84003003006'
       - input: ref('int_focus__school_year_first_day')
         format: sql
         rows: |
           select 2026 as syear, date '2026-08-11' as first_day_of_school
-      # d1 absent (new); d2/d3/d4 present in Focus with no exit recorded
+      # d1 absent (new); d2/d3/d4 present with no exit; d5 present with both exit
+      # fields recorded; d6 present with end_date but no drop_code
       - input: source('kippmiami_dlt_focus', 'student_enrollment')
         format: sql
         rows: |
@@ -711,6 +731,10 @@ unit_tests:
           select 84003003003, 2026, date '2026-08-11', cast(null as int64), cast(null as date)
           union all
           select 84003003004, 2026, date '2026-08-11', cast(null as int64), cast(null as date)
+          union all
+          select 84003003005, 2026, date '2026-08-11', 1234, date '2026-09-15'
+          union all
+          select 84003003006, 2026, date '2026-08-11', cast(null as int64), date '2026-10-20'
     expect:
       rows:
         - {
@@ -791,6 +815,36 @@ unit_tests:
             offender_transfer_stdt: null,
             came_from: null,
             moved_to: Prior Elementary,
+            sec_sch: null,
+            grde_prom_st: null,
+            good_cause_exempt: null,
+            graduation_requirement_program: null,
+            next_school: null,
+            next_grade: null,
+            district_ood: null,
+            sch_ood: null,
+            include_in_class_rank: null,
+            fl_days_present: null,
+            fl_days_absent: null,
+          }
+        - {
+            syear: 2026,
+            school_id: "0001",
+            student_id: "84003003006",
+            grade_id: "01",
+            start_date: "20260811",
+            enrollment_code: E01,
+            end_date: "20261020",
+            drop_code: (W3A) WD to public sch distr in FL,
+            calendar_id: null,
+            prior_dist: null,
+            prior_state: null,
+            prior_country: null,
+            ed_choice: null,
+            stdt_dis_affect: null,
+            offender_transfer_stdt: null,
+            came_from: null,
+            moved_to: Elsewhere,
             sec_sch: null,
             grde_prom_st: null,
             good_cause_exempt: null,

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -122,15 +122,19 @@ left join
     on ida.focus_student_id_prefixed = fe.focus_student_id
     and e.school_year_start = fe.focus_syear
     and e.start_date = fe.focus_start_date
--- delta feed: suppress rows Focus already holds identically. Keep a row only
--- when it is absent from Focus (new enrollment) or when the extract carries an
--- exit (transfer-out or end_date) that the matched Focus row has not recorded
--- yet. school_id / grade_id / enrollment_code are import codes translated by
--- Focus on load, so they are not comparable and are not used to detect changes.
+-- delta feed: suppress rows Focus already holds identically. Keep a row when it
+-- is absent from Focus (new enrollment), or when it carries an exit the matched
+-- Focus row has not recorded. end_date and drop_code are gated independently:
+-- drop_code is a raw Finalsite custom attribute not tied to enrollment_end_date,
+-- so the two exit fields can arrive in separate runs — a drop_code that lands
+-- after Focus already has the end_date (or vice versa) must still sync.
+-- school_id / grade_id / enrollment_code are import codes translated by Focus on
+-- load, so they are not comparable and are not used to detect changes.
 where
     fe.focus_student_id is null
+    or (e.enrollment_end_date is not null and not fe.has_end_date)
     or (
-        not fe.has_drop_code
-        and not fe.has_end_date
-        and (e.is_transfer_out or e.enrollment_end_date is not null)
+        e.is_transfer_out
+        and cca.fl_state_withdraw_codes_ss is not null
+        and not fe.has_drop_code
     )

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -1,39 +1,76 @@
+with
+    enrollments as (
+        select
+            l.school_year_start,
+            l.grade_canonical_name,
+            l.promotion_status,
+            l.assigned_school,
+            l.enrollment_end_date,
+            l.is_transfer_out,
+            l.finalsite_enrollment_id,
+
+            -- Finalsite emits pre-first-day enrolled_dates (contract/registration
+            -- dates); Focus matches enrollment on the first attendance calendar
+            -- date, so floor the start date up to the school year's first day
+            -- (derived per school year from the Focus attendance calendar). Rows
+            -- already on/after the first day, and years with no calendar, are
+            -- left unchanged.
+            greatest(
+                l.enrollment_start_date,
+                coalesce(fd.first_day_of_school, l.enrollment_start_date)
+            ) as start_date,
+        from {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+        left join
+            {{ ref("int_focus__school_year_first_day") }} as fd
+            on l.school_year_start = fd.syear
+        -- enrolled-only: pre-enrollment statuses (enrollment_in_progress,
+        -- assigned_school) carry no enrolled_date; Focus enrollment records
+        -- require an entry date, so defer these students until Finalsite mints
+        -- enrollment_start_date. See #4291.
+        where l.enrollment_start_date is not null
+    ),
+
+    -- Enrollments already loaded into Focus, deduped to one row per
+    -- (student_id, syear, start_date) so the anti-join below cannot fan out.
+    -- has_drop_code / has_end_date flag whether Focus has already recorded an
+    -- exit for that enrollment.
+    focus_enrollments as (
+        select
+            cast(student_id as string) as focus_student_id,
+            syear as focus_syear,
+            start_date as focus_start_date,
+
+            logical_or(drop_code is not null) as has_drop_code,
+            logical_or(end_date is not null) as has_end_date,
+        from {{ source("kippmiami_dlt_focus", "student_enrollment") }}
+        group by student_id, syear, start_date
+    )
+
 -- trunk-ignore(sqlfluff/ST06): column order fixed by Focus STUDENT_ENROLLMENT contract
 select
-    l.school_year_start as syear,
+    e.school_year_start as syear,
 
     sch.location_focus_school_id as school_id,
 
     ida.focus_student_id_prefixed as student_id,
 
     if(
-        l.grade_canonical_name = 'k',
+        e.grade_canonical_name = 'k',
         'KG',
         -- non-digit grade names (e.g. pk) yield null here; Miami is K-9 today
-        lpad(regexp_extract(l.grade_canonical_name, r'\d+'), 2, '0')
+        lpad(regexp_extract(e.grade_canonical_name, r'\d+'), 2, '0')
     ) as grade_id,
 
-    -- Finalsite emits pre-first-day enrolled_dates (contract/registration
-    -- dates); Focus matches enrollment on the first attendance calendar date, so
-    -- floor the start date up to the school year's first day (derived per school
-    -- year from the Focus attendance calendar). Rows already on/after the first
-    -- day, and years with no calendar, are left unchanged.
-    format_date(
-        '%Y%m%d',
-        greatest(
-            l.enrollment_start_date,
-            coalesce(fd.first_day_of_school, l.enrollment_start_date)
-        )
-    ) as start_date,
+    format_date('%Y%m%d', e.start_date) as start_date,
 
     -- enrollment_code is the entry action and does not change on transfer_out;
     -- a withdrawal is expressed by drop_code + end_date, not by clearing the
     -- entry code.
-    case when l.grade_canonical_name = 'k' then 'E05' else 'E01' end as enrollment_code,
+    case when e.grade_canonical_name = 'k' then 'E05' else 'E01' end as enrollment_code,
 
     -- enrollment_end_date is gated to transfer_out upstream in
     -- int_finalsite__enrollment_lifecycle, so end_date needs no re-gating.
-    format_date('%Y%m%d', l.enrollment_end_date) as end_date,
+    format_date('%Y%m%d', e.enrollment_end_date) as end_date,
 
     -- Focus import header is drop_code; this carries the raw Finalsite withdraw
     -- label, which the kippmiami reconciliation layer decodes to the Focus
@@ -42,7 +79,7 @@ select
     -- only meaningful for a withdrawal, and an ungated value would emit a drop
     -- code for a still-enrolled student downstream.
     if(
-        l.is_transfer_out, cca.fl_state_withdraw_codes_ss, cast(null as string)
+        e.is_transfer_out, cca.fl_state_withdraw_codes_ss, cast(null as string)
     ) as drop_code,
 
     cast(null as string) as calendar_id,
@@ -54,11 +91,11 @@ select
     cast(null as string) as offender_transfer_stdt,
     cast(null as string) as came_from,
 
-    if(l.is_transfer_out, cca.withdrawal_school_txt, cast(null as string)) as moved_to,
+    if(e.is_transfer_out, cca.withdrawal_school_txt, cast(null as string)) as moved_to,
 
     cast(null as string) as sec_sch,
 
-    l.promotion_status as grde_prom_st,
+    e.promotion_status as grde_prom_st,
 
     cast(null as string) as good_cause_exempt,
     cast(null as string) as graduation_requirement_program,
@@ -69,21 +106,31 @@ select
     cast(null as string) as include_in_class_rank,
     cast(null as int64) as fl_days_present,
     cast(null as int64) as fl_days_absent,
-from {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+from enrollments as e
 inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
-    on l.finalsite_enrollment_id = ida.finalsite_enrollment_id
+    on e.finalsite_enrollment_id = ida.finalsite_enrollment_id
     and ida.focus_student_id_prefixed is not null
 left join
     {{ ref("int_finalsite__contact_custom_attributes") }} as cca
-    on l.finalsite_enrollment_id = cca.finalsite_enrollment_id
+    on e.finalsite_enrollment_id = cca.finalsite_enrollment_id
 left join
     {{ ref("int_people__location_crosswalk") }} as sch
-    on l.assigned_school = sch.location_name
+    on e.assigned_school = sch.location_name
 left join
-    {{ ref("int_focus__school_year_first_day") }} as fd
-    on l.school_year_start = fd.syear
--- enrolled-only: pre-enrollment statuses (enrollment_in_progress, assigned_school)
--- carry no enrolled_date; Focus enrollment records require an entry date, so
--- defer these students until Finalsite mints enrollment_start_date. See #4291.
-where l.enrollment_start_date is not null
+    focus_enrollments as fe
+    on ida.focus_student_id_prefixed = fe.focus_student_id
+    and e.school_year_start = fe.focus_syear
+    and e.start_date = fe.focus_start_date
+-- delta feed: suppress rows Focus already holds identically. Keep a row only
+-- when it is absent from Focus (new enrollment) or when the extract carries an
+-- exit (transfer-out or end_date) that the matched Focus row has not recorded
+-- yet. school_id / grade_id / enrollment_code are import codes translated by
+-- Focus on load, so they are not comparable and are not used to detect changes.
+where
+    fe.focus_student_id is null
+    or (
+        not fe.has_drop_code
+        and not fe.has_end_date
+        and (e.is_transfer_out or e.enrollment_end_date is not null)
+    )

--- a/src/dbt/kipptaf/models/focus/sources-bigquery.yml
+++ b/src/dbt/kipptaf/models/focus/sources-bigquery.yml
@@ -3,8 +3,8 @@ sources:
     description: >-
       Focus SIS tables landed directly to BigQuery by the kippmiami Focus dlt
       pull (dagster_kippmiami_dlt_focus). Read here pre-staging for the school
-      calendar lookup; the dlt dataset is a stable production location with no
-      branch-deployment redirect.
+      calendar lookup and the enrollment delta filter; the dlt dataset is a
+      stable production location with no branch-deployment redirect.
     schema: dagster_kippmiami_dlt_focus
     tables:
       - name: attendance_calendar
@@ -27,3 +27,16 @@ sources:
                 - dlt
                 - focus
                 - attendance_calendars
+      - name: student_enrollment
+        description:
+          Focus enrollment records, one row per enrollment. Read by
+          rpt_focus__student_enrollment to suppress extract rows that already
+          exist in Focus (matched on student_id, syear, start_date).
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kippmiami
+                - dlt
+                - focus
+                - student_enrollment


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will make `rpt_focus__student_enrollment` a **delta feed** — it stops re-sending Focus enrollments that already exist unchanged.

Previously the extract emitted a full snapshot every run (1,587 rows on current data) even though most of those enrollments already exist identically in Focus `student_enrollment`. Now it emits only:

- enrollments **absent** from Focus (new registrations), and
- enrollments present in Focus but where the extract carries an **exit** (transfer-out or `end_date`) the Focus row has not recorded yet. `end_date` and `drop_code` are gated independently, so a `drop_code` that arrives after Focus already has the `end_date` still syncs.

Matching is on `student_id`, `syear`, and the floored `start_date` — the only fields comparable across the two systems. `school_id`, `grade_id`, and `enrollment_code` are Focus import codes translated on load (e.g. `2332A` maps to `58`, `01` maps to `339`, `E01` maps to `1507`), so they are not used for change detection.

Validated against current prod data: 1,587 rows drop to 495 (472 new + 23 changed), suppressing 1,092 redundant rows.

Changes:

- Add `student_enrollment` to the BQ-native Focus source (`models/focus/sources-bigquery.yml`).
- Anti-join it in `rpt_focus__student_enrollment.sql`, keeping the enrolled-only gate and the first-day floor.
- Add a unit test covering the delta cases (new, identical-suppressed, end_date-added, withdrawal-added, fully-recorded-suppressed, partial-exit-synced).

**Behavioral note (confirmed):** The Focus SFTP import is an **upsert** — omitted rows are left untouched and re-sent rows update in place. So suppressing already-matched enrollments is safe, and re-emitting a partial-exit row updates the existing Focus enrollment rather than duplicating it. Confirmed with the import owner.

Closes #4317

## AI Assistance

Claude Code authored the investigation, the anti-join, and the unit test under my direction. The delta semantics and the upsert confirmation were human-directed.

## Self-review

### dbt

- [x] Properties file updated for the modified model (description plus new unit test).
- [ ] Exposure — n/a (consumed by the kippmiami SFTP wrapper, not a dashboard).
- [x] Not a breaking schema change — same 28-column contract; the behavioral (row-count) change is noted above.
- [x] Source is BQ-native (`dagster_kippmiami_dlt_focus`, hardcoded schema), not an external table, so `stage_external_sources` does not apply — CI reads prod in all targets.

## CI checks

- [x] Trunk — passing
- [x] dbt Cloud — passing, no warnings (needed a Clone - Staging refresh so the deferred `int_focus__school_year_first_day` from #4312 resolved)
- [x] Dagster Cloud — not triggered (no Dagster code paths changed)
