### PR TITLE
feat(kipptaf): exclude reconciliation-flagged responses from kfwd career launch survey

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -236,6 +236,19 @@ with
                 ) as float64
             ) as annual_income_clean,
         from survey_pivot
+    ),
+
+    excluded_responses as (
+        select survey_response_id,
+        from {{ ref("int_surveys__kfwd_career_launch_reconciliation") }}
+        where reconcile_or_exclude = 'Exclude'
+    ),
+
+    survey_filtered as (
+        select sc.*,
+        from survey_clean as sc
+        left join excluded_responses as er on sc.response_id = er.survey_response_id
+        where er.survey_response_id is null
     )
 
 select
@@ -359,7 +372,7 @@ select
     ) as rn_respondent,
 from roster as r
 full join
-    survey_clean as sp
+    survey_filtered as sp
     on r.rn_graduated = 1
     and (
         r.sf_email = sp.respondent_user_principal_name

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__kfwd_career_launch_reconciliation.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__kfwd_career_launch_reconciliation.yml
@@ -1,13 +1,35 @@
 models:
   - name: int_surveys__kfwd_career_launch_reconciliation
+    description: >-
+      Career Launch survey reconciliation sourced from a Google Form. Maps a
+      Career Launch survey response to a Salesforce contact and records whether
+      the response should be reconciled (retained) or excluded from Career
+      Launch reporting. One row per survey response, keeping the most recent
+      submission.
     config:
       materialized: table
     columns:
       - name: survey_response_id
+        description: >-
+          Career Launch survey response ID being reconciled. Joins to the
+          response ID on the Career Launch survey.
         data_type: string
         data_tests:
           - unique
-      - name: sf_contact_id
-        data_type: string
       - name: reconcile_or_exclude
+        description: >-
+          Disposition selected in the reconciliation form. Exclude removes the
+          matching survey response from Career Launch reporting; NULL (legacy
+          responses submitted before this field existed) and Reconcile both
+          retain the response.
+        data_type: string
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [Reconcile, Exclude]
+              config:
+                severity: warn
+                where: reconcile_or_exclude is not null
+      - name: sf_contact_id
+        description: Salesforce contact ID the survey response is reconciled to.
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will let Ops exclude individual KFWD Career
Launch survey responses from reporting via the reconciliation Google Form.
Responses flagged `reconcile_or_exclude = 'Exclude'` are anti-joined out of
`rpt_tableau__kfwd_career_launch_survey`, so they no longer roll up on the
model or dashboard. `NULL` (legacy responses submitted before this field
existed) and `Reconcile` continue to be retained.

Implementation notes:

- Filtering uses a positive `= 'Exclude'` match feeding an anti-join, which
  avoids the SQL `NULL`-comparison trap a negated (`!= 'Exclude'`) filter would
  hit — that form would silently drop every legacy `NULL` row.
- Added a warn-level `accepted_values` test (scoped to non-null rows) and
  descriptions on `int_surveys__kfwd_career_launch_reconciliation` documenting
  the disposition semantics and catching a future dropdown-label typo.

Verified locally: `rpt` builds with contract enforced; the one test `Exclude`
response dropped from 1 to 0 rows; reconciliation tests pass; Trunk clean.

## AI Assistance

Claude Code authored the model changes and tests. The approach and semantics
(treating `NULL` and `Reconcile` as retained, filter-only change) were
human-directed.

## Self-review

### dbt

- [x] No new models — updated the existing properties file for the modified
      reconciliation model.
- [x] No exposure change — the Tableau exposure for this `rpt` is unchanged
      (no columns added, renamed, or removed).
- [x] Not a breaking change — filter-only logic plus an additive test and
      descriptions; no contracted columns touched.
- [x] No external source changes — `stage_external_sources` not needed.

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud — not triggered (no Dagster paths changed)
