### PR TITLE
feat(deanslist): add paterson behavior ingestion

### DIFF
--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -32,7 +32,6 @@ Consequences:
 
 - No `db_powerschool` or `ssh_powerschool` resources in `definitions.py`
 - No `db_bigquery` resource (no BigQuery writes from this location)
-- No `io_manager_gcs_file` resource (no file-based IO manager needed)
 - No extracts module (no BigQuery to query)
 - No `edplan`, `iready`, `overgrad`, `renlearn`, or `titan`
 

--- a/src/teamster/code_locations/kipppaterson/deanslist/assets.py
+++ b/src/teamster/code_locations/kipppaterson/deanslist/assets.py
@@ -8,10 +8,14 @@ from dagster import (
 )
 
 from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
-from teamster.code_locations.kipppaterson.deanslist.schema import ASSET_SCHEMA
+from teamster.code_locations.kipppaterson.deanslist.schema import (
+    ASSET_SCHEMA,
+    BEHAVIOR_SCHEMA,
+)
 from teamster.core.utils.classes import FiscalYearPartitionsDefinition
 from teamster.libraries.deanslist.assets import (
     build_deanslist_multi_partition_asset,
+    build_deanslist_paginated_multi_partition_asset,
     build_deanslist_static_partition_asset,
 )
 
@@ -75,6 +79,16 @@ year_partitioned_assets = [
         "endpoints"
     ]
 ]
+
+year_partitioned_assets.append(
+    build_deanslist_paginated_multi_partition_asset(
+        code_location=CODE_LOCATION,
+        endpoint="behavior",
+        api_version="v1",
+        schema=BEHAVIOR_SCHEMA,
+        partitions_def=DEANSLIST_FISCAL_MULTI_PARTITIONS_DEF,
+    )
+)
 
 assets = [
     *static_partitioned_assets,

--- a/src/teamster/code_locations/kipppaterson/definitions.py
+++ b/src/teamster/code_locations/kipppaterson/definitions.py
@@ -25,6 +25,7 @@ from teamster.core.resources import (
     SSH_RESOURCE_AMPLIFY,
     get_dbt_cli_resource,
     get_io_manager_gcs_avro,
+    get_io_manager_gcs_file,
     get_io_manager_gcs_pickle,
 )
 
@@ -57,6 +58,7 @@ defs = Definitions(
         "gcs": GCS_RESOURCE,
         "google_drive": GOOGLE_DRIVE_RESOURCE,
         "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),
+        "io_manager_gcs_file": get_io_manager_gcs_file(CODE_LOCATION),
         "io_manager": get_io_manager_gcs_pickle(CODE_LOCATION),
         "ssh_amplify": SSH_RESOURCE_AMPLIFY,
         "ssh_couchdrop": SSH_COUCHDROP,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add DeansList `behavior` ingestion for
`kipppaterson`, closing a gap from #4372: the `behavior` endpoint (a paginated
multi-partition asset) is ingested by `kippnewark`, `kippcamden`, and
`kippmiami` but was omitted from Paterson's DeansList module.

- Append the `behavior` paginated asset to `year_partitioned_assets` in
  `kipppaterson/deanslist/assets.py` — the same
  `build_deanslist_paginated_multi_partition_asset` call the other three
  districts use, reusing Paterson's SY25-26 fiscal partition definition.
- Wire the `io_manager_gcs_file` resource in `kipppaterson/definitions.py`; the
  paginated asset requires it (via the `io_manager_gcs_file` key).
- Remove the now-false "No `io_manager_gcs_file` resource" line from the code
  location `CLAUDE.md`.

This is a prerequisite for the dbt half of #4367: once this deploys and Paterson
`behavior` is materialized to GCS, the kipptaf `stg_deanslist__behavior` union
can include Paterson.

Refs #4367

## AI Assistance

AI-assisted (Claude Code), human-directed. The reviewer flagged that Paterson
was missing `behavior`; Claude implemented the fix by mirroring the existing
district modules.

## Self-review

### Dagster

- [x] New/changed assets follow the Library + Config pattern (paginated asset
      factory from `libraries/deanslist`, asset key
      `kipppaterson/deanslist/behavior`).
- [ ] `uv run dagster definitions validate` / `pytest
      tests/test_dagster_definitions.py` require the full deploy environment
      (unset locally in the codespace). The `kipppaterson.deanslist` submodule
      imports cleanly and lists all 8 assets incl. `behavior`; Dagster Cloud
      branch-deploy CI validates the complete definitions.

### Docs

- [x] Code location `CLAUDE.md` updated (removed the stale `io_manager_gcs_file`
      line).
- [ ] No new schedule/sensor — `behavior` runs under the existing
      `deanslist__year_partitioned_asset_job_schedule`, so the automations
      catalog is unchanged.

## CI checks

- [ ] **Trunk** — passes (`trunk check` clean locally on the 3 changed files).
- [ ] **Dagster Cloud** — expected to run (Dagster paths changed, non-draft).

## Post-merge (owner)

- [ ] Deploy lands (`kipppaterson` location reloads with this commit).
- [ ] Materialize `kipppaterson/deanslist/behavior` so its Avro lands at
      `gs://teamster-kipppaterson/dagster/kipppaterson/deanslist/behavior/`.
- [ ] Then proceed with the dbt PR (#4367) that unions Paterson behavior into
      kipptaf.
