### PR TITLE
feat(finalsite): fall back to financial relationship for contact_1 when no primary

### DIFF
--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -1,13 +1,48 @@
 with
+    contact_1_candidates as (
+        -- contact_1 is the student's ONE reportable parent contact. Finalsite
+        -- has no explicit contact rank, so we take the relationship it flags
+        -- `primary` (its parent1 designation) and fall back to the one flagged
+        -- `financial` when no primary is set — the two flags Ops maintains to
+        -- mark the responsible caregiver. A record with neither flag gets no
+        -- contact_1 (a Finalsite data-entry gap for Ops to resolve).
+        -- `primary`/`financial` are NULL (not false) when unset, so normalize
+        -- to false here to keep the downstream rank ordering deterministic. No
+        -- SIS scoping — downstream receivers filter to enrolled students by
+        -- joining on the student id.
+        select
+            finalsite_enrollment_id,
+            relationship_id,
+            rel_id,
+            rel_name,
+            rel_type,
+
+            coalesce(is_primary, false) as is_primary,
+            coalesce(is_financial, false) as is_financial,
+        from {{ ref("stg_finalsite__contact_relationships") }}
+        where is_primary or is_financial
+    ),
+
+    contact_1_ranked as (
+        -- Rank primary above financial; within a tier break on relationship_id.
+        -- Ties occur only among multiple `financial` relationships (a student
+        -- never has two `primary`); relationship_id is an arbitrary but stable
+        -- tiebreak — every candidate in a tier is a valid contact, and
+        -- Finalsite exposes no field that reproduces a caregiver ordering.
+        select
+            finalsite_enrollment_id,
+            rel_id,
+            rel_name,
+            rel_type,
+
+            row_number() over (
+                partition by finalsite_enrollment_id
+                order by is_primary desc, is_financial desc, relationship_id asc
+            ) as rn,
+        from contact_1_candidates
+    ),
+
     contact_1_typed as (
-        -- contact_1 is EXCLUSIVELY the relationship Finalsite flags `primary`
-        -- (its parent1 designation), resolved to the related person's own
-        -- contact record. No fallback: a record with no primary flag (a
-        -- Finalsite data-entry gap) gets no contact_1. `primary` is a
-        -- per-record singleton, so the filter alone is a deterministic pick
-        -- (the grain uniqueness test guards any future multi-primary anomaly).
-        -- No SIS scoping here — downstream receivers filter to enrolled
-        -- students by joining on the student id.
         select
             r.finalsite_enrollment_id,
             r.rel_name,
@@ -38,11 +73,11 @@ with
                 ),
                 ''
             ) as home_address,
-        from {{ ref("stg_finalsite__contact_relationships") }} as r
+        from contact_1_ranked as r
         inner join
             {{ ref("stg_finalsite__contacts") }} as cp
             on r.rel_id = cp.finalsite_enrollment_id
-        where r.is_primary
+        where r.rn = 1
     ),
 
     contact_1 as (

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,15 +3,16 @@ models:
     description:
       SIS-agnostic long-format contact list for Finalsite student records — one
       row per (student, contact slot), grain `(finalsite_enrollment_id,
-      contact_slot)`. `contact_slot` is `contact_1` (the student's relationship
-      flagged `primary` in Finalsite — its parent1 designation — resolved to
-      that person's own Finalsite contact record; absent when no relationship is
-      flagged primary, with no fallback to a non-primary relationship) or
-      `emergency_1` through `emergency_4` (the `custom_attributes` `emrg_N` sets
-      mapped positionally — `emergency_N` is `emrg_N` as-is, with no priority
-      re-sort and no gap-filling). Sparse — a slot row is emitted only when that
-      slot has data, so emergency slots may have gaps. Feeds the downstream
-      PowerSchool/Focus contact receivers built on top of this model.
+      contact_slot)`. `contact_slot` is `contact_1` (the student's single
+      reportable parent contact — the relationship flagged `primary` in
+      Finalsite, or the one flagged `financial` when no primary is set, resolved
+      to that person's own Finalsite contact record; absent when the student has
+      neither a primary nor a financial relationship) or `emergency_1` through
+      `emergency_4` (the `custom_attributes` `emrg_N` sets mapped positionally —
+      `emergency_N` is `emrg_N` as-is, with no priority re-sort and no
+      gap-filling). Sparse — a slot row is emitted only when that slot has data,
+      so emergency slots may have gaps. Feeds the downstream PowerSchool/Focus
+      contact receivers built on top of this model.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -49,7 +50,7 @@ models:
         data_type: string
         description:
           The contact person's own Finalsite contact UUID (their
-          `finalsite_enrollment_id`), resolved through the primary
+          `finalsite_enrollment_id`), resolved through the selected
           relationship's `rel_id`. Populated for `contact_1`; null for
           `emergency_*` slots, which are free-text custom-field sets with no
           linked contact record.


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will change `contact_1` selection in `int_finalsite__student_contacts` to fall back to the relationship flagged `financial` when no relationship is flagged `primary`. Previously `contact_1` was exclusively the `primary` relationship, so enrolled students whose Finalsite record has no `primary` flag (a data-entry gap) got no reportable parent contact at all.

Selection is now: the `primary` relationship, else the `financial` relationship, ranked with a stable `relationship_id` tiebreak for the rare case of multiple `financial` relationships (a student never has two `primary`). The grain `(finalsite_enrollment_id, contact_slot)` is unchanged, and `emergency_1..4` are untouched.

This is a value-only change (no new columns). It was validated against an Ops-provided Finalsite parent export: primary-then-financial reproduces the export's parent-1 selection for the students it covers. The financial-tier tiebreak is arbitrary-but-stable — no stored Finalsite field (neither `relationship_id` nor source array order) reproduces the export's ordering for the ~117 multi-financial students, and both candidates are valid financial contacts.

Built and tested through `kippnewark` with defer to prod: grain uniqueness, `not_null`, and `accepted_values` all pass. Network-wide `contact_1` coverage rises from 10,061 to 10,650 students, with exactly one `contact_1` per student.

Refs #4346

## AI Assistance

AI-assisted (Claude Code): the SQL change, docs, coverage validation, and this PR. Human-directed: the selection rule (primary then financial, no relationship-type logic) and the tiebreak decision, chosen after reviewing the Ops export.

## Self-review

### dbt

- [x] Properties file updated for the modified model (description reflects the new selection rule)
- [x] Exposures — no change; downstream column set and grain are unchanged
- [x] Breaking change? No — value-only; grain and columns unchanged, so contracted downstream consumers are unaffected
- [x] External sources — none added or modified

## CI checks

- [ ] Trunk — passes
- [ ] dbt Cloud — passes
- [ ] Dagster Cloud — not triggered (no Dagster path changes)