### PR TITLE
fix(kipptaf): dedupe finalsite scaffold enrollment join on infosnap_id

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__finalsite_student_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__finalsite_student_scaffold.sql
@@ -249,6 +249,35 @@ with
         from days_in_grouped_status_calc
     ),
 
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    enrollment_lookup as (
+        select
+            academic_year,
+            infosnap_id,
+            student_number,
+            enroll_status,
+            is_enrolled_fdos,
+            is_enrolled_oct01,
+            is_enrolled_oct15,
+            is_enrolled_mar15,
+        from {{ ref("int_extracts__student_enrollments") }}
+        where rn_year = 1 and infosnap_id is not null
+    ),
+
+    -- rn_year is computed per student, so two PowerSchool records sharing one
+    -- infosnap_id both carry rn_year = 1 and fan out the enrollment joins below.
+    -- Prefer the actively-enrolled record, then the newest student record.
+    -- TODO: remove once the duplicate PowerSchool student records are merged (#4326)
+    deduplicate_enrollments as (
+        {{
+            dbt_utils.deduplicate(
+                relation="enrollment_lookup",
+                partition_by="academic_year, infosnap_id",
+                order_by="(enroll_status = 0) desc, student_number desc",
+            )
+        }}
+    ),
+
     final_roster as (
         select
             enrollment_academic_year,
@@ -353,10 +382,9 @@ left join
     and r.goal_type = d.goal_type
     and r.goal_name = d.goal_name
 left join
-    {{ ref("int_extracts__student_enrollments") }} as e
+    deduplicate_enrollments as e
     on r.enrollment_academic_year = e.academic_year
     and r.finalsite_id = e.infosnap_id
-    and e.rn_year = 1
 where r.goal_name not in ('<= 4 Days', '>= 5 & <= 10 Days', '> 10 Days')
 
 union all
@@ -400,8 +428,7 @@ inner join
     and r.goal_type = d.goal_type
     and r.goal_name = d.goal_name
 left join
-    {{ ref("int_extracts__student_enrollments") }} as e
+    deduplicate_enrollments as e
     on r.enrollment_academic_year = e.academic_year
     and r.finalsite_id = e.infosnap_id
-    and e.rn_year = 1
 where r.goal_name in ('<= 4 Days', '>= 5 & <= 10 Days', '> 10 Days')


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the `int_tableau__finalsite_student_scaffold` uniqueness-test failure (89 rows, constant since 7/1) and with it the automation-sensor retry loop that has been relaunching the failing asset bundle every ~8 minutes — the driver of the elevated GKE Autopilot Arm pod costs since 7/1.

Root cause: `rn_year` in `int_extracts__student_enrollments` is computed per student, so duplicate PowerSchool student records sharing one Finalsite enrollment ID (8 pairs created at the 7/1 registration rollover) both carry `rn_year = 1`, and the scaffold's enrollment joins fan out every row for those students. This PR dedupes the enrollment lookup on the actual join key (`academic_year`, `infosnap_id`) via `dbt_utils.deduplicate`, preferring the actively-enrolled record, with a TODO pointing at the SIS cleanup (tracked in Asana: https://app.asana.com/1/913513768672/project/1205971774138578/task/1216275426543892).

Verified by running the fixed model's compiled SQL against prod: duplicate keys 89 → 0, row count 46,590 → 46,501 (exactly the 89 fan-out rows removed, nothing else).

Refs #4326

## AI Assistance

Claude Code diagnosed the root cause (traced from Cloud Billing anomaly → Dagster retry loop → failing test → duplicate SIS records), authored the fix, and verified it against prod data; human-directed scope and approach.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Properties file already exists for the modified model (no new models)
- [x] No exposure changes needed (no column additions/removals; output schema unchanged)
- [x] Not a breaking change — contract columns unchanged; only removes duplicate rows
- [x] No external source changes

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes (`trunk check --force` clean locally)
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)