### PR TITLE
feat(dbt): source dim/bridge student contacts from int_students__contacts

### DIFF
--- a/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
@@ -1,26 +1,56 @@
 with
-    students_union as (
-        select _dbt_source_relation, dcid, student_number,
-        from {{ ref("stg_powerschool__students") }}
+    contacts as (
+        select
+            student_number,
+            contact_slot,
+            relationship,
+            is_emergency,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            _dbt_source_project,
+
+            coalesce(finalsite_contact_id, personid) as person_identity,
+        from {{ ref("int_students__contacts") }}
+    ),
+
+    keyed as (
+        select
+            student_number,
+            contact_slot,
+            relationship,
+            is_emergency,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+
+            {{ dbt_utils.generate_surrogate_key(["student_number"]) }} as student_key,
+
+            -- keyed identically to dim_student_contact_persons: contact_1 by the
+            -- person's real identity, emergency by student + contact slot
+            if(
+                contact_slot = 'contact_1',
+                {{
+                    dbt_utils.generate_surrogate_key(
+                        ["_dbt_source_project", "person_identity"]
+                    )
+                }},
+                {{
+                    dbt_utils.generate_surrogate_key(
+                        ["_dbt_source_project", "student_number", "contact_slot"]
+                    )
+                }}
+            ) as student_contact_person_key,
+        from contacts
     )
 
 select
-    {{ dbt_utils.generate_surrogate_key(["s.student_number"]) }} as student_key,
-
-    {{ dbt_utils.generate_surrogate_key(["c._dbt_source_project", "c.personid"]) }}
-    as student_contact_person_key,
-
-    c.relationship_type,
-    c.contactpriorityorder as priority,
-
-    c.isemergency = 1 as is_emergency,
-    c.schoolpickupflg = 1 as is_pickup,
-    c.iscustodial = 1 as is_custodial,
-    c.liveswithflg = 1 as is_household_member,
-
-from {{ ref("int_powerschool__contacts") }} as c
-inner join
-    students_union as s
-    on c.studentdcid = s.dcid
-    and {{ union_dataset_join_clause(left_alias="c", right_alias="s") }}
-where c.person_type != 'self'
+    student_key,
+    student_contact_person_key,
+    relationship,
+    contact_slot,
+    is_emergency,
+    is_pickup,
+    is_custodial,
+    is_household_member,
+from keyed

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -1,23 +1,33 @@
 models:
   - name: bridge_student_contacts
     description: >-
-      Bridge table resolving the many-to-many between students and contact
-      persons. One row per student x contact person pair. Relationship
-      attributes that vary per pair (relationship type, priority, emergency
-      flag, etc.) live here rather than on dim_student_contact_persons. Foreign
-      keys to dim_students via student_key and to dim_student_contact_persons
-      via student_contact_person_key.
+      Bridge resolving the many-to-many between students and their contact
+      persons under the Finalsite 1+4 contact shape. One row per (student,
+      contact person, contact slot). The relationship and the emergency flags
+      that vary per student-contact pair live here; stable person attributes
+      (name, email, phones, address) live on dim_student_contact_persons.
+      Foreign keys to dim_students via student_key and to
+      dim_student_contact_persons via student_contact_person_key.
 
     constraints:
       - type: primary_key
-        columns: [student_key, student_contact_person_key]
+        columns: [student_key, student_contact_person_key, contact_slot]
         warn_unsupported: false
+
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_key
+              - student_contact_person_key
+              - contact_slot
+
     columns:
       - name: student_key
         data_type: string
         description: >-
           Surrogate key for the student. Foreign key to dim_students. Derived
-          from student_number via generate_surrogate_key.
+          from the student number.
         constraints:
           - type: foreign_key
             to: ref('dim_students')
@@ -30,12 +40,12 @@ models:
               arguments:
                 to: ref('dim_students')
                 field: student_key
+
       - name: student_contact_person_key
         data_type: string
         description: >-
           Surrogate key for the contact person. Foreign key to
-          dim_student_contact_persons. Derived from _dbt_source_project and
-          powerschool_person_id.
+          dim_student_contact_persons.
         constraints:
           - type: foreign_key
             to: ref('dim_student_contact_persons')
@@ -48,48 +58,35 @@ models:
               arguments:
                 to: ref('dim_student_contact_persons')
                 field: student_contact_person_key
-      - name: relationship_type
+
+      - name: relationship
+        data_type: string
+        description: The contact's relationship to the student.
+
+      - name: contact_slot
         data_type: string
         description: >-
-          Relationship between the contact person and the student (e.g., Mother,
-          Father, Grandparent) as coded in PowerSchool.
+          Which contact this pairing represents — contact_1 or emergency_1
+          through emergency_4.
 
-      - name: priority
-        data_type: int64
-        description: >-
-          Indicates the preferred order in which the student's contacts will be
-          selected.Valid values: 1-n. Defaults to 1. Indexed with Student DCID.
-          Required.
-
-        config:
-          meta:
-            source_system: PowerSchool
-            source_model: stg_powerschool__studentcontactassoc
-            source_column: contactpriorityorder
       - name: is_emergency
         data_type: boolean
-        description: >-
-          TRUE if this contact is designated as an emergency contact for this
-          student.
+        description: True for every emergency slot; false for contact_1.
 
       - name: is_pickup
         data_type: boolean
         description: >-
-          TRUE if this contact is authorized for school pickup for this student.
+          Whether the contact is authorized to pick the student up. Null for
+          Finalsite contact_1 rows.
 
       - name: is_custodial
         data_type: boolean
         description: >-
-          TRUE if this contact has custodial rights for this student.
+          Whether the contact has custody of the student. Null for Finalsite
+          contact_1 rows.
 
       - name: is_household_member
         data_type: boolean
         description: >-
-          TRUE if the student lives with this contact person (household member).
-
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - student_key
-              - student_contact_person_key
+          Whether the student lives with the contact. Null for Finalsite
+          contact_1 rows.

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
@@ -1,127 +1,90 @@
 with
-    person_contacts_union as (
-        {{
-            dbt_utils.union_relations(
-                relations=[
-                    source(
-                        "kippnewark_powerschool", "int_powerschool__person_contacts"
-                    ),
-                    source(
-                        "kippcamden_powerschool", "int_powerschool__person_contacts"
-                    ),
-                    source(
-                        "kippmiami_powerschool", "int_powerschool__person_contacts"
-                    ),
-                    source(
-                        "kipppaterson_powerschool", "int_powerschool__person_contacts"
-                    ),
-                ]
-            )
-        }}
-    ),
-
-    contacts_deduped as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_powerschool__contacts"),
-                partition_by="_dbt_source_project, personid",
-                order_by="contactpriorityorder asc",
-            )
-        }}
-    ),
-
-    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
-    phone_ranked as (
+    contacts as (
         select
-            _dbt_source_relation,
-            personid,
-            priority_order,
-            contact as phone,
+            student_number,
+            contact_slot,
+            contact_name,
+            email_current,
+            phone_mobile,
+            phone_home,
+            phone_daytime,
+            phone_work,
+            phone_primary,
+            address_home,
+            _dbt_source_project,
 
-            case
-                contact_type
-                when 'Mobile'
-                then 1
-                when 'Home'
-                then 2
-                when 'Daytime'
-                then 3
-                when 'Work'
-                then 4
-                else 5
-            end as type_rank,
-        from person_contacts_union
-        where
-            contact_category = 'Phone'
-            and contact_type in ('Mobile', 'Home', 'Daytime', 'Work', 'Not Set')
-            and is_primary = 1
+            coalesce(finalsite_contact_id, personid) as person_identity,
+        from {{ ref("int_students__contacts") }}
     ),
 
-    phone as (
-        {{
-            dbt_utils.deduplicate(
-                relation="phone_ranked",
-                partition_by="_dbt_source_relation, personid",
-                order_by="type_rank asc, priority_order asc",
-            )
-        }}
+    /* contact_1 is a real contact record that siblings share, so it keys on the
+       person's identity and collapses to one row per person. Every selected
+       attribute is functionally determined by (_dbt_source_project,
+       person_identity) — grain projection, not a mask for upstream duplicates. */
+    contact_1_persons as (
+        select distinct
+            contact_name,
+            email_current,
+            phone_mobile,
+            phone_home,
+            phone_daytime,
+            phone_work,
+            phone_primary,
+            address_home,
+            _dbt_source_project,
+            person_identity,
+        from contacts
+        where contact_slot = 'contact_1'
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
-    email_all as (
-        select _dbt_source_relation, personid, contact as email, priority_order,
-        from person_contacts_union
-        where contact_category = 'Email' and contact_type = 'Current'
-    ),
-
-    email as (
-        {{
-            dbt_utils.deduplicate(
-                relation="email_all",
-                partition_by="_dbt_source_relation, personid",
-                order_by="priority_order asc",
-            )
-        }}
-    ),
-
-    -- trunk-ignore(sqlfluff/ST03): referenced by string in dbt_utils.deduplicate
-    address_all as (
-        select _dbt_source_relation, personid, contact as address, priority_order,
-        from person_contacts_union
-        where contact_category = 'Address' and contact_type = 'Home'
-    ),
-
-    address as (
-        {{
-            dbt_utils.deduplicate(
-                relation="address_all",
-                partition_by="_dbt_source_relation, personid",
-                order_by="priority_order asc",
-            )
-        }}
+    /* emergency contacts have no stable person record under the Finalsite 1+4
+       shape, so each (student, slot) is its own person keyed by student + slot. */
+    emergency_persons as (
+        select
+            student_number,
+            contact_slot,
+            contact_name,
+            email_current,
+            phone_mobile,
+            phone_home,
+            phone_daytime,
+            phone_work,
+            phone_primary,
+            address_home,
+            _dbt_source_project,
+        from contacts
+        where contact_slot != 'contact_1'
     )
 
 select
-    {{ dbt_utils.generate_surrogate_key(["c._dbt_source_project", "c.personid"]) }}
+    {{ dbt_utils.generate_surrogate_key(["_dbt_source_project", "person_identity"]) }}
     as student_contact_person_key,
 
-    c.contact_name as full_name,
+    contact_name as full_name,
+    email_current as email,
+    phone_mobile,
+    phone_home,
+    phone_daytime,
+    phone_work,
+    phone_primary,
+    address_home as home_address,
+from contact_1_persons
 
-    ph.phone,
-    em.email,
+union all
 
-    ad.address as home_address,
-from contacts_deduped as c
-left join
-    phone as ph
-    on c.personid = ph.personid
-    and {{ union_dataset_join_clause(left_alias="c", right_alias="ph") }}
-left join
-    email as em
-    on c.personid = em.personid
-    and {{ union_dataset_join_clause(left_alias="c", right_alias="em") }}
-left join
-    address as ad
-    on c.personid = ad.personid
-    and {{ union_dataset_join_clause(left_alias="c", right_alias="ad") }}
-where c.person_type != 'self'
+select
+    {{
+        dbt_utils.generate_surrogate_key(
+            ["_dbt_source_project", "student_number", "contact_slot"]
+        )
+    }} as student_contact_person_key,
+
+    contact_name as full_name,
+    email_current as email,
+    phone_mobile,
+    phone_home,
+    phone_daytime,
+    phone_work,
+    phone_primary,
+    address_home as home_address,
+from emergency_persons

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -1,17 +1,23 @@
 models:
   - name: dim_student_contact_persons
     description: >-
-      Contact person dimension. One row per unique contact person, deduplicated
-      across students. A parent linked to multiple students (siblings) appears
-      once here and has multiple rows in bridge_student_contacts. Person
-      attributes (name, phone, email, address) are stable across student-contact
-      pairs and live on this dimension.
+      Contact person dimension. One row per unique student contact person. A
+      contact_1 person shared across siblings appears once here (keyed by their
+      real contact identity) and has one bridge_student_contacts row per
+      student. Emergency contacts have no stable person record under the
+      Finalsite 1+4 contact shape, so each is its own person keyed by student
+      and contact slot. Person attributes (name, email, typed phones, home
+      address) live on this dimension; the relationship and the emergency flags
+      that vary per student-contact pair live on bridge_student_contacts.
 
     columns:
       - name: student_contact_person_key
         data_type: string
-        description:
+        description: >-
           Surrogate key for the contact person. Primary key for this dimension.
+          For contact_1 it is hashed from the district and the contact's real
+          identity; for emergency contacts it is hashed from the district,
+          student, and contact slot.
         constraints:
           - type: primary_key
             warn_unsupported: false
@@ -21,33 +27,80 @@ models:
 
         config:
           meta:
-            source_system: PowerSchool
-            source_model: int_powerschool__contacts
-            source_column: personid
+            source_model: int_students__contacts
             column_role: primary_key
 
       - name: full_name
         data_type: string
         description: >-
-          Full name of the contact person (first + last, trimmed) as stored in
-          PowerSchool. Matches dim_staff.full_name and dim_students.full_name.
+          Full name of the contact person. Matches dim_students.full_name and
+          dim_staff.full_name naming.
 
-      - name: phone
-        data_type: string
-        description: >-
-          Primary phone number for the contact person. Prefers Mobile over Home
-          over Daytime over Work. Formatted as (NXX) NXX-XXXX. NULL if no phone
-          is recorded.
+        config:
+          meta:
+            source_column: contact_name
+            contains_pii: true
 
       - name: email
         data_type: string
+        description: Current email address for the contact person. Null if none.
+
+        config:
+          meta:
+            source_column: email_current
+            contains_pii: true
+
+      - name: phone_mobile
+        data_type: string
+        description: The contact's phone number typed as mobile or cell, if any.
+
+        config:
+          meta:
+            contains_pii: true
+
+      - name: phone_home
+        data_type: string
+        description: The contact's phone number typed as home, if any.
+
+        config:
+          meta:
+            contains_pii: true
+
+      - name: phone_daytime
+        data_type: string
         description: >-
-          Current email address for the contact person. NULL if no email is
-          recorded in PowerSchool.
+          The contact's phone number typed as daytime, if any. Always null for
+          Finalsite-sourced regions, which have no daytime phone type.
+
+        config:
+          meta:
+            contains_pii: true
+
+      - name: phone_work
+        data_type: string
+        description: The contact's phone number typed as work, if any.
+
+        config:
+          meta:
+            contains_pii: true
+
+      - name: phone_primary
+        data_type: string
+        description: >-
+          The contact's first or best phone number regardless of type — a
+          fallback for phones the typed columns miss.
+
+        config:
+          meta:
+            contains_pii: true
 
       - name: home_address
         data_type: string
         description: >-
-          Primary home address for the contact person. Single concatenated
-          address string from the PowerSchool Home contact type. NULL if no home
-          address is recorded.
+          The contact's home address as a single string. Always null for
+          emergency contacts, which carry no address.
+
+        config:
+          meta:
+            source_column: address_home
+            contains_pii: true


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request redefines `dim_student_contact_persons` and `bridge_student_contacts` to source from the network-wide 1+4 contact surface (`int_students__contacts`, added by #4368) instead of the PowerSchool-only contact models. This is the dim/bridge follow-up (PR A2) to the merged Finalsite NJ student-contacts consumption PR.

- `dim_student_contact_persons` — person grain. `contact_1` keys on the contact's real identity (`_dbt_source_project` plus `finalsite_contact_id` for NJ, `personid` for PowerSchool), collapsed across siblings; emergency contacts have no stable person record under the 1+4 shape, so each keys on (`_dbt_source_project`, `student_number`, `contact_slot`). Source-agnostic typed-phone columns (`phone_mobile`/`phone_home`/`phone_daytime`/`phone_work`/`phone_primary`) replace the single prioritized `phone`.
- `bridge_student_contacts` — grain (`student_key`, `student_contact_person_key`, `contact_slot`); carries `relationship` plus `is_emergency`/`is_pickup`/`is_custodial`/`is_household_member`. The person key is derived identically to the dim.

Coupling verified locally (dev, `--defer`): `bridge_survey_expectations` (which cross-joins every `dim_student_contact_persons` row for family survey expectations) rebuilds against the new dim with all FK and uniqueness tests passing; `bridge_student_contacts` FK relationships and composite uniqueness pass with 0 null FKs.

Data change to note: the new dim is the focused 1+4 surface (45,859 persons) rather than the old all-priorities PowerSchool surface (142,549), so family survey expectations drop from 427,647 to 137,577. This is expected, not a break — but it moves the family-survey response-rate denominator, so the survey/topline owner should be aware. Whether family expectations should be scoped further (contact_1 only) is a separate semantic decision left as a possible follow-up.

`fct_survey_submissions` is unaffected (its `student_contact_person_key` is always null; relationships test passes trivially). No Cube model reads these marts.

## AI Assistance

Authored by Claude Code (Opus 4.8) under human direction: model design, surrogate-key composition, and coupling verification were AI-assisted; the 1+4 design decisions and scope come from the phase-3b plan and #4346.

## Self-review

### dbt

- [x] Properties file included for both redefined models
- [x] Breaking-change review: the dim `phone` column is replaced by typed phones and the surrogate-key hash composition changes. The only consumers are `bridge_survey_expectations` (reads the dim PK only) and `fct_survey_submissions` (null FK) — neither reads the removed columns, and no Cube model or exposure reads these marts by column.

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud — not triggered (no Dagster paths)

Refs #4346