### PR TITLE
feat: add Special Projects dept to grow users sub admin role logic

### DIFF
--- a/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
+++ b/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
@@ -44,7 +44,8 @@ with
                         sr.home_department_name in (
                             'Teaching and Learning',
                             'School Support',
-                            'New Teacher Development'
+                            'New Teacher Development',
+                            'Special Projects'
                         )
                         and (
                             contains_substr(sr.job_title, 'Chief')


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will map staff in the **Special Projects** home department whose job title contains `Chief`, `Leader`, or `Director` to the **Sub Admin** role in the SchoolMint Grow users extract (`rpt_schoolmint_grow__users`). This matches the existing treatment of the Teaching and Learning, School Support, and New Teacher Development departments.

Verified against current prod roster data: the only staff member this newly affects is one Special Projects Director, who moves from no admin role to Sub Admin. No other current staff are pulled in by the change.

## AI Assistance

Human-directed one-line SQL edit (the department addition was made by the author). Claude Code was used to create the branch, verify the impact against the roster data, and open this PR.

## Self-review

### dbt

- [x] No new models, columns, or external sources — a value-only edit to an existing `WHEN` branch in an existing contracted `rpt_` model. No properties/exposure changes needed.
- [x] Not a breaking change — no column renamed or removed.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes.
- [x] **Dagster Cloud** — passes or not triggered.