### PR TITLE
fix(kipptaf): register Paterson payroll group code LCH partition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,14 @@ the allowlist.
   entity-encode `&`→`&amp;` and `"`→`&#34;` (not strip) — harmless in rendered
   prose but rendered literally inside code spans and in titles, so avoid `&` /
   `"` in PR/issue titles and code spans (use "and" / single quotes).
+- **The `mcp__github__*` read tools also sanitize on OUTPUT**:
+  `pull_request_read` / `issue_read` strip `<...>` and encode `'`→`&#39;` in the
+  body they return, so a just-written body read back through them shows phantom
+  corruption even when the stored body is intact (likely why the "even inside a
+  fence" stripping above reads worse than it stores). Verify the TRUE stored
+  body with raw `gh api repos/<owner>/<repo>/pulls/<n> --jq .body` (a GET —
+  works via Bash, whereas `gh pr view` is denied) before re-writing to "fix"
+  apparent corruption.
 - `mcp__github__pull_request_review_write` `method=create` requires the FULL
   40-char `commitID` — an abbreviated SHA fails with "Could not coerce value ...
   to GitObjectID".

--- a/src/teamster/code_locations/kipptaf/adp/payroll/assets.py
+++ b/src/teamster/code_locations/kipptaf/adp/payroll/assets.py
@@ -15,7 +15,7 @@ asset_key = AssetKey([CODE_LOCATION, "adp", "payroll", "general_ledger_file"])
 
 GENERAL_LEDGER_FILE_PARTITIONS_DEF = MultiPartitionsDefinition(
     {
-        "group_code": StaticPartitionsDefinition(["2Z3", "3LE", "47S", "9AM"]),
+        "group_code": StaticPartitionsDefinition(["2Z3", "3LE", "47S", "9AM", "LCH"]),
         "date": DynamicPartitionsDefinition(
             name=f"{asset_key.to_python_identifier()}__date"
         ),


### PR DESCRIPTION
## Summary and Motivation

When merged, this pull request will unblock ADP payroll ingestion by registering Paterson's payroll group code `LCH` as a valid partition.

The `kipptaf/adp/payroll/general_ledger_file` asset partitions by a `MultiPartitionsDefinition` whose `group_code` dimension is a static allow-list, last updated 2024-06-06 — before Paterson onboarded. Paterson's payroll group code `LCH` (business unit `KPAT`) was never added. The SFTP sensor's filename regex accepts any word:

```text
(?:ADP|adp)_[Pp]ayroll_(?P<date>\d+)_(?P<group_code>\w+)\.csv
```

so it matched Paterson's first GL file and emitted a run request for this partition key:

```text
20260701|LCH
```

Dagster rejected that unregistered key during sensor tick evaluation (`DagsterUnknownPartitionError`), crashing the entire `kipptaf__adp__payroll__sftp_sensor` tick — blocking ingestion for **every** group code, not just Paterson's. This adds `LCH` to the static set.

The group-code to region mapping was confirmed against `int_people__staff_roster` (95 Paterson staff already carry `LCH`). No dbt change is needed: the staging column `_dagster_partition_group_code` is a free string with no accepted-values constraint. The crashed tick never committed its cursor, so the file reprocesses automatically once deployed — no manual backfill.

### AI Assistance

Root-cause diagnosis, warehouse verification, and the one-line fix were Claude-assisted; human-directed and reviewed by @cbini.

## Self-review

### Dagster

- [x] Partition-def runtime check: the `group_code` dimension now accepts `LCH` and still rejects unknown codes; `MultiPartitionKey` reconstructs the exact failing key `20260701|LCH`.
- [x] Module import succeeds (`teamster.code_locations.kipptaf.adp.payroll.assets`).
- [ ] `uv run dagster definitions validate` — not runnable locally: fails on missing `src/dbt/kipptaf/target/manifest.json` (known codespace limitation, unrelated to this change; the trace fails in `dbt/assets.py`, never in the edited file). Authoritative validation runs in the Dagster Cloud branch deployment.

## CI checks

- [ ] **Trunk** — passes (file checked clean locally).
- [ ] **Dagster Cloud** — pending branch deployment.
