### PR TITLE
feat(kipptaf): add prior-quarter and prior-year Y1 GPA columns to grades extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -224,6 +224,21 @@ models:
         data_type: int64
         description:
           Failing Y1 grade count 28 days ago (current-year rows only).
+      - name: gpa_y1_prior_quarter
+        data_type: float64
+        description: >-
+          Weighted Y1 GPA as of the previous quarter (a Q3 row shows the Q2
+          value). Current-year quarter rows only — NULL on Q1, Y1, and
+          prior-year rows.
+      - name: gpa_y1_prior_year
+        data_type: float64
+        description: >-
+          The student's final weighted Y1 GPA from the prior academic year,
+          repeated on every current-year row (PowerSchool stores only
+          end-of-year Y1 grades, so no as-of-quarter prior-year value exists).
+          Credit-hour weighted across schools when the student attended more
+          than one school that year. NULL on prior-year rows and for students
+          without a prior-year record.
       - name: cumulative_y1_gpa
         data_type: float64
         description: Cumulative weighted Y1 GPA (current-year rows only).

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -13,6 +13,10 @@ with
             is_current_term as is_current_quarter,
             semester,
 
+            case
+                term when 'Q2' then 'Q1' when 'Q3' then 'Q2' when 'Q4' then 'Q3'
+            end as prior_quarter,
+
         from {{ ref("int_powerschool__terms") }}
 
         union all
@@ -30,8 +34,43 @@ with
             false as is_current_quarter,
             'S#' as semester,
 
+            cast(null as string) as prior_quarter,
+
         from {{ ref("stg_powerschool__terms") }}
         where isyearrec = 1
+    ),
+
+    prior_year_gpa_rollup as (
+        /* prior-year FINAL Y1 GPA — PowerSchool stores only end-of-year Y1
+           grades, so a true as-of-same-quarter value does not exist (#4382).
+           is_current picks the single Q4 row per school; the credit-hour
+           weighted sum blends multi-school years down to student grain */
+        select
+            studentid,
+            _dbt_source_project,
+
+            count(*) as n_school_rows,
+            max(gpa_y1) as gpa_y1_single_school,
+
+            round(
+                safe_divide(sum(weighted_gpa_points_y1), sum(total_credit_hours_y1)), 2
+            ) as gpa_y1_blended,
+        from {{ ref("int_powerschool__gpa_term") }}
+        where yearid = {{ var("current_academic_year") - 1991 }} and is_current
+        group by studentid, _dbt_source_project
+    ),
+
+    prior_year_gpa as (
+        /* single-school years use the stored gpa_y1 verbatim — the blend's
+           pre-rounded inputs drift +/-0.01 vs the exact value */
+        select
+            studentid,
+            _dbt_source_project,
+
+            if(
+                n_school_rows = 1, gpa_y1_single_school, gpa_y1_blended
+            ) as gpa_y1_prior_year,
+        from prior_year_gpa_rollup
     ),
 
     student_roster as (
@@ -109,6 +148,10 @@ with
             lb.n_failing_y1_2_week_prior,
             lb.n_failing_y1_4_week_prior,
 
+            gpq.gpa_y1 as gpa_y1_prior_quarter,
+
+            pyg.gpa_y1_prior_year,
+
             enr.academic_year
             = {{ var("current_academic_year") }} as is_current_academic_year,
 
@@ -157,6 +200,21 @@ with
             and enr.schoolid = lb.schoolid
             and enr.yearid = lb.yearid
             and {{ union_dataset_join_clause(left_alias="enr", right_alias="lb") }}
+        /* both comparison joins are current-year-only (as-of columns), gated
+           in ON so prior-year rows keep NULLs */
+        left join
+            {{ ref("int_powerschool__gpa_term") }} as gpq
+            on enr.studentid = gpq.studentid
+            and enr.yearid = gpq.yearid
+            and enr.schoolid = gpq.schoolid
+            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gpq") }}
+            and term.prior_quarter = gpq.term_name
+            and enr.academic_year = {{ var("current_academic_year") }}
+        left join
+            prior_year_gpa as pyg
+            on enr.studentid = pyg.studentid
+            and enr._dbt_source_project = pyg._dbt_source_project
+            and enr.academic_year = {{ var("current_academic_year") }}
         where
             enr.rn_year = 1
             and not enr.is_out_of_district
@@ -438,6 +496,9 @@ select
     s.n_failing_y1_1_week_prior,
     s.n_failing_y1_2_week_prior,
     s.n_failing_y1_4_week_prior,
+
+    s.gpa_y1_prior_quarter,
+    s.gpa_y1_prior_year,
 
     s.cumulative_y1_gpa,
     s.cumulative_y1_gpa_unweighted,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Closes #4382

Tableau handles lag/lead-style calculations poorly, so this precomputes two comparison columns on `rpt_tableau__student_course_grades`, populated on current-year rows only:

- **`gpa_y1_prior_quarter`** — weighted Y1 GPA as of the previous quarter (a Q3 row shows the Q2 value). Sourced from a second `int_powerschool__gpa_term` join keyed identically to the existing per-quarter join, matched on a `prior_quarter` column precomputed in the term spine. NULL on Q1, Y1, and prior-year rows.
- **`gpa_y1_prior_year`** — the student's **final** weighted Y1 GPA from the prior academic year. PowerSchool stores only end-of-year Y1 grades, so no as-of-quarter prior-year value exists; the final value was chosen deliberately over an approximate reconstruction. Keyed by `studentid` (not enrollment school), single-school years use the stored `gpa_y1` verbatim, multi-school years blend by credit hours. Repeated on every current-year row including Y1.

## AI Assistance

Claude Code authored the change end-to-end; column semantics (final prior-year value over reconstruction, current-year-only gating) were human-directed.

## Self-review

Validation (dev build with prod defer):

- Null gating verified per (year, quarter) bucket: prior-year rows all NULL; Q1/Y1 NULL for prior-quarter; prior-year value present on all current-year quarters incl. Y1.
- `gpa_y1_prior_quarter` ties out 0-mismatch against the previous quarter row's own `gpa_y1` across 25,749 student-quarter pairs.
- `gpa_y1_prior_year` matches the extract's prior-year Y1 rows exactly for every comparable student; the only 26 differences are students whose prior-year grades sit under a non-primary school, where the extract's school-keyed row reads NULL and the new studentid-keyed column finds the value (strictly more complete).
- No fan-out: PK uniqueness warn count unchanged from the dev baseline (72; the standing TODO(#3915) storedgrades dup warn); both new joins are grain-safe by construction.

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties file updated (two new contract columns with descriptions)
- [x] Exposure — no change; exposure work tracked in #4340 pending the workbook LSID
- [x] **Breaking change?** No — additive columns only
- [x] No external source changes

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.