### PR TITLE
perf(dbt): materialize assessment-scores star as tables for Cube query performance

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -6,8 +6,8 @@ models:
       Illuminate assessments are joined against. One row per (student, academic
       year, subject area, date enrolled), deduplicated to the latest exit per
       enrollment span.
-    # config:
-    #   materialized: table
+    config:
+      materialized: table
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -14,6 +14,8 @@ models:
       homeroom section active on the same anchor date. Scores with no matching
       section in either tier are dropped. The resolution_type column identifies
       which tier resolved the row.
+    config:
+      materialized: table
     columns:
       - name: source_type
         data_type: string

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -9,6 +9,8 @@ models:
       selection. `assessment_id` here is the canonical id, not the per-row
       member id; `assessment_ids` (array) preserves the underlying member ids
       for drilldown.
+    config:
+      materialized: table
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -12,6 +12,8 @@ models:
       scheduling column carry a typed NULL for that column (e.g. Illuminate and
       AP carry NULL administration_period; state branches carry NULL
       source_assessment_id).
+    config:
+      materialized: table
     columns:
       - name: assessment_administration_key
         data_type: string
@@ -23,6 +25,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -41,6 +44,7 @@ models:
             to: ref('dim_assessments')
             to_columns: [assessment_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -59,6 +63,7 @@ models:
             to: ref('dim_dates')
             to_columns: [date_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
@@ -18,6 +18,8 @@ models:
         land in the same bucket (e.g., SAT EBRW and ACT Reading combine to
         EBRW/Reading). Use this for apples-to-oranges comparisons across
         test families.
+    config:
+      materialized: table
     columns:
       - name: assessment_key
         data_type: string
@@ -31,6 +33,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_course_sections
+    config:
+      materialized: table
     description: >-
       Course section dimension. One row per section instance per source region.
       Sections are discrete scheduled offerings of a course at a school. Teacher
@@ -14,6 +16,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -28,6 +31,7 @@ models:
             to: ref('dim_courses')
             to_columns: [course_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - not_null
 
@@ -47,6 +51,7 @@ models:
             to: ref('dim_locations')
             to_columns: [location_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_courses
+    config:
+      materialized: table
     description: >-
       Course catalog dimension. One row per course per source region. Course
       numbers are not unique across regions, so the surrogate key includes the
@@ -15,6 +17,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_dates.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_dates.yml
@@ -14,6 +14,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_locations
+    config:
+      materialized: table
     description: >-
       School and office location dimension. One row per school or office.
       Conformed dimension. Region context is reached via the region_key FK to
@@ -21,6 +23,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -37,6 +40,7 @@ models:
             to: ref('dim_regions')
             to_columns: [region_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_regions
+    config:
+      materialized: table
     description: >-
       Region reference dimension. One row per KIPP region. Conformed dimension
       joinable from any fact or dimension that carries a region context.
@@ -21,6 +23,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_student_enrollments
+    config:
+      materialized: table
     description: >-
       Student enrollment dimension. One row per student x school x academic year
       enrollment record. Each re-enrollment within a year is a distinct record
@@ -16,6 +18,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -29,6 +32,7 @@ models:
             to: ref('dim_students')
             to_columns: [student_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - not_null
 
@@ -48,6 +52,7 @@ models:
             to: ref('dim_locations')
             to_columns: [location_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -69,6 +74,7 @@ models:
             to: ref('dim_dates')
             to_columns: [date_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -92,6 +98,7 @@ models:
             to: ref('dim_dates')
             to_columns: [date_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_student_section_enrollments
+    config:
+      materialized: table
     description: >-
       Student section enrollment dimension. One row per CC record — each
       enrollment of a student into a section. Multiple rows per student x
@@ -17,6 +19,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -35,6 +38,7 @@ models:
             to: ref('dim_student_enrollments')
             to_columns: [student_enrollment_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -50,6 +54,7 @@ models:
             to: ref('dim_course_sections')
             to_columns: [course_section_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - not_null
 
@@ -70,6 +75,7 @@ models:
             to: ref('dim_terms')
             to_columns: [term_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_students
+    config:
+      materialized: table
     description: >-
       Student person dimension. One row per student. Contains stable
       person-level attributes only. Enrollment history is in
@@ -13,6 +15,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
@@ -1,5 +1,7 @@
 models:
   - name: dim_terms
+    config:
+      materialized: table
     description: >-
       Generalized term/period dimension. One row per named period per region.
       Covers academic terms, performance management rounds, survey windows,
@@ -16,6 +18,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique:
               config:
@@ -35,6 +38,7 @@ models:
             to: ref('dim_locations')
             to_columns: [location_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -8,6 +8,8 @@ models:
       assessment administration (via assessment_administration_key) and to the
       student's resolved section enrollment (via student_section_enrollment_key
       and enrollment_resolution).
+    config:
+      materialized: table
     columns:
       - name: assessment_score_key
         data_type: string
@@ -16,6 +18,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
           - not_null
@@ -31,6 +34,7 @@ models:
             to: ref('dim_assessment_administrations')
             to_columns: [assessment_administration_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -63,6 +67,7 @@ models:
             to: ref('dim_student_section_enrollments')
             to_columns: [student_section_enrollment_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:
@@ -80,6 +85,7 @@ models:
             to: ref('dim_dates')
             to_columns: [date_key]
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - relationships:
               arguments:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Closes #4464

When merged, this pull request will materialize the assessment-scores star — 3 intermediates plus 11 marts (the fact and its full FK closure of dims) — as tables instead of views, eliminating the per-query recomputation that makes Cube MCP assessment queries cost ~5 slot-hours and run 95–495s each.

Profiling (14 days of `cube-cloud@` query history) showed the assessment star accounts for effectively 100% of Cube's BigQuery spend: every query re-expanded ~55 base tables through the all-view chain, recomputing `int_assessments__resolved_section_enrollments` (two non-equi date-range joins plus dedupe) up to 3x per query. Full detail in #4464.

Scope notes:

- The 11-mart set is the FK-constraint closure from the fact: BigQuery FK DDL requires every referenced relation to be a table with a PRIMARY KEY constraint, so the fact's dims (and their dims) convert together. It coincides exactly with the star's Cube join set.
- `warn_unenforced: false` added alongside `warn_unsupported: false` on the converted models' constraints (they now render into DDL, unenforced).
- Rebuild cost is small and fires only on real data changes: full star rebuild measured at ~2.4 min end-to-end (fact CTAS 17s); the chain's existing table (`int_assessments__scaffold`) rebuilds ~2x/day.
- Staging (`zz_stg_kipptaf_*`) copies of all 14 models were pre-built as tables (with PK constraints) so CI's defer-resolved FK references land on valid targets — dbt resolves FK constraint refs to the deferred relation whenever `--defer` is active, so CI would otherwise fail against the old staging views.

## AI Assistance

Claude Code profiled Cube query costs, identified the hotspot chain, authored the materialization configs, and validated dev + staging builds; scope and rollout sequencing decisions were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties files updated for all modified models (config-only changes; no new models)
- [x] Exposures unchanged — all models already covered by `cube_semantic_layer`
- [x] No breaking change — materialization conversion only; no column renames/removals, no surrogate-key churn. view→table conversion needs no manual drop (dbt replaces the view).
- [x] No external sources modified; staging copies pre-built via `dbt run --target staging` for the 14 converted models

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered