### PR TITLE
fix(dagster): resolve SSH remote_port from environment lazily

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -67,8 +67,9 @@ not appear in site navigation.
 adding, removing, or renaming schedules or sensors.
 
 The script imports every code location's `definitions` and silently SKIPS any
-that fail to import — so running it in the codespace (district `definitions`
-fail on unset `PS_SSH_PORT`, etc.) drops those locations from the catalog.
+that fail to import — so running it in the codespace (locations fail to import
+without their dbt manifests, and `kipptaf` additionally on unset
+Illuminate/Zendesk dlt credentials) drops those locations from the catalog.
 Regenerate only in a full environment where all locations load.
 
 ## `superpowers/` Directory

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -60,6 +60,13 @@ default "one short line max" rule.
 `check.not_none()` from `dagster_shared` — never `assert isinstance(...)`
 (`assert` is stripped by `-O`).
 
+**Int env-var config**: use `EnvVar.int("NAME")` for `int`-typed resource fields
+(e.g. ports) — it stays lazy and resolves at resource init like a string
+`EnvVar`. Never `int(EnvVar("NAME").get_value())`: `.get_value()` reads eagerly
+at construction and crashes module-load resource wiring when the var is unset
+(e.g. a codespace). `IntEnvVar` is not exported from `dagster` — reach it via
+`EnvVar.int`.
+
 ## Library Categories
 
 Libraries fall into four patterns based on how they ingest data:

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -213,9 +213,12 @@ codespace cause false errors unrelated to production failures. Fall back to
 `uv run python -c "import <module>"` for syntactic checks when validate fails on
 missing manifest or env vars.
 
-A district `definitions.py` itself won't import in the codespace —
-`get_powerschool_ssh_resource()` reads unset `PS_SSH_PORT` at module load, so
-the `import <module>` fallback fails for `.definitions`. Validate a
-per-integration change by importing that integration submodule alone (e.g.
-`import teamster.code_locations.kippnewark.finalsite`), not the `definitions`
+In the codespace, importing a district `definitions.py` first needs the dbt
+manifest (`dagster-dbt project prepare-and-package`, above). With the manifest,
+the powerschool districts (`kippnewark`, `kippcamden`, `kippmiami`) import
+cleanly. `kipptaf.definitions` still fails at module load because the
+Illuminate/Zendesk dlt credential specs call `EnvVar("...").get_value()` eagerly
+(unset in the codespace). For a `kipptaf` per-integration change, import that
+integration submodule alone (e.g.
+`import teamster.code_locations.kipptaf.finalsite`), not the `definitions`
 module.

--- a/src/teamster/code_locations/kipptaf/resources.py
+++ b/src/teamster/code_locations/kipptaf/resources.py
@@ -1,6 +1,5 @@
 from dagster import EnvVar
 from dagster_airbyte import AirbyteCloudWorkspace
-from dagster_shared import check
 
 from teamster.libraries.adp.workforce_now.api.resources import AdpWorkforceNowResource
 from teamster.libraries.coupa.resources import CoupaResource
@@ -138,7 +137,7 @@ SSH_RESOURCE_LATTICE = SSHResource(
 
 SSH_RESOURCE_LITTLESIS = SSHResource(
     remote_host=EnvVar("LITTLESIS_SFTP_HOST"),
-    remote_port=int(check.not_none(value=EnvVar("LITTLESIS_SFTP_PORT").get_value())),
+    remote_port=EnvVar.int("LITTLESIS_SFTP_PORT"),
     username=EnvVar("LITTLESIS_SFTP_USERNAME"),
     password=EnvVar("LITTLESIS_SFTP_PASSWORD"),
 )

--- a/src/teamster/core/resources.py
+++ b/src/teamster/core/resources.py
@@ -4,7 +4,6 @@ from dagster import EnvVar
 from dagster_dbt import DbtCliResource, DbtProject
 from dagster_dlt import DagsterDltResource
 from dagster_gcp import BigQueryResource, GCSResource
-from dagster_shared import check
 
 from teamster import GCS_PROJECT_NAME
 from teamster.core.io_managers.gcs import GCSIOManager
@@ -67,7 +66,7 @@ def get_dbt_cli_resource(dbt_project: DbtProject) -> DbtCliResource:
 def get_powerschool_ssh_resource() -> SSHResource:
     return SSHResource(
         remote_host=EnvVar("PS_SSH_HOST"),
-        remote_port=int(check.not_none(value=EnvVar("PS_SSH_PORT").get_value())),
+        remote_port=EnvVar.int("PS_SSH_PORT"),
         username=EnvVar("PS_SSH_USERNAME"),
         tunnel_remote_host=EnvVar("PS_SSH_REMOTE_BIND_HOST"),
     )

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -33,10 +33,14 @@ uv run pytest tests/assets/test_assets_dbt.py                         # requires
   check the token file first — don't investigate individual env vars.
 - **Archived tests**: `_test_` prefix in `archive/` subdirectories — ignored by
   pytest by convention, not markers.
-- **`EnvVar` in integration tests**: Use `EnvVar("X")` for `str` fields inside
-  `build_resources()`. For non-`str` fields (e.g. `int` ports), use
-  `int(check.not_none(EnvVar("X").get_value()))` — `EnvVar` resolves lazily, so
-  `int(EnvVar("X"))` casts the marker object, not the value.
+- **`EnvVar` in integration tests**: Use `EnvVar("X")` for `str` fields and
+  `EnvVar.int("X")` for `int` fields (e.g. ports) inside `build_resources()` —
+  both resolve lazily at resource init and never read the environment at
+  construction. Prefer these over `int(EnvVar("X").get_value())`: `.get_value()`
+  reads eagerly, which is harmless when a test always sets the var but crashes
+  module-load construction in production `resources.py` when it is unset (e.g. a
+  codespace) — so never copy that idiom there. Plain `int(EnvVar("X"))` casts
+  the marker object, not the value.
 - **Worktree tests**: VS Code doesn't discover tests in worktrees. Run manually
   ensuring `OP_SERVICE_ACCOUNT_TOKEN` is set, then
   `cd .worktrees/<branch> && uv run pytest ...`.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -49,6 +49,11 @@ uv run pytest tests/assets/test_assets_dbt.py                         # requires
   `build_resources()` context manager to instantiate, then call methods on
   `resources.<name>`. `PrivateAttr` fields (`_log`, `_service`) accept direct
   assignment; use `object.__setattr__` to monkey-patch methods.
+- **Testing env-var resolution offline**:
+  `resource.process_config_and_initialize()` returns an initialized copy with
+  `EnvVar` / `EnvVar.int` fields resolved but WITHOUT running
+  `setup_for_execution` — no live connection or secret file needed. Ideal for
+  asserting a config field resolves to the right value/type.
 - **Testing resource retry offline**: monkeypatch
   `<Resource>._request.retry.wait = wait_none()` (tenacity) to kill backoff,
   inject `object.__setattr__(r, "_session", SimpleNamespace(request=fake_fn))`

--- a/tests/resources/test_resource_ssh.py
+++ b/tests/resources/test_resource_ssh.py
@@ -1,7 +1,33 @@
 from dagster import EnvVar, build_init_resource_context
 from dagster_shared import check
 
+from teamster.core.resources import get_powerschool_ssh_resource
 from teamster.libraries.ssh.resources import SSHResource
+
+
+def test_get_powerschool_ssh_resource_port_is_lazy(monkeypatch):
+    """`PS_SSH_PORT` must resolve at resource init, not at construction.
+
+    Regression: the factory previously called
+    ``EnvVar("PS_SSH_PORT").get_value()`` eagerly, so constructing the resource
+    (which happens at district ``definitions.py`` module load) raised when the
+    variable was unset — e.g. in a codespace. See ``src/teamster/CLAUDE.md``.
+    """
+    monkeypatch.delenv("PS_SSH_PORT", raising=False)
+
+    # Construction must not touch the environment.
+    resource = get_powerschool_ssh_resource()
+
+    # At resource-init time the port resolves to a real int.
+    monkeypatch.setenv("PS_SSH_HOST", "ps.example.org")
+    monkeypatch.setenv("PS_SSH_PORT", "1521")
+    monkeypatch.setenv("PS_SSH_USERNAME", "svc_ps")
+    monkeypatch.setenv("PS_SSH_REMOTE_BIND_HOST", "oracle.internal")
+
+    initialized = resource.process_config_and_initialize()
+
+    assert initialized.remote_port == 1521
+    assert isinstance(initialized.remote_port, int)
 
 
 def _test_listdir_attr_r(ssh: SSHResource, remote_dir: str = "~"):

--- a/tests/resources/test_resource_ssh.py
+++ b/tests/resources/test_resource_ssh.py
@@ -1,6 +1,7 @@
 from dagster import EnvVar, build_init_resource_context
 from dagster_shared import check
 
+from teamster.code_locations.kipptaf.resources import SSH_RESOURCE_LITTLESIS
 from teamster.core.resources import get_powerschool_ssh_resource
 from teamster.libraries.ssh.resources import SSHResource
 
@@ -19,6 +20,9 @@ def test_get_powerschool_ssh_resource_port_is_lazy(monkeypatch):
     resource = get_powerschool_ssh_resource()
 
     # At resource-init time the port resolves to a real int.
+    # `process_config_and_initialize()` resolves config/env vars only; it does
+    # NOT run `setup_for_execution`, so the absent SSH secret file / password
+    # never blocks this test.
     monkeypatch.setenv("PS_SSH_HOST", "ps.example.org")
     monkeypatch.setenv("PS_SSH_PORT", "1521")
     monkeypatch.setenv("PS_SSH_USERNAME", "svc_ps")
@@ -27,6 +31,29 @@ def test_get_powerschool_ssh_resource_port_is_lazy(monkeypatch):
     initialized = resource.process_config_and_initialize()
 
     assert initialized.remote_port == 1521
+    assert isinstance(initialized.remote_port, int)
+
+
+def test_ssh_resource_littlesis_port_is_lazy(monkeypatch):
+    """`LITTLESIS_SFTP_PORT` resolves lazily for the module-level singleton.
+
+    ``SSH_RESOURCE_LITTLESIS`` is constructed at import of
+    ``kipptaf.resources`` (not lazily via a factory), so an eager port read
+    would crash that import when the variable is unset. Guard the singleton
+    directly: its ``remote_port`` stays an unresolved ``EnvVar.int`` marker
+    until resource init, then resolves to a real int.
+    """
+    # The imported singleton holds an unresolved lazy marker — no eager read.
+    assert isinstance(SSH_RESOURCE_LITTLESIS.remote_port, type(EnvVar.int("_probe")))
+
+    monkeypatch.setenv("LITTLESIS_SFTP_HOST", "sftp.example.org")
+    monkeypatch.setenv("LITTLESIS_SFTP_PORT", "22")
+    monkeypatch.setenv("LITTLESIS_SFTP_USERNAME", "svc")
+    monkeypatch.setenv("LITTLESIS_SFTP_PASSWORD", "pw")
+
+    initialized = SSH_RESOURCE_LITTLESIS.process_config_and_initialize()
+
+    assert initialized.remote_port == 22
     assert isinstance(initialized.remote_port, int)
 
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR stops SSH `remote_port` config from reading the environment
at module-load time.

`get_powerschool_ssh_resource()` and `SSH_RESOURCE_LITTLESIS` coerced the port
to `int` via `EnvVar("PS_SSH_PORT").get_value()` /
`EnvVar("LITTLESIS_SFTP_PORT").get_value()`. `.get_value()` resolves **eagerly**
at construction, and because these resources are built at module load (inside
the `Definitions` resources dict / as a module-level singleton), importing a
district `definitions.py` crashed with a `CheckError` whenever the port variable
was unset — e.g. in a codespace. This is the failure the `src/teamster/CLAUDE.md`
note documented.

The fix swaps both call sites to `EnvVar.int(...)` — Dagster's lazy integer
environment-variable wrapper (an `int` subclass that satisfies the `int | None`
field and resolves at resource init, exactly like the sibling string fields).
The now-unused `dagster_shared.check` imports are removed.

### Verification

- New regression test
  `tests/resources/test_resource_ssh.py::test_get_powerschool_ssh_resource_port_is_lazy`:
  red before (raised `CheckError`), green after; asserts lazy construction **and**
  `int` resolution at resource init.
- `kippnewark` / `kippcamden` / `kippmiami` `definitions` now import cleanly with
  the port variable unset (dbt manifest present); `kipptaf.resources` imports
  clean.
- Trunk clean on all changed files.

### Scope

Category A (SSH `remote_port`) only. A separate, larger eager-read pattern
remains in the Illuminate/Zendesk dlt credential specs
(`kipptaf/dlt/*/assets.py`), which build plain dlt credential objects (not
Dagster resources) and so cannot use the lazy wrapper without deferring
construction into asset setup — left as a follow-up.

## AI Assistance

AI-assisted (Claude Code): root-cause diagnosis, the `EnvVar.int` fix, the
regression test, and the `CLAUDE.md` corrections. Human-directed: the scope
decision (Category A only) and fix approach.

## Self-review

### Dagster

- [x] Verified modified code locations import — regression test green plus direct
      module import of `kippnewark`/`kippcamden`/`kippmiami` `definitions` and
      `kipptaf.resources`. Full `dagster definitions validate` was not run in the
      codespace (environment-limited); see Verification above.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — not applicable (no dbt model changes).
- [ ] **Dagster Cloud** — passes or not triggered.
