### PR TITLE
feat(cube-mcp): scope meta to specific views/cubes via /entities/all

### DIFF
--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -227,10 +227,13 @@ mcp = FastMCP(
     instructions=(
         "Query the Cube semantic layer (KIPP TEAM & Family metrics, dimensions, "
         "and views) via Cube Cloud's REST API.\n\n"
-        "Workflow: (1) call `meta` to discover available views, measures, and "
-        "dimensions — analyst-facing surfaces are views, e.g. `student_attendance_view` "
+        "Workflow: (1) call `meta` with no arguments once to discover available "
+        "view names — analyst-facing surfaces are views, e.g. `student_attendance_view` "
         "(one view per student domain) or `staff_directory` / `staff_pii` (staff "
-        "domain, split by access tier); (2) "
+        "domain, split by access tier); (2) call `meta` again with "
+        '`views=["<the-view-you-need>"]` to fetch just that view\'s measures '
+        "and dimensions — much smaller than the full catalog, prefer it once "
+        "you know which view(s) are relevant; (3) "
         "build a Cube "
         "query object (measures, dimensions, filters, timeDimensions, order, "
         "limit) and call `load` to execute, or `sql` to inspect the compiled "
@@ -333,31 +336,54 @@ def _with_default_timezone(query: dict[str, Any]) -> dict[str, Any]:
     return {**query, "timezone": DEFAULT_QUERY_TIMEZONE}
 
 
-def _meta_cache_path(email: str) -> Path:
-    digest = hashlib.sha256(email.encode("utf-8")).hexdigest()[:16]
+def _meta_scope_key(views: list[str] | None, cubes: list[str] | None) -> str:
+    """Distinguish a scoped `/entities/all` fetch from the full `/meta` catalog
+    in the cache key — a filtered call must never read or write the full
+    catalog's cache entry (and vice versa)."""
+    if not views and not cubes:
+        return "all"
+    return "entities:" + ",".join(sorted([*(views or []), *(cubes or [])]))
+
+
+def _meta_cache_path(email: str, scope: str) -> Path:
+    digest = hashlib.sha256(f"{email}:{scope}".encode()).hexdigest()[:16]
     return META_CACHE_DIR / f"cube-meta-{digest}.json"
 
 
-_meta_memory_cache: dict[str, tuple[int, dict[str, Any]]] = {}
+_meta_memory_cache: dict[tuple[str, str], tuple[int, dict[str, Any]]] = {}
 
 
 @mcp.tool()
-async def meta(ctx: Context, force_refresh: bool = False) -> dict[str, Any]:
+async def meta(
+    ctx: Context,
+    views: list[str] | None = None,
+    cubes: list[str] | None = None,
+    force_refresh: bool = False,
+) -> dict[str, Any]:
     """Discover available KIPP TEAM & Family data: students, attendance, grades,
     assessments, enrollment, demographics, staff, schools, regions, terms.
     Returns the catalog of views, measures, and dimensions queryable via `load`
     or `sql`.
 
-    Cached per-email for one hour (in-memory, with disk fallback across process
-    restarts). Pass `force_refresh=True` after a model deploy.
+    Call with no arguments first to discover which views exist (a lightweight
+    pass would still return the full catalog — there is no lighter discovery
+    call). Once you know the view(s) you need, pass `views` (and/or `cubes`) to
+    fetch only their measures/dimensions — this returns a fraction of the full
+    catalog's size and avoids exceeding a response size budget on large models.
+
+    Cached per (email, requested scope) for one hour (in-memory, with disk
+    fallback across process restarts) — a scoped call never reads or writes the
+    full-catalog cache entry, or another scope's. Pass `force_refresh=True`
+    after a model deploy.
     """
     email = await _get_user_email(ctx)
+    scope = _meta_scope_key(views, cubes)
     now = int(time.time())
     if not force_refresh:
-        memory_hit = _meta_memory_cache.get(email)
+        memory_hit = _meta_memory_cache.get((email, scope))
         if memory_hit and memory_hit[0] > now:
             return memory_hit[1]
-    cache_path = _meta_cache_path(email)
+    cache_path = _meta_cache_path(email, scope)
     if not force_refresh and cache_path.exists():
         try:
             cached = json.loads(cache_path.read_text(encoding="utf-8"))
@@ -367,11 +393,19 @@ async def meta(ctx: Context, force_refresh: bool = False) -> dict[str, Any]:
             cache_path.unlink(missing_ok=True)
         else:
             if expires_at > now and "payload" in cached:
-                _meta_memory_cache[email] = (expires_at, cached["payload"])
+                _meta_memory_cache[(email, scope)] = (expires_at, cached["payload"])
                 return cached["payload"]
-    payload = await _request("GET", "/meta", email=email)
+    if scope == "all":
+        payload = await _request("GET", "/meta", email=email)
+    else:
+        body: dict[str, list[str]] = {}
+        if cubes:
+            body["cubes"] = cubes
+        if views:
+            body["views"] = views
+        payload = await _request("POST", "/entities/all", json=body, email=email)
     expires_at = int(time.time()) + META_CACHE_TTL_SECONDS
-    _meta_memory_cache[email] = (expires_at, payload)
+    _meta_memory_cache[(email, scope)] = (expires_at, payload)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     # Atomic write: avoid corruption if two concurrent meta() calls race.
     tmp_path = cache_path.with_suffix(f".tmp.{os.getpid()}")

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -339,14 +339,20 @@ def _with_default_timezone(query: dict[str, Any]) -> dict[str, Any]:
 def _meta_scope_key(views: list[str] | None, cubes: list[str] | None) -> str:
     """Distinguish a scoped `/entities/all` fetch from the full `/meta` catalog
     in the cache key — a filtered call must never read or write the full
-    catalog's cache entry (and vice versa)."""
+    catalog's cache entry, or another scope's. Views and cubes are keyed on
+    separate axes: `/entities/all` can return different content for a name
+    requested as a view vs. as a cube, so folding both into one sorted list
+    would collide (e.g. views=["dates"] and cubes=["dates"] must not share a
+    cache entry)."""
     if not views and not cubes:
         return "all"
-    return "entities:" + ",".join(sorted([*(views or []), *(cubes or [])]))
+    v = ",".join(sorted(views or []))
+    c = ",".join(sorted(cubes or []))
+    return f"entities:views={v}:cubes={c}"
 
 
 def _meta_cache_path(email: str, scope: str) -> Path:
-    digest = hashlib.sha256(f"{email}:{scope}".encode()).hexdigest()[:16]
+    digest = hashlib.sha256(f"{email}:{scope}".encode("utf-8")).hexdigest()[:16]
     return META_CACHE_DIR / f"cube-meta-{digest}.json"
 
 

--- a/tests/cube/test_mcp_server.py
+++ b/tests/cube/test_mcp_server.py
@@ -365,6 +365,64 @@ def test_meta_scoped_call_with_cubes_and_views(
     assert sent_bodies == [{"cubes": ["dates"], "views": ["student_attendance_view"]}]
 
 
+def test_meta_scoped_call_with_cubes_only_omits_views_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
+        del args
+        sent_bodies.append(kwargs["json"])
+        return {"cubes": []}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    asyncio.run(server.meta(ctx, cubes=["dates"]))
+    assert sent_bodies == [{"cubes": ["dates"]}]
+
+
+def test_meta_same_name_as_view_vs_cube_does_not_collide_in_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression guard: a name requested as a view and the same name requested
+    as a cube must hit /entities/all independently, never share a cache entry.
+    `/entities/all` can return different content for the two axes."""
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
+        del args
+        sent_bodies.append(kwargs["json"])
+        # Distinguish the two axes' responses so a collision is detectable.
+        return {"requested_as": "view" if "views" in kwargs["json"] else "cube"}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    as_view = asyncio.run(server.meta(ctx, views=["dates"]))
+    as_cube = asyncio.run(server.meta(ctx, cubes=["dates"]))
+
+    # Two independent network calls, one per axis — no cache collision.
+    assert sent_bodies == [{"views": ["dates"]}, {"cubes": ["dates"]}]
+    assert as_view == {"requested_as": "view"}
+    assert as_cube == {"requested_as": "cube"}
+    assert as_view != as_cube
+
+
 def test_with_default_timezone_injects_utc_when_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cube/test_mcp_server.py
+++ b/tests/cube/test_mcp_server.py
@@ -219,7 +219,7 @@ def test_meta_cache_corruption_deletes_cache_file_and_refetches(
 
     # Point the meta cache at an isolated tmp dir.
     monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
-    cache_path = server._meta_cache_path("engineer@apps.teamschools.org")
+    cache_path = server._meta_cache_path("engineer@apps.teamschools.org", "all")
     cache_path.write_text("not-json-at-all", encoding="utf-8")
     assert cache_path.exists()
 
@@ -267,10 +267,102 @@ def test_meta_in_memory_cache_skips_disk_read_on_repeat_calls(
     # Cold call hit /meta once; second call served from memory.
     assert call_count == 1
     # Delete disk cache to prove the second hit didn't read from disk.
-    server._meta_cache_path("engineer@apps.teamschools.org").unlink()
+    server._meta_cache_path("engineer@apps.teamschools.org", "all").unlink()
     third = asyncio.run(server.meta(ctx))
     assert third == {"cubes": [{"name": "x"}]}
     assert call_count == 1
+
+
+def test_meta_scoped_call_hits_entities_all_not_meta(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def fake_request(
+        method: str, path: str, *, email: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        del email
+        calls.append((method, path, kwargs))
+        return {"cubes": [{"name": "student_attendance_view"}]}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    result = asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
+
+    assert result == {"cubes": [{"name": "student_attendance_view"}]}
+    assert len(calls) == 1
+    method, path, kwargs = calls[0]
+    assert method == "POST"
+    assert path == "/entities/all"
+    assert kwargs["json"] == {"views": ["student_attendance_view"]}
+
+
+def test_meta_scoped_and_full_catalog_calls_cache_separately(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    call_paths: list[str] = []
+
+    async def fake_request(
+        method: str, path: str, *, email: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        del method, email, kwargs
+        call_paths.append(path)
+        return {"cubes": [{"name": path}]}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    full = asyncio.run(server.meta(ctx))
+    scoped = asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
+
+    # Distinct cache entries — a scoped call didn't short-circuit into the
+    # full-catalog cache entry, or vice versa.
+    assert full != scoped
+    assert call_paths == ["/meta", "/entities/all"]
+
+    # Repeat calls hit cache, not the network, for each scope independently.
+    asyncio.run(server.meta(ctx))
+    asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
+    assert call_paths == ["/meta", "/entities/all"]
+
+
+def test_meta_scoped_call_with_cubes_and_views(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    sent_bodies: list[dict[str, Any]] = []
+
+    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
+        del args
+        sent_bodies.append(kwargs["json"])
+        return {"cubes": []}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    asyncio.run(server.meta(ctx, views=["student_attendance_view"], cubes=["dates"]))
+    assert sent_bodies == [{"cubes": ["dates"], "views": ["student_attendance_view"]}]
 
 
 def test_with_default_timezone_injects_utc_when_absent(


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

...let the `cube` MCP's `meta` tool fetch just the view(s) a caller needs
instead of always dumping the full Cube catalog. `meta` now accepts optional
`views`/`cubes` params; when passed, it calls Cube's `POST /entities/all`
(scoped detail for named cubes/views) instead of `GET /meta` (full catalog,
~135K chars in a recent session — enough on its own to exceed a subagent's
token budget). The full-catalog call remains the default for initial
discovery. Cache keys (memory + disk) now include the requested scope so a
scoped call can never read or write the full-catalog cache entry.

Refs #4470

## AI Assistance

Claude Code authored the change end to end (diagnosis, implementation, and
tests) after the user confirmed the direction; the user reviewed the plan and
approved opening the issue/branch/PR at each step.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — not applicable (no dbt changes).
- [ ] **Dagster Cloud** — not applicable (no Dagster changes).
