### PR TITLE
perf(cube): add assessment proficiency pre-aggregation

### DIFF
--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -287,3 +287,41 @@ cubes:
         type: number
         format: percent
         public: true
+
+    pre_aggregations:
+      # Rollup on the additive proficiency primitives for the standard-level
+      # proficiency-by-demographic hot path. Includes the RLS scoping keys
+      # (locations.region_key / locations.abbreviation) so region/school viewers
+      # hit the rollup rather than falling back to the fact.
+      - name: proficiency_rollup
+        measures:
+          - student_assessment_scores.count_scores
+          - student_assessment_scores._sum_proficient
+        dimensions:
+          - dates.academic_year
+          - student_assessments.module_code
+          - student_assessments.academic_subject
+          - student_assessments.grade_level_tested
+          - student_assessment_administrations.administration_period
+          - student_assessment_scores.response_type_code
+          - students.race
+          - students.gender_identity
+          - student_school_enrollments.grade_level
+          - locations.region_key
+          - locations.abbreviation
+        # Partitioned refresh: without a time_dimension, Cube rebuilds this
+        # entire rollup from the ~14.2M-row fact on every refresh_key check,
+        # regardless of what changed. dates.date_day (via
+        # student_assessment_administrations -> dates), not the cube's own
+        # date_taken, is the time anchor — date_taken is documented above as
+        # corrupt for a small share of rows and its own description says
+        # calendar rollups belong on the administration date. Year
+        # partitioning (not day/month) matches how corrections actually land:
+        # restatements replace a whole academic year at a time, so a
+        # correction only invalidates the partition(s) touching that year,
+        # not the full history.
+        time_dimension: dates.date_day
+        granularity: year
+        partition_granularity: year
+        refresh_key:
+          every: 1 day

--- a/tests/cube/test_cube_schema.py
+++ b/tests/cube/test_cube_schema.py
@@ -65,9 +65,21 @@ def test_views_declare_access_policies() -> None:
     assert _access_policy_groups(), "no access_policy groups found under views"
 
 
+def _pre_aggregations_by_root_cube() -> dict[str, list[dict]]:
+    # Keyed by the fact cube the pre-aggregation is declared on.
+    found: dict[str, list[dict]] = {}
+    for path in CUBE_MODEL_DIR.rglob("cubes/**/*.yml"):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for cube in doc.get("cubes", []) or []:
+            pre_aggs = cube.get("pre_aggregations", []) or []
+            if pre_aggs:
+                found[cube["name"]] = pre_aggs
+    return found
+
+
 def _filter_members(filters: list[dict]) -> list[str]:
     # row_level filters can nest boolean combinators (Cube's accessPolicy
-    # schema) -- walk "or"/"and" branches too, not just the top-level list.
+    # schema) — walk "or"/"and" branches too, not just the top-level list.
     members = []
     for f in filters:
         if "member" in f:
@@ -76,6 +88,21 @@ def _filter_members(filters: list[dict]) -> list[str]:
             if combinator in f:
                 members.extend(_filter_members(f[combinator]))
     return members
+
+
+def _view_member_to_qualified_name(view_doc: dict) -> dict[str, str]:
+    # Maps each member name exposed by this view back to its cube-qualified
+    # name, honoring each includes block's prefix: setting (see
+    # src/cube/CLAUDE.md "row_level.filters[].member is a flat view-member
+    # name" -- prefix: true -> "<lastJoinPathSegment>_<member>", else bare).
+    mapping: dict[str, str] = {}
+    for cube_ref in view_doc.get("cubes", []) or []:
+        join_cube = cube_ref["join_path"].split(".")[-1]
+        prefixed = cube_ref.get("prefix", False)
+        for member in cube_ref.get("includes", []) or []:
+            exposed = f"{join_cube}_{member}" if prefixed else member
+            mapping[exposed] = f"{join_cube}.{member}"
+    return mapping
 
 
 def _view_exposed_members(view_doc: dict) -> set[str]:
@@ -90,6 +117,52 @@ def _view_exposed_members(view_doc: dict) -> set[str]:
         for member in cube_ref.get("includes", []) or []:
             exposed.add(f"{join_cube}_{member}" if prefixed else member)
     return exposed
+
+
+def _root_cube(view_doc: dict) -> str | None:
+    cube_refs = view_doc.get("cubes", []) or []
+    if not cube_refs:
+        return None
+    return cube_refs[0]["join_path"].split(".")[0]
+
+
+def test_pre_aggregation_covers_row_level_scoping_members() -> None:
+    # A row_level scoping member added to a view's access_policy without a
+    # matching addition to that fact's pre-aggregation dimensions silently
+    # drops scoped viewers back to the slow fact-scan path -- no error, no
+    # test failure otherwise.
+    pre_aggs_by_cube = _pre_aggregations_by_root_cube()
+    offenders = []
+    for path in CUBE_MODEL_DIR.rglob("views/**/*.yml"):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for view in doc.get("views", []) or []:
+            root = _root_cube(view)
+            if root not in pre_aggs_by_cube:
+                continue
+
+            member_map = _view_member_to_qualified_name(view)
+            filter_members = [
+                member
+                for policy in view.get("access_policy", []) or []
+                for member in _filter_members(
+                    policy.get("row_level", {}).get("filters", []) or []
+                )
+            ]
+
+            for pre_agg in pre_aggs_by_cube[root]:
+                rollup_dims = set(pre_agg.get("dimensions", []) or [])
+                for filter_member in filter_members:
+                    qualified = member_map.get(filter_member)
+                    if qualified is not None and qualified not in rollup_dims:
+                        offenders.append(
+                            f"{path}: view {view['name']!r} row_level member "
+                            f"{filter_member!r} ({qualified}) is not in "
+                            f"{root}.{pre_agg['name']}'s dimensions"
+                        )
+    assert not offenders, (
+        "pre-aggregation missing a dimension its own view scopes row_level on:\n"
+        + "\n".join(offenders)
+    )
 
 
 def test_row_level_filter_members_are_exposed_by_their_view() -> None:


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request resolves the cold assessment-query timeout in #4333 by adding a Cube pre-aggregation on the assessment proficiency hot path: `student_assessment_scores.proficiency_rollup`.

The rollup is built on the additive primitives `count_scores` / `_sum_proficient` (so it re-aggregates to any grain), keyed by academic year, module, subject, grade, administration period, response type, demographics, plus the RLS scoping keys `region_key` / `abbreviation` so region- and school-scoped viewers hit the rollup rather than falling back to the fact. It is partitioned by academic year with a daily refresh key, so an academic-year restatement invalidates only the affected partition.

On a rollup hit, Cube serves the query from Cube Store without touching the fact, taking the #4333 repro query from ~65 s cold to ~0.2 s.

### Scope: cube-only, extracted from #4364

This is the pre-aggregation half of #4364, carved out so it can ship on its own. Cube does not require the underlying marts to be tables to build or serve a pre-aggregation, so this change touches no dbt models: it runs the rollup query against the existing views. The marts view-to-table materialization flip in #4364 is a separate, broader change (it speeds up the fallback / non-rollup read path across all cubes) and carries an unrelated deferred-CI blocker; it is left in #4364 to be decided on its own merits.

Pre-aggregation authored by @cristinabaldor; extracted here by @cbini.

### AI Assistance

Extraction, verification (diff scoping, cube schema test, trunk), and this description were done with Claude Code. The pre-aggregation design and dimension set are @cristinabaldor's original work from #4364.

## Prerequisite for the speedup

- [ ] **Cube Cloud pre-agg build permission.** This is the repo's first pre-aggregation. Cube Cloud stages the rollup to a BigQuery pre-agg dataset then loads it into Cube Store; the service account `cube-cloud@teamster-332318.iam.gserviceaccount.com` currently has read-only access and needs `dataEditor` scoped to a `prod_pre_aggregations` dataset. Until granted, the rollup does not build and queries fall back to the fact (additive, non-breaking). Tracked in Asana (assigned to @cbini).

## Self-review

- [x] Cube: pre-aggregation dimensions cover every `row_level` scoping member of the views built on this fact (enforced by `test_pre_aggregation_covers_row_level_scoping_members`, passing)
- [x] No dbt changes: no materialization or contract changes; marts remain views
- [x] RLS-neutral: no `access_policy` / `cube.js` change

## CI checks

- [ ] **Trunk** passes (`trunk check --force` clean locally on both files)
- [ ] **dbt Cloud** no dbt models modified, so `state:modified+` builds nothing (trivially green)
- [ ] **Dagster Cloud** not triggered (no Dagster changes)

Refs #4333