### PR TITLE
feat(kipptaf): add Career Conversation counts and checklist completion to kfwd career launch survey

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
@@ -251,3 +251,39 @@ models:
         description:
           Whether work samples were discussed during the KFWD career
           conversation. False when no conversation is recorded.
+      - name: cc1_count
+        data_type: int64
+        description:
+          Count of the alumnus's first Career Conversation (CC1) Salesforce
+          contact notes, summed across all academic years. Zero when none are
+          recorded.
+      - name: cc2_count
+        data_type: int64
+        description:
+          Count of the alumnus's second Career Conversation (CC2) Salesforce
+          contact notes, summed across all academic years. Zero when none are
+          recorded.
+      - name: cc3_count
+        data_type: int64
+        description:
+          Count of the alumnus's third Career Conversation (CC3) Salesforce
+          contact notes, summed across all academic years. Zero when none are
+          recorded.
+      - name: cc4_count
+        data_type: int64
+        description:
+          Count of the alumnus's fourth Career Conversation (CC4) Salesforce
+          contact notes, summed across all academic years. Zero when none are
+          recorded.
+      - name: cc5_count
+        data_type: int64
+        description:
+          Count of the alumnus's fifth Career Conversation (CC5) Salesforce
+          contact notes, summed across all academic years. Zero when none are
+          recorded.
+      - name: cc_total_count
+        data_type: int64
+        description:
+          Total count of the alumnus's Career Conversation (CC1 through CC5)
+          Salesforce contact notes, summed across all academic years. Zero when
+          none are recorded.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_career_launch_survey.yml
@@ -287,3 +287,17 @@ models:
           Total count of the alumnus's Career Conversation (CC1 through CC5)
           Salesforce contact notes, summed across all academic years. Zero when
           none are recorded.
+      - name: career_conversation_items_complete_count
+        data_type: int64
+        description:
+          Number of the seven KFWD career conversation checklist items (resume
+          score, LinkedIn, mock interview or prep, professional references list,
+          job search template, cover letter template, work samples) marked
+          complete for the alumnus in the Career Conversation Tracker AppSheet
+          app. Zero when no conversation is recorded.
+      - name: is_career_conversation_complete
+        data_type: boolean
+        description:
+          Whether all seven KFWD career conversation checklist items are marked
+          complete for the alumnus in the Career Conversation Tracker AppSheet
+          app. False when any item is incomplete or no conversation is recorded.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -50,40 +50,6 @@ with
         group by contact_id
     ),
 
-    career_conversation_checklist as (
-        select
-            contact_id,
-
-            (
-                select countif(item),
-                from
-                    unnest(
-                        [
-                            is_resume_score,
-                            is_linkedin,
-                            is_mock_interview_or_prep,
-                            is_professional_references_list,
-                            is_job_search_template,
-                            is_cover_letter_template,
-                            is_work_samples
-                        ]
-                    ) as item
-            ) as career_conversation_items_complete_count,
-
-            if(
-                is_resume_score
-                and is_linkedin
-                and is_mock_interview_or_prep
-                and is_professional_references_list
-                and is_job_search_template
-                and is_cover_letter_template
-                and is_work_samples,
-                true,
-                false
-            ) as is_career_conversation_complete,
-        from {{ ref("stg_google_appsheet__kfwd_career_conversations__output") }}
-    ),
-
     roster as (
         select
             r.contact_id,
@@ -153,11 +119,33 @@ with
             coalesce(ccr.cc4_count, 0) as cc4_count,
             coalesce(ccr.cc5_count, 0) as cc5_count,
             coalesce(ccr.cc_total_count, 0) as cc_total_count,
-            coalesce(
-                ccc.career_conversation_items_complete_count, 0
+
+            (
+                select countif(item),
+                from
+                    unnest(
+                        [
+                            cc.is_resume_score,
+                            cc.is_linkedin,
+                            cc.is_mock_interview_or_prep,
+                            cc.is_professional_references_list,
+                            cc.is_job_search_template,
+                            cc.is_cover_letter_template,
+                            cc.is_work_samples
+                        ]
+                    ) as item
             ) as career_conversation_items_complete_count,
-            coalesce(
-                ccc.is_career_conversation_complete, false
+
+            if(
+                cc.is_resume_score
+                and cc.is_linkedin
+                and cc.is_mock_interview_or_prep
+                and cc.is_professional_references_list
+                and cc.is_job_search_template
+                and cc.is_cover_letter_template
+                and cc.is_work_samples,
+                true,
+                false
             ) as is_career_conversation_complete,
 
             extract(
@@ -205,7 +193,6 @@ with
             {{ ref("stg_google_appsheet__kfwd_career_conversations__output") }} as cc
             on r.contact_id = cc.contact_id
         left join career_conversations as ccr on r.contact_id = ccr.contact_id
-        left join career_conversation_checklist as ccc on r.contact_id = ccc.contact_id
         where
             r.ktc_status in ('HSG', 'TAF')
             and r.ktc_cohort <= {{ var("current_academic_year") }}

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -36,6 +36,20 @@ with
         group by p.student
     ),
 
+    career_conversations as (
+        select
+            contact_id,
+
+            sum(cc1) as cc1_count,
+            sum(cc2) as cc2_count,
+            sum(cc3) as cc3_count,
+            sum(cc4) as cc4_count,
+            sum(cc5) as cc5_count,
+            sum(cc1 + cc2 + cc3 + cc4 + cc5) as cc_total_count,
+        from {{ ref("int_kippadb__contact_note_rollup") }}
+        group by contact_id
+    ),
+
     roster as (
         select
             r.contact_id,
@@ -99,6 +113,12 @@ with
             coalesce(cc.is_job_search_template, false) as is_job_search_template,
             coalesce(cc.is_cover_letter_template, false) as is_cover_letter_template,
             coalesce(cc.is_work_samples, false) as is_work_samples,
+            coalesce(ccr.cc1_count, 0) as cc1_count,
+            coalesce(ccr.cc2_count, 0) as cc2_count,
+            coalesce(ccr.cc3_count, 0) as cc3_count,
+            coalesce(ccr.cc4_count, 0) as cc4_count,
+            coalesce(ccr.cc5_count, 0) as cc5_count,
+            coalesce(ccr.cc_total_count, 0) as cc_total_count,
 
             extract(
                 month from r.contact_expected_college_graduation
@@ -144,6 +164,7 @@ with
         left join
             {{ ref("stg_google_appsheet__kfwd_career_conversations__output") }} as cc
             on r.contact_id = cc.contact_id
+        left join career_conversations as ccr on r.contact_id = ccr.contact_id
         where
             r.ktc_status in ('HSG', 'TAF')
             and r.ktc_cohort <= {{ var("current_academic_year") }}
@@ -310,6 +331,12 @@ select
     r.is_job_search_template,
     r.is_cover_letter_template,
     r.is_work_samples,
+    r.cc1_count,
+    r.cc2_count,
+    r.cc3_count,
+    r.cc4_count,
+    r.cc5_count,
+    r.cc_total_count,
 
     sp.survey_id,
     sp.survey_title,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_career_launch_survey.sql
@@ -50,6 +50,40 @@ with
         group by contact_id
     ),
 
+    career_conversation_checklist as (
+        select
+            contact_id,
+
+            (
+                select countif(item),
+                from
+                    unnest(
+                        [
+                            is_resume_score,
+                            is_linkedin,
+                            is_mock_interview_or_prep,
+                            is_professional_references_list,
+                            is_job_search_template,
+                            is_cover_letter_template,
+                            is_work_samples
+                        ]
+                    ) as item
+            ) as career_conversation_items_complete_count,
+
+            if(
+                is_resume_score
+                and is_linkedin
+                and is_mock_interview_or_prep
+                and is_professional_references_list
+                and is_job_search_template
+                and is_cover_letter_template
+                and is_work_samples,
+                true,
+                false
+            ) as is_career_conversation_complete,
+        from {{ ref("stg_google_appsheet__kfwd_career_conversations__output") }}
+    ),
+
     roster as (
         select
             r.contact_id,
@@ -119,6 +153,12 @@ with
             coalesce(ccr.cc4_count, 0) as cc4_count,
             coalesce(ccr.cc5_count, 0) as cc5_count,
             coalesce(ccr.cc_total_count, 0) as cc_total_count,
+            coalesce(
+                ccc.career_conversation_items_complete_count, 0
+            ) as career_conversation_items_complete_count,
+            coalesce(
+                ccc.is_career_conversation_complete, false
+            ) as is_career_conversation_complete,
 
             extract(
                 month from r.contact_expected_college_graduation
@@ -165,6 +205,7 @@ with
             {{ ref("stg_google_appsheet__kfwd_career_conversations__output") }} as cc
             on r.contact_id = cc.contact_id
         left join career_conversations as ccr on r.contact_id = ccr.contact_id
+        left join career_conversation_checklist as ccc on r.contact_id = ccc.contact_id
         where
             r.ktc_status in ('HSG', 'TAF')
             and r.ktc_cohort <= {{ var("current_academic_year") }}
@@ -337,6 +378,8 @@ select
     r.cc4_count,
     r.cc5_count,
     r.cc_total_count,
+    r.career_conversation_items_complete_count,
+    r.is_career_conversation_complete,
 
     sp.survey_id,
     sp.survey_title,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request adds Career Conversation fields to `rpt_tableau__kfwd_career_launch_survey`, at the alum grain (one row per `contact_id`):

- From `int_kippadb__contact_note_rollup` (Salesforce contact notes, grained by academic year): `cc1_count`, `cc2_count`, `cc3_count`, `cc4_count`, `cc5_count`, and `cc_total_count` — each summed across all academic years, so an alum with a `CC1` note in two different years reports `2`.
- From the Career Conversation Tracker AppSheet model (`stg_google_appsheet__kfwd_career_conversations__output`): `career_conversation_items_complete_count` (how many of the seven checklist items are complete) and `is_career_conversation_complete` (true only when all seven are complete).

Both new source aggregations are one row per `contact_id`, so the left joins to the roster cannot fan out. Counts and the completion flag coalesce to `0` / `false` for alumni with no recorded conversation, matching the existing `is_*` flag pattern on this report.

The Salesforce contact-note counts are distinct from the AppSheet-sourced `is_*` checklist flags already on the report.

## AI Assistance

AI-assisted (Claude Code), human-directed. The requirements, column naming, and design decisions were user-directed; Claude implemented the SQL/YAML, validated the contract via a dev build, and reconciled the output against the upstream models.

## Self-review

### dbt

- [x] Properties file updated with contract entries and descriptions for all eight new columns.
- [x] No new models — only added columns to an existing extract. Existing exposure covers it.
- [x] Not a breaking change — additive columns only; no renames or removals.
- [x] No external-source changes; no `stage_external_sources` needed.

Validation:

- Dev build passed with contract enforced (new `int64` / `boolean` columns accepted).
- Data reconciled 0-mismatch against upstreams: CC counts vs `int_kippadb__contact_note_rollup`; checklist count and flag vs the tracker model. `cc_total_count` tops out at 6; the checklist flag is currently false network-wide (max 6 of 7 items complete).
- The pre-existing `contact_id`+`response_id` uniqueness warn (128) is unchanged — the new joins add no rows.

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud

Refs #4448
Closes #4448

