### PR TITLE
fix(finalsite): gate blank records out of Focus import-once feeds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,6 +477,13 @@ or mart `facts`/`dimensions`/`bridges`) —
 `cursor=<evaluationId of the oldest record returned>` — not a timestamp or
 opaque token.
 
+- **Prod dbt models are materialized by `<loc>__automation_condition_sensor`
+  runs** (job `__ASSET_JOB`, tag `dagster/from_automation_condition`), NOT dbt
+  Cloud (CI-only) or crons. A merged model SQL change goes stale on CODE and is
+  rematerialized — including view models (distinct from the data-change
+  condition, which skips views) — within minutes of the post-merge location
+  deploy. To confirm a rollout landed: `get_location_load_history` (new commit
+  LOADED) → `list_runs` / `get_asset_materializations` for the asset.
 - **Schedule/sensor-launched runs report `assetSelection: null`** in
   `list_runs`. Read `stepKeysToExecute` and convert `__` → `/` to recover asset
   keys (`kipptaf__tableau__ops_dashboard` → `kipptaf/tableau/ops_dashboard`).

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -140,7 +140,9 @@ does not already have it, and nothing is ever overwritten:
   the student is enrolled** (has a start date); a withdrawal (end date + drop
   code) is filled in once when Focus has none yet.
 - **Addresses and Contacts** — a student's address / contacts are sent only if
-  Focus does not already have them for that student.
+  Focus does not already have them for that student **and** the record is
+  complete (a full address; a named contact). Blank or incomplete records are
+  held back until populated (see below).
 
 ### Forward-moving enrollments are protected
 
@@ -155,12 +157,31 @@ to the prior enrollment and is ignored.
 Household address values are cleaned before they go to Focus so the imports stay
 consistent:
 
-- A blank or space-only field (street, city, state, zip) is sent as **truly
-  empty**, not as a stray space.
+- A blank or space-only field (street, city, state, zip) is normalized to
+  **truly empty**, not a stray space.
 - The **state is upper-cased** (e.g. `fl` becomes `FL`).
 
-This is formatting only — it does not change which addresses or contacts are
-sent, and it follows the same import-once rule as everything else.
+This is formatting only — whether a record is complete enough to send is covered
+next.
+
+### Blank addresses and nameless contacts are held back
+
+Because addresses and contacts are import-once, an incomplete record sent now
+would be locked in — a student imported with a blank address would keep that
+empty address in Focus even after a real one is entered, because import-once
+never sends them again. To prevent that, the pipeline **holds a record back
+until it is complete**:
+
+- **Addresses** — a student's address is sent only once street, city, state, and
+  ZIP are all present. A student with a blank or partial address is skipped that
+  run and flows the first run the full address exists in Finalsite.
+- **Contacts** — a contact is sent only once it has a name. A nameless contact
+  is skipped and flows once the name is filled in.
+
+> **A student can be enrolled in Focus with no address yet.** That is expected
+> when Finalsite has no complete address for them — enter the address in
+> Finalsite and it flows on the next run. (Demographics is not held back this
+> way; a student's demographics import as soon as the student is new to Focus.)
 
 ## Where to make corrections
 
@@ -209,6 +230,10 @@ pipeline will not reconcile them for you.
   Enrollment file only once Finalsite has an enrollment start date; accepted or
   in-progress students wait until they enroll (they can still appear in
   Demographics, Address, and Contacts in the meantime).
+- **A complete address is required before it imports.** A student with a blank
+  or partial address in Finalsite gets no address in Focus — by design, since an
+  empty one would lock in. Enter the full street/city/state/ZIP in Finalsite and
+  it flows next run; likewise a contact needs a name before it is sent.
 - **Set the last-attended date** in Finalsite when a student withdraws — it is
   what triggers the end date and drop code being sent.
 - **Corrections after the first import are manual.** A wrong entry code, drop

--- a/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__addresses.yml
+++ b/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__addresses.yml
@@ -3,8 +3,11 @@ models:
     description: >-
       Address export for Focus SIS — import-once: emits a student's address only
       when the student has no address linked in Focus yet (anti-join on
-      stg_focus__students_join_address). Existing Focus addresses are never
-      overwritten; enrollment ops harmonize post-import changes manually.
+      stg_focus__students_join_address) and the mailable address is complete
+      (address, city, state, zipcode all present). The completeness gate keeps a
+      blank address from being imported once and then locking out the real one.
+      Existing Focus addresses are never overwritten; enrollment ops harmonize
+      post-import changes manually.
     columns:
       - name: student_id
         data_type: string
@@ -34,9 +37,10 @@ models:
 unit_tests:
   - name: addresses_import_once_suppresses_existing
     description: >-
-      Import-once — a student with no address in Focus is kept; a student who
-      already has an address (present in stg_focus__students_join_address) is
-      suppressed.
+      Import-once plus completeness gate — a student with a complete address and
+      no Focus address is kept; a student already in Focus is suppressed; a
+      student with a blank address is suppressed so an empty record is not
+      imported once and locked in.
     model: rpt_focus__addresses
     given:
       - input: source("kipptaf_extracts", "rpt_focus__addresses")
@@ -56,6 +60,15 @@ unit_tests:
               cast(null as string) as address2, 'Miami' as city,
               'FL' as state, '33102' as zipcode, cast(null as string) as phone,
               cast(null as string) as mailing,
+              cast(null as string) as mail_address,
+              cast(null as string) as mail_address2,
+              cast(null as string) as mail_city, cast(null as string) as mail_state
+          union all
+          select
+              '8400000003' as student_id, cast(null as string) as address,
+              cast(null as string) as address2, cast(null as string) as city,
+              cast(null as string) as state, cast(null as string) as zipcode,
+              cast(null as string) as phone, cast(null as string) as mailing,
               cast(null as string) as mail_address,
               cast(null as string) as mail_address2,
               cast(null as string) as mail_city, cast(null as string) as mail_state

--- a/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -115,8 +115,9 @@ unit_tests:
     description: >-
       Import-once plus named-contact gate — a named contact for a student not in
       Focus is kept; a student already in Focus has all rows suppressed; a
-      nameless contact row is suppressed so an empty person record is not
-      imported once and locked in.
+      nameless contact row is suppressed (both null names and empty-string
+      names, since Finalsite emits blanks for unset names) so an empty person
+      record is not imported once and locked in.
     model: rpt_focus__contacts
     given:
       - input: source("kipptaf_extracts", "rpt_focus__contacts")
@@ -215,6 +216,50 @@ unit_tests:
               1 as sort_order, cast(null as string) as first_name,
               cast(null as string) as middle_name,
               cast(null as string) as last_name,
+              cast(null as string) as resides_with_stud,
+              cast(null as string) as custody, cast(null as string) as emergency,
+              cast(null as string) as pickup, cast(null as string) as address,
+              cast(null as string) as address2, cast(null as string) as city,
+              cast(null as string) as state, cast(null as string) as zipcode,
+              cast(null as string) as email, cast(null as string) as contact1_type,
+              cast(null as string) as contact1_value,
+              cast(null as string) as contact1_blocked,
+              cast(null as string) as contact1_unlisted,
+              cast(null as string) as contact1_callout,
+              cast(null as string) as contact2_type,
+              cast(null as string) as contact2_value,
+              cast(null as string) as contact2_blocked,
+              cast(null as string) as contact2_unlisted,
+              cast(null as string) as contact2_callout,
+              cast(null as string) as contact3_type,
+              cast(null as string) as contact3_value,
+              cast(null as string) as contact3_blocked,
+              cast(null as string) as contact3_unlisted,
+              cast(null as string) as contact3_callout,
+              cast(null as string) as contact4_type,
+              cast(null as string) as contact4_value,
+              cast(null as string) as contact4_blocked,
+              cast(null as string) as contact4_unlisted,
+              cast(null as string) as contact4_callout,
+              cast(null as string) as contact5_type,
+              cast(null as string) as contact5_value,
+              cast(null as string) as contact5_blocked,
+              cast(null as string) as contact5_unlisted,
+              cast(null as string) as contact5_callout,
+              cast(null as string) as contact6_type,
+              cast(null as string) as contact6_value,
+              cast(null as string) as contact6_blocked,
+              cast(null as string) as contact6_unlisted,
+              cast(null as string) as contact6_callout,
+              cast(null as string) as contact7_type,
+              cast(null as string) as contact7_value,
+              cast(null as string) as contact7_blocked,
+              cast(null as string) as contact7_unlisted
+          union all
+          select
+              '8400000004' as student_id, 'parent' as student_relation,
+              1 as sort_order, '' as first_name,
+              cast(null as string) as middle_name, '' as last_name,
               cast(null as string) as resides_with_stud,
               cast(null as string) as custody, cast(null as string) as emergency,
               cast(null as string) as pickup, cast(null as string) as address,

--- a/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -3,9 +3,11 @@ models:
     description: >-
       Contacts export for Focus SIS — import-once: emits a student's contacts
       only when the student has no contact (person) linked in Focus yet
-      (anti-join on stg_focus__students_join_people). Existing Focus contacts
-      are never overwritten; enrollment ops harmonize post-import changes
-      manually.
+      (anti-join on stg_focus__students_join_people) and the contact has a name
+      (first_name or last_name). The name gate keeps a nameless contact from
+      being imported once and then locking the student out of a real one.
+      Existing Focus contacts are never overwritten; enrollment ops harmonize
+      post-import changes manually.
     columns:
       - name: student_id
         data_type: string
@@ -111,9 +113,10 @@ models:
 unit_tests:
   - name: contacts_import_once_suppresses_existing
     description: >-
-      Import-once — a student with no contact in Focus keeps all their contact
-      rows; a student who already has a contact (present in
-      stg_focus__students_join_people) has all rows suppressed.
+      Import-once plus named-contact gate — a named contact for a student not in
+      Focus is kept; a student already in Focus has all rows suppressed; a
+      nameless contact row is suppressed so an empty person record is not
+      imported once and locked in.
     model: rpt_focus__contacts
     given:
       - input: source("kipptaf_extracts", "rpt_focus__contacts")
@@ -167,6 +170,51 @@ unit_tests:
               '8400000002' as student_id, 'parent' as student_relation,
               1 as sort_order, 'John' as first_name,
               cast(null as string) as middle_name, 'Smith' as last_name,
+              cast(null as string) as resides_with_stud,
+              cast(null as string) as custody, cast(null as string) as emergency,
+              cast(null as string) as pickup, cast(null as string) as address,
+              cast(null as string) as address2, cast(null as string) as city,
+              cast(null as string) as state, cast(null as string) as zipcode,
+              cast(null as string) as email, cast(null as string) as contact1_type,
+              cast(null as string) as contact1_value,
+              cast(null as string) as contact1_blocked,
+              cast(null as string) as contact1_unlisted,
+              cast(null as string) as contact1_callout,
+              cast(null as string) as contact2_type,
+              cast(null as string) as contact2_value,
+              cast(null as string) as contact2_blocked,
+              cast(null as string) as contact2_unlisted,
+              cast(null as string) as contact2_callout,
+              cast(null as string) as contact3_type,
+              cast(null as string) as contact3_value,
+              cast(null as string) as contact3_blocked,
+              cast(null as string) as contact3_unlisted,
+              cast(null as string) as contact3_callout,
+              cast(null as string) as contact4_type,
+              cast(null as string) as contact4_value,
+              cast(null as string) as contact4_blocked,
+              cast(null as string) as contact4_unlisted,
+              cast(null as string) as contact4_callout,
+              cast(null as string) as contact5_type,
+              cast(null as string) as contact5_value,
+              cast(null as string) as contact5_blocked,
+              cast(null as string) as contact5_unlisted,
+              cast(null as string) as contact5_callout,
+              cast(null as string) as contact6_type,
+              cast(null as string) as contact6_value,
+              cast(null as string) as contact6_blocked,
+              cast(null as string) as contact6_unlisted,
+              cast(null as string) as contact6_callout,
+              cast(null as string) as contact7_type,
+              cast(null as string) as contact7_value,
+              cast(null as string) as contact7_blocked,
+              cast(null as string) as contact7_unlisted
+          union all
+          select
+              '8400000003' as student_id, 'parent' as student_relation,
+              1 as sort_order, cast(null as string) as first_name,
+              cast(null as string) as middle_name,
+              cast(null as string) as last_name,
               cast(null as string) as resides_with_stud,
               cast(null as string) as custody, cast(null as string) as emergency,
               cast(null as string) as pickup, cast(null as string) as address,

--- a/src/dbt/kippmiami/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kippmiami/models/extracts/focus/rpt_focus__addresses.sql
@@ -9,7 +9,16 @@ with
         select d.*,
         from {{ source("kipptaf_extracts", "rpt_focus__addresses") }} as d
         left join focus_address as f on d.student_id = f.student_id
-        where f.student_id is null
+        where
+            f.student_id is null
+            -- don't import a blank/partial address: presence-based import-once
+            -- would create an empty Focus address record and then suppress the
+            -- student forever, so the real address never syncs. Defer until the
+            -- mailable address is complete. See #4320.
+            and d.address is not null
+            and d.city is not null
+            and d.state is not null
+            and d.zipcode is not null
     )
 
 select

--- a/src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql
@@ -13,9 +13,14 @@ with
             f.student_id is null
             -- don't import a nameless contact: presence-based import-once would
             -- create the Focus person record and then suppress the student
-            -- forever, so a later-named contact never syncs. Defer until the
-            -- contact has a name. See #4320.
-            and (d.first_name is not null or d.last_name is not null)
+            -- forever, so a later-named contact never syncs. Unlike the address
+            -- fields, first_name / last_name are NOT nullif-normalized upstream
+            -- in stg_finalsite__contacts, and Finalsite emits empty strings for
+            -- unset names, so guard against blank/whitespace here. See #4320.
+            and (
+                nullif(trim(d.first_name), '') is not null
+                or nullif(trim(d.last_name), '') is not null
+            )
     )
 
 select

--- a/src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql
@@ -9,7 +9,13 @@ with
         select d.*,
         from {{ source("kipptaf_extracts", "rpt_focus__contacts") }} as d
         left join focus_contact as f on d.student_id = f.student_id
-        where f.student_id is null
+        where
+            f.student_id is null
+            -- don't import a nameless contact: presence-based import-once would
+            -- create the Focus person record and then suppress the student
+            -- forever, so a later-named contact never syncs. Defer until the
+            -- contact has a name. See #4320.
+            and (d.first_name is not null or d.last_name is not null)
     )
 
 select

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -103,6 +103,15 @@ view). A new kipptaf region source (`sources-kipp*.yml`) needs the
 `dev`/`staging` (`zz_stg_`)/prod schema branch, or single-PR cross-project CI
 can't read it.
 
+**finalsite→focus exception**: the kippmiami `rpt_focus__*` are NOT thin
+pass-throughs — they are the reconciliation layer (import-once / diff against
+current Focus via the `focus` package, which only kippmiami has). kipptaf
+`rpt_focus__*` are desired-state (all rows); the **kippmiami** output is the
+actual SFTP feed. Per feed: addresses/contacts/demographics import-once
+(presence anti-join, with a null/completeness gate #4320); enrollment diffs and
+additionally reads Focus in kipptaf via a BQ-native source (#4319). Spec:
+`docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md`.
+
 ## `dbt_project.yml` Inherited Defaults
 
 These are set at directory level — **do not repeat per-model** or flag their


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request stops the Focus import-once feeds from locking in blank records.

`kippmiami/rpt_focus__addresses` and `rpt_focus__contacts` use presence-based import-once (drop a student once a matching row exists in the Focus destination), with no check that the payload is populated. So a student first imported with a blank address (or a nameless contact) gets an empty Focus record created and is then suppressed forever — the real value never syncs. About 124 students currently have a fully-null address block and would lock in as Focus address linkage fills in (mid-rollout).

Fix — add a completeness gate so a blank record is deferred until it is populated (mirrors the enrollment enrolled-only gate):

- **Addresses** — emit only when `address`, `city`, `state`, `zipcode` are all present.
- **Contacts** — emit a contact row only when it has a name (`first_name` or `last_name`).

**Demographics is intentionally left student-presence-only** (owner decision); its optional fields can still lock in and can be revisited separately.

Validated against prod via a dev-defer build: addresses 1,880 to 1,756 (defers exactly the 124 blank-address students); contacts unchanged (no nameless contacts today — the gate is defensive). Import-once ownership is unchanged; later value changes still will not re-sync (separate value-diff question from #4279).

## AI Assistance

Claude Code found the lock-in, wrote the gates and unit tests, and validated against prod under my direction. The completeness criteria and the demographics-excluded decision were mine.

## Self-review

### dbt

- [x] Properties updated for both models (descriptions plus a blank-record suppression case added to each unit test).
- [ ] Exposure — n/a.
- [x] No schema/contract change — same columns; only the row filter changed.
- [x] No external source change — reads existing `stg_focus__*` and `kipptaf_extracts` sources.

## CI checks

- [ ] Trunk — passing locally.
- [ ] dbt Cloud — this is a district-only (kippmiami) change; the kipptaf-scoped CI job selects no models, so it is a no-op and does not validate this. Verified locally instead: `dbt build` of both models against prod-defer plus both unit tests pass.
- [ ] Dagster Cloud — not triggered (no Dagster code paths changed); kippmiami redeploys on merge and the automation sensor rematerializes the two views.

Closes #4320
