### PR TITLE
chore(dbt): roll current academic year to 2026, fiscal year to 2027

### DIFF
--- a/src/dbt/kippcamden/dbt_project.yml
+++ b/src/dbt/kippcamden/dbt_project.yml
@@ -23,8 +23,8 @@ data_tests:
 
 vars:
   local_timezone: America/New_York
-  current_academic_year: 2025
-  current_fiscal_year: 2026
+  current_academic_year: 2026
+  current_fiscal_year: 2027
   cloud_storage_uri_base: gs://teamster-kippcamden/dagster/kippcamden
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
 

--- a/src/dbt/kippmiami/dbt_project.yml
+++ b/src/dbt/kippmiami/dbt_project.yml
@@ -23,8 +23,8 @@ data_tests:
 
 vars:
   local_timezone: America/New_York
-  current_academic_year: 2025
-  current_fiscal_year: 2026
+  current_academic_year: 2026
+  current_fiscal_year: 2027
   cloud_storage_uri_base: gs://teamster-kippmiami/dagster/kippmiami
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
   focus_schema: dagster_kippmiami_dlt_focus

--- a/src/dbt/kippnewark/dbt_project.yml
+++ b/src/dbt/kippnewark/dbt_project.yml
@@ -23,8 +23,8 @@ data_tests:
 
 vars:
   local_timezone: America/New_York
-  current_academic_year: 2025
-  current_fiscal_year: 2026
+  current_academic_year: 2026
+  current_fiscal_year: 2027
   iready_schema: kippnj_iready
   renlearn_schema: kippnj_renlearn
   cloud_storage_uri_base: gs://teamster-kippnewark/dagster/kippnewark

--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -23,8 +23,8 @@ data_tests:
 
 vars:
   local_timezone: America/New_York
-  current_academic_year: 2025
-  current_fiscal_year: 2026
+  current_academic_year: 2026
+  current_fiscal_year: 2027
   cloud_storage_uri_base: gs://teamster-kipppaterson/dagster/kipppaterson
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
 

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -28,8 +28,8 @@ vars:
   local_timezone: America/New_York
   cloud_storage_uri_base: gs://teamster-kipptaf/dagster/kipptaf
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
-  current_academic_year: 2025
-  current_fiscal_year: 2026
+  current_academic_year: 2026
+  current_fiscal_year: 2027
 
 models:
   kipptaf:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will roll the annual `current_academic_year` var (2025 -> 2026) and `current_fiscal_year` var (2026 -> 2027) across all five district and network dbt projects — kippnewark, kippcamden, kippmiami, kipppaterson, kipptaf — advancing the network to SY2026-27. Both vars move together so they continue to denote the same school year (start-year 2026 / end-year 2027).

Scope is limited to the five `dbt_project.yml` var blocks (10 lines total). Intentionally left unchanged:

- The three GPA unit-test fixtures that pin `current_academic_year: 2025` — their `given`/`expect` rows are hardcoded to that year, so bumping the var without reworking the fixture data would break the tests.
- The `powerschool` and `focus` source-system sentinel defaults (`0`) — overridden per district, not "current".
- Python `CURRENT_FISCAL_YEAR` — computed dynamically from the current date, nothing to edit.

Downstream note: the marts/Cube `is_current_academic_year` classifier derives from this var but rolls over only on var update plus a mart rebuild, so the flag flips once the TABLE-materialized marts rematerialize after merge.

## AI Assistance

AI-assisted (Claude Code): located every var occurrence, made the edits in an isolated worktree, and verified YAML parsing. Human-directed: the scope decisions — also bumping the fiscal-year var for consistency, excluding the unit-test fixtures, and using a standalone branch.

## Self-review

### dbt

N/A for the specific items below — this is a variable-value change only, with no new/modified models, columns, contracts, exposures, or external sources.

- [ ] Include a properties file for all new models — no new models
- [ ] Include or update an exposure — no exposure-affecting changes
- [x] Breaking change? Not a contracted column rename/removal. This shifts the value of a logic-driving var (intended annual behavior), not the schema.
- [ ] External source staging — no source changes

## CI checks

- [ ] Trunk — passes
- [ ] dbt Cloud — passes
- [ ] Dagster Cloud — not triggered (pull_request paths exclude `src/dbt/**`)
