### PR TITLE
feat(deanslist): add deanslist to paterson and union into kipptaf

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -156,6 +156,16 @@ model to a shared source package, confirm the source ingestion exists in every
 consuming district, or the promoted model builds empty there (or fails on a
 missing external).
 
+**Partial-endpoint onboarding**: when a district ingests only a subset of a
+source package's endpoints, disable BOTH the unused `stg_*` models AND their
+`src_*` sources in the district `dbt_project.yml`. An enabled staging model over
+a disabled source is a parse error, and `stage_external_sources` fails creating
+an AVRO external over an empty GCS prefix (autodetect needs >=1 file). Don't
+copy a peer district's disable list blindly — a district that _once_ pulled an
+endpoint keeps stale Avro so its source still stages (e.g. Newark deanslist
+leaves `homework`/`lists`/`dff_stats` enabled), but a never-pulled district must
+disable them.
+
 To gate an _optional_ package layer per region, split the package into
 method/source subfolders (`api/`, `sftp/` — the amplify convention) and set
 `<package>: <method>: +enabled: false` in the unwired district's

--- a/src/dbt/kipppaterson/CLAUDE.md
+++ b/src/dbt/kipppaterson/CLAUDE.md
@@ -29,6 +29,12 @@ disabled.
   disabled in `dbt_project.yml`
 - `amplify` — both `dds` and `mclass/api` disabled
 - `finalsite`
+- `deanslist` — `behavior`, `comm_log`, `incidents`, `roster_assignments`,
+  `rosters`, `students`, `terms`, and `users` endpoints pulled. The
+  `stg_deanslist__dff_stats`, `stg_deanslist__followups`,
+  `stg_deanslist__homework`, and `stg_deanslist__lists` staging models (and
+  their `src_deanslist__*` sources) are disabled in `dbt_project.yml` — Paterson
+  does not pull those endpoints, so no Avro exists for them
 
 ## Models in package-named directories
 

--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -53,6 +53,17 @@ models:
         staging:
           stg_amplify__mclass__sftp__pm_student_summary_aimline:
             +enabled: false
+  deanslist:
+    +materialized: table
+    staging:
+      stg_deanslist__dff_stats:
+        +enabled: false
+      stg_deanslist__followups:
+        +enabled: false
+      stg_deanslist__homework:
+        +enabled: false
+      stg_deanslist__lists:
+        +enabled: false
   pearson:
     +materialized: table
     staging:
@@ -169,6 +180,16 @@ sources:
   finalsite:
     finalsite:
       contacts:
+        +enabled: false
+  deanslist:
+    deanslist:
+      src_deanslist__dff_stats:
+        +enabled: false
+      src_deanslist__followups:
+        +enabled: false
+      src_deanslist__homework:
+        +enabled: false
+      src_deanslist__lists:
         +enabled: false
   pearson:
     pearson:

--- a/src/dbt/kipppaterson/package-lock.yml
+++ b/src/dbt/kipppaterson/package-lock.yml
@@ -1,6 +1,8 @@
 packages:
   - local: ../amplify
     name: amplify
+  - local: ../deanslist
+    name: deanslist
   - local: ../finalsite
     name: finalsite
   - local: ../pearson
@@ -13,4 +15,4 @@ packages:
   - name: dbt_utils
     package: dbt-labs/dbt_utils
     version: 1.4.1
-sha1_hash: e8986a0f1726db71d70527227388fe1d2e0eaa70
+sha1_hash: 15227b8eff77471b17ff6a67f5b905d4aa92cdb8

--- a/src/dbt/kipppaterson/packages.yml
+++ b/src/dbt/kipppaterson/packages.yml
@@ -1,6 +1,7 @@
 # trunk-ignore-all(yamllint/quoted-strings)
 packages:
   - local: ../amplify
+  - local: ../deanslist
   - local: ../finalsite
   - local: ../pearson
   - local: ../powerschool

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__comm_log.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__comm_log.sql
@@ -6,6 +6,7 @@ with
                     source("kippnewark_deanslist", "int_deanslist__comm_log"),
                     source("kippcamden_deanslist", "int_deanslist__comm_log"),
                     source("kippmiami_deanslist", "int_deanslist__comm_log"),
+                    source("kipppaterson_deanslist", "int_deanslist__comm_log"),
                 ]
             )
         }}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
@@ -6,6 +6,7 @@ with
                     source("kippnewark_deanslist", "int_deanslist__incidents"),
                     source("kippcamden_deanslist", "int_deanslist__incidents"),
                     source("kippmiami_deanslist", "int_deanslist__incidents"),
+                    source("kipppaterson_deanslist", "int_deanslist__incidents"),
                 ]
             )
         }}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__attachments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__attachments.sql
@@ -4,6 +4,7 @@
             source("kippnewark_deanslist", "int_deanslist__incidents__attachments"),
             source("kippcamden_deanslist", "int_deanslist__incidents__attachments"),
             source("kippmiami_deanslist", "int_deanslist__incidents__attachments"),
+            source("kipppaterson_deanslist", "int_deanslist__incidents__attachments"),
         ]
     )
 }}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
@@ -12,6 +12,10 @@ with
                     source(
                         "kippmiami_deanslist", "int_deanslist__incidents__penalties"
                     ),
+                    source(
+                        "kipppaterson_deanslist",
+                        "int_deanslist__incidents__penalties",
+                    ),
                 ]
             )
         }}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
@@ -12,6 +12,9 @@ with
                     source(
                         "kippmiami_deanslist", "int_deanslist__roster_assignments"
                     ),
+                    source(
+                        "kipppaterson_deanslist", "int_deanslist__roster_assignments"
+                    ),
                 ]
             )
         }}

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__students__custom_fields__pivot.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__students__custom_fields__pivot.sql
@@ -4,6 +4,7 @@
             source("kippnewark_deanslist", model.name),
             source("kippcamden_deanslist", model.name),
             source("kippmiami_deanslist", model.name),
+            source("kipppaterson_deanslist", model.name),
         ]
     )
 }}

--- a/src/dbt/kipptaf/models/deanslist/api/sources-kipppaterson.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/sources-kipppaterson.yml
@@ -1,0 +1,154 @@
+sources:
+  - name: kipppaterson_deanslist
+    schema:
+      "{%- if target.name == 'dev' -%}zz_{{ env_var('GITHUB_USER', 'dev') }}_{%-
+      elif target.name == 'staging' -%}zz_stg_{%- endif
+      -%}kipppaterson_deanslist"
+    tables:
+      - name: stg_deanslist__behavior
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__behavior
+      - name: int_deanslist__comm_log
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__comm_log
+      - name: stg_deanslist__incidents
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__incidents
+      - name: stg_deanslist__terms
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__terms
+      - name: stg_deanslist__users
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__users
+      - name: int_deanslist__incidents__penalties
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__incidents__penalties
+      - name: int_deanslist__incidents__custom_fields
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__incidents__custom_fields
+      - name: int_deanslist__incidents__custom_fields__pivot
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__incidents__custom_fields__pivot
+      - name: int_deanslist__students__custom_fields
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__students__custom_fields
+      - name: int_deanslist__students__custom_fields__pivot
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__students__custom_fields__pivot
+      - name: int_deanslist__incidents__attachments
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__incidents__attachments
+      - name: int_deanslist__incidents
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__incidents
+      - name: int_deanslist__roster_assignments
+        config:
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - int_deanslist__roster_assignments
+      - name: stg_deanslist__roster_assignments
+        config:
+          enabled: false
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__roster_assignments
+      - name: stg_deanslist__rosters
+        config:
+          enabled: false
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__rosters
+      - name: stg_deanslist__followups
+        config:
+          enabled: false
+          meta:
+            dagster:
+              group: deanslist
+              asset_key:
+                - kipppaterson
+                - deanslist
+                - stg_deanslist__followups

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__behavior.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__behavior.sql
@@ -4,6 +4,7 @@
             source("kippnewark_deanslist", "stg_deanslist__behavior"),
             source("kippcamden_deanslist", "stg_deanslist__behavior"),
             source("kippmiami_deanslist", "stg_deanslist__behavior"),
+            source("kipppaterson_deanslist", "stg_deanslist__behavior"),
         ]
     )
 }}

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__terms.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__terms.sql
@@ -4,6 +4,7 @@
             source("kippnewark_deanslist", "stg_deanslist__terms"),
             source("kippcamden_deanslist", "stg_deanslist__terms"),
             source("kippmiami_deanslist", "stg_deanslist__terms"),
+            source("kipppaterson_deanslist", "stg_deanslist__terms"),
         ]
     )
 }}

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__users.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__users.sql
@@ -4,6 +4,7 @@
             source("kippnewark_deanslist", "stg_deanslist__users"),
             source("kippcamden_deanslist", "stg_deanslist__users"),
             source("kippmiami_deanslist", "stg_deanslist__users"),
+            source("kipppaterson_deanslist", "stg_deanslist__users"),
         ]
     )
 }}

--- a/src/teamster/libraries/deanslist/CLAUDE.md
+++ b/src/teamster/libraries/deanslist/CLAUDE.md
@@ -18,6 +18,15 @@ Date windows are computed from `FiscalYear` (July start). For
 `MonthlyPartitionsDefinition`, `EndDate` is the last day of the month; for
 `FiscalYearPartitionsDefinition`, it's the fiscal year end.
 
+## `behavior` is config-invisible
+
+`behavior` (the paginated endpoint) is wired directly in each district's
+`assets.py` — `build_deanslist_paginated_multi_partition_asset` appended to
+`year_partitioned_assets` — NOT in `config/*.yaml`. When adding deanslist to a
+district or auditing endpoint parity, check `assets.py`; diffing only the config
+YAMLs misses it (how Paterson shipped without behavior, #4376). A district using
+it must also wire `io_manager_gcs_file` in `definitions.py`.
+
 ## Resource: `DeansListResource`
 
 Configured with a single `api_key_dir` — a directory (the per-city


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make Paterson DeansList data queryable
network-wide by wiring the `deanslist` dbt package into `kipppaterson` and
unioning Paterson into the kipptaf cross-district DeansList models. This is the
dbt half of #4367 (the Dagster ingestion half landed in #4372, #4374, and
#4376).

**kipppaterson district project**

- `packages.yml`: import the local `deanslist` package.
- `dbt_project.yml`: materialize `deanslist` as tables; disable the
  `stg_deanslist__dff_stats`, `stg_deanslist__followups`,
  `stg_deanslist__homework`, and `stg_deanslist__lists` staging models and their
  `src_deanslist__*` sources — Paterson does not pull those endpoints, so no
  Avro exists for them (leaving them enabled would fail `stage_external_sources`
  and the staging build).
- Paterson pulls `behavior`, `comm_log`, `incidents`, `roster_assignments`,
  `rosters`, `students`, `terms`, and `users`.

**kipptaf cross-district unions**

- New `sources-kipppaterson.yml` (mirrors the other three districts) with the
  `dev` / `staging` (`zz_stg_`) / prod schema branch so the single-PR
  cross-project CI can read the staged Paterson tables.
- Added `source("kipppaterson_deanslist", ...)` to all 9 kipptaf `deanslist/api`
  union models: `stg_deanslist__{users,behavior,terms}` and
  `int_deanslist__{roster_assignments, incidents__attachments,
  students__custom_fields__pivot, incidents__penalties, incidents, comm_log}`.

`behavior` is included in the union because Paterson `behavior` ingestion was
added in #4376 (it was missing from the other districts' parity — a paginated
asset the other three ingest). This PR depends on #4376 being deployed and
Paterson `behavior` materialized.

> Note: after #4376 deployed and backfilled, Paterson's `behavior` endpoint
> returns **0 records** (the Avro files exist but are empty). The ingestion +
> staging pipeline is correct and verified end-to-end; Paterson simply has no
> DeansList behavior/points data logged yet. `behavior` is kept in the union for
> structural parity and forward-compatibility — it will populate automatically
> once data exists. Whether Paterson should have behavior data is a
> DeansList-side question, not a code issue.

## AI Assistance

AI-assisted (Claude Code), human-directed. Claude executed the plan at
`docs/superpowers/plans/2026-07-10-deanslist-paterson-and-per-school-keys.md`
(Tasks 9-11), flagged the missing `behavior` ingestion, and implemented both
this PR and #4376.

## Self-review

### dbt

- [x] Uniqueness tests / properties live on the per-region source-system
      package models (unchanged); the kipptaf-level union views are pure
      `union_relations` (no tests/materialization added), per convention.
- [x] External sources for the enabled Paterson endpoints must be staged with
      `--target staging` before CI can read them (see CI note below).
- [x] No contracted-column renames or removals — additive union of a new
      district only.

### Docs

- [x] `src/dbt/kipppaterson/CLAUDE.md` updated (added `deanslist` to Active
      Source Packages with the enabled/disabled endpoint split).

## CI checks

- [ ] **dbt Cloud** — requires the single-PR cross-project seeding first (kipptaf
      CI reads Paterson from `zz_stg_kipppaterson_deanslist` via the staging
      schema branch; the other three districts resolve to prod). Owner steps,
      after #4376 deploys and Paterson `behavior` finishes backfilling:
  1. `uv run dbt run-operation stage_external_sources --target staging
     --project-dir src/dbt/kipppaterson --vars '{ext_full_refresh: true}'`
  2. `uv run dbt build --select deanslist --target staging --project-dir
     src/dbt/kipppaterson` (builds Paterson `stg_`/`int_` deanslist into
     `zz_stg_kipppaterson_deanslist`; uniqueness tests should pass)
  3. Push so CI builds the 9 modified unions against the staged Paterson tables.
- [ ] **Trunk** — passes (`trunk check` clean locally on all changed files).

## Notes

CI is kipptaf-scoped; district-side correctness is verified with a local
`uv run dbt build --select deanslist --target staging --project-dir
src/dbt/kipppaterson`.

Closes #4367
