### PR TITLE
test(coupa): enforce stg_coupa__users uniqueness, drop dead active column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,13 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Git resuming**: Before resuming work on an existing branch, merge `main`:
   `git fetch origin main && git merge origin/main`.
 
+- **A mid-session Codespace restart can delete `.worktrees/` and desync local
+  git refs** (stale `main`, `git ls-remote <branch>` empty for a live branch, a
+  HEAD that reads as the pre-session commit yet holds merged content). Trust
+  GitHub over local git for ground truth: `gh api .../branches/main` and
+  `gh api .../pulls/<n>` (`merged` / `merge_commit_sha`), then re-fetch and
+  recreate any lost worktree off `origin/main`.
+
 - **Reverting experimental code to a docs-only PR**:
   `git checkout origin/main -- <file>` restores main's CURRENT blob, which can
   differ from the branch's merge-base and leak main's advancement into the
@@ -226,7 +233,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   monitor for a re-review after a fix push. A PR with all checks green but
   `mergeable_state: blocked` (from `gh api repos/<owner>/<repo>/pulls/<n>`) is
   awaiting a required review approval (CODEOWNERS `src/dbt/` =
-  analytics-engineers), not a CI failure.
+  analytics-engineers), not a CI failure. `claude-review` may leave TWO issue
+  comments — an initial "Reviewing…" status stub and a separate final findings
+  comment — and the stub can stay stuck mid-render even after the check-run
+  reports `success`. Fetch ALL issue comments and read the newest / longest, not
+  the first.
 
 - **Python**: Always `uv run` — never bare `python`, `python3`, or
   venv-installed tools (`dbt`, `dagster`, etc.).

--- a/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
+++ b/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
@@ -1,13 +1,43 @@
 models:
   - name: stg_coupa__users
+    description: >-
+      One row per Coupa user account, from the Coupa REST API users endpoint.
+      The identity keys (id, login, employee_number) are what rpt_coupa__users
+      resolves a staff member to their Coupa account on.
     columns:
       - name: id
         data_type: int64
-      - name: active
-        data_type: boolean
-      - name: purchasing_user
-        data_type: boolean
+        description: Coupa internal user id; the account primary key.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          - unique:
+              config:
+                severity: error
       - name: login
         data_type: string
+        description: >-
+          Coupa login, equal to the staff member Active Directory
+          sam_account_name. Unique per account and the primary key
+          rpt_coupa__users matches on (login first).
+        data_tests:
+          - unique:
+              config:
+                severity: error
       - name: employee_number
         data_type: int64
+        description: >-
+          ADP employee number cast from the Coupa custom field; blank on
+          accounts created outside the nightly feed. The fallback key
+          rpt_coupa__users matches on when login does not.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+      - name: active
+        data_type: boolean
+        description: Whether the Coupa account is active.
+      - name: purchasing_user
+        data_type: boolean
+        description: Whether the account holds a Coupa purchasing license.

--- a/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
+++ b/src/dbt/kipptaf/models/coupa/api/staging/properties/stg_coupa__users.yml
@@ -1,9 +1,9 @@
 models:
   - name: stg_coupa__users
     description: >-
-      One row per Coupa user account, from the Coupa REST API users endpoint.
-      The identity keys (id, login, employee_number) are what rpt_coupa__users
-      resolves a staff member to their Coupa account on.
+      One row per Coupa user account, from the Coupa REST API users endpoint. id
+      is the account primary key; login (first) then employee_number are the
+      keys rpt_coupa__users matches a staff member to their Coupa account on.
     columns:
       - name: id
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
+++ b/src/dbt/kipptaf/models/extracts/coupa/rpt_coupa__users.sql
@@ -54,7 +54,6 @@ with
 
             coalesce(cul.id, cue.id) as coupa_user_id,
 
-            if(cul.id is not null, cul.active, cue.active) as active,
             if(
                 cul.id is not null, cul.purchasing_user, cue.purchasing_user
             ) as purchasing_user,
@@ -82,7 +81,6 @@ with
             scm.sam_account_name,
             scm.user_principal_name,
             scm.mail,
-            scm.active,
 
             r.roles,
 
@@ -124,7 +122,6 @@ with
             scm.user_principal_name,
             scm.mail,
 
-            true as active,
             'Expense User' as roles,
             null as content_groups,
             null as days_terminated,
@@ -144,7 +141,6 @@ with
             au.legal_family_name,
             au.roles,
             au.assignment_status,
-            au.active,
             au.purchasing_user,
             au.content_groups,
             au.home_business_unit_code,


### PR DESCRIPTION
## Summary and Motivation

When merged, this addresses the `claude-review` findings on the merged Coupa Users Import fix (#4411).

- `stg_coupa__users`: add `unique` (severity `error`) on `id` (plus `not_null`), `login`, and `employee_number`, with column descriptions. The `rpt_coupa__users` login-first join (`staff_coupa_match`) guarantees at-most-one Coupa account per staffer only if `login` and `employee_number` are unique in `stg_coupa__users` — but that was unenforced (the model had no tests, missing the staging uniqueness-test convention), and the downstream `Login`/`Email` `unique` tests are warn-only, so a future Coupa duplicate would silently fan out the nightly feed with no CI failure. These error-level tests enforce the invariant at the source. Verified all three keys are unique today (0 dups).
- `rpt_coupa__users`: drop the internal `active` column — computed in `staff_coupa_match` and threaded through `all_users`/`sub` but never emitted (the output `Status` derives from `coupa_status`, and `active` is not in the contract). Removing it shrinks the join surface.

Validated locally: `dbt build` gave PASS=8 WARN=2 ERROR=0 — the four new `stg_coupa__users` tests pass at error level, `rpt_coupa__users` builds with the contract intact after the `active` removal, and the two WARNs are the pre-existing address fan-out `unique` tests tracked in #4409.

AI assistance: the review findings were triaged and the changes made with Claude Code; scope decisions were human-directed.

## Self-review

### dbt

- [x] Properties file updated for the modified model (`stg_coupa__users.yml`)
- [x] Breaking change reviewed — no output columns changed; the dropped `active` is an internal CTE column, not in the enforced contract
- [ ] Exposure — n/a (no consumer surface change)

## CI checks

- [ ] Trunk
- [ ] dbt Cloud

Refs #4409