### PR TITLE
refactor(powerschool): dlt intraday change-detection sensor across all districts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,13 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   partway through. Scope dispatches to one file / one commit; inspect the file
   diff and `git log` before marking complete — don't trust the self-report.
 
+- **Subagent worktree dispatches must spell out the absolute worktree path**: a
+  subagent starts in the MAIN checkout, so the dispatch prompt must give the
+  worktree path and mandate `git -C <worktree>` + `uv run` from it (bare edits
+  hit `main` silently), and state that IDE Pyright errors on worktree files
+  (`reportMissingImports`, "not accessed", "not iterable") are expected false
+  positives — trust `uv run` inside the worktree, not the IDE.
+
 - **The `Workflow`-tool orchestrator is unreliable for long fan-outs in this
   Codespace** — it stalled/died mid-run repeatedly (not OOM; 11Gi free), and a
   window reload left a prior run orphaned-but-alive that kept spawning
@@ -238,6 +245,12 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   comment — and the stub can stay stuck mid-render even after the check-run
   reports `success`. Fetch ALL issue comments and read the newest / longest, not
   the first.
+
+- **`dagster-cloud-deploy / deploy` emits one same-named check-run per code
+  location** (~5) — `get_check_runs` returns duplicates; wait for ALL to reach a
+  terminal conclusion before calling the deploy green. A shared-library change
+  (e.g. `libraries/dlt/`) redeploys every consuming location, not just the ones
+  whose config you edited.
 
 - **Python**: Always `uv run` — never bare `python`, `python3`, or
   venv-installed tools (`dbt`, `dagster`, etc.).

--- a/docs/superpowers/plans/2026-07-20-powerschool-dlt-intraday-sensor.md
+++ b/docs/superpowers/plans/2026-07-20-powerschool-dlt-intraday-sensor.md
@@ -1,0 +1,1570 @@
+# PowerSchool dlt Intraday Sensor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the PowerSchool dlt intraday `ScheduleDefinition` with a
+probe-driven sensor in all three dlt districts (`kippnewark`, `kippcamden`,
+`kipppaterson`) so unchanged tables are never planned and idle ticks launch
+nothing.
+
+**Architecture:** Change detection moves from the op into a new library sensor
+factory that probes each intraday table, compares against the dlt-state
+baseline, and emits `RunRequest(asset_selection=changed)` with the probe payload
+in `run_config` — or a `SkipReason`. The op becomes two-mode: probe payload
+present → load exactly the selection with the passed signatures; absent (nightly
+schedule or manual launch) → probe-then-load all selected unconditionally (full
+refresh + re-baseline). `config/assets.yaml` moves from a `schedule_tier` enum
+to `intraday`/`nightly` membership booleans.
+
+**Tech Stack:** Dagster 1.13 (sensors, pythonic run config), dlt 1.28.1
+(`resource_state` baselines), SQLAlchemy + oracledb over an SSH tunnel.
+
+**Spec:**
+`docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md`
+(Status: Approved, amended 2026-07-20). Read it before starting.
+
+## Global Constraints
+
+- **All file work happens in the worktree**
+  `/workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor`
+  — never the main checkout. Use `git -C <worktree>` for every git command.
+- Run tests from inside the worktree:
+  `cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor && uv run pytest ...`.
+- Python via `uv run` only; `requires-python = ">=3.13"`; built-in generics and
+  `X | None` unions; Google-style docstrings.
+- Commit messages: conventional commits. One commit per task.
+- Signature dict shape is ALWAYS `{"count": int, "max_cursor": str | None}` —
+  both keys present, no-cursor tables carry `max_cursor: None`. A count-only
+  dict would never compare equal to the run-config round-trip (which defaults
+  `max_cursor` to `None`) and every no-cursor table would reload every tick.
+- The probe in full-refresh mode runs BEFORE the load: dlt commits state only
+  from a resource actually extracted into a successful load; post-load writes
+  from the op body never round-trip.
+- The intraday schedule and the sensor must never coexist in one deploy (double
+  loads) — each district's migration removes the schedule and adds the sensor in
+  the same commit.
+- Trunk: do not run `trunk fmt`/`check` manually except the final doc check;
+  binary is `/workspaces/teamster/.trunk/tools/trunk`, run with cwd set to the
+  worktree.
+
+---
+
+### Task 1: `probe_signature` no-cursor support
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/powerschool/assets.py:52-77`
+  (`probe_signature`)
+- Test: `tests/libraries/test_dlt_powerschool_assets.py`
+
+**Interfaces:**
+
+- Consumes: existing `probe_signature(connection, table_name, cursor_column)`.
+- Produces:
+  `probe_signature(connection, table_name: str, cursor_column: str | None) -> dict[str, int | str | None]`
+  — when `cursor_column is None`, issues `SELECT COUNT(*)` only and returns
+  `{"count": n, "max_cursor": None}`. Tasks 3 and 4 call it with `None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/libraries/test_dlt_powerschool_assets.py` (the `FakeConnection`
+/ `FakeResult` fixtures at the top of the file already exist):
+
+```python
+def test_probe_signature_no_cursor_count_only():
+    # No-cursor tables are count-gated: COUNT(*) only, and the signature keeps
+    # the max_cursor key (None) so it compares equal to the run-config
+    # round-trip shape.
+    conn = FakeConnection((42,))
+
+    sig = probe_signature(conn, "gen", None)
+
+    assert sig == {"count": 42, "max_cursor": None}
+    assert "COUNT(*)" in conn.queries[0]
+    assert "MAX(" not in conn.queries[0]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+`uv run pytest tests/libraries/test_dlt_powerschool_assets.py::test_probe_signature_no_cursor_count_only -v`
+
+Expected: FAIL — `probe_signature` unpacks two columns from a one-column row
+(`ValueError: not enough values to unpack`) or builds `MAX(None)` SQL.
+
+- [ ] **Step 3: Implement**
+
+In `src/teamster/libraries/dlt/powerschool/assets.py`, replace the
+`probe_signature` function with:
+
+```python
+def probe_signature(
+    connection, table_name: str, cursor_column: str | None
+) -> dict[str, int | str | None]:
+    """Fetch the change signature for a table: total count + max cursor.
+
+    Equality-compared against the stored signature; drift in either value
+    (including a cursor regression) triggers a full replace. Tables without a
+    cursor column are count-only — the signature still carries
+    ``max_cursor: None`` so it compares equal to the run-config round-trip
+    shape (which defaults the key to None). Values are JSON-serializable for
+    dlt resource state.
+    """
+    if cursor_column is None:
+        (count,) = connection.execute(
+            # trunk-ignore(bandit/B608): table name from static YAML config
+            sa.text(f"SELECT COUNT(*) FROM {table_name}")
+        ).one()
+
+        return {"count": int(count), "max_cursor": None}
+
+    count, max_cursor = connection.execute(
+        # trunk-ignore(bandit/B608): table/column names from static YAML config
+        sa.text(f"SELECT COUNT(*), MAX({cursor_column}) FROM {table_name}")
+    ).one()
+
+    if max_cursor is None:
+        max_cursor_value = None
+    elif isinstance(max_cursor, (datetime, date)):
+        max_cursor_value = max_cursor.isoformat()
+    else:
+        # Non-temporal cursor (e.g. a numeric change column on a future table);
+        # store its string form so the signature stays JSON-serializable.
+        max_cursor_value = str(max_cursor)
+
+    # int(count): mirror the JSON-safe-scalar normalization done for max_cursor
+    # above (oracledb returns int today, but keep the state doc driver-agnostic).
+    return {"count": int(count), "max_cursor": max_cursor_value}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/libraries/test_dlt_powerschool_assets.py -v`
+
+Expected: all PASS (existing cursor-column tests unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/libraries/dlt/powerschool/assets.py tests/libraries/test_dlt_powerschool_assets.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "feat(dlt): count-only probe_signature for no-cursor powerschool tables"
+```
+
+---
+
+### Task 2: `_compute_changed` gates every table on signature equality
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/powerschool/assets.py:80-96`
+  (`_compute_changed`)
+- Test: `tests/libraries/test_dlt_powerschool_assets.py`
+
+**Interfaces:**
+
+- Produces:
+  `_compute_changed(selected: list[PowerSchoolTable], current: dict[str, dict], stored: dict[str, dict]) -> list[PowerSchoolTable]`
+  — a table is changed iff `current.get(name) != stored.get(name)`. The
+  no-cursor "always reload" special case is gone (the sensor probes no-cursor
+  tables too, per Task 1; the op no longer calls this function after Task 3 — it
+  becomes the sensor's gate).
+
+- [ ] **Step 1: Rewrite the `_compute_changed` tests**
+
+In `tests/libraries/test_dlt_powerschool_assets.py`, DELETE
+`test_compute_changed_no_cursor_table_always_included` and replace it with:
+
+```python
+def test_compute_changed_no_cursor_count_drift_included():
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    current = {"gen": {"count": 43, "max_cursor": None}}
+    stored = {"gen": {"count": 42, "max_cursor": None}}
+
+    changed = _compute_changed([table], current, stored)
+
+    assert changed == [table]
+
+
+def test_compute_changed_no_cursor_stable_count_excluded():
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    signature = {"count": 42, "max_cursor": None}
+    current = {"gen": dict(signature)}
+    stored = {"gen": dict(signature)}
+
+    changed = _compute_changed([table], current, stored)
+
+    assert changed == []
+
+
+def test_compute_changed_no_stored_baseline_included():
+    # Bootstrap: a table new to intraday (or first tick ever) has no stored
+    # signature and must load once to establish one.
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    current = {"gen": {"count": 42, "max_cursor": None}}
+
+    changed = _compute_changed([table], current, stored={})
+
+    assert changed == [table]
+```
+
+Then update `test_compute_changed_mixed_set_order_preserved`: the `no_cursor`
+table now needs a drifted signature to be included. Replace the body with:
+
+```python
+def test_compute_changed_mixed_set_order_preserved():
+    no_cursor = PowerSchoolTable(name="test", cursor_column=None)
+    drifted = PowerSchoolTable(name="students", cursor_column="transaction_date")
+    unchanged = PowerSchoolTable(name="users", cursor_column="whenmodified")
+    selected = [no_cursor, drifted, unchanged]
+
+    unchanged_signature = {"count": 5, "max_cursor": "2026-07-14T00:00:00"}
+    current = {
+        "test": {"count": 9, "max_cursor": None},
+        "students": {"count": 43, "max_cursor": "2026-07-16T00:00:00"},
+        "users": dict(unchanged_signature),
+    }
+    stored = {
+        "test": {"count": 8, "max_cursor": None},
+        "students": {"count": 42, "max_cursor": "2026-07-15T00:00:00"},
+        "users": dict(unchanged_signature),
+    }
+
+    changed = _compute_changed(selected, current, stored)
+
+    assert changed == [no_cursor, drifted]
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run:
+`uv run pytest tests/libraries/test_dlt_powerschool_assets.py -v -k compute_changed`
+
+Expected: `test_compute_changed_no_cursor_stable_count_excluded` FAILS (old code
+always includes no-cursor tables); the drift/bootstrap tests pass incidentally.
+
+- [ ] **Step 3: Implement**
+
+Replace `_compute_changed` in `src/teamster/libraries/dlt/powerschool/assets.py`
+with:
+
+```python
+def _compute_changed(
+    selected: list[PowerSchoolTable],
+    current: dict[str, dict],
+    stored: dict[str, dict],
+) -> list[PowerSchoolTable]:
+    """Select tables whose just-probed signature differs from the stored one.
+
+    Drift in count or max cursor — or a missing stored entry (first tick, or a
+    table new to intraday) — selects the table. No-cursor tables carry a
+    count-only signature (``max_cursor: None``), so a net row add/remove
+    selects them; in-place edits are caught by the nightly full refresh.
+    """
+    return [
+        table for table in selected if current.get(table.name) != stored.get(table.name)
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/libraries/test_dlt_powerschool_assets.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/libraries/dlt/powerschool/assets.py tests/libraries/test_dlt_powerschool_assets.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "refactor(dlt): gate powerschool _compute_changed purely on signature equality"
+```
+
+---
+
+### Task 3: Two-mode op (run-config probe payload / full-refresh)
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/powerschool/assets.py` (config classes,
+  pipeline helper, `build_powerschool_dlt_assets` op body)
+- Test: `tests/libraries/test_dlt_powerschool_assets.py`
+
+**Interfaces:**
+
+- Consumes: `probe_signature` with `cursor_column=None` (Task 1).
+- Produces:
+  - `class ProbeSignatureConfig(Config)` — fields `count: int`,
+    `max_cursor: str | None = None`.
+  - `class PowerSchoolDltConfig(Config)` — field
+    `probe: dict[str, ProbeSignatureConfig] | None = None`.
+  - `build_powerschool_dlt_pipeline(code_location: str) -> dlt.Pipeline` —
+    module-level helper; Task 4's sensor calls it.
+  - The op accepts run config
+    `{"ops": {"<loc>__powerschool": {"config": {"probe": {<table>: {"count": n, "max_cursor": s|None}}}}}}`
+    (sensor mode) or empty config (full-refresh mode).
+  - `_stored_signatures(dlt_pipeline, source_name)` stays exported unchanged
+    (the sensor uses it; the op no longer does).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/libraries/test_dlt_powerschool_assets.py`:
+
+```python
+def _resolved_probe_job(tables):
+    from dagster import Definitions, define_asset_job
+    from dagster_dlt import DagsterDltResource
+
+    from teamster.libraries.dlt.powerschool.resources import OracleResource
+    from teamster.libraries.ssh.resources import SSHResource
+
+    assets_def = build_powerschool_dlt_assets(
+        code_location="kipppaterson", tables=tables
+    )
+    defs = Definitions(
+        assets=[assets_def],
+        jobs=[define_asset_job("probe_job", selection=list(assets_def.keys))],
+        resources={
+            "dlt": DagsterDltResource(),
+            "ssh_powerschool": SSHResource(remote_host="localhost"),
+            "db_powerschool": OracleResource(
+                user="u", password="p", host="localhost", port="1521", service_name="s"
+            ),
+        },
+    )
+    return defs.resolve_job_def("probe_job")
+
+
+def test_run_config_schema_accepts_probe_payload():
+    job = _resolved_probe_job(
+        [
+            PowerSchoolTable(name="students", cursor_column="transaction_date"),
+            PowerSchoolTable(name="gen", cursor_column=None),
+        ]
+    )
+
+    from dagster import validate_run_config
+
+    validated = validate_run_config(
+        job,
+        {
+            "ops": {
+                "kipppaterson__powerschool": {
+                    "config": {
+                        "probe": {
+                            "students": {
+                                "count": 43,
+                                "max_cursor": "2026-07-16T00:00:00",
+                            },
+                            "gen": {"count": 10, "max_cursor": None},
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    assert validated
+
+
+def test_run_config_schema_accepts_empty_full_refresh():
+    job = _resolved_probe_job(
+        [PowerSchoolTable(name="students", cursor_column="transaction_date")]
+    )
+
+    from dagster import validate_run_config
+
+    assert validate_run_config(job, {})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+`uv run pytest tests/libraries/test_dlt_powerschool_assets.py -v -k run_config_schema`
+
+Expected: `test_run_config_schema_accepts_probe_payload` FAILS —
+`DagsterInvalidConfigError: ... received unexpected config entry "probe"` (the
+op declares no config schema yet). The empty-config test passes incidentally.
+
+- [ ] **Step 3: Implement**
+
+In `src/teamster/libraries/dlt/powerschool/assets.py`:
+
+1. Add `Config` to the dagster import:
+
+```python
+from dagster import AssetExecutionContext, AssetKey, AssetSpec, Config
+```
+
+1. Add the config classes and pipeline helper after `_resolve_extract_workers`:
+
+```python
+class ProbeSignatureConfig(Config):
+    """One table's probed change signature, passed by the intraday sensor."""
+
+    count: int
+    max_cursor: str | None = None
+
+
+class PowerSchoolDltConfig(Config):
+    """Run config selecting the op's mode.
+
+    probe present (intraday sensor): the sensor already probed and gated —
+    load exactly the run's asset selection, persisting the passed signatures.
+    probe absent (nightly schedule / manual launch): full refresh — probe the
+    selection once, then load it all unconditionally with fresh baselines.
+    """
+
+    probe: dict[str, ProbeSignatureConfig] | None = None
+
+
+def build_powerschool_dlt_pipeline(code_location: str) -> dlt.Pipeline:
+    """The shared BigQuery pipeline for one district's PowerSchool source.
+
+    Used by the assets factory (loads) and the intraday sensor (baseline
+    reads via sync_destination + resource state).
+    """
+    return dlt.pipeline(
+        pipeline_name=_SOURCE_NAME,
+        # No `autodetect_schema=True`: oracle_number_adapter +
+        # full_with_precision reflection are the authoritative decimal schema
+        # (see oracle_number_adapter docstring).
+        destination=bigquery(),
+        dataset_name=f"dagster_{code_location}_dlt_{_SOURCE_NAME}",
+        progress=LogCollector(dump_system_stats=False),
+    )
+```
+
+1. In `build_powerschool_dlt_assets`, replace the inline `dlt.pipeline(...)`
+   call with:
+
+```python
+    dlt_pipeline = build_powerschool_dlt_pipeline(code_location)
+```
+
+1. Replace the factory docstring's first two paragraphs with:
+
+```python
+    """Build ONE two-mode @dlt_assets over all PowerSchool tables.
+
+    The selection decision belongs to the caller: the intraday sensor probes,
+    gates, and passes per-table signatures via run config (`probe`); the
+    nightly schedule and manual launches pass no config and get an
+    unconditional full refresh. In both modes the op opens the SSH tunnel and
+    runs the pipeline over a source narrowed to the run's asset selection — a
+    full `replace` load per table — persisting each table's signature to dlt
+    resource_state WITH the load (dlt commits state only from extracted
+    resources, so failures self-heal: the old baseline survives and the table
+    re-selects next tick). See
+    docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md.
+    """
+```
+
+    (keep the existing `max_extract_workers` paragraph as-is).
+
+1. Replace the op body between the `selected = [...]` assignment and the
+   `dlt_pipeline.collector = ...` line (i.e. delete the `sync_destination`
+   try/except, the `_stored_signatures` call, the probe loop, the
+   `_compute_changed` call, the probe log line, and the `if not changed`
+   early-return) so the function reads:
+
+```python
+    def _assets(
+        context: AssetExecutionContext,
+        config: PowerSchoolDltConfig,
+        dlt: DagsterDltResource,
+        ssh_powerschool: SSHResource,
+        db_powerschool: OracleResource,
+    ) -> Iterator:
+        workers = _resolve_extract_workers(
+            context.run.tags.get("dlt_extract_workers"), max_extract_workers
+        )
+        if workers is not None:
+            # Set via dlt's config accessor (an in-memory provider that
+            # pipeline.extract() resolves `workers=ConfigValue` from) rather than
+            # os.environ — keeps the override inside dlt's config channel instead
+            # of mutating the process environment.
+            dlt.config["extract.workers"] = workers
+            context.log.info(f"dlt extract workers capped at {workers}")
+
+        # Diagnostic knob: Oracle cursor fetch size (rows/round-trip).
+        arraysize = int(context.run.tags.get("dlt_arraysize") or 10_000)
+        context.log.info(f"dlt oracle arraysize {arraysize}")
+
+        selected = [
+            tables_by_key[key]
+            for key in context.selected_asset_keys
+            if key in tables_by_key
+        ]
+
+        with ssh_powerschool.open_ssh_tunnel():
+            connection_url = db_powerschool.connection_url()
+
+            if config.probe is not None:
+                # Intraday sensor mode: the sensor probed and gated already —
+                # persist its signatures with the load, no re-probe.
+                signatures: dict[str, dict] = {
+                    name: {"count": sig.count, "max_cursor": sig.max_cursor}
+                    for name, sig in config.probe.items()
+                }
+                context.log.info(
+                    f"powerschool sensor-selected load: {sorted(signatures)}"
+                )
+            else:
+                # Full-refresh mode (nightly schedule / manual launch): load the
+                # whole selection unconditionally. Probe FIRST so fresh baseline
+                # signatures persist WITH the load — dlt commits state only from
+                # extracted resources, so a post-load write would not round-trip.
+                engine = sa.create_engine(connection_url)
+                try:
+                    with engine.connect() as connection:
+                        signatures = {
+                            table.name: probe_signature(
+                                connection, table.name, table.cursor_column
+                            )
+                            for table in selected
+                        }
+                finally:
+                    engine.dispose()
+                context.log.info(
+                    f"powerschool full-refresh load: {sorted(signatures)}"
+                )
+
+            # Stream dlt's periodic extract/normalize/load progress into the
+            # Dagster event log. The factory-built collector defaults to
+            # logger="stdout" (step-pod compute logs only); context.log is a
+            # DagsterLogManager (a logging.Logger), so pointing the collector at
+            # it surfaces progress as structured run events every log_period s.
+            dlt_pipeline.collector = LogCollector(
+                logger=context.log, log_period=30.0, dump_system_stats=False
+            )
+
+            try:
+                # fetch_row_count() attaches an authoritative per-table row_count
+                # to each materialization's metadata (surfaced in the asset
+                # catalog) alongside dagster-dlt's default load metadata.
+                yield from dlt.run(
+                    context=context,
+                    dlt_source=_powerschool_source(
+                        selected, signatures, connection_url, arraysize
+                    ),
+                    dlt_pipeline=dlt_pipeline,
+                    dagster_dlt_translator=translator,
+                    write_disposition="replace",
+                ).fetch_row_count()
+            except Exception:
+                # Surface dlt's per-table extracted row counts in the run log so a
+                # load failure is legible without walking the exception chain.
+                trace = dlt_pipeline.last_trace
+                if trace is not None and trace.last_normalize_info is not None:
+                    context.log.info(
+                        "dlt normalize row counts before failure: "
+                        f"{trace.last_normalize_info.row_counts}"
+                    )
+                raise
+```
+
+Keep `_stored_signatures` at the bottom of the module (the sensor imports it in
+Task 4). `_compute_changed` also stays (the sensor imports it).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/libraries/test_dlt_powerschool_assets.py -v`
+
+Expected: all PASS. If `test_run_config_schema_accepts_probe_payload` fails with
+a schema error about the `probe` field type, the
+`dict[str, ProbeSignatureConfig]` mapping is the problem — fall back to
+`probe: dict[str, dict] | None = None` is NOT acceptable (untyped dict isn't a
+valid Dagster config leaf); instead nest via
+`probe: dict[str, ProbeSignatureConfig] | None` debugging with
+`build_powerschool_dlt_assets(...).op.config_schema` printed in a REPL, and if
+genuinely unsupported, restructure to two parallel primitive maps
+(`probe_counts: dict[str, int] | None`,
+`probe_max_cursors: dict[str, str] | None`, with `None` cursor values encoded by
+key absence) and update Task 4's `_build_run_request` payload to match.
+
+- [ ] **Step 5: Verify the module still imports and existing factory tests
+      pass**
+
+Run:
+`uv run pytest tests/libraries/test_dlt_powerschool_assets.py tests/libraries/test_powerschool_dlt_extract_workers.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/libraries/dlt/powerschool/assets.py tests/libraries/test_dlt_powerschool_assets.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "refactor(dlt): two-mode powerschool op driven by sensor probe run config"
+```
+
+---
+
+### Task 4: Intraday sensor factory
+
+**Files:**
+
+- Create: `src/teamster/libraries/dlt/powerschool/sensors.py`
+- Test: `tests/libraries/test_dlt_powerschool_sensors.py` (create)
+
+**Interfaces:**
+
+- Consumes (from `teamster.libraries.dlt.powerschool.assets`):
+  `PowerSchoolTable`, `_SOURCE_NAME`, `_asset_key`, `_compute_changed`,
+  `_stored_signatures`, `build_powerschool_dlt_pipeline`, `probe_signature`.
+- Produces:
+  `build_powerschool_dlt_intraday_sensor(code_location: str, tables: list[PowerSchoolTable], nightly_schedule_name: str, minimum_interval_seconds: int = 900) -> SensorDefinition`
+  — sensor named `{code_location}__powerschool__dlt__intraday_sensor`, requiring
+  resources `ssh_powerschool` + `db_powerschool`. Tasks 5-7 wire it per
+  district.
+- Also produces the module-level helper
+  `_build_run_request(code_location, changed, current) -> RunRequest` (unit
+  seam).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/libraries/test_dlt_powerschool_sensors.py`:
+
+```python
+"""Unit tests for the PowerSchool dlt intraday sensor factory (no external deps)."""
+
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    _build_run_request,
+    build_powerschool_dlt_intraday_sensor,
+)
+
+
+def test_sensor_factory_shape():
+    sensor_def = build_powerschool_dlt_intraday_sensor(
+        code_location="kipppaterson",
+        tables=[PowerSchoolTable(name="students", cursor_column="transaction_date")],
+        nightly_schedule_name=(
+            "kipppaterson__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+
+    assert sensor_def.name == "kipppaterson__powerschool__dlt__intraday_sensor"
+    assert sensor_def.minimum_interval_seconds == 900
+    assert sensor_def.required_resource_keys == {"ssh_powerschool", "db_powerschool"}
+
+
+def test_build_run_request_selects_changed_and_passes_signatures():
+    changed = [
+        PowerSchoolTable(name="students", cursor_column="transaction_date"),
+        PowerSchoolTable(name="gen", cursor_column=None),
+    ]
+    current = {
+        "students": {"count": 43, "max_cursor": "2026-07-16T00:00:00"},
+        "gen": {"count": 10, "max_cursor": None},
+        # unchanged table present in the probe but not in `changed`:
+        "users": {"count": 1, "max_cursor": "2026-07-01T00:00:00"},
+    }
+
+    run_request = _build_run_request("kipppaterson", changed, current)
+
+    assert [k.to_user_string() for k in run_request.asset_selection] == [
+        "kipppaterson/powerschool/sis/students",
+        "kipppaterson/powerschool/sis/gen",
+    ]
+    assert run_request.run_config == {
+        "ops": {
+            "kipppaterson__powerschool": {
+                "config": {
+                    "probe": {
+                        "students": {
+                            "count": 43,
+                            "max_cursor": "2026-07-16T00:00:00",
+                        },
+                        "gen": {"count": 10, "max_cursor": None},
+                    }
+                }
+            }
+        }
+    }
+    assert run_request.tags["dagster/max_runtime"] == "3600"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/libraries/test_dlt_powerschool_sensors.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: ... sensors`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/teamster/libraries/dlt/powerschool/sensors.py`:
+
+```python
+import sqlalchemy as sa
+from dagster import (
+    DagsterRunStatus,
+    RunRequest,
+    RunsFilter,
+    SensorDefinition,
+    SensorEvaluationContext,
+    SkipReason,
+    sensor,
+)
+
+from teamster.libraries.dlt.powerschool.assets import (
+    _SOURCE_NAME,
+    PowerSchoolTable,
+    _asset_key,
+    _compute_changed,
+    _stored_signatures,
+    build_powerschool_dlt_pipeline,
+    probe_signature,
+)
+from teamster.libraries.dlt.powerschool.resources import OracleResource
+from teamster.libraries.ssh.resources import SSHResource
+
+_IN_FLIGHT_STATUSES = [
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
+]
+
+
+def _build_run_request(
+    code_location: str,
+    changed: list[PowerSchoolTable],
+    current: dict[str, dict],
+) -> RunRequest:
+    """RunRequest for the changed tables, passing their probed signatures.
+
+    The probe payload rides run config (the op's PowerSchoolDltConfig.probe
+    field): the op loads exactly this selection and persists these signatures
+    with the load — no re-probe, no gate.
+    """
+    return RunRequest(
+        asset_selection=[_asset_key(code_location, table.name) for table in changed],
+        run_config={
+            "ops": {
+                f"{code_location}__powerschool": {
+                    "config": {
+                        "probe": {table.name: current[table.name] for table in changed}
+                    }
+                }
+            }
+        },
+        tags={"dagster/max_runtime": "3600"},
+    )
+
+
+def build_powerschool_dlt_intraday_sensor(
+    code_location: str,
+    tables: list[PowerSchoolTable],
+    nightly_schedule_name: str,
+    minimum_interval_seconds: int = 900,
+) -> SensorDefinition:
+    """Build the intraday change-detection sensor for one district.
+
+    Each tick opens the SSH tunnel, probes every intraday table (COUNT(*) +
+    MAX(cursor); count-only for no-cursor tables), compares against the
+    baseline stored in dlt resource state, and requests a run for only the
+    changed tables — unchanged tables are never planned, and an idle tick
+    launches nothing. Skips while a run launched by this sensor or by the
+    nightly full-refresh schedule is in flight (the baseline advances only on
+    load success, so an in-flight table would re-select and double-launch).
+    See docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md.
+    """
+    sensor_name = f"{code_location}__powerschool__dlt__intraday_sensor"
+
+    @sensor(
+        name=sensor_name,
+        minimum_interval_seconds=minimum_interval_seconds,
+        asset_selection=[_asset_key(code_location, table.name) for table in tables],
+    )
+    def _sensor(
+        context: SensorEvaluationContext,
+        ssh_powerschool: SSHResource,
+        db_powerschool: OracleResource,
+    ) -> RunRequest | SkipReason:
+        for tag, value in (
+            ("dagster/sensor_name", sensor_name),
+            ("dagster/schedule_name", nightly_schedule_name),
+        ):
+            records = context.instance.get_run_records(
+                filters=RunsFilter(tags={tag: value}, statuses=_IN_FLIGHT_STATUSES),
+                limit=1,
+            )
+            if records:
+                return SkipReason(
+                    f"run {records[0].dagster_run.run_id} in flight ({value})"
+                )
+
+        dlt_pipeline = build_powerschool_dlt_pipeline(code_location)
+
+        with ssh_powerschool.open_ssh_tunnel():
+            connection_url = db_powerschool.connection_url()
+
+            # Restore prior signatures from the destination state table. On a
+            # truly first run (no dataset) this raises; treat as no prior state.
+            try:
+                dlt_pipeline.sync_destination()
+            except Exception as e:
+                context.log.info(
+                    f"dlt sync_destination failed ({e}); treating all tables "
+                    "as changed"
+                )
+
+            stored = _stored_signatures(dlt_pipeline, _SOURCE_NAME)
+
+            # One shared engine over the single tunnel, like the op's probe.
+            engine = sa.create_engine(connection_url)
+            try:
+                with engine.connect() as connection:
+                    current: dict[str, dict] = {
+                        table.name: probe_signature(
+                            connection, table.name, table.cursor_column
+                        )
+                        for table in tables
+                    }
+            finally:
+                engine.dispose()
+
+        changed = _compute_changed(tables, current, stored)
+
+        context.log.info(
+            f"powerschool probe: {len(changed)}/{len(tables)} changed; "
+            f"changed={sorted(table.name for table in changed)}"
+        )
+
+        if not changed:
+            return SkipReason(f"no change across {len(tables)} probed tables")
+
+        return _build_run_request(code_location, changed, current)
+
+    return _sensor
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+`uv run pytest tests/libraries/test_dlt_powerschool_sensors.py tests/libraries/test_dlt_powerschool_assets.py -v`
+
+Expected: all PASS. If `required_resource_keys` asserts differently (e.g.
+includes extras), print `sensor_def.required_resource_keys` and adjust the
+assertion to the actual resource-param set — it must contain exactly the two
+resources the sensor function declares.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/libraries/dlt/powerschool/sensors.py tests/libraries/test_dlt_powerschool_sensors.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "feat(dlt): powerschool intraday change-detection sensor factory"
+```
+
+---
+
+### Task 5: Migrate `kippnewark`
+
+**Files:**
+
+- Modify:
+  `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml`
+- Modify:
+  `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/schedules.py`
+- Create:
+  `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/sensors.py`
+- Modify:
+  `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/__init__.py`,
+  `src/teamster/code_locations/kippnewark/powerschool/sis/__init__.py`,
+  `src/teamster/code_locations/kippnewark/powerschool/__init__.py`,
+  `src/teamster/code_locations/kippnewark/definitions.py`
+
+**Interfaces:**
+
+- Consumes: `build_powerschool_dlt_intraday_sensor` (Task 4).
+- Produces: `powerschool.sensors` list re-exported to `definitions.py`; the YAML
+  membership schema (`table_name` / `cursor_column` / `intraday: bool` /
+  `nightly: bool`) that Tasks 6-7 replicate.
+
+- [ ] **Step 1: Write the YAML migration script (shared by Tasks 5-7)**
+
+Write `.claude/scratch/migrate_ps_dlt_config.py` in the worktree (`mkdir -p` the
+directory first; it is gitignored):
+
+```python
+"""Rewrite a powerschool dlt assets.yaml from schedule_tier to membership booleans.
+
+Rule: intraday tier -> intraday only; nightly tier with a cursor (gradebook
+cluster) -> nightly only; nightly tier without a cursor -> both (count-gated
+intraday, authoritative nightly full refresh).
+"""
+
+import sys
+
+import yaml
+
+entries = yaml.safe_load(open(sys.argv[1]))["assets"]
+
+
+def flags(entry):
+    if entry["schedule_tier"] == "intraday":
+        return True, False
+    if entry["cursor_column"] is None:
+        return True, True
+    return False, True
+
+
+groups = [
+    ("intraday only: cursor-gated by the sensor", (True, False)),
+    (
+        "intraday + nightly: no cursor — count-gated intraday, "
+        "authoritative nightly full refresh",
+        (True, True),
+    ),
+    ("nightly only: gradebook cluster, full-refreshed nightly", (False, True)),
+]
+
+lines = ["assets:"]
+for comment, membership in groups:
+    members = sorted(
+        (e for e in entries if flags(e) == membership),
+        key=lambda e: e["table_name"],
+    )
+    if not members:
+        continue
+    lines.append(f"  # {comment}")
+    for e in members:
+        intraday, nightly = flags(e)
+        cursor = e["cursor_column"] if e["cursor_column"] is not None else "null"
+        lines.append(f"  - table_name: {e['table_name']}")
+        lines.append(f"    cursor_column: {cursor}")
+        lines.append(f"    intraday: {str(intraday).lower()}")
+        lines.append(f"    nightly: {str(nightly).lower()}")
+
+print("\n".join(lines))
+```
+
+- [ ] **Step 2: Migrate the kippnewark YAML**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+mkdir -p .claude/scratch
+cfg=src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml
+uv run python .claude/scratch/migrate_ps_dlt_config.py "$cfg" > "$cfg.new" && mv "$cfg.new" "$cfg"
+```
+
+Verify membership counts (expected output
+`57 {(True, False): 27, (True, True): 18, (False, True): 12}`):
+
+```bash
+uv run python -c "
+import yaml
+from collections import Counter
+entries = yaml.safe_load(open('src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml'))['assets']
+print(len(entries), dict(Counter((e['intraday'], e['nightly']) for e in entries)))
+"
+```
+
+- [ ] **Step 3: Rewrite `schedules.py`**
+
+Replace the full contents of
+`src/teamster/code_locations/kippnewark/powerschool/sis/dlt/schedules.py` with:
+
+```python
+import pathlib
+
+import yaml
+from dagster import ScheduleDefinition
+
+from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
+
+config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
+config = yaml.safe_load(config_file.read_text())
+
+
+def _nightly_targets() -> list[str]:
+    assets = config["assets"]
+
+    orphaned = [a["table_name"] for a in assets if not (a["intraday"] or a["nightly"])]
+    if orphaned:
+        raise ValueError(
+            "table(s) in neither tier (would never materialize): "
+            + ", ".join(orphaned)
+        )
+
+    return [
+        f"{CODE_LOCATION}/powerschool/sis/{a['table_name']}"
+        for a in assets
+        if a["nightly"]
+    ]
+
+
+# Unconditional full refresh + re-baseline (the op's no-probe mode): the
+# authoritative sweep that catches in-place edits the intraday count gate
+# cannot see on no-cursor tables.
+powerschool_dlt_nightly_asset_job_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule",
+    cron_schedule="0 2 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    target=_nightly_targets(),
+    tags={"dagster/max_runtime": "3600"},
+)
+
+schedules = [powerschool_dlt_nightly_asset_job_schedule]
+```
+
+- [ ] **Step 4: Create `sensors.py`**
+
+Create `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/sensors.py`:
+
+```python
+import pathlib
+
+import yaml
+
+from teamster.code_locations.kippnewark import CODE_LOCATION
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    build_powerschool_dlt_intraday_sensor,
+)
+
+config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
+
+sensors = [
+    build_powerschool_dlt_intraday_sensor(
+        code_location=CODE_LOCATION,
+        tables=[
+            PowerSchoolTable(name=a["table_name"], cursor_column=a["cursor_column"])
+            for a in yaml.safe_load(config_file.read_text())["assets"]
+            if a["intraday"]
+        ],
+        nightly_schedule_name=(
+            f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+]
+```
+
+- [ ] **Step 5: Wire the re-export chain**
+
+Replace `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/__init__.py`
+with:
+
+```python
+from teamster.code_locations.kippnewark.powerschool.sis.dlt import (
+    assets,
+    schedules,
+    sensors,
+)
+
+__all__ = [
+    "assets",
+    "schedules",
+    "sensors",
+]
+```
+
+Replace `src/teamster/code_locations/kippnewark/powerschool/sis/__init__.py`
+with:
+
+```python
+from teamster.code_locations.kippnewark.powerschool.sis import dlt
+
+assets = [*dlt.assets.assets]
+
+schedules = [*dlt.schedules.schedules]
+
+sensors = [*dlt.sensors.sensors]
+
+__all__ = [
+    "assets",
+    "schedules",
+    "sensors",
+]
+```
+
+Replace `src/teamster/code_locations/kippnewark/powerschool/__init__.py` with:
+
+```python
+from teamster.code_locations.kippnewark.powerschool.sis import (
+    assets,
+    schedules,
+    sensors,
+)
+
+__all__ = [
+    "assets",
+    "schedules",
+    "sensors",
+]
+```
+
+In `src/teamster/code_locations/kippnewark/definitions.py`, add
+`*powerschool.sensors,` to the `sensors=[...]` list (alphabetical placement
+among the existing `*<module>.sensors` entries).
+
+- [ ] **Step 6: Verify by import**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+uv run python -c "
+from teamster.code_locations.kippnewark import powerschool
+assert len(powerschool.schedules) == 1
+assert powerschool.schedules[0].name == 'kippnewark__powerschool__dlt__nightly_asset_job_schedule'
+assert len(powerschool.sensors) == 1
+assert powerschool.sensors[0].name == 'kippnewark__powerschool__dlt__intraday_sensor'
+print('kippnewark ok')
+"
+```
+
+Expected: `kippnewark ok`. Also re-run the library suites:
+`uv run pytest tests/libraries/test_dlt_powerschool_assets.py tests/libraries/test_dlt_powerschool_sensors.py -q`
+— all PASS (they read the kipppaterson config, untouched here).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/code_locations/kippnewark
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "refactor(kippnewark): powerschool dlt intraday sensor replaces intraday schedule"
+```
+
+---
+
+### Task 6: Migrate `kippcamden`
+
+**Files:** the exact `kippcamden` counterparts of every Task 5 file.
+
+**IMPORTANT — read Task 5 of this plan file
+(`docs/superpowers/plans/2026-07-20-powerschool-dlt-intraday-sensor.md`) before
+starting: this task reuses Task 5's exact file contents and commands with
+`kippnewark` → `kippcamden` substituted, and they are not repeated here.**
+
+**Interfaces:** identical to Task 5 with `kippnewark` → `kippcamden` in every
+path, import, and name. Camden's table set matches Newark's (57 tables: 27
+intraday-only / 18 both / 12 nightly-only).
+
+- [ ] **Step 1: Migrate the YAML**
+
+Same commands as Task 5 Step 2 with
+`cfg=src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml`.
+Expected count check output:
+`57 {(True, False): 27, (True, True): 18, (False, True): 12}`.
+
+- [ ] **Step 2: Rewrite `schedules.py`, create `sensors.py`, wire `__init__.py`
+      chain and `definitions.py`**
+
+Apply the exact Task 5 Steps 3-5 file contents with every occurrence of
+`kippnewark` replaced by `kippcamden` (module paths and imports only — the
+schedule/sensor name templates already derive from `CODE_LOCATION`). The
+existing camden files are byte-identical to Newark's apart from the import line,
+so the replacements are mechanical.
+
+- [ ] **Step 3: Verify by import**
+
+Same check as Task 5 Step 6 with `kippnewark` → `kippcamden` (assert names
+`kippcamden__powerschool__dlt__nightly_asset_job_schedule` /
+`kippcamden__powerschool__dlt__intraday_sensor`). Expected: `kippcamden ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/code_locations/kippcamden
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "refactor(kippcamden): powerschool dlt intraday sensor replaces intraday schedule"
+```
+
+---
+
+### Task 7: Migrate `kipppaterson` + rewrite config-coupled tests
+
+**Files:**
+
+- Modify: the exact `kipppaterson` counterparts of every Task 5 file.
+- Modify: `tests/libraries/test_dlt_powerschool_assets.py` (config-schema and
+  schedule tests read the paterson config)
+- Modify: `tests/assets/test_powerschool_dlt_paterson_defs.py` (also fixes two
+  PRE-EXISTING failures: it asserts asset keys without the `sis` segment)
+
+**IMPORTANT — read Task 5 of this plan file
+(`docs/superpowers/plans/2026-07-20-powerschool-dlt-intraday-sensor.md`) before
+starting: Step 1 reuses Task 5's exact file contents and commands with
+`kippnewark` → `kipppaterson` substituted, and they are not repeated here.**
+
+**Interfaces:** identical to Task 5 with `kippnewark` → `kipppaterson`. Paterson
+has 48 tables: 23 intraday-only / 14 both / 11 nightly-only.
+
+- [ ] **Step 1: Migrate the YAML and code files**
+
+Apply Task 5 Steps 2-5 with `kipppaterson` substituted. Expected YAML count
+check output: `48 {(True, False): 23, (True, True): 14, (False, True): 11}`.
+
+- [ ] **Step 2: Rewrite the paterson-coupled tests in
+      `tests/libraries/test_dlt_powerschool_assets.py`**
+
+The module-level table-name sets (`INTRADAY_TRANSACTION_DATE`,
+`INTRADAY_WHENMODIFIED`, `NIGHTLY_WHENMODIFIED`, `NIGHTLY_NO_CURSOR`) stay
+as-is. Replace `test_config_matches_spec_cursor_map` with:
+
+```python
+def test_config_matches_spec_membership_map():
+    entries = yaml.safe_load(CONFIG.read_text())["assets"]
+    by_name = {e["table_name"]: e for e in entries}
+
+    assert len(entries) == 48
+
+    for name in INTRADAY_TRANSACTION_DATE:
+        assert by_name[name] == {
+            "table_name": name,
+            "cursor_column": "transaction_date",
+            "intraday": True,
+            "nightly": False,
+        }
+    for name in INTRADAY_WHENMODIFIED:
+        assert by_name[name] == {
+            "table_name": name,
+            "cursor_column": "whenmodified",
+            "intraday": True,
+            "nightly": False,
+        }
+    for name in NIGHTLY_WHENMODIFIED:
+        assert by_name[name] == {
+            "table_name": name,
+            "cursor_column": "whenmodified",
+            "intraday": False,
+            "nightly": True,
+        }
+    for name in NIGHTLY_NO_CURSOR:
+        assert by_name[name] == {
+            "table_name": name,
+            "cursor_column": None,
+            "intraday": True,
+            "nightly": True,
+        }
+```
+
+Replace `test_schedules_subset_by_tier` with:
+
+```python
+def test_nightly_schedule_and_intraday_sensor():
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
+        powerschool_dlt_nightly_asset_job_schedule as nightly,
+    )
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
+        schedules,
+    )
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.sensors import (
+        sensors,
+    )
+
+    assert schedules == [nightly]
+    assert nightly.cron_schedule == "0 2 * * *"
+    assert nightly.tags == {"dagster/max_runtime": "3600"}
+    assert sensors[0].name == "kipppaterson__powerschool__dlt__intraday_sensor"
+    assert sensors[0].minimum_interval_seconds == 900
+```
+
+Replace `test_tier_targets_sis_keys_and_counts` with:
+
+```python
+def test_nightly_targets_sis_keys_and_counts():
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
+        _nightly_targets,
+    )
+
+    nightly = _nightly_targets()
+
+    assert len(nightly) == 25
+    assert all(t.startswith("kipppaterson/powerschool/sis/") for t in nightly)
+    assert "kipppaterson/powerschool/sis/teachercategory" in nightly
+    assert "kipppaterson/powerschool/sis/test" in nightly
+    assert "kipppaterson/powerschool/sis/students" not in nightly
+```
+
+- [ ] **Step 3: Rewrite `tests/assets/test_powerschool_dlt_paterson_defs.py`**
+
+Replace the full file contents with (fixes the pre-existing missing-`sis`
+failures and covers the new trigger split):
+
+```python
+from dagster import AssetKey, ScheduleDefinition
+
+
+def test_paterson_powerschool_dlt_asset_keys():
+    import yaml
+
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt import assets
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.assets import (
+        config_file,
+    )
+
+    config = yaml.safe_load(config_file.read_text())
+
+    assert len(config["assets"]) == 48
+
+    keys = {key for a in assets.assets for key in a.keys}
+    assert keys == {
+        AssetKey(["kipppaterson", "powerschool", "sis", a["table_name"]])
+        for a in config["assets"]
+    }
+
+
+def test_paterson_powerschool_dlt_triggers():
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt import (
+        schedules,
+        sensors,
+    )
+
+    by_name = {s.name: s for s in schedules.schedules}
+
+    nightly = by_name["kipppaterson__powerschool__dlt__nightly_asset_job_schedule"]
+
+    assert isinstance(nightly, ScheduleDefinition)
+    assert nightly.cron_schedule == "0 2 * * *"
+    assert len(schedules.schedules) == 1  # intraday schedule replaced by sensor
+
+    (sensor_def,) = sensors.sensors
+    assert sensor_def.name == "kipppaterson__powerschool__dlt__intraday_sensor"
+
+
+def test_paterson_powerschool_dlt_triggers_cover_every_table():
+    """Every configured table belongs to at least one trigger.
+
+    A table with both membership flags false would silently never
+    materialize (the dlt assets carry no automation condition). The overlap
+    between tiers must be exactly the no-cursor set: count-gated intraday,
+    authoritative overnight.
+    """
+    import yaml
+
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt import (
+        schedules as schedules_module,
+    )
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.assets import (
+        config_file,
+    )
+
+    config = yaml.safe_load(config_file.read_text())
+
+    def key(name):
+        return f"kipppaterson/powerschool/sis/{name}"
+
+    expected = {key(a["table_name"]) for a in config["assets"]}
+    intraday = {key(a["table_name"]) for a in config["assets"] if a["intraday"]}
+    no_cursor = {
+        key(a["table_name"])
+        for a in config["assets"]
+        if a["cursor_column"] is None
+    }
+
+    # Resolve nightly targets through the real scheduling function — the exact
+    # code an orphaned membership would route around.
+    nightly = set(schedules_module._nightly_targets())
+
+    assert intraday | nightly == expected
+    assert intraday & nightly == no_cursor
+```
+
+- [ ] **Step 4: Run all affected tests**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+uv run pytest tests/libraries/test_dlt_powerschool_assets.py \
+  tests/libraries/test_dlt_powerschool_sensors.py \
+  tests/assets/test_powerschool_dlt_paterson_defs.py -v
+```
+
+Expected: all PASS (including the two previously-failing paterson key tests).
+Also run the paterson import check (Task 5 Step 6 pattern with `kipppaterson`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/code_locations/kipppaterson tests/libraries/test_dlt_powerschool_assets.py tests/assets/test_powerschool_dlt_paterson_defs.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "refactor(kipppaterson): powerschool dlt intraday sensor replaces intraday schedule"
+```
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/CLAUDE.md`,
+  `src/teamster/code_locations/kippcamden/CLAUDE.md`,
+  `src/teamster/code_locations/kipppaterson/CLAUDE.md`
+- Modify: `src/teamster/libraries/dlt/CLAUDE.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Update the three district CLAUDE.mds**
+
+In each district's Active Integrations table, change the `powerschool` row's
+Trigger cell from `schedules (intraday 15-min + nightly 2am)` (or that
+district's equivalent wording) to
+`sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh)`.
+
+In each district's "PowerSchool Configuration" section, update the config
+description: `per-table cursor_column + schedule_tier` becomes
+`per-table cursor_column + intraday/nightly membership booleans`, and add one
+sentence: "Intraday selection is decided by
+`{loc}__powerschool__dlt__intraday_sensor` (probe + dlt-state baseline); the
+nightly schedule full-refreshes its targets unconditionally and re-baselines."
+Read each file first — camden/paterson wording may differ slightly from
+newark's.
+
+- [ ] **Step 2: Update `src/teamster/libraries/dlt/CLAUDE.md`**
+
+In the `powerschool/` sub-library section, replace the first paragraph
+(`Loads PowerSchool SIS Oracle tables ... asset keys ...`) with:
+
+```markdown
+Loads PowerSchool SIS Oracle tables to BigQuery over an SSH tunnel
+(`table_rows` + PyArrow), full-replace. Change detection lives in the intraday
+sensor, not the op. Factories:
+`build_powerschool_dlt_assets(code_location, tables, op_tags=None, max_extract_workers=None)`
+and
+`build_powerschool_dlt_intraday_sensor(code_location, tables, nightly_schedule_name, minimum_interval_seconds=900)`
+(`sensors.py`); asset keys `[code_location, "powerschool", "sis", table]`.
+
+- **Op run-config contract** (`PowerSchoolDltConfig`): `probe` present (intraday
+  sensor) → load exactly the run's asset selection with the passed per-table
+  signatures — no re-probe, no gate. `probe` absent (nightly schedule / manual
+  launch) → probe the selection once BEFORE the load (count-only for no-cursor
+  tables), then load it all unconditionally. Signatures always persist WITH the
+  load via `resource_state` (dlt commits state only from extracted resources —
+  post-load writes never round-trip), so a failed load keeps the old baseline
+  and the table re-selects next tick.
+- **Signature shape is normalized**: `probe_signature` always returns
+  `{"count": n, "max_cursor": value-or-None}` — a count-only dict would never
+  compare equal to the run-config round-trip (which defaults `max_cursor` to
+  None) and no-cursor tables would reload every tick.
+- **Sensor tick**: skip if a sensor-launched or nightly-schedule run is in
+  flight (via `dagster/sensor_name` / `dagster/schedule_name` run tags); probe
+  every intraday table over one engine; compare to the dlt-state baseline
+  (`sync_destination()` + `_stored_signatures`); request only changed tables
+  with the probe payload in run config. Idle ticks launch nothing, so unchanged
+  tables are never planned (no `ASSET_FAILED_TO_MATERIALIZE`).
+```
+
+Keep the existing `DPY-4011` bullet and everything after it unchanged.
+
+- [ ] **Step 2b: Lint the edited markdown**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/teamster/code_locations/kippnewark/CLAUDE.md \
+  src/teamster/code_locations/kippcamden/CLAUDE.md \
+  src/teamster/code_locations/kipppaterson/CLAUDE.md \
+  src/teamster/libraries/dlt/CLAUDE.md </dev/null
+```
+
+Expected: no NEW issues on these files. Fix any MD040/MD001/MD036 findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  add src/teamster/code_locations/kippnewark/CLAUDE.md src/teamster/code_locations/kippcamden/CLAUDE.md src/teamster/code_locations/kipppaterson/CLAUDE.md src/teamster/libraries/dlt/CLAUDE.md
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor \
+  commit -m "docs: powerschool dlt intraday sensor + membership config"
+```
+
+Note: `docs/reference/automations.md` is GENERATED and cannot be regenerated in
+the codespace (kipptaf/kippmiami fail to import) — do NOT hand-edit it. Flag the
+deferred regeneration in the PR body.
+
+---
+
+### Task 9: Full verification
+
+**Files:** none created; verification only.
+
+- [ ] **Step 1: Run the full affected test set**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+uv run pytest tests/libraries/test_dlt_powerschool_assets.py \
+  tests/libraries/test_dlt_powerschool_sensors.py \
+  tests/libraries/test_powerschool_dlt_extract_workers.py \
+  tests/assets/test_powerschool_dlt_paterson_defs.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Validate definitions for the three districts**
+
+The manifest is required first, then validate (per `src/teamster/CLAUDE.md`; run
+in the worktree — `kippnewark` and `kippcamden` are known to import cleanly with
+the manifest, paterson likewise loads district modules):
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+for loc in kippnewark kippcamden kipppaterson; do
+  uv run dagster-dbt project prepare-and-package --file "src/teamster/code_locations/$loc/__init__.py"
+  uv run dagster definitions validate -m "teamster.code_locations.$loc.definitions"
+done
+```
+
+Expected: `Success` per location. If validate fails on missing env vars
+unrelated to this change, fall back to
+`uv run python -c "import teamster.code_locations.<loc>.definitions"` per the
+repo guidance and confirm the error predates this branch.
+
+- [ ] **Step 3: Trunk-check every changed file**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+git diff --name-only origin/main...HEAD | xargs /workspaces/teamster/.trunk/tools/trunk check --force --no-fix </dev/null
+```
+
+Expected: no new findings. Fix and amend/commit as needed.
+
+- [ ] **Step 4: Run the wider unit suite for regressions**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-powerschool-dlt-intraday-sensor
+uv run pytest tests/libraries tests/schedules -q
+```
+
+Expected: no failures introduced by this branch (compare any failure against
+`main` before attributing it here; the SSH suites exceed the 120s Bash timeout —
+use `run_in_background` if they are included).
+
+- [ ] **Step 5: Commit any stragglers**
+
+Only if Steps 1-4 produced fixes; otherwise nothing to commit.
+
+---
+
+## Post-merge cutover checklist (not plan-executable)
+
+These need prod access and happen after the PR merges and the three locations
+deploy:
+
+1. Confirm each location's post-merge deploy LOADED
+   (`mcp__dagster__get_location_load_history`).
+2. Start each sensor (`{loc}__powerschool__dlt__intraday_sensor`) via
+   `mcp__dagster__start_sensor` (preview with `confirm=False` first) — repo
+   sensors carry no `default_status`, so they deploy stopped; the nightly
+   schedule covers freshness until started.
+3. Watch the first ticks (`mcp__dagster__get_tick_history`): expect a first run
+   selecting all no-cursor tables (no stored baseline yet — one-time), then
+   `SkipReason` idle ticks. Measure tick duration against the 600s sensor-tick
+   cap (spec risk: `COUNT(*)` on `studenttestscore`/`testscore`/`log`).
+4. Confirm an idle tick plans nothing and a changed table materializes; verify
+   `kippnewark/powerschool/sis/attendance`'s DEGRADED badge clears on its next
+   real materialization.
+5. Branch-deployment caveat if validating pre-merge: the dlt dataset is NOT
+   branch-isolated — validate via probe/tick logs, not real branch loads.

--- a/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
+++ b/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
@@ -1,0 +1,237 @@
+# PowerSchool dlt intraday sensor — design
+
+- **Date:** 2026-07-20
+- **Issue:** [#4453](https://github.com/TEAMSchools/teamster/issues/4453)
+- **Status:** Draft
+- **Scope:** `kippnewark` first; library factory generalizes to other districts
+  later.
+
+## Problem
+
+The PowerSchool dlt intraday sync runs on a `*/15` `ScheduleDefinition` that
+targets every intraday-tier table. The schedule fixes the run's asset selection
+_before_ any change detection happens; the op then opens the tunnel, probes each
+selected table (`COUNT(*)` + `MAX(cursor)`), and loads only the changed ones via
+a narrowed dlt source. Unchanged tables are therefore **planned but never
+materialized** on every tick.
+
+Two consequences:
+
+1. **Planning artifacts.** A planned-but-unmaterialized asset emits
+   `ASSET_FAILED_TO_MATERIALIZE`. On a normal run this is a benign `SKIPPED`
+   (INFO), but when a run is terminated externally it becomes a `FAILED` and the
+   asset shows a DEGRADED health badge. Run `4894b6ca` (an externally-killed
+   intraday run) left `kippnewark/powerschool/sis/attendance` stuck DEGRADED
+   even though its data is intact — the badge only clears on a real
+   materialization, which an idle incremental will not produce.
+2. **Idle-tick compute.** Every tick launches a full run, step pod, and SSH
+   tunnel even when nothing changed. At `*/15` that is 96 runs/day, most of
+   which load nothing.
+
+The change-detection logic itself is sound and stays; the problem is _where_ it
+runs. Deciding the selection after the plan is fixed is what generates the
+artifacts.
+
+## Goals
+
+- Unchanged tables are never planned — no `ASSET_FAILED_TO_MATERIALIZE`, no
+  DEGRADED badges from idle ticks.
+- Idle ticks launch nothing (no run, pod, or tunnel).
+- Run history reflects real work: a run in the timeline means a load happened.
+- No-cursor tables gain intraday freshness for row add/remove.
+- Failure self-healing is preserved: a table that fails to load is re-selected
+  on the next tick.
+
+## Non-goals
+
+- Other districts. `kippnewark` is the first consumer; the factory is written to
+  generalize, but wiring other locations is out of scope here.
+- Changing the nightly schedule's target set (still the 30 tables it targets
+  today) — only its behavior changes to unconditional full-refresh.
+- Windowing/partitioning large tables — full-replace remains the load strategy
+  (see the dlt `powerschool` CLAUDE.md `DPY-4011` note).
+
+## Current architecture
+
+- [`build_powerschool_dlt_assets`](../../../src/teamster/libraries/dlt/powerschool/assets.py)
+  builds one probe-gated `@dlt_assets` multi-asset over all tables. The op
+  probes `selected`, computes `changed`, and loads only `changed`; the baseline
+  it compares against lives in dlt `resource_state` (persisted in the BigQuery
+  `_dlt_pipeline_state` table, restored via `sync_destination()`). dlt commits
+  that state **only from a resource actually extracted into a successful load**,
+  which is what makes failures self-heal.
+- Two `ScheduleDefinition`s subset the multi-asset by `schedule_tier`: intraday
+  (`*/15`) and nightly (`0 2`). `config/assets.yaml` carries each table's
+  `cursor_column` and `schedule_tier`.
+
+## Proposed architecture
+
+Move change detection into a sensor that requests only the changed tables, so
+unchanged tables are never in a run plan. The op keeps loading and writing
+signatures, but no longer decides the selection.
+
+### Tiering
+
+| Group                      | Count | Intraday (sensor) gate | Nightly      |
+| -------------------------- | ----- | ---------------------- | ------------ |
+| Cursor (existing intraday) | 27    | `count` + `max_cursor` | none         |
+| No-cursor                  | 18    | `count` only           | full refresh |
+| Gradebook FK cluster       | 12    | excluded               | full refresh |
+
+- **Intraday sensor set (45):** the 27 cursor tables plus the 18 no-cursor
+  tables.
+- **Nightly set (30):** the 18 no-cursor tables plus the 12 gradebook cluster
+  tables. Same target as today; the mode changes to unconditional full-refresh.
+- **Gradebook FK cluster (12, nightly-only):** `assignmentscore`,
+  `assignmentsection`, `assignmentcategoryassoc`, `districtteachercategory`,
+  `teachercategory`, `gradecalcformulaweight`, `gradecalcschoolassoc`,
+  `gradecalculationtype`, `gradeformulaset`, `gradeschoolconfig`,
+  `gradeschoolformulaassoc`, `gradesectionconfig`. Excluded from intraday
+  (`assignmentscore` is ~19M rows and its cluster changes throughout the day, so
+  intraday full-replaces would be costly).
+
+Cursor tables need no nightly refresh — their `max_cursor` catches in-place
+updates intraday. No-cursor tables appear in **both** tiers: intraday `COUNT(*)`
+catches net add/remove cheaply, and the nightly full-refresh is the
+authoritative sweep that catches in-place edits `COUNT(*)` cannot see.
+
+### Sensor
+
+New library factory
+`build_powerschool_dlt_intraday_sensor(code_location, tables, dlt_pipeline, minimum_interval_seconds=900)`
+in `libraries/dlt/powerschool/`, wired into `kippnewark`, replacing
+`powerschool_dlt_intraday_asset_job_schedule`. Requests resources
+`ssh_powerschool`, `db_powerschool`, and `dlt`.
+
+Each tick:
+
+1. Skip if a run for the target job is already in progress or queued (the
+   baseline advances only on load success, so an in-flight table would otherwise
+   re-select and launch a duplicate).
+2. Open the tunnel; probe each intraday table — `COUNT(*)` +
+   `MAX(cursor_column)` for cursor tables, `COUNT(*)` only for no-cursor tables.
+   Reuses `probe_signature` (extended for the no-cursor case) over one shared
+   engine.
+3. Read the stored baseline from dlt state (`sync_destination()` then
+   `_stored_signatures()` — the same path the op uses today).
+4. `changed = _compute_changed(...)` — reused, with no-cursor tables gated on
+   `count` drift instead of always-reload.
+5. If `changed` is non-empty, emit
+   `RunRequest(asset_selection=[changed keys], run_config=<probe payload>, tags={"dagster/max_runtime": "3600"})`.
+   Otherwise `SkipReason`.
+
+### Op run-argument contract
+
+The op reads an optional `probe` config value (the probe payload from the
+sensor). This one argument drives both modes and removes the gate from the op
+entirely — the selection decision now belongs to the sensor (intraday) or is
+absent (nightly loads all selected):
+
+- **Probe arg present (intraday):** load exactly `selected_asset_keys` using the
+  passed per-table signatures; write those signatures to `resource_state`. No
+  re-probe, no gate.
+- **Probe arg absent (nightly full-refresh):** load all `selected_asset_keys`
+  unconditionally; re-probe the selected set once to write fresh baseline
+  signatures (so the next intraday tick has a baseline). No gate.
+
+dlt still commits signatures only on successful load in both modes, preserving
+self-healing.
+
+### Config schema
+
+`config/assets.yaml` replaces the single `schedule_tier` enum with explicit
+membership so a table can belong to both tiers:
+
+```yaml
+assets:
+  - table_name: attendance
+    cursor_column: transaction_date
+    intraday: true # probed by the sensor
+    nightly: false # full-refreshed nightly
+  - table_name: log
+    cursor_column: null
+    intraday: true # count-gated
+    nightly: true # in-place edits caught overnight
+  - table_name: assignmentscore
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+```
+
+The old validation "intraday tables require a `cursor_column`" is removed — a
+no-cursor table may be intraday (count-gated). New validation: every table sets
+at least one of `intraday`/`nightly`.
+
+## State and correctness
+
+- **Baseline ownership.** dlt `resource_state` remains the single source of
+  truth for the last successfully-loaded signature. The sensor reads it; the op
+  writes it on load success. A failed load leaves the old signature, so the
+  table re-selects next tick.
+- **Overlapping runs.** The in-flight-skip guard prevents duplicate launches
+  while a (possibly long) run is committing. The `dlt_powerschool_<loc>` pool
+  additionally serializes step execution as a backstop.
+- **`COUNT(*)` limits.** Count catches net row add/remove but misses a net-zero
+  swap (one insert + one delete) and in-place edits. The nightly full-refresh is
+  the authoritative backstop, so no-cursor freshness is "best-effort intraday,
+  authoritative overnight."
+- **Signature freshness.** The sensor probes at tick time (`T0`); the op stores
+  those signatures at load time (`T0 + lag`). A source change in that gap causes
+  at most one redundant reload next tick — benign for full-replace.
+- **Bootstrap.** With no stored baseline (first tick, or a table new to
+  intraday), `_compute_changed` treats the absent baseline as changed, so the
+  table loads once and establishes its signature.
+
+## Risks
+
+- **`COUNT(*)` cost** on the larger no-cursor tables (`studenttestscore`,
+  `testscore`, `log`) every 15 min over the tunnel is heavier than
+  `MAX(indexed_cursor)`. Still expected to be well under the sensor-tick budget,
+  but worth measuring on the first branch run.
+- **`run_config` size.** The probe payload is at most 45 small entries
+  (`{count, max_cursor}`), a few KB of config — within limits, but passed via
+  `run_config` (structured), not tags.
+- **Sensor probe failures** (tunnel/auth) surface as tick errors, like the
+  existing SFTP sensors. The probe path reuses `ssh_powerschool.open_ssh_tunnel`
+  and should carry the same retry treatment.
+
+## Cutover
+
+Single deploy: remove `powerschool_dlt_intraday_asset_job_schedule`, add the
+sensor (started), switch the nightly schedule to full-refresh mode, and migrate
+`config/assets.yaml` to the new membership fields. The intraday schedule and the
+sensor must not both run (double loads), so this is one atomic change, not a
+staged rollout. Branch-deployment note: the dlt dataset is **not**
+branch-isolated (see the dlt CLAUDE.md), so branch testing writes to the prod
+dataset — validate via probe/log rather than a real branch load.
+
+## Testing
+
+- **Unit — sensor selection.** Mock the probe and stored signatures; assert the
+  `RunRequest.asset_selection` and `run_config` payload for changed tables, the
+  `SkipReason` when nothing changed, and the in-flight-skip branch. Reuses
+  `_compute_changed` as the tested seam.
+- **Unit — no-cursor count gate.** `_compute_changed` selects a no-cursor table
+  on count drift and skips it when the count is stable.
+- **Unit — op modes.** Probe arg present loads the passed set with passed
+  signatures (no re-probe); probe arg absent loads all selected and
+  re-baselines.
+- **E2E — branch deployment.** Confirm a changed table triggers a run and an
+  unchanged tick skips; verify against the shared-dataset caveat above.
+
+## Docs
+
+- Regenerate `docs/reference/automations.md` (new sensor, removed intraday
+  schedule) in a full environment where all locations import.
+- Update the `kippnewark` CLAUDE.md integration table: PowerSchool trigger
+  becomes "sensor (intraday) + schedule (nightly full-refresh)."
+- Update the dlt `powerschool` library CLAUDE.md to describe the sensor + op
+  run-arg contract.
+
+## Follow-ups
+
+- Generalize the sensor wiring to the other districts as their dlt PowerSchool
+  migrations land.
+- Revisit the intraday cadence: idle ticks are now probe-only, so a tighter
+  interval is cheap on the Dagster side but multiplies the Oracle probe load —
+  measure before changing.

--- a/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
+++ b/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
@@ -193,6 +193,13 @@ at least one of `intraday`/`nightly`.
   swap (one insert + one delete) and in-place edits. The nightly full-refresh is
   the authoritative backstop, so no-cursor freshness is "best-effort intraday,
   authoritative overnight."
+- **Cursor trust for intraday-only tables.** Intraday-only cursor tables
+  (`intraday: true, nightly: false` — the bulk of the config) have **no**
+  nightly backstop: a change that advances neither `COUNT(*)` nor `MAX(cursor)`
+  is invisible. This is an accepted trust assumption — PowerSchool advances
+  `whenmodified`/`transaction_date` on every edit — not a gap the design closes.
+  A table that needs a periodic authoritative sweep should be marked
+  `nightly: true` as well.
 - **Signature freshness.** The sensor probes at tick time (`T0`); the op stores
   those signatures at load time (`T0 + lag`). A source change in that gap causes
   at most one redundant reload next tick — benign for full-replace.

--- a/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
+++ b/docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md
@@ -2,9 +2,12 @@
 
 - **Date:** 2026-07-20
 - **Issue:** [#4453](https://github.com/TEAMSchools/teamster/issues/4453)
-- **Status:** Draft
-- **Scope:** `kippnewark` first; library factory generalizes to other districts
-  later.
+- **Status:** Approved (amended 2026-07-20: all three dlt districts migrate in
+  one cutover; nightly re-baseline is probe-before-load)
+- **Scope:** All three dlt PowerSchool districts — `kippnewark`, `kippcamden`,
+  `kipppaterson`. The shared op contract changes, so a partial migration would
+  leave the non-migrated districts' intraday schedules launching unconditional
+  full loads; migrating everyone at once avoids a legacy compatibility mode.
 
 ## Problem
 
@@ -44,10 +47,8 @@ artifacts.
 
 ## Non-goals
 
-- Other districts. `kippnewark` is the first consumer; the factory is written to
-  generalize, but wiring other locations is out of scope here.
-- Changing the nightly schedule's target set (still the 30 tables it targets
-  today) — only its behavior changes to unconditional full-refresh.
+- Changing the nightly schedules' target sets (still the tables they target
+  today) — only their behavior changes to unconditional full-refresh.
 - Windowing/partitioning large tables — full-replace remains the load strategy
   (see the dlt `powerschool` CLAUDE.md `DPY-4011` note).
 
@@ -72,16 +73,20 @@ signatures, but no longer decides the selection.
 
 ### Tiering
 
-| Group                      | Count | Intraday (sensor) gate | Nightly      |
-| -------------------------- | ----- | ---------------------- | ------------ |
-| Cursor (existing intraday) | 27    | `count` + `max_cursor` | none         |
-| No-cursor                  | 18    | `count` only           | full refresh |
-| Gradebook FK cluster       | 12    | excluded               | full refresh |
+Counts per district (`kippnewark` / `kippcamden` / `kipppaterson` — newark and
+camden share the same 57-table set; paterson has 48):
 
-- **Intraday sensor set (45):** the 27 cursor tables plus the 18 no-cursor
+| Group                      | NWK/CAM | PAT | Intraday (sensor) gate | Nightly      |
+| -------------------------- | ------- | --- | ---------------------- | ------------ |
+| Cursor (existing intraday) | 27      | 23  | `count` + `max_cursor` | none         |
+| No-cursor                  | 18      | 14  | `count` only           | full refresh |
+| Gradebook FK cluster       | 12      | 11  | excluded               | full refresh |
+
+- **Intraday sensor set (45 / 45 / 37):** the cursor tables plus the no-cursor
   tables.
-- **Nightly set (30):** the 18 no-cursor tables plus the 12 gradebook cluster
-  tables. Same target as today; the mode changes to unconditional full-refresh.
+- **Nightly set (30 / 30 / 25):** the no-cursor tables plus the gradebook
+  cluster tables. Same target as today; the mode changes to unconditional
+  full-refresh.
 - **Gradebook FK cluster (12, nightly-only):** `assignmentscore`,
   `assignmentsection`, `assignmentcategoryassoc`, `districtteachercategory`,
   `teachercategory`, `gradecalcformulaweight`, `gradecalcschoolassoc`,
@@ -98,16 +103,20 @@ authoritative sweep that catches in-place edits `COUNT(*)` cannot see.
 ### Sensor
 
 New library factory
-`build_powerschool_dlt_intraday_sensor(code_location, tables, dlt_pipeline, minimum_interval_seconds=900)`
-in `libraries/dlt/powerschool/`, wired into `kippnewark`, replacing
-`powerschool_dlt_intraday_asset_job_schedule`. Requests resources
-`ssh_powerschool`, `db_powerschool`, and `dlt`.
+`build_powerschool_dlt_intraday_sensor(code_location, tables, nightly_schedule_name, minimum_interval_seconds=900)`
+in `libraries/dlt/powerschool/sensors.py`, wired into all three districts,
+replacing each `powerschool_dlt_intraday_asset_job_schedule`. Requests resources
+`ssh_powerschool` and `db_powerschool`; the dlt pipeline (for baseline reads) is
+built internally via a shared helper, so no pipeline or dlt resource is passed
+in.
 
 Each tick:
 
-1. Skip if a run for the target job is already in progress or queued (the
-   baseline advances only on load success, so an in-flight table would otherwise
-   re-select and launch a duplicate).
+1. Skip if a run launched by this sensor OR by the district's nightly schedule
+   is already in progress or queued (the baseline advances only on load success,
+   so an in-flight table would otherwise re-select and launch a duplicate).
+   Detected via the auto-applied `dagster/sensor_name` / `dagster/schedule_name`
+   run tags.
 2. Open the tunnel; probe each intraday table — `COUNT(*)` +
    `MAX(cursor_column)` for cursor tables, `COUNT(*)` only for no-cursor tables.
    Reuses `probe_signature` (extended for the no-cursor case) over one shared
@@ -130,12 +139,21 @@ absent (nightly loads all selected):
 - **Probe arg present (intraday):** load exactly `selected_asset_keys` using the
   passed per-table signatures; write those signatures to `resource_state`. No
   re-probe, no gate.
-- **Probe arg absent (nightly full-refresh):** load all `selected_asset_keys`
-  unconditionally; re-probe the selected set once to write fresh baseline
-  signatures (so the next intraday tick has a baseline). No gate.
+- **Probe arg absent (nightly full-refresh, or any manual/ad-hoc launch):**
+  probe all `selected_asset_keys` once BEFORE the load (count-only for no-cursor
+  tables), then load them all unconditionally with those signatures. No gate.
+  The probe must precede the load because dlt commits state only from a resource
+  actually extracted into a successful load — a post-load write from the op body
+  never round-trips (see the dlt library CLAUDE.md). A source change during the
+  load causes at most one redundant intraday reload — the same benign staleness
+  window already accepted for the sensor.
 
 dlt still commits signatures only on successful load in both modes, preserving
-self-healing.
+self-healing. **Signature shape is normalized**: `probe_signature` always
+returns both keys (`{"count": n, "max_cursor": None}` for no-cursor tables) so a
+stored signature that round-trips through the op's run-config schema (which
+defaults `max_cursor` to `None`) compares equal to the next raw probe —
+otherwise every no-cursor table would re-select on every tick forever.
 
 ### Config schema
 
@@ -197,13 +215,18 @@ at least one of `intraday`/`nightly`.
 
 ## Cutover
 
-Single deploy: remove `powerschool_dlt_intraday_asset_job_schedule`, add the
-sensor (started), switch the nightly schedule to full-refresh mode, and migrate
-`config/assets.yaml` to the new membership fields. The intraday schedule and the
-sensor must not both run (double loads), so this is one atomic change, not a
-staged rollout. Branch-deployment note: the dlt dataset is **not**
-branch-isolated (see the dlt CLAUDE.md), so branch testing writes to the prod
-dataset — validate via probe/log rather than a real branch load.
+Single deploy across all three districts: remove each
+`powerschool_dlt_intraday_asset_job_schedule`, add each sensor (repo convention
+sets no `default_status`, so start each sensor post-deploy — until started, the
+nightly schedule still covers freshness), switch the nightly schedules to
+full-refresh mode, and migrate each `config/assets.yaml` to the new membership
+fields. The intraday schedule and the sensor must not both run (double loads),
+so this is one atomic change per district, not a staged rollout. One-time
+cutover effect: the no-cursor tables have no stored signature, so each
+district's first sensor tick loads all of them once and establishes baselines.
+Branch-deployment note: the dlt dataset is **not** branch-isolated (see the dlt
+CLAUDE.md), so branch testing writes to the prod dataset — validate via
+probe/log rather than a real branch load.
 
 ## Testing
 
@@ -221,17 +244,16 @@ dataset — validate via probe/log rather than a real branch load.
 
 ## Docs
 
-- Regenerate `docs/reference/automations.md` (new sensor, removed intraday
-  schedule) in a full environment where all locations import.
-- Update the `kippnewark` CLAUDE.md integration table: PowerSchool trigger
-  becomes "sensor (intraday) + schedule (nightly full-refresh)."
+- Regenerate `docs/reference/automations.md` (new sensors, removed intraday
+  schedules) in a full environment where all locations import.
+- Update the `kippnewark`, `kippcamden`, and `kipppaterson` CLAUDE.md
+  integration tables: PowerSchool trigger becomes "sensor (intraday) + schedule
+  (nightly full-refresh)."
 - Update the dlt `powerschool` library CLAUDE.md to describe the sensor + op
   run-arg contract.
 
 ## Follow-ups
 
-- Generalize the sensor wiring to the other districts as their dlt PowerSchool
-  migrations land.
 - Revisit the intraday cadence: idle ticks are now probe-only, so a tighter
   interval is cheap on the Dagster side but multiplies the Oracle probe load —
   measure before changing.

--- a/src/teamster/code_locations/kippcamden/CLAUDE.md
+++ b/src/teamster/code_locations/kippcamden/CLAUDE.md
@@ -26,14 +26,14 @@ GCS bucket: `teamster-kippcamden`
 
 ## PowerSchool Configuration
 
-Uses **dlt** (probe-gated, full-replace ingestion over 57 tables), not ODBC.
-Config at `powerschool/sis/dlt/config/assets.yaml` (per-table `cursor_column` +
-`intraday`/`nightly` membership booleans). Intraday selection is decided by
-`kippcamden__powerschool__dlt__intraday_sensor` (probe + dlt-state baseline);
-the nightly schedule full-refreshes its targets unconditionally and
-re-baselines. Resources `ssh_powerschool` (paramiko tunnel) and `db_powerschool`
-(Oracle creds) are built by the shared `core/resources.py` factories. Writes
-directly to BigQuery — no GCS IO manager.
+Uses **dlt** (sensor-gated intraday + unconditional nightly full-refresh, over
+57 tables), not ODBC. Config at `powerschool/sis/dlt/config/assets.yaml`
+(per-table `cursor_column` + `intraday`/`nightly` membership booleans). Intraday
+selection is decided by `kippcamden__powerschool__dlt__intraday_sensor` (probe +
+dlt-state baseline); the nightly schedule full-refreshes its targets
+unconditionally and re-baselines. Resources `ssh_powerschool` (paramiko tunnel)
+and `db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
+factories. Writes directly to BigQuery — no GCS IO manager.
 
 ## Extracts
 

--- a/src/teamster/code_locations/kippcamden/CLAUDE.md
+++ b/src/teamster/code_locations/kippcamden/CLAUDE.md
@@ -35,6 +35,11 @@ unconditionally and re-baselines. Resources `ssh_powerschool` (paramiko tunnel)
 and `db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
 factories. Writes directly to BigQuery — no GCS IO manager.
 
+The `dlt_powerschool_kippcamden` pool must stay at limit 1 (Dagster+ deployment
+setting) — it is the backstop against a manually-launched run overlapping a
+sensor/nightly load (the in-flight guard only sees sensor- and schedule-launched
+runs), and two concurrent full-`replace` loads of one table would corrupt it.
+
 ## Extracts
 
 `extracts/` queries BigQuery and pushes CSV/JSON files to PowerSchool SFTP via

--- a/src/teamster/code_locations/kippcamden/CLAUDE.md
+++ b/src/teamster/code_locations/kippcamden/CLAUDE.md
@@ -11,26 +11,29 @@ GCS bucket: `teamster-kippcamden`
 
 ## Active Integrations
 
-| Module        | Type              | Trigger                                               |
-| ------------- | ----------------- | ----------------------------------------------------- |
-| `dbt`         | dbt assets        | `AutomationConditionSensor`                           |
-| `powerschool` | dlt assets        | schedules (intraday 15-min + nightly 2am)             |
-| `deanslist`   | API assets        | schedule (nightly)                                    |
-| `edplan`      | SFTP asset        | sensor (`build_edplan_sftp_sensor`)                   |
-| `finalsite`   | API + SFTP assets | schedule (`contacts`, 4am) + sensor (`status_report`) |
-| `overgrad`    | API assets        | schedule                                              |
-| `pearson`     | SFTP assets       | `AutomationConditionSensor`                           |
-| `titan`       | SFTP assets       | sensor (`build_titan_sftp_sensor`)                    |
-| `extracts`    | BigQuery→SFTP     | schedule (nightly, 3am)                               |
-| `couchdrop`   | sensor only       | sensor (Google Drive watcher)                         |
+| Module        | Type              | Trigger                                                               |
+| ------------- | ----------------- | --------------------------------------------------------------------- |
+| `dbt`         | dbt assets        | `AutomationConditionSensor`                                           |
+| `powerschool` | dlt assets        | sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh) |
+| `deanslist`   | API assets        | schedule (nightly)                                                    |
+| `edplan`      | SFTP asset        | sensor (`build_edplan_sftp_sensor`)                                   |
+| `finalsite`   | API + SFTP assets | schedule (`contacts`, 4am) + sensor (`status_report`)                 |
+| `overgrad`    | API assets        | schedule                                                              |
+| `pearson`     | SFTP assets       | `AutomationConditionSensor`                                           |
+| `titan`       | SFTP assets       | sensor (`build_titan_sftp_sensor`)                                    |
+| `extracts`    | BigQuery→SFTP     | schedule (nightly, 3am)                                               |
+| `couchdrop`   | sensor only       | sensor (Google Drive watcher)                                         |
 
 ## PowerSchool Configuration
 
 Uses **dlt** (probe-gated, full-replace ingestion over 57 tables), not ODBC.
 Config at `powerschool/sis/dlt/config/assets.yaml` (per-table `cursor_column` +
-`schedule_tier`). Resources `ssh_powerschool` (paramiko tunnel) and
-`db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
-factories. Writes directly to BigQuery — no GCS IO manager.
+`intraday`/`nightly` membership booleans). Intraday selection is decided by
+`kippcamden__powerschool__dlt__intraday_sensor` (probe + dlt-state baseline);
+the nightly schedule full-refreshes its targets unconditionally and
+re-baselines. Resources `ssh_powerschool` (paramiko tunnel) and `db_powerschool`
+(Oracle creds) are built by the shared `core/resources.py` factories. Writes
+directly to BigQuery — no GCS IO manager.
 
 ## Extracts
 

--- a/src/teamster/code_locations/kippcamden/definitions.py
+++ b/src/teamster/code_locations/kippcamden/definitions.py
@@ -69,6 +69,7 @@ defs = Definitions(
     sensors=[
         *couchdrop.sensors,
         *edplan.sensors,
+        *powerschool.sensors,
         *titan.sensors,
         AutomationConditionSensorDefinition(
             name=f"{CODE_LOCATION}__automation_condition_sensor",

--- a/src/teamster/code_locations/kippcamden/powerschool/__init__.py
+++ b/src/teamster/code_locations/kippcamden/powerschool/__init__.py
@@ -1,6 +1,11 @@
-from teamster.code_locations.kippcamden.powerschool.sis import assets, schedules
+from teamster.code_locations.kippcamden.powerschool.sis import (
+    assets,
+    schedules,
+    sensors,
+)
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/__init__.py
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/__init__.py
@@ -4,7 +4,10 @@ assets = [*dlt.assets.assets]
 
 schedules = [*dlt.schedules.schedules]
 
+sensors = [*dlt.sensors.sensors]
+
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/__init__.py
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/__init__.py
@@ -1,9 +1,11 @@
 from teamster.code_locations.kippcamden.powerschool.sis.dlt import (
     assets,
     schedules,
+    sensors,
 )
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml
@@ -1,176 +1,232 @@
 assets:
-  # intraday, cursor transaction_date
+  # intraday only: cursor-gated by the sensor
   - table_name: attendance
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: cc
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: courses
     cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: pgfinalgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: schools
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: sections
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: storedgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: students
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: termbins
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: terms
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  # intraday, cursor whenmodified
+    intraday: true
+    nightly: false
   - table_name: gradescaleitem
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: pgfinalgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: roledef
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_crs_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_ren_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: schools
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: schoolstaff
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: sections
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: sectionteacher
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: storedgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: studentcorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: studentrace
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: students
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: termbins
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: terms
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: u_clg_et_stu
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_clg_et_stu_alt
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_expectations
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_storedgrades_de
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_studentsuserfields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: users
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: userscorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
-  # nightly, cursor whenmodified (gradebook)
-  - table_name: assignmentcategoryassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentscore
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentsection
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: districtteachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcformulaweight
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcschoolassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalculationtype
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeformulaset
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolconfig
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolformulaassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradesectionconfig
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: teachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  # nightly, no cursor (always fully replaced when selected)
+    intraday: true
+    nightly: false
+  # intraday + nightly: no cursor — count-gated intraday, authoritative nightly full refresh
   - table_name: attendance_code
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: attendance_conversion_items
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: bell_schedule
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: calendar_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: cycle_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: fte
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gen
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpnode
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubject
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubjectearned
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubjectenrolled
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: log
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: reenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: spenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttest
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttestscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: test
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: testscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
+  # nightly only: gradebook cluster, full-refreshed nightly
+  - table_name: assignmentcategoryassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentscore
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentsection
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: districtteachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcformulaweight
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcschoolassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalculationtype
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeformulaset
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolconfig
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolformulaassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradesectionconfig
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: teachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/schedules.py
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/schedules.py
@@ -8,59 +8,32 @@ from teamster.code_locations.kippcamden import CODE_LOCATION, LOCAL_TIMEZONE
 config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
 config = yaml.safe_load(config_file.read_text())
 
-_VALID_SCHEDULE_TIERS = {"intraday", "nightly"}
 
-
-def _tier_targets(tier: str) -> list[str]:
+def _nightly_targets() -> list[str]:
     assets = config["assets"]
 
-    invalid = [a for a in assets if a["schedule_tier"] not in _VALID_SCHEDULE_TIERS]
-    if invalid:
+    orphaned = [a["table_name"] for a in assets if not (a["intraday"] or a["nightly"])]
+    if orphaned:
         raise ValueError(
-            "Invalid schedule_tier for table(s): "
-            + ", ".join(
-                f"{a['table_name']!r} ({a['schedule_tier']!r})" for a in invalid
-            )
-            + f"; expected one of {sorted(_VALID_SCHEDULE_TIERS)}"
+            "table(s) in neither tier (would never materialize): " + ", ".join(orphaned)
         )
-
-    if tier == "intraday":
-        # no-cursor tables cannot be probe-gated, so they must not run intraday
-        ungated = [
-            a
-            for a in assets
-            if a["schedule_tier"] == "intraday" and a["cursor_column"] is None
-        ]
-        if ungated:
-            raise ValueError(
-                "intraday tables require a cursor_column: "
-                + ", ".join(a["table_name"] for a in ungated)
-            )
 
     return [
         f"{CODE_LOCATION}/powerschool/sis/{a['table_name']}"
         for a in assets
-        if a["schedule_tier"] == tier
+        if a["nightly"]
     ]
 
 
-powerschool_dlt_intraday_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__powerschool__dlt__intraday_asset_job_schedule",
-    cron_schedule="*/15 * * * *",
-    execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("intraday"),
-    tags={"dagster/max_runtime": "3600"},
-)
-
+# Unconditional full refresh + re-baseline (the op's no-probe mode): the
+# authoritative sweep that catches in-place edits the intraday count gate
+# cannot see on no-cursor tables.
 powerschool_dlt_nightly_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule",
     cron_schedule="0 2 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("nightly"),
+    target=_nightly_targets(),
     tags={"dagster/max_runtime": "3600"},
 )
 
-schedules = [
-    powerschool_dlt_intraday_asset_job_schedule,
-    powerschool_dlt_nightly_asset_job_schedule,
-]
+schedules = [powerschool_dlt_nightly_asset_job_schedule]

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/sensors.py
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/sensors.py
@@ -1,0 +1,25 @@
+import pathlib
+
+import yaml
+
+from teamster.code_locations.kippcamden import CODE_LOCATION
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    build_powerschool_dlt_intraday_sensor,
+)
+
+config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
+
+sensors = [
+    build_powerschool_dlt_intraday_sensor(
+        code_location=CODE_LOCATION,
+        tables=[
+            PowerSchoolTable(name=a["table_name"], cursor_column=a["cursor_column"])
+            for a in yaml.safe_load(config_file.read_text())["assets"]
+            if a["intraday"]
+        ],
+        nightly_schedule_name=(
+            f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+]

--- a/src/teamster/code_locations/kippnewark/CLAUDE.md
+++ b/src/teamster/code_locations/kippnewark/CLAUDE.md
@@ -37,3 +37,8 @@ dlt-state baseline); the nightly schedule full-refreshes its targets
 unconditionally and re-baselines. Resources `ssh_powerschool` (paramiko tunnel)
 and `db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
 factories. Writes directly to BigQuery — no GCS IO manager.
+
+The `dlt_powerschool_kippnewark` pool must stay at limit 1 (Dagster+ deployment
+setting) — it is the backstop against a manually-launched run overlapping a
+sensor/nightly load (the in-flight guard only sees sensor- and schedule-launched
+runs), and two concurrent full-`replace` loads of one table would corrupt it.

--- a/src/teamster/code_locations/kippnewark/CLAUDE.md
+++ b/src/teamster/code_locations/kippnewark/CLAUDE.md
@@ -11,26 +11,29 @@ GCS bucket: `teamster-kippnewark`
 
 ## Active Integrations
 
-| Module                  | Type          | Trigger                                     |
-| ----------------------- | ------------- | ------------------------------------------- |
-| `dbt`                   | dbt assets    | `AutomationConditionSensor`                 |
-| `powerschool`           | dlt assets    | schedules (intraday 15-min + nightly 2am)   |
-| `amplify` (mclass sftp) | SFTP assets   | sensor (`build_amplify_mclass_sftp_sensor`) |
-| `deanslist`             | API assets    | schedule (nightly)                          |
-| `edplan`                | SFTP asset    | sensor (`build_edplan_sftp_sensor`)         |
-| `finalsite`             | API + SFTP    | schedule (contacts 4am) + couchdrop sensor  |
-| `iready`                | SFTP assets   | sensor (`build_iready_sftp_sensor`)         |
-| `overgrad`              | API assets    | schedule                                    |
-| `pearson`               | SFTP assets   | `AutomationConditionSensor`                 |
-| `renlearn`              | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)       |
-| `titan`                 | SFTP assets   | sensor (`build_titan_sftp_sensor`)          |
-| `extracts`              | BigQuery→SFTP | schedule                                    |
-| `couchdrop`             | sensor only   | sensor (Google Drive watcher)               |
+| Module                  | Type          | Trigger                                                               |
+| ----------------------- | ------------- | --------------------------------------------------------------------- |
+| `dbt`                   | dbt assets    | `AutomationConditionSensor`                                           |
+| `powerschool`           | dlt assets    | sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh) |
+| `amplify` (mclass sftp) | SFTP assets   | sensor (`build_amplify_mclass_sftp_sensor`)                           |
+| `deanslist`             | API assets    | schedule (nightly)                                                    |
+| `edplan`                | SFTP asset    | sensor (`build_edplan_sftp_sensor`)                                   |
+| `finalsite`             | API + SFTP    | schedule (contacts 4am) + couchdrop sensor                            |
+| `iready`                | SFTP assets   | sensor (`build_iready_sftp_sensor`)                                   |
+| `overgrad`              | API assets    | schedule                                                              |
+| `pearson`               | SFTP assets   | `AutomationConditionSensor`                                           |
+| `renlearn`              | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                                 |
+| `titan`                 | SFTP assets   | sensor (`build_titan_sftp_sensor`)                                    |
+| `extracts`              | BigQuery→SFTP | schedule                                                              |
+| `couchdrop`             | sensor only   | sensor (Google Drive watcher)                                         |
 
 ## PowerSchool Configuration
 
 Uses **dlt** (probe-gated, full-replace ingestion over 57 tables), not ODBC.
 Config at `powerschool/sis/dlt/config/assets.yaml` (per-table `cursor_column` +
-`schedule_tier`). Resources `ssh_powerschool` (paramiko tunnel) and
-`db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
-factories. Writes directly to BigQuery — no GCS IO manager.
+`intraday`/`nightly` membership booleans). Intraday selection is decided by
+`kippnewark__powerschool__dlt__intraday_sensor` (probe + dlt-state baseline);
+the nightly schedule full-refreshes its targets unconditionally and
+re-baselines. Resources `ssh_powerschool` (paramiko tunnel) and `db_powerschool`
+(Oracle creds) are built by the shared `core/resources.py` factories. Writes
+directly to BigQuery — no GCS IO manager.

--- a/src/teamster/code_locations/kippnewark/CLAUDE.md
+++ b/src/teamster/code_locations/kippnewark/CLAUDE.md
@@ -29,11 +29,11 @@ GCS bucket: `teamster-kippnewark`
 
 ## PowerSchool Configuration
 
-Uses **dlt** (probe-gated, full-replace ingestion over 57 tables), not ODBC.
-Config at `powerschool/sis/dlt/config/assets.yaml` (per-table `cursor_column` +
-`intraday`/`nightly` membership booleans). Intraday selection is decided by
-`kippnewark__powerschool__dlt__intraday_sensor` (probe + dlt-state baseline);
-the nightly schedule full-refreshes its targets unconditionally and
-re-baselines. Resources `ssh_powerschool` (paramiko tunnel) and `db_powerschool`
-(Oracle creds) are built by the shared `core/resources.py` factories. Writes
-directly to BigQuery — no GCS IO manager.
+Uses **dlt** (sensor-gated intraday + unconditional nightly full-refresh, over
+57 tables), not ODBC. Config at `powerschool/sis/dlt/config/assets.yaml`
+(per-table `cursor_column` + `intraday`/`nightly` membership booleans). Intraday
+selection is decided by `kippnewark__powerschool__dlt__intraday_sensor` (probe +
+dlt-state baseline); the nightly schedule full-refreshes its targets
+unconditionally and re-baselines. Resources `ssh_powerschool` (paramiko tunnel)
+and `db_powerschool` (Oracle creds) are built by the shared `core/resources.py`
+factories. Writes directly to BigQuery — no GCS IO manager.

--- a/src/teamster/code_locations/kippnewark/definitions.py
+++ b/src/teamster/code_locations/kippnewark/definitions.py
@@ -80,6 +80,7 @@ defs = Definitions(
         *couchdrop.sensors,
         *edplan.sensors,
         *iready.sensors,
+        *powerschool.sensors,
         *renlearn.sensors,
         *titan.sensors,
         AutomationConditionSensorDefinition(

--- a/src/teamster/code_locations/kippnewark/powerschool/__init__.py
+++ b/src/teamster/code_locations/kippnewark/powerschool/__init__.py
@@ -1,6 +1,11 @@
-from teamster.code_locations.kippnewark.powerschool.sis import assets, schedules
+from teamster.code_locations.kippnewark.powerschool.sis import (
+    assets,
+    schedules,
+    sensors,
+)
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/__init__.py
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/__init__.py
@@ -4,7 +4,10 @@ assets = [*dlt.assets.assets]
 
 schedules = [*dlt.schedules.schedules]
 
+sensors = [*dlt.sensors.sensors]
+
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/__init__.py
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/__init__.py
@@ -1,9 +1,11 @@
 from teamster.code_locations.kippnewark.powerschool.sis.dlt import (
     assets,
     schedules,
+    sensors,
 )
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml
@@ -1,176 +1,232 @@
 assets:
-  # intraday, cursor transaction_date
+  # intraday only: cursor-gated by the sensor
   - table_name: attendance
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: cc
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: courses
     cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: pgfinalgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: schools
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: sections
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: storedgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: students
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: termbins
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: terms
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  # intraday, cursor whenmodified
+    intraday: true
+    nightly: false
   - table_name: gradescaleitem
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: pgfinalgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: roledef
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_crs_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_ren_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: schools
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: schoolstaff
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: sections
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: sectionteacher
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: storedgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: studentcorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: studentrace
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: students
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: termbins
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: terms
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: u_clg_et_stu
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_clg_et_stu_alt
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_expectations
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_storedgrades_de
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: u_studentsuserfields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: users
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: userscorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
-  # nightly, cursor whenmodified (gradebook)
-  - table_name: assignmentcategoryassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentscore
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentsection
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: districtteachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcformulaweight
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcschoolassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalculationtype
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeformulaset
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolconfig
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolformulaassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradesectionconfig
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: teachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  # nightly, no cursor (always fully replaced when selected)
+    intraday: true
+    nightly: false
+  # intraday + nightly: no cursor — count-gated intraday, authoritative nightly full refresh
   - table_name: attendance_code
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: attendance_conversion_items
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: bell_schedule
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: calendar_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: cycle_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: fte
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gen
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpnode
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubject
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubjectearned
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gpprogresssubjectenrolled
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: log
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: reenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: spenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttest
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttestscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: test
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: testscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
+  # nightly only: gradebook cluster, full-refreshed nightly
+  - table_name: assignmentcategoryassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentscore
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentsection
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: districtteachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcformulaweight
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcschoolassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalculationtype
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeformulaset
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolconfig
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolformulaassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradesectionconfig
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: teachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/schedules.py
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/schedules.py
@@ -8,59 +8,32 @@ from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
 config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
 config = yaml.safe_load(config_file.read_text())
 
-_VALID_SCHEDULE_TIERS = {"intraday", "nightly"}
 
-
-def _tier_targets(tier: str) -> list[str]:
+def _nightly_targets() -> list[str]:
     assets = config["assets"]
 
-    invalid = [a for a in assets if a["schedule_tier"] not in _VALID_SCHEDULE_TIERS]
-    if invalid:
+    orphaned = [a["table_name"] for a in assets if not (a["intraday"] or a["nightly"])]
+    if orphaned:
         raise ValueError(
-            "Invalid schedule_tier for table(s): "
-            + ", ".join(
-                f"{a['table_name']!r} ({a['schedule_tier']!r})" for a in invalid
-            )
-            + f"; expected one of {sorted(_VALID_SCHEDULE_TIERS)}"
+            "table(s) in neither tier (would never materialize): " + ", ".join(orphaned)
         )
-
-    if tier == "intraday":
-        # no-cursor tables cannot be probe-gated, so they must not run intraday
-        ungated = [
-            a
-            for a in assets
-            if a["schedule_tier"] == "intraday" and a["cursor_column"] is None
-        ]
-        if ungated:
-            raise ValueError(
-                "intraday tables require a cursor_column: "
-                + ", ".join(a["table_name"] for a in ungated)
-            )
 
     return [
         f"{CODE_LOCATION}/powerschool/sis/{a['table_name']}"
         for a in assets
-        if a["schedule_tier"] == tier
+        if a["nightly"]
     ]
 
 
-powerschool_dlt_intraday_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__powerschool__dlt__intraday_asset_job_schedule",
-    cron_schedule="*/15 * * * *",
-    execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("intraday"),
-    tags={"dagster/max_runtime": "3600"},
-)
-
+# Unconditional full refresh + re-baseline (the op's no-probe mode): the
+# authoritative sweep that catches in-place edits the intraday count gate
+# cannot see on no-cursor tables.
 powerschool_dlt_nightly_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule",
     cron_schedule="0 2 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("nightly"),
+    target=_nightly_targets(),
     tags={"dagster/max_runtime": "3600"},
 )
 
-schedules = [
-    powerschool_dlt_intraday_asset_job_schedule,
-    powerschool_dlt_nightly_asset_job_schedule,
-]
+schedules = [powerschool_dlt_nightly_asset_job_schedule]

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/sensors.py
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/sensors.py
@@ -1,0 +1,25 @@
+import pathlib
+
+import yaml
+
+from teamster.code_locations.kippnewark import CODE_LOCATION
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    build_powerschool_dlt_intraday_sensor,
+)
+
+config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
+
+sensors = [
+    build_powerschool_dlt_intraday_sensor(
+        code_location=CODE_LOCATION,
+        tables=[
+            PowerSchoolTable(name=a["table_name"], cursor_column=a["cursor_column"])
+            for a in yaml.safe_load(config_file.read_text())["assets"]
+            if a["intraday"]
+        ],
+        nightly_schedule_name=(
+            f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+]

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -11,16 +11,16 @@ GCS bucket: `teamster-kipppaterson`
 
 ## Active Integrations
 
-| Module                  | Type                         | Trigger                                               |
-| ----------------------- | ---------------------------- | ----------------------------------------------------- |
-| `dbt`                   | dbt assets                   | `AutomationConditionSensor`                           |
-| `powerschool` (sis/dlt) | dlt assets (Oracle→BigQuery) | schedule (intraday 15-min + nightly gradebook)        |
-| `amplify` (mclass sftp) | SFTP assets                  | sensor (`build_amplify_mclass_sftp_sensor`)           |
-| `deanslist`             | API assets                   | schedule (nightly)                                    |
-| `finalsite`             | API + SFTP assets            | schedule (`contacts`, 4am) + sensor (`status_report`) |
-| `pearson`               | SFTP assets                  | `AutomationConditionSensor`                           |
-| `extracts`              | BigQuery→SFTP                | schedule (3am)                                        |
-| `couchdrop`             | sensor only                  | sensor (Google Drive watcher, Finalsite only)         |
+| Module                  | Type                         | Trigger                                                               |
+| ----------------------- | ---------------------------- | --------------------------------------------------------------------- |
+| `dbt`                   | dbt assets                   | `AutomationConditionSensor`                                           |
+| `powerschool` (sis/dlt) | dlt assets (Oracle→BigQuery) | sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh) |
+| `amplify` (mclass sftp) | SFTP assets                  | sensor (`build_amplify_mclass_sftp_sensor`)                           |
+| `deanslist`             | API assets                   | schedule (nightly)                                                    |
+| `finalsite`             | API + SFTP assets            | schedule (`contacts`, 4am) + sensor (`status_report`)                 |
+| `pearson`               | SFTP assets                  | `AutomationConditionSensor`                                           |
+| `extracts`              | BigQuery→SFTP                | schedule (3am)                                                        |
+| `couchdrop`             | sensor only                  | sensor (Google Drive watcher, Finalsite only)                         |
 
 ## PowerSchool via dlt
 
@@ -28,13 +28,13 @@ Paterson ingests PowerSchool with **dlt**, syncing directly from its Oracle
 database through an in-process paramiko SSH tunnel (`ssh_powerschool` resource,
 `enable_legacy_rsa=True`) and landing to BigQuery via keyless ADC (issue #3807).
 This is the pilot/template for migrating the ODBC districts (`kippnewark`,
-`kippcamden`, `kippmiami`) off `sshpass`. ONE probe-gated `@dlt_assets`
-multi-asset covers all 48 tables (`powerschool/sis/dlt/`): the op probes each
-selected table's `COUNT(*)`/`MAX(cursor_column)` and full-replaces only on
-signature drift (signature in dlt resource state, restored from BigQuery);
-`cursor_column: null` tables always replace. Config in
-`powerschool/sis/dlt/config/assets.yaml`; two schedules in `schedules.py` subset
-the multi-asset (intraday 15-min = 23 cursor tables; nightly = 25). Design:
+`kippcamden`, `kippmiami`) off `sshpass`. ONE `@dlt_assets` multi-asset covers
+all 48 tables (`powerschool/sis/dlt/`); `cursor_column: null` tables always
+replace. Config in `powerschool/sis/dlt/config/assets.yaml` (per-table
+`cursor_column` + `intraday`/`nightly` membership booleans). Intraday selection
+is decided by `kipppaterson__powerschool__dlt__intraday_sensor` (probe +
+dlt-state baseline); the nightly schedule full-refreshes its targets
+unconditionally and re-baselines. Design:
 `docs/superpowers/specs/2026-07-16-powerschool-dlt-probe-gated-sync-design.md`.
 
 Consequences:
@@ -62,10 +62,12 @@ Consequences:
 
 ## Schedules
 
-Paterson has no freshness checks. PowerSchool dlt runs on two cron schedules
-(intraday 15-min + nightly gradebook, matching kippnewark's cadence). DeansList,
-Finalsite `contacts`, and the PowerSchool autocomm `extracts` job add nightly
-schedules; Finalsite `status_report` (`couchdrop_sftp_sensor`) and Amplify
-(`build_amplify_mclass_sftp_sensor`) are sensor-driven.
-`AutomationConditionSensor` handles any assets with an automation condition
-defined (e.g. `pearson`).
+Paterson has no freshness checks. PowerSchool dlt runs on an intraday
+change-detection sensor (`kipppaterson__powerschool__dlt__intraday_sensor`,
+15-min probe) plus one nightly cron schedule (unconditional full-refresh +
+re-baseline, matching kippnewark's cadence). DeansList, Finalsite `contacts`,
+and the PowerSchool autocomm `extracts` job add nightly schedules; Finalsite
+`status_report` (`couchdrop_sftp_sensor`), Amplify
+(`build_amplify_mclass_sftp_sensor`), and PowerSchool intraday are
+sensor-driven. `AutomationConditionSensor` handles any assets with an automation
+condition defined (e.g. `pearson`).

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -54,8 +54,8 @@ Consequences:
 - **Go-live cutover**: the `powerschool` pipeline is new (the migration's
   per-table pipelines were `powerschool_<table>`), and its all-`NULLABLE` schema
   cannot `replace`-load into the migration-era tables (their identity column is
-  `REQUIRED`). Before the first op-gate run against a dataset that already holds
-  migration-era tables, drop them so the pipeline recreates fresh:
+  `REQUIRED`). Before the first sensor/nightly load run against a dataset that
+  already holds migration-era tables, drop them so the pipeline recreates fresh:
   `DROP SCHEMA IF EXISTS` the `dagster_kipppaterson_dlt_powerschool` dataset
   `CASCADE`. The dataset name is not branch-isolated, so this applies to prod
   go-live, not just branch testing.

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -35,7 +35,7 @@ replace. Config in `powerschool/sis/dlt/config/assets.yaml` (per-table
 is decided by `kipppaterson__powerschool__dlt__intraday_sensor` (probe +
 dlt-state baseline); the nightly schedule full-refreshes its targets
 unconditionally and re-baselines. Design:
-`docs/superpowers/specs/2026-07-16-powerschool-dlt-probe-gated-sync-design.md`.
+`docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md`.
 
 Consequences:
 

--- a/src/teamster/code_locations/kipppaterson/definitions.py
+++ b/src/teamster/code_locations/kipppaterson/definitions.py
@@ -57,6 +57,7 @@ defs = Definitions(
     sensors=[
         *amplify.sensors,
         *couchdrop.sensors,
+        *powerschool.sensors,
         AutomationConditionSensorDefinition(
             name=f"{CODE_LOCATION}__automation_condition_sensor",
             target=AssetSelection.all(),

--- a/src/teamster/code_locations/kipppaterson/powerschool/__init__.py
+++ b/src/teamster/code_locations/kipppaterson/powerschool/__init__.py
@@ -1,6 +1,11 @@
-from teamster.code_locations.kipppaterson.powerschool.sis import assets, schedules
+from teamster.code_locations.kipppaterson.powerschool.sis import (
+    assets,
+    schedules,
+    sensors,
+)
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/__init__.py
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/__init__.py
@@ -4,7 +4,10 @@ assets = [*dlt.assets.assets]
 
 schedules = [*dlt.schedules.schedules]
 
+sensors = [*dlt.sensors.sensors]
+
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/__init__.py
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/__init__.py
@@ -1,9 +1,11 @@
 from teamster.code_locations.kipppaterson.powerschool.sis.dlt import (
     assets,
     schedules,
+    sensors,
 )
 
 __all__ = [
     "assets",
     "schedules",
+    "sensors",
 ]

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
@@ -1,149 +1,196 @@
 assets:
-  # intraday, cursor transaction_date
+  # intraday only: cursor-gated by the sensor
   - table_name: attendance
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: cc
     cursor_column: transaction_date
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: courses
     cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: pgfinalgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: schools
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: sections
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: storedgrades
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: students
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: termbins
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  - table_name: terms
-    cursor_column: transaction_date
-    schedule_tier: intraday
-  # intraday, cursor whenmodified
+    intraday: true
+    nightly: false
   - table_name: gradescaleitem
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: pgfinalgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: roledef
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_crs_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_ren_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_nj_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: s_stu_x
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: schools
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: schoolstaff
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: sections
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: sectionteacher
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: storedgrades
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: studentcorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: studentrace
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
+  - table_name: students
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: termbins
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
+  - table_name: terms
+    cursor_column: transaction_date
+    intraday: true
+    nightly: false
   - table_name: u_studentsuserfields
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: users
     cursor_column: whenmodified
-    schedule_tier: intraday
+    intraday: true
+    nightly: false
   - table_name: userscorefields
     cursor_column: whenmodified
-    schedule_tier: intraday
-  # nightly gradebook, cursor whenmodified
-  - table_name: assignmentcategoryassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentscore
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: assignmentsection
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: districtteachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcformulaweight
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalcschoolassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradecalculationtype
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeformulaset
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolconfig
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: gradeschoolformulaassoc
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  - table_name: teachercategory
-    cursor_column: whenmodified
-    schedule_tier: nightly
-  # nightly, no cursor -> unconditional replace
+    intraday: true
+    nightly: false
+  # intraday + nightly: no cursor — count-gated intraday, authoritative nightly full refresh
   - table_name: attendance_code
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: attendance_conversion_items
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: bell_schedule
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: calendar_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: cycle_day
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: fte
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: gen
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: log
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: reenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: spenrollments
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttest
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: studenttestscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: test
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
   - table_name: testscore
     cursor_column: null
-    schedule_tier: nightly
+    intraday: true
+    nightly: true
+  # nightly only: gradebook cluster, full-refreshed nightly
+  - table_name: assignmentcategoryassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentscore
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: assignmentsection
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: districtteachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcformulaweight
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalcschoolassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradecalculationtype
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeformulaset
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolconfig
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: gradeschoolformulaassoc
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true
+  - table_name: teachercategory
+    cursor_column: whenmodified
+    intraday: false
+    nightly: true

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/schedules.py
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/schedules.py
@@ -8,59 +8,32 @@ from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
 config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
 config = yaml.safe_load(config_file.read_text())
 
-_VALID_SCHEDULE_TIERS = {"intraday", "nightly"}
 
-
-def _tier_targets(tier: str) -> list[str]:
+def _nightly_targets() -> list[str]:
     assets = config["assets"]
 
-    invalid = [a for a in assets if a["schedule_tier"] not in _VALID_SCHEDULE_TIERS]
-    if invalid:
+    orphaned = [a["table_name"] for a in assets if not (a["intraday"] or a["nightly"])]
+    if orphaned:
         raise ValueError(
-            "Invalid schedule_tier for table(s): "
-            + ", ".join(
-                f"{a['table_name']!r} ({a['schedule_tier']!r})" for a in invalid
-            )
-            + f"; expected one of {sorted(_VALID_SCHEDULE_TIERS)}"
+            "table(s) in neither tier (would never materialize): " + ", ".join(orphaned)
         )
-
-    if tier == "intraday":
-        # no-cursor tables cannot be probe-gated, so they must not run intraday
-        ungated = [
-            a
-            for a in assets
-            if a["schedule_tier"] == "intraday" and a["cursor_column"] is None
-        ]
-        if ungated:
-            raise ValueError(
-                "intraday tables require a cursor_column: "
-                + ", ".join(a["table_name"] for a in ungated)
-            )
 
     return [
         f"{CODE_LOCATION}/powerschool/sis/{a['table_name']}"
         for a in assets
-        if a["schedule_tier"] == tier
+        if a["nightly"]
     ]
 
 
-powerschool_dlt_intraday_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__powerschool__dlt__intraday_asset_job_schedule",
-    cron_schedule="*/15 * * * *",
-    execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("intraday"),
-    tags={"dagster/max_runtime": "3600"},
-)
-
+# Unconditional full refresh + re-baseline (the op's no-probe mode): the
+# authoritative sweep that catches in-place edits the intraday count gate
+# cannot see on no-cursor tables.
 powerschool_dlt_nightly_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule",
     cron_schedule="0 2 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=_tier_targets("nightly"),
+    target=_nightly_targets(),
     tags={"dagster/max_runtime": "3600"},
 )
 
-schedules = [
-    powerschool_dlt_intraday_asset_job_schedule,
-    powerschool_dlt_nightly_asset_job_schedule,
-]
+schedules = [powerschool_dlt_nightly_asset_job_schedule]

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/sensors.py
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/sensors.py
@@ -1,0 +1,25 @@
+import pathlib
+
+import yaml
+
+from teamster.code_locations.kipppaterson import CODE_LOCATION
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    build_powerschool_dlt_intraday_sensor,
+)
+
+config_file = pathlib.Path(__file__).parent / "config" / "assets.yaml"
+
+sensors = [
+    build_powerschool_dlt_intraday_sensor(
+        code_location=CODE_LOCATION,
+        tables=[
+            PowerSchoolTable(name=a["table_name"], cursor_column=a["cursor_column"])
+            for a in yaml.safe_load(config_file.read_text())["assets"]
+            if a["intraday"]
+        ],
+        nightly_schedule_name=(
+            f"{CODE_LOCATION}__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+]

--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -49,10 +49,31 @@ using a vendored DLT Zendesk pipeline.
 ### `powerschool/`
 
 Loads PowerSchool SIS Oracle tables to BigQuery over an SSH tunnel
-(`table_rows` + PyArrow), probe-gated full-replace. Factory:
-`build_powerschool_dlt_assets(code_location, tables, op_tags=None, max_extract_workers=None)`;
-asset keys `[code_location, "powerschool", "sis", table]`.
+(`table_rows` + PyArrow), full-replace. Change detection lives in the intraday
+sensor, not the op. Factories:
+`build_powerschool_dlt_assets(code_location, tables, op_tags=None, max_extract_workers=None)`
+and
+`build_powerschool_dlt_intraday_sensor(code_location, tables, nightly_schedule_name, minimum_interval_seconds=900)`
+(`sensors.py`); asset keys `[code_location, "powerschool", "sis", table]`.
 
+- **Op run-config contract** (`PowerSchoolDltConfig`): `probe` present (intraday
+  sensor) → load exactly the run's asset selection with the passed per-table
+  signatures — no re-probe, no gate. `probe` absent (nightly schedule / manual
+  launch) → probe the selection once BEFORE the load (count-only for no-cursor
+  tables), then load it all unconditionally. Signatures always persist WITH the
+  load via `resource_state` (dlt commits state only from extracted resources —
+  post-load writes never round-trip), so a failed load keeps the old baseline
+  and the table re-selects next tick.
+- **Signature shape is normalized**: `probe_signature` always returns
+  `{"count": n, "max_cursor": value-or-None}` — a count-only dict would never
+  compare equal to the run-config round-trip (which defaults `max_cursor` to
+  None) and no-cursor tables would reload every tick.
+- **Sensor tick**: skip if a sensor-launched or nightly-schedule run is in
+  flight (via `dagster/sensor_name` / `dagster/schedule_name` run tags); probe
+  every intraday table over one engine; compare to the dlt-state baseline
+  (`sync_destination()` + `_stored_signatures`); request only changed tables
+  with the probe payload in run config. Idle ticks launch nothing, so unchanged
+  tables are never planned (no `ASSET_FAILED_TO_MATERIALIZE`).
 - **`DPY-4011` at ~512 MiB was a paramiko rekey bug, now fixed (not a volume
   cap)**: a large pull (`assignmentscore` ~19M) died with `oracledb DPY-4011`
   (connection closed) at a consistent **~8.6M rows** regardless of throughput

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -186,8 +186,11 @@ def _build_resource(
     """Build one full-replace, parallel-extracted dlt resource for a table.
 
     When a signature is provided it is persisted to the resource's dlt state
-    with the load package (so the next run can detect drift). No-cursor tables
-    are passed signature=None and carry no stored signature.
+    with the load package, becoming the baseline the next intraday tick
+    compares against. Every selected table is passed a signature now: cursor
+    tables a count + max-cursor pair, no-cursor tables a count-only signature
+    (``max_cursor`` None) whose count is the intraday change gate. A ``None``
+    signature persists nothing.
 
     `parallelized=True` runs each table's extract in its own dlt worker thread.
     The resource does NOT wrap `sql_table` (a `DltResource`) — nesting a resource

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -93,17 +93,15 @@ def _compute_changed(
     current: dict[str, dict],
     stored: dict[str, dict],
 ) -> list[PowerSchoolTable]:
-    """Select tables to load: no-cursor tables always, cursor tables on drift.
+    """Select tables whose just-probed signature differs from the stored one.
 
-    A table is changed when it has no cursor column (always reloaded when
-    selected) or its just-probed signature differs from the stored one
-    (drift, or first run when stored has no entry).
+    Drift in count or max cursor — or a missing stored entry (first tick, or a
+    table new to intraday) — selects the table. No-cursor tables carry a
+    count-only signature (``max_cursor: None``), so a net row add/remove
+    selects them; in-place edits are caught by the nightly full refresh.
     """
     return [
-        table
-        for table in selected
-        if table.cursor_column is None
-        or current.get(table.name) != stored.get(table.name)
+        table for table in selected if current.get(table.name) != stored.get(table.name)
     ]
 
 

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -50,14 +50,25 @@ class PowerSchoolTable:
 
 
 def probe_signature(
-    connection, table_name: str, cursor_column: str
+    connection, table_name: str, cursor_column: str | None
 ) -> dict[str, int | str | None]:
     """Fetch the change signature for a table: total count + max cursor.
 
     Equality-compared against the stored signature; drift in either value
-    (including a cursor regression) triggers a full replace. Values are
-    JSON-serializable for dlt resource state.
+    (including a cursor regression) triggers a full replace. Tables without a
+    cursor column are count-only — the signature still carries
+    ``max_cursor: None`` so it compares equal to the run-config round-trip
+    shape (which defaults the key to None). Values are JSON-serializable for
+    dlt resource state.
     """
+    if cursor_column is None:
+        (count,) = connection.execute(
+            # trunk-ignore(bandit/B608): table name from static YAML config
+            sa.text(f"SELECT COUNT(*) FROM {table_name}")
+        ).one()
+
+        return {"count": int(count), "max_cursor": None}
+
     count, max_cursor = connection.execute(
         # trunk-ignore(bandit/B608): table/column names from static YAML config
         sa.text(f"SELECT COUNT(*), MAX({cursor_column}) FROM {table_name}")

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 
 import dlt
 import sqlalchemy as sa
-from dagster import AssetExecutionContext, AssetKey, AssetSpec
+from dagster import AssetExecutionContext, AssetKey, AssetSpec, Config
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
@@ -113,6 +113,42 @@ def _resolve_extract_workers(tag_value: str | None, param: int | None) -> int | 
     return param
 
 
+class ProbeSignatureConfig(Config):
+    """One table's probed change signature, passed by the intraday sensor."""
+
+    count: int
+    max_cursor: str | None = None
+
+
+class PowerSchoolDltConfig(Config):
+    """Run config selecting the op's mode.
+
+    probe present (intraday sensor): the sensor already probed and gated —
+    load exactly the run's asset selection, persisting the passed signatures.
+    probe absent (nightly schedule / manual launch): full refresh — probe the
+    selection once, then load it all unconditionally with fresh baselines.
+    """
+
+    probe: dict[str, ProbeSignatureConfig] | None = None
+
+
+def build_powerschool_dlt_pipeline(code_location: str) -> dlt.Pipeline:
+    """The shared BigQuery pipeline for one district's PowerSchool source.
+
+    Used by the assets factory (loads) and the intraday sensor (baseline
+    reads via sync_destination + resource state).
+    """
+    return dlt.pipeline(
+        pipeline_name=_SOURCE_NAME,
+        # No `autodetect_schema=True`: oracle_number_adapter +
+        # full_with_precision reflection are the authoritative decimal schema
+        # (see oracle_number_adapter docstring).
+        destination=bigquery(),
+        dataset_name=f"dagster_{code_location}_dlt_{_SOURCE_NAME}",
+        progress=LogCollector(dump_system_stats=False),
+    )
+
+
 def oracle_number_adapter(col_type: TypeEngine) -> TypeEngine | None:
     """Keep Oracle NUMBER columns off FLOAT64 in BigQuery.
 
@@ -216,32 +252,25 @@ def build_powerschool_dlt_assets(
     op_tags: dict[str, object] | None = None,
     max_extract_workers: int | None = None,
 ):
-    """Build ONE probe-gated @dlt_assets over all PowerSchool tables.
+    """Build ONE two-mode @dlt_assets over all PowerSchool tables.
 
-    The op opens the SSH tunnel, restores prior per-table signatures from dlt
-    resource_state (persisted in the destination), probes each selected table's
-    COUNT(*)/MAX(cursor), and runs the pipeline over a source narrowed to only
-    the changed tables (`_powerschool_source(changed, current)`) — a full `replace`
-    load per changed table. Tables without a cursor_column are always loaded
-    when selected.
-    Unselected / unchanged tables are never in the run, so their destination
-    tables are untouched. Schedules subset the multi-asset per tier. See
-    docs/superpowers/specs/2026-07-16-powerschool-dlt-probe-gated-sync-design.md.
+    The selection decision belongs to the caller: the intraday sensor probes,
+    gates, and passes per-table signatures via run config (`probe`); the
+    nightly schedule and manual launches pass no config and get an
+    unconditional full refresh. In both modes the op opens the SSH tunnel and
+    runs the pipeline over a source narrowed to the run's asset selection — a
+    full `replace` load per table — persisting each table's signature to dlt
+    resource_state WITH the load (dlt commits state only from extracted
+    resources, so failures self-heal: the old baseline survives and the table
+    re-selects next tick). See
+    docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md.
 
     `max_extract_workers` caps concurrent dlt extract workers to avoid
     saturating the single SSH tunnel (see DPY-4011); None leaves dlt's
     default (5). A per-run `dlt_extract_workers` tag overrides this param for
     a manual concurrency sweep.
     """
-    dlt_pipeline = dlt.pipeline(
-        pipeline_name=_SOURCE_NAME,
-        # No `autodetect_schema=True`: oracle_number_adapter +
-        # full_with_precision reflection are the authoritative decimal schema
-        # (see oracle_number_adapter docstring).
-        destination=bigquery(),
-        dataset_name=f"dagster_{code_location}_dlt_{_SOURCE_NAME}",
-        progress=LogCollector(dump_system_stats=False),
-    )
+    dlt_pipeline = build_powerschool_dlt_pipeline(code_location)
 
     translator = PowerSchoolDagsterDltTranslator(code_location)
     tables_by_key = {_asset_key(code_location, t.name): t for t in tables}
@@ -258,6 +287,7 @@ def build_powerschool_dlt_assets(
     )
     def _assets(
         context: AssetExecutionContext,
+        config: PowerSchoolDltConfig,
         dlt: DagsterDltResource,
         ssh_powerschool: SSHResource,
         db_powerschool: OracleResource,
@@ -286,42 +316,33 @@ def build_powerschool_dlt_assets(
         with ssh_powerschool.open_ssh_tunnel():
             connection_url = db_powerschool.connection_url()
 
-            # Restore prior signatures from the destination state table. On a
-            # truly first run (no dataset) this raises; treat as no prior state.
-            try:
-                dlt_pipeline.sync_destination()
-            except Exception as e:
+            if config.probe is not None:
+                # Intraday sensor mode: the sensor probed and gated already —
+                # persist its signatures with the load, no re-probe.
+                signatures: dict[str, dict] = {
+                    name: {"count": sig.count, "max_cursor": sig.max_cursor}
+                    for name, sig in config.probe.items()
+                }
                 context.log.info(
-                    f"dlt sync_destination failed ({e}); treating all selected "
-                    "as changed"
+                    f"powerschool sensor-selected load: {sorted(signatures)}"
                 )
-
-            stored = _stored_signatures(dlt_pipeline, _SOURCE_NAME)
-
-            # Probe every selected table that has a cursor column (one shared
-            # engine over the single tunnel).
-            engine = sa.create_engine(connection_url)
-            try:
-                with engine.connect() as connection:
-                    current: dict[str, dict] = {
-                        table.name: probe_signature(
-                            connection, table.name, table.cursor_column
-                        )
-                        for table in selected
-                        if table.cursor_column is not None
-                    }
-            finally:
-                engine.dispose()
-
-            changed = _compute_changed(selected, current, stored)
-
-            context.log.info(
-                f"powerschool probe: {len(changed)}/{len(selected)} changed; "
-                f"changed={sorted(t.name for t in changed)}"
-            )
-
-            if not changed:
-                return  # idle tick: nothing to load
+            else:
+                # Full-refresh mode (nightly schedule / manual launch): load the
+                # whole selection unconditionally. Probe FIRST so fresh baseline
+                # signatures persist WITH the load — dlt commits state only from
+                # extracted resources, so a post-load write would not round-trip.
+                engine = sa.create_engine(connection_url)
+                try:
+                    with engine.connect() as connection:
+                        signatures = {
+                            table.name: probe_signature(
+                                connection, table.name, table.cursor_column
+                            )
+                            for table in selected
+                        }
+                finally:
+                    engine.dispose()
+                context.log.info(f"powerschool full-refresh load: {sorted(signatures)}")
 
             # Stream dlt's periodic extract/normalize/load progress into the
             # Dagster event log. The factory-built collector defaults to
@@ -339,7 +360,7 @@ def build_powerschool_dlt_assets(
                 yield from dlt.run(
                     context=context,
                     dlt_source=_powerschool_source(
-                        changed, current, connection_url, arraysize
+                        selected, signatures, connection_url, arraysize
                     ),
                     dlt_pipeline=dlt_pipeline,
                     dagster_dlt_translator=translator,

--- a/src/teamster/libraries/dlt/powerschool/sensors.py
+++ b/src/teamster/libraries/dlt/powerschool/sensors.py
@@ -1,6 +1,8 @@
 import sqlalchemy as sa
 from dagster import (
+    DagsterInstance,
     DagsterRunStatus,
+    RunRecord,
     RunRequest,
     RunsFilter,
     SensorDefinition,
@@ -30,7 +32,9 @@ _IN_FLIGHT_STATUSES = [
 ]
 
 
-def _in_flight_run(instance, sensor_name: str, nightly_schedule_name: str):
+def _in_flight_run(
+    instance: DagsterInstance, sensor_name: str, nightly_schedule_name: str
+) -> RunRecord | None:
     """Return the first in-flight run launched by this sensor or the nightly
     schedule, or None.
 
@@ -122,8 +126,12 @@ def build_powerschool_dlt_intraday_sensor(
             try:
                 dlt_pipeline.sync_destination()
             except Exception as e:
-                context.log.info(
-                    f"dlt sync_destination failed ({e}); treating all tables as changed"
+                # Expected only on the first tick / a brand-new dataset. A
+                # persistent failure here (bad perms, wrong dataset) would
+                # full-reload every table every tick, so surface it at warning.
+                context.log.warning(
+                    f"dlt sync_destination failed ({e}); treating all tables as "
+                    "changed (expected only on first run / new dataset)"
                 )
 
             stored = _stored_signatures(dlt_pipeline, _SOURCE_NAME)

--- a/src/teamster/libraries/dlt/powerschool/sensors.py
+++ b/src/teamster/libraries/dlt/powerschool/sensors.py
@@ -30,6 +30,29 @@ _IN_FLIGHT_STATUSES = [
 ]
 
 
+def _in_flight_run(instance, sensor_name: str, nightly_schedule_name: str):
+    """Return the first in-flight run launched by this sensor or the nightly
+    schedule, or None.
+
+    The intraday baseline advances only on load success, so while a run
+    launched by either trigger is still committing, re-selecting its tables
+    would double-launch. Checked over the non-terminal status set
+    (``_IN_FLIGHT_STATUSES``) against the auto-applied ``dagster/sensor_name``
+    and ``dagster/schedule_name`` run tags.
+    """
+    for tag, value in (
+        ("dagster/sensor_name", sensor_name),
+        ("dagster/schedule_name", nightly_schedule_name),
+    ):
+        records = instance.get_run_records(
+            filters=RunsFilter(tags={tag: value}, statuses=_IN_FLIGHT_STATUSES),
+            limit=1,
+        )
+        if records:
+            return records[0]
+    return None
+
+
 def _build_run_request(
     code_location: str,
     changed: list[PowerSchoolTable],
@@ -85,18 +108,9 @@ def build_powerschool_dlt_intraday_sensor(
         ssh_powerschool: SSHResource,
         db_powerschool: OracleResource,
     ) -> RunRequest | SkipReason:
-        for tag, value in (
-            ("dagster/sensor_name", sensor_name),
-            ("dagster/schedule_name", nightly_schedule_name),
-        ):
-            records = context.instance.get_run_records(
-                filters=RunsFilter(tags={tag: value}, statuses=_IN_FLIGHT_STATUSES),
-                limit=1,
-            )
-            if records:
-                return SkipReason(
-                    f"run {records[0].dagster_run.run_id} in flight ({value})"
-                )
+        in_flight = _in_flight_run(context.instance, sensor_name, nightly_schedule_name)
+        if in_flight is not None:
+            return SkipReason(f"run {in_flight.dagster_run.run_id} in flight")
 
         dlt_pipeline = build_powerschool_dlt_pipeline(code_location)
 

--- a/src/teamster/libraries/dlt/powerschool/sensors.py
+++ b/src/teamster/libraries/dlt/powerschool/sensors.py
@@ -1,0 +1,142 @@
+import sqlalchemy as sa
+from dagster import (
+    DagsterRunStatus,
+    RunRequest,
+    RunsFilter,
+    SensorDefinition,
+    SensorEvaluationContext,
+    SkipReason,
+    sensor,
+)
+
+from teamster.libraries.dlt.powerschool.assets import (
+    _SOURCE_NAME,
+    PowerSchoolTable,
+    _asset_key,
+    _compute_changed,
+    _stored_signatures,
+    build_powerschool_dlt_pipeline,
+    probe_signature,
+)
+from teamster.libraries.dlt.powerschool.resources import OracleResource
+from teamster.libraries.ssh.resources import SSHResource
+
+_IN_FLIGHT_STATUSES = [
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
+]
+
+
+def _build_run_request(
+    code_location: str,
+    changed: list[PowerSchoolTable],
+    current: dict[str, dict],
+) -> RunRequest:
+    """RunRequest for the changed tables, passing their probed signatures.
+
+    The probe payload rides run config (the op's PowerSchoolDltConfig.probe
+    field): the op loads exactly this selection and persists these signatures
+    with the load — no re-probe, no gate.
+    """
+    return RunRequest(
+        asset_selection=[_asset_key(code_location, table.name) for table in changed],
+        run_config={
+            "ops": {
+                f"{code_location}__powerschool": {
+                    "config": {
+                        "probe": {table.name: current[table.name] for table in changed}
+                    }
+                }
+            }
+        },
+        tags={"dagster/max_runtime": "3600"},
+    )
+
+
+def build_powerschool_dlt_intraday_sensor(
+    code_location: str,
+    tables: list[PowerSchoolTable],
+    nightly_schedule_name: str,
+    minimum_interval_seconds: int = 900,
+) -> SensorDefinition:
+    """Build the intraday change-detection sensor for one district.
+
+    Each tick opens the SSH tunnel, probes every intraday table (COUNT(*) +
+    MAX(cursor); count-only for no-cursor tables), compares against the
+    baseline stored in dlt resource state, and requests a run for only the
+    changed tables — unchanged tables are never planned, and an idle tick
+    launches nothing. Skips while a run launched by this sensor or by the
+    nightly full-refresh schedule is in flight (the baseline advances only on
+    load success, so an in-flight table would re-select and double-launch).
+    See docs/superpowers/specs/2026-07-20-powerschool-dlt-intraday-sensor-design.md.
+    """
+    sensor_name = f"{code_location}__powerschool__dlt__intraday_sensor"
+
+    @sensor(
+        name=sensor_name,
+        minimum_interval_seconds=minimum_interval_seconds,
+        asset_selection=[_asset_key(code_location, table.name) for table in tables],
+    )
+    def _sensor(
+        context: SensorEvaluationContext,
+        ssh_powerschool: SSHResource,
+        db_powerschool: OracleResource,
+    ) -> RunRequest | SkipReason:
+        for tag, value in (
+            ("dagster/sensor_name", sensor_name),
+            ("dagster/schedule_name", nightly_schedule_name),
+        ):
+            records = context.instance.get_run_records(
+                filters=RunsFilter(tags={tag: value}, statuses=_IN_FLIGHT_STATUSES),
+                limit=1,
+            )
+            if records:
+                return SkipReason(
+                    f"run {records[0].dagster_run.run_id} in flight ({value})"
+                )
+
+        dlt_pipeline = build_powerschool_dlt_pipeline(code_location)
+
+        with ssh_powerschool.open_ssh_tunnel():
+            connection_url = db_powerschool.connection_url()
+
+            # Restore prior signatures from the destination state table. On a
+            # truly first run (no dataset) this raises; treat as no prior state.
+            try:
+                dlt_pipeline.sync_destination()
+            except Exception as e:
+                context.log.info(
+                    f"dlt sync_destination failed ({e}); treating all tables as changed"
+                )
+
+            stored = _stored_signatures(dlt_pipeline, _SOURCE_NAME)
+
+            # One shared engine over the single tunnel, like the op's probe.
+            engine = sa.create_engine(connection_url)
+            try:
+                with engine.connect() as connection:
+                    current: dict[str, dict] = {
+                        table.name: probe_signature(
+                            connection, table.name, table.cursor_column
+                        )
+                        for table in tables
+                    }
+            finally:
+                engine.dispose()
+
+        changed = _compute_changed(tables, current, stored)
+
+        context.log.info(
+            f"powerschool probe: {len(changed)}/{len(tables)} changed; "
+            f"changed={sorted(table.name for table in changed)}"
+        )
+
+        if not changed:
+            return SkipReason(f"no change across {len(tables)} probed tables")
+
+        return _build_run_request(code_location, changed, current)
+
+    return _sensor

--- a/tests/assets/test_powerschool_dlt_paterson_defs.py
+++ b/tests/assets/test_powerschool_dlt_paterson_defs.py
@@ -15,35 +15,36 @@ def test_paterson_powerschool_dlt_asset_keys():
 
     keys = {key for a in assets.assets for key in a.keys}
     assert keys == {
-        AssetKey(["kipppaterson", "powerschool", a["table_name"]])
+        AssetKey(["kipppaterson", "powerschool", "sis", a["table_name"]])
         for a in config["assets"]
     }
 
 
-def test_paterson_powerschool_dlt_schedules():
+def test_paterson_powerschool_dlt_triggers():
     from teamster.code_locations.kipppaterson.powerschool.sis.dlt import (
         schedules,
+        sensors,
     )
 
     by_name = {s.name: s for s in schedules.schedules}
 
-    intraday = by_name["kipppaterson__powerschool__dlt__intraday_asset_job_schedule"]
     nightly = by_name["kipppaterson__powerschool__dlt__nightly_asset_job_schedule"]
 
-    assert isinstance(intraday, ScheduleDefinition)
-    assert intraday.cron_schedule == "*/15 * * * *"
+    assert isinstance(nightly, ScheduleDefinition)
     assert nightly.cron_schedule == "0 2 * * *"
+    assert len(schedules.schedules) == 1  # intraday schedule replaced by sensor
+
+    (sensor_def,) = sensors.sensors
+    assert sensor_def.name == "kipppaterson__powerschool__dlt__intraday_sensor"
 
 
-def test_paterson_powerschool_dlt_schedules_cover_every_table_exactly_once():
-    """Every configured table is scheduled in exactly one of the two tiers.
+def test_paterson_powerschool_dlt_triggers_cover_every_table():
+    """Every configured table belongs to at least one trigger.
 
-    `_tier_targets()` filters by exact-match `schedule_tier` — a misspelled
-    tier would silently drop a table from BOTH schedules, and since the dlt
-    assets carry no automation condition, it would never materialize (a
-    silent data gap). This asserts the union of the two schedules' resolved
-    asset selections equals the full configured asset-key set, with no
-    drops and no duplicates.
+    A table with both membership flags false would silently never
+    materialize (the dlt assets carry no automation condition). The overlap
+    between tiers must be exactly the no-cursor set: count-gated intraday,
+    authoritative overnight.
     """
     import yaml
 
@@ -55,14 +56,19 @@ def test_paterson_powerschool_dlt_schedules_cover_every_table_exactly_once():
     )
 
     config = yaml.safe_load(config_file.read_text())
-    expected = {f"kipppaterson/powerschool/{a['table_name']}" for a in config["assets"]}
 
-    # Resolve targets through the real scheduling function — the exact code a
-    # typo'd tier would silently route around.
-    intraday = schedules_module._tier_targets("intraday")
-    nightly = schedules_module._tier_targets("nightly")
+    def key(name):
+        return f"kipppaterson/powerschool/sis/{name}"
 
-    # No table dropped...
-    assert set(intraday) | set(nightly) == expected
-    # ...and no table scheduled in more than one tier.
-    assert len(intraday) + len(nightly) == len(expected)
+    expected = {key(a["table_name"]) for a in config["assets"]}
+    intraday = {key(a["table_name"]) for a in config["assets"] if a["intraday"]}
+    no_cursor = {
+        key(a["table_name"]) for a in config["assets"] if a["cursor_column"] is None
+    }
+
+    # Resolve nightly targets through the real scheduling function — the exact
+    # code an orphaned membership would route around.
+    nightly = set(schedules_module._nightly_targets())
+
+    assert intraday | nightly == expected
+    assert intraday & nightly == no_cursor

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -358,3 +358,69 @@ def test_stored_signatures_first_run_empty_state():
     stored = _stored_signatures(pipeline, "powerschool")
 
     assert stored == {}
+
+
+def _resolved_probe_job(tables):
+    from dagster import Definitions, define_asset_job
+    from dagster_dlt import DagsterDltResource
+
+    from teamster.libraries.dlt.powerschool.resources import OracleResource
+    from teamster.libraries.ssh.resources import SSHResource
+
+    assets_def = build_powerschool_dlt_assets(
+        code_location="kipppaterson", tables=tables
+    )
+    defs = Definitions(
+        assets=[assets_def],
+        jobs=[define_asset_job("probe_job", selection=list(assets_def.keys))],
+        resources={
+            "dlt": DagsterDltResource(),
+            "ssh_powerschool": SSHResource(remote_host="localhost"),
+            "db_powerschool": OracleResource(
+                user="u", password="p", host="localhost", port="1521", service_name="s"
+            ),
+        },
+    )
+    return defs.resolve_job_def("probe_job")
+
+
+def test_run_config_schema_accepts_probe_payload():
+    job = _resolved_probe_job(
+        [
+            PowerSchoolTable(name="students", cursor_column="transaction_date"),
+            PowerSchoolTable(name="gen", cursor_column=None),
+        ]
+    )
+
+    from dagster import validate_run_config
+
+    validated = validate_run_config(
+        job,
+        {
+            "ops": {
+                "kipppaterson__powerschool": {
+                    "config": {
+                        "probe": {
+                            "students": {
+                                "count": 43,
+                                "max_cursor": "2026-07-16T00:00:00",
+                            },
+                            "gen": {"count": 10, "max_cursor": None},
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    assert validated
+
+
+def test_run_config_schema_accepts_empty_full_refresh():
+    job = _resolved_probe_job(
+        [PowerSchoolTable(name="students", cursor_column="transaction_date")]
+    )
+
+    from dagster import validate_run_config
+
+    assert validate_run_config(job, {})

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -238,13 +238,34 @@ def test_tier_targets_sis_keys_and_counts():
     assert "kipppaterson/powerschool/sis/teachercategory" in nightly
 
 
-def test_compute_changed_no_cursor_table_always_included():
-    # No-cursor tables are always reloaded when selected, regardless of
-    # whatever current/stored signatures happen to hold (there's nothing to
-    # compare — signature is never probed or persisted for these tables).
-    table = PowerSchoolTable(name="test", cursor_column=None)
+def test_compute_changed_no_cursor_count_drift_included():
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    current = {"gen": {"count": 43, "max_cursor": None}}
+    stored = {"gen": {"count": 42, "max_cursor": None}}
 
-    changed = _compute_changed([table], current={}, stored={})
+    changed = _compute_changed([table], current, stored)
+
+    assert changed == [table]
+
+
+def test_compute_changed_no_cursor_stable_count_excluded():
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    signature = {"count": 42, "max_cursor": None}
+    current = {"gen": dict(signature)}
+    stored = {"gen": dict(signature)}
+
+    changed = _compute_changed([table], current, stored)
+
+    assert changed == []
+
+
+def test_compute_changed_no_stored_baseline_included():
+    # Bootstrap: a table new to intraday (or first tick ever) has no stored
+    # signature and must load once to establish one.
+    table = PowerSchoolTable(name="gen", cursor_column=None)
+    current = {"gen": {"count": 42, "max_cursor": None}}
+
+    changed = _compute_changed([table], current, stored={})
 
     assert changed == [table]
 
@@ -293,10 +314,12 @@ def test_compute_changed_mixed_set_order_preserved():
 
     unchanged_signature = {"count": 5, "max_cursor": "2026-07-14T00:00:00"}
     current = {
+        "test": {"count": 9, "max_cursor": None},
         "students": {"count": 43, "max_cursor": "2026-07-16T00:00:00"},
         "users": dict(unchanged_signature),
     }
     stored = {
+        "test": {"count": 8, "max_cursor": None},
         "students": {"count": 42, "max_cursor": "2026-07-15T00:00:00"},
         "users": dict(unchanged_signature),
     }

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -166,7 +166,7 @@ NIGHTLY_NO_CURSOR = {
 }
 
 
-def test_config_matches_spec_cursor_map():
+def test_config_matches_spec_membership_map():
     entries = yaml.safe_load(CONFIG.read_text())["assets"]
     by_name = {e["table_name"]: e for e in entries}
 
@@ -176,40 +176,48 @@ def test_config_matches_spec_cursor_map():
         assert by_name[name] == {
             "table_name": name,
             "cursor_column": "transaction_date",
-            "schedule_tier": "intraday",
+            "intraday": True,
+            "nightly": False,
         }
     for name in INTRADAY_WHENMODIFIED:
         assert by_name[name] == {
             "table_name": name,
             "cursor_column": "whenmodified",
-            "schedule_tier": "intraday",
+            "intraday": True,
+            "nightly": False,
         }
     for name in NIGHTLY_WHENMODIFIED:
         assert by_name[name] == {
             "table_name": name,
             "cursor_column": "whenmodified",
-            "schedule_tier": "nightly",
+            "intraday": False,
+            "nightly": True,
         }
     for name in NIGHTLY_NO_CURSOR:
         assert by_name[name] == {
             "table_name": name,
             "cursor_column": None,
-            "schedule_tier": "nightly",
+            "intraday": True,
+            "nightly": True,
         }
 
 
-def test_schedules_subset_by_tier():
-    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
-        powerschool_dlt_intraday_asset_job_schedule as intraday,
-    )
+def test_nightly_schedule_and_intraday_sensor():
     from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
         powerschool_dlt_nightly_asset_job_schedule as nightly,
     )
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
+        schedules,
+    )
+    from teamster.code_locations.kipppaterson.powerschool.sis.dlt.sensors import (
+        sensors,
+    )
 
-    assert intraday.cron_schedule == "*/15 * * * *"
+    assert schedules == [nightly]
     assert nightly.cron_schedule == "0 2 * * *"
-    assert intraday.tags == {"dagster/max_runtime": "3600"}
     assert nightly.tags == {"dagster/max_runtime": "3600"}
+    assert sensors[0].name == "kipppaterson__powerschool__dlt__intraday_sensor"
+    assert sensors[0].minimum_interval_seconds == 900
 
 
 def test_assets_module_exposes_single_def():
@@ -221,21 +229,18 @@ def test_assets_module_exposes_single_def():
     assert len(list(assets[0].keys)) == 48
 
 
-def test_tier_targets_sis_keys_and_counts():
+def test_nightly_targets_sis_keys_and_counts():
     from teamster.code_locations.kipppaterson.powerschool.sis.dlt.schedules import (
-        _tier_targets,
+        _nightly_targets,
     )
 
-    intraday = _tier_targets("intraday")
-    nightly = _tier_targets("nightly")
+    nightly = _nightly_targets()
 
-    assert len(intraday) == 23
     assert len(nightly) == 25
-    assert all(
-        t.startswith("kipppaterson/powerschool/sis/") for t in intraday + nightly
-    )
-    assert "kipppaterson/powerschool/sis/students" in intraday
+    assert all(t.startswith("kipppaterson/powerschool/sis/") for t in nightly)
     assert "kipppaterson/powerschool/sis/teachercategory" in nightly
+    assert "kipppaterson/powerschool/sis/test" in nightly
+    assert "kipppaterson/powerschool/sis/students" not in nightly
 
 
 def test_compute_changed_no_cursor_count_drift_included():

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -62,6 +62,19 @@ def test_probe_signature_non_datetime_cursor_stringified():
     assert sig == {"count": 7, "max_cursor": "12345"}
 
 
+def test_probe_signature_no_cursor_count_only():
+    # No-cursor tables are count-gated: COUNT(*) only, and the signature keeps
+    # the max_cursor key (None) so it compares equal to the run-config
+    # round-trip shape.
+    conn = FakeConnection((42,))
+
+    sig = probe_signature(conn, "gen", None)
+
+    assert sig == {"count": 42, "max_cursor": None}
+    assert "COUNT(*)" in conn.queries[0]
+    assert "MAX(" not in conn.queries[0]
+
+
 def test_powerschool_table_dataclass():
     t = PowerSchoolTable(name="students", cursor_column="transaction_date")
     n = PowerSchoolTable(name="test", cursor_column=None)

--- a/tests/libraries/test_dlt_powerschool_sensors.py
+++ b/tests/libraries/test_dlt_powerschool_sensors.py
@@ -1,8 +1,12 @@
 """Unit tests for the PowerSchool dlt intraday sensor factory (no external deps)."""
 
+import types
+
 from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
 from teamster.libraries.dlt.powerschool.sensors import (
+    _IN_FLIGHT_STATUSES,
     _build_run_request,
+    _in_flight_run,
     build_powerschool_dlt_intraday_sensor,
 )
 
@@ -56,3 +60,56 @@ def test_build_run_request_selects_changed_and_passes_signatures():
         }
     }
     assert run_request.tags["dagster/max_runtime"] == "3600"
+
+
+class _FakeInstance:
+    """Minimal stand-in for DagsterInstance.get_run_records for the in-flight
+    guard test: returns canned records keyed by the single tag value in the
+    filter, and records each query's tag value + status set."""
+
+    def __init__(self, records_by_value):
+        self._by_value = records_by_value
+        self.queried_values = []
+        self.seen_statuses = None
+
+    def get_run_records(self, filters, limit):
+        (value,) = filters.tags.values()
+        self.queried_values.append(value)
+        self.seen_statuses = filters.statuses
+        return self._by_value.get(value, [])
+
+
+def _fake_record(run_id):
+    return types.SimpleNamespace(dagster_run=types.SimpleNamespace(run_id=run_id))
+
+
+def test_in_flight_run_returns_sensor_run_and_checks_status_set():
+    rec = _fake_record("sensor-run")
+    instance = _FakeInstance({"the_sensor": [rec]})
+
+    result = _in_flight_run(instance, "the_sensor", "the_nightly_schedule")
+
+    assert result is rec
+    # short-circuits on the sensor tag before querying the schedule tag
+    assert instance.queried_values == ["the_sensor"]
+    assert instance.seen_statuses == _IN_FLIGHT_STATUSES
+
+
+def test_in_flight_run_returns_schedule_run_when_only_schedule_live():
+    rec = _fake_record("nightly-run")
+    instance = _FakeInstance({"the_nightly_schedule": [rec]})
+
+    result = _in_flight_run(instance, "the_sensor", "the_nightly_schedule")
+
+    assert result is rec
+    # sensor tag queried first (empty), then the schedule tag
+    assert instance.queried_values == ["the_sensor", "the_nightly_schedule"]
+
+
+def test_in_flight_run_none_when_neither_live():
+    instance = _FakeInstance({})
+
+    result = _in_flight_run(instance, "the_sensor", "the_nightly_schedule")
+
+    assert result is None
+    assert instance.queried_values == ["the_sensor", "the_nightly_schedule"]

--- a/tests/libraries/test_dlt_powerschool_sensors.py
+++ b/tests/libraries/test_dlt_powerschool_sensors.py
@@ -35,6 +35,7 @@ def test_build_run_request_selects_changed_and_passes_signatures():
 
     run_request = _build_run_request("kipppaterson", changed, current)
 
+    # trunk-ignore(pyright): asset_selection is always set in our RunRequests
     assert [k.to_user_string() for k in run_request.asset_selection] == [
         "kipppaterson/powerschool/sis/students",
         "kipppaterson/powerschool/sis/gen",

--- a/tests/libraries/test_dlt_powerschool_sensors.py
+++ b/tests/libraries/test_dlt_powerschool_sensors.py
@@ -1,0 +1,57 @@
+"""Unit tests for the PowerSchool dlt intraday sensor factory (no external deps)."""
+
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+from teamster.libraries.dlt.powerschool.sensors import (
+    _build_run_request,
+    build_powerschool_dlt_intraday_sensor,
+)
+
+
+def test_sensor_factory_shape():
+    sensor_def = build_powerschool_dlt_intraday_sensor(
+        code_location="kipppaterson",
+        tables=[PowerSchoolTable(name="students", cursor_column="transaction_date")],
+        nightly_schedule_name=(
+            "kipppaterson__powerschool__dlt__nightly_asset_job_schedule"
+        ),
+    )
+
+    assert sensor_def.name == "kipppaterson__powerschool__dlt__intraday_sensor"
+    assert sensor_def.minimum_interval_seconds == 900
+    assert sensor_def.required_resource_keys == {"ssh_powerschool", "db_powerschool"}
+
+
+def test_build_run_request_selects_changed_and_passes_signatures():
+    changed = [
+        PowerSchoolTable(name="students", cursor_column="transaction_date"),
+        PowerSchoolTable(name="gen", cursor_column=None),
+    ]
+    current = {
+        "students": {"count": 43, "max_cursor": "2026-07-16T00:00:00"},
+        "gen": {"count": 10, "max_cursor": None},
+        # unchanged table present in the probe but not in `changed`:
+        "users": {"count": 1, "max_cursor": "2026-07-01T00:00:00"},
+    }
+
+    run_request = _build_run_request("kipppaterson", changed, current)
+
+    assert [k.to_user_string() for k in run_request.asset_selection] == [
+        "kipppaterson/powerschool/sis/students",
+        "kipppaterson/powerschool/sis/gen",
+    ]
+    assert run_request.run_config == {
+        "ops": {
+            "kipppaterson__powerschool": {
+                "config": {
+                    "probe": {
+                        "students": {
+                            "count": 43,
+                            "max_cursor": "2026-07-16T00:00:00",
+                        },
+                        "gen": {"count": 10, "max_cursor": None},
+                    }
+                }
+            }
+        }
+    }
+    assert run_request.tags["dagster/max_runtime"] == "3600"


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

Closes #4453.

When merged, this pull request replaces the PowerSchool dlt **intraday `ScheduleDefinition`** with a change-detection **sensor** in all three dlt districts (`kippnewark`, `kippcamden`, `kipppaterson`), so unchanged tables are never planned and idle ticks launch nothing.

**Why:** the intraday schedule fixed each run's asset selection *before* change detection ran; the op then probed and loaded only the changed tables, leaving unchanged tables **planned but never materialized** every tick. On an externally-killed run those planned-but-unmaterialized assets flip to `FAILED` and the asset shows a DEGRADED badge that only a real materialization clears (e.g. run `4894b6ca` left `kippnewark/powerschool/sis/attendance` stuck DEGRADED). At `*/15` that is 96 runs/day, most loading nothing.

**What changed:**

- **Change detection moved into a sensor** (`libraries/dlt/powerschool/sensors.py`, `build_powerschool_dlt_intraday_sensor`): each tick probes every intraday table (`COUNT(*)` + `MAX(cursor)`, count-only for no-cursor tables), compares against the dlt-state baseline, and requests a run for **only** the changed tables — or emits a `SkipReason`. Skips while a run launched by the sensor or the nightly schedule is in flight.
- **Two-mode op** (`libraries/dlt/powerschool/assets.py`): `probe` present (sensor) loads exactly the run's selection with the passed signatures, no re-probe/gate; `probe` absent (nightly / manual) probes the whole selection first, then full-refreshes and re-baselines. Signatures persist only from the extracted resource, so a failed load keeps the old baseline and the table re-selects next tick (self-healing preserved).
- **No-cursor tables gain intraday freshness**: gated on `COUNT(*)` drift intraday, with the nightly full-refresh as the authoritative sweep for in-place edits count cannot see.
- **Config**: each `config/assets.yaml` moves from a `schedule_tier` enum to `intraday`/`nightly` membership booleans (a table can be in both).
- Docs (district + dlt library `CLAUDE.md`) updated.

**AI assistance:** AI-authored end-to-end under human direction (Claude Code, subagent-driven execution of an approved spec + plan). Design decisions (all-district scope, probe-before-load re-baseline, config schema) were human-approved; each task was independently spec- and quality-reviewed, plus a final whole-branch review.

### Post-merge follow-ups (require prod / full environment)

1. **Start each sensor** (`{loc}__powerschool__dlt__intraday_sensor`) — repo sensors carry no `default_status`, so they deploy stopped; the nightly schedule covers freshness until started. First tick per district bootstrap-loads all no-cursor tables once (no baseline yet).
1. **Regenerate `docs/reference/automations.md`** in a full environment (the codespace cannot import all locations). It is already stale pre-PR.
1. **`kipppaterson`**: the one-time migration-era `DROP SCHEMA ... CASCADE` cutover still applies.
1. The dlt dataset is **not** branch-isolated — validate on the branch deployment via probe/tick logs, not a real load.
1. Nightly is now an **unconditional** full-refresh of its targets — expected per spec; heads-up to Ops on nightly runtime/cost.

## Self-review

### Dagster

- [x] Full `definitions` module import verified for all three districts (`kippnewark`, `kippcamden`, `kipppaterson`) — the intraday sensor is wired and the old intraday schedule is absent.
- [x] `uv run pytest` — 30/30 affected tests pass (`tests/libraries/test_dlt_powerschool_assets.py`, `test_dlt_powerschool_sensors.py`, `test_powerschool_dlt_extract_workers.py`, `tests/assets/test_powerschool_dlt_paterson_defs.py`, which also fixes two pre-existing paterson asset-key failures).

### Docs

- [ ] `docs/reference/automations.md` regeneration deferred to a full environment (see post-merge follow-up 2).
- [x] District `CLAUDE.md` files updated (PowerSchool trigger + config).

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — no dbt changes; passes or not triggered.
- [ ] **Dagster Cloud** — branch deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)