### PR TITLE
feat(finalsite): emit finalsite_contact_id on int_finalsite__student_contacts

### DIFF
--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -13,6 +13,7 @@ with
             r.rel_name,
             r.rel_type,
 
+            cp.finalsite_enrollment_id as finalsite_contact_id,
             cp.email,
             cp.phone_1_number,
 
@@ -47,6 +48,7 @@ with
     contact_1 as (
         select
             finalsite_enrollment_id,
+            finalsite_contact_id,
             email,
             phone_mobile,
             phone_home,
@@ -226,6 +228,7 @@ with
 
             true as is_emergency,
 
+            cast(null as string) as finalsite_contact_id,
             cast(null as string) as phone_daytime,
             cast(null as string) as home_address,
         from emergency_long
@@ -234,6 +237,7 @@ with
 select
     finalsite_enrollment_id,
     contact_slot,
+    finalsite_contact_id,
     contact_name,
     relationship,
     email,
@@ -254,6 +258,7 @@ union all
 select
     finalsite_enrollment_id,
     contact_slot,
+    finalsite_contact_id,
     contact_name,
     relationship,
     email,

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -45,6 +45,14 @@ models:
                   - emergency_4
               config:
                 severity: error
+      - name: finalsite_contact_id
+        data_type: string
+        description:
+          The contact person's own Finalsite contact UUID (their
+          `finalsite_enrollment_id`), resolved through the primary
+          relationship's `rel_id`. Populated for `contact_1`; null for
+          `emergency_*` slots, which are free-text custom-field sets with no
+          linked contact record.
       - name: contact_name
         data_type: string
         description:


### PR DESCRIPTION
## Summary and Motivation

When merged, this adds a `finalsite_contact_id` column to
`int_finalsite__student_contacts` — the contact person's own Finalsite contact
UUID (their `finalsite_enrollment_id`), resolved through the primary
relationship's `rel_id`. Populated for `contact_1`; null for `emergency_*` slots,
which are free-text custom-field sets with no linked contact record.

Small, additive foundation fix that unblocks the kipptaf contact-consumption work
(Phase 3b). The network `dim_student_contact_persons` keys on a per-person
surrogate; without this id the NJ Finalsite branch had no person identity to key
on. Emitting it at the source keeps the SIS-agnostic model complete rather than
re-deriving the id downstream in kipptaf.

Verified in dev (kippnewark defer build): `contact_1` = 10,061 rows all populated
(7,918 distinct — contacts shared across siblings dedupe correctly);
`emergency_*` all null; grain uniqueness + `not_null` + `accepted_values` all
pass (4/4).

### AI Assistance

AI-authored (Claude Code), human-directed — fixing the id at the source was the
maintainer's explicit direction.

## Self-review

### dbt

- [x] Properties file updated with the new column and description
- [x] Additive column, grain unchanged — no contract break, no rename/removal
- [x] No external source change
- [x] No kipptaf consumer yet, so no exposure impact (Phase 3b will consume it)

## CI checks

- [x] Trunk — `trunk check --force` clean on both files
- [x] dbt build + tests pass in dev (4/4)

Refs #4346