### PR TITLE
fix(deanslist): start Paterson date partitions at SY25-26

### DIFF
--- a/src/teamster/code_locations/kipppaterson/deanslist/assets.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/assets.py
@@ -21,7 +21,7 @@ DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF = MultiPartitionsDefinition(
     partitions_defs={
         "school": DEANSLIST_STATIC_PARTITIONS_DEF,
         "date": FiscalYearPartitionsDefinition(
-            start_date="2016-07-01",
+            start_date="2025-07-01",
             start_month=7,
             timezone=str(LOCAL_TIMEZONE),
             end_offset=1,
@@ -52,7 +52,7 @@ month_partitioned_assets = [
             partitions_defs={
                 "school": DEANSLIST_STATIC_PARTITIONS_DEF,
                 "date": MonthlyPartitionsDefinition(
-                    start_date="2016-07-01", timezone=str(LOCAL_TIMEZONE), end_offset=1
+                    start_date="2025-07-01", timezone=str(LOCAL_TIMEZONE), end_offset=1
                 ),
             }
         ),


### PR DESCRIPTION
## Summary & Motivation

When merged, Paterson's DeansList date partitions will begin with **SY 2025-26** (`2025-07-01`) instead of `2016-07-01`.

Paterson's fiscal (`comm_log`) and monthly (`incidents`) partition definitions were copied verbatim from `kippnewark`, which starts at `2016-07-01`. Paterson only began using DeansList in SY 2025-26, so there is no data before then and no reason to define ~9 years of empty partitions. Both `start_date`s in `kipppaterson/deanslist/assets.py` now use `2025-07-01`.

No backfill/cleanup needed: the date-partitioned assets (`incidents`, `comm_log`) have not been materialized yet, so no pre-2025 partitions exist to retire. The already-materialized static endpoints (`users`/`terms`/`rosters`/`roster_assignments`/`students`) are school-partitioned only and unaffected.

Follow-up to #4372.

### AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### Dagster

- [x] Two-line partition-start correction in `kipppaterson/deanslist/assets.py`; the `deanslist` submodule imports cleanly.

## CI checks

- [ ] Trunk — passes
- [ ] Dagster Cloud — passes or not triggered
