### PR TITLE
chore: bump dagster-plus-mcp to latest main

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 [[package]]
 name = "dagster-plus-mcp"
 version = "0.1.0"
-source = { git = "https://github.com/TEAMSchools/dagster-plus-mcp.git#ad33e97bca1dc0cc8fbf533dd5161d68a419a600" }
+source = { git = "https://github.com/TEAMSchools/dagster-plus-mcp.git#e4cf661163a4876e2845feba3712258f978d4d02" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will bump the `dagster-plus-mcp` git pin in `uv.lock` from `ad33e97` to `e4cf661` (latest main). This picks up per-call deployment targeting (`list_deployments` plus a `deployment` argument on every tool), ten operational mutation tools (`terminate_runs`, backfill/schedule/sensor controls, `reload_code_location`, `free_concurrency_slots`, `set_sensor_cursor`), and the refreshed GraphQL schema dump — TEAMSchools/dagster-plus-mcp PRs #11 and #12, closing dagster-plus-mcp#1, dagster-plus-mcp#10, and #3549.

The MCP launcher (`scripts/dagster-mcp-launch.sh`) resolves the package from the teamster venv, so this pin bump is what actually ships the new tools to Claude Code sessions. Verified locally: the upgraded package registers all 36 tools including the new ones.

## AI Assistance

Claude Code authored the dependency bump and this PR; the underlying dagster-plus-mcp changes were Claude-authored with human review and merge.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Not applicable — lockfile-only change; no code location modified.

### dbt _(skip if no dbt changes)_

Not applicable.

### Docs _(skip if no schedule, sensor, or integration changes)_

Not applicable.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.