### PR TITLE
perf(cube): add assessment proficiency pre-aggregation (bounded build range)

### DIFF
--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -287,3 +287,55 @@ cubes:
         type: number
         format: percent
         public: true
+
+    pre_aggregations:
+      # Rollup on the additive proficiency primitives for the standard-level
+      # proficiency-by-demographic hot path. Includes the RLS scoping keys
+      # (locations.region_key / locations.abbreviation) so region/school viewers
+      # hit the rollup rather than falling back to the fact.
+      - name: proficiency_rollup
+        measures:
+          - student_assessment_scores.count_scores
+          - student_assessment_scores._sum_proficient
+        dimensions:
+          - dates.academic_year
+          - student_assessments.module_code
+          - student_assessments.academic_subject
+          - student_assessments.grade_level_tested
+          - student_assessment_administrations.administration_period
+          - student_assessment_scores.response_type_code
+          - students.race
+          - students.gender_identity
+          - student_school_enrollments.grade_level
+          - locations.region_key
+          - locations.abbreviation
+        # Partitioned refresh: without a time_dimension, Cube rebuilds this
+        # entire rollup from the ~14.2M-row fact on every refresh_key check,
+        # regardless of what changed. dates.date_day (via
+        # student_assessment_administrations -> dates), not the cube's own
+        # date_taken, is the time anchor — date_taken is documented above as
+        # corrupt for a small share of rows and its own description says
+        # calendar rollups belong on the administration date. Year
+        # partitioning (not day/month) matches how corrections actually land:
+        # restatements replace a whole academic year at a time, so a
+        # correction only invalidates the partition(s) touching that year,
+        # not the full history.
+        time_dimension: dates.date_day
+        granularity: year
+        partition_granularity: year
+        # Bound the build range to real assessment history. Without this, Cube
+        # derives the range from the time_dimension's min/max — and
+        # dates.date_day resolves through dim_dates, whose calendar spine runs
+        # to 9999, so the scheduled-refresh worker enumerates ~8,000 empty
+        # yearly partitions (this is why #4460 was reverted). Floor is set below
+        # the earliest administration date carrying a score (2015-08-14,
+        # verified against the fact 2026-07-20); the end tracks today. Yields
+        # ~12 partitions. ~2.9% of score rows have a null administration date
+        # and are not covered by this partitioned rollup — those queries fall
+        # back to the fact, which is correct.
+        build_range_start:
+          sql: SELECT DATE('2015-07-01')
+        build_range_end:
+          sql: SELECT CURRENT_DATE('America/New_York')
+        refresh_key:
+          every: 1 day

--- a/tests/cube/test_cube_schema.py
+++ b/tests/cube/test_cube_schema.py
@@ -65,9 +65,21 @@ def test_views_declare_access_policies() -> None:
     assert _access_policy_groups(), "no access_policy groups found under views"
 
 
+def _pre_aggregations_by_root_cube() -> dict[str, list[dict]]:
+    # Keyed by the fact cube the pre-aggregation is declared on.
+    found: dict[str, list[dict]] = {}
+    for path in CUBE_MODEL_DIR.rglob("cubes/**/*.yml"):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for cube in doc.get("cubes", []) or []:
+            pre_aggs = cube.get("pre_aggregations", []) or []
+            if pre_aggs:
+                found[cube["name"]] = pre_aggs
+    return found
+
+
 def _filter_members(filters: list[dict]) -> list[str]:
     # row_level filters can nest boolean combinators (Cube's accessPolicy
-    # schema) -- walk "or"/"and" branches too, not just the top-level list.
+    # schema) — walk "or"/"and" branches too, not just the top-level list.
     members = []
     for f in filters:
         if "member" in f:
@@ -76,6 +88,21 @@ def _filter_members(filters: list[dict]) -> list[str]:
             if combinator in f:
                 members.extend(_filter_members(f[combinator]))
     return members
+
+
+def _view_member_to_qualified_name(view_doc: dict) -> dict[str, str]:
+    # Maps each member name exposed by this view back to its cube-qualified
+    # name, honoring each includes block's prefix: setting (see
+    # src/cube/CLAUDE.md "row_level.filters[].member is a flat view-member
+    # name" -- prefix: true -> "<lastJoinPathSegment>_<member>", else bare).
+    mapping: dict[str, str] = {}
+    for cube_ref in view_doc.get("cubes", []) or []:
+        join_cube = cube_ref["join_path"].split(".")[-1]
+        prefixed = cube_ref.get("prefix", False)
+        for member in cube_ref.get("includes", []) or []:
+            exposed = f"{join_cube}_{member}" if prefixed else member
+            mapping[exposed] = f"{join_cube}.{member}"
+    return mapping
 
 
 def _view_exposed_members(view_doc: dict) -> set[str]:
@@ -90,6 +117,52 @@ def _view_exposed_members(view_doc: dict) -> set[str]:
         for member in cube_ref.get("includes", []) or []:
             exposed.add(f"{join_cube}_{member}" if prefixed else member)
     return exposed
+
+
+def _root_cube(view_doc: dict) -> str | None:
+    cube_refs = view_doc.get("cubes", []) or []
+    if not cube_refs:
+        return None
+    return cube_refs[0]["join_path"].split(".")[0]
+
+
+def test_pre_aggregation_covers_row_level_scoping_members() -> None:
+    # A row_level scoping member added to a view's access_policy without a
+    # matching addition to that fact's pre-aggregation dimensions silently
+    # drops scoped viewers back to the slow fact-scan path -- no error, no
+    # test failure otherwise.
+    pre_aggs_by_cube = _pre_aggregations_by_root_cube()
+    offenders = []
+    for path in CUBE_MODEL_DIR.rglob("views/**/*.yml"):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for view in doc.get("views", []) or []:
+            root = _root_cube(view)
+            if root not in pre_aggs_by_cube:
+                continue
+
+            member_map = _view_member_to_qualified_name(view)
+            filter_members = [
+                member
+                for policy in view.get("access_policy", []) or []
+                for member in _filter_members(
+                    policy.get("row_level", {}).get("filters", []) or []
+                )
+            ]
+
+            for pre_agg in pre_aggs_by_cube[root]:
+                rollup_dims = set(pre_agg.get("dimensions", []) or [])
+                for filter_member in filter_members:
+                    qualified = member_map.get(filter_member)
+                    if qualified is not None and qualified not in rollup_dims:
+                        offenders.append(
+                            f"{path}: view {view['name']!r} row_level member "
+                            f"{filter_member!r} ({qualified}) is not in "
+                            f"{root}.{pre_agg['name']}'s dimensions"
+                        )
+    assert not offenders, (
+        "pre-aggregation missing a dimension its own view scopes row_level on:\n"
+        + "\n".join(offenders)
+    )
 
 
 def test_row_level_filter_members_are_exposed_by_their_view() -> None:


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

Re-introduces the `student_assessment_scores.proficiency_rollup` pre-aggregation (reverted in #4462), this time with an explicit `build_range_start` / `build_range_end` so it can safely serve the #4333 assessment-proficiency hot path from Cube Store.

## What changed vs the reverted version (#4460)

Only the build range. #4460 shipped the rollup with no bound, so Cube derived the range from the `time_dimension` (`dates.date_day`) min/max — which resolves through `dim_dates`, whose calendar spine runs to 9999 — and the prod refresh worker began enumerating ~8,000 empty yearly partitions. This version pins:

```yaml
build_range_start:
  sql: SELECT DATE('2015-07-01')
build_range_end:
  sql: SELECT CURRENT_DATE('America/New_York')
```

The floor sits just below the earliest scored administration date (2015-08-14, verified against the fact on 2026-07-20); the end tracks today. Result: ~12 yearly partitions instead of ~8,000.

Coverage note: ~2.9% of score rows have a null administration date and fall outside this partitioned rollup. Those queries fall back to the fact, which is correct.

## DO NOT MERGE until validated on a branch staging environment

> [!WARNING]
> Merging auto-deploys to prod and triggers the prod refresh worker to build this rollup. Because the last attempt caused a prod runaway, validate the bound on a Cube Cloud branch staging deployment FIRST.

Pre-merge checklist:

- [x] Add this branch in Cube Cloud (Data Model, Dev Mode / branch staging) and let the pre-agg build.
- [ ] Confirm in BigQuery that the `cube-cloud` service account enumerates only ~12 yearly partitions (2015 through the current year), not thousands. (Query `INFORMATION_SCHEMA.JOBS_BY_PROJECT` for the build jobs.)
- [ ] Confirm the Cube Cloud `dataEditor` grant on the `prod_pre_aggregations` dataset is in place (it appeared to be, during the incident cleanup).
- [ ] Only then mark ready and merge.

## Incident context

- #4460 merged, prod redeployed, the unbounded rollup enumerated partitions across `dim_dates` (1999 to 9999).
- Reverted via #4462; prod rolled back and cleaned up. `main` is currently pre-agg-free.
- This PR is the corrected re-introduction.

Pre-aggregation design by @cristinabaldor; build-range bound added here.

## CI checks

- [ ] **Trunk** passes (`trunk check --force` clean locally on both files)
- [ ] **dbt Cloud** no dbt changes (cube + test only); `state:modified+` builds nothing
- [ ] **Dagster Cloud** not triggered

Refs #4333