### PR TITLE
chore: enable filesystem MCP server for the project

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -49,6 +49,14 @@
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
     },
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/workspaces/teamster"
+      ]
+    },
     "tableau": {
       "command": "/workspaces/teamster/scripts/tableau-mcp-launch.sh",
       "args": [],


### PR DESCRIPTION
Add the official @modelcontextprotocol/server-filesystem to .mcp.json,
scoped to the /workspaces/teamster project root (matching the path
convention used by the other stdio servers). Launched via npx, with the
allowed directory passed as a positional arg per the server's docs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FME5qhj5ujX1KbBnG5Nq4k