### PR TITLE
feat(kippnewark): add Finalsite contacts ingestion

### DIFF
--- a/.k8s/1password/items.yaml
+++ b/.k8s/1password/items.yaml
@@ -390,3 +390,11 @@ metadata:
   namespace: dagster-cloud
 spec:
   itemPath: vaults/Data Team/items/Finalsite API - Miami
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-finalsite-api-kippnewark
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/Finalsite API - Newark

--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -7,6 +7,10 @@ on GKE Autopilot.
 
 - GKE Autopilot: `autopilot-cluster-dagster-hybrid-1` in `us-central1`
   (`kubectl config current-context`).
+- **`kubectl` from the Claude Bash tool is classifier-blocked regardless of
+  in-conversation consent** — even read-only `kubectl config current-context`.
+  Hand cluster ops (`kubectl apply` of 1Password items, secret-key verification)
+  to the user, like `git push origin main`; don't retry.
 - `kubectl cordon` is ineffective on Autopilot — Google manages node lifecycle
   and may ignore cordon or replace the node entirely.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -66,6 +66,11 @@ not appear in site navigation.
 `uv run scripts/gen-automations-doc.py`. Never edit it directly. Regenerate when
 adding, removing, or renaming schedules or sensors.
 
+The script imports every code location's `definitions` and silently SKIPS any
+that fail to import — so running it in the codespace (district `definitions`
+fail on unset `PS_SSH_PORT`, etc.) drops those locations from the catalog.
+Regenerate only in a full environment where all locations load.
+
 ## `superpowers/` Directory
 
 Design specs (`specs/`) and implementation plans (`plans/`) for major features

--- a/docs/superpowers/plans/2026-07-08-finalsite-contacts-nj-phase1-ingestion.md
+++ b/docs/superpowers/plans/2026-07-08-finalsite-contacts-nj-phase1-ingestion.md
@@ -38,21 +38,17 @@ IO manager, BigQuery external tables.
 - **Conventional commits**; branch `cbini/feat/claude-finalsite-contacts-nj`
   (already created, linked to #4346).
 
-## Open config value (resolve before Task 4 deploy)
+## Confirmed config values
 
-- **Finalsite server subdomain for Newark.** `FinalsiteResource._service_root`
-  is `https://{server}.fsenrollment.com/api/external`. Miami passes
-  `server=CODE_LOCATION` → `kippmiami.fsenrollment.com`. This plan defaults
-  Newark to the same pattern (`server=CODE_LOCATION` → `kippnewark`), but the
-  actual Newark Finalsite subdomain MUST be confirmed with whoever provisioned
-  Newark's API access. If it differs, pass an explicit string instead of
-  `CODE_LOCATION` in Task 1.
-- **k8s secret provisioning.** Task 4 assumes a k8s secret named
-  `op-finalsite-api-kippnewark` with keys `username` (credential id) and
-  `password` (secret) exists in the `dagster-cloud` namespace, mirroring
-  `op-finalsite-api-kippmiami`. Creating it from 1Password is an Ops task
-  outside this repo — confirm it exists before deploy, or the asset run fails
-  auth at `setup_for_execution`.
+- **Finalsite server subdomain for Newark:** `kippnewark.fsenrollment.com`
+  (confirmed) — matches the `server=CODE_LOCATION` default, so Task 1 needs no
+  change.
+- **Newark 1Password item:** `vaults/Data Team/items/Finalsite API - Newark`
+  (confirmed). The `op-finalsite-api-kippnewark` k8s secret does NOT exist yet —
+  Task 4 declares the `OnePasswordItem` that syncs it. The field internal names
+  are ASSUMED to be `username` (credential id) / `password` (secret), mirroring
+  the Miami item; Task 4 Step 4 verifies this against the synced secret before
+  Task 5 wires `secretKeyRef.key`.
 
 ---
 
@@ -335,14 +331,93 @@ git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
 
 ---
 
-## Task 4: k8s secret env-var wiring in `dagster-cloud.yaml`
+## Task 4: Declare the Newark Finalsite 1Password item
+
+The `op-finalsite-api-kippnewark` k8s secret does not exist. The
+1Password-Connect operator creates each k8s secret from an `OnePasswordItem`
+manifest declared in `.k8s/1password/items.yaml`. Add Newark's, mirroring the
+Miami entry (lines 385-392). Applying the manifest to the cluster is a manual
+`kubectl` step (Step 3) that needs cluster access — hand it to the user if
+Claude lacks `kubectl` context.
+
+**Files:**
+
+- Modify: `.k8s/1password/items.yaml`
+
+- [ ] **Step 1: Append the Newark `OnePasswordItem`**
+
+Append to the end of `.k8s/1password/items.yaml` (each item is a `---`-separated
+document; match the Miami finalsite entry shape exactly):
+
+```yaml
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-finalsite-api-kippnewark
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/Finalsite API - Newark
+```
+
+- [ ] **Step 2: Validate YAML + trunk-check**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj && \
+  VIRTUAL_ENV= uv run python -c "import yaml; docs=list(yaml.safe_load_all(open('.k8s/1password/items.yaml'))); print(sum(1 for d in docs if d and d['metadata']['name']=='op-finalsite-api-kippnewark'), 'newark item')" && \
+  /workspaces/teamster/.trunk/tools/trunk check --force .k8s/1password/items.yaml
+```
+
+Expected: prints `1 newark item`, then `✔ No issues`.
+
+- [ ] **Step 3: Apply to the cluster (manual / user)**
+
+Requires `dagster-cloud` cluster credentials (see `.k8s/setup.sh`). Hand to the
+user if Claude has no `kubectl` context:
+
+```bash
+kubectl apply -f .k8s/1password/items.yaml
+```
+
+The operator then creates the `op-finalsite-api-kippnewark` secret from the
+1Password item (may take a few seconds to sync).
+
+- [ ] **Step 4: Verify the synced secret's key names**
+
+k8s secret keys come from the 1Password field's INTERNAL name, not the UI label
+(`.k8s/CLAUDE.md` — SFTP items remap `password` → `newPassword`, etc.). Confirm
+Task 5's `secretKeyRef.key` values before wiring:
+
+```bash
+kubectl -n dagster-cloud get secret op-finalsite-api-kippnewark -o jsonpath='{.data}' | jq keys
+```
+
+Expected: includes `"username"` and `"password"`. If the Newark item uses
+different field names, use those exact names as the `key:` values in Task 5
+instead of `username`/`password`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  add .k8s/1password/items.yaml
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  commit -m "feat(k8s): declare Newark Finalsite API 1Password item. Refs #4346"
+```
+
+---
+
+## Task 5: k8s secret env-var wiring in `dagster-cloud.yaml`
 
 `FinalsiteResource` reads `FINALSITE_CREDENTIAL_ID` and `FINALSITE_SECRET` from
 the environment. These must be projected from the k8s secret into BOTH the
 `server_k8s_config` (code-server pod) and `run_k8s_config` (run pod) env blocks,
 mirroring `kippmiami/dagster-cloud.yaml` lines 190-199 (server) and 218-227
 (run). Miami sources them from secret `op-finalsite-api-kippmiami`; Newark uses
-`op-finalsite-api-kippnewark`.
+`op-finalsite-api-kippnewark` (declared in Task 4). Use the key names verified
+in Task 4 Step 4 (defaults `username`/`password` below).
 
 **Files:**
 
@@ -410,13 +485,13 @@ git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
 
 > **Deploy note:** merging a change to a code location's `dagster-cloud.yaml`
 > triggers that location's prod deploy. Confirm the
-> `op-finalsite-api-kippnewark` k8s secret exists (see "Open config value")
+> `op-finalsite-api-kippnewark` k8s secret exists (Task 4 applied + synced)
 > BEFORE merge, or the code server boots without the credential and the first
 > `contacts` run fails auth.
 
 ---
 
-## Task 5: Open the PR
+## Task 6: Open the PR
 
 **Files:** none (PR only).
 
@@ -529,15 +604,18 @@ is the input to the Phase 3 dbt plan.
 
 ## Self-review notes
 
-- **Spec coverage (Phase 1 scope only):** Tasks 1-4 cover the spec's "Dagster
-  ingestion (per NJ region)" bullets for Newark; the discovery section covers
-  the spec's "Discovery checklist (Phase 2)". The `Relationship` schema
-  extension, finalsite package models, kipptaf union/pivot/dim/bridge, consumer
-  updates, and the `+enabled` flip are Phase 3+ and intentionally OUT of this
-  plan.
+- **Spec coverage (Phase 1 scope only):** Tasks 1-5 cover the spec's "Dagster
+  ingestion (per NJ region)" bullets for Newark (resource, asset, schedule,
+  1Password secret sync, k8s env wiring); Task 6 opens the PR; the discovery
+  section covers the spec's "Discovery checklist (Phase 2)". The `Relationship`
+  schema extension, finalsite package models, kipptaf union/pivot/dim/bridge,
+  consumer updates, and the `+enabled` flip are Phase 3+ and intentionally OUT
+  of this plan.
 - **No library edits** this phase — the rank field can't be added to the
   `Relationship` model until discovery names it. The `contacts` asset ingests
   the full raw payload regardless, so discovery has everything it needs without
   the schema change.
-- **Deferred decisions:** Finalsite server subdomain and k8s secret existence
-  are flagged as pre-deploy gates, not silently assumed.
+- **Confirmed config:** Newark subdomain `kippnewark.fsenrollment.com`; secret
+  item `vaults/Data Team/items/Finalsite API - Newark` (secret not yet synced —
+  Task 4 declares + applies it; Task 4 Step 4 verifies key names before Task 5
+  wires them).

--- a/docs/superpowers/plans/2026-07-08-finalsite-contacts-nj-phase1-ingestion.md
+++ b/docs/superpowers/plans/2026-07-08-finalsite-contacts-nj-phase1-ingestion.md
@@ -1,0 +1,543 @@
+# Finalsite NJ Contacts — Phase 1 (Newark Ingestion + Discovery) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the Finalsite Contacts API `contacts` asset into the `kippnewark`
+Dagster code location (mirroring the existing `kippmiami` integration), deploy
+it, and run the discovery queries that unblock the dbt modeling phase.
+
+**Architecture:** `kippnewark` gains a location-local `resources.py` holding a
+`FinalsiteResource` instance, a `contacts` Avro asset built from the shared
+`build_finalsite_asset()` factory, a daily schedule, and the k8s secret env-var
+wiring in `dagster-cloud.yaml`. No library changes in this phase — the
+`Relationship` schema extension for the rank field is deferred to Phase 3, after
+discovery reveals the field name.
+
+**Tech Stack:** Dagster (Python 3.13), `dagster-k8s`, `py_avro_schema`, GCS Avro
+IO manager, BigQuery external tables.
+
+## Global Constraints
+
+- **Python**: always `uv run` — never bare `python`/`python3`.
+  `requires-python = ">=3.13"`.
+- **Worktree**: all work happens in
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj`.
+  Every `git` call uses `git -C <worktree>`; every Python call uses
+  `VIRTUAL_ENV= uv --directory <worktree> run python ...` with an absolute
+  script path (or run from the worktree cwd).
+- **Asset key convention**: `[code_location, integration, asset_name]` →
+  `["kippnewark", "finalsite", "contacts"]`.
+- **Library/code-location split**: no edits to `libraries/finalsite/` in this
+  phase. Reuse `build_finalsite_asset()` and `FinalsiteResource` unchanged.
+- **Do not commit secret VALUES.** `dagster-cloud.yaml` references k8s secret
+  NAMES and keys only (`op-finalsite-api-kippnewark`), never the credential
+  itself.
+- **Conventional commits**; branch `cbini/feat/claude-finalsite-contacts-nj`
+  (already created, linked to #4346).
+
+## Open config value (resolve before Task 4 deploy)
+
+- **Finalsite server subdomain for Newark.** `FinalsiteResource._service_root`
+  is `https://{server}.fsenrollment.com/api/external`. Miami passes
+  `server=CODE_LOCATION` → `kippmiami.fsenrollment.com`. This plan defaults
+  Newark to the same pattern (`server=CODE_LOCATION` → `kippnewark`), but the
+  actual Newark Finalsite subdomain MUST be confirmed with whoever provisioned
+  Newark's API access. If it differs, pass an explicit string instead of
+  `CODE_LOCATION` in Task 1.
+- **k8s secret provisioning.** Task 4 assumes a k8s secret named
+  `op-finalsite-api-kippnewark` with keys `username` (credential id) and
+  `password` (secret) exists in the `dagster-cloud` namespace, mirroring
+  `op-finalsite-api-kippmiami`. Creating it from 1Password is an Ops task
+  outside this repo — confirm it exists before deploy, or the asset run fails
+  auth at `setup_for_execution`.
+
+---
+
+## Task 1: Newark `FinalsiteResource`
+
+`kippnewark` currently has no `resources.py` — every resource comes from
+`core.resources`. Finalsite is location-specific (per-instance credentials), so
+it needs a location-local resource file, exactly as `kippmiami` has.
+
+**Files:**
+
+- Create: `src/teamster/code_locations/kippnewark/resources.py`
+
+**Interfaces:**
+
+- Produces: `FINALSITE_RESOURCE: FinalsiteResource` — imported by
+  `definitions.py` (Task 3) as the `"finalsite"` resource.
+
+- [ ] **Step 1: Create the resource file**
+
+Create `src/teamster/code_locations/kippnewark/resources.py`:
+
+```python
+from dagster import EnvVar
+
+from teamster.code_locations.kippnewark import CODE_LOCATION
+from teamster.libraries.finalsite.api.resources import FinalsiteResource
+
+# NOTE: server defaults to CODE_LOCATION ("kippnewark") →
+# kippnewark.fsenrollment.com. Confirm Newark's actual Finalsite subdomain
+# before deploy (see plan "Open config value"); pass an explicit string here if
+# it differs.
+FINALSITE_RESOURCE = FinalsiteResource(
+    server=CODE_LOCATION,
+    credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),
+    secret=EnvVar("FINALSITE_SECRET"),
+)
+```
+
+- [ ] **Step 2: Validate it imports**
+
+Run:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  run python -c "from teamster.code_locations.kippnewark.resources import FINALSITE_RESOURCE; print(type(FINALSITE_RESOURCE).__name__)"
+```
+
+Expected: prints `FinalsiteResource` with no import error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  add src/teamster/code_locations/kippnewark/resources.py
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  commit -m "feat(kippnewark): add FinalsiteResource. Refs #4346"
+```
+
+---
+
+## Task 2: Newark `contacts` asset, schema, and schedule
+
+Add the Avro schema, the asset, and a daily schedule to the existing
+`kippnewark/finalsite/` module, and export the schedule from its `__init__.py`.
+`kippnewark/finalsite/schema.py` currently defines only `STATUS_REPORT_SCHEMA`;
+`assets.py` currently defines only the `status_report` SFTP asset; there is no
+`schedules.py` yet.
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/finalsite/schema.py`
+- Modify: `src/teamster/code_locations/kippnewark/finalsite/assets.py`
+- Create: `src/teamster/code_locations/kippnewark/finalsite/schedules.py`
+- Modify: `src/teamster/code_locations/kippnewark/finalsite/__init__.py`
+
+**Interfaces:**
+
+- Consumes: `build_finalsite_asset()` (library), `Contact` Pydantic model
+  (library), `CODE_LOCATION` / `LOCAL_TIMEZONE` (unchanged; `LOCAL_TIMEZONE`
+  must be added to the `kippnewark` `__init__.py` import in Step 3).
+- Produces: `assets` list (now includes `contacts`), `schedules` list — both
+  consumed by `definitions.py` (Task 3).
+
+- [ ] **Step 1: Add `CONTACTS_SCHEMA` to `schema.py`**
+
+Edit `src/teamster/code_locations/kippnewark/finalsite/schema.py` to import the
+`Contact` model and generate its Avro schema. Final file contents:
+
+```python
+import json
+
+import py_avro_schema
+
+from teamster.libraries.finalsite.api.schema import Contact
+from teamster.libraries.finalsite.sftp.schema import StatusReport
+
+pas_options = py_avro_schema.Option.NO_DOC | py_avro_schema.Option.NO_AUTO_NAMESPACE
+
+STATUS_REPORT_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=StatusReport, options=pas_options)
+)
+
+CONTACTS_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=Contact, options=pas_options)
+)
+```
+
+- [ ] **Step 2: Add the `contacts` asset to `assets.py`**
+
+Edit `src/teamster/code_locations/kippnewark/finalsite/assets.py`. Add the
+`build_finalsite_asset` and `CONTACTS_SCHEMA` imports, define the `contacts`
+asset, and add it to the `assets` list. The `status_report` asset stays
+unchanged. Resulting imports + additions:
+
+```python
+from teamster.code_locations.kippnewark import CODE_LOCATION, CURRENT_FISCAL_YEAR
+from teamster.code_locations.kippnewark.finalsite.schema import (
+    CONTACTS_SCHEMA,
+    STATUS_REPORT_SCHEMA,
+)
+from teamster.libraries.finalsite.api.assets import build_finalsite_asset
+from teamster.libraries.finalsite.sftp.assets import (
+    get_finalsite_school_year_partition_keys,
+)
+from teamster.libraries.sftp.assets import build_sftp_file_asset
+
+# ... existing status_report asset unchanged ...
+
+contacts = build_finalsite_asset(
+    code_location=CODE_LOCATION,
+    asset_name="contacts",
+    schema=CONTACTS_SCHEMA,
+    params={"includes": "contacts.relationships"},
+)
+
+assets = [
+    status_report,
+    contacts,
+]
+```
+
+- [ ] **Step 3: Create `schedules.py`**
+
+`kippnewark/__init__.py` currently exports `CODE_LOCATION` and
+`CURRENT_FISCAL_YEAR` but not `LOCAL_TIMEZONE` — it IS defined there, so the
+import works. Create
+`src/teamster/code_locations/kippnewark/finalsite/schedules.py` mirroring
+Miami's (daily 04:00 ET):
+
+```python
+from dagster import ScheduleDefinition
+
+from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
+
+finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
+    cron_schedule="0 4 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    target=[f"{CODE_LOCATION}/finalsite/contacts"],
+)
+
+schedules = [
+    finalsite_contacts_daily_asset_job_schedule,
+]
+```
+
+- [ ] **Step 4: Export `schedules` from `__init__.py`**
+
+Edit `src/teamster/code_locations/kippnewark/finalsite/__init__.py` to match
+Miami's export shape:
+
+```python
+from teamster.code_locations.kippnewark.finalsite.assets import assets
+from teamster.code_locations.kippnewark.finalsite.schedules import schedules
+
+__all__ = [
+    "assets",
+    "schedules",
+]
+```
+
+- [ ] **Step 5: Validate imports (schema generation + module load)**
+
+Run:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  run python -c "from teamster.code_locations.kippnewark import finalsite; print(len(finalsite.assets), 'assets', len(finalsite.schedules), 'schedules')"
+```
+
+Expected: prints `2 assets 1 schedules` (Avro schema generation for `Contact`
+succeeds, no import error).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  add src/teamster/code_locations/kippnewark/finalsite/
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  commit -m "feat(kippnewark): add Finalsite contacts asset and daily schedule. Refs #4346"
+```
+
+---
+
+## Task 3: Wire Finalsite into `kippnewark/definitions.py`
+
+The asset auto-loads via `load_assets_from_modules([... finalsite ...])`
+(already present). What is missing: the `"finalsite"` resource and the
+`finalsite.schedules` registration.
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/definitions.py`
+
+**Interfaces:**
+
+- Consumes: `FINALSITE_RESOURCE` (Task 1), `finalsite.schedules` (Task 2).
+
+- [ ] **Step 1: Import `FINALSITE_RESOURCE`**
+
+Edit `src/teamster/code_locations/kippnewark/definitions.py`. After the
+`from teamster.code_locations.kippnewark import (...)` block, add:
+
+```python
+from teamster.code_locations.kippnewark.resources import FINALSITE_RESOURCE
+```
+
+- [ ] **Step 2: Register the schedule**
+
+In the `schedules=[...]` list, add `*finalsite.schedules,` (keep existing
+entries):
+
+```python
+    schedules=[
+        *extracts.schedules,
+        *deanslist.schedules,
+        *finalsite.schedules,
+        *overgrad.schedules,
+        *powerschool.schedules,
+    ],
+```
+
+- [ ] **Step 3: Register the resource**
+
+In the `resources={...}` dict, add the `"finalsite"` key (alphabetical slot,
+after `"dbt_cli"`/`"deanslist"` and before `"gcs"`):
+
+```python
+        "finalsite": FINALSITE_RESOURCE,
+```
+
+- [ ] **Step 4: Validate the full code location**
+
+Run:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  run dagster definitions validate -m teamster.code_locations.kippnewark.definitions
+```
+
+Expected: `Validation successful`. If it fails ONLY on missing env vars /
+manifest (codespace has no prod secrets), fall back to the import check:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  run python -c "from teamster.code_locations.kippnewark.definitions import defs; print('ok')"
+```
+
+Expected: prints `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  add src/teamster/code_locations/kippnewark/definitions.py
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  commit -m "feat(kippnewark): register Finalsite resource and contacts schedule. Refs #4346"
+```
+
+---
+
+## Task 4: k8s secret env-var wiring in `dagster-cloud.yaml`
+
+`FinalsiteResource` reads `FINALSITE_CREDENTIAL_ID` and `FINALSITE_SECRET` from
+the environment. These must be projected from the k8s secret into BOTH the
+`server_k8s_config` (code-server pod) and `run_k8s_config` (run pod) env blocks,
+mirroring `kippmiami/dagster-cloud.yaml` lines 190-199 (server) and 218-227
+(run). Miami sources them from secret `op-finalsite-api-kippmiami`; Newark uses
+`op-finalsite-api-kippnewark`.
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/dagster-cloud.yaml`
+
+- [ ] **Step 1: Inspect Newark's current env blocks**
+
+Read `src/teamster/code_locations/kippnewark/dagster-cloud.yaml` and locate the
+`server_k8s_config.container_config.env` list and the
+`run_k8s_config.container_config.env` list.
+
+- [ ] **Step 2: Add the two env vars to the `server_k8s_config` env list**
+
+Append to the `server_k8s_config.container_config.env` list (2-space list-item
+indentation matching siblings):
+
+```yaml
+- name: FINALSITE_CREDENTIAL_ID
+  valueFrom:
+    secretKeyRef:
+      name: op-finalsite-api-kippnewark
+      key: username
+- name: FINALSITE_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: op-finalsite-api-kippnewark
+      key: password
+```
+
+- [ ] **Step 3: Add the same two env vars to the `run_k8s_config` env list**
+
+Append the identical block to the `run_k8s_config.container_config.env` list.
+
+- [ ] **Step 4: Validate YAML parses**
+
+Run:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  run python -c "import yaml,sys; d=yaml.safe_load(open('src/teamster/code_locations/kippnewark/dagster-cloud.yaml')); print('parsed', d['locations'][0]['location_name'])"
+```
+
+Expected: prints `parsed kippnewark`.
+
+- [ ] **Step 5: Trunk-check the edited YAML**
+
+Run from inside the worktree:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj && \
+  /workspaces/teamster/.trunk/tools/trunk check --force \
+  src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+```
+
+Expected: `✔ No issues` (or auto-fixed formatting applied).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  add src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  commit -m "feat(kippnewark): project Finalsite API credentials into k8s env. Refs #4346"
+```
+
+> **Deploy note:** merging a change to a code location's `dagster-cloud.yaml`
+> triggers that location's prod deploy. Confirm the
+> `op-finalsite-api-kippnewark` k8s secret exists (see "Open config value")
+> BEFORE merge, or the code server boots without the credential and the first
+> `contacts` run fails auth.
+
+---
+
+## Task 5: Open the PR
+
+**Files:** none (PR only).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-contacts-nj \
+  push -u origin cbini/feat/claude-finalsite-contacts-nj
+```
+
+- [ ] **Step 2: Create the PR**
+
+Use `mcp__github__create_pull_request` with base `main`, head
+`cbini/feat/claude-finalsite-contacts-nj`, body from
+`.github/pull_request_template.md`, and `Refs #4346` in the body. Title:
+`feat(kippnewark): add Finalsite contacts ingestion`.
+
+- [ ] **Step 3: Verify CI**
+
+Wait for Trunk / CodeQL check-runs to go green
+(`mcp__github__pull_request_read get_check_runs`). dbt Cloud CI is a no-op here
+(no dbt models changed). Address any Trunk failures and re-push.
+
+---
+
+## Post-deploy: discovery (unblocks Phase 3 dbt modeling)
+
+These steps are OPERATIONAL, not code — they run AFTER the PR merges, the
+`kippnewark` location redeploys, and the `contacts` asset materializes at least
+once in prod. They produce the spec addendum that pins the dbt SQL shape. Do NOT
+mark Phase 1 "done" until the discovery findings are recorded.
+
+- [ ] **Step 1: Materialize the Newark contacts asset in prod**
+
+Hand off to the user (prod materialization is classifier-blocked for Claude), or
+via Dagster UI: materialize `kippnewark/finalsite/contacts`. Confirm success and
+a non-zero `record_count` via
+`mcp__dagster__get_asset_materializations(asset_key="kippnewark/finalsite/contacts")`.
+
+- [ ] **Step 2: Stage the external source for the new region**
+
+The `finalsite` package's `api/` models are `+enabled: false` for `kippnewark`
+today (Phase 3 flips this). The raw external table lands under the Newark
+Finalsite dataset regardless. Confirm the external exists via BigQuery MCP
+(`<dataset>.__TABLES__`, look for the `contacts` external).
+
+- [ ] **Step 3: Run the discovery queries**
+
+Against the Newark `contacts` external / `stg`-equivalent, answer each spec
+discovery-checklist item. Keep all PII in the Codespace / scratch — write only
+aggregates and field NAMES to the addendum. Queries (BigQuery MCP):
+
+- **Rank field on relationships** — inspect the `relationships` repeated field's
+  subfields and whether any encodes rank/order distinct from `primary`:
+
+  ```sql
+  select r.rel_type, r.primary, count(*) n
+  from `<newark_finalsite_dataset>.src_finalsite__contacts`,
+    unnest(relationships) as r
+  group by 1, 2
+  order by 3 desc
+  ```
+
+  Also list the raw JSON keys present on a relationship element (the Avro/struct
+  field list) to see if a rank/order/sequence field exists that the current
+  `Relationship` Pydantic model omits.
+
+- **Non-student contact records reachable via `rel_id`** — check whether the
+  contacts payload includes parent/guardian records that `rel_id` joins to, and
+  which detail fields (phone/email/address) they carry:
+
+  ```sql
+  select count(*) n_total,
+    countif(array_length(relationships) > 0) n_with_rel,
+    countif(email is not null) n_with_email,
+    countif(array_length(households) > 0) n_with_household
+  from `<newark_finalsite_dataset>.src_finalsite__contacts`
+  ```
+
+- **Emergency-contact custom field sets** — list every `custom_attributes`
+  `field_name` and its populated value subtype, to identify the 4 emergency
+  sets:
+
+  ```sql
+  select ca.field_name,
+    countif(ca.value.string_value is not null) n_str,
+    countif(ca.value.boolean_value is not null) n_bool,
+    countif(ca.value.array_string_value is not null) n_arr,
+    count(*) n
+  from `<newark_finalsite_dataset>.src_finalsite__contacts`,
+    unnest(custom_attributes) as ca
+  group by 1
+  order by 1
+  ```
+
+- **Track-siloed vs global** — repeat the field_name listing over
+  `track_attributes` to determine whether the emergency sets are global
+  (`custom_attributes`) or per-track (`track_attributes`).
+
+- [ ] **Step 4: Record findings as a spec addendum**
+
+Append an `## Addendum: Discovery findings (YYYY-MM-DD)` section to
+`docs/superpowers/specs/2026-07-08-finalsite-contacts-nj-design.md` on this
+branch (or a Phase-3 branch): the rank field name + semantics, the 4 emergency
+field-set names and their attributes, whether `rel_id` resolves to a
+detail-bearing record, and the custom-vs-track placement. Commit. This addendum
+is the input to the Phase 3 dbt plan.
+
+---
+
+## Self-review notes
+
+- **Spec coverage (Phase 1 scope only):** Tasks 1-4 cover the spec's "Dagster
+  ingestion (per NJ region)" bullets for Newark; the discovery section covers
+  the spec's "Discovery checklist (Phase 2)". The `Relationship` schema
+  extension, finalsite package models, kipptaf union/pivot/dim/bridge, consumer
+  updates, and the `+enabled` flip are Phase 3+ and intentionally OUT of this
+  plan.
+- **No library edits** this phase — the rank field can't be added to the
+  `Relationship` model until discovery names it. The `contacts` asset ingests
+  the full raw payload regardless, so discovery has everything it needs without
+  the schema change.
+- **Deferred decisions:** Finalsite server subdomain and k8s secret existence
+  are flagged as pre-deploy gates, not silently assumed.

--- a/docs/superpowers/specs/2026-07-08-finalsite-contacts-nj-design.md
+++ b/docs/superpowers/specs/2026-07-08-finalsite-contacts-nj-design.md
@@ -1,0 +1,220 @@
+# Finalsite Student Contacts for NJ Regions — Design
+
+- **Issue**: [#4346](https://github.com/TEAMSchools/teamster/issues/4346)
+- **Date**: 2026-07-08
+- **Status**: Approved design; discovery-dependent details flagged inline
+
+## Problem
+
+Student contact reporting for the NJ regions (Newark, Camden, Paterson) is
+sourced from PowerSchool contact tables. Finalsite is becoming the source of
+truth for student contacts in those regions. The PowerSchool contact models must
+be deprecated as the reporting source and replaced with Finalsite data.
+
+Contact reporting requirements for the new source:
+
+1. Only the **top-ranked contact** from the Finalsite contacts module is
+   reported.
+2. The remaining reported contacts are **emergency contacts**, sourced from 4
+   sets of custom fields on the student contact record — not the contacts
+   module.
+
+Constraints:
+
+- Finalsite Contacts API ingestion currently exists only for `kippmiami`. API
+  credentials exist only for Newark's Finalsite instance today; Camden and
+  Paterson are pending.
+- Miami's contact **sourcing** is out of scope — it is handled by the Focus
+  migration work. Miami's PowerSchool data is mapped into the new surface shape
+  in the interim.
+
+## Decisions (from brainstorming)
+
+| Question                   | Decision                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Downstream surface         | Swap the source under the existing surfaces (dim, bridge, enrollment contact columns, extracts)                           |
+| Surface shape              | **Redefine** around the 1+4 model — `contact_1` + `emergency_1..4`; `contact_2` and `pickup_*` slots removed network-wide |
+| Miami                      | Sourcing out of scope; PS data mapped into the new 1+4 shape via an inline CTE (temporary until Focus contacts)           |
+| Rank field                 | Not in our current schema — discover from the Newark API payload                                                          |
+| Emergency field sets       | Discover names from Newark data                                                                                           |
+| Phasing                    | Newark first, per-region cutover as credentials arrive                                                                    |
+| Finalsite shaping location | Finalsite package `api/intermediate` (SIS-agnostic), following the existing convention                                    |
+
+## New contact shape (1+4)
+
+- `contact_1` — the top-ranked relationship from the Finalsite contacts module.
+  Person details (name/email/phones/address) resolved by joining `rel_id` back
+  to the contact's own record.
+- `emergency_1` … `emergency_4` — from 4 sets of custom fields on the student
+  contact record. These are field values, **not** linked person records — they
+  carry only what the field sets contain.
+- `contact_2` and `pickup_{n}` slots are removed from all surfaces, network-wide
+  (including Miami's PS-mapped rows).
+
+## Architecture
+
+```text
+Dagster (per NJ region, Newark first)
+  <region>/finalsite/contacts  ──►  GCS Avro  ──►  BQ external
+
+dbt finalsite package (api/, enabled per region as ingestion lands)
+  stg_finalsite__contacts
+  stg_finalsite__contact_relationships   (+ rank field — discovery)
+  int_finalsite__contact_custom_attributes (+ emergency field sets — discovery)
+  int_finalsite__student_contacts        (NEW — 1+4 long format, SIS-agnostic)
+
+kipptaf
+  int_students__contacts (NEW — union; name settled in planning)
+    ├─ NJ finalsite branches via source(), joined to student_number
+    │    through int_finalsite__contact_id_attributes
+    └─ inline PS-mapped CTE (regions not yet cut over + Miami)  -- TODO(focus)
+    ──► redefined pivot (NEW kipptaf model, 1 row per student)
+    ──► dim_student_contact_persons  (redefined)
+    ──► bridge_student_contacts     (redefined)
+```
+
+### Finalsite package (`api/`)
+
+1. **`stg_finalsite__contact_relationships`** — add the rank field (exact name
+   pending discovery) surfaced from the extended `Relationship` Pydantic schema.
+2. **`int_finalsite__contact_custom_attributes`** — extend the explicit PIVOT
+   field list with the 4 emergency-contact field sets (names pending discovery).
+3. **`int_finalsite__student_contacts`** (new) — 1+4 long format.
+   - Grain: `(finalsite_enrollment_id, contact_slot)`,
+     `contact_slot ∈ ('contact_1', 'emergency_1'..'emergency_4')`.
+   - `contact_1` rows: pick the top-ranked relationship; join `rel_id` back to
+     `stg_finalsite__contacts` for person details.
+   - `emergency_n` rows: from the pivoted custom fields.
+   - Slots with no data are omitted (sparse long format).
+   - SIS-agnostic: no PowerSchool references; the `student_number` join happens
+     downstream.
+
+### kipptaf
+
+1. **`int_students__contacts`** (new; final name settled during planning against
+   existing `kipptaf/models/powerschool/intermediate/` naming) — union of:
+   - Per-NJ-region `int_finalsite__student_contacts` via `source()`, joined to
+     `student_number` through the id-attributes pivot
+     (`powerschool_student_number`).
+   - One inline PS-mapped CTE covering regions not yet cut over plus Miami,
+     marked `-- TODO(focus): remove when Focus contacts land`. Mapping:
+     - `contact_1` ← top-priority PS contact (`contactpriorityorder = 1`,
+       `person_type != 'self'`)
+     - `emergency_1..4` ← PS contacts with `isemergency = 1`, ranked by
+       `contactpriorityorder`, capped at 4
+     - Phone/email/address resolution follows the current
+       `dim_student_contact_persons` logic (mobile→home→daytime→work primary
+       phone; current email; home address).
+   - Grain: `(student_number, _dbt_source_project, contact_slot)`.
+   - The CTE's region list shrinks as each region cuts over; the mapping is
+     intentionally lossy — non-top-priority, non-emergency PS contacts (today's
+     `contact_2`, `pickup_*`) drop out of the surface.
+2. **Redefined pivot** — a NEW kipptaf model that replaces the powerschool
+   package's `int_powerschool__student_contacts_pivot` as the reporting source.
+   One row per student; `contact_1_*` and `emergency_1_*`..`emergency_4_*`
+   column sets. Exact sub-columns pinned after discovery (emergency field sets
+   may carry fewer attributes than the contacts module).
+3. **`dim_student_contact_persons` / `bridge_student_contacts` redefined** from
+   the long model.
+   - `contact_1` rows key on the real contact identity (Finalsite contact id for
+     NJ; `personid` for PS-mapped rows).
+   - Emergency rows have no person record — person key =
+     `surrogate_key(source, student, slot)`.
+   - Dim slims to name/phone/email/address; bridge carries student ↔ person
+     links with slot and `is_emergency`.
+   - Cube reads both (`cube.yml` exposure) — grep `src/cube/model/` for removed
+     columns and ship Cube updates in the same change.
+4. **Contact columns move out of the powerschool package** — drop the `scw.*`
+   pivot columns from `base_powerschool__student_enrollments` (the package
+   cannot reference finalsite models); `int_extracts__student_enrollments` joins
+   the new kipptaf pivot instead. Downstream consumers updating to the 1+4
+   columns:
+   - `int_extracts__student_enrollments` (+ `_subjects_weeks`)
+   - `rpt_deanslist__student_misc`
+   - `rpt_gsheets__kfwd_taf_contact_feed`, `rpt_gsheets__kippfwd_collab_roster`,
+     `rpt_gsheets__kippfwd_miami_roster`,
+     `rpt_gsheets__njsmart_transfer_unverified`,
+     `rpt_gsheets__student_contact_info`
+   - `rpt_tableau__next_year_status`
+   - `int_kippadb__roster`
+   - `rpt_clever__students`
+   - `int_powerschool__student_contacts` /
+     `int_powerschool__student_contacts_pivot` (package level) and the kipptaf
+     union wrapper are deprecated as reporting sources once no consumer reads
+     them (full deletion waits for Miami/Focus).
+
+### Dagster ingestion (per NJ region)
+
+- `code_locations/kippnewark/finalsite/`: add `contacts` asset via
+  `build_finalsite_asset(..., params={"includes": "contacts.relationships"})`,
+  `CONTACTS_SCHEMA` in `schema.py` (generated from the shared library Pydantic
+  models), and a daily schedule mirroring Miami's (4am local).
+- `code_locations/kippnewark/resources.py`: `FinalsiteResource` instance for
+  Newark's Finalsite instance (server / credential id / secret via the same
+  secret-management path as Miami's).
+- Library change: extend the `Relationship` Pydantic model with the rank field
+  once discovered (regenerates every region's Avro schema; the Avro check warns
+  on drift, and the fix is declaring the field — one edit covers all regions).
+- Camden/Paterson: identical wiring when credentials arrive. No other library
+  changes expected.
+- dbt gating: flip `finalsite: api: +enabled: true` in the region's
+  `dbt_project.yml` when its ingestion lands (Newark in this effort); the
+  external source must be staged with `--target staging` before dbt Cloud CI
+  passes.
+
+## Rollout phases
+
+| Phase | Work                                                                                                            | Gate                  |
+| ----- | --------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 1     | Newark ingestion (resource, asset, schedule); raw data in BQ                                                    | Credentials (in hand) |
+| 2     | Discovery: rank field, emergency field-set names, `rel_id` resolution shape; documented as spec addendum        | Phase 1 data          |
+| 3     | `Relationship` schema extension + finalsite package models; enable `api` for kippnewark                         | Phase 2 findings      |
+| 4     | kipptaf layer: union (Newark = Finalsite; Camden/Paterson/Miami = PS CTE), pivot, dim, bridge, consumer updates | Phase 3               |
+| 5+    | Per region (Camden, Paterson): repeat Phase 1 + 3 wiring; move region from the PS CTE to a Finalsite branch     | Credentials           |
+
+## Discovery checklist (Phase 2)
+
+Blocks final SQL shape; answers recorded as a spec addendum:
+
+- [ ] Rank field on relationships: name, type, semantics (is `primary` a
+      separate concept?)
+- [ ] Whether the contacts endpoint returns non-student contact records
+      (parents) that `rel_id` can join to, and which detail fields they carry
+- [ ] The 4 emergency-contact custom field sets: field names and attributes per
+      set (name / phone / relationship / …?)
+- [ ] Whether emergency custom fields are track-siloed (`track_attributes`) or
+      global (`custom_attributes`)
+
+## Testing & data quality
+
+- Standard layer requirements: contracts + uniqueness tests on all new models.
+  Grain tests:
+  - `int_finalsite__student_contacts`: `(finalsite_enrollment_id, contact_slot)`
+  - kipptaf union: `(student_number, _dbt_source_project, contact_slot)`
+- **Cutover validation per region** (plan-time query, not a permanent test):
+  compare Finalsite-sourced vs PS-sourced coverage — % of enrolled students with
+  `contact_1`, % with ≥1 emergency contact. A material coverage drop blocks the
+  region's flip.
+- Warn-level coverage test on the pivot (`contact_1_name` not null, scoped to
+  enrolled students) to surface silent feed breakage.
+- Match-rate check on the `student_number` join: unmatched Finalsite records are
+  expected for prospects/applicants; unmatched **enrolled** students should be
+  ~0.
+
+## Error handling
+
+- Finalsite API: `FinalsiteResource` already handles 429 retry-after; JWT window
+  (55 min) already handled. No new library error paths.
+- Empty-region builds: package `api/` models build empty in regions without
+  ingestion — gated by `+enabled: false`, per the existing convention.
+- Union during transition mixes sources by region; `_dbt_source_project`
+  discriminates, matching the existing cross-district pattern.
+
+## Out of scope
+
+- Miami contact sourcing (Focus migration owns it; the PS-mapped CTE is the
+  interim bridge)
+- Finalsite → SIS enrollment integration (`int_finalsite__enrollment_lifecycle`
+  — separate, existing work)
+- Deleting the PowerSchool contact staging/int models (raw PS contact tables
+  keep loading; deletion waits for Miami/Focus)

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -212,3 +212,10 @@ uv run dagster-dbt project prepare-and-package --file src/teamster/code_location
 codespace cause false errors unrelated to production failures. Fall back to
 `uv run python -c "import <module>"` for syntactic checks when validate fails on
 missing manifest or env vars.
+
+A district `definitions.py` itself won't import in the codespace —
+`get_powerschool_ssh_resource()` reads unset `PS_SSH_PORT` at module load, so
+the `import <module>` fallback fails for `.definitions`. Validate a
+per-integration change by importing that integration submodule alone (e.g.
+`import teamster.code_locations.kippnewark.finalsite`), not the `definitions`
+module.

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -185,6 +185,16 @@ locations:
                   secretKeyRef:
                     name: op-amplify-sftp-kipptaf
                     key: username
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippnewark
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippnewark
+                    key: password
         run_k8s_config:
           container_config:
             env:
@@ -227,6 +237,16 @@ locations:
                 valueFrom:
                   secretKeyRef:
                     name: op-ps-ssh-kippnewark
+                    key: password
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippnewark
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippnewark
                     key: password
               - name: PS_SSH_PORT
                 valueFrom:

--- a/src/teamster/code_locations/kippnewark/definitions.py
+++ b/src/teamster/code_locations/kippnewark/definitions.py
@@ -24,6 +24,7 @@ from teamster.code_locations.kippnewark import (
     renlearn,
     titan,
 )
+from teamster.code_locations.kippnewark.resources import FINALSITE_RESOURCE
 from teamster.core.freshness import apply_freshness_policies
 from teamster.core.resources import (
     BIGQUERY_RESOURCE,
@@ -69,6 +70,7 @@ defs = Definitions(
     schedules=[
         *extracts.schedules,
         *deanslist.schedules,
+        *finalsite.schedules,
         *overgrad.schedules,
         *powerschool.schedules,
     ],
@@ -90,6 +92,7 @@ defs = Definitions(
         "db_powerschool": DB_POWERSCHOOL,
         "dbt_cli": get_dbt_cli_resource(DBT_PROJECT),
         "deanslist": DEANSLIST_RESOURCE,
+        "finalsite": FINALSITE_RESOURCE,
         "gcs": GCS_RESOURCE,
         "google_drive": GOOGLE_DRIVE_RESOURCE,
         "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),

--- a/src/teamster/code_locations/kippnewark/finalsite/__init__.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/__init__.py
@@ -1,5 +1,7 @@
 from teamster.code_locations.kippnewark.finalsite.assets import assets
+from teamster.code_locations.kippnewark.finalsite.schedules import schedules
 
 __all__ = [
     "assets",
+    "schedules",
 ]

--- a/src/teamster/code_locations/kippnewark/finalsite/assets.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/assets.py
@@ -1,5 +1,9 @@
 from teamster.code_locations.kippnewark import CODE_LOCATION, CURRENT_FISCAL_YEAR
-from teamster.code_locations.kippnewark.finalsite.schema import STATUS_REPORT_SCHEMA
+from teamster.code_locations.kippnewark.finalsite.schema import (
+    CONTACTS_SCHEMA,
+    STATUS_REPORT_SCHEMA,
+)
+from teamster.libraries.finalsite.api.assets import build_finalsite_asset
 from teamster.libraries.finalsite.sftp.assets import (
     get_finalsite_school_year_partition_keys,
 )
@@ -17,6 +21,15 @@ status_report = build_sftp_file_asset(
     avro_schema=STATUS_REPORT_SCHEMA,
     ssh_resource_key="ssh_couchdrop",
 )
+
+contacts = build_finalsite_asset(
+    code_location=CODE_LOCATION,
+    asset_name="contacts",
+    schema=CONTACTS_SCHEMA,
+    params={"includes": "contacts.relationships"},
+)
+
 assets = [
     status_report,
+    contacts,
 ]

--- a/src/teamster/code_locations/kippnewark/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/schedules.py
@@ -1,0 +1,14 @@
+from dagster import ScheduleDefinition
+
+from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
+
+finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
+    cron_schedule="0 4 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    target=[f"{CODE_LOCATION}/finalsite/contacts"],
+)
+
+schedules = [
+    finalsite_contacts_daily_asset_job_schedule,
+]

--- a/src/teamster/code_locations/kippnewark/finalsite/schema.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/schema.py
@@ -2,10 +2,15 @@ import json
 
 import py_avro_schema
 
+from teamster.libraries.finalsite.api.schema import Contact
 from teamster.libraries.finalsite.sftp.schema import StatusReport
 
 pas_options = py_avro_schema.Option.NO_DOC | py_avro_schema.Option.NO_AUTO_NAMESPACE
 
 STATUS_REPORT_SCHEMA = json.loads(
     py_avro_schema.generate(py_type=StatusReport, options=pas_options)
+)
+
+CONTACTS_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=Contact, options=pas_options)
 )

--- a/src/teamster/code_locations/kippnewark/resources.py
+++ b/src/teamster/code_locations/kippnewark/resources.py
@@ -1,0 +1,14 @@
+from dagster import EnvVar
+
+from teamster.code_locations.kippnewark import CODE_LOCATION
+from teamster.libraries.finalsite.api.resources import FinalsiteResource
+
+# NOTE: server defaults to CODE_LOCATION ("kippnewark") →
+# kippnewark.fsenrollment.com. Confirm Newark's actual Finalsite subdomain
+# before deploy (see plan "Open config value"); pass an explicit string here if
+# it differs.
+FINALSITE_RESOURCE = FinalsiteResource(
+    server=CODE_LOCATION,
+    credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),
+    secret=EnvVar("FINALSITE_SECRET"),
+)

--- a/src/teamster/code_locations/kippnewark/resources.py
+++ b/src/teamster/code_locations/kippnewark/resources.py
@@ -3,10 +3,6 @@ from dagster import EnvVar
 from teamster.code_locations.kippnewark import CODE_LOCATION
 from teamster.libraries.finalsite.api.resources import FinalsiteResource
 
-# NOTE: server defaults to CODE_LOCATION ("kippnewark") →
-# kippnewark.fsenrollment.com. Confirm Newark's actual Finalsite subdomain
-# before deploy (see plan "Open config value"); pass an explicit string here if
-# it differs.
 FINALSITE_RESOURCE = FinalsiteResource(
     server=CODE_LOCATION,
     credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will wire the Finalsite Contacts API `contacts` asset into the `kippnewark` Dagster code location, mirroring the existing `kippmiami` Finalsite integration. This is Phase 1 (ingestion only) of replacing PowerSchool student contacts with Finalsite as the source of truth for NJ regions (Refs #4346).

Changes:

- New `kippnewark/resources.py` with a `FinalsiteResource` (server `kippnewark.fsenrollment.com`; credentials from environment variables).
- New `contacts` Avro asset plus `CONTACTS_SCHEMA` (generated from the shared `Contact` Pydantic model) plus a daily 04:00 ET schedule in `kippnewark/finalsite/`.
- Registered the resource and schedule in `kippnewark/definitions.py`.
- Declared the `op-finalsite-api-kippnewark` 1Password item and projected its credentials into both pod environment blocks in `kippnewark/dagster-cloud.yaml`.

No dbt models and no shared-library changes in this phase. The dbt modeling (top-ranked contact plus 4 emergency contacts) is a later phase, gated on a discovery step against the ingested Newark data. Design spec and plan live at `docs/superpowers/specs/2026-07-08-finalsite-contacts-nj-design.md` and `docs/superpowers/plans/2026-07-08-finalsite-contacts-nj-phase1-ingestion.md`.

### Pre-merge dependencies (Ops)

The `op-finalsite-api-kippnewark` k8s secret does not exist yet. Merging triggers the kippnewark prod deploy, so before merge apply the 1Password item and confirm the secret synced with `username`/`password` keys:

```bash
kubectl apply -f .k8s/1password/items.yaml
kubectl -n dagster-cloud get secret op-finalsite-api-kippnewark -o jsonpath='{.data}' | jq keys
```

If the synced keys differ from `username`/`password`, update the `secretKeyRef.key` values in `kippnewark/dagster-cloud.yaml` to match.

## AI Assistance

Claude Code authored this PR end-to-end (brainstorm, spec, plan, implementation via subagent-driven development, and review) under human direction. Human-directed decisions: the source-of-truth switch, the 1-plus-4 contact shape, per-region phasing (Newark first), and the two config values (Newark subdomain and 1Password item path).

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [ ] Review the Claude Code Review comment posted on this PR

### Dagster

- [x] `dagster definitions validate` — passes for the kippnewark location; the finalsite module loads cleanly (2 assets, 1 schedule, asset key `kippnewark/finalsite/contacts` matching the schedule target). Full-location load in the Codespace is gated by a pre-existing, unrelated PowerSchool environment-variable gap, so CI and the branch deployment are the definitive check.
- [ ] `pytest tests/test_dagster_definitions.py` — deferred to CI (needs the full-location environment that the Codespace lacks).
- [x] Follows the Library plus Config pattern (asset key `kippnewark/finalsite/contacts`, GCS Avro IO manager); reuses the shared factory with no library changes.

### Docs

- [ ] Regenerate the automations catalog (`scripts/gen-automations-doc.py`) — NOT run locally on purpose: the script skips any code location whose definitions fail to import, and the pre-existing environment-variable gap makes kippnewark fail to load in the Codespace, so a local run would drop kippnewark (and other) entries from the catalog. Run it in a full environment so the new `kippnewark__finalsite__contacts__daily_asset_job_schedule` is added without dropping existing entries.
- [ ] kippnewark CLAUDE.md — finalsite was already present (status_report); contacts extends it rather than adding a brand-new integration. Optional follow-up.

## CI checks

- [ ] Trunk — expected to pass (`trunk check` ran locally on all 8 changed files, clean).
- [ ] dbt Cloud — no dbt changes (no-op run).
- [ ] Dagster Cloud — branch deployment validates the kippnewark location load.