### PR TITLE
fix(cube): pin resolveAccess BigQuery client to teamster-332318

### DIFF
--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -88,7 +88,21 @@ async function resolveAccess(email) {
 
   try {
     const { BigQuery } = require("@google-cloud/bigquery");
-    const bq = new BigQuery();
+    // Cube's data driver is configured via CUBEJS_DB_BQ_* and runs jobs in
+    // teamster-332318. This hand-rolled client inherits none of that: a bare
+    // `new BigQuery()` defaults to the Cube Cloud host project (cubejs-cloud),
+    // where this identity has no bigquery.jobs.create — so every identity read
+    // throws, resolveAccess fails closed, and the whole network is denied
+    // (#4466). Pin the project + credentials to the driver's own config.
+    const bq = new BigQuery({
+      projectId: process.env.CUBEJS_DB_BQ_PROJECT_ID,
+      credentials: JSON.parse(
+        Buffer.from(
+          process.env.CUBEJS_DB_BQ_CREDENTIALS ?? "",
+          "base64",
+        ).toString("utf8"),
+      ),
+    });
     const [rows] = await bq.query({
       query:
         "SELECT * FROM `kipptaf_marts.dim_staff_cube_access` WHERE google_email = @email ORDER BY staff_key LIMIT 1",


### PR DESCRIPTION
## Summary and Motivation

When merged, this PR restores Cube access for the entire network. After the #4269 security-redesign deploy, every viewer was denied on every API (MCP/REST and SQL/Superset/Tableau) — `meta` returned `{"cubes":[]}` even for a network-scope viewer with correct access data.

Root cause: `resolveAccess` in `src/cube/cube.js` built its own BigQuery client with a bare `new BigQuery()` — no `projectId`/`credentials`. In the Cube Cloud runtime that client defaulted to the host project `cubejs-cloud`, so every identity read threw:

```text
ApiError: Access Denied: Project cubejs-cloud: User does not have
bigquery.jobs.create permission in project cubejs-cloud.
```

The read fails closed to an empty `securityContext`, so all viewers were denied. Cube's own data driver was unaffected because it is configured via the `CUBEJS_DB_BQ_*` variables — which the hand-rolled client inherited none of.

Fix: construct the client with `projectId` and `credentials` sourced from the same `CUBEJS_DB_BQ_PROJECT_ID` / `CUBEJS_DB_BQ_CREDENTIALS` config Cube's driver uses, so identity jobs run in `teamster-332318`.

Diagnosis confirmed the data path is healthy: `dim_staff_cube_access`, `dim_staff_reporting_chain`, and `dim_locations` are all deployed and populated; a network viewer's access row is correct. The fault was purely the misconfigured client.

Closes #4466

## AI Assistance

Diagnosed and implemented with Claude Code. Human-directed: the outage report and the Cube Cloud log line that pinpointed the failing project. AI-assisted: root-cause isolation across the warehouse/code/config boundaries, the one-line client fix, and this write-up.

## Self-review

### General

- [ ] Review the Claude Code Review comment posted on this PR.

### Docs

- N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] Trunk — passes (pre-commit fmt and pre-push check clean locally)
- [ ] dbt Cloud — no dbt model changes; expected no-op or green
- [ ] Dagster Cloud — not triggered (no deploy-path changes)

## Post-merge verification

Once prod redeploys on merge, confirm `meta` returns cubes for a resolved viewer, and that `CUBEJS_DB_BQ_PROJECT_ID` / `CUBEJS_DB_BQ_CREDENTIALS` are set correctly on the prod deployment.
