### PR TITLE
fix: surface AP exam scores with no matching course enrollment

### DIFF
--- a/docs/superpowers/plans/2026-07-14-ap-dashboard-exam-only-scores.md
+++ b/docs/superpowers/plans/2026-07-14-ap-dashboard-exam-only-scores.md
@@ -1,0 +1,866 @@
+# AP Dashboard Exam-Only Scores Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `rpt_tableau__ap_assessment_dashboard` so a student's AP exam
+score is no longer silently dropped when they have no matching AP course
+enrollment (issue [#4391](https://github.com/TEAMSchools/teamster/issues/4391)).
+
+**Architecture:** Restructure the model's join chain around a new `subjects`
+bridge CTE that unions AP subject codes from course enrollments and exam scores
+independently, so the exam-score join no longer chains through the
+course-enrollment join. Add a `subject_code` grain column, a third
+`test_subject_area` state (`'Took AP exam, not enrolled in course.'`), and an
+`ap_course_name` fallback to the exam's own crosswalk-resolved name.
+
+**Tech Stack:** dbt (BigQuery), `kipptaf` project, dbt unit tests (dict-format
+fixtures), BigQuery MCP for manual verification queries.
+
+## Global Constraints
+
+- Full design and validated queries:
+  `docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md`.
+- Never write student names, DOB, or other PII to a committed file, PR, or issue
+  comment — chat/terminal output only (repo `CLAUDE.md` PII policy).
+- All SQL follows `.trunk/config/.sqlfluff` (BigQuery dialect, trailing commas,
+  single-quoted strings, 88-char lines). Run
+  `/workspaces/teamster/.trunk/tools/trunk check --force <file>` from inside the
+  branch checkout before pushing — the pre-commit hook only runs `fmt`, not the
+  sqlfluff/yamllint checks that fire at pre-push/CI.
+- `given`/`expect` dict scalars in dbt unit tests are normally UNQUOTED per repo
+  convention, **except** a scalar containing a literal comma (e.g.
+  `"Smith, Jane"`, `"Took course, but not AP exam."`) — inside a YAML flow
+  mapping (`{ ... }`), an unquoted comma is parsed as a field separator, not as
+  part of the string, and silently produces a bogus extra key. Quote only those
+  values.
+- `dbt` invocations: always `uv run`, never bare `python`/`dbt`. Use
+  `DBT_PROFILES_DIR=/workspaces/teamster/.dbt` and
+  `--project-dir /workspaces/teamster/src/dbt/kipptaf` on every call from the
+  main repo (or the worktree-equivalent absolute paths per repo `CLAUDE.md` if
+  executing from a worktree).
+- Only one other file in the repo references this model:
+  `src/dbt/kipptaf/models/exposures/tableau.yml` (the Tableau exposure
+  definition). No downstream dbt model `ref()`s it — verified via
+  `grep -rl "rpt_tableau__ap_assessment_dashboard" src/dbt`. No exposure edit is
+  needed; this fix is self-contained to the one model + its properties file.
+- Out of scope, do not touch: the `int_collegeboard__ap_unpivot` dedup bug
+  (collapses multiple unresolved-crosswalk students via `dbt_utils.deduplicate`
+  on a shared NULL `powerschool_student_number` — not tracked yet) and the
+  PowerSchool AP-course-tagging gap tracked in #4390 (a data problem, not a
+  join-structure problem). Also out of scope: how multiple exam attempts for the
+  same subject are deduplicated (`int_assessments__ap_assessments.rn_highest` is
+  not filtered on here, same as pre-fix behavior).
+
+---
+
+### Task 1: Add failing unit tests for the exam-only fix
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml:150`
+  (append `unit_tests:` block at end of file; nothing else in the file changes
+  in this task)
+
+**Interfaces:**
+
+- Consumes: the model's current (pre-fix) column set — `academic_year`,
+  `student_number`, `ap_course_subject`, `test_name`, `test_subject`,
+  `exam_score`, `data_source`, `ps_ap_course_subject_code`, `ap_course_name`,
+  `course_name`, `test_subject_area`, `expected_scope`, `expected_test_type`.
+- Produces: 5 unit tests that reference a `subject_code` output column the model
+  does not yet have — these MUST fail until Task 2 adds it. Task 2 depends on
+  these exact test names and fixture data existing:
+  `test_course_enrollment_no_exam`, `test_course_enrollment_and_matching_exam`,
+  `test_exam_only_no_course_enrollment`, `test_no_course_no_exam`,
+  `test_two_exam_only_subjects_produce_two_distinct_rows`.
+
+- [ ] **Step 1: Append the unit tests block**
+
+Append this block to the end of
+`src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml`
+(the file currently ends after the `expected_test_type` column's `description:`
+— add a blank line, then this):
+
+```yaml
+unit_tests:
+  - name: test_course_enrollment_no_exam
+    description: >-
+      A student enrolled in an AP course who did not take the exam shows 'Took
+      course, but not AP exam.' and resolves ap_course_name from the course-side
+      crosswalk. Regression check: this branch existed before the fix and must
+      keep working.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 101,
+              student_number: 1001,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows:
+          - {
+              cc_studentid: 101,
+              cc_academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__cc,
+              ap_course_subject: ENGLANG,
+              is_dropped_section: false,
+              rn_course_number_year: 1,
+              courses_course_name: AP English Language,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
+              sections_external_expression: P3,
+              teacher_lastfirst: "Smith, Jane",
+            }
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows:
+          - {
+              PS_AP_Course_Subject_Code: ENGLANG,
+              AP_Course_Name: AP English Language and Composition,
+              Data_Source: CB File,
+            }
+      - input: ref('int_assessments__ap_assessments')
+        rows: []
+    expect:
+      rows:
+        - {
+            subject_code: ENGLANG,
+            course_name: AP English Language,
+            ap_course_name: AP English Language and Composition,
+            test_subject_area: "Took course, but not AP exam.",
+            expected_scope: AP,
+            expected_test_type: Official,
+          }
+
+  - name: test_course_enrollment_and_matching_exam
+    description: >-
+      A student enrolled in an AP course who also has a matching exam score
+      shows the exam's course name as test_subject_area. Regression check for
+      the pre-existing matched case.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 102,
+              student_number: 1002,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows:
+          - {
+              cc_studentid: 102,
+              cc_academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__cc,
+              ap_course_subject: BIOLOGY,
+              is_dropped_section: false,
+              rn_course_number_year: 1,
+              courses_course_name: AP Biology,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
+              sections_external_expression: P4,
+              teacher_lastfirst: "Doe, John",
+            }
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows:
+          - {
+              PS_AP_Course_Subject_Code: BIOLOGY,
+              AP_Course_Name: AP Biology,
+              Data_Source: CB File,
+            }
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1002,
+              test_name: AP Biology,
+              test_subject: Biology,
+              exam_score: 4,
+              ps_ap_course_subject_code: BIOLOGY,
+              ap_course_name: AP Biology,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: BIOLOGY,
+            course_name: AP Biology,
+            ap_course_name: AP Biology,
+            test_subject_area: AP Biology,
+            expected_scope: AP,
+            expected_test_type: Official,
+          }
+
+  - name: test_exam_only_no_course_enrollment
+    description: >-
+      Fix for #4391: a student with an AP exam score but no matching AP course
+      enrollment now surfaces as its own row with 'Took AP exam, not enrolled in
+      course.' instead of disappearing. ap_course_name falls back to the exam's
+      own crosswalk-resolved name since there is no course-side match.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 103,
+              student_number: 1003,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1003,
+              test_name: AP Chemistry,
+              test_subject: Chemistry,
+              exam_score: 3,
+              ps_ap_course_subject_code: CHEM,
+              ap_course_name: AP Chemistry,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: CHEM,
+            ap_course_subject: null,
+            course_name: Not an AP course,
+            ap_course_name: AP Chemistry,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+            expected_scope: Not applicable,
+            expected_test_type: Not applicable,
+          }
+
+  - name: test_no_course_no_exam
+    description: >-
+      A non-participating HS student (no AP course, no AP exam) still gets
+      exactly one row, unchanged from pre-fix behavior.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 104,
+              student_number: 1004,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows: []
+    expect:
+      rows:
+        - {
+            subject_code: null,
+            course_name: Not an AP course,
+            ap_course_name: Not an AP course,
+            test_subject_area: Not applicable,
+            expected_scope: Not applicable,
+            expected_test_type: Not applicable,
+          }
+
+  - name: test_two_exam_only_subjects_produce_two_distinct_rows
+    description: >-
+      A student with exam scores in two different subjects and no course
+      enrollment in either gets two distinct rows keyed by subject_code, proving
+      the new grain key prevents the collision that ap_course_subject (always
+      NULL for both rows) would cause.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 105,
+              student_number: 1005,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1005,
+              test_name: AP Chemistry,
+              test_subject: Chemistry,
+              exam_score: 3,
+              ps_ap_course_subject_code: CHEM,
+              ap_course_name: AP Chemistry,
+              data_source: CB File,
+            }
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1005,
+              test_name: AP Physics 1,
+              test_subject: Physics 1,
+              exam_score: 5,
+              ps_ap_course_subject_code: PHYS1,
+              ap_course_name: AP Physics 1,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: CHEM,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+          }
+        - {
+            subject_code: PHYS1,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+          }
+```
+
+- [ ] **Step 2: Run the unit tests and confirm they fail RED**
+
+Run:
+
+```bash
+DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+  --select test_type:unit,rpt_tableau__ap_assessment_dashboard \
+  --target dev --defer --state target/prod \
+  --project-dir /workspaces/teamster/src/dbt/kipptaf
+```
+
+Expected: `Done. PASS=0 WARN=0 ERROR=5 SKIP=0 NO-OP=0 TOTAL=5`, with each of the
+5 failures showing:
+
+```text
+Compilation Error in unit_test <test_name> (models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml)
+  Invalid column name: 'subject_code' in unit test fixture for expected output.
+  Accepted columns for expected output are: ['academic_year', ... 'expected_test_type']
+```
+
+This confirms the tests correctly detect that `subject_code` doesn't exist on
+the model yet — the RED state driving Task 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+git commit -m "test: add failing unit tests for AP dashboard exam-only scores (#4391)"
+```
+
+---
+
+### Task 2: Restructure the model and make the tests pass
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql`
+  (full rewrite)
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml:1-149`
+  (model description, uniqueness test key, new `subject_code` column, updated
+  `ap_course_name`/`test_subject_area` descriptions — the `unit_tests:` block
+  from Task 1 is untouched)
+
+**Interfaces:**
+
+- Consumes: the 5 unit tests from Task 1 (must all pass after this task).
+  Upstream refs unchanged: `int_extracts__student_enrollments`,
+  `base_powerschool__course_enrollments`,
+  `stg_google_sheets__collegeboard__ap_course_crosswalk`,
+  `int_assessments__ap_assessments`.
+- Produces: `subject_code` (STRING) — the bridged grain key other tasks/future
+  consumers would join on. `ap_course_subject` keeps its exact prior meaning
+  (course-enrollment-only, nullable).
+
+- [ ] **Step 1: Replace the model SQL**
+
+Replace the full contents of
+`src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql`
+with:
+
+```sql
+with
+    course_enrollments as (
+        select
+            _dbt_source_relation,
+            cc_studentid,
+            cc_academic_year,
+            ap_course_subject,
+            cc_dateenrolled,
+            cc_dateleft,
+            sections_external_expression,
+            teacher_lastfirst,
+            courses_course_name,
+        from {{ ref("base_powerschool__course_enrollments") }}
+        where rn_course_number_year = 1 and ap_course_subject is not null and not is_dropped_section
+    ),
+
+    ap_assessments as (
+        select
+            academic_year,
+            powerschool_student_number,
+            test_name,
+            test_subject,
+            exam_score,
+            irregularity_code_1,
+            irregularity_code_2,
+            data_source,
+            ps_ap_course_subject_code,
+            ap_course_name,
+        from {{ ref("int_assessments__ap_assessments") }}
+        where test_subject != 'Calculus BC: AB Subscore'
+    ),
+
+    subjects as (
+        select distinct
+            e.studentid,
+            e.student_number,
+            e.academic_year,
+            e._dbt_source_relation,
+            c.ap_course_subject as subject_code,
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        inner join
+            course_enrollments as c
+            on e.studentid = c.cc_studentid
+            and e.academic_year = c.cc_academic_year
+            and {{ union_dataset_join_clause(left_alias="e", right_alias="c") }}
+
+        union distinct
+
+        select distinct
+            e.studentid,
+            e.student_number,
+            e.academic_year,
+            e._dbt_source_relation,
+            ap.ps_ap_course_subject_code as subject_code,
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        inner join
+            ap_assessments as ap
+            on e.academic_year = ap.academic_year
+            and e.student_number = ap.powerschool_student_number
+    )
+
+select
+    e.academic_year,
+    e.academic_year_display,
+    e.region,
+    e.schoolid,
+    e.school,
+    e.student_number,
+    e.student_name,
+    e.grade_level,
+    e.enroll_status,
+    e.entrydate,
+    e.exitdate,
+    e.cohort,
+    e.advisory,
+    e.is_enrolled_recent,
+    e.is_enrolled_y1,
+    e.is_504 as c_504_status,
+    e.lep_status,
+    e.gifted_and_talented,
+    e.salesforce_id as contact_id,
+    e.ktc_cohort,
+    e.graduation_year,
+
+    sub.subject_code,
+
+    s.cc_dateenrolled as ap_date_enrolled,
+    s.cc_dateleft as ap_date_left,
+    s.sections_external_expression as ap_course_section,
+    s.teacher_lastfirst as ap_teacher_name,
+    s.ap_course_subject,
+
+    a.test_name,
+    a.test_subject,
+    a.exam_score,
+    a.irregularity_code_1,
+    a.irregularity_code_2,
+    a.data_source,
+    a.ps_ap_course_subject_code,
+
+    coalesce(x.ap_course_name, a.ap_course_name, 'Not an AP course') as ap_course_name,
+
+    coalesce(s.courses_course_name, 'Not an AP course') as course_name,
+
+    case
+        when s.courses_course_name is null and a.test_name is null
+        then 'Not applicable'
+        when s.courses_course_name is not null and a.test_name is null
+        then 'Took course, but not AP exam.'
+        when s.courses_course_name is null and a.test_name is not null
+        then 'Took AP exam, not enrolled in course.'
+        else a.ap_course_name
+    end as test_subject_area,
+
+    if(e.iep_status = 'No IEP', 0, 1) as sped,
+
+    if(s.courses_course_name is null, 'Not applicable', 'AP') as expected_scope,
+
+    if(
+        s.courses_course_name is null, 'Not applicable', 'Official'
+    ) as expected_test_type,
+
+from {{ ref("int_extracts__student_enrollments") }} as e
+left join
+    subjects as sub
+    on e.studentid = sub.studentid
+    and e.academic_year = sub.academic_year
+    and {{ union_dataset_join_clause(left_alias="e", right_alias="sub") }}
+left join
+    course_enrollments as s
+    on sub.studentid = s.cc_studentid
+    and sub.academic_year = s.cc_academic_year
+    and sub.subject_code = s.ap_course_subject
+    and {{ union_dataset_join_clause(left_alias="sub", right_alias="s") }}
+left join
+    ap_assessments as a
+    on sub.student_number = a.powerschool_student_number
+    and sub.academic_year = a.academic_year
+    and sub.subject_code = a.ps_ap_course_subject_code
+left join
+    {{ ref("stg_google_sheets__collegeboard__ap_course_crosswalk") }} as x
+    on sub.subject_code = x.ps_ap_course_subject_code
+    and x.data_source = 'CB File'
+where
+    e.rn_year = 1
+    and e.school_level = 'HS'
+    and date(e.academic_year + 1, 05, 01) between e.entrydate and e.exitdate
+```
+
+- [ ] **Step 2: Update the properties file**
+
+In
+`src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml`,
+make these four edits (the `unit_tests:` block from Task 1 stays as-is at the
+end of the file):
+
+1. Model `description:` (currently ends "...who did not take the exam.") —
+   replace with:
+
+   ```yaml
+   description: >
+     AP assessment scores joined to student enrollment and course schedules for
+     Tableau reporting. One row per student per AP course subject, including
+     students enrolled in AP courses who did not take the exam and students who
+     took an exam with no matching AP course enrollment.
+   ```
+
+2. `data_tests.dbt_utils.unique_combination_of_columns.arguments.combination_of_columns`
+   — change the third entry from `ap_course_subject` to `subject_code`:
+
+   ```yaml
+   data_tests:
+     - dbt_utils.unique_combination_of_columns:
+         arguments:
+           combination_of_columns:
+             - academic_year
+             - student_number
+             - subject_code
+   ```
+
+3. Insert a new column entry immediately after `graduation_year` and before
+   `ap_date_enrolled`:
+
+   ```yaml
+   - name: subject_code
+     data_type: string
+     description: >
+       AP subject code bridging course enrollment and exam records for the
+       report grain — the course-enrollment subject code when the student is
+       enrolled in an AP course, otherwise the exam's own College Board subject
+       code. NULL only when the student has neither.
+   ```
+
+4. Replace the `ap_course_name` and `test_subject_area` column `description:`
+   fields:
+
+   ```yaml
+   - name: ap_course_name
+     data_type: string
+     description: >
+       AP course name from the College Board crosswalk when the student has an
+       AP course enrollment; otherwise the exam's own crosswalk-resolved name
+       when the student took the exam with no matching course; 'Not an AP
+       course' if neither resolves.
+   ```
+
+   ```yaml
+   - name: test_subject_area
+     data_type: string
+     description: >
+       Derived field indicating exam relationship to course: 'Not applicable' if
+       no AP course and no exam, 'Took course, but not AP exam.' if enrolled but
+       did not test, 'Took AP exam, not enrolled in course.' if tested with no
+       matching course enrollment, otherwise the College Board AP course name.
+   ```
+
+- [ ] **Step 3: Run the unit tests and confirm GREEN**
+
+Run the same command as Task 1 Step 2:
+
+```bash
+DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt test \
+  --select test_type:unit,rpt_tableau__ap_assessment_dashboard \
+  --target dev --defer --state target/prod \
+  --project-dir /workspaces/teamster/src/dbt/kipptaf
+```
+
+Expected: `Done. PASS=5 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=5`.
+
+- [ ] **Step 4: Full dev build and contract/uniqueness check**
+
+Run:
+
+```bash
+DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt build \
+  --select rpt_tableau__ap_assessment_dashboard \
+  --target dev --defer --state target/prod \
+  --project-dir /workspaces/teamster/src/dbt/kipptaf
+```
+
+Expected: the 5 unit tests PASS, the view builds (`CREATE VIEW (0 processed)`),
+and the uniqueness test reports `WARN 3` (not an ERROR) —
+`Got 3 results, configured to warn if != 0`. This WARN is **expected and
+pre-existing**, not a regression: it is the same 3-row duplicate (academic_year
+2021, `subject_code = '4'` / Calculus BC, three Newark students, each with two
+PowerSchool course-enrollment rows for distinct `course_number`s both tagged
+`ap_course_subject = '4'` — a main section plus a companion "Recitation"
+section) that already exists in prod today keyed on
+`(academic_year, student_number, ap_course_subject)`. Confirm this by running,
+via BigQuery MCP:
+
+```sql
+select academic_year, student_number, ap_course_subject, count(*) as n
+from `teamster-332318`.kipptaf_tableau.rpt_tableau__ap_assessment_dashboard
+group by academic_year, student_number, ap_course_subject
+having count(*) > 1
+```
+
+This should return the same 3 rows. If it returns different rows or a different
+count, stop and investigate before proceeding — that would mean the fix
+introduced a new duplication source, not carried forward an old one. Do not add
+a defensive dedupe for this — it matches the repo's standing convention for the
+similar `base_powerschool__course_enrollments` double-write issue (#3900/#3915):
+downgrade/track, don't dedupe. No action needed here since the test already
+defaults to WARN (no severity override in this model's yml).
+
+- [ ] **Step 5: Format and lint**
+
+```bash
+/workspaces/teamster/.trunk/tools/trunk fmt \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+```
+
+Expected: `✔ No issues` after `fmt` resolves any formatting-only diffs. Fix
+anything `check` reports before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
+git add src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+git commit -m "fix: surface AP exam scores with no matching course enrollment (#4391)"
+```
+
+---
+
+### Task 3: Verify against prod — row diff, reconciliation, and known cases
+
+**Files:** none — this task is read-only verification via the BigQuery MCP
+(`mcp__bigquery__execute_sql`) against the dev build from Task 2 and the prod
+table. Nothing here is committed to git; PII-adjacent results (student names)
+stay in chat only per repo policy.
+
+**Interfaces:**
+
+- Consumes: the dev-schema table materialized in Task 2 Step 4
+  (`zz_<your-github-username>_kipptaf_tableau.rpt_tableau__ap_assessment_dashboard`
+  — find the exact schema name from the Task 2 Step 4 build log, or query
+  `INFORMATION_SCHEMA.SCHEMATA` per repo `CLAUDE.md` "Local dev schema naming"
+  guidance) and the prod table
+  `kipptaf_tableau.rpt_tableau__ap_assessment_dashboard`.
+- Produces: a chat-only summary (added/deleted counts by `test_subject_area`,
+  reconciliation result, spot-check confirmation) — no file output.
+
+- [ ] **Step 1: Run the null-safe row diff**
+
+Run via BigQuery MCP (substitute `<dev_schema>` with your actual dev schema from
+Task 2 Step 4):
+
+```sql
+with
+    prod as (
+        select
+            academic_year, student_number,
+            ifnull(ap_course_subject, '__none__') as subject_code_key,
+            test_subject_area
+        from `teamster-332318`.kipptaf_tableau.rpt_tableau__ap_assessment_dashboard
+    ),
+    dev as (
+        select
+            academic_year, student_number,
+            ifnull(subject_code, '__none__') as subject_code_key,
+            test_subject_area
+        from `teamster-332318`.<dev_schema>.rpt_tableau__ap_assessment_dashboard
+    ),
+    added as (
+        select dev.*
+        from dev
+        left join prod
+            on dev.academic_year = prod.academic_year
+            and dev.student_number = prod.student_number
+            and dev.subject_code_key = prod.subject_code_key
+        where prod.student_number is null
+    ),
+    deleted as (
+        select prod.*
+        from prod
+        left join dev
+            on prod.academic_year = dev.academic_year
+            and prod.student_number = dev.student_number
+            and prod.subject_code_key = dev.subject_code_key
+        where dev.student_number is null
+    )
+select 'added' as change_type, test_subject_area, count(*) as row_count
+from added
+group by test_subject_area
+union all
+select 'deleted' as change_type, test_subject_area, count(*) as row_count
+from deleted
+group by test_subject_area
+order by change_type
+```
+
+Expected shape (validated 2026-07-14 against then-current prod data; your exact
+counts will differ since underlying enrollment/exam data changes daily — that's
+fine, only the _shape_ matters):
+
+- One `added` row grouped under
+  `test_subject_area = 'Took AP exam, not enrolled in course.'` — nonzero,
+  spanning potentially many historical academic years (this bug predates 2018
+  and isn't year-scoped, so the fix surfaces more than just the 3 cases cited in
+  #4391).
+- If `added` shows ANY other `test_subject_area` value, stop — that's unexpected
+  and needs investigation before merging.
+- One or more `deleted` rows, likely under
+  `test_subject_area = 'Not applicable'`.
+
+- [ ] **Step 2: Run the reconciliation check on the `deleted` bucket**
+
+A `deleted` row is not automatically a regression — a student who was a total
+non-participant (`'Not applicable'` placeholder row) and turns out to have an
+exam-only score gets that placeholder _replaced_ by a real subject row, which
+looks like one delete + one add for the same student/year, not a net loss. Run
+(reusing the `added`/`deleted` CTEs from Step 1):
+
+```sql
+select
+    count(*) as deleted_rows,
+    countif(a.student_number is not null) as accounted_for_by_an_added_row,
+    countif(a.student_number is null) as true_regressions
+from deleted as d
+left join (select distinct academic_year, student_number from added) as a
+    on d.academic_year = a.academic_year and d.student_number = a.student_number
+```
+
+Expected: `true_regressions = 0` (validated 0/119 on 2026-07-14 prod data). If
+`true_regressions > 0`, stop and investigate those specific
+`(academic_year, student_number)` pairs before merging — that means the
+restructured joins lost a row with no offsetting replacement.
+
+- [ ] **Step 3: Spot-check the 3 originally-reported students (chat only)**
+
+Using the 3 student identities from #4391 (kept local — do not paste them into
+any committed file, issue comment, or PR description), query the dev table and
+confirm each now shows
+`test_subject_area = 'Took AP exam, not enrolled in course.'` with a populated
+`ap_course_name`. Report the confirmation in chat as "3/3 confirmed", not by
+pasting the student rows into any persisted output.
+
+- [ ] **Step 4: Summarize findings in chat**
+
+Report to the user: total `added` count and its single `test_subject_area`
+bucket, total `deleted` count, `true_regressions` count (must be 0 to proceed),
+and the 3/3 spot-check confirmation. This is the deliverable for this task — no
+commit.
+
+---
+
+### Task 4: Finish the branch
+
+**Files:** none (repo-level checks only).
+
+**Interfaces:**
+
+- Consumes: the committed changes from Tasks 1–2 and the verification findings
+  from Task 3.
+- Produces: a PR-ready branch.
+
+- [ ] **Step 1: Full project sanity check**
+
+```bash
+DBT_PROFILES_DIR=/workspaces/teamster/.dbt uv run dbt parse --target prod \
+  --project-dir /workspaces/teamster/src/dbt/kipptaf
+```
+
+Expected: parses cleanly with no errors (confirms nothing else in the 750-model
+kipptaf project broke from this change — no warehouse write, safe to run without
+prod-deploy approval per repo `CLAUDE.md`).
+
+- [ ] **Step 2: Review the full diff**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expected: 2 commits (Task 1's test commit, Task 2's fix commit), touching only
+the model `.sql` and its `properties.yml`.
+
+- [ ] **Step 3: Hand off**
+
+Report the Task 3 verification summary to the user and invoke
+`superpowers:finishing-a-development-branch` to decide on PR vs. further changes
+— do not push or open a PR without the user's go-ahead per repo `CLAUDE.md`
+conventions (dbt Cloud CI state check before pushing, PR template usage, etc.).

--- a/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
+++ b/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
@@ -142,16 +142,25 @@ exam status, since those fields describe course-side expectations.
 3. **Prod vs. new-build row diff** — run via BigQuery MCP, comparing the dev
    build against the prod table. Prod's `ap_course_subject` stands in for the
    old grain key (pre-fix, that column _was_ the full grain), so this is
-   apples-to-apples:
+   apples-to-apples. **`subject_code`/`ap_course_subject` is NULL for every
+   non-participating student, and SQL `NULL = NULL` never matches** — a plain
+   equality join on the raw column makes every non-participant look like both an
+   add and a delete. Coalesce both sides to a sentinel before joining:
 
    ```sql
    with
        prod as (
-           select academic_year, student_number, ap_course_subject as subject_code
+           select
+               academic_year, student_number,
+               ifnull(ap_course_subject, '__none__') as subject_code_key,
+               test_subject_area
            from `teamster-332318`.kipptaf_tableau.rpt_tableau__ap_assessment_dashboard
        ),
        dev as (
-           select academic_year, student_number, subject_code
+           select
+               academic_year, student_number,
+               ifnull(subject_code, '__none__') as subject_code_key,
+               test_subject_area
            from `teamster-332318`.<dev_schema>.rpt_tableau__ap_assessment_dashboard
        ),
        added as (
@@ -160,7 +169,7 @@ exam status, since those fields describe course-side expectations.
            left join prod
                on dev.academic_year = prod.academic_year
                and dev.student_number = prod.student_number
-               and dev.subject_code = prod.subject_code
+               and dev.subject_code_key = prod.subject_code_key
            where prod.student_number is null
        ),
        deleted as (
@@ -169,23 +178,51 @@ exam status, since those fields describe course-side expectations.
            left join dev
                on prod.academic_year = dev.academic_year
                and prod.student_number = dev.student_number
-               and prod.subject_code = dev.subject_code
+               and prod.subject_code_key = dev.subject_code_key
            where dev.student_number is null
        )
-   select 'added' as change_type, count(*) as row_count
+   select 'added' as change_type, test_subject_area, count(*) as row_count
    from added
+   group by test_subject_area
    union all
-   select 'deleted' as change_type, count(*) as row_count
+   select 'deleted' as change_type, test_subject_area, count(*) as row_count
    from deleted
+   group by test_subject_area
+   order by change_type
+   ```
+
+   Dry-run validated against current prod data (2026-07-14): `added` = 245,
+   entirely `'Took AP exam, not enrolled in course.'` rows, spanning many
+   historical academic years, not just the 3 cases cited in #4391 — the bug has
+   been silently dropping exam-only scores since before 2018, the fix isn't
+   year-scoped. `deleted` = 119, entirely `'Not applicable'` rows.
+
+   **A `deleted` row is not automatically a regression.** A student who was
+   previously a total non-participant (`'Not applicable'`, one placeholder row)
+   and turns out to have an exam-only score gets their placeholder row
+   _replaced_ by a real subject row — that shows up as one `deleted` + one
+   `added` for the same `(academic_year, student_number)`, not a net loss. Run
+   this reconciliation before trusting the `deleted` count:
+
+   ```sql
+   select
+       count(*) as deleted_rows,
+       countif(a.student_number is not null) as accounted_for_by_an_added_row,
+       countif(a.student_number is null) as true_regressions
+   from deleted as d
+   left join (select distinct academic_year, student_number from added) as a
+       on d.academic_year = a.academic_year and d.student_number = a.student_number
    ```
 
    Expected outcome and follow-up:
    - `added` should be > 0 and, when grouped by `test_subject_area`, should
      consist entirely of `'Took AP exam, not enrolled in course.'` rows —
      anything else in that bucket needs a look before merging.
-   - `deleted` should be **0**. Any deleted row means the restructured joins
-     lost a row that used to show up — a regression, not an improvement — and
-     blocks the fix until explained.
+   - `true_regressions` (from the reconciliation query) must be **0**. Any row
+     there means the restructured joins lost a row that used to show up for a
+     student with no offsetting new row — a real regression, not an improvement
+     — and blocks the fix until explained. (Validated 0/119 on current prod
+     data.)
    - Cross-check: `count(dev) = count(prod) + added - deleted`.
 
 ## Scope

--- a/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
+++ b/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
@@ -4,6 +4,22 @@
 - **Status:** Design
 - **Date:** 2026-07-14
 
+> **Amendment (pre-existing uniqueness warning):** a full dev build of the fixed
+> model surfaced a WARN on the `subject_code` uniqueness test for 3 rows
+> (academic_year 2021, three Newark students, `subject_code = '4'` / Calculus
+> BC). Verified this is **pre-existing, not caused by this fix**: the current
+> prod table already has the identical 3-row duplicate keyed on
+> `(academic_year, student_number, ap_course_subject)` — each of these students
+> has two separate PowerSchool course-enrollment rows both tagged
+> `ap_course_subject = '4'` (a main "AP Calculus BC" section plus a companion
+> "Math IV Calculus AP BC Recitation" section, distinct `course_number`s so
+> `rn_course_number_year = 1` doesn't collapse them). The fix's
+> `course_enrollments` CTE filters identically to the original model's `s` join,
+> so this data-quality quirk carries forward unchanged. No action item for this
+> fix; do not add defensive dedupe for it (matches this repo's standing
+> convention for the similar `base_powerschool__course_enrollments` double-write
+> issue, #3900/#3915 — downgrade/track, don't dedupe).
+
 ## Summary
 
 `rpt_tableau__ap_assessment_dashboard`

--- a/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
+++ b/docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md
@@ -1,0 +1,204 @@
+# AP dashboard: surface exam scores with no matching course enrollment
+
+- **Issue:** [#4391](https://github.com/TEAMSchools/teamster/issues/4391)
+- **Status:** Design
+- **Date:** 2026-07-14
+
+## Summary
+
+`rpt_tableau__ap_assessment_dashboard`
+([`src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql`](../../../src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql))
+silently drops a student's AP exam score whenever they have no matching
+AP-tagged course enrollment for that subject. College Board doesn't require
+course enrollment to sit an exam, so this is a real, expected scenario — not
+every AP exam-taker has a matching PowerSchool course record. The fix
+restructures the model's joins so the exam-score join no longer depends on a
+course-enrollment match, adds a new grain key column, and adds a new dashboard
+state for this case.
+
+## Problem
+
+The current join chain is:
+
+```sql
+from int_extracts__student_enrollments as e
+left join base_powerschool__course_enrollments as s
+    on e.studentid = s.cc_studentid
+    and e.academic_year = s.cc_academic_year
+    and s.ap_course_subject is not null
+    and not s.is_dropped_section
+left join stg_google_sheets__collegeboard__ap_course_crosswalk as x
+    on s.ap_course_subject = x.ps_ap_course_subject_code
+left join int_assessments__ap_assessments as a
+    on e.academic_year = a.academic_year
+    and e.student_number = a.powerschool_student_number
+    and s.ap_course_subject = a.ps_ap_course_subject_code
+```
+
+The `a` (exam score) join predicate references `s.ap_course_subject`. Since `s`
+only produces a row when the student has a matching AP-tagged course enrollment,
+a student with no such enrollment gets `s` = NULL — which means the `a` join can
+never fire either, even when the student genuinely has a score in
+`int_assessments__ap_assessments` for that subject. The row isn't mislabeled;
+it's invisible.
+
+Found while auditing the 2025-2026 AP data pipeline (#4390): 3 exam-score rows
+present in `int_collegeboard__ap_unpivot` were absent from the dashboard, each
+tracing to this join structure rather than a data gap.
+
+## Approach: subject-bridge CTE
+
+Add a CTE that unions the distinct AP subject codes a student is associated
+with, from either side — course enrollment or exam score — then join course
+enrollment (`s`), the course-crosswalk (`x`), and exam scores (`a`)
+independently off that bridge instead of chaining `a` through `s`:
+
+```sql
+subjects as (
+    select distinct academic_year, student_number, ap_course_subject as subject_code
+    from course_enrollments -- s, same filters as today: ap_course_subject is not null,
+                            -- not is_dropped_section, rn_course_number_year = 1
+    union distinct
+    select distinct
+        academic_year, powerschool_student_number as student_number,
+        ps_ap_course_subject_code as subject_code
+    from ap_assessments -- a, same filter as today: test_subject != 'Calculus BC: AB Subscore'
+)
+
+...
+
+from e
+left join subjects using (academic_year, student_number)
+left join course_enrollments as s
+    using (academic_year, student_number, subject_code) -- plus union_dataset_join_clause
+left join ap_assessments as a
+    using (academic_year, student_number, subject_code)
+left join ap_course_crosswalk as x
+    on subjects.subject_code = x.ps_ap_course_subject_code
+    and x.data_source = 'CB File'
+```
+
+A non-participating HS student (no AP course, no AP exam) still gets exactly one
+row — `subjects` has no match, so `s`/`a`/`x` all stay NULL, same as today. A
+participant gets one row per distinct subject drawn from either source.
+
+## New column: `subject_code`
+
+The existing uniqueness test keys on
+`(academic_year, student_number, ap_course_subject)`. `ap_course_subject` is
+sourced only from `s` and can be NULL — once `a` no longer depends on `s`, two
+exam-only rows in different subjects would both have `ap_course_subject = NULL`
+and collide on the grain.
+
+Rather than changing what `ap_course_subject` means (it stays
+course-enrollment-only, exactly as today, including NULL when there's no
+course), add a new column `subject_code` — the bridged value, populated for
+every participant regardless of which side matched — and move the uniqueness
+test onto it:
+
+```yaml
+data_tests:
+  - dbt_utils.unique_combination_of_columns:
+      arguments:
+        combination_of_columns:
+          - academic_year
+          - student_number
+          - subject_code
+```
+
+## Display logic
+
+`test_subject_area` gets a third branch, and `ap_course_name` falls back to the
+exam's own crosswalk-resolved name (`a.ap_course_name`, already computed
+upstream in `int_assessments__ap_assessments` independent of the course-side
+crosswalk `x`) when there's no course-side match:
+
+```sql
+case
+    when s.courses_course_name is null and a.test_name is null
+    then 'Not applicable'
+    when s.courses_course_name is not null and a.test_name is null
+    then 'Took course, but not AP exam.'
+    when s.courses_course_name is null and a.test_name is not null
+    then 'Took AP exam, not enrolled in course.'
+    else a.ap_course_name
+end as test_subject_area,
+
+coalesce(x.ap_course_name, a.ap_course_name, 'Not an AP course') as ap_course_name,
+```
+
+`course_name`, `expected_scope`, and `expected_test_type` are unchanged — they
+stay `'Not applicable'` whenever there's no course enrollment, regardless of
+exam status, since those fields describe course-side expectations.
+
+## Testing plan
+
+1. `dbt build --select rpt_tableau__ap_assessment_dashboard --target dev --defer --state <prod manifest>`
+   to materialize the fix into a dev schema.
+2. Spot-check the 3 known-affected students from #4391 in chat only (never in a
+   committed file, per repo PII policy) — confirm each now appears with
+   `test_subject_area = 'Took AP exam, not enrolled in course.'` and a populated
+   `ap_course_name`.
+3. **Prod vs. new-build row diff** — run via BigQuery MCP, comparing the dev
+   build against the prod table. Prod's `ap_course_subject` stands in for the
+   old grain key (pre-fix, that column _was_ the full grain), so this is
+   apples-to-apples:
+
+   ```sql
+   with
+       prod as (
+           select academic_year, student_number, ap_course_subject as subject_code
+           from `teamster-332318`.kipptaf_tableau.rpt_tableau__ap_assessment_dashboard
+       ),
+       dev as (
+           select academic_year, student_number, subject_code
+           from `teamster-332318`.<dev_schema>.rpt_tableau__ap_assessment_dashboard
+       ),
+       added as (
+           select dev.*
+           from dev
+           left join prod
+               on dev.academic_year = prod.academic_year
+               and dev.student_number = prod.student_number
+               and dev.subject_code = prod.subject_code
+           where prod.student_number is null
+       ),
+       deleted as (
+           select prod.*
+           from prod
+           left join dev
+               on prod.academic_year = dev.academic_year
+               and prod.student_number = dev.student_number
+               and prod.subject_code = dev.subject_code
+           where dev.student_number is null
+       )
+   select 'added' as change_type, count(*) as row_count
+   from added
+   union all
+   select 'deleted' as change_type, count(*) as row_count
+   from deleted
+   ```
+
+   Expected outcome and follow-up:
+   - `added` should be > 0 and, when grouped by `test_subject_area`, should
+     consist entirely of `'Took AP exam, not enrolled in course.'` rows —
+     anything else in that bucket needs a look before merging.
+   - `deleted` should be **0**. Any deleted row means the restructured joins
+     lost a row that used to show up — a regression, not an improvement — and
+     blocks the fix until explained.
+   - Cross-check: `count(dev) = count(prod) + added - deleted`.
+
+## Scope
+
+Distinct from two related issues also found during the #4390 audit:
+
+- The `int_collegeboard__ap_unpivot` dedup bug (collapses multiple
+  unresolved-crosswalk students into one row via `dbt_utils.deduplicate` on a
+  shared NULL `powerschool_student_number`) — not tracked yet, not this fix.
+- The PowerSchool AP-course-tagging gap tracked in #4390 — a data problem, not a
+  join-structure problem, and separately owned.
+
+This fix only changes join structure, adds one column, and adds one dashboard
+state. It does not change how multiple exam attempts for the same subject are
+deduplicated (`int_assessments__ap_assessments.rn_highest` is not filtered on
+here, same as before this fix) — that's pre-existing behavior, out of scope.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -147,3 +147,268 @@ models:
         description: >
           'Official' if student is enrolled in an AP course, 'Not applicable'
           otherwise.
+
+unit_tests:
+  - name: test_course_enrollment_no_exam
+    description: >-
+      A student enrolled in an AP course who did not take the exam shows 'Took
+      course, but not AP exam.' and resolves ap_course_name from the course-side
+      crosswalk. Regression check: this branch existed before the fix and must
+      keep working.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 101,
+              student_number: 1001,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows:
+          - {
+              cc_studentid: 101,
+              cc_academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__cc,
+              ap_course_subject: ENGLANG,
+              is_dropped_section: false,
+              rn_course_number_year: 1,
+              courses_course_name: AP English Language,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
+              sections_external_expression: P3,
+              teacher_lastfirst: "Smith, Jane",
+            }
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows:
+          - {
+              PS_AP_Course_Subject_Code: ENGLANG,
+              AP_Course_Name: AP English Language and Composition,
+              Data_Source: CB File,
+            }
+      - input: ref('int_assessments__ap_assessments')
+        rows: []
+    expect:
+      rows:
+        - {
+            subject_code: ENGLANG,
+            course_name: AP English Language,
+            ap_course_name: AP English Language and Composition,
+            test_subject_area: "Took course, but not AP exam.",
+            expected_scope: AP,
+            expected_test_type: Official,
+          }
+
+  - name: test_course_enrollment_and_matching_exam
+    description: >-
+      A student enrolled in an AP course who also has a matching exam score
+      shows the exam's course name as test_subject_area. Regression check for
+      the pre-existing matched case.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 102,
+              student_number: 1002,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows:
+          - {
+              cc_studentid: 102,
+              cc_academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__cc,
+              ap_course_subject: BIOLOGY,
+              is_dropped_section: false,
+              rn_course_number_year: 1,
+              courses_course_name: AP Biology,
+              cc_dateenrolled: 2024-09-01,
+              cc_dateleft: 2025-06-15,
+              sections_external_expression: P4,
+              teacher_lastfirst: "Doe, John",
+            }
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows:
+          - {
+              PS_AP_Course_Subject_Code: BIOLOGY,
+              AP_Course_Name: AP Biology,
+              Data_Source: CB File,
+            }
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1002,
+              test_name: AP Biology,
+              test_subject: Biology,
+              exam_score: 4,
+              ps_ap_course_subject_code: BIOLOGY,
+              ap_course_name: AP Biology,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: BIOLOGY,
+            course_name: AP Biology,
+            ap_course_name: AP Biology,
+            test_subject_area: AP Biology,
+            expected_scope: AP,
+            expected_test_type: Official,
+          }
+
+  - name: test_exam_only_no_course_enrollment
+    description: >-
+      Fix for #4391: a student with an AP exam score but no matching AP course
+      enrollment now surfaces as its own row with 'Took AP exam, not enrolled in
+      course.' instead of disappearing. ap_course_name falls back to the exam's
+      own crosswalk-resolved name since there is no course-side match.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 103,
+              student_number: 1003,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1003,
+              test_name: AP Chemistry,
+              test_subject: Chemistry,
+              exam_score: 3,
+              ps_ap_course_subject_code: CHEM,
+              ap_course_name: AP Chemistry,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: CHEM,
+            ap_course_subject: null,
+            course_name: Not an AP course,
+            ap_course_name: AP Chemistry,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+            expected_scope: Not applicable,
+            expected_test_type: Not applicable,
+          }
+
+  - name: test_no_course_no_exam
+    description: >-
+      A non-participating HS student (no AP course, no AP exam) still gets
+      exactly one row, unchanged from pre-fix behavior.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 104,
+              student_number: 1004,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows: []
+    expect:
+      rows:
+        - {
+            subject_code: null,
+            course_name: Not an AP course,
+            ap_course_name: Not an AP course,
+            test_subject_area: Not applicable,
+            expected_scope: Not applicable,
+            expected_test_type: Not applicable,
+          }
+
+  - name: test_two_exam_only_subjects_produce_two_distinct_rows
+    description: >-
+      A student with exam scores in two different subjects and no course
+      enrollment in either gets two distinct rows keyed by subject_code, proving
+      the new grain key prevents the collision that ap_course_subject (always
+      NULL for both rows) would cause.
+    model: rpt_tableau__ap_assessment_dashboard
+    given:
+      - input: ref('int_extracts__student_enrollments')
+        rows:
+          - {
+              studentid: 105,
+              student_number: 1005,
+              academic_year: 2024,
+              _dbt_source_relation: kippnewark_powerschool.stg_powerschool__students,
+              rn_year: 1,
+              school_level: HS,
+              entrydate: 2024-08-01,
+              exitdate: 2025-06-15,
+              iep_status: No IEP,
+            }
+      - input: ref('base_powerschool__course_enrollments')
+        rows: []
+      - input: ref('stg_google_sheets__collegeboard__ap_course_crosswalk')
+        rows: []
+      - input: ref('int_assessments__ap_assessments')
+        rows:
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1005,
+              test_name: AP Chemistry,
+              test_subject: Chemistry,
+              exam_score: 3,
+              ps_ap_course_subject_code: CHEM,
+              ap_course_name: AP Chemistry,
+              data_source: CB File,
+            }
+          - {
+              academic_year: 2024,
+              powerschool_student_number: 1005,
+              test_name: AP Physics 1,
+              test_subject: Physics 1,
+              exam_score: 5,
+              ps_ap_course_subject_code: PHYS1,
+              ap_course_name: AP Physics 1,
+              data_source: CB File,
+            }
+    expect:
+      rows:
+        - {
+            subject_code: CHEM,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+          }
+        - {
+            subject_code: PHYS1,
+            test_subject_area: "Took AP exam, not enrolled in course.",
+          }

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -129,10 +129,9 @@ models:
       - name: ap_course_name
         data_type: string
         description: >
-          AP course name from the College Board crosswalk when the student has
-          an AP course enrollment; otherwise the exam's own crosswalk-resolved
-          name when the student took the exam with no matching course; 'Not an
-          AP course' if neither resolves.
+          AP course name resolved by subject code, in priority order — the
+          course-side College Board crosswalk first, then the exam's own
+          crosswalk-resolved name, then 'Not an AP course' if neither resolves.
       - name: course_name
         data_type: string
         description: >

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -3,14 +3,15 @@ models:
     description: >
       AP assessment scores joined to student enrollment and course schedules for
       Tableau reporting. One row per student per AP course subject, including
-      students enrolled in AP courses who did not take the exam.
+      students enrolled in AP courses who did not take the exam and students who
+      took an exam with no matching AP course enrollment.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - academic_year
               - student_number
-              - ap_course_subject
+              - subject_code
     columns:
       - name: academic_year
         data_type: int64
@@ -81,6 +82,13 @@ models:
       - name: graduation_year
         data_type: int64
         description: Student graduation year.
+      - name: subject_code
+        data_type: string
+        description: >
+          AP subject code bridging course enrollment and exam records for the
+          report grain — the course-enrollment subject code when the student is
+          enrolled in an AP course, otherwise the exam's own College Board
+          subject code. NULL only when the student has neither.
       - name: ap_date_enrolled
         data_type: date
         description: Date the student enrolled in the AP course section.
@@ -121,8 +129,10 @@ models:
       - name: ap_course_name
         data_type: string
         description: >
-          AP course name from the College Board crosswalk; 'Not an AP course' if
-          no match found.
+          AP course name from the College Board crosswalk when the student has
+          an AP course enrollment; otherwise the exam's own crosswalk-resolved
+          name when the student took the exam with no matching course; 'Not an
+          AP course' if neither resolves.
       - name: course_name
         data_type: string
         description: >
@@ -132,8 +142,10 @@ models:
         data_type: string
         description: >
           Derived field indicating exam relationship to course: 'Not applicable'
-          if no AP course, 'Took course, but not AP exam.' if enrolled but did
-          not test, otherwise the College Board AP course name.
+          if no AP course and no exam, 'Took course, but not AP exam.' if
+          enrolled but did not test, 'Took AP exam, not enrolled in course.' if
+          tested with no matching course enrollment, otherwise the College Board
+          AP course name.
       - name: sped
         data_type: int64
         description: Special education indicator (1 = has IEP, 0 = no IEP).

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
@@ -1,3 +1,67 @@
+with
+    course_enrollments as (
+        select
+            _dbt_source_relation,
+            cc_studentid,
+            cc_academic_year,
+            ap_course_subject,
+            cc_dateenrolled,
+            cc_dateleft,
+            sections_external_expression,
+            teacher_lastfirst,
+            courses_course_name,
+        from {{ ref("base_powerschool__course_enrollments") }}
+        where
+            rn_course_number_year = 1
+            and ap_course_subject is not null
+            and not is_dropped_section
+    ),
+
+    ap_assessments as (
+        select
+            academic_year,
+            powerschool_student_number,
+            test_name,
+            test_subject,
+            exam_score,
+            irregularity_code_1,
+            irregularity_code_2,
+            data_source,
+            ps_ap_course_subject_code,
+            ap_course_name,
+        from {{ ref("int_assessments__ap_assessments") }}
+        where test_subject != 'Calculus BC: AB Subscore'
+    ),
+
+    subjects as (
+        select distinct
+            e.studentid,
+            e.student_number,
+            e.academic_year,
+            e._dbt_source_relation,
+            c.ap_course_subject as subject_code,
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        inner join
+            course_enrollments as c
+            on e.studentid = c.cc_studentid
+            and e.academic_year = c.cc_academic_year
+            and {{ union_dataset_join_clause(left_alias="e", right_alias="c") }}
+
+        union distinct
+
+        select distinct
+            e.studentid,
+            e.student_number,
+            e.academic_year,
+            e._dbt_source_relation,
+            ap.ps_ap_course_subject_code as subject_code,
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        inner join
+            ap_assessments as ap
+            on e.academic_year = ap.academic_year
+            and e.student_number = ap.powerschool_student_number
+    )
+
 select
     e.academic_year,
     e.academic_year_display,
@@ -21,6 +85,8 @@ select
     e.ktc_cohort,
     e.graduation_year,
 
+    sub.subject_code,
+
     s.cc_dateenrolled as ap_date_enrolled,
     s.cc_dateleft as ap_date_left,
     s.sections_external_expression as ap_course_section,
@@ -35,15 +101,17 @@ select
     a.data_source,
     a.ps_ap_course_subject_code,
 
-    coalesce(x.ap_course_name, 'Not an AP course') as ap_course_name,
+    coalesce(x.ap_course_name, a.ap_course_name, 'Not an AP course') as ap_course_name,
 
     coalesce(s.courses_course_name, 'Not an AP course') as course_name,
 
     case
-        when s.courses_course_name is null
+        when s.courses_course_name is null and a.test_name is null
         then 'Not applicable'
         when s.courses_course_name is not null and a.test_name is null
         then 'Took course, but not AP exam.'
+        when s.courses_course_name is null and a.test_name is not null
+        then 'Took AP exam, not enrolled in course.'
         else a.ap_course_name
     end as test_subject_area,
 
@@ -57,23 +125,25 @@ select
 
 from {{ ref("int_extracts__student_enrollments") }} as e
 left join
-    {{ ref("base_powerschool__course_enrollments") }} as s
-    on e.studentid = s.cc_studentid
-    and e.academic_year = s.cc_academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
-    and s.rn_course_number_year = 1
-    and s.ap_course_subject is not null
-    and not s.is_dropped_section
+    subjects as sub
+    on e.studentid = sub.studentid
+    and e.academic_year = sub.academic_year
+    and {{ union_dataset_join_clause(left_alias="e", right_alias="sub") }}
+left join
+    course_enrollments as s
+    on sub.studentid = s.cc_studentid
+    and sub.academic_year = s.cc_academic_year
+    and sub.subject_code = s.ap_course_subject
+    and {{ union_dataset_join_clause(left_alias="sub", right_alias="s") }}
+left join
+    ap_assessments as a
+    on sub.student_number = a.powerschool_student_number
+    and sub.academic_year = a.academic_year
+    and sub.subject_code = a.ps_ap_course_subject_code
 left join
     {{ ref("stg_google_sheets__collegeboard__ap_course_crosswalk") }} as x
-    on s.ap_course_subject = x.ps_ap_course_subject_code
+    on sub.subject_code = x.ps_ap_course_subject_code
     and x.data_source = 'CB File'
-left join
-    {{ ref("int_assessments__ap_assessments") }} as a
-    on e.academic_year = a.academic_year
-    and e.student_number = a.powerschool_student_number
-    and s.ap_course_subject = a.ps_ap_course_subject_code
-    and a.test_subject != 'Calculus BC: AB Subscore'
 where
     e.rn_year = 1
     and e.school_level = 'HS'

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
@@ -60,6 +60,7 @@ with
             ap_assessments as ap
             on e.academic_year = ap.academic_year
             and e.student_number = ap.powerschool_student_number
+            and ap.ps_ap_course_subject_code is not null
     )
 
 select

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ap_assessment_dashboard.sql
@@ -34,7 +34,7 @@ with
     ),
 
     subjects as (
-        select distinct
+        select
             e.studentid,
             e.student_number,
             e.academic_year,
@@ -49,7 +49,7 @@ with
 
         union distinct
 
-        select distinct
+        select
             e.studentid,
             e.student_number,
             e.academic_year,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

make AP exam scores visible on the AP assessment dashboard for students who took the exam but have no matching AP course enrollment in PowerSchool -- today those rows are silently dropped.

Restructures `rpt_tableau__ap_assessment_dashboard`'s joins around a `subjects` bridge CTE that unions AP subject codes from course enrollments and exam scores independently, instead of chaining the exam join through the course-enrollment join. Adds a `subject_code` grain column, a new `test_subject_area` state (`Took AP exam, not enrolled in course.`), and an `ap_course_name` fallback to the exam's own crosswalk-resolved name.

Verified against current prod data: 245 previously-hidden exam-only rows surface (spanning many historical years, not just the 3 cases cited in the issue), 119 generic "Not applicable" placeholder rows are replaced by real subject rows for students who turn out to have exam-only scores, and a reconciliation check confirms 0 true regressions.

Closes #4391

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was AI-assisted vs. human-directed in the summary above

Claude Code designed and implemented this fix end-to-end: brainstormed the design (spec at `docs/superpowers/specs/2026-07-14-ap-dashboard-exam-only-scores-design.md`), wrote an implementation plan (`docs/superpowers/plans/2026-07-14-ap-dashboard-exam-only-scores.md`), and executed it via subagent-driven development with a task review after each task and a final whole-branch review. All SQL/YAML changes, the dry-run validation against prod data, and the test fixtures were AI-authored; a human directed the design decisions through the brainstorming Q&A captured in the spec and chose the merge path.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file included — `rpt_tableau__ap_assessment_dashboard.yml` updated with the new `subject_code` column, the uniqueness test moved to it, and updated descriptions for `ap_course_name`/`test_subject_area`.
- [x] Exposure — no change needed; the existing Tableau exposure in `models/exposures/tableau.yml` is unaffected (no column renames/removals, only additive changes).
- [x] Breaking change? No — purely additive (new column, new dashboard state, no renames or removals). No downstream dbt model `ref()`s this model (verified via `grep`); only the Tableau exposure references it.
- [x] No new external source — n/a

## CI checks

- [ ] **Trunk** — pending
- [ ] **dbt Cloud** — pending
- [ ] **Dagster Cloud** — not triggered (dbt-only change, no schedule/sensor/integration changes)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216565418570028