### PR TITLE
feat(dagster): add Finalsite contacts ingestion for Camden and Paterson

### DIFF
--- a/.k8s/1password/items.yaml
+++ b/.k8s/1password/items.yaml
@@ -422,3 +422,19 @@ metadata:
   namespace: dagster-cloud
 spec:
   itemPath: vaults/Data Team/items/Finalsite API - Newark
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-finalsite-api-kippcamden
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/Finalsite API - Camden
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: op-finalsite-api-kipppaterson
+  namespace: dagster-cloud
+spec:
+  itemPath: vaults/Data Team/items/Finalsite API - Paterson

--- a/src/teamster/code_locations/kippcamden/CLAUDE.md
+++ b/src/teamster/code_locations/kippcamden/CLAUDE.md
@@ -11,18 +11,18 @@ GCS bucket: `teamster-kippcamden`
 
 ## Active Integrations
 
-| Module        | Type          | Trigger                                   |
-| ------------- | ------------- | ----------------------------------------- |
-| `dbt`         | dbt assets    | `AutomationConditionSensor`               |
-| `powerschool` | ODBC assets   | sensor (`build_powerschool_asset_sensor`) |
-| `deanslist`   | API assets    | schedule (nightly)                        |
-| `edplan`      | SFTP asset    | sensor (`build_edplan_sftp_sensor`)       |
-| `finalsite`   | API assets    | `AutomationConditionSensor`               |
-| `overgrad`    | API assets    | schedule                                  |
-| `pearson`     | SFTP assets   | `AutomationConditionSensor`               |
-| `titan`       | SFTP assets   | sensor (`build_titan_sftp_sensor`)        |
-| `extracts`    | BigQuery→SFTP | schedule (nightly, 3am)                   |
-| `couchdrop`   | sensor only   | sensor (Google Drive watcher)             |
+| Module        | Type              | Trigger                                               |
+| ------------- | ----------------- | ----------------------------------------------------- |
+| `dbt`         | dbt assets        | `AutomationConditionSensor`                           |
+| `powerschool` | ODBC assets       | sensor (`build_powerschool_asset_sensor`)             |
+| `deanslist`   | API assets        | schedule (nightly)                                    |
+| `edplan`      | SFTP asset        | sensor (`build_edplan_sftp_sensor`)                   |
+| `finalsite`   | API + SFTP assets | schedule (`contacts`, 4am) + sensor (`status_report`) |
+| `overgrad`    | API assets        | schedule                                              |
+| `pearson`     | SFTP assets       | `AutomationConditionSensor`                           |
+| `titan`       | SFTP assets       | sensor (`build_titan_sftp_sensor`)                    |
+| `extracts`    | BigQuery→SFTP     | schedule (nightly, 3am)                               |
+| `couchdrop`   | sensor only       | sensor (Google Drive watcher)                         |
 
 ## PowerSchool Configuration
 

--- a/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
@@ -138,6 +138,16 @@ locations:
                   secretKeyRef:
                     name: op-overgrad-api-kippcamden
                     key: credential
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippcamden
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippcamden
+                    key: password
         run_k8s_config:
           container_config:
             env:
@@ -241,3 +251,13 @@ locations:
                   secretKeyRef:
                     name: op-overgrad-api-kippcamden
                     key: credential
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippcamden
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kippcamden
+                    key: password

--- a/src/teamster/code_locations/kippcamden/definitions.py
+++ b/src/teamster/code_locations/kippcamden/definitions.py
@@ -21,6 +21,7 @@ from teamster.code_locations.kippcamden import (
     powerschool,
     titan,
 )
+from teamster.code_locations.kippcamden.resources import FINALSITE_RESOURCE
 from teamster.core.freshness import apply_freshness_policies
 from teamster.core.resources import (
     BIGQUERY_RESOURCE,
@@ -60,6 +61,7 @@ defs = Definitions(
     schedules=[
         *extracts.schedules,
         *deanslist.schedules,
+        *finalsite.schedules,
         *overgrad.schedules,
         *powerschool.schedules,
     ],
@@ -78,6 +80,7 @@ defs = Definitions(
         "db_powerschool": DB_POWERSCHOOL,
         "dbt_cli": get_dbt_cli_resource(DBT_PROJECT),
         "deanslist": DEANSLIST_RESOURCE,
+        "finalsite": FINALSITE_RESOURCE,
         "gcs": GCS_RESOURCE,
         "google_drive": GOOGLE_DRIVE_RESOURCE,
         "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),

--- a/src/teamster/code_locations/kippcamden/finalsite/__init__.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/__init__.py
@@ -1,5 +1,7 @@
 from teamster.code_locations.kippcamden.finalsite.assets import assets
+from teamster.code_locations.kippcamden.finalsite.schedules import schedules
 
 __all__ = [
     "assets",
+    "schedules",
 ]

--- a/src/teamster/code_locations/kippcamden/finalsite/assets.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/assets.py
@@ -1,5 +1,9 @@
 from teamster.code_locations.kippcamden import CODE_LOCATION, CURRENT_FISCAL_YEAR
-from teamster.code_locations.kippcamden.finalsite.schema import STATUS_REPORT_SCHEMA
+from teamster.code_locations.kippcamden.finalsite.schema import (
+    CONTACTS_SCHEMA,
+    STATUS_REPORT_SCHEMA,
+)
+from teamster.libraries.finalsite.api.assets import build_finalsite_asset
 from teamster.libraries.finalsite.sftp.assets import (
     get_finalsite_school_year_partition_keys,
 )
@@ -20,6 +24,14 @@ status_report = build_sftp_file_asset(
     ssh_resource_key="ssh_couchdrop",
 )
 
+contacts = build_finalsite_asset(
+    code_location=CODE_LOCATION,
+    asset_name="contacts",
+    schema=CONTACTS_SCHEMA,
+    params={"includes": "contacts.relationships"},
+)
+
 assets = [
     status_report,
+    contacts,
 ]

--- a/src/teamster/code_locations/kippcamden/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/schedules.py
@@ -1,0 +1,14 @@
+from dagster import ScheduleDefinition
+
+from teamster.code_locations.kippcamden import CODE_LOCATION, LOCAL_TIMEZONE
+
+finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
+    cron_schedule="0 4 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    target=[f"{CODE_LOCATION}/finalsite/contacts"],
+)
+
+schedules = [
+    finalsite_contacts_daily_asset_job_schedule,
+]

--- a/src/teamster/code_locations/kippcamden/finalsite/schema.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/schema.py
@@ -2,10 +2,15 @@ import json
 
 import py_avro_schema
 
+from teamster.libraries.finalsite.api.schema import Contact
 from teamster.libraries.finalsite.sftp.schema import StatusReport
 
 pas_options = py_avro_schema.Option.NO_DOC | py_avro_schema.Option.NO_AUTO_NAMESPACE
 
 STATUS_REPORT_SCHEMA = json.loads(
     py_avro_schema.generate(py_type=StatusReport, options=pas_options)
+)
+
+CONTACTS_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=Contact, options=pas_options)
 )

--- a/src/teamster/code_locations/kippcamden/resources.py
+++ b/src/teamster/code_locations/kippcamden/resources.py
@@ -1,0 +1,10 @@
+from dagster import EnvVar
+
+from teamster.code_locations.kippcamden import CODE_LOCATION
+from teamster.libraries.finalsite.api.resources import FinalsiteResource
+
+FINALSITE_RESOURCE = FinalsiteResource(
+    server=CODE_LOCATION,
+    credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),
+    secret=EnvVar("FINALSITE_SECRET"),
+)

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -11,15 +11,15 @@ GCS bucket: `teamster-kipppaterson`
 
 ## Active Integrations
 
-| Module                   | Type                      | Trigger                                     |
-| ------------------------ | ------------------------- | ------------------------------------------- |
-| `dbt`                    | dbt assets                | `AutomationConditionSensor`                 |
-| `powerschool` (sis/sftp) | SFTP assets via Couchdrop | sensor (`couchdrop_sftp_sensor`)            |
-| `amplify` (mclass sftp)  | SFTP assets               | sensor (`build_amplify_mclass_sftp_sensor`) |
-| `deanslist`              | API assets                | schedule (nightly)                          |
-| `finalsite`              | API assets                | `AutomationConditionSensor`                 |
-| `pearson`                | SFTP assets               | `AutomationConditionSensor`                 |
-| `couchdrop`              | sensor only               | sensor (Google Drive watcher)               |
+| Module                   | Type                      | Trigger                                               |
+| ------------------------ | ------------------------- | ----------------------------------------------------- |
+| `dbt`                    | dbt assets                | `AutomationConditionSensor`                           |
+| `powerschool` (sis/sftp) | SFTP assets via Couchdrop | sensor (`couchdrop_sftp_sensor`)                      |
+| `amplify` (mclass sftp)  | SFTP assets               | sensor (`build_amplify_mclass_sftp_sensor`)           |
+| `deanslist`              | API assets                | schedule (nightly)                                    |
+| `finalsite`              | API + SFTP assets         | schedule (`contacts`, 4am) + sensor (`status_report`) |
+| `pearson`                | SFTP assets               | `AutomationConditionSensor`                           |
+| `couchdrop`              | sensor only               | sensor (Google Drive watcher)                         |
 
 ## Critical Difference: PowerSchool via SFTP
 
@@ -37,8 +37,8 @@ Consequences:
 
 ## Schedules
 
-Paterson has no freshness checks. DeansList adds nightly data-pull schedules;
-all other ingestion is sensor-driven (`couchdrop_sftp_sensor` for PowerSchool,
+Paterson has no freshness checks. DeansList and Finalsite `contacts` add nightly
+data-pull schedules; all other ingestion is sensor-driven
+(`couchdrop_sftp_sensor` for PowerSchool and Finalsite `status_report`,
 `build_amplify_mclass_sftp_sensor` for Amplify). `AutomationConditionSensor`
-handles any assets with an automation condition defined (e.g. `finalsite`,
-`pearson`).
+handles any assets with an automation condition defined (e.g. `pearson`).

--- a/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
@@ -62,6 +62,16 @@ locations:
                   secretKeyRef:
                     name: op-amplify-sftp-kipppaterson
                     key: username
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kipppaterson
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kipppaterson
+                    key: password
         run_k8s_config:
           container_config:
             env:
@@ -95,3 +105,13 @@ locations:
                   secretKeyRef:
                     name: op-amplify-sftp-kipppaterson
                     key: username
+              - name: FINALSITE_CREDENTIAL_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kipppaterson
+                    key: username
+              - name: FINALSITE_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: op-finalsite-api-kipppaterson
+                    key: password

--- a/src/teamster/code_locations/kipppaterson/definitions.py
+++ b/src/teamster/code_locations/kipppaterson/definitions.py
@@ -17,6 +17,7 @@ from teamster.code_locations.kipppaterson import (
     pearson,
     powerschool,
 )
+from teamster.code_locations.kipppaterson.resources import FINALSITE_RESOURCE
 from teamster.core.resources import (
     DEANSLIST_RESOURCE,
     GCS_RESOURCE,
@@ -43,6 +44,7 @@ defs = Definitions(
     ),
     schedules=[
         *deanslist.schedules,
+        *finalsite.schedules,
     ],
     sensors=[
         *amplify.sensors,
@@ -55,6 +57,7 @@ defs = Definitions(
     resources={
         "dbt_cli": get_dbt_cli_resource(DBT_PROJECT),
         "deanslist": DEANSLIST_RESOURCE,
+        "finalsite": FINALSITE_RESOURCE,
         "gcs": GCS_RESOURCE,
         "google_drive": GOOGLE_DRIVE_RESOURCE,
         "io_manager_gcs_avro": get_io_manager_gcs_avro(CODE_LOCATION),

--- a/src/teamster/code_locations/kipppaterson/finalsite/__init__.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/__init__.py
@@ -1,5 +1,7 @@
 from teamster.code_locations.kipppaterson.finalsite.assets import assets
+from teamster.code_locations.kipppaterson.finalsite.schedules import schedules
 
 __all__ = [
     "assets",
+    "schedules",
 ]

--- a/src/teamster/code_locations/kipppaterson/finalsite/assets.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/assets.py
@@ -1,5 +1,9 @@
 from teamster.code_locations.kipppaterson import CODE_LOCATION, CURRENT_FISCAL_YEAR
-from teamster.code_locations.kipppaterson.finalsite.schema import STATUS_REPORT_SCHEMA
+from teamster.code_locations.kipppaterson.finalsite.schema import (
+    CONTACTS_SCHEMA,
+    STATUS_REPORT_SCHEMA,
+)
+from teamster.libraries.finalsite.api.assets import build_finalsite_asset
 from teamster.libraries.finalsite.sftp.assets import (
     get_finalsite_school_year_partition_keys,
 )
@@ -20,6 +24,14 @@ status_report = build_sftp_file_asset(
     ssh_resource_key="ssh_couchdrop",
 )
 
+contacts = build_finalsite_asset(
+    code_location=CODE_LOCATION,
+    asset_name="contacts",
+    schema=CONTACTS_SCHEMA,
+    params={"includes": "contacts.relationships"},
+)
+
 assets = [
     status_report,
+    contacts,
 ]

--- a/src/teamster/code_locations/kipppaterson/finalsite/schedules.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/schedules.py
@@ -1,0 +1,14 @@
+from dagster import ScheduleDefinition
+
+from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
+
+finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
+    cron_schedule="0 4 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    target=[f"{CODE_LOCATION}/finalsite/contacts"],
+)
+
+schedules = [
+    finalsite_contacts_daily_asset_job_schedule,
+]

--- a/src/teamster/code_locations/kipppaterson/finalsite/schema.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/schema.py
@@ -2,10 +2,15 @@ import json
 
 import py_avro_schema
 
+from teamster.libraries.finalsite.api.schema import Contact
 from teamster.libraries.finalsite.sftp.schema import StatusReport
 
 pas_options = py_avro_schema.Option.NO_DOC | py_avro_schema.Option.NO_AUTO_NAMESPACE
 
 STATUS_REPORT_SCHEMA = json.loads(
     py_avro_schema.generate(py_type=StatusReport, options=pas_options)
+)
+
+CONTACTS_SCHEMA = json.loads(
+    py_avro_schema.generate(py_type=Contact, options=pas_options)
 )

--- a/src/teamster/code_locations/kipppaterson/resources.py
+++ b/src/teamster/code_locations/kipppaterson/resources.py
@@ -1,0 +1,10 @@
+from dagster import EnvVar
+
+from teamster.code_locations.kipppaterson import CODE_LOCATION
+from teamster.libraries.finalsite.api.resources import FinalsiteResource
+
+FINALSITE_RESOURCE = FinalsiteResource(
+    server=CODE_LOCATION,
+    credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),
+    secret=EnvVar("FINALSITE_SECRET"),
+)


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this adds Finalsite `contacts` API ingestion to the `kippcamden` and `kipppaterson` code locations, replicating the Newark pattern. It is **Phase 1 (ingestion only)** of cutting both NJ regions over from PowerSchool-sourced to Finalsite-sourced student contacts (the NJ source of truth) — the reason those two regions still sit on the PowerSchool-mapped branch of `int_students__contacts` while Newark is on Finalsite.

Per region (`kippcamden`, `kipppaterson`):

- `finalsite/schema.py`: add `CONTACTS_SCHEMA` (from the shared `Contact` Pydantic model).
- `finalsite/assets.py`: add the `contacts` asset via `build_finalsite_asset` (with the `contacts.relationships` include); the existing SFTP `status_report` asset is untouched.
- `finalsite/schedules.py` (new): daily 4am `contacts` schedule.
- `resources.py` (new): `FinalsiteResource` (server = code location; credentials from the two Finalsite API environment variables).
- `definitions.py`: register the resource and the schedule.
- `dagster-cloud.yaml`: add the two Finalsite API credential environment variables to the server and run k8s config, referencing the per-region 1Password items (`op-finalsite-api-kippcamden` / `op-finalsite-api-kipppaterson`, confirmed to exist).
- `CLAUDE.md`: correct the stale finalsite row.

## Deferred (gated on this running)

Phase 1 wires ingestion only; the finalsite dbt api layer stays `+enabled: false` for both regions. After merge and deploy, the 4am schedule pulls live contacts, then: **Phase 2** enables the dbt api layer plus per-region emergency-field / phone-type / custom-field discovery from the live data (the Newark Phase-2 step), and **Phase 3** adds both regions to the kipptaf `int_finalsite__student_contacts` union and widens the `int_students__contacts` PowerSchool-branch filter, with a coverage go/no-go.

## AI Assistance

Authored by Claude Code (Opus 4.8) under human direction: the wiring is a mechanical mirror of the Newark Finalsite contacts ingestion; scope and sequencing come from the Finalsite NJ rollout spec and #4346.

## Self-review

### Dagster

- [x] Follows the Library + Config pattern — no library changes; both regions call the existing `build_finalsite_asset` / `FinalsiteResource` with per-location config, matching Newark.
- Validation: `dagster definitions validate` false-fails locally for every location on the unbuilt dbt manifest (a documented codespace artifact), so I validated via direct submodule import (`teamster.code_locations.kippcamden.finalsite` / `kipppaterson.finalsite` and `.resources`): both `contacts` and `status_report` assets, the daily schedule, and `FinalsiteResource` construct, and the per-location schedule target (`kippcamden/finalsite/contacts`, `kipppaterson/finalsite/contacts`) matches the built asset key. Full definitions validation runs in the Dagster Cloud branch deploy on this PR.

## CI checks

- [ ] Trunk
- [ ] Dagster Cloud (branch deploy — validates both locations)
- dbt Cloud — not triggered (no dbt changes)

Refs #4346