### PR TITLE
perf(cube): extend proficiency rollup to cover IEP-by-standard cut

### DIFF
--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -300,15 +300,32 @@ cubes:
         dimensions:
           - dates.academic_year
           - student_assessments.module_code
+          # module_type is functionally determined by module_code above, so it
+          # adds no rollup rows; it lets queries filter by the coarser
+          # QA / MQQ / CRQ grouping.
+          - student_assessments.module_type
           - student_assessments.academic_subject
           - student_assessments.grade_level_tested
           - student_assessment_administrations.administration_period
           - student_assessment_scores.response_type_code
+          # response_type (overall / strand / standard) and its human-readable
+          # description are both functionally determined by response_type_code
+          # above (zero added rows). They serve standard-level cuts: filter
+          # response_type = 'standard' and break out by response_type_description
+          # (the IEP-vs-gen-ed-by-standard pilot pattern, WG 2026-07-02).
+          - student_assessment_scores.response_type
+          - student_assessment_scores.response_type_description
           - students.race
           - students.gender_identity
           - student_school_enrollments.grade_level
+          # is_iep is the one independent addition (binary, so at most 2x rows);
+          # it serves the IEP-vs-gen-ed disparity cut.
+          - student_enrollment_status.is_iep
           - locations.region_key
           - locations.abbreviation
+          # region_name is functionally determined by region_key above (zero
+          # added rows) — supports region-name filter phrasing (e.g. "Newark").
+          - regions.region_name
         # Partitioned refresh: without a time_dimension, Cube rebuilds this
         # entire rollup from the ~14.2M-row fact on every refresh_key check,
         # regardless of what changed. dates.date_day (via


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

Extends `student_assessment_scores.proficiency_rollup` so the working-group pilot's headline query — IEP vs gen-ed proficiency **by standard** (2026-07-02 session log) — resolves against the rollup instead of falling back to the fact view.

Today that query compiles to `FROM kipptaf_marts.fct_assessment_scores_enrollment_scoped` (verified via the `sql` API on 2026-07-20) because it slices/filters on members the rollup doesn't carry. This adds those five members:

| Member | Role in the pilot query | Cardinality cost |
| --- | --- | --- |
| `student_enrollment_status.is_iep` | breakout (IEP vs gen-ed) | independent, binary, at most 2x rows |
| `student_assessment_scores.response_type_description` | breakout (standard label) | determined by `response_type_code` (already in rollup) → ~0 |
| `student_assessment_scores.response_type` | filter `= 'standard'` | determined by `response_type_code` → ~0 |
| `student_assessments.module_type` | filter (QA / MQQ / CRQ) | determined by `module_code` (already in rollup) → ~0 |
| `regions.region_name` | filter phrasing ("Newark") | determined by `region_key` (already in rollup) → ~0 |

Four of the five are functionally determined by a dimension already in the rollup, so they add no rows. Only `is_iep` is independent, so the rollup grows by at most 2x and stays ~12 yearly partitions.

Adding dimensions does not break the existing demographic-proficiency coverage: the measures are additive, so queries using fewer dimensions still match the rollup by aggregating over the extras.

## DO NOT MERGE until validated on a branch staging deployment

> [!WARNING]
> Same gate as #4463. Merging auto-deploys to prod and rebuilds the rollup with the wider grain. Validate on a Cube Cloud branch staging deployment first.

Pre-merge checklist:

- [ ] Add this branch in Cube Cloud (Data Model, Dev Mode / branch staging) and let the rollup rebuild.
- [ ] Confirm in BigQuery that the `cube-cloud` service account still builds only ~12 yearly partitions (bounded), and the partition-table row count is within ~2x of the current rollup.
- [ ] Confirm via the `sql` API that the IEP-by-standard query now compiles to `FROM prod_pre_aggregations.student_assessment_scores_proficiency_rollup` (not the fact view).
- [ ] Only then mark ready and merge.

## Context

- Builds on the bounded rollup from #4463 (already on `main`).
- `~2.9%` of score rows have a null administration date and remain outside the partitioned rollup (fall back to the fact) — unchanged by this PR.
- Pre-aggregation design by @cristinabaldor; this dimension extension added here.

## CI checks

- [ ] **Trunk** passes (`trunk check --force` clean locally)
- [ ] **dbt Cloud** no dbt changes (cube only); `state:modified+` builds nothing
- [ ] **Dagster Cloud** not triggered

Refs #4333