### PR TITLE
fix(powerschool): add missing sla_presentation to dlt s_nj_stu_x staging

### DIFF
--- a/src/dbt/powerschool/models/sis/staging/dlt/stg_powerschool__s_nj_stu_x.sql
+++ b/src/dbt/powerschool/models/sis/staging/dlt/stg_powerschool__s_nj_stu_x.sql
@@ -234,6 +234,7 @@ select
     sla_examiner_smid,
     sla_extended_time,
     sla_humanreader_signer,
+    sla_presentation,
     sla_science_response_el,
     sla_selected_response,
     sla_spanish_trans,


### PR DESCRIPTION
## Summary & Motivation

When merged, this PR fixes the enforced-contract build failure on the `dlt` variant of `stg_powerschool__s_nj_stu_x` that broke prod materialization for kippnewark.

The Newark PowerSchool-to-dlt migration (#4429) enabled the `dlt` variant of this model for kippnewark. Unlike the `odbc` variant (`select * except (...)`, which passes columns through), the `dlt` variant enumerates every column explicitly, and the transcription dropped `sla_presentation`. The shared contract still declares `sla_presentation` (STRING), so `assert_columns_equivalent` failed at CTAS with "missing in definition", failing the prod `__ASSET_JOB` run.

**Fix:** add `sla_presentation` as a bare string projection (dlt landing type STRING(25)) in contract/odbc order. A full contract-vs-model diff confirmed this was the only gap (433 contract columns vs 432 projected), so no second contract failure is hiding behind it.

**Not breaking:** this adds a column the contract already required; nothing renamed or removed, no downstream schema change. The dlt source is BQ-native (`sources-bigquery.yml`), so no `stage_external_sources` is needed.

**Verified locally:** `dbt build --select stg_powerschool__s_nj_stu_x --target dev` completed successfully (table created, `unique` test passed); the built table contains `sla_presentation`; `trunk check` reports no issues.

## AI Assistance

AI-assisted (Claude Code, Opus 4.8): diagnosed the failed Dagster run, isolated the missing column via a full contract-vs-model diff, applied the one-line fix, and verified with a dev build plus trunk check. Human-directed: branch and PR setup, and review.

## Self-review

### dbt

- [x] Not a new model — single column added to an existing contracted model to match its existing properties file.
- [x] Not a breaking change — adds a column the contract already declared; nothing renamed or removed.
- [x] No external-source change — the dlt source is BQ-native; `stage_external_sources` not required.

## CI checks

- [ ] **Trunk** — expected to pass (verified locally with `trunk check --force`).
- [ ] **dbt Cloud** — expected to pass; the dlt landing table exists in prod and the model builds cleanly.
- [ ] **Dagster Cloud** — not triggered (dbt-only change; `src/dbt/**` is excluded from the deploy `pull_request` paths).