### PR TITLE
fix(coupa): match users on login, drop null identities, add guardrails

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -373,6 +373,15 @@ resolved to dev by grepping the compiled SQL (`target/compiled/.../<model>.sql`)
 for `zz_<user>_` refs — dev-schema refs mean `--defer` was shadowed; validate
 against prod (or an ad-hoc prod query) instead.
 
+To validate a MODIFIED `rpt_`/view against prod (the deployed view is still the
+OLD code, and a dev build is stale-shadowed), rewrite its compiled SQL
+(`target/compiled/.../<model>.sql`): `zz_<user>_` refs → prod schemas, and
+inline any `stg_` you changed from its `source()` (prod lacks the new column);
+run via `bq`. Tell live drift from a real logic change with distinct-key counts
+(`total - dup`) vs a FRESH same-moment prod baseline — an unchanged distinct set
+means the row delta is fan-out/drift (warehouse tables rematerialize
+mid-session), not your change.
+
 ## Column-rename refactors strand dependent prod views
 
 When a staging column is dropped or renamed and a downstream view's SQL is

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -366,6 +366,13 @@ Same trap applies to mart PK `unique` tests — a stale dev parent fans out a
 date-range join. Query prod before filing upstream bugs or adding defensive
 dedupe from a dev mart-test failure.
 
+Also manifests as false row-count / row-presence deltas (not just
+`relationships`/PK tests): a stale dev `int_people__staff_roster` missing recent
+hires makes a dev-built rpt look like it dropped rows. Confirm which upstreams
+resolved to dev by grepping the compiled SQL (`target/compiled/.../<model>.sql`)
+for `zz_<user>_` refs — dev-schema refs mean `--defer` was shadowed; validate
+against prod (or an ad-hoc prod query) instead.
+
 ## Column-rename refactors strand dependent prod views
 
 When a staging column is dropped or renamed and a downstream view's SQL is

--- a/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
+++ b/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
@@ -7,5 +7,7 @@ models:
         data_type: boolean
       - name: purchasing_user
         data_type: boolean
+      - name: login
+        data_type: string
       - name: employee_number
         data_type: int64

--- a/src/dbt/kipptaf/models/coupa/api/staging/stg_coupa__users.sql
+++ b/src/dbt/kipptaf/models/coupa/api/staging/stg_coupa__users.sql
@@ -1,3 +1,7 @@
 select
-    id, active, purchasing_user, safe_cast(employee_number as int) as employee_number,
+    id,
+    active,
+    purchasing_user,
+    login,
+    safe_cast(employee_number as int) as employee_number,
 from {{ source("coupa", "src_coupa__users") }}

--- a/src/dbt/kipptaf/models/extracts/coupa/properties/rpt_coupa__users.yml
+++ b/src/dbt/kipptaf/models/extracts/coupa/properties/rpt_coupa__users.yml
@@ -1,11 +1,39 @@
 models:
   - name: rpt_coupa__users
+    description: >-
+      Desired-state Coupa user feed built from the staff roster joined to
+      current Coupa accounts, exported nightly to Coupa via SFTP.
     columns:
       - name: "`Login`"
         data_type: string
-      - name: "`Sso Identifier`"
-        data_type: string
+        description: >-
+          Coupa login, from the staff member Active Directory sam_account_name.
+          Unique per user; also matches existing Coupa accounts.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          # TODO(#4409): restore severity error once Ops removes the duplicate
+          # active Coupa addresses and the duplicate school_name_lookup key that
+          # fan out rows
+          - unique:
+              config:
+                severity: warn
       - name: "`Email`"
+        data_type: string
+        description: >-
+          Staff email address (ADP mail) used as the Coupa email; required by
+          Coupa.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          # TODO(#4409): restore severity error once the row fan-out data dupes
+          # are removed
+          - unique:
+              config:
+                severity: warn
+      - name: "`Sso Identifier`"
         data_type: string
       - name: "`First Name`"
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
+++ b/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
@@ -26,8 +26,14 @@ with
         group by user_id
     ),
 
-    all_users as (
-        /* existing users */
+    staff_coupa_match as (
+        /* Resolve each staffer to one Coupa account, login first then
+           employee_number — mirroring Coupa's own load precedence
+           (user id, then login, then employee number). login and
+           employee_number are each unique in Coupa, so this returns at most one
+           account and cannot fan out. If the two keys ever point at different
+           accounts, login wins — the account Coupa itself will update — so we
+           read values from the same account Coupa writes to. */
         select
             sr.employee_number,
             sr.legal_given_name,
@@ -42,8 +48,41 @@ with
             sr.sam_account_name,
             sr.user_principal_name,
             sr.mail,
+            sr.is_prestart,
+            sr.worker_termination_date,
+            sr.worker_type_code,
 
-            cu.active,
+            coalesce(cul.id, cue.id) as coupa_user_id,
+
+            if(cul.id is not null, cul.active, cue.active) as active,
+            if(
+                cul.id is not null, cul.purchasing_user, cue.purchasing_user
+            ) as purchasing_user,
+        from {{ ref("int_people__staff_roster") }} as sr
+        left join
+            {{ ref("stg_coupa__users") }} as cul on sr.sam_account_name = cul.login
+        left join
+            {{ ref("stg_coupa__users") }} as cue
+            on sr.employee_number = cue.employee_number
+    ),
+
+    all_users as (
+        /* existing users */
+        select
+            scm.employee_number,
+            scm.legal_given_name,
+            scm.legal_family_name,
+            scm.assignment_status,
+            scm.home_business_unit_code,
+            scm.home_department_name,
+            scm.job_title,
+            scm.home_work_location_name,
+            scm.uac_account_disable,
+            scm.physical_delivery_office_name,
+            scm.sam_account_name,
+            scm.user_principal_name,
+            scm.mail,
+            scm.active,
 
             r.roles,
 
@@ -51,65 +90,51 @@ with
 
             date_diff(
                 current_date('{{ var("local_timezone") }}'),
-                sr.worker_termination_date,
+                scm.worker_termination_date,
                 day
             ) as days_terminated,
 
-            if(cu.purchasing_user, 'Yes', 'No') as purchasing_user,
-        from {{ ref("int_people__staff_roster") }} as sr
-        /* match on login as well as employee_number: a Coupa account created
-           directly (blank employee_number) or an entity-switcher whose number
-           changed won't match on number, so it must resolve by login or Coupa
-           duplicates it on the next load */
-        inner join
-            {{ ref("stg_coupa__users") }} as cu
-            on sr.employee_number = cu.employee_number
-            or sr.sam_account_name = cu.login
-        inner join roles as r on cu.id = r.user_id
-        left join business_groups as bg on cu.id = bg.user_id
+            if(scm.purchasing_user, 'Yes', 'No') as purchasing_user,
+        from staff_coupa_match as scm
+        inner join roles as r on scm.coupa_user_id = r.user_id
+        left join business_groups as bg on scm.coupa_user_id = bg.user_id
         where
-            not sr.is_prestart
+            not scm.is_prestart
             and coalesce(
-                sr.worker_termination_date, current_date('{{ var("local_timezone") }}')
+                scm.worker_termination_date, current_date('{{ var("local_timezone") }}')
             )
             >= '{{ var("current_academic_year") - 1 }}-07-01'
-            and not regexp_contains(sr.worker_type_code, r'Part Time|Intern')
+            and not regexp_contains(scm.worker_type_code, r'Part Time|Intern')
 
         union all
 
-        /* new users */
+        /* new users — matched by neither login nor employee_number */
         select
-            sr.employee_number,
-            sr.legal_given_name,
-            sr.legal_family_name,
-            sr.assignment_status,
-            sr.home_business_unit_code,
-            sr.home_department_name,
-            sr.job_title,
-            sr.home_work_location_reporting_name as home_work_location_name,
-            sr.uac_account_disable,
-            sr.physical_delivery_office_name,
-            sr.sam_account_name,
-            sr.user_principal_name,
-            sr.mail,
+            scm.employee_number,
+            scm.legal_given_name,
+            scm.legal_family_name,
+            scm.assignment_status,
+            scm.home_business_unit_code,
+            scm.home_department_name,
+            scm.job_title,
+            scm.home_work_location_name,
+            scm.uac_account_disable,
+            scm.physical_delivery_office_name,
+            scm.sam_account_name,
+            scm.user_principal_name,
+            scm.mail,
 
             true as active,
             'Expense User' as roles,
             null as content_groups,
             null as days_terminated,
             'No' as purchasing_user,
-        from {{ ref("int_people__staff_roster") }} as sr
-        left join
-            {{ ref("stg_coupa__users") }} as cu
-            on sr.employee_number = cu.employee_number
-            or sr.sam_account_name = cu.login
+        from staff_coupa_match as scm
         where
-            not sr.is_prestart
-            and sr.assignment_status not in ('Terminated', 'Deceased')
-            and not regexp_contains(sr.worker_type_code, r'Part Time|Intern')
-            /* cu.id (not cu.employee_number): a login-matched account can have a
-               blank employee_number but is still an existing user, not new */
-            and cu.id is null
+            not scm.is_prestart
+            and scm.assignment_status not in ('Terminated', 'Deceased')
+            and not regexp_contains(scm.worker_type_code, r'Part Time|Intern')
+            and scm.coupa_user_id is null
     ),
 
     sub as (

--- a/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
+++ b/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
@@ -57,9 +57,14 @@ with
 
             if(cu.purchasing_user, 'Yes', 'No') as purchasing_user,
         from {{ ref("int_people__staff_roster") }} as sr
+        /* match on login as well as employee_number: a Coupa account created
+           directly (blank employee_number) or an entity-switcher whose number
+           changed won't match on number, so it must resolve by login or Coupa
+           duplicates it on the next load */
         inner join
             {{ ref("stg_coupa__users") }} as cu
             on sr.employee_number = cu.employee_number
+            or sr.sam_account_name = cu.login
         inner join roles as r on cu.id = r.user_id
         left join business_groups as bg on cu.id = bg.user_id
         where
@@ -97,11 +102,14 @@ with
         left join
             {{ ref("stg_coupa__users") }} as cu
             on sr.employee_number = cu.employee_number
+            or sr.sam_account_name = cu.login
         where
             not sr.is_prestart
             and sr.assignment_status not in ('Terminated', 'Deceased')
             and not regexp_contains(sr.worker_type_code, r'Part Time|Intern')
-            and cu.employee_number is null
+            /* cu.id (not cu.employee_number): a login-matched account can have a
+               blank employee_number but is still an existing user, not new */
+            and cu.id is null
     ),
 
     sub as (
@@ -323,3 +331,7 @@ left join
     on sub.home_business_unit_code = ill3.adp_business_unit_home_code
     and ill3.adp_department_home_name = 'Default'
     and ill3.adp_job_title = 'Default'
+/* Coupa rejects rows with a blank Login or Email as required-field errors;
+   drop deprovisioned identities (e.g. terminated staff still in the window)
+   that cannot be represented in the feed */
+where sub.sam_account_name is not null and sub.mail is not null

--- a/src/teamster/code_locations/kipptaf/CLAUDE.md
+++ b/src/teamster/code_locations/kipptaf/CLAUDE.md
@@ -34,6 +34,11 @@ GCS bucket: `teamster-kipptaf`
 | `zendesk`                | assets                                                    | schedule         | —                       |
 | `couchdrop`              | sensor only                                               | —                | sensor                  |
 
+**Coupa Dagster code is aliased `l`** — resource `lResource`, env vars `l_*`
+(`l_SFTP_*`, `l_API_*`), asset group `l`, and `libraries/l/` + `kipptaf/l/`
+modules that the `coupa` submodule wires from. Grep `l` as well as `coupa`. The
+dbt side is cleanly named `coupa`.
+
 ## dbt Asset Groups (`dbt/assets.py`)
 
 Kipptaf splits dbt into **three separate asset groups** with different resource


### PR DESCRIPTION
## Summary and Motivation

When merged, this fixes the recurring nightly Coupa Users Import errors for entity-switchers and directly-created Coupa accounts, and adds guardrails so identity problems fail in CI/Dagster instead of silently on Coupa's file-status page.

Coupa matches our feed by login (its match precedence is user ID, then login, then employee number; our file carries no Coupa user ID). The model, though, decided existing-vs-new only on `employee_number` — blank on ~67% of active Coupa accounts (created directly in Coupa, or the number changed on an entity switch) — so a login-matching staffer fell into the new-user branch and we emitted reset values. Coupa then applies those on its login-keyed update, overwriting the account's real roles and content. This PR:

- `stg_coupa__users`: expose `login`.
- `rpt_coupa__users`: match existing accounts on `employee_number` OR `login`. Both keys are unique and never conflict in current prod data (validated: at most one Coupa account matches per staffer, so no fan-out). This keeps switchers on the identity-preserving branch instead of resetting them to `Expense User` only — the two affected staff today carry approver / power-user / receiver roles that the reset would have wiped.
- `rpt_coupa__users`: drop rows with a null Login or Email (deprovisioned identities Coupa cannot ingest — the intermittent 'Email is a required field' rows).
- Guardrails: `not_null` (error) and `unique` (warn) on Login and Email.

`unique` is `warn`, not `error`, because a separate data issue currently fans out ~98 rows: duplicate ACTIVE Coupa addresses (e.g. `KIPP Life Academy` has two) plus one duplicate key in the `school_name_lookup` sheet. Those are Ops data cleanups tracked in #4409, along with the missing-address failures (an Ops crosswalk fix). Flip `unique` to `error` once those land.

Validated against prod data: total row count unchanged (2,013), the two mis-branched staff now resolve to their existing accounts (so we send their real roles/content instead of resets), no null identities emitted, no new fan-out.

AI assistance: root-cause investigation, prod data validation, and the dbt changes were done with Claude Code; the scope decisions (single PR, warn-level guardrails, Ops-owned data fixes) were human-directed.

## Self-review

### dbt

- [x] Properties files updated for both modified models
- [x] Breaking change reviewed — no columns renamed or removed; `login` added to the `stg_coupa__users` contract, new tests added
- [ ] Exposure — n/a (outbound extract, no dashboard)

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud — not triggered (dbt-only change)

Refs #4409
