### PR TITLE
feat(kipptaf): add postsec_completed_enrollment_id to int_kippadb__enrollment_pivot

### DIFF
--- a/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
+++ b/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
@@ -82,7 +82,7 @@ Insert this column immediately after the existing `ugrad_enrollment_id` CASE
                             aa.start_date
                         ),
                         struct(
-                            e.cte_enrollment_id,
+                            e.vocational_enrollment_id,
                             if(cte.status = 'Graduated', 1, 0),
                             1,
                             cte.start_date

--- a/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
+++ b/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
@@ -10,13 +10,13 @@
 returns a student's best post-secondary enrollment, preferring a completed
 (`Graduated`) enrollment over any in-progress or withdrawn one.
 
-**Architecture:** In the `enrollment_wide` CTE, add a compact
-`unnest`-of-structs scalar subquery beside the existing `ugrad_enrollment_id`
-CASE that ranks the three already-resolved track picks (`ba`/`aa`/`cte`) by
-completed-tier → degree level → recency. Carry the id into the final `select`
-and add two `stg_kippadb__enrollment` / `stg_kippadb__account` joins to surface
-the parallel attribute columns. Additive only — no existing column or consumer
-changes.
+**Architecture:** In the `enrollment_wide` CTE, add a `coalesce` of guarded ids
+beside the existing `ugrad_enrollment_id` CASE that ranks the three
+already-resolved track picks (`ba`/`aa`/`cte`) by completed-tier → degree level
+(`coalesce` returns the first non-null in priority order). Carry the id into the
+final `select` and add two `stg_kippadb__enrollment` / `stg_kippadb__account`
+joins to surface the parallel attribute columns. Additive only — no existing
+column or consumer changes.
 
 **Tech Stack:** dbt (BigQuery), `uv run dbt`, trunk (sqlfluff + yamllint).
 
@@ -57,7 +57,7 @@ ls src/dbt/kipptaf/target/prod/manifest.json \
 - Modify:
   `src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql`
 
-- [ ] **Step 1: Add the pick subquery in `enrollment_wide`**
+- [ ] **Step 1: Add the pick in `enrollment_wide`**
 
 Insert this column immediately after the existing `ugrad_enrollment_id` CASE
 (currently ends `end as ugrad_enrollment_id,` at line 290), before the
@@ -65,35 +65,17 @@ Insert this column immediately after the existing `ugrad_enrollment_id` CASE
 `ba`/`aa`/`cte` are the already-joined `stg_kippadb__enrollment` picks.
 
 ```sql
-            (
-                select cand.enrollment_id
-                from
-                    unnest([
-                        struct(
-                            e.ba_enrollment_id as enrollment_id,
-                            if(ba.status = 'Graduated', 1, 0) as is_completed,
-                            3 as degree_rank,
-                            ba.start_date as start_date
-                        ),
-                        struct(
-                            e.aa_enrollment_id,
-                            if(aa.status = 'Graduated', 1, 0),
-                            2,
-                            aa.start_date
-                        ),
-                        struct(
-                            e.vocational_enrollment_id,
-                            if(cte.status = 'Graduated', 1, 0),
-                            1,
-                            cte.start_date
-                        )
-                    ]) as cand
-                where cand.enrollment_id is not null
-                order by
-                    cand.is_completed desc,
-                    cand.degree_rank desc,
-                    cand.start_date desc
-                limit 1
+            -- pick the student's single best post-secondary enrollment:
+            -- completed (Graduated) first, then degree level (BA > AA > CTE).
+            -- coalesce returns the first non-null in priority order: graduated
+            -- BA/AA/CTE, then any BA/AA/CTE. null when the student has none.
+            coalesce(
+                if(ba.status = 'Graduated', e.ba_enrollment_id, null),
+                if(aa.status = 'Graduated', e.aa_enrollment_id, null),
+                if(cte.status = 'Graduated', e.vocational_enrollment_id, null),
+                e.ba_enrollment_id,
+                e.aa_enrollment_id,
+                e.vocational_enrollment_id
             ) as postsec_completed_enrollment_id,
 ```
 
@@ -207,8 +189,7 @@ Immediately after the `ugrad_enrollment_id` entry (currently lines 18-19), add:
     Enrollment id of the student's best post-secondary enrollment across the BA,
     AA, and CTE track picks — preferring a completed (Graduated) enrollment over
     any in-progress or withdrawn one, then higher degree level (BA over AA over
-    CTE), then most recent start date. Null when the student has no BA, AA, or
-    CTE enrollment.
+    CTE). Null when the student has no BA, AA, or CTE enrollment.
 ```
 
 - [ ] **Step 2: Add the attribute column entries**
@@ -448,11 +429,11 @@ is green before requesting human review.
 
 ## Self-review
 
-- **Spec coverage:** candidate pool (Task 1 Step 1 — BA/AA/CTE structs);
-  completed = Graduated (`if(status = 'Graduated', ...)`); ranking order
-  (`order by is_completed desc, degree_rank desc, start_date desc`); full
-  attribute set (Task 1 Steps 3-4, Task 2); grain unchanged (Task 3 Step 4);
-  null when no BA/AA/CTE (Task 3 Step 5). All covered.
+- **Spec coverage:** candidate pool (Task 1 Step 1 — BA/AA/CTE arms); completed
+  = Graduated (`if(<x>.status = 'Graduated', ...)`); ranking order (graduated
+  arms before unguarded arms, `BA → AA → CTE` within each tier); full attribute
+  set (Task 1 Steps 3-4, Task 2); grain unchanged (Task 3 Step 4); null when no
+  BA/AA/CTE (Task 3 Step 5). All covered.
 - **Placeholder scan:** no TBD/TODO; all code and commands are concrete.
 - **Type consistency:** alias `pce`/`pcea` and column name
   `postsec_completed_enrollment_id` are used identically across the SQL joins,

--- a/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
+++ b/docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md
@@ -1,0 +1,460 @@
+# postsec_completed_enrollment_id Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `postsec_completed_enrollment_id` column (plus its full parallel
+`postsec_completed_*` attribute set) to `int_kippadb__enrollment_pivot` that
+returns a student's best post-secondary enrollment, preferring a completed
+(`Graduated`) enrollment over any in-progress or withdrawn one.
+
+**Architecture:** In the `enrollment_wide` CTE, add a compact
+`unnest`-of-structs scalar subquery beside the existing `ugrad_enrollment_id`
+CASE that ranks the three already-resolved track picks (`ba`/`aa`/`cte`) by
+completed-tier → degree level → recency. Carry the id into the final `select`
+and add two `stg_kippadb__enrollment` / `stg_kippadb__account` joins to surface
+the parallel attribute columns. Additive only — no existing column or consumer
+changes.
+
+**Tech Stack:** dbt (BigQuery), `uv run dbt`, trunk (sqlfluff + yamllint).
+
+**Spec:**
+`docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md`
+(Issue #4331, PR #4332)
+
+---
+
+## File structure
+
+- Modify:
+  `src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql`
+  — add the pick, carry the id to the final select, add the attribute joins and
+  columns.
+- Modify:
+  `src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml`
+  — document the new id and attribute columns.
+
+All work happens on branch
+`CGibson17/feat/claude-postsec-completed-enrollment-id` (already checked out).
+
+**Preflight (run once before Task 3 build/verify):** confirm the prod manifest
+used for `--defer` exists; regenerate if missing.
+
+```bash
+ls src/dbt/kipptaf/target/prod/manifest.json \
+  || VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt parse --target prod \
+       --project-dir src/dbt/kipptaf --target-path target/prod
+```
+
+---
+
+## Task 1: Add the completed-first pick and attribute set to the model SQL
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql`
+
+- [ ] **Step 1: Add the pick subquery in `enrollment_wide`**
+
+Insert this column immediately after the existing `ugrad_enrollment_id` CASE
+(currently ends `end as ugrad_enrollment_id,` at line 290), before the
+`coalesce(emp.start_date, ...)` block. `e` is `enrollment_grouped`;
+`ba`/`aa`/`cte` are the already-joined `stg_kippadb__enrollment` picks.
+
+```sql
+            (
+                select cand.enrollment_id
+                from
+                    unnest([
+                        struct(
+                            e.ba_enrollment_id as enrollment_id,
+                            if(ba.status = 'Graduated', 1, 0) as is_completed,
+                            3 as degree_rank,
+                            ba.start_date as start_date
+                        ),
+                        struct(
+                            e.aa_enrollment_id,
+                            if(aa.status = 'Graduated', 1, 0),
+                            2,
+                            aa.start_date
+                        ),
+                        struct(
+                            e.cte_enrollment_id,
+                            if(cte.status = 'Graduated', 1, 0),
+                            1,
+                            cte.start_date
+                        )
+                    ]) as cand
+                where cand.enrollment_id is not null
+                order by
+                    cand.is_completed desc,
+                    cand.degree_rank desc,
+                    cand.start_date desc
+                limit 1
+            ) as postsec_completed_enrollment_id,
+```
+
+- [ ] **Step 2: Carry the id into the final `select`**
+
+In the final `select` block, add this line immediately after
+`ew.ugrad_enrollment_id,` (currently line 336):
+
+```sql
+    ew.postsec_completed_enrollment_id,
+```
+
+- [ ] **Step 3: Add the parallel attribute columns**
+
+In the final `select`, immediately after the last `ugrad_*` column
+(`uga.adjusted_6_year_minority_graduation_rate as ugrad_adjusted_6_year_minority_graduation_rate,`,
+currently line 442) and before the `is_never_enrolled` expression, insert:
+
+```sql
+    pce.name as postsec_completed_school_name,
+    pce.pursuing_degree_type as postsec_completed_pursuing_degree_type,
+    pce.status as postsec_completed_status,
+    pce.start_date as postsec_completed_start_date,
+    pce.actual_end_date as postsec_completed_actual_end_date,
+    pce.anticipated_graduation as postsec_completed_anticipated_graduation,
+    pce.account_type as postsec_completed_account_type,
+    pce.major as postsec_completed_major,
+    pce.major_area as postsec_completed_major_area,
+    pce.college_major_declared as postsec_completed_college_major_declared,
+    pce.date_last_verified as postsec_completed_date_last_verified,
+    pce.of_credits_required_for_graduation
+    as postsec_completed_credits_required_for_graduation,
+
+    pcea.name as postsec_completed_account_name,
+    pcea.billing_state as postsec_completed_billing_state,
+    pcea.nces_id as postsec_completed_nces_id,
+    pcea.act_composite_25_75 as postsec_completed_act_composite_25_75,
+    pcea.competitiveness_ranking as postsec_completed_competitiveness_ranking,
+    pcea.adjusted_6_year_minority_graduation_rate
+    as postsec_completed_adjusted_6_year_minority_graduation_rate,
+```
+
+- [ ] **Step 4: Add the attribute joins**
+
+At the very end of the model, immediately after the existing `ug`/`uga` joins
+(currently the last two lines, `left join ... as uga on ug.school = uga.id`),
+append:
+
+```sql
+left join
+    {{ ref("stg_kippadb__enrollment") }} as pce
+    on ew.postsec_completed_enrollment_id = pce.id
+left join {{ ref("stg_kippadb__account") }} as pcea on pce.school = pcea.id
+```
+
+- [ ] **Step 5: Compile to validate refs and SQL**
+
+Run:
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt compile \
+  --select int_kippadb__enrollment_pivot --target prod \
+  --project-dir src/dbt/kipptaf 2>&1 | tail -15
+```
+
+Expected: `Compiled node 'int_kippadb__enrollment_pivot'` with no errors.
+(`--target prod` compile does no warehouse write and is not classifier-blocked.)
+
+- [ ] **Step 6: Lint the model**
+
+Run from the repo root:
+
+```bash
+.trunk/tools/trunk check --force \
+  src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql \
+  2>&1 | tail -20
+```
+
+Expected: `✔ No issues`. If sqlfluff ST06 (column ordering) fires on the pick
+subquery's placement, move `postsec_completed_enrollment_id` so it sits with the
+other complex/CASE expressions (adjacent to `ugrad_enrollment_id`) and re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
+git commit -m "feat(kipptaf): add postsec_completed_enrollment_id to enrollment pivot
+
+Refs #4331
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Document the new columns in the properties YAML
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml`
+
+- [ ] **Step 1: Add the id column entry**
+
+Immediately after the `ugrad_enrollment_id` entry (currently lines 18-19), add:
+
+```yaml
+- name: postsec_completed_enrollment_id
+  data_type: string
+  description:
+    Enrollment id of the student's best post-secondary enrollment across the BA,
+    AA, and CTE track picks — preferring a completed (Graduated) enrollment over
+    any in-progress or withdrawn one, then higher degree level (BA over AA over
+    CTE), then most recent start date. Null when the student has no BA, AA, or
+    CTE enrollment.
+```
+
+- [ ] **Step 2: Add the attribute column entries**
+
+Immediately after the last `ugrad_*` entry
+(`ugrad_adjusted_6_year_minority_graduation_rate`, currently lines 230-231) and
+before the `is_never_enrolled` entry, add. Data types mirror the corresponding
+`ugrad_*` columns exactly.
+
+```yaml
+- name: postsec_completed_school_name
+  data_type: string
+  description:
+    Name of the enrollment identified by postsec_completed_enrollment_id.
+- name: postsec_completed_pursuing_degree_type
+  data_type: string
+  description:
+    Pursuing degree type of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_status
+  data_type: string
+  description:
+    Status of the enrollment identified by postsec_completed_enrollment_id.
+- name: postsec_completed_start_date
+  data_type: date
+  description:
+    Start date of the enrollment identified by postsec_completed_enrollment_id.
+- name: postsec_completed_actual_end_date
+  data_type: date
+  description:
+    Actual end date of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_anticipated_graduation
+  data_type: date
+  description:
+    Anticipated graduation date of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_account_type
+  data_type: string
+  description:
+    Account type of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_major
+  data_type: string
+  description:
+    Major of the enrollment identified by postsec_completed_enrollment_id.
+- name: postsec_completed_major_area
+  data_type: string
+  description:
+    Major area of the enrollment identified by postsec_completed_enrollment_id.
+- name: postsec_completed_college_major_declared
+  data_type: boolean
+  description:
+    Whether a college major was declared for the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_date_last_verified
+  data_type: date
+  description:
+    Date the enrollment identified by postsec_completed_enrollment_id was last
+    verified.
+- name: postsec_completed_credits_required_for_graduation
+  data_type: numeric
+  description:
+    Credits required for graduation for the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_account_name
+  data_type: string
+  description:
+    Account name for the school of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_billing_state
+  data_type: string
+  description:
+    Billing state for the school of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_nces_id
+  data_type: string
+  description:
+    NCES id for the school of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_act_composite_25_75
+  data_type: string
+  description:
+    ACT composite 25th-75th percentile range for the school of the enrollment
+    identified by postsec_completed_enrollment_id.
+- name: postsec_completed_competitiveness_ranking
+  data_type: string
+  description:
+    Competitiveness ranking for the school of the enrollment identified by
+    postsec_completed_enrollment_id.
+- name: postsec_completed_adjusted_6_year_minority_graduation_rate
+  data_type: numeric
+  description:
+    Adjusted 6-year minority graduation rate for the school of the enrollment
+    identified by postsec_completed_enrollment_id.
+```
+
+- [ ] **Step 3: Reparse to bind the new descriptions**
+
+Partial parse caches unbound state; force a full parse.
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt parse --no-partial-parse \
+  --target prod --project-dir src/dbt/kipptaf 2>&1 | tail -5
+```
+
+Expected: parses with no errors.
+
+- [ ] **Step 4: Lint the YAML**
+
+```bash
+.trunk/tools/trunk check --force \
+  src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml \
+  2>&1 | tail -20
+```
+
+Expected: `✔ No issues` (trunk-fmt may reflow the `description` scalars — accept
+the reformat).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml
+git commit -m "docs(kipptaf): document postsec_completed_* columns
+
+Refs #4331
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Build and verify behavior
+
+Builds into the developer's dev dataset using prod upstreams via `--defer`; no
+prod write.
+
+- [ ] **Step 1: Define the acceptance check**
+
+The core behavior is: for at least some students the new field returns a
+`Graduated` enrollment while `ugrad_enrollment_id` returns a non-graduated one.
+This query (used in Step 3) is the acceptance criterion — it must return rows:
+
+```sql
+select
+    ei.student,
+    ei.ugrad_enrollment_id,
+    ei.ugrad_status,
+    ei.postsec_completed_enrollment_id,
+    ei.postsec_completed_status,
+from {{ ref('int_kippadb__enrollment_pivot') }} as ei
+where
+    ei.postsec_completed_enrollment_id != ei.ugrad_enrollment_id
+    and ei.postsec_completed_status = 'Graduated'
+    and ei.ugrad_status != 'Graduated'
+```
+
+- [ ] **Step 2: Build the model into dev**
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt build \
+  --select int_kippadb__enrollment_pivot --target dev \
+  --defer --state target/prod --project-dir src/dbt/kipptaf 2>&1 | tail -25
+```
+
+Expected: model builds; the `student` uniqueness test passes (`PASS`). If the
+build reports the dev relation for an upstream is missing, add
+`dbt clone --select <upstream>` or ensure `--state target/prod` is fresh
+(preflight parse).
+
+- [ ] **Step 3: Run the divergence acceptance check**
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt show --inline "$(cat <<'SQL'
+select
+    ei.student,
+    ei.ugrad_status,
+    ei.postsec_completed_status,
+from {{ ref('int_kippadb__enrollment_pivot') }} as ei
+where
+    ei.postsec_completed_enrollment_id != ei.ugrad_enrollment_id
+    and ei.postsec_completed_status = 'Graduated'
+    and ei.ugrad_status != 'Graduated'
+SQL
+)" --target dev --project-dir src/dbt/kipptaf --limit 20 2>&1 | tail -30
+```
+
+Expected: one or more rows where `postsec_completed_status = Graduated` and
+`ugrad_status` is something else (e.g. `Attending`) — proving the
+completed-first pick diverges from recency-first as intended.
+
+- [ ] **Step 4: Confirm grain is preserved**
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt show --inline "$(cat <<'SQL'
+select count(*) as dupes
+from (
+    select ei.student
+    from {{ ref('int_kippadb__enrollment_pivot') }} as ei
+    group by ei.student
+    having count(*) > 1
+)
+SQL
+)" --target dev --project-dir src/dbt/kipptaf --limit 5 2>&1 | tail -10
+```
+
+Expected: `dupes = 0`.
+
+- [ ] **Step 5: Confirm null behavior aligns with is_never_enrolled**
+
+```bash
+VIRTUAL_ENV= DBT_PROFILES_DIR=.dbt uv run dbt show --inline "$(cat <<'SQL'
+select
+    ei.is_never_enrolled,
+    countif(ei.postsec_completed_enrollment_id is null) as n_null,
+    count(*) as n_total,
+from {{ ref('int_kippadb__enrollment_pivot') }} as ei
+group by ei.is_never_enrolled
+SQL
+)" --target dev --project-dir src/dbt/kipptaf --limit 5 2>&1 | tail -10
+```
+
+Expected: every `is_never_enrolled = true` row has a null
+`postsec_completed_enrollment_id` (both derive from the same BA/AA/CTE pool).
+
+- [ ] **Step 6: Push and mark the PR ready**
+
+```bash
+git push origin CGibson17/feat/claude-postsec-completed-enrollment-id
+```
+
+Then mark PR #4332 ready for review (via the GitHub UI or `gh pr ready 4332`) so
+dbt Cloud CI and `claude-review` fire on the full change. Confirm dbt Cloud CI
+is green before requesting human review.
+
+---
+
+## Self-review
+
+- **Spec coverage:** candidate pool (Task 1 Step 1 — BA/AA/CTE structs);
+  completed = Graduated (`if(status = 'Graduated', ...)`); ranking order
+  (`order by is_completed desc, degree_rank desc, start_date desc`); full
+  attribute set (Task 1 Steps 3-4, Task 2); grain unchanged (Task 3 Step 4);
+  null when no BA/AA/CTE (Task 3 Step 5). All covered.
+- **Placeholder scan:** no TBD/TODO; all code and commands are concrete.
+- **Type consistency:** alias `pce`/`pcea` and column name
+  `postsec_completed_enrollment_id` are used identically across the SQL joins,
+  the final select, and the YAML entries; attribute `data_type`s mirror the
+  verified `ugrad_*` types (`date`/`numeric`/`boolean`/`string`).

--- a/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
+++ b/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
@@ -1,0 +1,181 @@
+# Design: `postsec_completed_enrollment_id` in `int_kippadb__enrollment_pivot`
+
+- **Issue:** [#4331](https://github.com/TEAMSchools/teamster/issues/4331)
+- **Date:** 2026-07-06
+- **Model:**
+  `src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql`
+
+## Problem
+
+`int_kippadb__enrollment_pivot` exposes `ugrad_enrollment_id`, which picks a
+student's single undergraduate enrollment between their best `BA` and best `AA`
+track rows. Its tiebreak is **recency only** — the enrollment with the later
+`start_date` wins (`BA` also wins when there is no `AA`):
+
+```sql
+case
+    when ba.start_date > aa.start_date then e.ba_enrollment_id
+    when aa.start_date is null then e.ba_enrollment_id
+    else e.aa_enrollment_id
+end as ugrad_enrollment_id
+```
+
+This means a student who **graduated** an `AA` in 2020 but is currently
+**Attending** a `BA` resolves to the in-progress `BA`, not the credential they
+actually earned. KIPP Forward reporting needs a field that surfaces the
+**completed** post-secondary enrollment when one exists.
+
+## Requirements (confirmed)
+
+- **Candidate pool:** the three post-secondary track picks already resolved in
+  the model — `ba_enrollment_id`, `aa_enrollment_id`, `cte_enrollment_id` (`CTE`
+  = the `Vocational` pick). Excludes `HS`, `Graduate`, `Employment`. This
+  matches the pool used by the model's `is_never_enrolled` flag.
+- **Completed definition:** `status = 'Graduated'` only. Equivalent to the
+  existing `is_graduated` flag; `Completed Coursework` and other statuses do
+  **not** count.
+- **Ranking** (first non-null candidate wins, in order):
+  1. Completed tier — `Graduated` beats everything else.
+  2. Degree level — `BA` > `AA` > `CTE`.
+  3. Recency — later `start_date`.
+- **Output:** the id column plus the full parallel attribute set, mirroring the
+  existing `ugrad_*` block down through the final `select`.
+- **Grain unchanged:** one row per `student`.
+
+## Status domain reference
+
+Distinct `status` values in `stg_kippadb__enrollment` (profiled 2026-07-06), for
+context on why `Graduated`-only is the completed definition:
+
+| status               | rows   | bucket            |
+| -------------------- | ------ | ----------------- |
+| Graduated            | 10,330 | completed         |
+| Attending            | 4,379  | in progress       |
+| Withdrawn            | 3,972  | withdrawn         |
+| Transferred out      | 2,297  | withdrawn         |
+| Did Not Enroll       | 727    | filtered upstream |
+| Matriculated         | 66     | in progress       |
+| Unknown              | 33     | other             |
+| Leave of Absence     | 27     | in progress       |
+| Completed Coursework | 17     | not counted       |
+| Expelled             | 15     | withdrawn         |
+| Special Circumstance | 11     | other             |
+| Other                | 9      | other             |
+| Deferred             | 9      | in progress       |
+
+Only `Graduated` is treated as completed; every other retained status is a
+non-completed candidate ranked by degree level then recency.
+
+## Design
+
+### The pick
+
+Each of `ba` / `aa` / `cte` in the `enrollment_wide` CTE is already the best row
+within its track (chosen upstream by
+`rn_degree_desc = is_graduated desc, start_date desc`), and each is joined to
+`stg_kippadb__enrollment`, exposing `.status` and `.start_date`. So the
+completed-first pick is a compact `unnest`-of-structs scalar subquery placed
+beside the existing `ugrad_enrollment_id` case:
+
+```sql
+(
+    select cand.enrollment_id
+    from
+        unnest([
+            struct(
+                e.ba_enrollment_id as enrollment_id,
+                if(ba.status = 'Graduated', 1, 0) as is_completed,
+                3 as degree_rank,
+                ba.start_date as start_date
+            ),
+            struct(
+                e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2, aa.start_date
+            ),
+            struct(
+                e.cte_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1, cte.start_date
+            )
+        ]) as cand
+    where cand.enrollment_id is not null
+    order by cand.is_completed desc, cand.degree_rank desc, cand.start_date desc
+    limit 1
+) as postsec_completed_enrollment_id
+```
+
+Notes:
+
+- `where cand.enrollment_id is not null` drops tracks the student never enrolled
+  in, so a student with no `BA`/`AA`/`CTE` yields `NULL`.
+- The `order by ... limit 1` is the pick mechanism inside a scalar subquery, not
+  cosmetic output ordering; the repo "no `ORDER BY`" rule does not apply. Will
+  confirm lint-clean with `trunk check`.
+- `start_date desc` sorts `NULL` last (BigQuery default), so a candidate with a
+  known start date beats one without on the recency tiebreak.
+- The literal `unnest([...])` is not a correlated join to another table, so it
+  is not subject to BigQuery's correlated-subquery restriction.
+
+### Attribute set
+
+Add a `postsec_completed_*` block mirroring the `ugrad_*` block, keyed on the
+new id. This requires:
+
+1. Carrying `postsec_completed_enrollment_id` out of `enrollment_wide` and into
+   the final `select`.
+2. Two new joins at the bottom of the model, paralleling the `ug` / `uga` joins:
+
+   ```sql
+   left join
+       {{ ref("stg_kippadb__enrollment") }} as pce
+       on ew.postsec_completed_enrollment_id = pce.id
+   left join {{ ref("stg_kippadb__account") }} as pcea on pce.school = pcea.id
+   ```
+
+3. The parallel columns (prefix `postsec_completed_`), matching the `ugrad_*`
+   set exactly:
+
+   | new column                                                   | source                                          |
+   | ------------------------------------------------------------ | ----------------------------------------------- |
+   | `postsec_completed_school_name`                              | `pce.name`                                      |
+   | `postsec_completed_pursuing_degree_type`                     | `pce.pursuing_degree_type`                      |
+   | `postsec_completed_status`                                   | `pce.status`                                    |
+   | `postsec_completed_start_date`                               | `pce.start_date`                                |
+   | `postsec_completed_actual_end_date`                          | `pce.actual_end_date`                           |
+   | `postsec_completed_anticipated_graduation`                   | `pce.anticipated_graduation`                    |
+   | `postsec_completed_account_type`                             | `pce.account_type`                              |
+   | `postsec_completed_major`                                    | `pce.major`                                     |
+   | `postsec_completed_major_area`                               | `pce.major_area`                                |
+   | `postsec_completed_college_major_declared`                   | `pce.college_major_declared`                    |
+   | `postsec_completed_date_last_verified`                       | `pce.date_last_verified`                        |
+   | `postsec_completed_credits_required_for_graduation`          | `pce.of_credits_required_for_graduation`        |
+   | `postsec_completed_account_name`                             | `pcea.name`                                     |
+   | `postsec_completed_billing_state`                            | `pcea.billing_state`                            |
+   | `postsec_completed_nces_id`                                  | `pcea.nces_id`                                  |
+   | `postsec_completed_act_composite_25_75`                      | `pcea.act_composite_25_75`                      |
+   | `postsec_completed_competitiveness_ranking`                  | `pcea.competitiveness_ranking`                  |
+   | `postsec_completed_adjusted_6_year_minority_graduation_rate` | `pcea.adjusted_6_year_minority_graduation_rate` |
+
+### Properties YAML
+
+Add all new columns (`postsec_completed_enrollment_id` plus the attribute set)
+to `properties/int_kippadb__enrollment_pivot.yml`, placed adjacent to the
+corresponding `ugrad_*` entries, each with `data_type` and a `description`. This
+intermediate model has no contract block, so the YAML is documentation only; the
+`student` uniqueness test is unchanged.
+
+## Testing / verification
+
+- `dbt build --select int_kippadb__enrollment_pivot` (via a consuming path /
+  `--target staging`) succeeds and the `student` uniqueness test still passes.
+- Spot-check queries against `stg_kippadb__enrollment`:
+  - A student with a graduated `AA` and an in-progress `BA` resolves
+    `postsec_completed_enrollment_id` to the `AA`, while `ugrad_enrollment_id`
+    still resolves to the `BA` (demonstrates the divergence).
+  - A student with only in-progress enrollments resolves to the highest
+    degree-level / most-recent candidate (no completed row).
+  - A student with no `BA`/`AA`/`CTE` yields `NULL`.
+- `trunk check` clean on the modified `.sql` and `.yml`.
+
+## Out of scope
+
+- No change to `ugrad_enrollment_id` or any existing column.
+- No consumer wiring — `rpt_*` models opt in later as needed. This PR only adds
+  the columns to the pivot and its properties YAML.

--- a/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
+++ b/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
@@ -92,7 +92,7 @@ beside the existing `ugrad_enrollment_id` case:
                 e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2, aa.start_date
             ),
             struct(
-                e.cte_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1, cte.start_date
+                e.vocational_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1, cte.start_date
             )
         ]) as cand
     where cand.enrollment_id is not null

--- a/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
+++ b/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
@@ -39,9 +39,8 @@ actually earned. KIPP Forward reporting needs a field that surfaces the
   2. Degree level — `BA` > `AA` > `CTE`.
 
   The candidate pool is exactly the three track picks, each with a distinct
-  degree level, so `(is_completed, degree_rank)` totally orders them and a
-  recency tiebreak is never reachable. `start_date` is therefore not part of the
-  pick.
+  degree level, so completed-tier then degree-level totally orders them — no
+  recency tiebreak is reachable, so `start_date` is not part of the pick.
 
 - **Output:** the id column plus the full parallel attribute set, mirroring the
   existing `ugrad_*` block down through the final `select`.
@@ -78,43 +77,32 @@ non-completed candidate ranked by degree level.
 Each of `ba` / `aa` / `cte` in the `enrollment_wide` CTE is already the best row
 within its track (chosen upstream by
 `rn_degree_desc = is_graduated desc, start_date desc`), and each is joined to
-`stg_kippadb__enrollment`, exposing `.status` and `.start_date`. So the
-completed-first pick is a compact `unnest`-of-structs scalar subquery placed
-beside the existing `ugrad_enrollment_id` case:
+`stg_kippadb__enrollment`, exposing `.status`. So the completed-first pick is a
+`coalesce` of guarded ids placed beside the existing `ugrad_enrollment_id` case
+— `coalesce` returns the first non-null in priority order:
 
 ```sql
-(
-    select cand.enrollment_id
-    from
-        unnest([
-            struct(
-                e.ba_enrollment_id as enrollment_id,
-                if(ba.status = 'Graduated', 1, 0) as is_completed,
-                3 as degree_rank
-            ),
-            struct(e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2),
-            struct(
-                e.vocational_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1
-            )
-        ]) as cand
-    where cand.enrollment_id is not null
-    order by cand.is_completed desc, cand.degree_rank desc
-    limit 1
+coalesce(
+    if(ba.status = 'Graduated', e.ba_enrollment_id, null),
+    if(aa.status = 'Graduated', e.aa_enrollment_id, null),
+    if(cte.status = 'Graduated', e.vocational_enrollment_id, null),
+    e.ba_enrollment_id,
+    e.aa_enrollment_id,
+    e.vocational_enrollment_id
 ) as postsec_completed_enrollment_id
 ```
 
 Notes:
 
-- `where cand.enrollment_id is not null` drops tracks the student never enrolled
-  in, so a student with no `BA`/`AA`/`CTE` yields `NULL`.
-- The `order by ... limit 1` is the pick mechanism inside a scalar subquery, not
-  cosmetic output ordering; the repo "no `ORDER BY`" rule does not apply. Will
-  confirm lint-clean with `trunk check`.
-- `degree_rank` is a distinct literal per candidate, so
-  `(is_completed, degree_rank)` fully orders the pool — there is no `start_date`
-  recency tiebreak to reach.
-- The literal `unnest([...])` is not a correlated join to another table, so it
-  is not subject to BigQuery's correlated-subquery restriction.
+- The graduated-first arms (`if(<x>.status = 'Graduated', ...)`) precede the
+  unguarded arms, so a completed enrollment always wins; within each tier the
+  arm order `BA → AA → CTE` encodes the degree-level preference.
+- A student with no `BA`/`AA`/`CTE` has all six arms null, so `coalesce` yields
+  `NULL` — aligned with `is_never_enrolled`.
+- This is the repo's blessed priority-pick form (see `src/dbt/CLAUDE.md` → SQL
+  conventions): no subquery and no `ORDER BY`, so the "no `ORDER BY`" rule is
+  satisfied rather than argued around. It is also only 1 level of function
+  nesting (`coalesce(if(...))`), within the readability limit.
 
 ### Attribute set
 

--- a/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
+++ b/docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md
@@ -37,7 +37,12 @@ actually earned. KIPP Forward reporting needs a field that surfaces the
 - **Ranking** (first non-null candidate wins, in order):
   1. Completed tier — `Graduated` beats everything else.
   2. Degree level — `BA` > `AA` > `CTE`.
-  3. Recency — later `start_date`.
+
+  The candidate pool is exactly the three track picks, each with a distinct
+  degree level, so `(is_completed, degree_rank)` totally orders them and a
+  recency tiebreak is never reachable. `start_date` is therefore not part of the
+  pick.
+
 - **Output:** the id column plus the full parallel attribute set, mirroring the
   existing `ugrad_*` block down through the final `select`.
 - **Grain unchanged:** one row per `student`.
@@ -64,7 +69,7 @@ context on why `Graduated`-only is the completed definition:
 | Deferred             | 9      | in progress       |
 
 Only `Graduated` is treated as completed; every other retained status is a
-non-completed candidate ranked by degree level then recency.
+non-completed candidate ranked by degree level.
 
 ## Design
 
@@ -85,18 +90,15 @@ beside the existing `ugrad_enrollment_id` case:
             struct(
                 e.ba_enrollment_id as enrollment_id,
                 if(ba.status = 'Graduated', 1, 0) as is_completed,
-                3 as degree_rank,
-                ba.start_date as start_date
+                3 as degree_rank
             ),
+            struct(e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2),
             struct(
-                e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2, aa.start_date
-            ),
-            struct(
-                e.vocational_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1, cte.start_date
+                e.vocational_enrollment_id, if(cte.status = 'Graduated', 1, 0), 1
             )
         ]) as cand
     where cand.enrollment_id is not null
-    order by cand.is_completed desc, cand.degree_rank desc, cand.start_date desc
+    order by cand.is_completed desc, cand.degree_rank desc
     limit 1
 ) as postsec_completed_enrollment_id
 ```
@@ -108,8 +110,9 @@ Notes:
 - The `order by ... limit 1` is the pick mechanism inside a scalar subquery, not
   cosmetic output ordering; the repo "no `ORDER BY`" rule does not apply. Will
   confirm lint-clean with `trunk check`.
-- `start_date desc` sorts `NULL` last (BigQuery default), so a candidate with a
-  known start date beats one without on the recency tiebreak.
+- `degree_rank` is a distinct literal per candidate, so
+  `(is_completed, degree_rank)` fully orders the pool — there is no `start_date`
+  recency tiebreak to reach.
 - The literal `unnest([...])` is not a correlated join to another table, so it
   is not subject to BigQuery's correlated-subquery restriction.
 
@@ -158,13 +161,16 @@ new id. This requires:
 Add all new columns (`postsec_completed_enrollment_id` plus the attribute set)
 to `properties/int_kippadb__enrollment_pivot.yml`, placed adjacent to the
 corresponding `ugrad_*` entries, each with `data_type` and a `description`. This
-intermediate model has no contract block, so the YAML is documentation only; the
-`student` uniqueness test is unchanged.
+intermediate model has no contract block, so the column YAML is documentation
+only. The model was also missing the intermediate-layer uniqueness test required
+by `src/dbt/CLAUDE.md`, so add a `unique` (`severity: error`) test on `student`
+and a model-level `description`.
 
 ## Testing / verification
 
 - `dbt build --select int_kippadb__enrollment_pivot` (via a consuming path /
-  `--target staging`) succeeds and the `student` uniqueness test still passes.
+  `--target staging`) succeeds and the newly-added `student` uniqueness test
+  passes (verified in prod: 10,100 rows = 10,100 distinct students).
 - Spot-check queries against `stg_kippadb__enrollment`:
   - A student with a graduated `AA` and an in-progress `BA` resolves
     `postsec_completed_enrollment_id` to the `AA`, while `ugrad_enrollment_id`

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
@@ -289,6 +289,37 @@ with
                 else e.aa_enrollment_id
             end as ugrad_enrollment_id,
 
+            (
+                select cand.enrollment_id,
+                from
+                    unnest(
+                        [
+                            struct(
+                                e.ba_enrollment_id as enrollment_id,
+                                if(ba.status = 'Graduated', 1, 0) as is_completed,
+                                3 as degree_rank,
+                                ba.start_date as start_date
+                            ),
+                            struct(
+                                e.aa_enrollment_id,
+                                if(aa.status = 'Graduated', 1, 0),
+                                2,
+                                aa.start_date
+                            ),
+                            struct(
+                                e.cte_enrollment_id,
+                                if(cte.status = 'Graduated', 1, 0),
+                                1,
+                                cte.start_date
+                            )
+                        ]
+                    ) as cand
+                where cand.enrollment_id is not null
+                order by
+                    cand.is_completed desc, cand.degree_rank desc, cand.start_date desc
+                limit 1
+            ) as postsec_completed_enrollment_id,
+
             coalesce(
                 emp.start_date, emp.enlist_date, emp.bmt_start_date, emp.meps_start_date
             ) as emp_start_date,
@@ -334,6 +365,7 @@ select
     ew.cte_enrollment_id,
     ew.graduate_enrollment_id,
     ew.ugrad_enrollment_id,
+    ew.postsec_completed_enrollment_id,
     ew.cur_enrollment_id,
     ew.ba_school_name,
     ew.ba_pursuing_degree_type,
@@ -441,6 +473,28 @@ select
     uga.adjusted_6_year_minority_graduation_rate
     as ugrad_adjusted_6_year_minority_graduation_rate,
 
+    pce.name as postsec_completed_school_name,
+    pce.pursuing_degree_type as postsec_completed_pursuing_degree_type,
+    pce.status as postsec_completed_status,
+    pce.start_date as postsec_completed_start_date,
+    pce.actual_end_date as postsec_completed_actual_end_date,
+    pce.anticipated_graduation as postsec_completed_anticipated_graduation,
+    pce.account_type as postsec_completed_account_type,
+    pce.major as postsec_completed_major,
+    pce.major_area as postsec_completed_major_area,
+    pce.college_major_declared as postsec_completed_college_major_declared,
+    pce.date_last_verified as postsec_completed_date_last_verified,
+    pce.of_credits_required_for_graduation
+    as postsec_completed_credits_required_for_graduation,
+
+    pcea.name as postsec_completed_account_name,
+    pcea.billing_state as postsec_completed_billing_state,
+    pcea.nces_id as postsec_completed_nces_id,
+    pcea.act_composite_25_75 as postsec_completed_act_composite_25_75,
+    pcea.competitiveness_ranking as postsec_completed_competitiveness_ranking,
+    pcea.adjusted_6_year_minority_graduation_rate
+    as postsec_completed_adjusted_6_year_minority_graduation_rate,
+
     if(
         ew.ba_enrollment_id is null
         and ew.aa_enrollment_id is null
@@ -451,3 +505,7 @@ select
 from enrollment_wide as ew
 left join {{ ref("stg_kippadb__enrollment") }} as ug on ew.ugrad_enrollment_id = ug.id
 left join {{ ref("stg_kippadb__account") }} as uga on ug.school = uga.id
+left join
+    {{ ref("stg_kippadb__enrollment") }} as pce
+    on ew.postsec_completed_enrollment_id = pce.id
+left join {{ ref("stg_kippadb__account") }} as pcea on pce.school = pcea.id

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
@@ -289,6 +289,10 @@ with
                 else e.aa_enrollment_id
             end as ugrad_enrollment_id,
 
+            -- pick the student's single best post-secondary enrollment:
+            -- completed (Graduated) first, then degree level (BA > AA > CTE).
+            -- degree_rank is unique per candidate, so it is the final
+            -- discriminator; no recency tiebreak is reachable.
             (
                 select cand.enrollment_id,
                 from
@@ -297,26 +301,20 @@ with
                             struct(
                                 e.ba_enrollment_id as enrollment_id,
                                 if(ba.status = 'Graduated', 1, 0) as is_completed,
-                                3 as degree_rank,
-                                ba.start_date as start_date
+                                3 as degree_rank
                             ),
                             struct(
-                                e.aa_enrollment_id,
-                                if(aa.status = 'Graduated', 1, 0),
-                                2,
-                                aa.start_date
+                                e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2
                             ),
                             struct(
                                 e.vocational_enrollment_id,
                                 if(cte.status = 'Graduated', 1, 0),
-                                1,
-                                cte.start_date
+                                1
                             )
                         ]
                     ) as cand
                 where cand.enrollment_id is not null
-                order by
-                    cand.is_completed desc, cand.degree_rank desc, cand.start_date desc
+                order by cand.is_completed desc, cand.degree_rank desc
                 limit 1
             ) as postsec_completed_enrollment_id,
 

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
@@ -307,7 +307,7 @@ with
                                 aa.start_date
                             ),
                             struct(
-                                e.cte_enrollment_id,
+                                e.vocational_enrollment_id,
                                 if(cte.status = 'Graduated', 1, 0),
                                 1,
                                 cte.start_date

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__enrollment_pivot.sql
@@ -291,31 +291,15 @@ with
 
             -- pick the student's single best post-secondary enrollment:
             -- completed (Graduated) first, then degree level (BA > AA > CTE).
-            -- degree_rank is unique per candidate, so it is the final
-            -- discriminator; no recency tiebreak is reachable.
-            (
-                select cand.enrollment_id,
-                from
-                    unnest(
-                        [
-                            struct(
-                                e.ba_enrollment_id as enrollment_id,
-                                if(ba.status = 'Graduated', 1, 0) as is_completed,
-                                3 as degree_rank
-                            ),
-                            struct(
-                                e.aa_enrollment_id, if(aa.status = 'Graduated', 1, 0), 2
-                            ),
-                            struct(
-                                e.vocational_enrollment_id,
-                                if(cte.status = 'Graduated', 1, 0),
-                                1
-                            )
-                        ]
-                    ) as cand
-                where cand.enrollment_id is not null
-                order by cand.is_completed desc, cand.degree_rank desc
-                limit 1
+            -- coalesce returns the first non-null in priority order: graduated
+            -- BA/AA/CTE, then any BA/AA/CTE. null when the student has none.
+            coalesce(
+                if(ba.status = 'Graduated', e.ba_enrollment_id, null),
+                if(aa.status = 'Graduated', e.aa_enrollment_id, null),
+                if(cte.status = 'Graduated', e.vocational_enrollment_id, null),
+                e.ba_enrollment_id,
+                e.aa_enrollment_id,
+                e.vocational_enrollment_id
             ) as postsec_completed_enrollment_id,
 
             coalesce(

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml
@@ -1,8 +1,17 @@
 models:
   - name: int_kippadb__enrollment_pivot
+    description:
+      One row per KIPP alumni student, pivoting the student's post-secondary and
+      employment enrollments into track-specific picks (BA, AA, CTE, HS,
+      graduate, undergraduate, completed post-secondary, current, employment)
+      alongside the attributes of each picked enrollment.
     columns:
       - name: student
         data_type: string
+        data_tests:
+          - unique:
+              config:
+                severity: error
       - name: ba_enrollment_id
         data_type: string
       - name: aa_enrollment_id
@@ -23,8 +32,8 @@ models:
           Enrollment id of the student's best post-secondary enrollment across
           the BA, AA, and CTE track picks — preferring a completed (Graduated)
           enrollment over any in-progress or withdrawn one, then higher degree
-          level (BA over AA over CTE), then most recent start date. Null when
-          the student has no BA, AA, or CTE enrollment.
+          level (BA over AA over CTE). Null when the student has no BA, AA, or
+          CTE enrollment.
       - name: cur_enrollment_id
         data_type: string
       - name: ba_school_name

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__enrollment_pivot.yml
@@ -17,6 +17,14 @@ models:
         data_type: string
       - name: ugrad_enrollment_id
         data_type: string
+      - name: postsec_completed_enrollment_id
+        data_type: string
+        description:
+          Enrollment id of the student's best post-secondary enrollment across
+          the BA, AA, and CTE track picks — preferring a completed (Graduated)
+          enrollment over any in-progress or withdrawn one, then higher degree
+          level (BA over AA over CTE), then most recent start date. Null when
+          the student has no BA, AA, or CTE enrollment.
       - name: cur_enrollment_id
         data_type: string
       - name: ba_school_name
@@ -229,6 +237,94 @@ models:
         data_type: string
       - name: ugrad_adjusted_6_year_minority_graduation_rate
         data_type: numeric
+      - name: postsec_completed_school_name
+        data_type: string
+        description:
+          Name of the enrollment identified by postsec_completed_enrollment_id.
+      - name: postsec_completed_pursuing_degree_type
+        data_type: string
+        description:
+          Pursuing degree type of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_status
+        data_type: string
+        description:
+          Status of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_start_date
+        data_type: date
+        description:
+          Start date of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_actual_end_date
+        data_type: date
+        description:
+          Actual end date of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_anticipated_graduation
+        data_type: date
+        description:
+          Anticipated graduation date of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_account_type
+        data_type: string
+        description:
+          Account type of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_major
+        data_type: string
+        description:
+          Major of the enrollment identified by postsec_completed_enrollment_id.
+      - name: postsec_completed_major_area
+        data_type: string
+        description:
+          Major area of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_college_major_declared
+        data_type: boolean
+        description:
+          Whether a college major was declared for the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_date_last_verified
+        data_type: date
+        description:
+          Date the enrollment identified by postsec_completed_enrollment_id was
+          last verified.
+      - name: postsec_completed_credits_required_for_graduation
+        data_type: numeric
+        description:
+          Credits required for graduation for the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_account_name
+        data_type: string
+        description:
+          Account name for the school of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_billing_state
+        data_type: string
+        description:
+          Billing state for the school of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_nces_id
+        data_type: string
+        description:
+          NCES id for the school of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_act_composite_25_75
+        data_type: string
+        description:
+          ACT composite 25th-75th percentile range for the school of the
+          enrollment identified by postsec_completed_enrollment_id.
+      - name: postsec_completed_competitiveness_ranking
+        data_type: string
+        description:
+          Competitiveness ranking for the school of the enrollment identified by
+          postsec_completed_enrollment_id.
+      - name: postsec_completed_adjusted_6_year_minority_graduation_rate
+        data_type: numeric
+        description:
+          Adjusted 6-year minority graduation rate for the school of the
+          enrollment identified by postsec_completed_enrollment_id.
       - name: is_never_enrolled
         data_type: boolean
         description:


### PR DESCRIPTION
## Summary and Motivation

> When merged, this pull request will add a completed-first sibling to `ugrad_enrollment_id` in `int_kippadb__enrollment_pivot`.

The new `postsec_completed_enrollment_id` picks a student's single best post-secondary enrollment across the BA/AA/CTE track picks, preferring a completed (`status = 'Graduated'`) enrollment over any in-progress or withdrawn one, then higher degree level (BA over AA over CTE). It surfaces the id plus the full parallel attribute set (`postsec_completed_*`, 18 columns), mirroring the existing `ugrad_*` block. Additive only — no existing column or consumer changes.

The implementation is complete in this branch (model SQL + properties YAML). Spec and plan: `docs/superpowers/specs/2026-07-06-postsec-completed-enrollment-id-design.md`, `docs/superpowers/plans/2026-07-06-postsec-completed-enrollment-id.md`.

Refs #4331

### AI Assistance

Claude Code drafted the spec via a guided brainstorm and implemented the change task-by-task; design decisions (scope = BA/AA/CTE, completed = Graduated only, tiebreak = degree level, full attribute set) were human-directed.

## Self-review

### dbt

- [x] Properties file updated with all new columns (id + 18 attributes), each described; model-level description added.
- [x] Added the required intermediate-layer `unique` test on `student` (severity error).
- [x] Additive only — no renamed or removed columns, so no downstream exposure breakage.
- [x] No external source added or modified — kippadb is a BQ-native source, so no `stage_external_sources` step needed.
- [x] No exposure change — no dashboard/application consumes the new columns yet.

### Verification (local, dev build with prod-deferred upstreams)

- [x] `dbt build --select int_kippadb__enrollment_pivot --target dev` succeeds; `unique` test on `student` passes.
- [x] Grain intact: 10,087 rows = 10,087 distinct students.
- [x] Behavior confirmed: 127 students where the new field returns a Graduated enrollment while `ugrad_*` returns a non-graduated one.
- [x] Null alignment: 0 `is_never_enrolled` students carry a non-null `postsec_completed_enrollment_id`.

## CI checks

- [ ] Trunk — passes locally on both changed files.
- [ ] dbt Cloud — confirm green before merge.
