### PR TITLE
feat(kipptaf): union int_powerschool__gpa_cumulative_year and expose needed-GPA columns

### DIFF
--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative_year.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative_year.sql
@@ -1,0 +1,15 @@
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
+    )
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative.yml
@@ -45,6 +45,33 @@ models:
         data_type: float64
       - name: core_cumulative_y1_gpa
         data_type: float64
+      - name: potential_gpa_credits_cum_projected
+        data_type: float64
+        description: >-
+          Sum of potential GPA credit hours across all years, including
+          in-progress current-year courses — the denominator behind
+          `cumulative_y1_gpa_projected`.
+      - name: potential_gpa_credits_current_year
+        data_type: float64
+        description: >-
+          Potential GPA credit hours the student is enrolled in for the current
+          academic year. NULL when the student has no current-year GPA credits.
+      - name: gpa_needed_for_cumulative_3_0
+        data_type: float64
+        description: >-
+          Weighted Y1 GPA the student must average across all current-year GPA
+          credits to finish with a projected cumulative Y1 GPA of exactly 3.00.
+          Negative values mean 3.00 is already guaranteed; values above the
+          student's scale maximum are not attainable this year. NULL when the
+          student has no current-year GPA credits.
+      - name: is_cumulative_3_0_attainable
+        data_type: boolean
+        description: >-
+          True when `gpa_needed_for_cumulative_3_0` is at or below the
+          credit-weighted maximum weighted GPA achievable across the student's
+          current-year courses. NULL when the needed value is NULL, or when any
+          in-progress course's grade scale cannot be resolved — the max is then
+          unknowable, so the flag reads unknown rather than a misstated false.
       - name: _dbt_source_project
         data_type: string
         description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
@@ -1,0 +1,69 @@
+models:
+  - name: int_powerschool__gpa_cumulative_year
+    description: >-
+      Network union of the district int_powerschool__gpa_cumulative_year models
+      (Newark, Camden, Miami) — one row per student, school, and academic year
+      with cumulative Y1 GPA as of the end of that year; current-year rows are
+      projected (is_projected = true) and match int_powerschool__gpa_cumulative
+      projected values exactly.
+    config:
+      materialized: table
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - _dbt_source_relation
+              - studentid
+              - schoolid
+              - academic_year
+    columns:
+      - name: _dbt_source_relation
+        data_type: string
+      - name: studentid
+        data_type: int64
+        description:
+          The internal number and ID of the associated Students record.
+      - name: schoolid
+        data_type: int64
+        description: >-
+          School_Number of the school where the grades were stored (completed
+          years) or where the student is currently enrolled (projected row).
+      - name: academic_year
+        data_type: int64
+        description: >-
+          Academic year the cumulative values run through — start-year
+          convention (2024 means SY2024-25).
+      - name: grade_level
+        data_type: int64
+        description: >-
+          Student's grade level in that academic year, from the year's primary
+          enrollment. NULL for stored years with no matching enrollment.
+      - name: earned_credits_cum
+        data_type: float64
+        description: >-
+          Running earned credit hours through this academic year
+          (graduation-credit basis). Projected basis on the current-year row.
+      - name: potential_gpa_credits_cum
+        data_type: float64
+        description: >-
+          Running potential GPA credit hours through this academic year — the
+          denominator of the cumulative GPAs.
+      - name: cumulative_y1_gpa
+        data_type: float64
+        description: >-
+          Cumulative weighted Y1 GPA through this academic year. On the
+          current-year row this matches cumulative_y1_gpa_projected verbatim.
+      - name: cumulative_y1_gpa_unweighted
+        data_type: float64
+        description: >-
+          Cumulative unweighted Y1 GPA through this academic year. On the
+          current-year row this matches cumulative_y1_gpa_projected_unweighted
+          verbatim.
+      - name: is_projected
+        data_type: boolean
+        description: >-
+          False for completed years recomputed from stored grades; true for the
+          current-year row sourced from projected values.
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
@@ -19,15 +19,27 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+        description: Source relation identifier from dbt_utils.union_relations.
       - name: studentid
         data_type: int64
         description:
           The internal number and ID of the associated Students record.
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: stg_powerschool__storedgrades
+            source_column: studentid
+            column_role: foreign_key
       - name: schoolid
         data_type: int64
         description: >-
           School_Number of the school where the grades were stored (completed
           years) or where the student is currently enrolled (projected row).
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: stg_powerschool__students
+            source_column: schoolid
       - name: academic_year
         data_type: int64
         description: >-
@@ -52,12 +64,12 @@ models:
         data_type: float64
         description: >-
           Cumulative weighted Y1 GPA through this academic year. On the
-          current-year row this matches cumulative_y1_gpa_projected verbatim.
+          current-year row this matches `cumulative_y1_gpa_projected` verbatim.
       - name: cumulative_y1_gpa_unweighted
         data_type: float64
         description: >-
           Cumulative unweighted Y1 GPA through this academic year. On the
-          current-year row this matches cumulative_y1_gpa_projected_unweighted
+          current-year row this matches `cumulative_y1_gpa_projected_unweighted`
           verbatim.
       - name: is_projected
         data_type: boolean

--- a/src/dbt/kipptaf/models/powerschool/sources-kippcamden.yml
+++ b/src/dbt/kipptaf/models/powerschool/sources-kippcamden.yml
@@ -770,6 +770,15 @@ sources:
                 - kippcamden
                 - powerschool
                 - int_powerschool__gpa_cumulative
+      - name: int_powerschool__gpa_cumulative_year
+        config:
+          meta:
+            dagster:
+              group: powerschool
+              asset_key:
+                - kippcamden
+                - powerschool
+                - int_powerschool__gpa_cumulative_year
       - name: int_powerschool__gradebook_assignments
         config:
           meta:

--- a/src/dbt/kipptaf/models/powerschool/sources-kippmiami.yml
+++ b/src/dbt/kipptaf/models/powerschool/sources-kippmiami.yml
@@ -724,6 +724,15 @@ sources:
                 - kippmiami
                 - powerschool
                 - int_powerschool__gpa_cumulative
+      - name: int_powerschool__gpa_cumulative_year
+        config:
+          meta:
+            dagster:
+              group: powerschool
+              asset_key:
+                - kippmiami
+                - powerschool
+                - int_powerschool__gpa_cumulative_year
       - name: int_powerschool__gradebook_assignments
         config:
           meta:

--- a/src/dbt/kipptaf/models/powerschool/sources-kippnewark.yml
+++ b/src/dbt/kipptaf/models/powerschool/sources-kippnewark.yml
@@ -770,6 +770,15 @@ sources:
                 - kippnewark
                 - powerschool
                 - int_powerschool__gpa_cumulative
+      - name: int_powerschool__gpa_cumulative_year
+        config:
+          meta:
+            dagster:
+              group: powerschool
+              asset_key:
+                - kippnewark
+                - powerschool
+                - int_powerschool__gpa_cumulative_year
       - name: int_powerschool__gradebook_assignments
         config:
           meta:


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

Closes #4295

PR 2 of 2 (PR 1 was #4296, merged 2026-07-06). When merged, this pull request will surface the new district GPA models at the network level:

1. **New kipptaf union model `int_powerschool__gpa_cumulative_year`** — `dbt_utils.union_relations` over the three district prod tables (Newark, Camden, Miami) plus `_dbt_source_project`, with a uniqueness test on the union grain (`_dbt_source_relation`, `studentid`, `schoolid`, `academic_year`).
2. **Source entries** for the new district table in `sources-kippnewark.yml` / `sources-kippcamden.yml` / `sources-kippmiami.yml` with Dagster asset keys.
3. **Documentation of the four needed-GPA columns** on the existing kipptaf `int_powerschool__gpa_cumulative` properties YAML — the columns flow through the existing `ur.*` union automatically now that district prod carries them.

Deployment sequencing: PR 1 rebuilt district prod via Dagster on merge (verified all three districts materialized both models post-merge before starting this PR — the compile-time `union_relations` introspection requirement documented in PR 1). The `zz_stg_(district)_powerschool` staging copies of both models were re-cloned from post-merge prod so dbt Cloud CI can introspect the new shapes.

Design spec: `docs/superpowers/specs/2026-07-02-gpa-cumulative-year-needed-gpa-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-02-gpa-cumulative-year-needed-gpa.md`.

## AI Assistance

Claude Code authored the implementation per the plan approved in PR 1's design session; staging-clone seeding was human-authorized.

## Self-review

_Complete only the sections relevant to your changes._

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but do not ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [ ] Include (or update) an exposure for all models consumed by a dashboard,
      analysis, or application _(N/A — INT layer only; downstream surfacing is a
      follow-up effort)_
- [x] **Breaking change?** No — new model plus additive column documentation;
      existing kipptaf model SQL untouched
- [x] External sources: no external-table changes; district staging copies
      re-cloned from prod for CI introspection

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes (large `state:modified+` fan-out expected: the
      three sources file edits mark those sources modified)
- [ ] **Dagster Cloud** — kipptaf deploy triggered by sources file changes