### PR TITLE
fix(powerschool): add sla_presentation to s_nj_stu_x contract

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -271,6 +271,18 @@ standalone — build/test them via a **consuming district** project-dir with tha
 district's prod manifest for `--defer` (e.g. focus → kippmiami):
 `uv run dbt build --select <model> --project-dir src/dbt/kippmiami --defer --state src/dbt/kippmiami/target/prod --target dev`.
 
+**A contract-enforced change needs a real `dbt build` to verify, not a prod
+SELECT** — `assert_columns_equivalent` runs only inside `dbt build`/CTAS, so a
+SELECT against the prod external validates data/logic but NOT the column set,
+and an all-NULL new source column that `select *` passes through slips past
+(this shipped a 2nd prod contract failure a build would have caught). For an
+Avro/GCS-source model, the dev source copy
+`zz_<GITHUB_USER>_<district>_<source>` may be stale/missing the new column —
+re-stage YOUR copy first:
+`dbt run-operation stage_external_sources --args "select: <source>.<table>" --vars '{ext_full_refresh: true}' --target dev --project-dir src/dbt/<district>`
+(personal schema, NOT classifier-blocked, unlike `--target staging`), then
+`dbt build --select <model> --target dev`.
+
 ## Local dev schema naming
 
 Local dev builds land in `zz_<GITHUB_USER>_<district>[_<source>]` (repo

--- a/src/dbt/powerschool/CLAUDE.md
+++ b/src/dbt/powerschool/CLAUDE.md
@@ -56,6 +56,20 @@ don't assume. Source is `sources-bigquery.yml` schema
 `dagster_<district>_dlt_powerschool`, read in every target (dlt writes the prod
 dataset even on branch deploys).
 
+## ODBC source schema drift (recurring on `s_nj_stu_x`)
+
+The odbc Avro schema is inferred from the Oracle cursor type
+(`libraries/powerschool/sis/odbc/schema.py` `ORACLE_AVRO_SCHEMA_TYPES`): NUMBER
+→ `STRUCT<int_value, double_value, bytes_decimal_value>`, VARCHAR/CHAR → STRING.
+Two drift modes both surface as failed `stg_powerschool__*` builds: (1)
+PowerSchool retypes a column NUMBER→VARCHAR → the `.int_value` unwrap fails
+"Cannot access field int_value on a value with type STRING" — fix by casting
+(`cast(col as int)`, matching the sftp/dlt variants); (2) PowerSchool adds a new
+column → `select *` passes it through and the enforced contract fails "missing
+in contract" — fix by declaring it in `properties.yml`. Diff the full source
+column set (`INFORMATION_SCHEMA.COLUMNS`) against the contract to catch ALL new
+columns at once — dbt reports only the first.
+
 ## GPA Gotchas
 
 - **`storecode = 'Y1'` only**: Q1–Q4 records have `gpa_points = 0` by design —

--- a/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__s_nj_stu_x.yml
+++ b/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__s_nj_stu_x.yml
@@ -522,6 +522,8 @@ models:
         data_type: string
       - name: sla_humanreader_signer
         data_type: string
+      - name: sla_presentation
+        data_type: string
       - name: sla_science_response_el
         data_type: string
       - name: sla_selected_response


### PR DESCRIPTION
## Summary & Motivation

When merged, this fixes the failed materialization of `stg_powerschool__s_nj_stu_x` (ODBC) in kippcamden and kippnewark, which broke with a contract enforcement error:

```text
This model has an enforced contract that failed.
| column_name      | definition_type | contract_type | mismatch_reason     |
| sla_presentation | STRING          |               | missing in contract |
```

PowerSchool added a new column `sla_presentation` (an NJSLA accommodation field) to the `s_nj_stu_x` extension table. The model passes it through via `select *`, but the enforced contract did not declare it. Fix: add `sla_presentation` with `data_type: string`, matching the sibling passthrough `sla_*` text columns.

Root-caused from Dagster run `9b1c058e-5827-4401-b568-c2c1cf91d9ef`. A full two-way diff of the live source schema (433 columns) vs the contract confirmed `sla_presentation` is the only discrepancy (zero stale contract entries), so this is a complete single-column fix. The column is scalar STRING and currently all-NULL in both districts, so no SQL change is needed. One edit to the shared package properties file fixes both odbc districts; paterson (dlt) and miami (no NJ table) are unaffected.

AI assistance: root-cause investigation, fix, and validation by Claude Code; human-directed.

## Self-review

### dbt

- [x] Contract-only change — added one column declaration to match a new source column. No SQL change, no new models, no column renames or removals.
- [x] Verified locally: post-edit the contract column set exactly equals the source column set (433 vs 433, no diff either direction); `dbt parse` succeeds; `trunk check` clean.
- [x] Not a breaking change — no existing column renamed or removed; output column names and types unchanged.

## Also included — CLAUDE.md guidance (2 files)

Two `docs(dbt)` commits fold in the lessons from this incident so future work defaults to catching it pre-merge:

- `src/dbt/CLAUDE.md` — a contract-enforced change must be verified with a real `dbt build` (which runs `assert_columns_equivalent`), not a prod SELECT; and how to re-stage your personal dev external for a new source column.
- `src/dbt/powerschool/CLAUDE.md` — the recurring PowerSchool ODBC source-schema drift on `s_nj_stu_x` (NUMBER→VARCHAR retype vs. new column) and the fix for each.

## CI checks

- [ ] **Trunk** — passes (checked locally).
- [ ] **dbt Cloud** — expected to pass — district CI reads the prod external, which already has `sla_presentation`, so the build outputs 433 columns matching the contract.
- [ ] **Dagster Cloud** — not applicable (no Dagster code changes).

