### PR TITLE
feat(dbt): add iReady, STAR, DIBELS to fct_assessment_scores_enrollment_scoped

### DIFF
--- a/docs/superpowers/plans/2026-07-13-vendor-assessments-enrollment-scoped-fact.md
+++ b/docs/superpowers/plans/2026-07-13-vendor-assessments-enrollment-scoped-fact.md
@@ -13,11 +13,15 @@
 spec
 `docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md`.
 
-**Architecture:** Inline branches (spec Approach A). Each vendor intermediate
-gains two additive columns (`_dbt_source_project`, `illuminate_subject`); then
-the section resolver, both assessment dims, and the fact each gain vendor
-branches mirroring the existing `state_nj`/`state_fl` pattern. iReady and STAR
-fact branches dedupe at PK grain (verified upstream duplicates).
+**Architecture:** Inline branches (spec Approach A). Each vendor source model
+gains additive columns (`_dbt_source_project`, `illuminate_subject`, plus a DATE
+test date for STAR) — iReady on `int_iready__diagnostic_results`, DIBELS on
+`int_amplify__all_assessments`, STAR on `stg_renlearn__star` (the consolidated
+union view; the old `int_renlearn__star_rollup` was retired in Nov 2025 and
+stays disabled — see the Task 3 PLAN CORRECTION). Then the section resolver,
+both assessment dims, and the fact each gain vendor branches mirroring the
+existing `state_nj`/`state_fl` pattern. iReady and STAR fact branches dedupe at
+PK grain (verified upstream duplicates).
 
 **Tech Stack:** dbt (BigQuery), `dbt_utils.generate_surrogate_key`,
 `dbt_utils.deduplicate`.
@@ -43,7 +47,8 @@ fact branches dedupe at PK grain (verified upstream duplicates).
   `-- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below`.
 - Hash values 'iready' / 'star' / 'dibels' (`score_source` = `source_type` =
   `assessment_type`) must be byte-identical across resolver, dims, and fact.
-- Dedupe TODOs reference the follow-up issues from Task 1 as `TODO(#NNNN)`.
+- Dedupe TODOs reference the follow-up issues filed in Task 1: `TODO(#4387)`
+  (iReady), `TODO(#4388)` (renlearn).
 - Do not run `--target prod` builds or `stage_external_sources` — not needed
   here; all touched models read existing prod/staging relations via `--defer`.
 - Trunk: verify SQL/YAML with
@@ -58,7 +63,8 @@ fact branches dedupe at PK grain (verified upstream duplicates).
 
 **Interfaces:**
 
-- Produces: two issue numbers used in `TODO(#NNNN)` comments in Task 7.
+- Produces: two issue numbers used in the `TODO(...)` comments in Task 8 (filed:
+  #4387 iReady, #4388 renlearn).
 
 - [ ] **Step 1: ASK THE USER for approval to open two issues** (repo rule: never
       open issues without asking). If declined, use `TODO:` without numbers in
@@ -166,128 +172,205 @@ Refs #3625"
 
 ---
 
-### Task 3: STAR rollup — additive columns
+### Task 3: STAR staging — additive columns
+
+**PLAN CORRECTION (supersedes the original approach):**
+`int_renlearn__star_rollup` was **deliberately disabled**
+(`config: enabled: false`) by the Nov 2025 "consolidate star calcs" refactor,
+which moved its logic into `stg_renlearn__star` and repointed all 8 STAR
+consumers there. Do **NOT** revive or edit the rollup — leave it disabled. Add
+the vendor-needed columns to `stg_renlearn__star` (the consolidated
+kipptaf-level union view, materialized as a table, contract-enforced) instead.
+This was confirmed with the user, who also chose the crosswalk (not
+`extract_code_location`) for district resolution.
 
 **Files:**
 
+- Modify: `{wt}/src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql`
 - Modify:
-  `{wt}/src/dbt/kipptaf/models/renlearn/intermediate/int_renlearn__star_rollup.sql`
-- Modify:
-  `{wt}/src/dbt/kipptaf/models/renlearn/intermediate/properties/int_renlearn__star_rollup.yml`
+  `{wt}/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml`
 
 **Interfaces:**
 
-- Produces: columns `completed_date` (DATE), `percentile_rank` (int64),
-  `assessment_id` (string), `_dbt_source_project` (string), `illuminate_subject`
-  (string) on `int_renlearn__star_rollup`. Existing columns and row set
-  unchanged. Consumed by Tasks 5–8.
+- Produces THREE new columns on `stg_renlearn__star`: `illuminate_subject`
+  (string), `completed_date_value` (date), `_dbt_source_project` (string).
+  Existing columns, row set, and window columns unchanged. Consumed by Tasks
+  5–8, which source STAR from `stg_renlearn__star` directly (not the rollup).
+- STAR column map for downstream tasks (all already on `stg_renlearn__star`
+  except the three new ones): student id = `student_display_id`; academic year =
+  `academic_year`; module/subject = `star_subject`; administration period =
+  `screening_period_window_name` (Fall/Winter/Spring); scale score =
+  `unified_score`; growth percentile = `percentile_rank`; proficiency =
+  `state_benchmark_category_name`; mastery =
+  `state_benchmark_proficient = 'Yes'`; dedupe tiebreaker = `assessment_id`;
+  test date (DATE) = new `completed_date_value`; course subject = new
+  `illuminate_subject`; district = new `_dbt_source_project`. The staging model
+  already filters `where deactivation_reason is null`, so vendor branches must
+  NOT re-filter it.
 
-- [ ] **Step 1: Replace the model SQL** with (the crosswalk join requires
-      aliasing every existing column with `s.`; window functions unchanged):
+- [ ] **Step 1: Verify blast radius is nil** — confirm no contract-enforced
+      `select *` consumer of `stg_renlearn__star` (adding columns would break
+      one). Already checked during planning: all 8 consumers enumerate columns,
+      none does `select *` off it. Re-confirm quickly:
 
-```sql
-select
-    s.student_display_id,
-    s.state_benchmark_category_level,
-    s.state_benchmark_category_name,
-    s.state_benchmark_proficient,
-    s.district_benchmark_category_level,
-    s.district_benchmark_category_name,
-    s.district_benchmark_proficient,
-    s.unified_score,
-    s.screening_period_window_name,
-    s.percentile_rank,
-    s.assessment_id,
-
-    lc.location_dagster_code_location as _dbt_source_project,
-
-    safe_cast(left(s.school_year, 4) as int) as academic_year,
-
-    safe_cast(if(s.grade = 'K', '0', s.grade) as int) as grade_level,
-
-    cast(left(s.completed_date_local, 10) as date) as completed_date,
-
-    case
-        when s.state_benchmark_proficient = 'Yes'
-        then 1
-        when s.state_benchmark_proficient = 'No'
-        then 0
-    end as is_state_benchmark_proficient_int,
-
-    case
-        when s.district_benchmark_proficient = 'Yes'
-        then 1
-        when s.district_benchmark_proficient = 'No'
-        then 0
-    end as is_district_benchmark_proficient_int,
-
-    case
-        when s._dagster_partition_subject = 'SM'
-        then 'Math'
-        when s._dagster_partition_subject = 'SR'
-        then 'Reading'
-        when s._dagster_partition_subject = 'SEL'
-        then 'Early Literacy'
-    end as star_subject,
-
-    case
-        when s._dagster_partition_subject = 'SM'
-        then 'Math'
-        when s.grade = 'K' and s._dagster_partition_subject = 'SEL'
-        then 'ELA'
-        when s._dagster_partition_subject = 'SR'
-        then 'ELA'
-    end as star_discipline,
-
-    if(
-        s._dagster_partition_subject = 'SM', 'Mathematics', 'Text Study'
-    ) as illuminate_subject,
-
-    row_number() over (
-        partition by
-            s.student_display_id,
-            s._dagster_partition_subject,
-            s.school_year,
-            s.screening_period_window_name
-        order by s.completed_date desc
-    ) as rn_subj_round,
-
-    row_number() over (
-        partition by
-            s.student_display_id,
-            s._dagster_partition_subject,
-            s.school_year,
-            s.screening_period_window_name
-        order by s.completed_date desc
-    ) as rn_subj_year,
-from {{ ref("stg_renlearn__star") }} as s
-left join
-    {{ ref("int_people__location_crosswalk") }} as lc
-    on s.school_name = lc.location_name
-where s.deactivation_reason is null
+```bash
+grep -rln "stg_renlearn__star\b" {wt}/src/dbt/kipptaf/models --include=*.sql \
+  | grep -v "staging/stg_renlearn__star.sql"
 ```
 
-Notes: `illuminate_subject` maps Reading AND Early Literacy to `Text Study` (all
-reading-family scores resolve to ELA sections — per spec). `completed_date`
-casts the LOCAL datetime string's date part (`completed_date_local`, format
-`YYYY-MM-DD HH:MM:SS.mmm`). Do NOT change the two `row_number()` definitions
-(existing consumers filter on them; ordering by the raw string
-`s.completed_date` is lexicographically correct for ISO datetimes).
+For any hit, eyeball its SELECT from `stg_renlearn__star` — if any is a bare
+`select *`, STOP and flag it (its contract yml would need the 3 columns too).
 
-- [ ] **Step 2: Add the five new columns to the properties yml** `columns:`
-      list:
+- [ ] **Step 2: Edit the model SQL.** The current model is
+      `select *, <derived...> from union_relations where deactivation_reason is null`.
+      Wrap the existing logic in a `derived` CTE (so the existing bare-column
+      derivations keep working with no join in scope), add the two row-local
+      derived columns there, then add the crosswalk join in a final SELECT.
+      Replace the entire file body with:
+
+```sql
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnj_renlearn", "stg_renlearn__star"),
+                    source("kippmiami_renlearn", "stg_renlearn__star"),
+                ]
+            )
+        }}
+    ),
+
+    -- trunk-ignore(sqlfluff/AM04)
+    derived as (
+        select
+            *,
+
+            _dagster_partition_fiscal_year - 1 as academic_year,
+
+            safe_cast(if(grade = 'K', '0', grade) as int) as grade_level,
+
+            cast(left(completed_date_local, 10) as date) as completed_date_value,
+
+            case
+                when _dagster_partition_subject = 'SM'
+                then 'Math'
+                when _dagster_partition_subject = 'SR'
+                then 'Reading'
+                when _dagster_partition_subject = 'SEL'
+                then 'Early Literacy'
+            end as star_subject,
+
+            case
+                when _dagster_partition_subject = 'SM'
+                then 'Math'
+                when grade = 'K' and _dagster_partition_subject = 'SEL'
+                then 'ELA'
+                when _dagster_partition_subject = 'SR'
+                then 'ELA'
+            end as star_discipline,
+
+            case
+                _dagster_partition_subject
+                when 'SR'
+                then 'Reading'
+                when 'SM'
+                then 'Math'
+                when 'SEL'
+                then 'Reading'
+            end as `subject`,
+
+            case
+                screening_period_window_name
+                when 'Fall'
+                then 'BOY'
+                when 'Winter'
+                then 'MOY'
+                when 'Spring'
+                then 'EOY'
+            end as administration_window,
+
+            if(
+                _dagster_partition_subject = 'SM', 'Mathematics', 'Text Study'
+            ) as illuminate_subject,
+
+            case
+                when district_benchmark_proficient = 'Yes'
+                then 1
+                when district_benchmark_proficient = 'No'
+                then 0
+            end as is_district_benchmark_proficient_int,
+
+            case
+                when state_benchmark_proficient = 'Yes'
+                then 1
+                when state_benchmark_proficient = 'No'
+                then 0
+            end as is_state_benchmark_proficient_int,
+
+            row_number() over (
+                partition by
+                    _dbt_source_relation,
+                    _dagster_partition_subject,
+                    _dagster_partition_fiscal_year,
+                    student_identifier,
+                    screening_period_window_name
+                order by completed_date desc
+            ) as rn_subject_round,
+
+            row_number() over (
+                partition by
+                    _dbt_source_relation,
+                    _dagster_partition_subject,
+                    _dagster_partition_fiscal_year,
+                    student_identifier
+                order by completed_date desc
+            ) as rn_subject_year,
+        from union_relations
+        where deactivation_reason is null
+    )
+
+select
+    d.*,
+
+    lc.location_dagster_code_location as _dbt_source_project,
+from derived as d
+left join
+    {{ ref("int_people__location_crosswalk") }} as lc
+    on d.school_name = lc.location_name
+```
+
+Notes:
+
+- This preserves every existing derived column and the existing
+  `where deactivation_reason is null` filter — the ONLY additions are
+  `completed_date_value`, `illuminate_subject`, and `_dbt_source_project`. The
+  existing `completed_date` (raw string) and the window
+  `order by completed_date desc` are unchanged (raw-string ISO ordering is
+  correct).
+- `completed_date_value` = the local calendar date, cast from
+  `completed_date_local` (`YYYY-MM-DD HH:MM:SS.mmm`).
+- `illuminate_subject` maps Math → `Mathematics`, everything else (Reading,
+  Early Literacy) → `Text Study` (reading-family resolves to ELA sections).
+- `_dbt_source_project` via `int_people__location_crosswalk` on `school_name`
+  (each crosswalk row is one alias → verify no fan-out in Step 4).
+
+- [ ] **Step 3: Add the three new columns to the properties yml** `columns:`
+      list (contract-enforced — order-independent, name+type must match):
 
 ```yaml
-- name: percentile_rank
-  data_type: int64
+- name: completed_date_value
+  data_type: date
   description: >-
-    National percentile rank for the attempt, passed through from
-    stg_renlearn__star.
-- name: assessment_id
+    Local-time completion calendar date of the attempt, cast from the
+    completed_date_local datetime string. Distinct from the raw string
+    completed_date column.
+- name: illuminate_subject
   data_type: string
   description: >-
-    Renaissance per-attempt assessment identifier, passed through from
-    stg_renlearn__star. Used downstream as a deterministic dedupe tiebreaker.
+    Course-subject mapping used by the assessment section-enrollment resolver —
+    Math partitions map to Mathematics; Reading and Early Literacy map to Text
+    Study.
 - name: _dbt_source_project
   data_type: string
   description: >-
@@ -295,31 +378,20 @@ casts the LOCAL datetime string's date part (`completed_date_local`, format
     school_name. Required because NJ districts share one Renaissance instance
     (kippnj), so the source relation cannot identify the district. NULL when the
     school name has no crosswalk alias.
-- name: completed_date
-  data_type: date
-  description: >-
-    Local-time completion date of the attempt, cast from the
-    completed_date_local datetime string.
-- name: illuminate_subject
-  data_type: string
-  description: >-
-    Course-subject mapping used by the section-enrollment resolver — Math
-    partitions map to Mathematics; Reading and Early Literacy map to Text Study.
 ```
 
-Check `assessment_id`'s actual staging type first
-(`grep -A1 'name: assessment_id' {wt}/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml`)
-and mirror it.
-
-- [ ] **Step 3: Build and verify:**
+- [ ] **Step 4: Build and verify:**
 
 ```bash
-uv run dbt build --select int_renlearn__star_rollup \
+uv run dbt build --select stg_renlearn__star \
   --project-dir {wt}/src/dbt/kipptaf --target dev \
   --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
 ```
 
-Then via BigQuery MCP:
+Expected: contract passes (the 3 new columns matched). Then via BigQuery MCP
+(find the dev schema if the name differs:
+`select schema_name from \`teamster-332318\`.INFORMATION_SCHEMA.SCHEMATA where
+schema_name like '%kipptaf_renlearn%'`):
 
 ```sql
 select
@@ -327,21 +399,29 @@ select
     illuminate_subject,
 
     count(*) as n_rows,
-    countif(completed_date is null) as n_null_date,
-    countif(percentile_rank is null) as n_null_pr,
-from `teamster-332318.zz_cbini_kipptaf_renlearn.int_renlearn__star_rollup`
+    countif(completed_date_value is null) as n_null_date,
+from `teamster-332318.zz_cbini_kipptaf_renlearn.stg_renlearn__star`
 group by 1, 2
 ```
 
-Expected: rows land under a `kipp*` project (currently Miami-only, one school);
-`n_null_date` ~8 (rows with null `completed_date_local`); row count unchanged
-from before the edit (~9,843 active rows).
+Expected: rows land under a `kipp*` project (Miami-only today, one school);
+`n_null_date` small (~8, null `completed_date_local`). **Fan-out check:** the
+total row count must equal the pre-change active-row count (~9,843) — if the
+crosswalk join multiplied rows, `school_name` matched multiple alias rows and
+you must dedupe the crosswalk side. Compare:
 
-- [ ] **Step 4: Commit:**
+```sql
+select count(*) as n_after,
+from `teamster-332318.zz_cbini_kipptaf_renlearn.stg_renlearn__star`
+```
+
+against prod `teamster-332318.kipptaf_renlearn.stg_renlearn__star` count.
+
+- [ ] **Step 5: Commit:**
 
 ```bash
-git -C {wt} add src/dbt/kipptaf/models/renlearn
-git -C {wt} commit -m "feat(renlearn): add project, subject mapping, date, percentile to star rollup
+git -C {wt} add src/dbt/kipptaf/models/renlearn/staging
+git -C {wt} commit -m "feat(renlearn): add source project, subject mapping, date to stg_renlearn__star
 
 Refs #3625"
 ```
@@ -473,14 +553,14 @@ Refs #3625"
             illuminate_subject as subject_area,
             _dbt_source_project,
 
-            completed_date as anchor_date,
+            completed_date_value as anchor_date,
 
             cast(null as int64) as canonical_assessment_id,
 
             'star' as source_type,
-        from {{ ref("int_renlearn__star_rollup") }}
+        from {{ ref("stg_renlearn__star") }}
         where
-            completed_date is not null
+            completed_date_value is not null
             and unified_score is not null
             and _dbt_source_project is not null
     ),
@@ -633,8 +713,8 @@ Refs #3625"
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
-        from {{ ref("int_renlearn__star_rollup") }}
-        where completed_date is not null and unified_score is not null
+        from {{ ref("stg_renlearn__star") }}
+        where completed_date_value is not null and unified_score is not null
     ),
 
     -- grain projection: every selected column is functionally determined
@@ -772,9 +852,9 @@ Refs #3625"
             cast(null as int64) as grade_level,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as test_type,
-        from {{ ref("int_renlearn__star_rollup") }}
+        from {{ ref("stg_renlearn__star") }}
         where
-            completed_date is not null
+            completed_date_value is not null
             and unified_score is not null
             and _dbt_source_project is not null
     ),
@@ -876,8 +956,9 @@ Refs #3625"
   `assessment_score_key`; new contract column `growth_percentile` (numeric).
 
 - [ ] **Step 1: Add vendor CTEs** after the `state_union` CTE (inside the `with`
-      block; remember to add a comma after the `state_union` closing paren).
-      Replace `#NNNN1` / `#NNNN2` with Task 1's issue numbers:
+      block; remember to add a comma after the `state_union` closing paren). The
+      TODO issue numbers below are already filled in (#4387 iReady, #4388
+      renlearn):
 
 ```sql
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
@@ -904,7 +985,7 @@ Refs #3625"
         where overall_scale_score is not null
     ),
 
-    -- TODO(#NNNN1): stg_iready__diagnostic_results has no uniqueness test;
+    -- TODO(#4387): stg_iready__diagnostic_results has no uniqueness test;
     -- same-day retests and duplicate rows exist upstream. Remove this dedupe
     -- when staging is fixed.
     iready_scores as (
@@ -932,7 +1013,7 @@ Refs #3625"
             star_subject as module_code,
             illuminate_subject,
             screening_period_window_name as administration_period,
-            completed_date as test_date,
+            completed_date_value as test_date,
             assessment_id,
             _dbt_source_project,
 
@@ -944,14 +1025,14 @@ Refs #3625"
             cast(percentile_rank as numeric) as growth_percentile,
 
             state_benchmark_proficient = 'Yes' as is_mastery,
-        from {{ ref("int_renlearn__star_rollup") }}
+        from {{ ref("stg_renlearn__star") }}
         where
-            completed_date is not null
+            completed_date_value is not null
             and unified_score is not null
             and _dbt_source_project is not null
     ),
 
-    -- TODO(#NNNN2): stg_renlearn__star holds fiscal-year re-pull duplicates
+    -- TODO(#4388): stg_renlearn__star holds fiscal-year re-pull duplicates
     -- (same assessment_id in two partitions) and same-day retests. Remove
     -- this dedupe when staging is fixed.
     star_scores as (
@@ -1210,7 +1291,7 @@ Closes #3625"
 ```bash
 git -C {wt} fetch origin main && git -C {wt} merge origin/main
 uv run dbt build \
-  --select int_iready__diagnostic_results int_renlearn__star_rollup \
+  --select int_iready__diagnostic_results stg_renlearn__star \
     int_amplify__all_assessments int_assessments__resolved_section_enrollments \
     dim_assessments dim_assessment_administrations \
     fct_assessment_scores_enrollment_scoped \
@@ -1226,13 +1307,16 @@ caveat).
       guards against an accidental non-additive edit):
 
 ```bash
-uv run dbt ls --select int_renlearn__star_rollup+1 int_iready__diagnostic_results+1 \
+uv run dbt ls --select stg_renlearn__star+1 int_iready__diagnostic_results+1 \
     int_amplify__all_assessments+1 --project-dir {wt}/src/dbt/kipptaf --target dev
-uv run dbt compile --select int_renlearn__star_rollup+1 int_iready__diagnostic_results+1 \
+uv run dbt compile --select stg_renlearn__star+1 int_iready__diagnostic_results+1 \
     int_amplify__all_assessments+1 \
   --project-dir {wt}/src/dbt/kipptaf --target dev \
   --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
 ```
+
+Note: `stg_renlearn__star+1` includes its 8 existing consumers — a build/compile
+guard confirming the additive columns didn't break any enumerating consumer.
 
 Expected: compile green (additive columns cannot break enumerating consumers;
 this guards against accidental non-additive edits).
@@ -1242,7 +1326,7 @@ this guards against accidental non-additive edits).
 ```bash
 cd {wt} && /workspaces/teamster/.trunk/tools/trunk check --no-fix \
   src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql \
-  src/dbt/kipptaf/models/renlearn/intermediate/int_renlearn__star_rollup.sql \
+  src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql \
   src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql \
   src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql \
   src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql \

--- a/docs/superpowers/plans/2026-07-13-vendor-assessments-enrollment-scoped-fact.md
+++ b/docs/superpowers/plans/2026-07-13-vendor-assessments-enrollment-scoped-fact.md
@@ -1,0 +1,1281 @@
+# Vendor Assessments in Enrollment-Scoped Fact — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking. Every implementer MUST first invoke
+> the `Skill` tool with skill `dbt:using-dbt-for-analytics-engineering` before
+> touching any dbt file.
+
+**Goal:** Add iReady, STAR/Renaissance, and DIBELS/Amplify scores to
+`fct_assessment_scores_enrollment_scoped` (issue
+[#3625](https://github.com/TEAMSchools/teamster/issues/3625)), per the approved
+spec
+`docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md`.
+
+**Architecture:** Inline branches (spec Approach A). Each vendor intermediate
+gains two additive columns (`_dbt_source_project`, `illuminate_subject`); then
+the section resolver, both assessment dims, and the fact each gain vendor
+branches mirroring the existing `state_nj`/`state_fl` pattern. iReady and STAR
+fact branches dedupe at PK grain (verified upstream duplicates).
+
+**Tech Stack:** dbt (BigQuery), `dbt_utils.generate_surrogate_key`,
+`dbt_utils.deduplicate`.
+
+## Global Constraints
+
+- Worktree:
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-fct-assessment-scores-vendor-sources`
+  (call it `{wt}` below — substitute the full path; use lowercase shell vars).
+  ALL file edits target `{wt}/...` paths, never the main checkout.
+- Git: `git -C {wt} ...` on every git command. Conventional commits.
+- dbt runs:
+  `uv run dbt <cmd> --project-dir {wt}/src/dbt/kipptaf --target dev --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod`
+  (absolute `--state`; run `uv run dbt deps --project-dir {wt}/src/dbt/kipptaf`
+  once first).
+- SQL conventions (sqlfluff/CI-enforced; see `src/dbt/CLAUDE.md`): trailing
+  commas; no `ORDER BY`/`QUALIFY`/`GROUP BY ALL`; max 1 level of function
+  nesting; ST06 column order (plain refs by table, then constants, simple
+  functions, nested functions, logicals, case, window); reserved words
+  backticked (`` `period` ``); generic tests need `arguments:` nesting.
+- `dbt_utils.deduplicate` `order_by` on BigQuery: `desc` OK, no
+  `asc nulls last`. Input CTE referenced only by `deduplicate` needs
+  `-- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below`.
+- Hash values 'iready' / 'star' / 'dibels' (`score_source` = `source_type` =
+  `assessment_type`) must be byte-identical across resolver, dims, and fact.
+- Dedupe TODOs reference the follow-up issues from Task 1 as `TODO(#NNNN)`.
+- Do not run `--target prod` builds or `stage_external_sources` — not needed
+  here; all touched models read existing prod/staging relations via `--defer`.
+- Trunk: verify SQL/YAML with
+  `cd {wt} && /workspaces/teamster/.trunk/tools/trunk check --no-fix <files> </dev/null`
+  before push (pre-commit hook only formats).
+
+---
+
+### Task 1: File follow-up issues for upstream duplicates
+
+**Files:** none (GitHub only).
+
+**Interfaces:**
+
+- Produces: two issue numbers used in `TODO(#NNNN)` comments in Task 7.
+
+- [ ] **Step 1: ASK THE USER for approval to open two issues** (repo rule: never
+      open issues without asking). If declined, use `TODO:` without numbers in
+      Task 7 and skip this task.
+
+- [ ] **Step 2: Open the issues** via `mcp__github__issue_write` (owner
+      `TEAMSchools`, repo `teamster`), labels `bug`, `dbt` plus source label:
+
+  1. Title:
+     `fix(iready): stg_iready__diagnostic_results lacks uniqueness test; duplicate and same-day retest rows`
+     — body: at grain (project, student, year, round, subject, day) there are
+     3,835 duplicate groups (max 16 rows); ~1,300 groups are byte-identical
+     rows; staging yml has only a `not_null` on `student_id`. Downstream,
+     `fct_assessment_scores_enrollment_scoped` dedupes defensively — remove that
+     dedupe when fixed. Refs #3625.
+  2. Title:
+     `fix(renlearn): stg_renlearn__star fiscal-year partition overlap duplicates assessment_id rows`
+     — body: ~2,296 `assessment_id`s appear in two
+     `_dagster_partition_fiscal_year` partitions with identical data columns;
+     plus no uniqueness test. Downstream fact dedupes defensively — remove when
+     fixed. Refs #3625.
+
+- [ ] **Step 3: Record the two issue numbers** for Task 7's TODO comments.
+
+---
+
+### Task 2: iReady intermediate — additive columns
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql`
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__diagnostic_results.yml`
+
+**Interfaces:**
+
+- Produces: columns `_dbt_source_project` (string; values `kippnewark`,
+  `kippcamden`, `kippmiami`, ...) and `illuminate_subject` (string; `Text Study`
+  | `Mathematics`) on `int_iready__diagnostic_results`. Consumed by Tasks 5–8.
+
+- [ ] **Step 1: Add the two columns to the final SELECT.** In the final select
+      (starts `select wc.*,`), after the line
+      `right(rt.code, 1) as round_number,` insert:
+
+```sql
+    {{ extract_code_location("wc") }} as _dbt_source_project,
+```
+
+and immediately after the `end as iready_proficiency,` case block insert:
+
+```sql
+    case
+        wc.subject when 'Reading' then 'Text Study' when 'Math' then 'Mathematics'
+    end as illuminate_subject,
+```
+
+- [ ] **Step 2: Add both columns to the properties yml** `columns:` list (they
+      are documentation entries; this model has no enforced contract):
+
+```yaml
+- name: _dbt_source_project
+  data_type: string
+  description: >-
+    Dagster code location (kippnewark, kippcamden, kippmiami, ...) extracted
+    from the crosswalk-rewritten _dbt_source_relation. Promoted here per the
+    marts _dbt_source_project pattern so consumers join and hash a materialized
+    column.
+- name: illuminate_subject
+  data_type: string
+  description: >-
+    Course-subject mapping used by the section-enrollment resolver — Reading
+    maps to Text Study, Math to Mathematics. Matches the illuminate_subject
+    convention in int_pearson__all_assessments and int_fldoe__all_assessments.
+```
+
+- [ ] **Step 3: Build and verify:**
+
+```bash
+uv run dbt build --select int_iready__diagnostic_results \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: model builds green. Then via BigQuery MCP:
+
+```sql
+select _dbt_source_project, illuminate_subject, count(*) as n_rows,
+from `teamster-332318.zz_cbini_kipptaf_iready.int_iready__diagnostic_results`
+group by 1, 2
+```
+
+Expected: only (`kipp*`, `Text Study`/`Mathematics`) combos, no NULL
+`illuminate_subject`; NULL `_dbt_source_project` only where the crosswalk missed
+(should be ~0).
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/iready
+git -C {wt} commit -m "feat(iready): add _dbt_source_project and illuminate_subject to diagnostic results
+
+Refs #3625"
+```
+
+---
+
+### Task 3: STAR rollup — additive columns
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/renlearn/intermediate/int_renlearn__star_rollup.sql`
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/renlearn/intermediate/properties/int_renlearn__star_rollup.yml`
+
+**Interfaces:**
+
+- Produces: columns `completed_date` (DATE), `percentile_rank` (int64),
+  `assessment_id` (string), `_dbt_source_project` (string), `illuminate_subject`
+  (string) on `int_renlearn__star_rollup`. Existing columns and row set
+  unchanged. Consumed by Tasks 5–8.
+
+- [ ] **Step 1: Replace the model SQL** with (the crosswalk join requires
+      aliasing every existing column with `s.`; window functions unchanged):
+
+```sql
+select
+    s.student_display_id,
+    s.state_benchmark_category_level,
+    s.state_benchmark_category_name,
+    s.state_benchmark_proficient,
+    s.district_benchmark_category_level,
+    s.district_benchmark_category_name,
+    s.district_benchmark_proficient,
+    s.unified_score,
+    s.screening_period_window_name,
+    s.percentile_rank,
+    s.assessment_id,
+
+    lc.location_dagster_code_location as _dbt_source_project,
+
+    safe_cast(left(s.school_year, 4) as int) as academic_year,
+
+    safe_cast(if(s.grade = 'K', '0', s.grade) as int) as grade_level,
+
+    cast(left(s.completed_date_local, 10) as date) as completed_date,
+
+    case
+        when s.state_benchmark_proficient = 'Yes'
+        then 1
+        when s.state_benchmark_proficient = 'No'
+        then 0
+    end as is_state_benchmark_proficient_int,
+
+    case
+        when s.district_benchmark_proficient = 'Yes'
+        then 1
+        when s.district_benchmark_proficient = 'No'
+        then 0
+    end as is_district_benchmark_proficient_int,
+
+    case
+        when s._dagster_partition_subject = 'SM'
+        then 'Math'
+        when s._dagster_partition_subject = 'SR'
+        then 'Reading'
+        when s._dagster_partition_subject = 'SEL'
+        then 'Early Literacy'
+    end as star_subject,
+
+    case
+        when s._dagster_partition_subject = 'SM'
+        then 'Math'
+        when s.grade = 'K' and s._dagster_partition_subject = 'SEL'
+        then 'ELA'
+        when s._dagster_partition_subject = 'SR'
+        then 'ELA'
+    end as star_discipline,
+
+    if(
+        s._dagster_partition_subject = 'SM', 'Mathematics', 'Text Study'
+    ) as illuminate_subject,
+
+    row_number() over (
+        partition by
+            s.student_display_id,
+            s._dagster_partition_subject,
+            s.school_year,
+            s.screening_period_window_name
+        order by s.completed_date desc
+    ) as rn_subj_round,
+
+    row_number() over (
+        partition by
+            s.student_display_id,
+            s._dagster_partition_subject,
+            s.school_year,
+            s.screening_period_window_name
+        order by s.completed_date desc
+    ) as rn_subj_year,
+from {{ ref("stg_renlearn__star") }} as s
+left join
+    {{ ref("int_people__location_crosswalk") }} as lc
+    on s.school_name = lc.location_name
+where s.deactivation_reason is null
+```
+
+Notes: `illuminate_subject` maps Reading AND Early Literacy to `Text Study` (all
+reading-family scores resolve to ELA sections — per spec). `completed_date`
+casts the LOCAL datetime string's date part (`completed_date_local`, format
+`YYYY-MM-DD HH:MM:SS.mmm`). Do NOT change the two `row_number()` definitions
+(existing consumers filter on them; ordering by the raw string
+`s.completed_date` is lexicographically correct for ISO datetimes).
+
+- [ ] **Step 2: Add the five new columns to the properties yml** `columns:`
+      list:
+
+```yaml
+- name: percentile_rank
+  data_type: int64
+  description: >-
+    National percentile rank for the attempt, passed through from
+    stg_renlearn__star.
+- name: assessment_id
+  data_type: string
+  description: >-
+    Renaissance per-attempt assessment identifier, passed through from
+    stg_renlearn__star. Used downstream as a deterministic dedupe tiebreaker.
+- name: _dbt_source_project
+  data_type: string
+  description: >-
+    Dagster code location resolved via int_people__location_crosswalk on
+    school_name. Required because NJ districts share one Renaissance instance
+    (kippnj), so the source relation cannot identify the district. NULL when the
+    school name has no crosswalk alias.
+- name: completed_date
+  data_type: date
+  description: >-
+    Local-time completion date of the attempt, cast from the
+    completed_date_local datetime string.
+- name: illuminate_subject
+  data_type: string
+  description: >-
+    Course-subject mapping used by the section-enrollment resolver — Math
+    partitions map to Mathematics; Reading and Early Literacy map to Text Study.
+```
+
+Check `assessment_id`'s actual staging type first
+(`grep -A1 'name: assessment_id' {wt}/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml`)
+and mirror it.
+
+- [ ] **Step 3: Build and verify:**
+
+```bash
+uv run dbt build --select int_renlearn__star_rollup \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Then via BigQuery MCP:
+
+```sql
+select
+    _dbt_source_project,
+    illuminate_subject,
+
+    count(*) as n_rows,
+    countif(completed_date is null) as n_null_date,
+    countif(percentile_rank is null) as n_null_pr,
+from `teamster-332318.zz_cbini_kipptaf_renlearn.int_renlearn__star_rollup`
+group by 1, 2
+```
+
+Expected: rows land under a `kipp*` project (currently Miami-only, one school);
+`n_null_date` ~8 (rows with null `completed_date_local`); row count unchanged
+from before the edit (~9,843 active rows).
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/renlearn
+git -C {wt} commit -m "feat(renlearn): add project, subject mapping, date, percentile to star rollup
+
+Refs #3625"
+```
+
+---
+
+### Task 4: Amplify intermediate — additive columns
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql`
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/amplify/intermediate/properties/int_amplify__all_assessments.yml`
+
+**Interfaces:**
+
+- Produces: columns `_dbt_source_project` (string,
+  `concat('kipp', lower(region))`) and `illuminate_subject` (string, constant
+  `Text Study`) on `int_amplify__all_assessments`. Consumed by Tasks 5–8.
+
+- [ ] **Step 1: Add two columns to BOTH final union branches** (the model ends
+      in two `select ... from max_score as s left join probe_eligible_tag as p`
+      branches — Benchmark and PM). In EACH branch, immediately after the line
+      `p.eoy as eoy_composite,` insert (identical position in both branches —
+      UNION ALL aligns positionally):
+
+```sql
+    'Text Study' as illuminate_subject,
+
+    concat('kipp', lower(s.region)) as _dbt_source_project,
+```
+
+- [ ] **Step 2: Add both columns to the properties yml** `columns:` list:
+
+```yaml
+- name: illuminate_subject
+  data_type: string
+  description: >-
+    Course-subject mapping used by the section-enrollment resolver. All DIBELS
+    measures are reading-family, so this is constant Text Study.
+- name: _dbt_source_project
+  data_type: string
+  description: >-
+    Dagster code location derived from the region name (kipp + lowercased
+    region). Promoted here per the marts _dbt_source_project pattern so
+    consumers join and hash a materialized column.
+```
+
+- [ ] **Step 3: Build and verify:**
+
+```bash
+uv run dbt build --select int_amplify__all_assessments \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Then via BigQuery MCP:
+
+```sql
+select _dbt_source_project, count(*) as n_rows,
+from `teamster-332318.zz_cbini_kipptaf_amplify.int_amplify__all_assessments`
+group by 1
+```
+
+Expected: exactly `kippnewark`, `kippcamden`, `kippmiami`, `kipppaterson`.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/amplify
+git -C {wt} commit -m "feat(amplify): add _dbt_source_project and illuminate_subject to all_assessments
+
+Refs #3625"
+```
+
+---
+
+### Task 5: Resolver — vendor score branches
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql`
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml`
+
+**Interfaces:**
+
+- Consumes: Task 2–4 columns (`_dbt_source_project`, `illuminate_subject`).
+- Produces: resolver rows with `source_type` in (`iready`, `star`, `dibels`),
+  resolving on `subject_area` = the vendor `illuminate_subject`,
+  `administration_period` = vendor window, `academic_year` = vendor year. Task
+  8's fact joins these on
+  `(powerschool_student_number, academic_year, administration_period, subject_area, _dbt_source_project, source_type)`.
+
+- [ ] **Step 1: Add three score CTEs** after the `state_fl_scores` CTE (before
+      the `scores` CTE):
+
+```sql
+    -- iReady diagnostics. test_round is the reporting-terms IR window (BOY /
+    -- MOY / EOY / Outside Round); illuminate_subject maps Reading -> Text
+    -- Study, Math -> Mathematics upstream.
+    iready_scores as (
+        select
+            student_id as powerschool_student_number,
+            academic_year_int as academic_year,
+            test_round as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            completion_date as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'iready' as source_type,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where completion_date is not null and overall_scale_score is not null
+    ),
+
+    -- STAR attempts. screening_period_window_name is the vendor window (Fall /
+    -- Winter / Spring); rows without a crosswalk-resolved project cannot join
+    -- course enrollments and are dropped (out of scope).
+    star_scores as (
+        select
+            student_display_id as powerschool_student_number,
+            academic_year,
+            screening_period_window_name as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            completed_date as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'star' as source_type,
+        from {{ ref("int_renlearn__star_rollup") }}
+        where
+            completed_date is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- DIBELS benchmark composites. One row per student x benchmark window
+    -- (BOY / MOY / EOY); PM probes and subskill measures are out of scope.
+    dibels_scores as (
+        select
+            student_number as powerschool_student_number,
+            academic_year,
+            `period` as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            client_date as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'dibels' as source_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where
+            assessment_type = 'Benchmark'
+            and measure_standard = 'Composite'
+            and client_date is not null
+    ),
+```
+
+- [ ] **Step 2: Union them into the `scores` CTE** — append three
+      `union all select <same 8 columns> from <cte>` blocks matching the
+      existing three, e.g.:
+
+```sql
+        union all
+
+        select
+            powerschool_student_number,
+            canonical_assessment_id,
+            academic_year,
+            administration_period,
+            subject_area,
+            _dbt_source_project,
+            anchor_date,
+            source_type,
+        from iready_scores
+```
+
+(repeat for `star_scores` and `dibels_scores`).
+
+- [ ] **Step 3: Update the properties yml**: extend the `source_type`
+      `accepted_values` to
+      `values: [internal, state_nj, state_fl, iready, star, dibels]`, extend the
+      `source_type` column description with the three new values, and extend the
+      model `description` to mention the vendor sources.
+
+- [ ] **Step 4: Build and verify:**
+
+```bash
+uv run dbt build --select int_assessments__resolved_section_enrollments \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Then via BigQuery MCP — resolver hit-rate per new source:
+
+```sql
+select source_type, resolution_type, count(*) as n_rows,
+from `teamster-332318.zz_cbini_kipptaf_assessments.int_assessments__resolved_section_enrollments`
+where source_type in ('iready', 'star', 'dibels')
+group by 1, 2
+```
+
+Expected: non-zero rows for all three source types; DIBELS mostly
+`homeroom`-resolved (K–2). If a source returns 0 rows, STOP — the subject
+mapping or join keys are wrong; do not proceed to Task 8.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/assessments
+git -C {wt} commit -m "feat(dbt): resolve section enrollments for iready, star, dibels scores
+
+Refs #3625"
+```
+
+---
+
+### Task 6: `dim_assessments` — vendor branches
+
+**Files:**
+
+- Modify: `{wt}/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql`
+
+**Interfaces:**
+
+- Produces: dim rows with `assessment_key` =
+  `generate_surrogate_key([assessment_type, module_code, source_assessment_id, test_type])`
+  for the vendor values below. Task 7/8 hash the same inputs. Vendor values:
+  (`iready`, module `subject`), (`star`, module `star_subject`), (`dibels`,
+  module `measure_standard` = `Composite`);
+  `source_assessment_id`/`test_type`/`module_type`/`grade_level` NULL,
+  `is_internal_assessment` false, `assessment_scope` `'enrollment'`.
+
+- [ ] **Step 1: Add three CTEs** after `state_fl_science` (before
+      `college_assessments`):
+
+```sql
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    iready_assessments as (
+        select distinct
+            subject as subject_area,
+            subject as module_code,
+
+            'iready' as assessment_type,
+            'i-Ready Diagnostic' as title,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            if(subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    star_assessments as (
+        select distinct
+            star_subject as subject_area,
+            star_subject as module_code,
+
+            'star' as assessment_type,
+            'STAR' as title,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            if(star_subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("int_renlearn__star_rollup") }}
+        where completed_date is not null and unified_score is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    dibels_assessments as (
+        select distinct
+            measure_standard as module_code,
+
+            'Reading' as subject_area,
+            'dibels' as assessment_type,
+            'DIBELS' as title,
+            'ELA' as scope,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+```
+
+- [ ] **Step 2: Add three union entries** in `all_assessments_unioned` (after
+      the `state_fl_science` entry):
+
+```sql
+        union all
+        select {{ union_cols }},
+        from iready_assessments
+        union all
+        select {{ union_cols }},
+        from star_assessments
+        union all
+        select {{ union_cols }},
+        from dibels_assessments
+```
+
+- [ ] **Step 3: Build and verify:**
+
+```bash
+uv run dbt build --select dim_assessments \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: build + `unique` test on `assessment_key` green. Then:
+
+```sql
+select `type`, module_code, title, academic_subject,
+from `teamster-332318.zz_cbini_kipptaf_marts.dim_assessments`
+where `type` in ('iready', 'star', 'dibels')
+```
+
+Expected: 2 iready rows (Reading, Math), 3 star rows (Reading, Math, Early
+Literacy), 1 dibels row (Composite).
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+git -C {wt} commit -m "feat(dbt): add iready, star, dibels to dim_assessments
+
+Refs #3625"
+```
+
+---
+
+### Task 7: `dim_assessment_administrations` — vendor branches
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql`
+
+**Interfaces:**
+
+- Produces: dim rows with `assessment_administration_key` =
+  `generate_surrogate_key([assessment_type, module_code, administered_date, academic_year, _dbt_source_project, administration_period, source_assessment_id, test_type])`
+  where `administered_date` / `source_assessment_id` / `test_type` are NULL for
+  vendor rows. Task 8 hashes the same inputs (`null` literals for the NULL
+  slots).
+
+- [ ] **Step 1: Add three CTEs** after `state_fl_science_administrations`
+      (before `college_administrations`):
+
+```sql
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- iReady: one administration per (subject, test_round, academic_year,
+    -- _dbt_source_project).
+    iready_administrations as (
+        select distinct
+            subject as subject_area,
+            subject as module_code,
+            academic_year_int as academic_year,
+            test_round as administration_period,
+            _dbt_source_project,
+
+            'iready' as assessment_type,
+            'i-Ready Diagnostic' as title,
+
+            if(subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null and _dbt_source_project is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- STAR: one administration per (star_subject, screening window,
+    -- academic_year, _dbt_source_project).
+    star_administrations as (
+        select distinct
+            star_subject as subject_area,
+            star_subject as module_code,
+            academic_year,
+            screening_period_window_name as administration_period,
+            _dbt_source_project,
+
+            'star' as assessment_type,
+            'STAR' as title,
+
+            if(star_subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+        from {{ ref("int_renlearn__star_rollup") }}
+        where
+            completed_date is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- DIBELS: one administration per (benchmark window, academic_year,
+    -- _dbt_source_project); module_code is the Composite measure.
+    dibels_administrations as (
+        select distinct
+            measure_standard as module_code,
+            academic_year,
+            `period` as administration_period,
+            _dbt_source_project,
+
+            'Reading' as subject_area,
+            'dibels' as assessment_type,
+            'DIBELS' as title,
+            'ELA' as scope,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+```
+
+Note the inner `where assessment_type = 'Benchmark'` filters the SOURCE column
+`int_amplify__all_assessments.assessment_type` (Benchmark vs PM) — a different
+thing from the `'dibels' as assessment_type` output constant.
+
+- [ ] **Step 2: Add three union entries** in `all_administrations` (after the
+      `state_fl_science_administrations` entry), matching the existing pattern:
+
+```sql
+        union all
+        select {{ union_cols }},
+        from iready_administrations
+        union all
+        select {{ union_cols }},
+        from star_administrations
+        union all
+        select {{ union_cols }},
+        from dibels_administrations
+```
+
+- [ ] **Step 3: Build and verify:**
+
+```bash
+uv run dbt build --select dim_assessment_administrations \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: build + PK `unique` test green (vendor rows cannot collide with
+existing rows — `assessment_type` is in the hash). Then sanity — the dim doesn't
+expose `assessment_type`, so count new rows as the delta vs prod:
+
+```sql
+select administration_period, count(*) as n_rows,
+from `teamster-332318.zz_cbini_kipptaf_marts.dim_assessment_administrations`
+where
+    administration_period
+    in ('BOY', 'MOY', 'EOY', 'Fall', 'Winter', 'Spring', 'Outside Round')
+group by 1
+```
+
+Expected: non-zero counts for the vendor windows (BOY/MOY/EOY also appear for
+existing sources — compare against the same query on
+`kipptaf_marts.dim_assessment_administrations` to confirm growth).
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+git -C {wt} commit -m "feat(dbt): add iready, star, dibels to dim_assessment_administrations
+
+Refs #3625"
+```
+
+---
+
+### Task 8: Fact — vendor branches + `growth_percentile`
+
+**Files:**
+
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql`
+- Modify:
+  `{wt}/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml`
+
+**Interfaces:**
+
+- Consumes: resolver `source_type` values and join keys (Task 5); dim hash
+  compositions (Tasks 6–7); issue numbers from Task 1 for TODOs.
+- Produces: fact rows with `score_source` values hashed into
+  `assessment_score_key`; new contract column `growth_percentile` (numeric).
+
+- [ ] **Step 1: Add vendor CTEs** after the `state_union` CTE (inside the `with`
+      block; remember to add a comma after the `state_union` closing paren).
+      Replace `#NNNN1` / `#NNNN2` with Task 1's issue numbers:
+
+```sql
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    iready_scores_raw as (
+        select
+            student_id as student_number,
+            academic_year_int as academic_year,
+            subject as module_code,
+            illuminate_subject,
+            test_round as administration_period,
+            completion_date as test_date,
+            `start_date`,
+            _dbt_source_project,
+
+            overall_relative_placement as proficiency_level,
+
+            'iready' as score_source,
+
+            cast(overall_scale_score as numeric) as scale_score,
+            cast(percentile as numeric) as growth_percentile,
+
+            overall_relative_placement_int >= 4 as is_mastery,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null
+    ),
+
+    -- TODO(#NNNN1): stg_iready__diagnostic_results has no uniqueness test;
+    -- same-day retests and duplicate rows exist upstream. Remove this dedupe
+    -- when staging is fixed.
+    iready_scores as (
+        {{
+            dbt_utils.deduplicate(
+                relation="iready_scores_raw",
+                partition_by="""
+                    _dbt_source_project,
+                    student_number,
+                    academic_year,
+                    administration_period,
+                    module_code,
+                    test_date
+                """,
+                order_by="start_date desc, scale_score desc",
+            )
+        }}
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    star_scores_raw as (
+        select
+            student_display_id as student_number,
+            academic_year,
+            star_subject as module_code,
+            illuminate_subject,
+            screening_period_window_name as administration_period,
+            completed_date as test_date,
+            assessment_id,
+            _dbt_source_project,
+
+            state_benchmark_category_name as proficiency_level,
+
+            'star' as score_source,
+
+            cast(unified_score as numeric) as scale_score,
+            cast(percentile_rank as numeric) as growth_percentile,
+
+            state_benchmark_proficient = 'Yes' as is_mastery,
+        from {{ ref("int_renlearn__star_rollup") }}
+        where
+            completed_date is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- TODO(#NNNN2): stg_renlearn__star holds fiscal-year re-pull duplicates
+    -- (same assessment_id in two partitions) and same-day retests. Remove
+    -- this dedupe when staging is fixed.
+    star_scores as (
+        {{
+            dbt_utils.deduplicate(
+                relation="star_scores_raw",
+                partition_by="""
+                    _dbt_source_project,
+                    student_number,
+                    academic_year,
+                    administration_period,
+                    module_code,
+                    test_date
+                """,
+                order_by="scale_score desc, assessment_id desc",
+            )
+        }}
+    ),
+
+    -- DIBELS benchmark composites are unique at this grain upstream
+    -- (verified); no dedupe needed.
+    dibels_scores as (
+        select
+            student_number,
+            academic_year,
+            measure_standard as module_code,
+            illuminate_subject,
+            `period` as administration_period,
+            client_date as test_date,
+            _dbt_source_project,
+
+            measure_standard_level as proficiency_level,
+
+            'dibels' as score_source,
+
+            cast(measure_standard_score as numeric) as scale_score,
+            cast(measure_percentile as numeric) as growth_percentile,
+
+            measure_standard_level_int >= 3 as is_mastery,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+
+    vendor_all as (
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from iready_scores
+
+        union all
+
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from star_scores
+
+        union all
+
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from dibels_scores
+    )
+```
+
+(The `deduplicate` output CTEs carry the raw CTEs' full column list, so the
+`vendor_all` enumerations resolve. `iready_scores` retains `start_date` and
+`star_scores` retains `assessment_id` — they are dropped by `vendor_all`'s
+explicit column list.)
+
+- [ ] **Step 2: Add `growth_percentile` to both existing final branches.** In
+      the internal branch, after `ia.percent_correct,` insert:
+
+```sql
+    cast(null as numeric) as growth_percentile,
+```
+
+In the state branch, after `su.percent_correct,` insert the same line. (Position
+matters — UNION ALL aligns by position; it must sit between `percent_correct`
+and `proficiency_level` in every branch.)
+
+- [ ] **Step 3: Append the vendor final branch** at the end of the model:
+
+```sql
+union all
+
+/* vendor assessments (iReady, STAR, DIBELS) */
+select
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "va.score_source",
+                "va._dbt_source_project",
+                "va.student_number",
+                "va.academic_year",
+                "va.administration_period",
+                "va.module_code",
+                "va.test_date",
+            ]
+        )
+    }} as assessment_score_key,
+
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "va.score_source",
+                "va.module_code",
+                "null",
+                "va.academic_year",
+                "va._dbt_source_project",
+                "va.administration_period",
+                "null",
+                "null",
+            ]
+        )
+    }} as assessment_administration_key,
+
+    sr.student_section_enrollment_key,
+
+    va.test_date as test_date_key,
+
+    va.scale_score,
+
+    cast(null as numeric) as percent_correct,
+
+    va.growth_percentile,
+    va.proficiency_level,
+    va.is_mastery,
+
+    cast(null as string) as response_type,
+    cast(null as string) as response_type_code,
+    cast(null as string) as response_type_description,
+    cast(null as string) as response_type_root_description,
+    cast(null as bool) as is_replacement,
+    cast(null as numeric) as performance_band_label_number,
+
+    sr.resolution_type as enrollment_resolution,
+from vendor_all as va
+-- the resolver keys vendor scores on illuminate_subject (the vendor->course
+-- subject mapping), not the raw vendor subject the assessment_score_key
+-- hashes. INNER scopes the fact to vendor scores with a resolved section.
+inner join
+    {{ ref("int_assessments__resolved_section_enrollments") }} as sr
+    on va.student_number = sr.powerschool_student_number
+    and va.academic_year = sr.academic_year
+    and va.administration_period = sr.administration_period
+    and va.illuminate_subject = sr.subject_area
+    and va._dbt_source_project = sr._dbt_source_project
+    and va.score_source = sr.source_type
+```
+
+Positional check against the other branches' SELECT lists: keys, enrollment key,
+`test_date_key`, `scale_score`, `percent_correct`, `growth_percentile`,
+`proficiency_level`, `is_mastery`, five response NULLs +
+`performance_band_label_number`, `enrollment_resolution` — must match the column
+ORDER of the internal branch after Step 2.
+
+- [ ] **Step 4: Update the properties yml:**
+  - Model `description`: replace "Covers internal Illuminate assessments and
+    state assessments (NJSLA, NJGPA, FAST)." with "Covers internal Illuminate
+    assessments, state assessments (NJSLA, NJGPA, FAST), and vendor benchmark
+    assessments (i-Ready Diagnostic, STAR, DIBELS Composite)."
+  - Add after the `percent_correct` column entry:
+
+```yaml
+- name: growth_percentile
+  data_type: numeric
+  description: >-
+    National percentile for the attempt where the vendor provides one (i-Ready
+    percentile, STAR percentile rank, DIBELS measure percentile). Null for
+    internal and state assessments.
+```
+
+- [ ] **Step 5: Build and verify:**
+
+```bash
+uv run dbt build --select fct_assessment_scores_enrollment_scoped \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: contract passes; PK `unique` + `not_null` tests green.
+Relationship-test caveat: warnings against `dim_student_section_enrollments` or
+the dims may be stale-dev-defer false positives (see `src/dbt/CLAUDE.md` "Stale
+dev tables shadow --defer") — if any fire, rebuild the parent dims into dev
+(`--select dim_assessments dim_assessment_administrations`) or verify orphans
+against prod before treating as real.
+
+- [ ] **Step 6: Validate FK population and per-source counts** via BigQuery MCP
+      (reproducing the score_source from the hash is unnecessary — recompute
+      per-source expected counts from the resolver side):
+
+```sql
+select
+    countif(assessment_administration_key is null) as n_null_admin_fk,
+    countif(student_section_enrollment_key is null) as n_null_enroll_fk,
+    countif(growth_percentile is not null) as n_growth_pop,
+
+    count(*) as n_rows,
+from `teamster-332318.zz_cbini_kipptaf_marts.fct_assessment_scores_enrollment_scoped`
+```
+
+Expected: 0 null FKs; `n_growth_pop` > 0; `n_rows` grew vs prod
+(`select count(*) from kipptaf_marts.fct_assessment_scores_enrollment_scoped`)
+by roughly the resolver-matched vendor volume (order of magnitude: iReady 100k+,
+DIBELS tens of thousands, STAR thousands).
+
+- [ ] **Step 7: Commit:**
+
+```bash
+git -C {wt} add src/dbt/kipptaf/models/marts/facts
+git -C {wt} commit -m "feat(dbt): add iready, star, dibels to fct_assessment_scores_enrollment_scoped
+
+Closes #3625"
+```
+
+---
+
+### Task 9: Full-graph validation, trunk, push, PR
+
+**Files:** none new.
+
+- [ ] **Step 1: Merge main and full build** of all touched models plus immediate
+      children:
+
+```bash
+git -C {wt} fetch origin main && git -C {wt} merge origin/main
+uv run dbt build \
+  --select int_iready__diagnostic_results int_renlearn__star_rollup \
+    int_amplify__all_assessments int_assessments__resolved_section_enrollments \
+    dim_assessments dim_assessment_administrations \
+    fct_assessment_scores_enrollment_scoped \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: all green (warn-severity orphan warnings evaluated per Task 8 Step 5
+caveat).
+
+- [ ] **Step 2: Verify existing downstream consumers of the edited intermediates
+      still compile** (additive columns can't break enumerating consumers; this
+      guards against an accidental non-additive edit):
+
+```bash
+uv run dbt ls --select int_renlearn__star_rollup+1 int_iready__diagnostic_results+1 \
+    int_amplify__all_assessments+1 --project-dir {wt}/src/dbt/kipptaf --target dev
+uv run dbt compile --select int_renlearn__star_rollup+1 int_iready__diagnostic_results+1 \
+    int_amplify__all_assessments+1 \
+  --project-dir {wt}/src/dbt/kipptaf --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: compile green (additive columns cannot break enumerating consumers;
+this guards against accidental non-additive edits).
+
+- [ ] **Step 3: Trunk check all touched files:**
+
+```bash
+cd {wt} && /workspaces/teamster/.trunk/tools/trunk check --no-fix \
+  src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql \
+  src/dbt/kipptaf/models/renlearn/intermediate/int_renlearn__star_rollup.sql \
+  src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql \
+  src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql \
+  src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql \
+  src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql \
+  src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql \
+  docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md \
+  docs/superpowers/plans/2026-07-13-vendor-assessments-enrollment-scoped-fact.md \
+  </dev/null
+```
+
+Also check the edited `.yml` properties files. Expected: no issues (fix any
+sqlfluff findings before push).
+
+- [ ] **Step 4: Push and open the PR** (confirm with the user before pushing if
+      anything looks off):
+
+```bash
+git -C {wt} push -u origin cbini/feat/claude-fct-assessment-scores-vendor-sources
+```
+
+Create the PR with `mcp__github__create_pull_request` using
+`.github/pull_request_template.md` as the body skeleton; body must include
+`Closes #3625`. Title:
+`feat(dbt): add iReady, STAR, DIBELS to fct_assessment_scores_enrollment_scoped`.
+
+- [ ] **Step 5: Monitor dbt Cloud CI** (commit STATUS, not check runs) plus
+      Trunk/CodeQL check runs. After CI passes, fetch warnings with
+      `mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)` and run
+      the marts pre-merge checklist (`src/dbt/kipptaf/models/marts/CLAUDE.md`):
+      diamond-path scan, rubric scan, CI-warning triage, project-board bonus
+      scan.
+
+- [ ] **Step 6: Post-CI validation on the PR-branch schema** (dataset
+      `dbt_cloud_pr_<job_definition_id>_<pr>_<schema>`): re-run the Task 8 Step
+      6 query against the PR-branch fact; compare per-window vendor counts to
+      the dev-schema numbers.

--- a/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
+++ b/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
@@ -30,9 +30,12 @@ Models touched:
 
 ## Decisions (from brainstorming)
 
-- **Grain**: native attempt grain. iReady = every completed diagnostic; STAR =
-  every attempt per screening window; DIBELS = the `Composite`
+- **Grain**: one row per student x subject x administration window x test day
+  per source. iReady = every completed diagnostic (deduped to one per day); STAR
+  = every attempt (deduped to one per day); DIBELS = the `Composite`
   `measure_standard` row per benchmark window only (no subskill measures).
+  Day-grain dedup was adopted during planning after data validation found
+  same-day retests and upstream duplicate rows (see _Duplicate findings_).
 - **Contract**: add one nullable numeric column, `growth_percentile`. Existing
   sources carry NULL. No other new columns.
 - **STAR proficiency**: state benchmark family (`state_benchmark_category_name`
@@ -41,44 +44,70 @@ Models touched:
 
 ## Column mapping
 
-| fact concept                       | iReady (`int_iready__diagnostic_results`)    | STAR (`int_renlearn__star_rollup`)                                | DIBELS (`int_amplify__all_assessments`)                              |
-| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
-| grain filter                       | every completed diagnostic                   | every attempt (rollup already excludes deactivated)               | `assessment_type = 'Benchmark'` and `measure_standard = 'Composite'` |
-| `student_number`                   | `student_id`                                 | `student_display_id`                                              | `student_number`                                                     |
-| `academic_year`                    | `academic_year_int`                          | `academic_year`                                                   | `academic_year`                                                      |
-| course subject (resolver)          | Reading → `Text Study`, Math → `Mathematics` | ELA → `Text Study`, Math → `Mathematics` (from `star_discipline`) | `Text Study`                                                         |
-| `administration_period`            | `test_round`                                 | `screening_period_window_name`                                    | `period` (BOY/MOY/EOY)                                               |
-| test/anchor date                   | `completion_date`                            | `completed_date` (upstream edit)                                  | `client_date`                                                        |
-| `scale_score`                      | `overall_scale_score`                        | `unified_score`                                                   | `measure_standard_score`                                             |
-| `growth_percentile`                | `percentile`                                 | `percentile_rank` (upstream edit)                                 | `measure_percentile`                                                 |
-| `proficiency_level`                | `overall_relative_placement`                 | `state_benchmark_category_name`                                   | `measure_standard_level`                                             |
-| `is_mastery`                       | `overall_relative_placement_int >= 4`        | `state_benchmark_proficient = 'Yes'`                              | `measure_standard_level_int >= 3`                                    |
-| `_dbt_source_project`              | from its rewritten `_dbt_source_relation`    | via location crosswalk on `school_name` (upstream edit)           | `'kipp' \|\| lower(region)`                                          |
-| `assessment_type` / `title` (dims) | `iready` / i-Ready Diagnostic                | `star` / STAR                                                     | `dibels` / DIBELS                                                    |
-| `module_code` (hash input)         | `subject`                                    | `star_subject`                                                    | `measure_standard` (`Composite`)                                     |
+| fact concept                       | iReady (`int_iready__diagnostic_results`)    | STAR (`int_renlearn__star_rollup`)                      | DIBELS (`int_amplify__all_assessments`)                              |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------- |
+| grain filter                       | every completed diagnostic                   | every attempt (rollup already excludes deactivated)     | `assessment_type = 'Benchmark'` and `measure_standard = 'Composite'` |
+| `student_number`                   | `student_id`                                 | `student_display_id`                                    | `student_number`                                                     |
+| `academic_year`                    | `academic_year_int`                          | `academic_year`                                         | `academic_year`                                                      |
+| course subject (resolver)          | Reading → `Text Study`, Math → `Mathematics` | Math (`SM`) → `Mathematics`, else `Text Study`          | `Text Study`                                                         |
+| `administration_period`            | `test_round`                                 | `screening_period_window_name`                          | `period` (BOY/MOY/EOY)                                               |
+| test/anchor date                   | `completion_date`                            | `completed_date` (upstream edit)                        | `client_date`                                                        |
+| `scale_score`                      | `overall_scale_score`                        | `unified_score`                                         | `measure_standard_score`                                             |
+| `growth_percentile`                | `percentile`                                 | `percentile_rank` (upstream edit)                       | `measure_percentile`                                                 |
+| `proficiency_level`                | `overall_relative_placement`                 | `state_benchmark_category_name`                         | `measure_standard_level`                                             |
+| `is_mastery`                       | `overall_relative_placement_int >= 4`        | `state_benchmark_proficient = 'Yes'`                    | `measure_standard_level_int >= 3`                                    |
+| `_dbt_source_project`              | from its rewritten `_dbt_source_relation`    | via location crosswalk on `school_name` (upstream edit) | `'kipp' \|\| lower(region)`                                          |
+| `assessment_type` / `title` (dims) | `iready` / i-Ready Diagnostic                | `star` / STAR                                           | `dibels` / DIBELS                                                    |
+| `module_code` (hash input)         | `subject`                                    | `star_subject`                                          | `measure_standard` (`Composite`)                                     |
 
 Internal-only fact columns (`response_type*`, `is_replacement`,
 `performance_band_label_number`) and `percent_correct` are NULL for all three
 sources.
 
-## Upstream additive edits (STAR only)
+## Upstream additive edits
 
-`int_renlearn__star_rollup` today projects neither a test date, a percentile,
-nor any region/project column. Add, additively:
+Per the marts CLAUDE.md `_dbt_source_project` promotion pattern
+([#3142](https://github.com/TEAMSchools/teamster/issues/3142)) and the
+`illuminate_subject` precedent in `int_pearson__all_assessments` /
+`int_fldoe__all_assessments`, each vendor intermediate gains two additive
+columns so the resolver, dims, and fact all read materialized values instead of
+re-deriving them per consumer:
 
-- `completed_date` (exists in `stg_renlearn__star`)
-- `percentile_rank` (exists in `stg_renlearn__star`)
-- `_dbt_source_project`, derived via `int_people__location_crosswalk` on
-  `school_name` → `location_dagster_code_location`. Required because NJ
-  districts share one Renaissance instance (`kippnj`), so the staging
-  `_dbt_source_relation` cannot identify the district.
+- `_dbt_source_project` — iReady: `extract_code_location()` on its rewritten
+  `_dbt_source_relation`; DIBELS: `concat('kipp', lower(region))`; STAR: via
+  `int_people__location_crosswalk` on `school_name` →
+  `location_dagster_code_location` (required because NJ districts share one
+  Renaissance instance, `kippnj`, so the staging `_dbt_source_relation` cannot
+  identify the district).
+- `illuminate_subject` — the state→course subject mapping: iReady Reading →
+  `Text Study`, Math → `Mathematics`; STAR `SM` partition → `Mathematics`, else
+  `Text Study` (Reading and Early Literacy both resolve to ELA sections); DIBELS
+  constant `Text Study`.
 
-iReady and DIBELS intermediates already carry everything needed.
+`int_renlearn__star_rollup` additionally gains `completed_date` (DATE, cast from
+`completed_date_local`'s first 10 chars — the staging column is a local datetime
+string) and `percentile_rank` (both exist in `stg_renlearn__star`).
+
+## Duplicate findings (data-verified during planning)
+
+- **iReady**: `stg_iready__diagnostic_results` has NO uniqueness test. At the
+  proposed PK grain (project, student, year, round, subject, day), 3,835
+  duplicate groups exist (up to 16 rows/group): ~2,500 are same-day retests with
+  different scores; ~1,300 are byte-identical duplicate rows. Fact branch
+  dedupes at PK grain, `order_by="start_date desc, scale_score desc"`, with a
+  TODO naming the upstream fix (follow-up issue).
+- **STAR**: `stg_renlearn__star` holds ~2,300 duplicated `assessment_id`s — 100%
+  cross-`_dagster_partition_fiscal_year` re-pulls, identical in every data
+  column — plus ~144 same-day multi-attempts. Fact branch dedupes at PK grain,
+  `order_by="scale_score desc, assessment_id desc"`, with a TODO (follow-up
+  issue).
+- **DIBELS**: verified unique at PK grain (55,221 = 55,221). No dedupe.
 
 ## Resolver changes
 
 Three new score CTEs in `int_assessments__resolved_section_enrollments`, with
-`source_type` values `iready`, `star`, `dibels`. Each projects
+`source_type` values `iready`, `star`, `dibels` (added to the `source_type`
+`accepted_values` test in its properties yml). Each projects
 `(powerschool_student_number, academic_year, administration_period, subject_area, _dbt_source_project, anchor_date)`
 where `subject_area` is the course-mapped subject from the table above, then
 unions into the existing `scores` CTE. Rows with a NULL anchor date or NULL
@@ -105,10 +134,11 @@ rows.
 
 ## Fact changes
 
-Three new union branches in `fct_assessment_scores_enrollment_scoped`, each
-INNER JOINing the resolver on
-`(student_number, academic_year, administration_period, course-mapped subject_area, _dbt_source_project, source_type)`
-— the same shape as the state branch.
+Three vendor CTEs (with the iReady/STAR dedupes above) union into one
+`vendor_all` CTE — the same shape the state branches use (`state_nj` +
+`state_fl` → `state_all`) — and one new final union branch INNER JOINs the
+resolver on
+`(student_number, academic_year, administration_period, illuminate_subject = subject_area, _dbt_source_project, score_source = source_type)`.
 
 - `assessment_score_key` =
   `[score_source, _dbt_source_project, student_number, academic_year, administration_period, module_code, test_date]`.
@@ -130,6 +160,10 @@ INNER JOINing the resolver on
   resolved to a section); `growth_percentile` population per source.
 - Local `dbt build --select <touched models>+ --defer` before push; dbt Cloud CI
   (`state:modified+`) as the gate.
+- File follow-up issues (with user approval) for the two upstream duplicate
+  sources: missing uniqueness test / duplicate rows in
+  `stg_iready__diagnostic_results`, and fiscal-year re-pull overlap in
+  `stg_renlearn__star`. The fact dedupe TODOs reference these issues.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
+++ b/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
@@ -1,0 +1,140 @@
+# Vendor Assessments in `fct_assessment_scores_enrollment_scoped` — Design
+
+Implements [#3625](https://github.com/TEAMSchools/teamster/issues/3625): add
+iReady, STAR/Renaissance, and DIBELS/Amplify scores to
+`fct_assessment_scores_enrollment_scoped`.
+
+## Scope correction
+
+The issue title also names FAST, but FAST is already present via the `state_fl`
+branch — `int_fldoe__all_assessments` unions the FAST/FAST_NEW source systems,
+and `dim_assessment_administrations` /`dim_assessments` carry `state_fl_fast`
+branches. Only iReady, STAR, and DIBELS are in scope.
+
+## Approach
+
+Inline branches (Approach A): each new source gets its own branch in the four
+models that every score source must touch, mirroring the existing `state_nj` /
+`state_fl` pattern. A consolidating vendor-scores intermediate (Approach B) was
+considered and deferred as a later refactor.
+
+Models touched:
+
+1. `int_assessments__resolved_section_enrollments` — score branches so vendor
+   scores resolve to a section enrollment
+2. `dim_assessment_administrations` — administration grain-projection CTEs
+3. `dim_assessments` — assessment grain-projection CTEs
+4. `fct_assessment_scores_enrollment_scoped` — union branches + new
+   `growth_percentile` contract column
+5. `int_renlearn__star_rollup` — additive upstream edits (STAR only)
+
+## Decisions (from brainstorming)
+
+- **Grain**: native attempt grain. iReady = every completed diagnostic; STAR =
+  every attempt per screening window; DIBELS = the `Composite`
+  `measure_standard` row per benchmark window only (no subskill measures).
+- **Contract**: add one nullable numeric column, `growth_percentile`. Existing
+  sources carry NULL. No other new columns.
+- **STAR proficiency**: state benchmark family (`state_benchmark_category_name`
+  / `state_benchmark_proficient`), not district benchmarks — consistent with the
+  fact's state-anchored proficiency semantics.
+
+## Column mapping
+
+| fact concept                       | iReady (`int_iready__diagnostic_results`)    | STAR (`int_renlearn__star_rollup`)                                | DIBELS (`int_amplify__all_assessments`)                              |
+| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
+| grain filter                       | every completed diagnostic                   | every attempt (rollup already excludes deactivated)               | `assessment_type = 'Benchmark'` and `measure_standard = 'Composite'` |
+| `student_number`                   | `student_id`                                 | `student_display_id`                                              | `student_number`                                                     |
+| `academic_year`                    | `academic_year_int`                          | `academic_year`                                                   | `academic_year`                                                      |
+| course subject (resolver)          | Reading → `Text Study`, Math → `Mathematics` | ELA → `Text Study`, Math → `Mathematics` (from `star_discipline`) | `Text Study`                                                         |
+| `administration_period`            | `test_round`                                 | `screening_period_window_name`                                    | `period` (BOY/MOY/EOY)                                               |
+| test/anchor date                   | `completion_date`                            | `completed_date` (upstream edit)                                  | `client_date`                                                        |
+| `scale_score`                      | `overall_scale_score`                        | `unified_score`                                                   | `measure_standard_score`                                             |
+| `growth_percentile`                | `percentile`                                 | `percentile_rank` (upstream edit)                                 | `measure_percentile`                                                 |
+| `proficiency_level`                | `overall_relative_placement`                 | `state_benchmark_category_name`                                   | `measure_standard_level`                                             |
+| `is_mastery`                       | `overall_relative_placement_int >= 4`        | `state_benchmark_proficient = 'Yes'`                              | `measure_standard_level_int >= 3`                                    |
+| `_dbt_source_project`              | from its rewritten `_dbt_source_relation`    | via location crosswalk on `school_name` (upstream edit)           | `'kipp' \|\| lower(region)`                                          |
+| `assessment_type` / `title` (dims) | `iready` / i-Ready Diagnostic                | `star` / STAR                                                     | `dibels` / DIBELS                                                    |
+| `module_code` (hash input)         | `subject`                                    | `star_subject`                                                    | `measure_standard` (`Composite`)                                     |
+
+Internal-only fact columns (`response_type*`, `is_replacement`,
+`performance_band_label_number`) and `percent_correct` are NULL for all three
+sources.
+
+## Upstream additive edits (STAR only)
+
+`int_renlearn__star_rollup` today projects neither a test date, a percentile,
+nor any region/project column. Add, additively:
+
+- `completed_date` (exists in `stg_renlearn__star`)
+- `percentile_rank` (exists in `stg_renlearn__star`)
+- `_dbt_source_project`, derived via `int_people__location_crosswalk` on
+  `school_name` → `location_dagster_code_location`. Required because NJ
+  districts share one Renaissance instance (`kippnj`), so the staging
+  `_dbt_source_relation` cannot identify the district.
+
+iReady and DIBELS intermediates already carry everything needed.
+
+## Resolver changes
+
+Three new score CTEs in `int_assessments__resolved_section_enrollments`, with
+`source_type` values `iready`, `star`, `dibels`. Each projects
+`(powerschool_student_number, academic_year, administration_period, subject_area, _dbt_source_project, anchor_date)`
+where `subject_area` is the course-mapped subject from the table above, then
+unions into the existing `scores` CTE. Rows with a NULL anchor date or NULL
+student number are dropped (out of scope), matching the state branches.
+
+The two-tier resolution (subject section, then homeroom) and the
+`score_grain_key` dedup work unchanged. DIBELS (K–2) mostly resolves via the
+homeroom tier. Multiple attempts within one window share a `score_grain_key` and
+therefore one resolved section — correct, because the fact joins back at window
+grain.
+
+## Dimension changes
+
+One grain-projection CTE per source (`select distinct` over the same
+intermediates and filters as the fact branches) in each dim:
+
+- `dim_assessment_administrations`: hash
+  `[assessment_type, module_code, administered_date (null), academic_year, _dbt_source_project, administration_period, source_assessment_id (null), test_type (null)]`
+- `dim_assessments`: hash
+  `[assessment_type, module_code, source_assessment_id (null), test_type (null)]`
+
+Both hashes reuse the models' existing compositions — no hash-change to existing
+rows.
+
+## Fact changes
+
+Three new union branches in `fct_assessment_scores_enrollment_scoped`, each
+INNER JOINing the resolver on
+`(student_number, academic_year, administration_period, course-mapped subject_area, _dbt_source_project, source_type)`
+— the same shape as the state branch.
+
+- `assessment_score_key` =
+  `[score_source, _dbt_source_project, student_number, academic_year, administration_period, module_code, test_date]`.
+  `test_date` is a required hash input here (unlike the state branch) because
+  iReady and STAR keep every attempt within a window.
+- `assessment_administration_key` = the dim's composition above.
+- New contract column `growth_percentile` (numeric, nullable): vendor percentile
+  per the mapping table; NULL on the internal and state branches. Added to the
+  fact SQL and `properties/fct_assessment_scores_enrollment_scoped.yml`.
+
+## Testing and validation
+
+- Existing fact PK `unique` test must stay green — `test_date` in the score hash
+  covers within-window retests.
+- Existing `relationships` tests to `dim_assessment_administrations` /
+  `dim_assessments` must stay green — guaranteed by identical hash inputs.
+- Post-build checks (BigQuery, PR-branch schema): per-source row counts vs the
+  source intermediates; resolver hit-rate per source (share of scores that
+  resolved to a section); `growth_percentile` population per source.
+- Local `dbt build --select <touched models>+ --defer` before push; dbt Cloud CI
+  (`state:modified+`) as the gate.
+
+## Out of scope
+
+- FAST (already present — see Scope correction)
+- Cube model changes — the column add is non-breaking and new rows flow through
+  the existing cube
+- The Approach B refactor (consolidating vendor-scores intermediate)
+- `fct_assessment_scores_student_scoped` — enrollment-scoped sources only

--- a/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
+++ b/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
@@ -25,7 +25,7 @@ Models touched:
 2. `dim_assessment_administrations` — administration grain-projection CTEs
 3. `dim_assessments` — assessment grain-projection CTEs
 4. `fct_assessment_scores_enrollment_scoped` — union branches + new
-   `growth_percentile` contract column
+   `national_percentile` contract column
 5. Vendor source models — additive columns (`_dbt_source_project`,
    `illuminate_subject`): `int_iready__diagnostic_results` (iReady),
    `int_amplify__all_assessments` (DIBELS), and `stg_renlearn__star` (STAR — the
@@ -41,8 +41,14 @@ Models touched:
   `measure_standard` row per benchmark window only (no subskill measures).
   Day-grain dedup was adopted during planning after data validation found
   same-day retests and upstream duplicate rows (see _Duplicate findings_).
-- **Contract**: add one nullable numeric column, `growth_percentile`. Existing
-  sources carry NULL. No other new columns.
+- **Contract**: add one nullable numeric column, `national_percentile`. Existing
+  sources carry NULL. No other new columns. (Named `national_percentile`, not
+  `growth_percentile` as the issue proposed — the mapped values are all
+  norm-referenced achievement percentiles, not growth; the codebase already uses
+  `*growth_percentile*` for genuine growth fields, e.g. STAR SGP and DIBELS
+  composite growth, and a prior column-naming audit flagged the old
+  `growth_percentile` on this fact for removal as dead plumbing. Renamed during
+  PR review per the `claude-review` finding.)
 - **STAR proficiency**: state benchmark family (`state_benchmark_category_name`
   / `state_benchmark_proficient`), not district benchmarks — consistent with the
   fact's state-anchored proficiency semantics.
@@ -58,7 +64,7 @@ Models touched:
 | `administration_period`            | `test_round`                                 | `screening_period_window_name`                          | `period` (BOY/MOY/EOY)                                               |
 | test/anchor date                   | `completion_date`                            | `completed_date_value` (new DATE on staging)            | `client_date`                                                        |
 | `scale_score`                      | `overall_scale_score`                        | `unified_score`                                         | `measure_standard_score`                                             |
-| `growth_percentile`                | `percentile`                                 | `percentile_rank` (upstream edit)                       | `measure_percentile`                                                 |
+| `national_percentile`              | `percentile`                                 | `percentile_rank` (upstream edit)                       | `measure_percentile`                                                 |
 | `proficiency_level`                | `overall_relative_placement`                 | `state_benchmark_category_name`                         | `measure_standard_level`                                             |
 | `is_mastery`                       | `overall_relative_placement_int >= 4`        | `state_benchmark_proficient = 'Yes'`                    | `measure_standard_level_int >= 3`                                    |
 | `_dbt_source_project`              | from its rewritten `_dbt_source_relation`    | via location crosswalk on `school_name` (upstream edit) | `'kipp' \|\| lower(region)`                                          |
@@ -157,9 +163,10 @@ resolver on
   `test_date` is a required hash input here (unlike the state branch) because
   iReady and STAR keep every attempt within a window.
 - `assessment_administration_key` = the dim's composition above.
-- New contract column `growth_percentile` (numeric, nullable): vendor percentile
-  per the mapping table; NULL on the internal and state branches. Added to the
-  fact SQL and `properties/fct_assessment_scores_enrollment_scoped.yml`.
+- New contract column `national_percentile` (numeric, nullable): vendor
+  percentile per the mapping table; NULL on the internal and state branches.
+  Added to the fact SQL and
+  `properties/fct_assessment_scores_enrollment_scoped.yml`.
 
 ## Testing and validation
 
@@ -169,7 +176,7 @@ resolver on
   `dim_assessments` must stay green — guaranteed by identical hash inputs.
 - Post-build checks (BigQuery, PR-branch schema): per-source row counts vs the
   source intermediates; resolver hit-rate per source (share of scores that
-  resolved to a section); `growth_percentile` population per source.
+  resolved to a section); `national_percentile` population per source.
 - Local `dbt build --select <touched models>+ --defer` before push; dbt Cloud CI
   (`state:modified+`) as the gate.
 - File follow-up issues (with user approval) for the two upstream duplicate

--- a/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
+++ b/docs/superpowers/specs/2026-07-13-vendor-assessments-enrollment-scoped-fact-design.md
@@ -26,7 +26,12 @@ Models touched:
 3. `dim_assessments` — assessment grain-projection CTEs
 4. `fct_assessment_scores_enrollment_scoped` — union branches + new
    `growth_percentile` contract column
-5. `int_renlearn__star_rollup` — additive upstream edits (STAR only)
+5. Vendor source models — additive columns (`_dbt_source_project`,
+   `illuminate_subject`): `int_iready__diagnostic_results` (iReady),
+   `int_amplify__all_assessments` (DIBELS), and `stg_renlearn__star` (STAR — the
+   consolidated union view; also gains a DATE `completed_date_value`). The old
+   `int_renlearn__star_rollup` was retired in Nov 2025 and stays disabled — see
+   the plan's Task 3 correction.
 
 ## Decisions (from brainstorming)
 
@@ -44,14 +49,14 @@ Models touched:
 
 ## Column mapping
 
-| fact concept                       | iReady (`int_iready__diagnostic_results`)    | STAR (`int_renlearn__star_rollup`)                      | DIBELS (`int_amplify__all_assessments`)                              |
+| fact concept                       | iReady (`int_iready__diagnostic_results`)    | STAR (`stg_renlearn__star`)                             | DIBELS (`int_amplify__all_assessments`)                              |
 | ---------------------------------- | -------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------- |
 | grain filter                       | every completed diagnostic                   | every attempt (rollup already excludes deactivated)     | `assessment_type = 'Benchmark'` and `measure_standard = 'Composite'` |
 | `student_number`                   | `student_id`                                 | `student_display_id`                                    | `student_number`                                                     |
 | `academic_year`                    | `academic_year_int`                          | `academic_year`                                         | `academic_year`                                                      |
 | course subject (resolver)          | Reading → `Text Study`, Math → `Mathematics` | Math (`SM`) → `Mathematics`, else `Text Study`          | `Text Study`                                                         |
 | `administration_period`            | `test_round`                                 | `screening_period_window_name`                          | `period` (BOY/MOY/EOY)                                               |
-| test/anchor date                   | `completion_date`                            | `completed_date` (upstream edit)                        | `client_date`                                                        |
+| test/anchor date                   | `completion_date`                            | `completed_date_value` (new DATE on staging)            | `client_date`                                                        |
 | `scale_score`                      | `overall_scale_score`                        | `unified_score`                                         | `measure_standard_score`                                             |
 | `growth_percentile`                | `percentile`                                 | `percentile_rank` (upstream edit)                       | `measure_percentile`                                                 |
 | `proficiency_level`                | `overall_relative_placement`                 | `state_benchmark_category_name`                         | `measure_standard_level`                                             |
@@ -69,7 +74,7 @@ sources.
 Per the marts CLAUDE.md `_dbt_source_project` promotion pattern
 ([#3142](https://github.com/TEAMSchools/teamster/issues/3142)) and the
 `illuminate_subject` precedent in `int_pearson__all_assessments` /
-`int_fldoe__all_assessments`, each vendor intermediate gains two additive
+`int_fldoe__all_assessments`, each vendor source model gains two additive
 columns so the resolver, dims, and fact all read materialized values instead of
 re-deriving them per consumer:
 
@@ -84,9 +89,16 @@ re-deriving them per consumer:
   `Text Study` (Reading and Early Literacy both resolve to ELA sections); DIBELS
   constant `Text Study`.
 
-`int_renlearn__star_rollup` additionally gains `completed_date` (DATE, cast from
-`completed_date_local`'s first 10 chars — the staging column is a local datetime
-string) and `percentile_rank` (both exist in `stg_renlearn__star`).
+STAR's columns land on `stg_renlearn__star` (the consolidated kipptaf union
+view), NOT on `int_renlearn__star_rollup` — that rollup was disabled by the Nov
+2025 "consolidate star calcs" refactor and every STAR consumer already reads the
+staging model. `stg_renlearn__star` additionally gains `completed_date_value`
+(DATE, cast from `completed_date_local`'s first 10 chars); `percentile_rank`,
+`unified_score`, `star_subject`, `screening_period_window_name`,
+`academic_year`, and the benchmark columns already exist there. This puts a
+crosswalk join in a staging model (a layering trade-off), accepted because the
+model is functionally a kipptaf-level union view and it is the single promotion
+point.
 
 ## Duplicate findings (data-verified during planning)
 

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -251,6 +251,14 @@ short canonical names (`Newark` / `Camden` / `Miami` / `Paterson`). For region
 lookups by short name, use `city`. For mapping `_dbt_source_project` to region,
 use `dim_regions.dagster_code_location`.
 
+**`stg_renlearn__star` is the consolidated STAR model** — the Nov-2025
+"consolidate star calcs" refactor disabled `int_renlearn__star_rollup`
+(`config: enabled: false`; leave it) and folded the derived columns
+(`academic_year`, `star_subject`/`star_discipline`, `administration_window`
+Fall/Winter/Spring→BOY/MOY/EOY, benchmark int-flags, `rn_subject_*`) into this
+kipptaf-level `union_relations` view (materialized table). All STAR consumers
+read it. Edit/consume STAR here, not the rollup.
+
 ## Exposures
 
 Every external consumer **must** have a dbt exposure in `models/exposures/`.

--- a/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
+++ b/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
@@ -1,4 +1,9 @@
 with
+    data_farming as (
+        select *, concat('kipp', lower(region)) as _dbt_source_project,
+        from {{ source("amplify", "int_amplify__dds__data_farming_unpivot") }}
+    ),
+
     assessments_scores as (
         -- benchmark scores
         select
@@ -10,6 +15,7 @@ with
             bss.benchmark_period as `period`,
             bss.client_date,
             bss.sync_date,
+            bss._dbt_source_project,
 
             u.surrogate_key,
             u.measure_name,
@@ -63,6 +69,7 @@ with
             df.period,
             df.`date` as client_date,
             df.`date` as sync_date,
+            df._dbt_source_project,
 
             df.surrogate_key,
             df.measure_name,
@@ -86,7 +93,7 @@ with
             e.end_date,
             e.matching_pm_season as matching_season,
 
-        from {{ source("amplify", "int_amplify__dds__data_farming_unpivot") }} as df
+        from data_farming as df
         inner join
             {{ ref("int_google_sheets__dibels_expected_assessments") }} as e
             on df.academic_year = e.academic_year
@@ -109,6 +116,7 @@ with
             p.pm_period as `period`,
             p.client_date,
             p.sync_date,
+            p._dbt_source_project,
             p.surrogate_key,
             p.measure_name,
             p.measure_name_code,
@@ -224,6 +232,7 @@ select
     s.matching_season,
     s.client_date,
     s.sync_date,
+    s._dbt_source_project,
     s.measure_name,
     s.measure_name_code,
     s.measure_standard,
@@ -244,8 +253,6 @@ select
     p.eoy as eoy_composite,
 
     'Text Study' as illuminate_subject,
-
-    concat('kipp', lower(s.region)) as _dbt_source_project,
 
     case
         s.period when 'BOY' then 'MOY' when 'MOY' then 'EOY'
@@ -309,6 +316,7 @@ select
     s.matching_season,
     s.client_date,
     s.sync_date,
+    s._dbt_source_project,
     s.measure_name,
     s.measure_name_code,
     s.measure_standard,
@@ -329,8 +337,6 @@ select
     p.eoy as eoy_composite,
 
     'Text Study' as illuminate_subject,
-
-    concat('kipp', lower(s.region)) as _dbt_source_project,
 
     'NA' as benchmark_goal_season,
 

--- a/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
+++ b/src/dbt/kipptaf/models/amplify/intermediate/int_amplify__all_assessments.sql
@@ -243,6 +243,10 @@ select
     p.moy as moy_composite,
     p.eoy as eoy_composite,
 
+    'Text Study' as illuminate_subject,
+
+    concat('kipp', lower(s.region)) as _dbt_source_project,
+
     case
         s.period when 'BOY' then 'MOY' when 'MOY' then 'EOY'
     end as benchmark_goal_season,
@@ -323,6 +327,10 @@ select
     p.boy as boy_composite,
     p.moy as moy_composite,
     p.eoy as eoy_composite,
+
+    'Text Study' as illuminate_subject,
+
+    concat('kipp', lower(s.region)) as _dbt_source_project,
 
     'NA' as benchmark_goal_season,
 

--- a/src/dbt/kipptaf/models/amplify/intermediate/properties/int_amplify__all_assessments.yml
+++ b/src/dbt/kipptaf/models/amplify/intermediate/properties/int_amplify__all_assessments.yml
@@ -123,6 +123,17 @@ models:
         data_type: string
       - name: eoy_composite
         data_type: string
+      - name: illuminate_subject
+        data_type: string
+        description: >-
+          Course-subject mapping used by the section-enrollment resolver. All
+          DIBELS measures are reading-family, so this is constant Text Study.
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Dagster code location derived from the region name (kipp + lowercased
+          region). Promoted here per the marts _dbt_source_project pattern so
+          consumers join and hash a materialized column.
       - name: benchmark_goal_season
         data_type: string
       - name: aggregated_measure_standard_level

--- a/src/dbt/kipptaf/models/amplify/intermediate/properties/int_amplify__all_assessments.yml
+++ b/src/dbt/kipptaf/models/amplify/intermediate/properties/int_amplify__all_assessments.yml
@@ -131,9 +131,11 @@ models:
       - name: _dbt_source_project
         data_type: string
         description: >-
-          Dagster code location derived from the region name (kipp + lowercased
-          region). Promoted here per the marts _dbt_source_project pattern so
-          consumers join and hash a materialized column.
+          Dagster code location. Passed through from the mclass union models
+          (int_amplify__mclass__benchmark_student_summary and
+          int_amplify__mclass__pm_student_summary), where it is the crosswalk
+          location_dagster_code_location; the frozen 7/8 SY24 branch derives it
+          from region. Materialized so consumers join and hash a column.
       - name: benchmark_goal_season
         data_type: string
       - name: aggregated_measure_standard_level

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__benchmark_student_summary.sql
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__benchmark_student_summary.sql
@@ -20,6 +20,7 @@ with
 
             x.location_abbreviation as school,
             x.location_powerschool_school_id as schoolid,
+            x.location_dagster_code_location as _dbt_source_project,
 
             initcap(
                 regexp_extract(x.location_dagster_code_location, r'kipp(\w+)')

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__pm_student_summary.sql
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__pm_student_summary.sql
@@ -17,6 +17,7 @@ with
 
             x.location_abbreviation as school,
             x.location_powerschool_school_id as schoolid,
+            x.location_dagster_code_location as _dbt_source_project,
 
             initcap(
                 regexp_extract(x.location_dagster_code_location, r'kipp(\w+)')

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__benchmark_student_summary.yml
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__benchmark_student_summary.yml
@@ -464,6 +464,8 @@ models:
         data_type: string
       - name: schoolid
         data_type: int64
+      - name: _dbt_source_project
+        data_type: string
       - name: _dagster_partition_key
         data_type: string
         description: Dagster partition key (school year).

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__pm_student_summary.yml
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__pm_student_summary.yml
@@ -388,6 +388,8 @@ models:
             source_column: enrollment_grade_int
       - name: school
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: multi_district_organization_name
         data_type: string
         description: Multi-district organization name.

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -95,6 +95,71 @@ with
         where test_date is not null and student_number is not null
     ),
 
+    -- iReady diagnostics. test_round is the reporting-terms IR window (BOY /
+    -- MOY / EOY / Outside Round); illuminate_subject maps Reading -> Text
+    -- Study, Math -> Mathematics upstream.
+    iready_scores as (
+        select
+            student_id as powerschool_student_number,
+            academic_year_int as academic_year,
+            test_round as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            completion_date as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'iready' as source_type,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where completion_date is not null and overall_scale_score is not null
+    ),
+
+    -- STAR attempts. screening_period_window_name is the vendor window (Fall /
+    -- Winter / Spring); rows without a crosswalk-resolved project cannot join
+    -- course enrollments and are dropped (out of scope).
+    star_scores as (
+        select
+            student_display_id as powerschool_student_number,
+            academic_year,
+            screening_period_window_name as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            completed_date_value as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'star' as source_type,
+        from {{ ref("stg_renlearn__star") }}
+        where
+            completed_date_value is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- DIBELS benchmark composites. One row per student x benchmark window
+    -- (BOY / MOY / EOY); PM probes and subskill measures are out of scope.
+    dibels_scores as (
+        select
+            student_number as powerschool_student_number,
+            academic_year,
+            `period` as administration_period,
+            illuminate_subject as subject_area,
+            _dbt_source_project,
+
+            client_date as anchor_date,
+
+            cast(null as int64) as canonical_assessment_id,
+
+            'dibels' as source_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where
+            assessment_type = 'Benchmark'
+            and measure_standard = 'Composite'
+            and client_date is not null
+    ),
+
     scores as (
         select
             powerschool_student_number,
@@ -132,6 +197,45 @@ with
             anchor_date,
             source_type,
         from state_fl_scores
+
+        union all
+
+        select
+            powerschool_student_number,
+            canonical_assessment_id,
+            academic_year,
+            administration_period,
+            subject_area,
+            _dbt_source_project,
+            anchor_date,
+            source_type,
+        from iready_scores
+
+        union all
+
+        select
+            powerschool_student_number,
+            canonical_assessment_id,
+            academic_year,
+            administration_period,
+            subject_area,
+            _dbt_source_project,
+            anchor_date,
+            source_type,
+        from star_scores
+
+        union all
+
+        select
+            powerschool_student_number,
+            canonical_assessment_id,
+            academic_year,
+            administration_period,
+            subject_area,
+            _dbt_source_project,
+            anchor_date,
+            source_type,
+        from dibels_scores
     ),
 
     -- course_subject is the section subject the resolver matches against. For

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -256,6 +256,7 @@ with
                     [
                         "powerschool_student_number",
                         "_dbt_source_project",
+                        "source_type",
                         "canonical_assessment_id",
                         "academic_year",
                         "administration_period",

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -306,3 +306,71 @@ unit_tests:
             source_type: state_nj,
             resolution_type: subject_section,
           }
+
+  - name: test_iready_dibels_source_type_prevents_grain_collision
+    description: >-
+      Regression test for #3625 (fixed in a743b7d6c). An iReady Reading score
+      and a DIBELS Composite score for the same student/project/academic
+      year/administration_period/subject_area (Text Study) agree on every
+      score_grain_key input except source_type. Both must resolve to the subject
+      section and survive as distinct output rows -- if source_type were dropped
+      from score_grain_key the two would hash identically and the resolved-tier
+      dedupe would silently collapse them into one.
+    model: int_assessments__resolved_section_enrollments
+    given:
+      - input: ref('int_assessments__scaffold')
+        rows: []
+      - input: ref('int_assessments__assessments_canonical')
+        rows: []
+      - input: ref('int_assessments__course_enrollments')
+        rows:
+          - {
+              powerschool_student_number: 5,
+              _dbt_source_project: kippnewark,
+              illuminate_subject_area: Text Study,
+              courses_credittype: ELA,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
+              cc_dcid: 555,
+            }
+      - input: ref('int_pearson__all_assessments')
+        rows: []
+      - input: ref('int_fldoe__all_assessments')
+        rows: []
+      - input: ref('int_iready__diagnostic_results')
+        format: sql
+        rows: |
+          select
+              5 as student_id,
+              2024 as academic_year_int,
+              'BOY' as test_round,
+              'Text Study' as illuminate_subject,
+              'kippnewark' as _dbt_source_project,
+              date('2024-09-15') as completion_date,
+              650 as overall_scale_score
+      - input: ref('stg_renlearn__star')
+        rows: []
+      - input: ref('int_amplify__all_assessments')
+        format: sql
+        rows: |
+          select
+              5 as student_number,
+              2024 as academic_year,
+              'BOY' as `period`,
+              'Text Study' as illuminate_subject,
+              'kippnewark' as _dbt_source_project,
+              date('2024-09-20') as client_date,
+              'Benchmark' as assessment_type,
+              'Composite' as measure_standard
+    expect:
+      rows:
+        - {
+            powerschool_student_number: 5,
+            source_type: iready,
+            student_section_enrollment_key: 862d5edd93004a2ab12782487a3292a7,
+          }
+        - {
+            powerschool_student_number: 5,
+            source_type: dibels,
+            student_section_enrollment_key: 862d5edd93004a2ab12782487a3292a7,
+          }

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -2,26 +2,30 @@ models:
   - name: int_assessments__resolved_section_enrollments
     description: >-
       Resolves one PowerSchool course-section enrollment per score row for all
-      assessment types — internal (Illuminate-sourced), NJ state (Pearson), and
-      FL state (FLDOE). Joins the course-enrollment inventory from
-      int_assessments__course_enrollments directly; does not carry cc_dcid as an
-      output column. Resolution is tiered: tier 1 matches a subject section
-      whose half-open enrollment window contains the score's anchor date
-      (earliest date_taken across the canonical's members, falling back to the
-      canonical administered_date for internal; test_date for state rows); tier
-      2 falls back to the homeroom section active on the same anchor date.
-      Scores with no matching section in either tier are dropped. The
-      resolution_type column identifies which tier resolved the row.
+      assessment types — internal (Illuminate-sourced), NJ state (Pearson), FL
+      state (FLDOE), and vendor assessments (iReady, STAR, DIBELS). Joins the
+      course-enrollment inventory from int_assessments__course_enrollments
+      directly; does not carry cc_dcid as an output column. Resolution is
+      tiered: tier 1 matches a subject section whose half-open enrollment window
+      contains the score's anchor date (earliest date_taken across the
+      canonical's members, falling back to the canonical administered_date for
+      internal; test_date for state rows; the vendor completion/screening/
+      client date for iReady, STAR, and DIBELS); tier 2 falls back to the
+      homeroom section active on the same anchor date. Scores with no matching
+      section in either tier are dropped. The resolution_type column identifies
+      which tier resolved the row.
     columns:
       - name: source_type
         data_type: string
         description: >-
           Assessment source branch that produced the score row. One of internal
-          (Illuminate-sourced), state_nj (Pearson NJ), or state_fl (FLDOE FL).
+          (Illuminate-sourced), state_nj (Pearson NJ), state_fl (FLDOE FL),
+          iready (i-Ready diagnostics), star (Renaissance STAR), or dibels
+          (Amplify DIBELS benchmark composites).
         data_tests:
           - accepted_values:
               arguments:
-                values: [internal, state_nj, state_fl]
+                values: [internal, state_nj, state_fl, iready, star, dibels]
       - name: resolution_type
         data_type: string
         description: >-
@@ -153,6 +157,12 @@ unit_tests:
         rows: []
       - input: ref('int_fldoe__all_assessments')
         rows: []
+      - input: ref('int_iready__diagnostic_results')
+        rows: []
+      - input: ref('stg_renlearn__star')
+        rows: []
+      - input: ref('int_amplify__all_assessments')
+        rows: []
     expect:
       rows:
         - {
@@ -198,6 +208,12 @@ unit_tests:
         rows: []
       - input: ref('int_fldoe__all_assessments')
         rows: []
+      - input: ref('int_iready__diagnostic_results')
+        rows: []
+      - input: ref('stg_renlearn__star')
+        rows: []
+      - input: ref('int_amplify__all_assessments')
+        rows: []
     expect:
       rows:
         - {
@@ -231,6 +247,12 @@ unit_tests:
       - input: ref('int_pearson__all_assessments')
         rows: []
       - input: ref('int_fldoe__all_assessments')
+        rows: []
+      - input: ref('int_iready__diagnostic_results')
+        rows: []
+      - input: ref('stg_renlearn__star')
+        rows: []
+      - input: ref('int_amplify__all_assessments')
         rows: []
     expect:
       rows: []
@@ -267,6 +289,12 @@ unit_tests:
               test_date: 2025-04-10,
             }
       - input: ref('int_fldoe__all_assessments')
+        rows: []
+      - input: ref('int_iready__diagnostic_results')
+        rows: []
+      - input: ref('stg_renlearn__star')
+        rows: []
+      - input: ref('int_amplify__all_assessments')
         rows: []
     expect:
       rows:

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
@@ -127,6 +127,8 @@ select
 
     right(rt.code, 1) as round_number,
 
+    {{ extract_code_location("wc") }} as _dbt_source_project,
+
     case
         when wc.overall_relative_placement_int <= 2
         then 'Below/Far Below'
@@ -135,6 +137,10 @@ select
         when wc.overall_relative_placement_int >= 4
         then 'At/Above'
     end as iready_proficiency,
+
+    case
+        wc.subject when 'Reading' then 'Text Study' when 'Math' then 'Mathematics'
+    end as illuminate_subject,
 
     if(
         cwp.scale_low - wc.most_recent_overall_scale_score <= 0,

--- a/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__diagnostic_results.yml
+++ b/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__diagnostic_results.yml
@@ -305,3 +305,17 @@ models:
       - name: test_round
         data_type: string
         description: First non-null of name.
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Dagster code location (kippnewark, kippcamden, kippmiami, ...)
+          extracted from the crosswalk-rewritten _dbt_source_relation. Promoted
+          here per the marts _dbt_source_project pattern so consumers join and
+          hash a materialized column.
+      - name: illuminate_subject
+        data_type: string
+        description: >-
+          Course-subject mapping used by the section-enrollment resolver —
+          Reading maps to Text Study, Math to Mathematics. Matches the
+          illuminate_subject convention in int_pearson__all_assessments and
+          int_fldoe__all_assessments.

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -214,6 +214,83 @@ with
         where scale_score is not null
     ),
 
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- iReady: one administration per (subject, test_round, academic_year,
+    -- _dbt_source_project).
+    iready_administrations as (
+        select distinct
+            subject as subject_area,
+            subject as module_code,
+            academic_year_int as academic_year,
+            test_round as administration_period,
+            _dbt_source_project,
+
+            'iready' as assessment_type,
+            'i-Ready Diagnostic' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+
+            if(subject = 'Math', 'Math', 'ELA') as scope,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null and _dbt_source_project is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- STAR: one administration per (star_subject, screening window,
+    -- academic_year, _dbt_source_project).
+    star_administrations as (
+        select distinct
+            star_subject as subject_area,
+            star_subject as module_code,
+            academic_year,
+            screening_period_window_name as administration_period,
+            _dbt_source_project,
+
+            'star' as assessment_type,
+            'STAR' as title,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+
+            if(star_subject = 'Math', 'Math', 'ELA') as scope,
+        from {{ ref("stg_renlearn__star") }}
+        where
+            completed_date_value is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    -- DIBELS: one administration per (benchmark window, academic_year,
+    -- _dbt_source_project); module_code is the Composite measure.
+    dibels_administrations as (
+        select distinct
+            measure_standard as module_code,
+            academic_year,
+            `period` as administration_period,
+            _dbt_source_project,
+
+            'Reading' as subject_area,
+            'dibels' as assessment_type,
+            'DIBELS' as title,
+            'ELA' as scope,
+
+            cast(null as date) as administered_date,
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as test_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+
     -- College Official: one administration per (score_type, test_date,
     -- administration_round). _dbt_source_project is null because college tests
     -- are region-agnostic.
@@ -322,6 +399,15 @@ with
         union all
         select {{ union_cols }},
         from state_fl_science_administrations
+        union all
+        select {{ union_cols }},
+        from iready_administrations
+        union all
+        select {{ union_cols }},
+        from star_administrations
+        union all
+        select {{ union_cols }},
+        from dibels_administrations
         union all
         select {{ union_cols }},
         from college_administrations

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -223,6 +223,80 @@ with
 
     -- grain projection: every selected column is functionally determined
     -- by the partition key; not a mask for upstream duplicates
+    iready_assessments as (
+        select distinct
+            subject as subject_area,
+            subject as module_code,
+
+            'iready' as assessment_type,
+            'i-Ready Diagnostic' as title,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            if(subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    star_assessments as (
+        select distinct
+            star_subject as subject_area,
+            star_subject as module_code,
+
+            'star' as assessment_type,
+            'STAR' as title,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            if(star_subject = 'Math', 'Math', 'ELA') as scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("stg_renlearn__star") }}
+        where completed_date_value is not null and unified_score is not null
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
+    dibels_assessments as (
+        select distinct
+            measure_standard as module_code,
+
+            'Reading' as subject_area,
+            'dibels' as assessment_type,
+            'DIBELS' as title,
+            'ELA' as scope,
+            false as is_internal_assessment,
+            'enrollment' as assessment_scope,
+
+            cast(null as int64) as grade_level,
+            cast(null as int64) as source_assessment_id,
+            cast(null as string) as module_type,
+            cast(null as string) as combined_academic_subject,
+            cast(null as string) as aligned_academic_subject,
+            cast(null as string) as credit_category,
+            cast(null as string) as test_type,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+
+    -- grain projection: every selected column is functionally determined
+    -- by the partition key; not a mask for upstream duplicates
     college_assessments as (
         select distinct
             scope as title,
@@ -337,6 +411,15 @@ with
         union all
         select {{ union_cols }},
         from state_fl_science
+        union all
+        select {{ union_cols }},
+        from iready_assessments
+        union all
+        select {{ union_cols }},
+        from star_assessments
+        union all
+        select {{ union_cols }},
+        from dibels_assessments
         union all
         select {{ union_cols }},
         from college_assessments

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -233,8 +233,6 @@ with
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
-            if(subject = 'Math', 'Math', 'ELA') as scope,
-
             cast(null as int64) as grade_level,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as module_type,
@@ -242,6 +240,8 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
+
+            if(subject = 'Math', 'Math', 'ELA') as scope,
         from {{ ref("int_iready__diagnostic_results") }}
         where overall_scale_score is not null
     ),
@@ -258,8 +258,6 @@ with
             false as is_internal_assessment,
             'enrollment' as assessment_scope,
 
-            if(star_subject = 'Math', 'Math', 'ELA') as scope,
-
             cast(null as int64) as grade_level,
             cast(null as int64) as source_assessment_id,
             cast(null as string) as module_type,
@@ -267,6 +265,8 @@ with
             cast(null as string) as aligned_academic_subject,
             cast(null as string) as credit_category,
             cast(null as string) as test_type,
+
+            if(star_subject = 'Math', 'Math', 'ELA') as scope,
         from {{ ref("stg_renlearn__star") }}
         where completed_date_value is not null and unified_score is not null
     ),

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -183,11 +183,14 @@ with
             'iready' as score_source,
 
             cast(overall_scale_score as numeric) as scale_score,
-            cast(percentile as numeric) as growth_percentile,
+            cast(percentile as numeric) as national_percentile,
 
             overall_relative_placement_int >= 4 as is_mastery,
         from {{ ref("int_iready__diagnostic_results") }}
-        where overall_scale_score is not null and _dbt_source_project is not null
+        where
+            overall_scale_score is not null
+            and _dbt_source_project is not null
+            and completion_date is not null
     ),
 
     -- TODO(#4387): stg_iready__diagnostic_results has no uniqueness test;
@@ -226,7 +229,7 @@ with
             'star' as score_source,
 
             cast(unified_score as numeric) as scale_score,
-            cast(percentile_rank as numeric) as growth_percentile,
+            cast(percentile_rank as numeric) as national_percentile,
 
             state_benchmark_proficient = 'Yes' as is_mastery,
         from {{ ref("stg_renlearn__star") }}
@@ -273,11 +276,14 @@ with
             'dibels' as score_source,
 
             cast(measure_standard_score as numeric) as scale_score,
-            cast(measure_percentile as numeric) as growth_percentile,
+            cast(measure_percentile as numeric) as national_percentile,
 
             measure_standard_level_int >= 3 as is_mastery,
         from {{ ref("int_amplify__all_assessments") }}
-        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+        where
+            assessment_type = 'Benchmark'
+            and measure_standard = 'Composite'
+            and client_date is not null
     ),
 
     vendor_all as (
@@ -292,7 +298,7 @@ with
             proficiency_level,
             score_source,
             scale_score,
-            growth_percentile,
+            national_percentile,
             is_mastery,
         from iready_scores
 
@@ -309,7 +315,7 @@ with
             proficiency_level,
             score_source,
             scale_score,
-            growth_percentile,
+            national_percentile,
             is_mastery,
         from star_scores
 
@@ -326,7 +332,7 @@ with
             proficiency_level,
             score_source,
             scale_score,
-            growth_percentile,
+            national_percentile,
             is_mastery,
         from dibels_scores
     )
@@ -368,7 +374,7 @@ select
     ia.scale_score,
     ia.percent_correct,
 
-    cast(null as numeric) as growth_percentile,
+    cast(null as numeric) as national_percentile,
 
     ia.proficiency_level,
     ia.is_mastery,
@@ -430,7 +436,7 @@ select
     su.scale_score,
     su.percent_correct,
 
-    cast(null as numeric) as growth_percentile,
+    cast(null as numeric) as national_percentile,
 
     su.performance_band as proficiency_level,
     su.is_proficient as is_mastery,
@@ -498,7 +504,7 @@ select
 
     cast(null as numeric) as percent_correct,
 
-    va.growth_percentile,
+    va.national_percentile,
     va.proficiency_level,
     va.is_mastery,
 

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -165,6 +165,170 @@ with
                 cast(sa.student_number as string), sa.state_student_id
             ) as student_identifier,
         from state_all as sa
+    ),
+
+    iready_scores_raw as (
+        select
+            student_id as student_number,
+            academic_year_int as academic_year,
+            subject as module_code,
+            illuminate_subject,
+            test_round as administration_period,
+            completion_date as test_date,
+            `start_date`,
+            _dbt_source_project,
+
+            overall_relative_placement as proficiency_level,
+
+            'iready' as score_source,
+
+            cast(overall_scale_score as numeric) as scale_score,
+            cast(percentile as numeric) as growth_percentile,
+
+            overall_relative_placement_int >= 4 as is_mastery,
+        from {{ ref("int_iready__diagnostic_results") }}
+        where overall_scale_score is not null
+    ),
+
+    -- TODO(#4387): stg_iready__diagnostic_results has no uniqueness test;
+    -- same-day retests and duplicate rows exist upstream. Remove this dedupe
+    -- when staging is fixed.
+    iready_scores as (
+        {{
+            dbt_utils.deduplicate(
+                relation="iready_scores_raw",
+                partition_by="""
+                    _dbt_source_project,
+                    student_number,
+                    academic_year,
+                    administration_period,
+                    module_code,
+                    test_date
+                """,
+                order_by="start_date desc, scale_score desc",
+            )
+        }}
+    ),
+
+    star_scores_raw as (
+        select
+            student_display_id as student_number,
+            academic_year,
+            star_subject as module_code,
+            illuminate_subject,
+            screening_period_window_name as administration_period,
+            completed_date_value as test_date,
+            assessment_id,
+            _dbt_source_project,
+
+            state_benchmark_category_name as proficiency_level,
+
+            'star' as score_source,
+
+            cast(unified_score as numeric) as scale_score,
+            cast(percentile_rank as numeric) as growth_percentile,
+
+            state_benchmark_proficient = 'Yes' as is_mastery,
+        from {{ ref("stg_renlearn__star") }}
+        where
+            completed_date_value is not null
+            and unified_score is not null
+            and _dbt_source_project is not null
+    ),
+
+    -- TODO(#4388): stg_renlearn__star holds fiscal-year re-pull duplicates
+    -- (same assessment_id in two partitions) and same-day retests. Remove
+    -- this dedupe when staging is fixed.
+    star_scores as (
+        {{
+            dbt_utils.deduplicate(
+                relation="star_scores_raw",
+                partition_by="""
+                    _dbt_source_project,
+                    student_number,
+                    academic_year,
+                    administration_period,
+                    module_code,
+                    test_date
+                """,
+                order_by="scale_score desc, assessment_id desc",
+            )
+        }}
+    ),
+
+    -- DIBELS benchmark composites are unique at this grain upstream
+    -- (verified); no dedupe needed.
+    dibels_scores as (
+        select
+            student_number,
+            academic_year,
+            measure_standard as module_code,
+            illuminate_subject,
+            `period` as administration_period,
+            client_date as test_date,
+            _dbt_source_project,
+
+            measure_standard_level as proficiency_level,
+
+            'dibels' as score_source,
+
+            cast(measure_standard_score as numeric) as scale_score,
+            cast(measure_percentile as numeric) as growth_percentile,
+
+            measure_standard_level_int >= 3 as is_mastery,
+        from {{ ref("int_amplify__all_assessments") }}
+        where assessment_type = 'Benchmark' and measure_standard = 'Composite'
+    ),
+
+    vendor_all as (
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from iready_scores
+
+        union all
+
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from star_scores
+
+        union all
+
+        select
+            student_number,
+            academic_year,
+            module_code,
+            illuminate_subject,
+            administration_period,
+            test_date,
+            _dbt_source_project,
+            proficiency_level,
+            score_source,
+            scale_score,
+            growth_percentile,
+            is_mastery,
+        from dibels_scores
     )
 
 /* internal assessments */
@@ -203,6 +367,9 @@ select
 
     ia.scale_score,
     ia.percent_correct,
+
+    cast(null as numeric) as growth_percentile,
+
     ia.proficiency_level,
     ia.is_mastery,
     ia.response_type,
@@ -262,6 +429,9 @@ select
 
     su.scale_score,
     su.percent_correct,
+
+    cast(null as numeric) as growth_percentile,
+
     su.performance_band as proficiency_level,
     su.is_proficient as is_mastery,
 
@@ -286,3 +456,69 @@ inner join
     and su.illuminate_subject = sr.subject_area
     and su._dbt_source_project = sr._dbt_source_project
     and sr.source_type in ('state_nj', 'state_fl')
+
+union all
+
+/* vendor assessments (iReady, STAR, DIBELS) */
+select
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "va.score_source",
+                "va._dbt_source_project",
+                "va.student_number",
+                "va.academic_year",
+                "va.administration_period",
+                "va.module_code",
+                "va.test_date",
+            ]
+        )
+    }} as assessment_score_key,
+
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "va.score_source",
+                "va.module_code",
+                "null",
+                "va.academic_year",
+                "va._dbt_source_project",
+                "va.administration_period",
+                "null",
+                "null",
+            ]
+        )
+    }} as assessment_administration_key,
+
+    sr.student_section_enrollment_key,
+
+    va.test_date as test_date_key,
+
+    va.scale_score,
+
+    cast(null as numeric) as percent_correct,
+
+    va.growth_percentile,
+    va.proficiency_level,
+    va.is_mastery,
+
+    cast(null as string) as response_type,
+    cast(null as string) as response_type_code,
+    cast(null as string) as response_type_description,
+    cast(null as string) as response_type_root_description,
+    cast(null as bool) as is_replacement,
+    cast(null as numeric) as performance_band_label_number,
+
+    sr.resolution_type as enrollment_resolution,
+from vendor_all as va
+-- the resolver keys vendor scores on illuminate_subject (the vendor->course
+-- subject mapping), not the raw vendor subject the assessment_score_key
+-- hashes. INNER scopes the fact to vendor scores with a resolved section.
+inner join
+    {{ ref("int_assessments__resolved_section_enrollments") }} as sr
+    on va.student_number = sr.powerschool_student_number
+    and va.academic_year = sr.academic_year
+    and va.administration_period = sr.administration_period
+    and va.illuminate_subject = sr.subject_area
+    and va._dbt_source_project = sr._dbt_source_project
+    and va.score_source = sr.source_type

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -187,7 +187,7 @@ with
 
             overall_relative_placement_int >= 4 as is_mastery,
         from {{ ref("int_iready__diagnostic_results") }}
-        where overall_scale_score is not null
+        where overall_scale_score is not null and _dbt_source_project is not null
     ),
 
     -- TODO(#4387): stg_iready__diagnostic_results has no uniqueness test;

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -97,12 +97,13 @@ models:
         description: >-
           Percent of questions answered correctly. Null for state assessments.
 
-      - name: growth_percentile
+      - name: national_percentile
         data_type: numeric
         description: >-
-          National percentile for the attempt where the vendor provides one
-          (i-Ready percentile, STAR percentile rank, DIBELS measure percentile).
-          Null for internal and state assessments.
+          National norm-referenced percentile rank for the attempt where the
+          vendor provides one (i-Ready percentile, STAR percentile rank, DIBELS
+          measure percentile). This is an achievement percentile, not a growth
+          percentile. Null for internal and state assessments.
 
       - name: proficiency_level
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -2,8 +2,9 @@ models:
   - name: fct_assessment_scores_enrollment_scoped
     description: >-
       Enrollment-scoped assessment score fact table. One row per student x
-      assessment x administration. Covers internal Illuminate assessments and
-      state assessments (NJSLA, NJGPA, FAST). Each row is linked to an
+      assessment x administration. Covers internal Illuminate assessments, state
+      assessments (NJSLA, NJGPA, FAST), and vendor benchmark assessments
+      (i-Ready Diagnostic, STAR, DIBELS Composite). Each row is linked to an
       assessment administration (via assessment_administration_key) and to the
       student's resolved section enrollment (via student_section_enrollment_key
       and enrollment_resolution).
@@ -95,6 +96,13 @@ models:
         data_type: numeric
         description: >-
           Percent of questions answered correctly. Null for state assessments.
+
+      - name: growth_percentile
+        data_type: numeric
+        description: >-
+          National percentile for the attempt where the vendor provides one
+          (i-Ready percentile, STAR percentile rank, DIBELS measure percentile).
+          Null for internal and state assessments.
 
       - name: proficiency_level
         data_type: string

--- a/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml
+++ b/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml
@@ -269,3 +269,22 @@ models:
         data_type: int64
       - name: teacher_state_id
         data_type: int64
+      - name: completed_date_value
+        data_type: date
+        description: >-
+          Local-time completion calendar date of the attempt, cast from the
+          completed_date_local datetime string. Distinct from the raw string
+          completed_date column.
+      - name: illuminate_subject
+        data_type: string
+        description: >-
+          Course-subject mapping used by the assessment section-enrollment
+          resolver — Math partitions map to Mathematics; Reading and Early
+          Literacy map to Text Study.
+      - name: _dbt_source_project
+        data_type: string
+        description: >-
+          Dagster code location resolved via int_people__location_crosswalk on
+          school_name. Required because NJ districts share one Renaissance
+          instance (kippnj), so the source relation cannot identify the
+          district. NULL when the school name has no crosswalk alias.

--- a/src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql
+++ b/src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql
@@ -8,85 +8,99 @@ with
                 ]
             )
         }}
+    ),
+
+    derived as (
+        -- trunk-ignore(sqlfluff/AM04)
+        select
+            *,
+
+            cast(left(completed_date_local, 10) as date) as completed_date_value,
+
+            _dagster_partition_fiscal_year - 1 as academic_year,
+
+            safe_cast(if(grade = 'K', '0', grade) as int) as grade_level,
+
+            if(
+                _dagster_partition_subject = 'SM', 'Mathematics', 'Text Study'
+            ) as illuminate_subject,
+
+            case
+                when _dagster_partition_subject = 'SM'
+                then 'Math'
+                when _dagster_partition_subject = 'SR'
+                then 'Reading'
+                when _dagster_partition_subject = 'SEL'
+                then 'Early Literacy'
+            end as star_subject,
+
+            case
+                when _dagster_partition_subject = 'SM'
+                then 'Math'
+                when grade = 'K' and _dagster_partition_subject = 'SEL'
+                then 'ELA'
+                when _dagster_partition_subject = 'SR'
+                then 'ELA'
+            end as star_discipline,
+
+            case
+                _dagster_partition_subject
+                when 'SR'
+                then 'Reading'
+                when 'SM'
+                then 'Math'
+                when 'SEL'
+                then 'Reading'
+            end as `subject`,
+
+            case
+                screening_period_window_name
+                when 'Fall'
+                then 'BOY'
+                when 'Winter'
+                then 'MOY'
+                when 'Spring'
+                then 'EOY'
+            end as administration_window,
+
+            case
+                when district_benchmark_proficient = 'Yes'
+                then 1
+                when district_benchmark_proficient = 'No'
+                then 0
+            end as is_district_benchmark_proficient_int,
+
+            case
+                when state_benchmark_proficient = 'Yes'
+                then 1
+                when state_benchmark_proficient = 'No'
+                then 0
+            end as is_state_benchmark_proficient_int,
+
+            row_number() over (
+                partition by
+                    _dbt_source_relation,
+                    _dagster_partition_subject,
+                    _dagster_partition_fiscal_year,
+                    student_identifier,
+                    screening_period_window_name
+                order by completed_date desc
+            ) as rn_subject_round,
+
+            row_number() over (
+                partition by
+                    _dbt_source_relation,
+                    _dagster_partition_subject,
+                    _dagster_partition_fiscal_year,
+                    student_identifier
+                order by completed_date desc
+            ) as rn_subject_year,
+        from union_relations
+        where deactivation_reason is null
     )
 
--- trunk-ignore(sqlfluff/AM04)
-select
-    *,
-
-    _dagster_partition_fiscal_year - 1 as academic_year,
-
-    safe_cast(if(grade = 'K', '0', grade) as int) as grade_level,
-
-    case
-        when _dagster_partition_subject = 'SM'
-        then 'Math'
-        when _dagster_partition_subject = 'SR'
-        then 'Reading'
-        when _dagster_partition_subject = 'SEL'
-        then 'Early Literacy'
-    end as star_subject,
-
-    case
-        when _dagster_partition_subject = 'SM'
-        then 'Math'
-        when grade = 'K' and _dagster_partition_subject = 'SEL'
-        then 'ELA'
-        when _dagster_partition_subject = 'SR'
-        then 'ELA'
-    end as star_discipline,
-
-    case
-        _dagster_partition_subject
-        when 'SR'
-        then 'Reading'
-        when 'SM'
-        then 'Math'
-        when 'SEL'
-        then 'Reading'
-    end as `subject`,
-
-    case
-        screening_period_window_name
-        when 'Fall'
-        then 'BOY'
-        when 'Winter'
-        then 'MOY'
-        when 'Spring'
-        then 'EOY'
-    end as administration_window,
-
-    case
-        when district_benchmark_proficient = 'Yes'
-        then 1
-        when district_benchmark_proficient = 'No'
-        then 0
-    end as is_district_benchmark_proficient_int,
-
-    case
-        when state_benchmark_proficient = 'Yes'
-        then 1
-        when state_benchmark_proficient = 'No'
-        then 0
-    end as is_state_benchmark_proficient_int,
-
-    row_number() over (
-        partition by
-            _dbt_source_relation,
-            _dagster_partition_subject,
-            _dagster_partition_fiscal_year,
-            student_identifier,
-            screening_period_window_name
-        order by completed_date desc
-    ) as rn_subject_round,
-
-    row_number() over (
-        partition by
-            _dbt_source_relation,
-            _dagster_partition_subject,
-            _dagster_partition_fiscal_year,
-            student_identifier
-        order by completed_date desc
-    ) as rn_subject_year,
-from union_relations
-where deactivation_reason is null
+select d.*, lc.location_dagster_code_location as _dbt_source_project,
+from derived as d
+left join
+    {{ ref("int_people__location_crosswalk") }} as lc
+    on d.school_name = lc.location_name


### PR DESCRIPTION
## Summary and Motivation

When merged, this pull request will add iReady, STAR/Renaissance, and DIBELS/Amplify scores to `fct_assessment_scores_enrollment_scoped`, which previously covered only Illuminate internal and NJ/FL state assessments. This completes the Assessment Domain of the star-schema mart (#3543).

Each vendor source is resolved to a student section enrollment and unioned into the fact, mirroring the existing state-assessment pattern. A new nullable `growth_percentile` column (additive; NULL for existing sources) carries the vendors' percentile signal.

Key implementation notes:

- Vendor source models gain additive `_dbt_source_project` and `illuminate_subject` columns; `stg_renlearn__star` also gains a DATE `completed_date_value`. The retired `int_renlearn__star_rollup` stays disabled, so STAR flows through the consolidated `stg_renlearn__star`.
- The section resolver, `dim_assessments`, and `dim_assessment_administrations` each gain iReady/STAR/DIBELS branches.
- The resolver `score_grain_key` now includes `source_type` so iReady Reading and DIBELS (which share course subject and testing window) resolve independently instead of colliding and dropping rows.
- FAST is already present via the existing FL state branch (the issue title was stale) and is out of scope.

Follow-up issues for pre-existing upstream duplicates the fact defensively dedupes around: #4387 (iReady staging), #4388 (STAR staging).

**AI Assistance:** Authored by Claude Code via subagent-driven development, human-directed at each design decision (score grain, STAR proficiency mapping, STAR sourcing model) with a review gate per task and a whole-branch review before this PR.

Closes #3625.

## Self-review

### dbt

- [x] Properties file included for all changed models (all edits are additive columns/branches on existing models with existing properties files; `growth_percentile` added to the fact contract yml).
- [x] Breaking change check: `growth_percentile` is an additive nullable column; no columns renamed or removed. Cube reads the fact by named column and is unaffected. No new or modified external sources, so `stage_external_sources` is not required.

## CI checks

- [ ] Trunk passes.
- [ ] dbt Cloud passes.
- [ ] Dagster Cloud passes or not triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)