### PR TITLE
feat(deanslist): add Paterson and restructure per-school API keys

### DIFF
--- a/.k8s/1password/items.yaml
+++ b/.k8s/1password/items.yaml
@@ -282,10 +282,34 @@ spec:
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
-  name: op-deanslist-api
+  name: op-deanslist-api-kippnewark
   namespace: dagster-cloud
 spec:
-  itemPath: vaults/Data Team/items/DeansList API
+  itemPath: vaults/Data Team/items/DeansList API - Newark
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-deanslist-api-kippcamden
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/DeansList API - Camden
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-deanslist-api-kippmiami
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/DeansList API - Miami
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-deanslist-api-kipppaterson
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/DeansList API - Paterson
 ---
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem

--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -84,6 +84,9 @@ k8s Secret keys come from the 1Password field's internal name, not the UI label.
 Known re-mappings on SFTP items: `password` → `newPassword`, `host` → `url`.
 Verify before writing `secretKeyRef.key`:
 `kubectl -n dagster-cloud get secret <op-name> -o jsonpath='{.data}' | jq keys`.
+Custom (user-added) text fields sync under their label verbatim (verified:
+numeric DeansList school-id labels → keys `121`, `966`); the remaps above only
+hit built-in login/SFTP-template fields.
 
 ## Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   unchanged and dirties `main` (the worktree commit then reports "nothing to
   commit").
 
+- **IDE Pyright diagnostics on worktree files are false-positive-prone** — it
+  resolves imports against the MAIN checkout, so worktree-only signature/symbol
+  changes surface phantom `unknown import` / `no parameter named X` errors.
+  Trust `uv run` executed inside the worktree, not the IDE.
+
 - **Branch switch**: with an issue,
   `gh issue develop <number> --name <branch> --checkout`; if the user explicitly
   declined an issue, `git checkout -b <branch>`.
@@ -332,7 +337,8 @@ tagging.
 - **`trunk check` the spec/plan `.md` you write before pushing** — markdownlint
   (MD040 fenced-block language, MD036) fires only at pre-push/CI, not the
   pre-commit `fmt` hook; checking only the code files misses a doc-only Trunk
-  failure.
+  failure. Run it non-interactively (`--no-fix </dev/null`) — `--force` on a
+  large `.md` can hang on the interactive "Apply formatting?" prompt.
 
 - **`finishing-a-development-branch` / `using-git-worktrees` tests & setup**:
   this repo uses `uv`, not `poetry`/`pip`, and

--- a/docs/superpowers/plans/2026-07-10-deanslist-paterson-and-per-school-keys.md
+++ b/docs/superpowers/plans/2026-07-10-deanslist-paterson-and-per-school-keys.md
@@ -45,6 +45,13 @@ projected secret volumes via the 1Password Operator, dbt (BigQuery) with
   dedicated, non-nested volume — chosen over the spec's illustrative
   `/etc/secret-volume/deanslist` to avoid mounting one projected volume inside
   another).
+- **Per-city secrets (amendment):** the 1Password item is split by city — each
+  district mounts `op-deanslist-api-<district>`, NOT the monolithic
+  `op-deanslist-api` shown in the Task 3/6 snippets. Add one `OnePasswordItem`
+  CR per city to `.k8s/1password/items.yaml`, and remove the vestigial
+  `DEANSLIST_SUBDOMAIN` mapping from `kipptaf`'s `dagster-cloud.yaml` (SFTP-only
+  location — the dangling ref would break its pods once the monolithic secret is
+  deleted).
 - **PR boundary:** Tasks 1-8 are PR 1 (Python + K8s, no dbt). Tasks 9-11 are PR
   2 (dbt only). Do not mix dbt changes into PR 1.
 - **Markdown/YAML/SQL:** fenced blocks need a language (MD040); headings

--- a/docs/superpowers/plans/2026-07-10-deanslist-paterson-and-per-school-keys.md
+++ b/docs/superpowers/plans/2026-07-10-deanslist-paterson-and-per-school-keys.md
@@ -1,0 +1,980 @@
+# DeansList Paterson and Per-School API Keys Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure DeansList school API keys into per-school 1Password fields
+loaded from a mounted directory, and extend the DeansList integration to
+Paterson end-to-end (Dagster ingestion, district dbt, kipptaf unions).
+
+**Architecture:** `DeansListResource` stops parsing a YAML blob and instead
+reads one shared, mounted secret directory: the subdomain from a `subdomain`
+file and the `{school_id: key}` map from numeric-named files. All four API
+districts share this resource, so PR 1 migrates them together and adds Paterson
+ingestion. PR 2 wires the dbt side (Paterson district project plus kipptaf
+cross-district unions), which depends on Paterson Avro already existing in GCS.
+
+**Tech Stack:** Python 3.13 + Dagster (`ConfigurableResource`), Kubernetes
+projected secret volumes via the 1Password Operator, dbt (BigQuery) with
+`dbt_utils.union_relations`.
+
+**Spec:**
+`docs/superpowers/specs/2026-07-10-deanslist-paterson-and-per-school-keys-design.md`
+
+**Issue:** [#4367](https://github.com/TEAMSchools/teamster/issues/4367)
+
+## Global Constraints
+
+- **Worktree:** all work happens in
+  `/workspaces/teamster/.worktrees/deanslist-paterson` on branch
+  `cbini/feat/claude-deanslist-paterson-integration`. Prefix every git call with
+  `git -C /workspaces/teamster/.worktrees/deanslist-paterson`. Run `uv`/`pytest`
+  and `dbt` from inside the worktree (or pass `--project-dir`).
+- **Python:** `requires-python >=3.13`. Always `uv run`; never bare `python`.
+  Built-in generics, `X | None`, return-type annotations on resource methods.
+- **Trunk:** do not run `trunk fmt`/`check` casually — the pre-commit hook runs
+  `fmt`. Before pushing, run
+  `/workspaces/teamster/.trunk/tools/trunk check --force <files>` from **inside
+  the worktree** (the binary lives only in the main repo).
+- **dbt targets:** `stage_external_sources --target staging` and `--target prod`
+  builds are classifier-blocked — **hand them to the user**.
+  `dbt parse`/`compile` and `dbt build --target dev` are runnable locally.
+- **Mount path:** the DeansList key directory mounts at **`/etc/deanslist`** (a
+  dedicated, non-nested volume — chosen over the spec's illustrative
+  `/etc/secret-volume/deanslist` to avoid mounting one projected volume inside
+  another).
+- **PR boundary:** Tasks 1-8 are PR 1 (Python + K8s, no dbt). Tasks 9-11 are PR
+  2 (dbt only). Do not mix dbt changes into PR 1.
+- **Markdown/YAML/SQL:** fenced blocks need a language (MD040); headings
+  increment by one (MD001); backtick identifiers in prose. SQL follows
+  `.trunk/config/.sqlfluff` (BigQuery, trailing commas, single quotes, 88 cols).
+
+## Human-gated prerequisites (not code tasks)
+
+These are owner actions in 1Password / the cluster. They gate specific tasks;
+the plan notes where.
+
+- **P1 (before PR 1 merges):** In the `DeansList API` 1Password item (vault
+  `Data Team`), add one text field per school — label = DeansList `school_id`
+  (e.g. `121`), value = that school's API key — for **all** existing districts
+  (re-entered from the current YAML blob) **plus Paterson's schools**. Leave the
+  existing YAML blob field in place for now.
+- **P2 (verify before merging Task 1):** Confirm the numeric fields sync to
+  secret keys under their labels:
+  `kubectl -n dagster-cloud get secret op-deanslist-api -o jsonpath='{.data}' | jq keys`.
+  Expected keys include `subdomain`, `121`, `122`, …. If labels are remapped,
+  use the fallback in Task 1's note (`school_id|key` in the value).
+- **P3 (after PR 1 deploys and is verified):** Delete the old YAML blob field
+  from the `DeansList API` item.
+- **P4 (inputs):** Paterson's DeansList `school_id` list (for Task 4) and the
+  set of endpoints Paterson pulls (for Tasks 4 and 9-11). Default assumption if
+  unspecified: the same core endpoints as Newark (`users`, `terms`, `rosters`,
+  `roster-assignments`, `students`, `incidents`, `comm-log`).
+
+---
+
+## PR 1 — Keys plus Paterson ingestion (Python and K8s)
+
+### Task 1: `DeansListResource` loads from a mounted directory
+
+**Files:**
+
+- Modify: `src/teamster/libraries/deanslist/resources.py`
+- Test: `tests/resources/test_resource_deanslist.py` (create)
+
+**Interfaces:**
+
+- Produces: `DeansListResource(api_key_dir: str, request_timeout: float = 60.0)`
+  — the `subdomain` and `api_key_map` config fields are removed. Module-level
+  helper
+  `load_deanslist_config(key_dir: pathlib.Path) -> tuple[str, dict[int, str]]`
+  returns `(subdomain, api_key_map)`.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/resources/test_resource_deanslist.py`:
+
+```python
+import pathlib
+
+from teamster.libraries.deanslist.resources import load_deanslist_config
+
+
+def test_load_deanslist_config(tmp_path: pathlib.Path):
+    (tmp_path / "subdomain").write_text("kippnj\n")
+    (tmp_path / "121").write_text("key-121\n")
+    (tmp_path / "122").write_text("key-122")
+    # projected-secret volumes stage data behind dot-prefixed entries
+    (tmp_path / "..data").mkdir()
+    (tmp_path / ".hidden").write_text("ignore-me")
+
+    subdomain, api_key_map = load_deanslist_config(tmp_path)
+
+    assert subdomain == "kippnj"
+    assert api_key_map == {121: "key-121", 122: "key-122"}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run pytest tests/resources/test_resource_deanslist.py -v`
+Expected: FAIL with `ImportError` /
+`cannot import name 'load_deanslist_config'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/teamster/libraries/deanslist/resources.py`: remove `import yaml`; add
+the helper; swap the config fields; rewrite `setup_for_execution`. The full head
+of the file becomes:
+
+```python
+import pathlib
+
+import fastavro
+import fastavro.types
+from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
+from dagster_shared import check
+from pydantic import PrivateAttr
+from requests import Session
+from requests.exceptions import HTTPError
+
+
+def load_deanslist_config(
+    key_dir: pathlib.Path,
+) -> tuple[str, dict[int, str]]:
+    subdomain = (key_dir / "subdomain").read_text().strip()
+
+    api_key_map = {
+        int(f.name): f.read_text().strip()
+        for f in key_dir.iterdir()
+        if f.is_file() and not f.name.startswith(".") and f.name.isdigit()
+    }
+
+    return subdomain, api_key_map
+
+
+class DeansListResource(ConfigurableResource):
+    api_key_dir: str
+    request_timeout: float = 60.0
+
+    _session: Session = PrivateAttr(default_factory=Session)
+    _base_url: str = PrivateAttr()
+    _api_key_map: dict = PrivateAttr()
+    _log: DagsterLogManager = PrivateAttr()
+
+    def setup_for_execution(self, context: InitResourceContext) -> None:
+        self._log = check.not_none(value=context.log)
+
+        subdomain, self._api_key_map = load_deanslist_config(
+            pathlib.Path(self.api_key_dir)
+        )
+
+        self._base_url = f"https://{subdomain}.deanslistsoftware.com/api"
+```
+
+Leave `_get_url`, `_request`, `get`, and `list` unchanged (they already read
+`self._api_key_map[school_id]`).
+
+> **Fallback (only if P2 shows remapped keys):** change the dict comprehension
+> to parse the value instead of the filename — each file's contents are
+> `"<school_id>|<key>"`; split on `|`, cast the left side to `int`. Keep the
+> `subdomain` read as-is (its key is already proven).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run pytest tests/resources/test_resource_deanslist.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/libraries/deanslist/resources.py \
+  tests/resources/test_resource_deanslist.py
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "refactor(deanslist): load api keys from mounted directory"
+```
+
+### Task 2: Update the shared resource instantiation
+
+**Files:**
+
+- Modify: `src/teamster/core/resources.py:86-90`
+
+**Interfaces:**
+
+- Consumes: `DeansListResource(api_key_dir=...)` from Task 1.
+
+- [ ] **Step 1: Edit the instantiation**
+
+Replace lines 86-90 of `src/teamster/core/resources.py`:
+
+```python
+DEANSLIST_RESOURCE = DeansListResource(
+    api_key_dir="/etc/deanslist",
+    request_timeout=90.0,
+)
+```
+
+- [ ] **Step 2: Verify the module imports**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run python -c "import teamster.core.resources"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add src/teamster/core/resources.py
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "refactor(deanslist): point shared resource at key directory"
+```
+
+### Task 3: Migrate Newark, Camden, and Miami deploy config
+
+Each of the three files has an identical DeansList block. For each district, (a)
+move the `op-deanslist-api` secret out of the shared `secret-volume` into its
+own `deanslist-keys` volume mounted at `/etc/deanslist`, and (b) remove the
+`DEANSLIST_SUBDOMAIN` environment-variable mapping from **both** the
+`server_k8s_config` and `run_k8s_config` blocks.
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/dagster-cloud.yaml`
+- Modify: `src/teamster/code_locations/kippcamden/dagster-cloud.yaml`
+- Modify: `src/teamster/code_locations/kippmiami/dagster-cloud.yaml`
+
+- [ ] **Step 1: Rework the volume block (each district)**
+
+In each file, replace the `volume_mounts:` + `volumes:` block (near the top,
+under `k8s:`) so `op-deanslist-api` becomes its own volume. Newark example — the
+`op-ps-ssh-kippnewark` source stays; `op-ps-ssh-<district>` differs per
+district:
+
+```yaml
+volume_mounts:
+  - name: secret-volume
+    readOnly: true
+    mountPath: /etc/secret-volume
+  - name: deanslist-keys
+    readOnly: true
+    mountPath: /etc/deanslist
+volumes:
+  - name: secret-volume
+    projected:
+      sources:
+        - secret:
+            name: op-ps-ssh-kippnewark
+            items:
+              - key: password
+                path: powerschool_ssh_password.txt
+  - name: deanslist-keys
+    projected:
+      sources:
+        - secret:
+            name: op-deanslist-api
+```
+
+Camden uses `op-ps-ssh-kippcamden`; Miami uses `op-ps-ssh-kippmiami`. The
+`deanslist-keys` volume is identical in all three (no `items:` — every key
+becomes a file).
+
+- [ ] **Step 2: Remove the `DEANSLIST_SUBDOMAIN` env mapping (each district)**
+
+In each file, delete this block from **both** the `server_k8s_config` and
+`run_k8s_config` `env:` lists (two occurrences per file):
+
+```yaml
+- name: DEANSLIST_SUBDOMAIN
+  valueFrom:
+    secretKeyRef:
+      name: op-deanslist-api
+      key: subdomain
+```
+
+- [ ] **Step 3: Verify no stray references remain**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && grep -rn "DEANSLIST_SUBDOMAIN\|deanslist_api_key_map" src/teamster/code_locations/kippnewark src/teamster/code_locations/kippcamden src/teamster/code_locations/kippmiami`
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/code_locations/kippnewark/dagster-cloud.yaml \
+  src/teamster/code_locations/kippcamden/dagster-cloud.yaml \
+  src/teamster/code_locations/kippmiami/dagster-cloud.yaml
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "chore(deanslist): mount key directory for nj and miami locations"
+```
+
+### Task 4: Create the Paterson DeansList Dagster module
+
+**Files:**
+
+- Create: `src/teamster/code_locations/kipppaterson/deanslist/__init__.py`
+- Create: `src/teamster/code_locations/kipppaterson/deanslist/schema.py`
+- Create: `src/teamster/code_locations/kipppaterson/deanslist/assets.py`
+- Create: `src/teamster/code_locations/kipppaterson/deanslist/schedules.py`
+- Create:
+  `src/teamster/code_locations/kipppaterson/deanslist/config/static-partition-assets.yaml`
+- Create:
+  `src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-monthly-assets.yaml`
+- Create:
+  `src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-fiscal-assets.yaml`
+
+**Interfaces:**
+
+- Produces: `assets` (list) and `schedules` (list) exported from the module
+  `__init__.py`, consumed by Task 5.
+- Consumes: `build_deanslist_*` factories from
+  `teamster.libraries.deanslist.assets` and `build_deanslist_job_schedule` from
+  `teamster.libraries.deanslist.schedules`.
+
+- [ ] **Step 1: Copy the schema module verbatim**
+
+`kippnewark/deanslist/schema.py` has no code-location-specific code (it only
+generates Avro from the shared library models). Copy it unchanged:
+
+```bash
+cp /workspaces/teamster/.worktrees/deanslist-paterson/src/teamster/code_locations/kippnewark/deanslist/schema.py \
+   /workspaces/teamster/.worktrees/deanslist-paterson/src/teamster/code_locations/kipppaterson/deanslist/schema.py
+```
+
+- [ ] **Step 2: Write `config/` files**
+
+Enable only the endpoints Paterson pulls (P4). Using the Newark default set:
+
+`config/static-partition-assets.yaml`:
+
+```yaml
+endpoints:
+  - endpoint: users
+    api_version: v1
+    params:
+      IncludeInactive: Y
+  - endpoint: terms
+    api_version: v1
+  - endpoint: rosters
+    api_version: v1
+    params:
+      show_inactive: Y
+  - endpoint: roster-assignments
+    api_version: beta
+  - endpoint: students
+    api_version: v1
+    params:
+      IncludeCustomFields: Y
+      IncludeUnenrolled: Y
+      IncludeParents: Y
+```
+
+`config/multi-partition-monthly-assets.yaml`:
+
+```yaml
+endpoints:
+  - endpoint: incidents
+    params:
+      IncludeDeleted: Y
+      cf: Y
+      attachments: Y
+```
+
+`config/multi-partition-fiscal-assets.yaml`:
+
+```yaml
+endpoints:
+  - endpoint: comm-log
+    params:
+      IncludeSentReports: "yes"
+      IncludeTwoWayTexts: "yes"
+```
+
+- [ ] **Step 3: Write `assets.py`**
+
+Identical to Newark's except the code-location import and the school-id list.
+Replace `PATERSON_SCHOOL_IDS_HERE` with the P4 list (strings):
+
+```python
+import pathlib
+
+from dagster import (
+    MonthlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    config_from_files,
+)
+
+from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kipppaterson.deanslist.schema import (
+    ASSET_SCHEMA,
+    BEHAVIOR_SCHEMA,
+)
+from teamster.core.utils.classes import FiscalYearPartitionsDefinition
+from teamster.libraries.deanslist.assets import (
+    build_deanslist_multi_partition_asset,
+    build_deanslist_paginated_multi_partition_asset,
+    build_deanslist_static_partition_asset,
+)
+
+DEANSLIST_STATIC_PARTITIONS_DEF = StaticPartitionsDefinition(
+    [PATERSON_SCHOOL_IDS_HERE]
+)
+
+DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF = MultiPartitionsDefinition(
+    partitions_defs={
+        "school": DEANSLIST_STATIC_PARTITIONS_DEF,
+        "date": FiscalYearPartitionsDefinition(
+            start_date="2016-07-01",
+            start_month=7,
+            timezone=str(LOCAL_TIMEZONE),
+            end_offset=1,
+        ),
+    }
+)
+
+config_dir = pathlib.Path(__file__).parent / "config"
+
+static_partitioned_assets = [
+    build_deanslist_static_partition_asset(
+        code_location=CODE_LOCATION,
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=DEANSLIST_STATIC_PARTITIONS_DEF,
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/static-partition-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+month_partitioned_assets = [
+    build_deanslist_multi_partition_asset(
+        code_location=CODE_LOCATION,
+        api_version="v1",
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=MultiPartitionsDefinition(
+            partitions_defs={
+                "school": DEANSLIST_STATIC_PARTITIONS_DEF,
+                "date": MonthlyPartitionsDefinition(
+                    start_date="2016-07-01", timezone=str(LOCAL_TIMEZONE), end_offset=1
+                ),
+            }
+        ),
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/multi-partition-monthly-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+year_partitioned_assets = [
+    build_deanslist_multi_partition_asset(
+        code_location=CODE_LOCATION,
+        api_version="v1",
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF,
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/multi-partition-fiscal-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+assets = [
+    *static_partitioned_assets,
+    *month_partitioned_assets,
+    *year_partitioned_assets,
+]
+```
+
+> Note: the Newark `behavior` paginated asset and its midday `comm_log` schedule
+> are only needed if Paterson pulls those endpoints. The config above omits
+> `behavior`; do not append the paginated asset unless P4 includes it.
+
+- [ ] **Step 4: Write `schedules.py`**
+
+Identical to Newark's, minus the `midday_commlog` schedule (add it back only if
+Paterson pulls `comm-log` on that cadence):
+
+```python
+from teamster.code_locations.kipppaterson import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
+from teamster.code_locations.kipppaterson.deanslist.assets import (
+    month_partitioned_assets,
+    static_partitioned_assets,
+    year_partitioned_assets,
+)
+from teamster.libraries.deanslist.schedules import build_deanslist_job_schedule
+
+deanslist_static_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__static_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=static_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+deanslist_month_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__month_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=month_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+deanslist_year_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__year_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=year_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+schedules = [
+    deanslist_month_partitioned_assets_job_schedule,
+    deanslist_static_partitioned_assets_job_schedule,
+    deanslist_year_partitioned_assets_job_schedule,
+]
+```
+
+- [ ] **Step 5: Write `__init__.py`**
+
+```python
+from teamster.code_locations.kipppaterson.deanslist.assets import assets
+from teamster.code_locations.kipppaterson.deanslist.schedules import schedules
+
+__all__ = [
+    "assets",
+    "schedules",
+]
+```
+
+- [ ] **Step 6: Verify the module imports**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run python -c "import teamster.code_locations.kipppaterson.deanslist"`
+Expected: no output, exit 0. (A `KeyError` on `ASSET_SCHEMA[...]` means a config
+endpoint name has no schema entry — fix the config.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/code_locations/kipppaterson/deanslist
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "feat(deanslist): add paterson deanslist ingestion module"
+```
+
+### Task 5: Wire DeansList into Paterson `definitions.py`
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kipppaterson/definitions.py`
+
+**Interfaces:**
+
+- Consumes: `deanslist` module (Task 4), `DEANSLIST_RESOURCE` (Task 2).
+
+- [ ] **Step 1: Add the import**
+
+In the `from teamster.code_locations.kipppaterson import (...)` block, add
+`deanslist` (alphabetical, after `couchdrop`). In the
+`from teamster.core.resources import (...)` block, add `DEANSLIST_RESOURCE`.
+
+- [ ] **Step 2: Register assets, schedules, and the resource**
+
+- Add `deanslist,` to the `load_assets_from_modules(modules=[...])` list.
+- Add a `schedules=[*deanslist.schedules],` argument to `Definitions(...)`.
+- Add `"deanslist": DEANSLIST_RESOURCE,` to the `resources={...}` dict.
+
+The resulting `Definitions(...)` call:
+
+```python
+defs = Definitions(
+    executor=k8s_job_executor,
+    assets=load_assets_from_modules(
+        modules=[
+            dbt,
+            amplify,
+            deanslist,
+            finalsite,
+            pearson,
+            powerschool,
+        ]
+    ),
+    schedules=[
+        *deanslist.schedules,
+    ],
+    sensors=[
+        *amplify.sensors,
+        *couchdrop.sensors,
+        AutomationConditionSensorDefinition(
+            name=f"{CODE_LOCATION}__automation_condition_sensor",
+            target=AssetSelection.all(),
+        ),
+    ],
+    resources={
+        "dbt_cli": get_dbt_cli_resource(DBT_PROJECT),
+        "deanslist": DEANSLIST_RESOURCE,
+        "gcs": GCS_RESOURCE,
+        "google_drive": GOOGLE_DRIVE_RESOURCE,
+        "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),
+        "io_manager": get_io_manager_gcs_pickle(CODE_LOCATION),
+        "ssh_amplify": SSH_RESOURCE_AMPLIFY,
+        "ssh_couchdrop": SSH_COUCHDROP,
+    },
+)
+```
+
+- [ ] **Step 2b: Add the file IO manager if the paginated asset is used**
+
+Only if Task 4 kept the `behavior` paginated asset: import
+`get_io_manager_gcs_file` and add
+`"io_manager_gcs_file": get_io_manager_gcs_file(CODE_LOCATION),` to `resources`.
+Otherwise skip.
+
+- [ ] **Step 3: Verify the submodule imports**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run python -c "import teamster.code_locations.kipppaterson.deanslist"`
+Expected: exit 0. (The full `.definitions` module cannot import in the codespace
+— `get_powerschool_ssh_resource()` reads unset env vars — so validate the
+submodule, not `definitions`, per `src/teamster/CLAUDE.md`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/code_locations/kipppaterson/definitions.py
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "feat(deanslist): register paterson deanslist assets and schedules"
+```
+
+### Task 6: Add the key-directory mount to Paterson deploy config
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kipppaterson/dagster-cloud.yaml`
+
+- [ ] **Step 1: Add `volume_mounts` and `volumes` under `k8s:`**
+
+Paterson has no volume block today. Insert these two keys directly under
+`container_context.k8s:` (as siblings of `server_k8s_config`, before it):
+
+```yaml
+container_context:
+  k8s:
+    volume_mounts:
+      - name: deanslist-keys
+        readOnly: true
+        mountPath: /etc/deanslist
+    volumes:
+      - name: deanslist-keys
+        projected:
+          sources:
+            - secret:
+                name: op-deanslist-api
+    server_k8s_config:
+```
+
+Do **not** add a `DEANSLIST_SUBDOMAIN` env variable — the subdomain is read from
+the mounted `subdomain` file.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run python -c "import yaml; yaml.safe_load(open('src/teamster/code_locations/kipppaterson/dagster-cloud.yaml'))"`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "chore(deanslist): mount key directory for paterson location"
+```
+
+### Task 7: Update Paterson code-location docs
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kipppaterson/CLAUDE.md`
+
+- [ ] **Step 1: Add DeansList to Active Integrations**
+
+Add a row to the Active Integrations table:
+
+```markdown
+| `deanslist` | API assets | schedule (nightly) |
+```
+
+- [ ] **Step 2: Remove DeansList from the "does not use" list**
+
+In the "Critical Difference" consequences list, drop `deanslist` from the line
+`No deanslist, edplan, iready, overgrad, renlearn, or titan`.
+
+- [ ] **Step 3: Reconcile the "No Schedules" section**
+
+The doc's "No Asset Checks, No Schedules" heading is now partly false. Change
+the heading to "Schedules" and note that DeansList adds nightly data-pull
+schedules while all other ingestion remains sensor-driven.
+
+- [ ] **Step 4: Lint and commit**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && /workspaces/teamster/.trunk/tools/trunk check --force src/teamster/code_locations/kipppaterson/CLAUDE.md`
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/teamster/code_locations/kipppaterson/CLAUDE.md
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "docs(deanslist): note paterson deanslist integration"
+```
+
+### Task 8: Open PR 1
+
+- [ ] **Step 1: Lint the whole change set**
+
+Run (from inside the worktree):
+`/workspaces/teamster/.trunk/tools/trunk check --force $(git -C /workspaces/teamster/.worktrees/deanslist-paterson diff --name-only origin/main)`
+Fix anything flagged.
+
+- [ ] **Step 2: Push and open the PR**
+
+Push the branch (the user pushes if the classifier blocks it), then open a PR
+with the `.github/pull_request_template.md` body, `Refs #4367`. Note in the PR
+description that **P1 must be done and P2 verified before merge, and P3 after
+deploy**.
+
+- [ ] **Step 3: Post-merge verification (owner-run)**
+
+After deploy: materialize a sample DeansList partition for Newark, Camden, and
+Miami (existing schools) and confirm non-zero rows plus a passing Avro schema
+check. Then materialize Paterson's DeansList assets so Avro lands at
+`gs://teamster-kipppaterson/dagster/kipppaterson/deanslist/...`. Then do P3.
+
+---
+
+## PR 2 — dbt (Paterson district plus kipptaf unions)
+
+> Prerequisite: PR 1 deployed and Paterson DeansList assets materialized in prod
+> (so the external sources stage against real data). Land the two projects
+> together via the single-PR cross-project workflow in
+> `src/dbt/kipptaf/CLAUDE.md`.
+
+### Task 9: Add the `deanslist` package to the Paterson district project
+
+**Files:**
+
+- Modify: `src/dbt/kipppaterson/packages.yml`
+- Modify: `src/dbt/kipppaterson/dbt_project.yml`
+- Modify: `src/dbt/kipppaterson/CLAUDE.md`
+
+**Interfaces:**
+
+- Produces: `kipppaterson_deanslist.stg_deanslist__*` and `int_deanslist__*`
+  tables consumed by Task 10.
+
+- [ ] **Step 1: Add the package dependency**
+
+In `src/dbt/kipppaterson/packages.yml`, add under `packages:` (before the
+`dbt-labs/dbt_external_tables` entry):
+
+```yaml
+- local: ../deanslist
+```
+
+- [ ] **Step 2: Configure the package models**
+
+In `src/dbt/kipppaterson/dbt_project.yml`, under the top-level `models:` map (as
+a sibling of the existing `pearson:` / `powerschool:` package keys), add.
+Disable the staging models for endpoints Paterson does **not** pull (mirror the
+Newark pattern, which disables only `stg_deanslist__followups`):
+
+```yaml
+deanslist:
+  +materialized: table
+  staging:
+    stg_deanslist__followups:
+      +enabled: false
+```
+
+- [ ] **Step 3: Install the package and parse**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run dbt deps --project-dir src/dbt/kipppaterson`
+then
+`uv run dbt parse --target prod --project-dir src/dbt/kipppaterson --target-path target/prod`
+Expected: parse succeeds; `deanslist` package models appear in the graph.
+
+- [ ] **Step 4: Stage the external sources (owner-run — classifier-blocked)**
+
+The external tables must be staged before dbt Cloud CI can read them, and
+Paterson Avro must already exist (PR 1). The owner runs:
+`uv run dbt run-operation stage_external_sources --target staging --project-dir src/dbt/kipppaterson --vars '{ext_full_refresh: true}'`
+
+- [ ] **Step 5: Build the Paterson deanslist models (owner-run against
+      staging)**
+
+`uv run dbt build --select deanslist --target staging --project-dir src/dbt/kipppaterson`
+Expected: `stg_deanslist__*` / `int_deanslist__*` build and their uniqueness
+tests pass.
+
+- [ ] **Step 6: Update the district CLAUDE.md**
+
+In `src/dbt/kipppaterson/CLAUDE.md`, add `deanslist` to "Active Source Packages"
+and note which endpoints/models are enabled.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/dbt/kipppaterson/packages.yml \
+  src/dbt/kipppaterson/package-lock.yml \
+  src/dbt/kipppaterson/dbt_project.yml \
+  src/dbt/kipppaterson/CLAUDE.md
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "feat(deanslist): add deanslist package to paterson project"
+```
+
+### Task 10: Add Paterson to the kipptaf cross-district unions
+
+**Files:**
+
+- Create: `src/dbt/kipptaf/models/deanslist/api/sources-kipppaterson.yml`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__users.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__behavior.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__terms.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__attachments.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__students__custom_fields__pivot.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql`
+- Modify:
+  `src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__comm_log.sql`
+
+- [ ] **Step 1: Create the Paterson source file**
+
+Copy `sources-kippnewark.yml` and rename the district throughout:
+
+```bash
+sed 's/kippnewark/kipppaterson/g' \
+  /workspaces/teamster/.worktrees/deanslist-paterson/src/dbt/kipptaf/models/deanslist/api/sources-kippnewark.yml \
+  > /workspaces/teamster/.worktrees/deanslist-paterson/src/dbt/kipptaf/models/deanslist/api/sources-kipppaterson.yml
+```
+
+- [ ] **Step 2: Add the Paterson relation to each union model**
+
+In each of the 9 SQL files above, add a
+`source("kipppaterson_deanslist", "<M>")` line to the `relations=[...]` list of
+the `dbt_utils.union_relations(...)` call, where `<M>` is that model's unioned
+table name (it matches the model file name). Example —
+`int_deanslist__comm_log.sql` becomes:
+
+```sql
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_deanslist", "int_deanslist__comm_log"),
+                    source("kippcamden_deanslist", "int_deanslist__comm_log"),
+                    source("kippmiami_deanslist", "int_deanslist__comm_log"),
+                    source("kipppaterson_deanslist", "int_deanslist__comm_log"),
+                ]
+            )
+        }}
+    )
+
+select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+from union_relations as ur
+```
+
+> Only add Paterson to a union whose model Paterson actually builds (Task 9). If
+> Paterson omits an endpoint, skip that file and log the omission in the PR.
+
+- [ ] **Step 3: Parse kipptaf**
+
+Run:
+`cd /workspaces/teamster/.worktrees/deanslist-paterson && uv run dbt parse --target prod --project-dir src/dbt/kipptaf --target-path target/prod`
+Expected: parse succeeds; the new source resolves.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/deanslist-paterson add \
+  src/dbt/kipptaf/models/deanslist/api
+git -C /workspaces/teamster/.worktrees/deanslist-paterson commit -m \
+  "feat(deanslist): union paterson into kipptaf deanslist models"
+```
+
+### Task 11: Validate PR 2 and open it
+
+- [ ] **Step 1: Seed staging for CI (single-PR cross-project workflow,
+      owner-run)**
+
+Per `src/dbt/kipptaf/CLAUDE.md`: add the `target=staging` branch to
+`sources-kipppaterson.yml` if the copied file lacks it (it inherits Newark's dev
+branch — confirm it routes to `zz_stg_kipppaterson_deanslist` under staging),
+`dbt clone`/`build` the Paterson deanslist models into `zz_stg_kipppaterson_*`,
+and clone+build `zz_stg_kipptaf` so kipptaf reads its own union models from
+staging.
+
+- [ ] **Step 2: Build the affected kipptaf models (owner-run against staging)**
+
+`uv run dbt build --select +int_deanslist__comm_log +stg_deanslist__users --target staging --project-dir src/dbt/kipptaf`
+(extend the selection to every modified union model). Expected: builds pass and
+Paterson rows carry a `_dbt_source_project` of `kipppaterson`.
+
+- [ ] **Step 3: Lint**
+
+Run:
+`/workspaces/teamster/.trunk/tools/trunk check --force $(git -C /workspaces/teamster/.worktrees/deanslist-paterson diff --name-only origin/main)`
+
+- [ ] **Step 4: Push and open PR 2**
+
+Push (user pushes if blocked); open the PR with the template body and
+`Closes #4367`. Flag that CI needs the staged Paterson tables from Step 1.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Part 1 (per-school key fields to a mounted directory) → Tasks 1, 2, 3, 6.
+- Part 1 risk (field label vs secret key) → prerequisite P2 + Task 1 fallback
+  note.
+- Part 2 (Paterson Dagster ingestion) → Tasks 4, 5, 6, 7.
+- Part 3 (Paterson district dbt) → Task 9.
+- Part 4 (kipptaf cross-district inclusion) → Task 10.
+- Rollout / sequencing (two PRs, 1Password bracketing steps) → PR-section split,
+  P1/P3, Tasks 8 and 11.
+- Testing/validation → Task 1 unit test; import/parse/build checks per task;
+  post-merge materialization in Task 8.
+
+**Type consistency:** `DeansListResource(api_key_dir=...)` and
+`load_deanslist_config(key_dir) -> tuple[str, dict[int, str]]` are used
+identically in Tasks 1 and 2. `assets` / `schedules` exports (Task 4) match the
+imports in Task 5.
+
+**Open inputs (P4), not placeholders:** the Paterson `school_id` list (Task 4
+Step 3) and the enabled-endpoint set (Tasks 4, 9, 10) are external data the
+owner supplies; every task shows the exact shape and the one substitution point.

--- a/docs/superpowers/specs/2026-07-10-deanslist-paterson-and-per-school-keys-design.md
+++ b/docs/superpowers/specs/2026-07-10-deanslist-paterson-and-per-school-keys-design.md
@@ -4,6 +4,16 @@
 - **Status:** Design
 - **Date:** 2026-07-10
 
+> **Amendment (per-city secrets):** during implementation the monolithic
+> `op-deanslist-api` item was split **by city** — one 1Password item and K8s
+> secret per district (`op-deanslist-api-<district>`), each repeating the
+> `subdomain` field plus that city's school keys, synced by one
+> `OnePasswordItem` CR per city in `.k8s/1password/items.yaml`. Read every
+> "single shared secret" statement below as per-city; the resource mechanism is
+> unchanged (it still reads one mounted directory). kipptaf's vestigial
+> `DEANSLIST_SUBDOMAIN` mapping (an SFTP-only location that never used the API
+> resource) was removed as part of the split.
+
 ## Summary
 
 Two related changes to the DeansList integration:

--- a/docs/superpowers/specs/2026-07-10-deanslist-paterson-and-per-school-keys-design.md
+++ b/docs/superpowers/specs/2026-07-10-deanslist-paterson-and-per-school-keys-design.md
@@ -1,0 +1,331 @@
+# DeansList: add Paterson and restructure per-school API keys
+
+- **Issue:** [#4367](https://github.com/TEAMSchools/teamster/issues/4367)
+- **Status:** Design
+- **Date:** 2026-07-10
+
+## Summary
+
+Two related changes to the DeansList integration:
+
+1. **Restructure per-school API key storage** so that adding or rotating a
+   school key is a single field edit in the 1Password UI, instead of
+   hand-editing a fragile multi-line YAML blob. This touches the shared
+   `DeansListResource`, so it migrates all four API districts at once.
+2. **Extend the DeansList integration to Paterson** end-to-end: Dagster
+   ingestion, the district dbt project, and the kipptaf cross-district models.
+
+## Background: current architecture
+
+### Key delivery
+
+- One 1Password item, `DeansList API` (vault `Data Team`), is synced by the
+  1Password Kubernetes Operator into the `op-deanslist-api` secret in the
+  `dagster-cloud` namespace. Each field of the item becomes one key of the
+  secret. The `OnePasswordItem` custom resource lives in
+  [`.k8s/1password/items.yaml`](../../../.k8s/1password/items.yaml).
+- Today the item has two fields: `subdomain` and a single field holding an
+  entire YAML blob (`api_key_map: {school_id: key, ...}`) covering every school
+  across the network.
+- Each district's `dagster-cloud.yaml` projects the blob field into the code and
+  run pods as a file under `/etc/secret-volume/`, and sets `DEANSLIST_SUBDOMAIN`
+  from the `subdomain` key.
+- `DeansListResource`
+  ([`src/teamster/libraries/deanslist/resources.py`](../../../src/teamster/libraries/deanslist/resources.py))
+  is a single shared instance
+  ([`src/teamster/core/resources.py`](../../../src/teamster/core/resources.py)),
+  configured with `subdomain` and `api_key_map` (the file path). At startup it
+  parses the YAML into `self._api_key_map`, then looks up
+  `self._api_key_map[school_id]` per request. All API districts share this one
+  resource and one subdomain.
+
+### Pain points
+
+- The YAML blob is a single 1Password field: no per-school history, easy to
+  break indentation, awkward to diff or edit.
+- Adding a school is at least two edits (the key blob, plus the district's
+  partition list) followed by a redeploy. This spec targets the **key** half.
+
+### District ingestion
+
+- API districts (`kippnewark`, `kippcamden`, `kippmiami`) each have a
+  `<district>/deanslist/` module: `assets.py` (a `StaticPartitionsDefinition` of
+  the district's DeansList `school_id`s, plus factory calls from
+  [`libraries/deanslist/assets.py`](../../../src/teamster/libraries/deanslist/assets.py)),
+  `schema.py`, `schedules.py`, `__init__.py`, and `config/*.yaml`.
+- `kipppaterson` has **no** DeansList module today, and its CLAUDE.md lists
+  DeansList as absent. Paterson also has no ODBC PowerSchool and no BigQuery
+  writes from its location (its PowerSchool arrives via Couchdrop SFTP), but
+  that does not affect DeansList, which is a direct REST pull.
+
+### dbt
+
+- The `deanslist` source-system package produces `stg_deanslist__*` and
+  `int_deanslist__*` models. It builds inside each **consuming district**
+  project (`kippnewark`, `kippcamden`, `kippmiami`), reading that district's own
+  `src_deanslist__*` external tables. `kipppaterson` does not import the
+  package.
+- `kipptaf` does not import the package. It has its own `models/deanslist/api/`
+  union layer: one `sources-kipp<district>.yml` per district plus `stg_`/`int_`
+  models that
+  `dbt_utils.union_relations([source("kippnewark_deanslist", ...), ...])` across
+  the three API districts. Downstream kipptaf models (for example
+  `int_students__attendance_interventions`) consume those union models.
+
+## Goals
+
+- Editing or rotating a school key is a single 1Password field edit; no YAML, no
+  `dagster-cloud.yaml` change, no code change.
+- The four API districts share one consistent key mechanism after migration.
+- Paterson DeansList data is ingested and queryable network-wide (district
+  project plus kipptaf unions).
+
+## Non-goals
+
+- Deriving the Dagster school-partition list dynamically. The per-district
+  `StaticPartitionsDefinition` stays explicit (an intentional scope decision).
+  Adding a school still requires a small code edit plus redeploy; only the key
+  edit is being simplified.
+- Changing the secret store (staying on 1Password) or moving to a runtime
+  secrets API.
+- Per-district subdomains. Paterson joins the existing shared subdomain.
+
+## Design
+
+### Part 1 — Per-school key fields to a mounted directory
+
+The operator maps each 1Password field to one secret key. We exploit that: store
+one field per school, then mount the whole secret as a directory of files and
+let the resource assemble the map.
+
+#### 1Password item
+
+`DeansList API` keeps its `subdomain` field and gains one text field per school:
+field label = the DeansList `school_id` (for example `121`), value = that
+school's API key. `op-deanslist-api` then synchronizes to a secret with keys
+`subdomain`, `121`, `122`, and so on.
+
+#### Deploy config (`dagster-cloud.yaml`, all four districts)
+
+Mount the whole `op-deanslist-api` secret as a **directory** in its own
+`mountPath` (for example `/etc/secret-volume/deanslist`), with no `items:`
+filter, so every field lands as a file whose name is the school id and whose
+content is the key. The `subdomain` field lands as a file in the same directory,
+so the resource reads it from there too — the separate `DEANSLIST_SUBDOMAIN`
+environment-variable mapping is **removed** from all four `dagster-cloud.yaml`
+files. One directory is now the sole loading mechanism. Both `server_k8s_config`
+and `run_k8s_config` consumers apply.
+
+The field-to-directory chain is two hops, and only the first is
+1Password-specific:
+
+1. **Operator maps field to secret key** (already how `subdomain` works today):
+   the 1Password Operator writes each field of the `DeansList API` item as one
+   key of the `op-deanslist-api` Secret.
+2. **kubelet maps secret key to file** (standard Kubernetes): a Secret mounted
+   as a volume is written as one file per key, filename = key, contents = value.
+   Today's `items:` filter cherry-picks the single blob key as one file;
+   dropping it materializes every key as its own file.
+
+So the change adds fields and removes one filter — no new infrastructure.
+
+Example projected-volume source:
+
+```yaml
+volumes:
+  - name: deanslist-keys
+    projected:
+      sources:
+        - secret:
+            name: op-deanslist-api
+volumeMounts:
+  - name: deanslist-keys
+    readOnly: true
+    mountPath: /etc/secret-volume/deanslist
+```
+
+#### Resource change
+
+The resource loads everything from the one mounted directory. Both config fields
+(`subdomain` and `api_key_map`) collapse into a single `api_key_dir`: the
+subdomain comes from the `subdomain` file, and the key map from the
+numeric-named files.
+
+```python
+def setup_for_execution(self, context: InitResourceContext) -> None:
+    self._log = check.not_none(value=context.log)
+
+    key_dir = pathlib.Path(self.api_key_dir)
+
+    subdomain = (key_dir / "subdomain").read_text().strip()
+    self._base_url = f"https://{subdomain}.deanslistsoftware.com/api"
+
+    self._api_key_map = {
+        int(f.name): f.read_text().strip()
+        for f in key_dir.iterdir()
+        if f.is_file() and not f.name.startswith(".") and f.name.isdigit()
+    }
+```
+
+The `subdomain` file is read explicitly; the `f.name.isdigit()` filter keeps it
+(and the projected-volume symlink entries `..data` / timestamped dirs) out of
+the key map. `get()` and `list()` are unchanged; they already look up
+`self._api_key_map[school_id]` with an `int` key. The single instantiation in
+`core/resources.py` passes only `api_key_dir="/etc/secret-volume/deanslist"` —
+the `subdomain=EnvVar("DEANSLIST_SUBDOMAIN")` argument is dropped.
+
+#### Blast radius
+
+Because the resource is shared, this converts all four districts at once. A
+one-time manual step (owner: whoever administers the 1Password item): re-enter
+the existing keys as individual fields, then delete the YAML blob field — done
+in the additive-first order below so nothing breaks mid-migration.
+
+#### Risk: field label vs secret key name
+
+`.k8s/CLAUDE.md` warns that a secret key can come from a field's internal name,
+not its UI label (known remaps on login-template fields, for example `password`
+to `newPassword`). We rely on custom numeric fields syncing as `121`, `122`, and
+so on. The `subdomain` field is already proven safe — it syncs to secret key
+`subdomain` today (the existing `secretKeyRef`), so reading the `subdomain` file
+carries no new risk and gives a working reference point for the numeric fields.
+
+- **Verify early** (owner-side; `kubectl` is blocked from this tool): add one
+  test field, then
+  `kubectl -n dagster-cloud get secret op-deanslist-api -o jsonpath='{.data}' | jq keys`.
+- **Fallback if labels do not survive:** store `school_id|key` in the field
+  _value_ and parse each file's contents instead of trusting the filename. The
+  resource logic changes from "filename is the id" to "split the value on `|`".
+
+### Part 2 — Paterson Dagster ingestion
+
+Add `src/teamster/code_locations/kipppaterson/deanslist/`, mirroring
+`kippnewark`:
+
+- `assets.py` — a `StaticPartitionsDefinition` of Paterson's DeansList
+  `school_id`s (**supplied separately**, see Prerequisites), plus the same
+  factory calls (`build_deanslist_static_partition_asset`,
+  `build_deanslist_multi_partition_asset`,
+  `build_deanslist_paginated_multi_partition_asset`) driven by `config/*.yaml`.
+- `schema.py` — the Pydantic and Avro schemas Paterson needs (start from
+  Newark's; trim to the endpoints Paterson uses).
+- `schedules.py`, `__init__.py`, and `config/` (`static-partition-assets.yaml`,
+  `multi-partition-monthly-assets.yaml`, `multi-partition-fiscal-assets.yaml`) —
+  copied from Newark and adjusted to Paterson's endpoint set.
+
+Wire-up:
+
+- `kipppaterson/definitions.py`: import `DEANSLIST_RESOURCE`, add
+  `"deanslist": DEANSLIST_RESOURCE` to resources, and add the module's assets
+  and schedules.
+- `kipppaterson/dagster-cloud.yaml`: add the directory mount from Part 1 (no
+  `DEANSLIST_SUBDOMAIN` variable — the subdomain is read from the mounted
+  `subdomain` file, same shared subdomain).
+- `kipppaterson/CLAUDE.md`: remove DeansList from the "does not use" list and
+  add it to Active Integrations (schedule-driven).
+
+### Part 3 — Paterson district dbt project
+
+- `src/dbt/kipppaterson/packages.yml`: add `- local: ../deanslist`.
+- `src/dbt/kipppaterson/dbt_project.yml`: add a `deanslist:` models block
+  (`+materialized: table`, and disable any models Paterson does not use,
+  matching the Newark pattern that disables `stg_deanslist__followups`). Confirm
+  the external-source variables the package needs (`cloud_storage_uri_base` is
+  already set at the project level; the package sources resolve schema via
+  `{{ project_name }}`).
+- Stage the new external sources with `--target staging` before the dbt Cloud CI
+  job will pass (per the External Table Pattern in `src/dbt/CLAUDE.md`). This
+  requires Paterson DeansList Avro to have landed in GCS first.
+
+### Part 4 — kipptaf cross-district inclusion
+
+- Add `src/dbt/kipptaf/models/deanslist/api/sources-kipppaterson.yml`, mirroring
+  the existing three per-district source files.
+- Add `source("kipppaterson_deanslist", "<model>")` to the `relations=[...]`
+  list of every kipptaf `deanslist/api` union model (staging and intermediate).
+- No downstream kipptaf model logic changes — they read the union outputs, which
+  now include Paterson.
+
+## Rollout and sequencing
+
+There is one hard ordering constraint, and it is data-dependent: Paterson
+DeansList Avro must exist in GCS before the dbt external sources can be staged,
+and staging is what lets dbt Cloud CI pass. That single seam — everything that
+_produces_ the data, then everything that _reads_ it — splits the work into
+**two PRs**.
+
+Bracketing both PRs are two manual 1Password steps (owner: whoever administers
+the `DeansList API` item), done additive-first so nothing breaks mid-migration:
+
+- **Before PR 1 merges:** add every school as its own field — existing
+  districts' keys re-entered from the blob, plus Paterson's — while leaving the
+  YAML blob field in place.
+- **After PR 1 deploys and is verified:** delete the old YAML blob field.
+
+### PR 1 — Keys plus Paterson ingestion (Python and K8s only)
+
+- The `DeansListResource` directory change and its `core/resources.py`
+  instantiation.
+- The directory-mount change to all four `dagster-cloud.yaml` files.
+- The new `kipppaterson/deanslist` module and its `definitions.py`,
+  `dagster-cloud.yaml`, and CLAUDE.md wiring.
+
+No dbt changes, so dbt Cloud CI is a no-op on this PR. After the post-merge
+deploy: verify Newark/Camden/Miami still pull DeansList (a sample school
+partition materializes), materialize Paterson's assets so its Avro lands in prod
+GCS, then remove the blob field.
+
+### PR 2 — All dbt (Paterson district plus kipptaf unions)
+
+- Paterson district project: `packages.yml`, `dbt_project.yml`, and staging the
+  new external sources.
+- kipptaf: `sources-kipppaterson.yml` and Paterson added to each
+  `union_relations` list.
+
+Land these together via the single-PR cross-project workflow in
+`src/dbt/kipptaf/CLAUDE.md` (stage/clone the Paterson district models into
+`zz_stg_*` so kipptaf CI reads them). This depends on PR 1 being deployed and
+Paterson's DeansList assets materialized in prod, so the external sources stage
+against real data.
+
+**Optional third PR:** if you would rather verify the network-wide key migration
+in isolation before adding a new district, lift the `DeansListResource` plus
+four-`dagster-cloud.yaml` change out of PR 1 into its own PR ahead of Paterson.
+Two PRs is the floor; this makes it three.
+
+## Testing and validation
+
+- **Resource unit behavior:** a focused test that points the resource at a temp
+  directory of numeric-named files plus a `subdomain` file and a `..data`-style
+  entry, asserting the base URL uses the subdomain and the key map contains only
+  the numeric files with `int` keys.
+- **Existing districts unaffected:** after PR 1 deploys, materialize one static
+  and one multi-partition DeansList asset per existing district for a known
+  school and confirm row counts are non-zero and the Avro schema check passes.
+- **Paterson ingestion:** materialize Paterson DeansList assets; confirm Avro in
+  the Paterson GCS path and passing schema checks.
+- **dbt:** `uv run dbt build --select <paterson deanslist models>` against the
+  district project; then the kipptaf union models after Paterson prod exists.
+  kipptaf CI only builds kipptaf, so district-side correctness is verified with
+  a local district build.
+
+## Alternatives considered
+
+- **Per-school fields exposed as individual environment variables** rather than
+  a mounted directory. Rejected: adding a school would require editing
+  `dagster-cloud.yaml` (two blocks) every time — it re-creates the toil this
+  change removes.
+- **Runtime fetch from the in-cluster 1Password Connect API**, skipping the
+  synced secret entirely. Rejected: adds a network dependency and token handling
+  at run time — disproportionate to an "easier to edit" goal.
+- **Dynamically derived partitions** (single source of truth). Explicitly out of
+  scope per the scope decision; the partition list stays explicit.
+
+## Prerequisites and open items
+
+- **Paterson DeansList `school_id`s and API keys** must be provided (the ids for
+  the partition definition, the keys for the 1Password fields).
+- **Field-label sync verification** (Part 1 risk) should be confirmed before
+  committing to filename-as-id, with the value-encoded fallback ready.
+- **Endpoint set for Paterson:** confirm which DeansList endpoints Paterson uses
+  (to trim `schema.py` and `config/*.yaml` from the Newark copy).

--- a/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
@@ -28,7 +28,7 @@ locations:
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
+                    name: op-deanslist-api-kippcamden
         server_k8s_config:
           pod_spec_config:
             affinity:

--- a/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
@@ -12,20 +12,23 @@ locations:
           - name: secret-volume
             readOnly: true
             mountPath: /etc/secret-volume
+          - name: deanslist-keys
+            readOnly: true
+            mountPath: /etc/deanslist
         volumes:
           - name: secret-volume
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
-                    items:
-                      - key: deanslist_api_key_map.yaml
-                        path: deanslist_api_key_map_yaml
-                - secret:
                     name: op-ps-ssh-kippcamden
                     items:
                       - key: password
                         path: powerschool_ssh_password.txt
+          - name: deanslist-keys
+            projected:
+              sources:
+                - secret:
+                    name: op-deanslist-api
         server_k8s_config:
           pod_spec_config:
             affinity:
@@ -130,11 +133,6 @@ locations:
                   secretKeyRef:
                     name: op-titan-sftp-kippcamden
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: OVERGRAD_API_KEY
                 valueFrom:
                   secretKeyRef:
@@ -238,11 +236,6 @@ locations:
                   secretKeyRef:
                     name: op-titan-sftp-kippcamden
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: OVERGRAD_API_KEY
                 valueFrom:
                   secretKeyRef:

--- a/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
@@ -12,20 +12,23 @@ locations:
           - name: secret-volume
             readOnly: true
             mountPath: /etc/secret-volume
+          - name: deanslist-keys
+            readOnly: true
+            mountPath: /etc/deanslist
         volumes:
           - name: secret-volume
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
-                    items:
-                      - key: deanslist_api_key_map.yaml
-                        path: deanslist_api_key_map_yaml
-                - secret:
                     name: op-ps-ssh-kippmiami
                     items:
                       - key: password
                         path: powerschool_ssh_password.txt
+          - name: deanslist-keys
+            projected:
+              sources:
+                - secret:
+                    name: op-deanslist-api
         server_k8s_config:
           pod_spec_config:
             affinity:
@@ -135,11 +138,6 @@ locations:
                   secretKeyRef:
                     name: op-ps-ssh-kippmiami
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: FOCUS_DB__CREDENTIALS__DRIVERNAME
                 valueFrom:
                   secretKeyRef:
@@ -315,11 +313,6 @@ locations:
                   secretKeyRef:
                     name: op-ps-ssh-kippmiami
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: FOCUS_DB__CREDENTIALS__DRIVERNAME
                 valueFrom:
                   secretKeyRef:

--- a/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
@@ -28,7 +28,7 @@ locations:
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
+                    name: op-deanslist-api-kippmiami
         server_k8s_config:
           pod_spec_config:
             affinity:

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -12,20 +12,23 @@ locations:
           - name: secret-volume
             readOnly: true
             mountPath: /etc/secret-volume
+          - name: deanslist-keys
+            readOnly: true
+            mountPath: /etc/deanslist
         volumes:
           - name: secret-volume
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
-                    items:
-                      - key: deanslist_api_key_map.yaml
-                        path: deanslist_api_key_map_yaml
-                - secret:
                     name: op-ps-ssh-kippnewark
                     items:
                       - key: password
                         path: powerschool_ssh_password.txt
+          - name: deanslist-keys
+            projected:
+              sources:
+                - secret:
+                    name: op-deanslist-api
         server_k8s_config:
           pod_spec_config:
             affinity:
@@ -160,11 +163,6 @@ locations:
                   secretKeyRef:
                     name: op-titan-sftp-kippnewark
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: OVERGRAD_API_KEY
                 valueFrom:
                   secretKeyRef:
@@ -333,11 +331,6 @@ locations:
                   secretKeyRef:
                     name: op-titan-sftp-kippnewark
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: OVERGRAD_API_KEY
                 valueFrom:
                   secretKeyRef:

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -28,7 +28,7 @@ locations:
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
+                    name: op-deanslist-api-kippnewark
         server_k8s_config:
           pod_spec_config:
             affinity:

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -16,6 +16,7 @@ GCS bucket: `teamster-kipppaterson`
 | `dbt`                    | dbt assets                | `AutomationConditionSensor`                 |
 | `powerschool` (sis/sftp) | SFTP assets via Couchdrop | sensor (`couchdrop_sftp_sensor`)            |
 | `amplify` (mclass sftp)  | SFTP assets               | sensor (`build_amplify_mclass_sftp_sensor`) |
+| `deanslist`              | API assets                | schedule (nightly)                          |
 | `finalsite`              | API assets                | `AutomationConditionSensor`                 |
 | `pearson`                | SFTP assets               | `AutomationConditionSensor`                 |
 | `couchdrop`              | sensor only               | sensor (Google Drive watcher)               |
@@ -33,12 +34,12 @@ Consequences:
 - No `db_bigquery` resource (no BigQuery writes from this location)
 - No `io_manager_gcs_file` resource (no file-based IO manager needed)
 - No extracts module (no BigQuery to query)
-- No `deanslist`, `edplan`, `iready`, `overgrad`, `renlearn`, or `titan`
+- No `edplan`, `iready`, `overgrad`, `renlearn`, or `titan`
 
-## No Asset Checks, No Schedules
+## Schedules
 
-Paterson has no freshness checks and no data-pull schedules. All ingestion is
-sensor-driven (`couchdrop_sftp_sensor` for PowerSchool,
+Paterson has no freshness checks. DeansList adds nightly data-pull schedules;
+all other ingestion is sensor-driven (`couchdrop_sftp_sensor` for PowerSchool,
 `build_amplify_mclass_sftp_sensor` for Amplify). `AutomationConditionSensor`
 handles any assets with an automation condition defined (e.g. `finalsite`,
 `pearson`).

--- a/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
@@ -17,7 +17,7 @@ locations:
             projected:
               sources:
                 - secret:
-                    name: op-deanslist-api
+                    name: op-deanslist-api-kipppaterson
         server_k8s_config:
           pod_spec_config:
             affinity:

--- a/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
@@ -8,6 +8,16 @@ locations:
     working_directory: /app
     container_context:
       k8s:
+        volume_mounts:
+          - name: deanslist-keys
+            readOnly: true
+            mountPath: /etc/deanslist
+        volumes:
+          - name: deanslist-keys
+            projected:
+              sources:
+                - secret:
+                    name: op-deanslist-api
         server_k8s_config:
           pod_spec_config:
             affinity:

--- a/src/teamster/code_locations/kipppaterson/deanslist/__init__.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/__init__.py
@@ -1,0 +1,7 @@
+from teamster.code_locations.kipppaterson.deanslist.assets import assets
+from teamster.code_locations.kipppaterson.deanslist.schedules import schedules
+
+__all__ = [
+    "assets",
+    "schedules",
+]

--- a/src/teamster/code_locations/kipppaterson/deanslist/assets.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/assets.py
@@ -1,0 +1,83 @@
+import pathlib
+
+from dagster import (
+    MonthlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    config_from_files,
+)
+
+from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kipppaterson.deanslist.schema import ASSET_SCHEMA
+from teamster.core.utils.classes import FiscalYearPartitionsDefinition
+from teamster.libraries.deanslist.assets import (
+    build_deanslist_multi_partition_asset,
+    build_deanslist_static_partition_asset,
+)
+
+DEANSLIST_STATIC_PARTITIONS_DEF = StaticPartitionsDefinition(["966", "1070"])
+
+DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF = MultiPartitionsDefinition(
+    partitions_defs={
+        "school": DEANSLIST_STATIC_PARTITIONS_DEF,
+        "date": FiscalYearPartitionsDefinition(
+            start_date="2016-07-01",
+            start_month=7,
+            timezone=str(LOCAL_TIMEZONE),
+            end_offset=1,
+        ),
+    }
+)
+
+config_dir = pathlib.Path(__file__).parent / "config"
+
+static_partitioned_assets = [
+    build_deanslist_static_partition_asset(
+        code_location=CODE_LOCATION,
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=DEANSLIST_STATIC_PARTITIONS_DEF,
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/static-partition-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+month_partitioned_assets = [
+    build_deanslist_multi_partition_asset(
+        code_location=CODE_LOCATION,
+        api_version="v1",
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=MultiPartitionsDefinition(
+            partitions_defs={
+                "school": DEANSLIST_STATIC_PARTITIONS_DEF,
+                "date": MonthlyPartitionsDefinition(
+                    start_date="2016-07-01", timezone=str(LOCAL_TIMEZONE), end_offset=1
+                ),
+            }
+        ),
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/multi-partition-monthly-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+year_partitioned_assets = [
+    build_deanslist_multi_partition_asset(
+        code_location=CODE_LOCATION,
+        api_version="v1",
+        schema=ASSET_SCHEMA[e["endpoint"]],
+        partitions_def=DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF,
+        **e,
+    )
+    for e in config_from_files([f"{config_dir}/multi-partition-fiscal-assets.yaml"])[
+        "endpoints"
+    ]
+]
+
+assets = [
+    *static_partitioned_assets,
+    *month_partitioned_assets,
+    *year_partitioned_assets,
+]

--- a/src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-fiscal-assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-fiscal-assets.yaml
@@ -1,0 +1,5 @@
+endpoints:
+  - endpoint: comm-log
+    params:
+      IncludeSentReports: "yes"
+      IncludeTwoWayTexts: "yes"

--- a/src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-monthly-assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/deanslist/config/multi-partition-monthly-assets.yaml
@@ -1,0 +1,6 @@
+endpoints:
+  - endpoint: incidents
+    params:
+      IncludeDeleted: Y
+      cf: Y
+      attachments: Y

--- a/src/teamster/code_locations/kipppaterson/deanslist/config/static-partition-assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/deanslist/config/static-partition-assets.yaml
@@ -1,0 +1,19 @@
+endpoints:
+  - endpoint: users
+    api_version: v1
+    params:
+      IncludeInactive: Y
+  - endpoint: terms
+    api_version: v1
+  - endpoint: rosters
+    api_version: v1
+    params:
+      show_inactive: Y
+  - endpoint: roster-assignments
+    api_version: beta
+  - endpoint: students
+    api_version: v1
+    params:
+      IncludeCustomFields: Y
+      IncludeUnenrolled: Y
+      IncludeParents: Y

--- a/src/teamster/code_locations/kipppaterson/deanslist/schedules.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/schedules.py
@@ -1,0 +1,41 @@
+from teamster.code_locations.kipppaterson import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
+from teamster.code_locations.kipppaterson.deanslist.assets import (
+    month_partitioned_assets,
+    static_partitioned_assets,
+    year_partitioned_assets,
+)
+from teamster.libraries.deanslist.schedules import build_deanslist_job_schedule
+
+deanslist_static_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__static_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=static_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+deanslist_month_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__month_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=month_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+deanslist_year_partitioned_assets_job_schedule = build_deanslist_job_schedule(
+    schedule_name=f"{CODE_LOCATION}__deanslist__year_partitioned_asset_job_schedule",
+    cron_schedule="0 0 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=year_partitioned_assets,
+    current_fiscal_year=CURRENT_FISCAL_YEAR,
+)
+
+schedules = [
+    deanslist_month_partitioned_assets_job_schedule,
+    deanslist_static_partitioned_assets_job_schedule,
+    deanslist_year_partitioned_assets_job_schedule,
+]

--- a/src/teamster/code_locations/kipppaterson/deanslist/schema.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/schema.py
@@ -1,0 +1,69 @@
+import json
+
+import py_avro_schema
+
+from teamster.libraries.deanslist.schema import (
+    Behavior,
+    CommLog,
+    DFFStats,
+    Followup,
+    Homework,
+    Incident,
+    ListModel,
+    ReconcileAttendance,
+    ReconcileSuspensions,
+    Roster,
+    RosterAssignment,
+    Student,
+    Term,
+    User,
+)
+
+
+class behavior_record(Behavior):
+    """helper class for backwards compatibility"""
+
+
+class followups_record(Followup):
+    """helper class for backwards compatibility"""
+
+
+class homework_record(Homework):
+    """helper class for backwards compatibility"""
+
+
+pas_options = py_avro_schema.Option.NO_DOC | py_avro_schema.Option.NO_AUTO_NAMESPACE
+
+BEHAVIOR_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=behavior_record, options=pas_options)
+)
+
+INCIDENTS_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=Incident, options=pas_options)
+)
+
+ASSET_SCHEMA = {
+    "comm-log": json.loads(py_avro_schema.generate(py_type=CommLog)),
+    "lists": json.loads(py_avro_schema.generate(py_type=ListModel)),
+    "roster-assignments": json.loads(py_avro_schema.generate(py_type=RosterAssignment)),
+    "rosters": json.loads(py_avro_schema.generate(py_type=Roster)),
+    "students": json.loads(py_avro_schema.generate(py_type=Student)),
+    "terms": json.loads(py_avro_schema.generate(py_type=Term)),
+    "users": json.loads(py_avro_schema.generate(py_type=User)),
+    "reconcile_attendance": json.loads(
+        py_avro_schema.generate(py_type=ReconcileAttendance)
+    ),
+    "reconcile_suspensions": json.loads(
+        py_avro_schema.generate(py_type=ReconcileSuspensions)
+    ),
+    "followups": json.loads(
+        py_avro_schema.generate(py_type=followups_record, options=pas_options)
+    ),
+    "homework": json.loads(
+        py_avro_schema.generate(py_type=homework_record, options=pas_options)
+    ),
+    "incidents": INCIDENTS_SCHEMA,
+    "dff/stats": json.loads(
+        py_avro_schema.generate(py_type=DFFStats, options=pas_options)
+    ),
+}

--- a/src/teamster/code_locations/kipppaterson/definitions.py
+++ b/src/teamster/code_locations/kipppaterson/definitions.py
@@ -12,11 +12,13 @@ from teamster.code_locations.kipppaterson import (
     amplify,
     couchdrop,
     dbt,
+    deanslist,
     finalsite,
     pearson,
     powerschool,
 )
 from teamster.core.resources import (
+    DEANSLIST_RESOURCE,
     GCS_RESOURCE,
     GOOGLE_DRIVE_RESOURCE,
     SSH_COUCHDROP,
@@ -32,11 +34,15 @@ defs = Definitions(
         modules=[
             dbt,
             amplify,
+            deanslist,
             finalsite,
             pearson,
             powerschool,
         ]
     ),
+    schedules=[
+        *deanslist.schedules,
+    ],
     sensors=[
         *amplify.sensors,
         *couchdrop.sensors,
@@ -47,6 +53,7 @@ defs = Definitions(
     ],
     resources={
         "dbt_cli": get_dbt_cli_resource(DBT_PROJECT),
+        "deanslist": DEANSLIST_RESOURCE,
         "gcs": GCS_RESOURCE,
         "google_drive": GOOGLE_DRIVE_RESOURCE,
         "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),

--- a/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
@@ -295,11 +295,6 @@ locations:
                   secretKeyRef:
                     name: op-coupa-sftp
                     key: host
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: DEANSLIST_SFTP_HOST
                 valueFrom:
                   secretKeyRef:
@@ -683,11 +678,6 @@ locations:
                   secretKeyRef:
                     name: op-coupa-api
                     key: hostname
-              - name: DEANSLIST_SUBDOMAIN
-                valueFrom:
-                  secretKeyRef:
-                    name: op-deanslist-api
-                    key: subdomain
               - name: DEANSLIST_SFTP_HOST
                 valueFrom:
                   secretKeyRef:

--- a/src/teamster/core/resources.py
+++ b/src/teamster/core/resources.py
@@ -84,8 +84,7 @@ DB_POWERSCHOOL = PowerSchoolODBCResource(
 )
 
 DEANSLIST_RESOURCE = DeansListResource(
-    subdomain=EnvVar("DEANSLIST_SUBDOMAIN"),
-    api_key_map="/etc/secret-volume/deanslist_api_key_map_yaml",
+    api_key_dir="/etc/deanslist",
     request_timeout=90.0,
 )
 

--- a/src/teamster/libraries/deanslist/CLAUDE.md
+++ b/src/teamster/libraries/deanslist/CLAUDE.md
@@ -20,5 +20,8 @@ Date windows are computed from `FiscalYear` (July start). For
 
 ## Resource: `DeansListResource`
 
-Configured with `subdomain` + `api_key_map` (a YAML file mapping school IDs to
-API keys). Provides `get()` and `list()` methods.
+Configured with a single `api_key_dir` — a directory (the per-city
+`op-deanslist-api-<district>` K8s secret mounted at `/etc/deanslist`) holding
+one file per school (filename = `school_id`, contents = API key) plus a
+`subdomain` file. `load_deanslist_config()` reads the subdomain and builds the
+`{school_id: key}` map from numeric-named files. Provides `get()` and `list()`.

--- a/src/teamster/libraries/deanslist/resources.py
+++ b/src/teamster/libraries/deanslist/resources.py
@@ -2,7 +2,6 @@ import pathlib
 
 import fastavro
 import fastavro.types
-import yaml
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster_shared import check
 from pydantic import PrivateAttr
@@ -10,9 +9,22 @@ from requests import Session
 from requests.exceptions import HTTPError
 
 
+def load_deanslist_config(
+    key_dir: pathlib.Path,
+) -> tuple[str, dict[int, str]]:
+    subdomain = (key_dir / "subdomain").read_text().strip()
+
+    api_key_map = {
+        int(f.name): f.read_text().strip()
+        for f in key_dir.iterdir()
+        if f.is_file() and not f.name.startswith(".") and f.name.isdigit()
+    }
+
+    return subdomain, api_key_map
+
+
 class DeansListResource(ConfigurableResource):
-    subdomain: str
-    api_key_map: str
+    api_key_dir: str
     request_timeout: float = 60.0
 
     _session: Session = PrivateAttr(default_factory=Session)
@@ -22,10 +34,12 @@ class DeansListResource(ConfigurableResource):
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         self._log = check.not_none(value=context.log)
-        self._base_url = f"https://{self.subdomain}.deanslistsoftware.com/api"
 
-        with open(self.api_key_map) as f:
-            self._api_key_map = yaml.safe_load(f)["api_key_map"]
+        subdomain, self._api_key_map = load_deanslist_config(
+            pathlib.Path(self.api_key_dir)
+        )
+
+        self._base_url = f"https://{subdomain}.deanslistsoftware.com/api"
 
     def _get_url(self, api_version: str, endpoint: str, *args):
         if api_version == "beta":

--- a/src/teamster/libraries/deanslist/resources.py
+++ b/src/teamster/libraries/deanslist/resources.py
@@ -29,7 +29,7 @@ class DeansListResource(ConfigurableResource):
 
     _session: Session = PrivateAttr(default_factory=Session)
     _base_url: str = PrivateAttr()
-    _api_key_map: dict = PrivateAttr()
+    _api_key_map: dict[int, str] = PrivateAttr()
     _log: DagsterLogManager = PrivateAttr()
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
@@ -56,7 +56,16 @@ class DeansListResource(ConfigurableResource):
     def _request(self, method: str, url: str, school_id: int, params: dict, **kwargs):
         self._log.info(f"GET:\t{url}\nSCHOOL_ID:\t{school_id}\nPARAMS:\t{params}")
 
-        params["apikey"] = self._api_key_map[school_id]
+        api_key = self._api_key_map.get(school_id)
+
+        if api_key is None:
+            raise KeyError(
+                f"No DeansList API key for school_id {school_id} in "
+                f"{self.api_key_dir}: add a field labeled '{school_id}' to the "
+                "district's DeansList 1Password item, then re-sync the secret."
+            )
+
+        params["apikey"] = api_key
 
         response = self._session.request(
             method=method,

--- a/tests/resources/test_resource_deanslist.py
+++ b/tests/resources/test_resource_deanslist.py
@@ -1,6 +1,12 @@
+import logging
 import pathlib
 
-from teamster.libraries.deanslist.resources import load_deanslist_config
+import pytest
+
+from teamster.libraries.deanslist.resources import (
+    DeansListResource,
+    load_deanslist_config,
+)
 
 
 def test_load_deanslist_config(tmp_path: pathlib.Path):
@@ -15,3 +21,14 @@ def test_load_deanslist_config(tmp_path: pathlib.Path):
 
     assert subdomain == "kippnj"
     assert api_key_map == {121: "key-121", 122: "key-122"}
+
+
+def test_request_missing_school_key_raises_named_error():
+    resource = DeansListResource(api_key_dir="/etc/deanslist")
+    object.__setattr__(resource, "_api_key_map", {121: "key-121"})
+    object.__setattr__(resource, "_log", logging.getLogger("test"))
+
+    # school_id 999 has no key file synced — the guard must raise before any
+    # network call, naming the school id and the mount
+    with pytest.raises(KeyError, match="No DeansList API key for school_id 999"):
+        resource._request(method="GET", url="https://x/api", school_id=999, params={})

--- a/tests/resources/test_resource_deanslist.py
+++ b/tests/resources/test_resource_deanslist.py
@@ -1,20 +1,17 @@
-from dagster import build_resources
+import pathlib
 
-from teamster.core.resources import DEANSLIST_RESOURCE
-from teamster.libraries.deanslist.resources import DeansListResource
+from teamster.libraries.deanslist.resources import load_deanslist_config
 
 
-def test_behavior_paginated():
-    with build_resources(resources={"deanslist": DEANSLIST_RESOURCE}) as resources:
-        deanslist: DeansListResource = resources.deanslist
+def test_load_deanslist_config(tmp_path: pathlib.Path):
+    (tmp_path / "subdomain").write_text("kippnj\n")
+    (tmp_path / "121").write_text("key-121\n")
+    (tmp_path / "122").write_text("key-122")
+    # projected-secret volumes stage data behind dot-prefixed entries
+    (tmp_path / "..data").mkdir()
+    (tmp_path / ".hidden").write_text("ignore-me")
 
-    deanslist.list(
-        api_version="v1",
-        endpoint="behavior",
-        school_id=124,
-        params={
-            "UpdatedSince": "2024-07-01",
-            "StartDate": "2024-07-01",
-            "EndDate": "2025-06-30",
-        },
-    )
+    subdomain, api_key_map = load_deanslist_config(tmp_path)
+
+    assert subdomain == "kippnj"
+    assert api_key_map == {121: "key-121", 122: "key-122"}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restructure how DeansList per-school API
keys are delivered to Dagster, and add the DeansList integration to the Paterson
code location.

**1. Per-school keys via a mounted directory.** `DeansListResource` no longer
parses a single hand-edited YAML blob. It reads one mounted secret **directory**
(`/etc/deanslist`): the subdomain from a `subdomain` file and the
`{school_id: key}` map from numeric-named files. Adding or rotating a key becomes
a single 1Password field edit — no YAML, no `dagster-cloud.yaml` change, no code
change. The 1Password item is split **per city**, so each district mounts its own
`op-deanslist-api-{district}` secret (least-privilege: each pod sees only its own
region's keys).

**2. Paterson DeansList ingestion.** New `kipppaterson/deanslist/` module (school
ids `966`, `1070`; the standard endpoint set) wired into the location's
`definitions.py` and deploy config.

This PR is the Python + Kubernetes half. The dbt side (Paterson district models
plus kipptaf cross-district unions) follows in a second PR once Paterson Avro has
landed in GCS.

Refs #4367

### AI Assistance

AI-assisted (Claude Code), human-directed. The design, the per-city 1Password
split, and the school ids were human decisions; the implementation, tests, and
review were AI-driven per the spec and plan under
`docs/superpowers/`.

## Deployment ordering (important — do before/with merge)

The deploy rebuilds pods that mount `op-deanslist-api-{district}`. Those secrets
must exist first, or pods fail to start on a missing `secretKeyRef`.

1. Create the four per-city 1Password items (`DeansList API - Newark/Camden/Miami/Paterson`),
   each with a `subdomain` field plus one field per school id (Paterson: `966`,
   `1070`).
2. `kubectl apply` the updated `.k8s/1password/items.yaml` so the operator syncs
   the four per-city K8s secrets. Verify keys populate, e.g.
   `kubectl -n dagster-cloud get secret op-deanslist-api-kipppaterson -o jsonpath='{.data}' | jq keys`
   → expect `subdomain`, `966`, `1070`. If a numeric field's label does not sync
   as its key, use the `school_id|key`-in-value fallback noted in the spec.
3. Merge → deploy. Each affected location redeploys (its own files changed) and
   picks up the shared resource change.
4. Delete the old monolithic `op-deanslist-api` item/secret after verifying pulls
   succeed.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [ ] Review the Claude Code Review comment posted on this PR

### Dagster

- [x] New integration follows the Library + Config pattern with the correct
      asset key format and IO manager (`kipppaterson/deanslist/` mirrors
      `kippnewark`; `io_manager_gcs_avro`)
- [ ] `uv run dagster definitions validate` / `uv run pytest tests/test_dagster_definitions.py`
      — run in a full environment (district `definitions` do not import in the
      codespace without the dbt manifest). `tests/resources/test_resource_deanslist.py`
      passes locally.

### Docs

- [x] Updated `kipppaterson/CLAUDE.md` for the new integration
- [ ] Regenerate the automations catalog (`uv run scripts/gen-automations-doc.py`)
      in a full environment — three new Paterson DeansList schedules

## CI checks

- [ ] Trunk — passes
- [ ] Dagster Cloud — passes or not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
