### PR TITLE
fix(kipptaf): filter grades extracts to is_enrolled_recent

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gpa_cumulative_year.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gpa_cumulative_year.yml
@@ -6,9 +6,11 @@ models:
       as of the end of that year, joined to that year's enrollment attributes
       (demographics are as-of-that-year, not current). The current-year row is
       the projected row (is_projected = true) and matches the main extract's
-      projected cumulative columns exactly. Related to
-      rpt_tableau__student_course_grades in Tableau on student_number. Miami
-      hard-excluded.
+      projected cumulative columns exactly. Students filtered to
+      is_enrolled_recent — the year was completed or the enrollment is currently
+      active, so mid-year withdrawals drop but completed prior years of students
+      who later left are kept. Related to rpt_tableau__student_course_grades in
+      Tableau on student_number. Miami hard-excluded.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -76,7 +78,10 @@ models:
         description: School name in that year.
       - name: enroll_status
         data_type: int64
-        description: Current PowerSchool enroll_status (0 active, 3 graduated).
+        description: >-
+          Current PowerSchool enroll_status (0 active, 2 transferred out, 3
+          graduated). Student-level and current-only — a leaver's completed
+          prior-year rows carry their status today, not as of that year.
       - name: cohort
         data_type: int64
         description: Graduation cohort year.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -6,9 +6,11 @@ models:
       prior academic year. Decoupled from the gradebook-audit lineage: no
       assignment-level data, audit flags, comments, or citizenship.
       Student-grain as-of-today measures (cumulative GPA, needed-GPA, 1/2/4-week
-      lookbacks) populate current-year rows only. Newark and Camden only — Miami
-      is hard-excluded (region unsupported in the rebuilt dashboard) and
-      Paterson is pending gradebook data.
+      lookbacks) populate current-year rows only. Students filtered to
+      is_enrolled_recent — the year was completed or the enrollment is currently
+      active, so mid-year withdrawals drop. Newark and Camden only — Miami is
+      hard-excluded (region unsupported in the rebuilt dashboard) and Paterson
+      is pending gradebook data.
     data_tests:
       # TODO(#3915): returns to error when the storedgrades double-write cleanup
       # completes. All duplicates are prior-year storedgrades rows; current-year

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_cumulative_year.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_cumulative_year.sql
@@ -58,9 +58,9 @@ inner join
 where
     e.rn_year = 1
     and not e.is_out_of_district
-    /* pre-registered rows can pass is_enrolled_recent (future entry, year-end
-       exit), so the status guard stays */
-    and e.enroll_status != -1
+    /* status guard drops pre-registered (-1, which can pass
+       is_enrolled_recent) and invalid (1) rows */
+    and e.enroll_status in (0, 2, 3)
     and e.is_enrolled_recent
     /* Miami hard-excluded: region unsupported in the rebuilt dashboard
        (#4340) */

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_cumulative_year.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_cumulative_year.sql
@@ -58,7 +58,10 @@ inner join
 where
     e.rn_year = 1
     and not e.is_out_of_district
-    and e.enroll_status in (0, 3)
+    /* pre-registered rows can pass is_enrolled_recent (future entry, year-end
+       exit), so the status guard stays */
+    and e.enroll_status != -1
+    and e.is_enrolled_recent
     /* Miami hard-excluded: region unsupported in the rebuilt dashboard
        (#4340) */
     -- TODO(#4340): add Paterson once PS gradebook data is populated

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -160,9 +160,9 @@ with
         where
             enr.rn_year = 1
             and not enr.is_out_of_district
-            /* pre-registered rows can pass is_enrolled_recent (future entry,
-               year-end exit), so the status guard stays */
-            and enr.enroll_status != -1
+            /* status guard drops pre-registered (-1, which can pass
+               is_enrolled_recent) and invalid (1) rows */
+            and enr.enroll_status in (0, 2, 3)
             and enr.is_enrolled_recent
             /* upper bound keeps next-year pre-enrollment stubs out of the
                2-year window */

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -160,8 +160,14 @@ with
         where
             enr.rn_year = 1
             and not enr.is_out_of_district
+            /* pre-registered rows can pass is_enrolled_recent (future entry,
+               year-end exit), so the status guard stays */
             and enr.enroll_status != -1
+            and enr.is_enrolled_recent
+            /* upper bound keeps next-year pre-enrollment stubs out of the
+               2-year window */
             and enr.academic_year >= {{ var("current_academic_year") - 1 }}
+            and enr.academic_year <= {{ var("current_academic_year") }}
             /* Miami hard-excluded: region unsupported in the rebuilt
                dashboard (#4340) */
             -- TODO(#4340): add Paterson once PS gradebook data is populated


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Filter both rebuilt gradebook extracts (`rpt_tableau__student_course_grades`, `rpt_tableau__gpa_cumulative_year`) to `is_enrolled_recent` from `int_extracts__student_enrollments`, so the student population is "completed the year or currently enrolled." Follow-up to #4341 / refs #4340.

What changes:

- **Main extract**: adds `is_enrolled_recent` to the enrollment filter (keeping the `enroll_status != -1` pre-registered guard, since pre-registered rows can pass the flag). Also caps the `academic_year` window at the current year — the merged design is a 2-year window, but the lower bound alone let next-year pre-enrollment stubs leak in (8,916 stray AY2026 single-row students in prod today).
- **Companion**: replaces `enroll_status in (0, 3)` with `enroll_status != -1 and is_enrolled_recent`. Completed prior years of students who later transferred out are now **kept** (previously dropped entirely); mid-year withdrawals still drop.
- Model/column descriptions updated to document the population.

Validation (dev build with prod defer, prod vs dev comparison):

- Companion uniqueness test passes; main extract's warn is the pre-existing TODO(#3915) storedgrades dup warn.
- Main extract AY2024 students 11,806 to 8,496: 2,810 of the 3,310 dropped are alumni graduate-placeholder rows (`grade_level = 99`, NULL entry/exit dates) that produced NULL-grade stubs; the rest are genuine mid-year withdrawals (4-8% per grade). Grade 12 keeps 383/392 — June graduates are not clipped by the calendar-end comparison.
- AY2026 stub rows are fully gone with the window cap.

## AI Assistance

Claude Code authored the change end-to-end; population rule (`is_enrolled_recent`) and filter shape were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties files updated for both modified models
- [x] Exposure — no change; exposure work tracked in #4340 pending the workbook LSID
- [x] **Breaking change?** No columns renamed or removed; population-only change plus description updates
- [x] No external source changes

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.