### PR TITLE
fix(collegeboard): drop source_file_name from stg_collegeboard__ap contract

### DIFF
--- a/src/dbt/kipptaf/models/collegeboard/staging/stg_collegeboard__ap.sql
+++ b/src/dbt/kipptaf/models/collegeboard/staging/stg_collegeboard__ap.sql
@@ -1,5 +1,7 @@
 select
-    * except (_dagster_partition_school_year, date_of_birth, grade_level),
+    * except (
+        _dagster_partition_school_year, date_of_birth, grade_level, source_file_name
+    ),
 
     _dagster_partition_school_year as enrollment_school_year,
 


### PR DESCRIPTION
## Summary

- `source_file_name` is injected by the SFTP IO manager into every row but was missing from the enforced contract, causing `stg_collegeboard__ap` to fail on rebuild
- Fix: add `source_file_name` to the `except` list in the staging model SQL

## Test plan

- [ ] Re-trigger `stg_collegeboard__ap` materialization in Dagster after merge and confirm run succeeds


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216538153051967