### PR TITLE
fix(iready): declare and surface new vendor columns

### DIFF
--- a/src/dbt/iready/models/staging/properties/stg_iready__instruction_by_lesson_pro.yml
+++ b/src/dbt/iready/models/staging/properties/stg_iready__instruction_by_lesson_pro.yml
@@ -29,6 +29,12 @@ models:
         data_type: int64
       - name: skills_successful
         data_type: int64
+      - name: items_completed
+        data_type: int64
+      - name: items_correct
+        data_type: int64
+      - name: percent_items_correct
+        data_type: numeric
       - name: completion_date
         data_type: date
       - name: student_grade

--- a/src/dbt/iready/models/staging/properties/stg_iready__personalized_instruction_summary.yml
+++ b/src/dbt/iready/models/staging/properties/stg_iready__personalized_instruction_summary.yml
@@ -187,6 +187,18 @@ models:
         data_type: int64
       - name: geometric_measurement_and_figures_skills_successful
         data_type: int64
+      - name: number_relationships_and_operation_concepts_percent_k_2_skills_successful
+        data_type: int64
+      - name: number_relationships_and_operation_concepts_k_2_skills_completed
+        data_type: int64
+      - name: number_relationships_and_operation_concepts_k_2_skills_successful
+        data_type: int64
+      - name: number_sense_percent_k_2_skills_successful
+        data_type: int64
+      - name: number_sense_k_2_skills_completed
+        data_type: int64
+      - name: number_sense_k_2_skills_successful
+        data_type: int64
       - name: rational_numbers_and_operations_percent_skills_successful
         data_type: int64
       - name: rational_numbers_and_operations_skills_completed

--- a/src/dbt/iready/models/staging/stg_iready__instruction_by_lesson_pro.sql
+++ b/src/dbt/iready/models/staging/stg_iready__instruction_by_lesson_pro.sql
@@ -14,6 +14,9 @@ select
     cast(skills_completed as int) as skills_completed,
     cast(skills_successful as int) as skills_successful,
     cast(percent_skills_successful as numeric) as percent_skills_successful,
+    cast(items_completed as int) as items_completed,
+    cast(items_correct as int) as items_correct,
+    cast(percent_items_correct as numeric) as percent_items_correct,
 
     safe_cast(student_id as int) as student_id,
 

--- a/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
+++ b/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
@@ -105,6 +105,28 @@ select
         i_ready_pro_geometric_measurement_and_figures_skills_successful as int
     ) as geometric_measurement_and_figures_skills_successful,
     cast(
+        -- trunk-ignore(sqlfluff/LT05): vendor column name exceeds 88 chars
+        i_ready_pro_number_relationships_and_operation_concepts_percent_k_2_skills_successful
+        as int
+    ) as number_relationships_and_operation_concepts_percent_k_2_skills_successful,
+    cast(
+        i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_completed
+        as int
+    ) as number_relationships_and_operation_concepts_k_2_skills_completed,
+    cast(
+        i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_successful
+        as int
+    ) as number_relationships_and_operation_concepts_k_2_skills_successful,
+    cast(
+        i_ready_pro_number_sense_percent_k_2_skills_successful as int
+    ) as number_sense_percent_k_2_skills_successful,
+    cast(
+        i_ready_pro_number_sense_k_2_skills_completed as int
+    ) as number_sense_k_2_skills_completed,
+    cast(
+        i_ready_pro_number_sense_k_2_skills_successful as int
+    ) as number_sense_k_2_skills_successful,
+    cast(
         i_ready_pro_rational_numbers_and_operations_percent_skills_successful as int
     ) as rational_numbers_and_operations_percent_skills_successful,
     cast(

--- a/src/teamster/libraries/iready/schema.py
+++ b/src/teamster/libraries/iready/schema.py
@@ -308,6 +308,8 @@ class InstructionByLesson(IReadyBaseModel):
     completion_date: str | None = None
     foundational_skills_completed: str | None = None
     foundational_skills_successful: str | None = None
+    items_completed: str | None = None
+    items_correct: str | None = None
     language_comprehension_items_completed: str | None = None
     language_comprehension_items_correct: str | None = None
     lesson_language: str | None = None
@@ -320,6 +322,7 @@ class InstructionByLesson(IReadyBaseModel):
     lesson: str | None = None
     level: str | None = None
     percent_foundational_skills_successful: str | None = None
+    percent_items_correct: str | None = None
     percent_language_comprehension_items_correct: str | None = None
     percent_skills_successful: str | None = None
     skills_completed: str | None = None
@@ -427,6 +430,18 @@ class PersonalizedInstructionSummary(BaseModel):
     ) = None
     i_ready_pro_geometric_measurement_and_figures_skills_completed: str | None = None
     i_ready_pro_geometric_measurement_and_figures_skills_successful: str | None = None
+    i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_completed: (
+        str | None
+    ) = None
+    i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_successful: (
+        str | None
+    ) = None
+    i_ready_pro_number_relationships_and_operation_concepts_percent_k_2_skills_successful: (
+        str | None
+    ) = None
+    i_ready_pro_number_sense_k_2_skills_completed: str | None = None
+    i_ready_pro_number_sense_k_2_skills_successful: str | None = None
+    i_ready_pro_number_sense_percent_k_2_skills_successful: str | None = None
     i_ready_pro_rational_numbers_and_operations_percent_skills_successful: (
         str | None
     ) = None


### PR DESCRIPTION
## Summary & Motivation

When merged, this handles the new columns i-Ready recently added to two SFTP
exports, end to end:

1. **Declare them (drift fix).** Adds 9 fields to the shared Pydantic models in
   `libraries/iready/schema.py`, clearing the `avro_schema_valid` WARN alerts on
   `instruction_by_lesson` and `personalized_instruction_summary` (kippmiami +
   kippnewark) and stopping the new columns being silently dropped from the Avro
   output. Root cause is vendor schema drift — the check succeeded ~2 days ago
   and began warning ~1 day ago with no code change on our side.
2. **Surface them (dbt).** Adds the columns to the two staging models and their
   enforced contracts so the metrics reach the warehouse:
   - `stg_iready__instruction_by_lesson_pro`: `items_completed`, `items_correct`,
     `percent_items_correct`
   - `stg_iready__personalized_instruction_summary`: the Number Sense (K-2) and
     Number Relationships and Operation Concepts (K-2) skills columns

Both Pydantic models and both staging models are shared, so kippmiami and
kippnewark are fixed together.

### Sequencing / rollout note (read before merging)

The staging models reference the new columns by name, so `dbt build` errors
`Name items_completed not found` until the external table actually has them —
which only happens after this deploys **and** an i-Ready re-pull rewrites the
Avro with the new schema. Expect a transient staging-build failure on the
affected assets until a re-pull lands; re-pull the affected `math` partitions
right after deploy to close the window. Additionally, because the Avro external
autodetects and old + new partition files coexist, the new columns read **NULL
for every row** until all partitions are re-encoded to the new schema
(`scripts/reencode_avro_partitions.py`) — see `src/dbt/CLAUDE.md` "External
Table Pattern".

### Follow-up (not in this PR)

Found a pre-existing bug in `int_iready__personalized_instruction_unpivot.sql`:
a missing comma between `'single_syllable'` and `'whole_numbers_and_operations'`
in the `lesson_type` CASE concatenates them, so both domains fall through to
`lesson_type = NULL`. Tracking separately.

## AI Assistance

AI-assisted end to end (Claude Code, systematic-debugging skill): diagnosis from
three flagged Dagster runs, tracing to the shared models, the schema fix, and
the staging/contract additions. Human-directed: the request, scope and
branch/sequencing decisions, and review.

## Self-review

### Dagster

- [x] Reproduced the drift, then confirmed both shared models regenerate Avro
      with all 9 new fields for kippmiami and kippnewark and the real
      `check_avro_schema_valid` passes (extras empty).
- [ ] `uv run dagster definitions validate` — not run locally:
      `kippmiami.definitions` cannot import in the codespace (unrelated Focus
      dlt credential, documented in CLAUDE.md). The `iready` schema submodules
      import and regenerate cleanly; CI and the branch deploy validate fully.

### dbt

- [x] All 9 new SQL aliases map 1:1 to their enforced-contract columns, with
      matching types (int64 / numeric).
- [x] `trunk check` clean on the changed SQL and contract files (one long vendor
      column name suppressed with a targeted `trunk-ignore(sqlfluff/LT05)`).
- [ ] Full `dbt build` not run: the external table lacks the new columns until a
      prod re-pull (see sequencing note), and the codespace SA cannot read prod
      GCS. Verified statically instead (sqlfmt parse + contract-alias match).

## CI checks

- [ ] Trunk — expected green (verified locally).
- [ ] dbt Cloud — iReady is a source-system package; CI builds only kipptaf, so
      this selects models only if kipptaf consumes the changed schemas.
- [ ] Dagster Cloud — see sequencing note; the staging build depends on a
      re-pull.
