### PR TITLE
fix(kipptaf): anchor kfwd grade/grad-year flag on exit academic year

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -531,6 +531,11 @@ models:
         data_type: string
       - name: exit_school_name
         data_type: string
+      - name: exit_grade_level
+        data_type: int64
+        description: >
+          Grade level recorded on the student's most recent undergraduate
+          enrollment in PowerSchool (grades 8 through 12).
       - name: graduation_year
         data_type: int64
       - name: highest_sat_score
@@ -608,6 +613,16 @@ models:
         description: >
           True if the student has tagged more than one school as #1 Choice in
           Overgrad. False if the student has no Overgrad top-choice data.
+      - name: is_grade_grad_year
+        data_type: boolean
+        description: >
+          True when the graduation year implied by the PowerSchool exit grade
+          level matches the Salesforce-derived graduation year. Implied year is
+          (13 minus exit grade level) plus the academic year the exit grade was
+          recorded, anchoring on that academic year rather than the current one
+          because most rows are alumni whose last enrollment predates the
+          current year. False flags a student whose grade level and graduation
+          year do not comport.
       - name: es_attended
         data_type: string
       - name: total_aid_amount

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -290,6 +290,7 @@ select
     c.is_dlm,
     c.contact_graduation_year as graduation_year,
     c.exit_school_name,
+    c.exit_grade_level,
     c.powerschool_enroll_status,
     c.contact_postsec_advisor_name as postsec_advisor,
     c.best_guess_pathway as bgp,
@@ -719,6 +720,9 @@ select
     coalesce(
         ogc.has_duplicate_overgrad_1st_choice, false
     ) as has_duplicate_overgrad_1st_choice,
+
+    (13 - c.exit_grade_level) + c.exit_academic_year
+    = c.contact_graduation_year as is_grade_grad_year,
 from {{ ref("int_kippadb__roster") }} as c
 cross join year_scaffold as ay
 left join {{ ref("int_kippadb__enrollment_pivot") }} as ei on c.contact_id = ei.student


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will correct the new `is_grade_grad_year` flag on `rpt_tableau__kfwd_dashboard` and declare it (plus `exit_grade_level`) in the model contract.

The flag compares the graduation year implied by a student's PowerSchool exit grade level against the Salesforce-derived `contact_graduation_year`. It was anchored on `current_academic_year`, which is only correct for students enrolled in the current academic year. Because `exit_grade_level` is the grade from a student's most-recent enrollment row (paired with `exit_academic_year`), and most rows on this KIPP Forward dashboard are alumni (`HSG`/`TAF`/`TAFHS`) whose last enrollment predates the current year, the flag mismarked the large majority of students.

Fix: anchor the arithmetic on `exit_academic_year` (the year the exit grade was recorded) instead of `current_academic_year` — mirroring how the upstream roster already computes `current_grade_level_projection`.

Impact against prod `int_kippadb__roster` (TRUE = grade comports with grad year):

```text
ktc_status  rows   current_ay (before)   exit_ay (after)
HS9          560            48                503
HS10         521            65                453
HS11         449            47                401
HS12         398            16                381
HSG        2,950           383              2,937
TAF        2,212            6              2,112
TAFHS        926           75                811
```

**AI Assistance:** Human-directed. Claude diagnosed the wrong-anchor bug, quantified it against prod, applied the one-word SQL fix, and added the two contract entries with descriptions.

## Self-review

### dbt

- [x] Contract entries added for both new columns (`exit_grade_level`, `is_grade_grad_year`) with descriptions in the properties file.
- [x] No new/renamed/removed existing columns — additive only, no breaking change for downstream exposures.
- [x] No external source changes.

## CI checks

- [x] **Trunk** — passes locally (`trunk check --force` on both changed files, no issues).
- [ ] **dbt Cloud** — pending.
