### PR TITLE
fix(cube-mcp): filter /meta client-side instead of calling /entities/all

### DIFF
--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -336,19 +336,13 @@ def _with_default_timezone(query: dict[str, Any]) -> dict[str, Any]:
     return {**query, "timezone": DEFAULT_QUERY_TIMEZONE}
 
 
-def _meta_scope_key(views: list[str] | None, cubes: list[str] | None) -> str:
-    """Distinguish a scoped `/entities/all` fetch from the full `/meta` catalog
-    in the cache key — a filtered call must never read or write the full
-    catalog's cache entry, or another scope's. Views and cubes are keyed on
-    separate axes: `/entities/all` can return different content for a name
-    requested as a view vs. as a cube, so folding both into one sorted list
-    would collide (e.g. views=["dates"] and cubes=["dates"] must not share a
-    cache entry)."""
-    if not views and not cubes:
+def _meta_scope_key(views: list[str] | None) -> str:
+    """Distinguish a filtered fetch from the full `/meta` catalog in the cache
+    key — a filtered call must never read or write the full catalog's cache
+    entry, or another view-set's."""
+    if not views:
         return "all"
-    v = ",".join(sorted(views or []))
-    c = ",".join(sorted(cubes or []))
-    return f"entities:views={v}:cubes={c}"
+    return "views:" + ",".join(sorted(views))
 
 
 def _meta_cache_path(email: str, scope: str) -> Path:
@@ -363,7 +357,6 @@ _meta_memory_cache: dict[tuple[str, str], tuple[int, dict[str, Any]]] = {}
 async def meta(
     ctx: Context,
     views: list[str] | None = None,
-    cubes: list[str] | None = None,
     force_refresh: bool = False,
 ) -> dict[str, Any]:
     """Discover available KIPP TEAM & Family data: students, attendance, grades,
@@ -371,19 +364,23 @@ async def meta(
     Returns the catalog of views, measures, and dimensions queryable via `load`
     or `sql`.
 
-    Call with no arguments first to discover which views exist (a lightweight
-    pass would still return the full catalog — there is no lighter discovery
-    call). Once you know the view(s) you need, pass `views` (and/or `cubes`) to
-    fetch only their measures/dimensions — this returns a fraction of the full
-    catalog's size and avoids exceeding a response size budget on large models.
+    Call with no arguments first to discover which views exist. Once you know
+    the view(s) you need, pass `views` to get back just their measures and
+    dimensions — a fraction of the full catalog's size, filtered client-side
+    from the same underlying `/meta` fetch (Cube's REST API doesn't take a
+    filter param, and its separate `/entities` endpoints need a differently
+    scoped token this server doesn't mint) — so it avoids exceeding a response
+    size budget on large models without any extra round trip once the full
+    catalog is cached.
 
     Cached per (email, requested scope) for one hour (in-memory, with disk
-    fallback across process restarts) — a scoped call never reads or writes the
-    full-catalog cache entry, or another scope's. Pass `force_refresh=True`
-    after a model deploy.
+    fallback across process restarts) — a filtered call never reads or writes
+    the full-catalog cache entry, or another view-set's, though it does reuse
+    the full catalog's cached fetch to build its filtered result. Pass
+    `force_refresh=True` after a model deploy.
     """
     email = await _get_user_email(ctx)
-    scope = _meta_scope_key(views, cubes)
+    scope = _meta_scope_key(views)
     now = int(time.time())
     if not force_refresh:
         memory_hit = _meta_memory_cache.get((email, scope))
@@ -404,12 +401,16 @@ async def meta(
     if scope == "all":
         payload = await _request("GET", "/meta", email=email)
     else:
-        body: dict[str, list[str]] = {}
-        if cubes:
-            body["cubes"] = cubes
-        if views:
-            body["views"] = views
-        payload = await _request("POST", "/entities/all", json=body, email=email)
+        # Reuses (and populates) the full-catalog cache entry via the same
+        # code path above, rather than a second network round trip per call.
+        full_payload = await meta(ctx, force_refresh=force_refresh)
+        wanted = set(views or [])
+        payload = {
+            **full_payload,
+            "cubes": [
+                c for c in full_payload.get("cubes", []) if c.get("name") in wanted
+            ],
+        }
     expires_at = int(time.time()) + META_CACHE_TTL_SECONDS
     _meta_memory_cache[(email, scope)] = (expires_at, payload)
     cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -353,6 +353,59 @@ def _meta_cache_path(email: str, scope: str) -> Path:
 _meta_memory_cache: dict[tuple[str, str], tuple[int, dict[str, Any]]] = {}
 
 
+def _read_meta_cache(
+    email: str, scope: str, force_refresh: bool
+) -> dict[str, Any] | None:
+    """Return a cached payload for (email, scope) if fresh, else None. Checks
+    the in-memory cache first, then falls back to disk (surviving process
+    restarts) — writing back through the disk hit to warm the memory cache."""
+    now = int(time.time())
+    if not force_refresh:
+        memory_hit = _meta_memory_cache.get((email, scope))
+        if memory_hit and memory_hit[0] > now:
+            return memory_hit[1]
+    cache_path = _meta_cache_path(email, scope)
+    if not force_refresh and cache_path.exists():
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            expires_at = int(cached.get("expires_at", 0))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            # Corrupt cache file — drop it so subsequent runs don't keep failing.
+            cache_path.unlink(missing_ok=True)
+        else:
+            if expires_at > now and "payload" in cached:
+                _meta_memory_cache[(email, scope)] = (expires_at, cached["payload"])
+                return cached["payload"]
+    return None
+
+
+def _write_meta_cache(email: str, scope: str, payload: dict[str, Any]) -> None:
+    expires_at = int(time.time()) + META_CACHE_TTL_SECONDS
+    _meta_memory_cache[(email, scope)] = (expires_at, payload)
+    cache_path = _meta_cache_path(email, scope)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic write: avoid corruption if two concurrent meta() calls race.
+    tmp_path = cache_path.with_suffix(f".tmp.{os.getpid()}")
+    tmp_path.write_text(
+        json.dumps({"expires_at": expires_at, "payload": payload}),
+        encoding="utf-8",
+    )
+    os.replace(tmp_path, cache_path)
+
+
+async def _fetch_full_meta(email: str, force_refresh: bool) -> dict[str, Any]:
+    """Fetch (or serve from cache) the full `/meta` catalog for `email`. A
+    private helper — not the `meta` tool itself — so the filtered-view path
+    below can reuse it without resolving the caller's email or hitting
+    `/meta` twice."""
+    cached = _read_meta_cache(email, "all", force_refresh)
+    if cached is not None:
+        return cached
+    payload = await _request("GET", "/meta", email=email)
+    _write_meta_cache(email, "all", payload)
+    return payload
+
+
 @mcp.tool()
 async def meta(
     ctx: Context,
@@ -381,46 +434,21 @@ async def meta(
     """
     email = await _get_user_email(ctx)
     scope = _meta_scope_key(views)
-    now = int(time.time())
-    if not force_refresh:
-        memory_hit = _meta_memory_cache.get((email, scope))
-        if memory_hit and memory_hit[0] > now:
-            return memory_hit[1]
-    cache_path = _meta_cache_path(email, scope)
-    if not force_refresh and cache_path.exists():
-        try:
-            cached = json.loads(cache_path.read_text(encoding="utf-8"))
-            expires_at = int(cached.get("expires_at", 0))
-        except (json.JSONDecodeError, TypeError, ValueError):
-            # Corrupt cache file — drop it so subsequent runs don't keep failing.
-            cache_path.unlink(missing_ok=True)
-        else:
-            if expires_at > now and "payload" in cached:
-                _meta_memory_cache[(email, scope)] = (expires_at, cached["payload"])
-                return cached["payload"]
     if scope == "all":
-        payload = await _request("GET", "/meta", email=email)
-    else:
-        # Reuses (and populates) the full-catalog cache entry via the same
-        # code path above, rather than a second network round trip per call.
-        full_payload = await meta(ctx, force_refresh=force_refresh)
-        wanted = set(views or [])
-        payload = {
-            **full_payload,
-            "cubes": [
-                c for c in full_payload.get("cubes", []) if c.get("name") in wanted
-            ],
-        }
-    expires_at = int(time.time()) + META_CACHE_TTL_SECONDS
-    _meta_memory_cache[(email, scope)] = (expires_at, payload)
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    # Atomic write: avoid corruption if two concurrent meta() calls race.
-    tmp_path = cache_path.with_suffix(f".tmp.{os.getpid()}")
-    tmp_path.write_text(
-        json.dumps({"expires_at": expires_at, "payload": payload}),
-        encoding="utf-8",
-    )
-    os.replace(tmp_path, cache_path)
+        return await _fetch_full_meta(email, force_refresh)
+
+    cached = _read_meta_cache(email, scope, force_refresh)
+    if cached is not None:
+        return cached
+    full_payload = await _fetch_full_meta(email, force_refresh)
+    wanted = set(views or [])
+    payload = {
+        **full_payload,
+        "cubes": [
+            dict(c) for c in full_payload.get("cubes", []) if c.get("name") in wanted
+        ],
+    }
+    _write_meta_cache(email, scope, payload)
     return payload
 
 

--- a/tests/cube/test_mcp_server.py
+++ b/tests/cube/test_mcp_server.py
@@ -405,6 +405,69 @@ def test_meta_scoped_call_for_unknown_view_returns_empty_cubes(
     assert result["cubes"] == []
 
 
+def test_meta_scoped_call_first_also_populates_full_catalog_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reverse of test_meta_scoped_and_full_catalog_calls_cache_separately: a
+    cold scoped call must populate the full-catalog cache entry too, so a
+    subsequent full call is served from cache rather than refetching."""
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    call_count = 0
+
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args, kwargs
+        nonlocal call_count
+        call_count += 1
+        return {
+            "cubes": [
+                {"name": "student_attendance_view", "measures": []},
+                {"name": "staff_directory", "measures": []},
+            ]
+        }
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    scoped = asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
+    full = asyncio.run(server.meta(ctx))
+
+    assert call_count == 1
+    assert len(scoped["cubes"]) == 1
+    assert len(full["cubes"]) == 2
+
+
+def test_meta_force_refresh_on_scoped_call_refetches_full_catalog(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
+    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    server = _load_server(monkeypatch)
+    server._meta_memory_cache.clear()
+    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
+
+    call_count = 0
+
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args, kwargs
+        nonlocal call_count
+        call_count += 1
+        return {"cubes": [{"name": "student_attendance_view"}]}
+
+    monkeypatch.setattr(server, "_request", fake_request)
+
+    ctx = MagicMock()
+    asyncio.run(server.meta(ctx, views=["student_attendance_view"], force_refresh=True))
+    asyncio.run(server.meta(ctx, views=["student_attendance_view"], force_refresh=True))
+    assert call_count == 2
+
+
 def test_with_default_timezone_injects_utc_when_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cube/test_mcp_server.py
+++ b/tests/cube/test_mcp_server.py
@@ -273,7 +273,7 @@ def test_meta_in_memory_cache_skips_disk_read_on_repeat_calls(
     assert call_count == 1
 
 
-def test_meta_scoped_call_hits_entities_all_not_meta(
+def test_meta_scoped_call_filters_full_catalog_client_side(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
@@ -283,26 +283,29 @@ def test_meta_scoped_call_hits_entities_all_not_meta(
     server._meta_memory_cache.clear()
     monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
 
-    calls: list[tuple[str, str, dict[str, Any]]] = []
+    calls: list[tuple[str, str]] = []
 
-    async def fake_request(
-        method: str, path: str, *, email: str, **kwargs: Any
-    ) -> dict[str, Any]:
+    async def fake_request(method: str, path: str, *, email: str) -> dict[str, Any]:
         del email
-        calls.append((method, path, kwargs))
-        return {"cubes": [{"name": "student_attendance_view"}]}
+        calls.append((method, path))
+        return {
+            "cubes": [
+                {"name": "student_attendance_view", "measures": []},
+                {"name": "staff_directory", "measures": []},
+            ]
+        }
 
     monkeypatch.setattr(server, "_request", fake_request)
 
     ctx = MagicMock()
     result = asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
 
-    assert result == {"cubes": [{"name": "student_attendance_view"}]}
-    assert len(calls) == 1
-    method, path, kwargs = calls[0]
-    assert method == "POST"
-    assert path == "/entities/all"
-    assert kwargs["json"] == {"views": ["student_attendance_view"]}
+    # No /entities endpoint — Cube's REST API only exposes filtering via a
+    # differently-scoped token this server doesn't mint (verified live: it
+    # 403s "Required scope is missing" against our JWT). Filter the one
+    # working /meta fetch client-side instead.
+    assert calls == [("GET", "/meta")]
+    assert result["cubes"] == [{"name": "student_attendance_view", "measures": []}]
 
 
 def test_meta_scoped_and_full_catalog_calls_cache_separately(
@@ -315,14 +318,18 @@ def test_meta_scoped_and_full_catalog_calls_cache_separately(
     server._meta_memory_cache.clear()
     monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
 
-    call_paths: list[str] = []
+    call_count = 0
 
-    async def fake_request(
-        method: str, path: str, *, email: str, **kwargs: Any
-    ) -> dict[str, Any]:
-        del method, email, kwargs
-        call_paths.append(path)
-        return {"cubes": [{"name": path}]}
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args, kwargs
+        nonlocal call_count
+        call_count += 1
+        return {
+            "cubes": [
+                {"name": "student_attendance_view", "measures": []},
+                {"name": "staff_directory", "measures": []},
+            ]
+        }
 
     monkeypatch.setattr(server, "_request", fake_request)
 
@@ -330,18 +337,22 @@ def test_meta_scoped_and_full_catalog_calls_cache_separately(
     full = asyncio.run(server.meta(ctx))
     scoped = asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
 
-    # Distinct cache entries — a scoped call didn't short-circuit into the
-    # full-catalog cache entry, or vice versa.
+    # Distinct cache entries — the filtered result didn't overwrite (or read
+    # from) the full-catalog cache entry, or vice versa.
     assert full != scoped
-    assert call_paths == ["/meta", "/entities/all"]
+    assert len(full["cubes"]) == 2
+    assert len(scoped["cubes"]) == 1
+    # One network call for the full catalog, reused (not refetched) to build
+    # the filtered result.
+    assert call_count == 1
 
     # Repeat calls hit cache, not the network, for each scope independently.
     asyncio.run(server.meta(ctx))
     asyncio.run(server.meta(ctx, views=["student_attendance_view"]))
-    assert call_paths == ["/meta", "/entities/all"]
+    assert call_count == 1
 
 
-def test_meta_scoped_call_with_cubes_and_views(
+def test_meta_scoped_call_with_multiple_views(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
@@ -351,21 +362,29 @@ def test_meta_scoped_call_with_cubes_and_views(
     server._meta_memory_cache.clear()
     monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
 
-    sent_bodies: list[dict[str, Any]] = []
-
-    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
-        del args
-        sent_bodies.append(kwargs["json"])
-        return {"cubes": []}
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args, kwargs
+        return {
+            "cubes": [
+                {"name": "student_attendance_view"},
+                {"name": "staff_directory"},
+                {"name": "staff_pii"},
+            ]
+        }
 
     monkeypatch.setattr(server, "_request", fake_request)
 
     ctx = MagicMock()
-    asyncio.run(server.meta(ctx, views=["student_attendance_view"], cubes=["dates"]))
-    assert sent_bodies == [{"cubes": ["dates"], "views": ["student_attendance_view"]}]
+    result = asyncio.run(
+        server.meta(ctx, views=["student_attendance_view", "staff_pii"])
+    )
+    assert {c["name"] for c in result["cubes"]} == {
+        "student_attendance_view",
+        "staff_pii",
+    }
 
 
-def test_meta_scoped_call_with_cubes_only_omits_views_key(
+def test_meta_scoped_call_for_unknown_view_returns_empty_cubes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
@@ -375,52 +394,15 @@ def test_meta_scoped_call_with_cubes_only_omits_views_key(
     server._meta_memory_cache.clear()
     monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
 
-    sent_bodies: list[dict[str, Any]] = []
-
-    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
-        del args
-        sent_bodies.append(kwargs["json"])
-        return {"cubes": []}
+    async def fake_request(*args: object, **kwargs: object) -> dict[str, Any]:
+        del args, kwargs
+        return {"cubes": [{"name": "student_attendance_view"}]}
 
     monkeypatch.setattr(server, "_request", fake_request)
 
     ctx = MagicMock()
-    asyncio.run(server.meta(ctx, cubes=["dates"]))
-    assert sent_bodies == [{"cubes": ["dates"]}]
-
-
-def test_meta_same_name_as_view_vs_cube_does_not_collide_in_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Regression guard: a name requested as a view and the same name requested
-    as a cube must hit /entities/all independently, never share a cache entry.
-    `/entities/all` can return different content for the two axes."""
-    monkeypatch.setenv("CUBE_USER_EMAIL", "engineer@apps.teamschools.org")
-    monkeypatch.delenv("AUTHKIT_DOMAIN", raising=False)
-    monkeypatch.delenv("PUBLIC_URL", raising=False)
-    server = _load_server(monkeypatch)
-    server._meta_memory_cache.clear()
-    monkeypatch.setattr(server, "META_CACHE_DIR", tmp_path)
-
-    sent_bodies: list[dict[str, Any]] = []
-
-    async def fake_request(*args: object, **kwargs: Any) -> dict[str, Any]:
-        del args
-        sent_bodies.append(kwargs["json"])
-        # Distinguish the two axes' responses so a collision is detectable.
-        return {"requested_as": "view" if "views" in kwargs["json"] else "cube"}
-
-    monkeypatch.setattr(server, "_request", fake_request)
-
-    ctx = MagicMock()
-    as_view = asyncio.run(server.meta(ctx, views=["dates"]))
-    as_cube = asyncio.run(server.meta(ctx, cubes=["dates"]))
-
-    # Two independent network calls, one per axis — no cache collision.
-    assert sent_bodies == [{"views": ["dates"]}, {"cubes": ["dates"]}]
-    assert as_view == {"requested_as": "view"}
-    assert as_cube == {"requested_as": "cube"}
-    assert as_view != as_cube
+    result = asyncio.run(server.meta(ctx, views=["does_not_exist"]))
+    assert result["cubes"] == []
 
 
 def test_with_default_timezone_injects_utc_when_absent(


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

...fix a live regression introduced by #4471. That PR's `meta(views=..., cubes=...)`
called Cube's `POST /entities/all`, which turned out to 403
(`"Required scope is missing."`) against this server's self-signed JWT once
tested live post-merge — Cube's docs show `/v1/entities` needs a token minted
through a separate Control Plane endpoint carrying an explicit `scopes` claim,
a different auth path this server doesn't implement.

This PR drops the `/entities/all` call (and the now-dead `cubes` param — every
cube in this deployment has `public: false` at the cube level per
`src/cube/CLAUDE.md`, so `/meta`, which excludes non-public cubes entirely,
could never return anything a `cubes=` filter would match). `meta(views=[...])`
now fetches/caches the full `/meta` payload exactly as before and filters the
returned `cubes` list client-side, reusing the full-catalog cache entry so a
scoped call costs no extra network round trip once cached. Verified live
against the deployed server post-#4471-merge to confirm the 403, and the new
test suite exercises the filter logic (22 tests, all passing).

Refs #4470

## AI Assistance

Claude Code authored the change end to end, including live-testing the prior
PR's deployed behavior (which surfaced this regression), diagnosing the auth
scope mismatch from Cube's docs, and implementing/testing the client-side
filter fix. The user directed the fix approach after being presented with two
options.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — not applicable (no dbt changes).
- [ ] **Dagster Cloud** — not applicable (no Dagster changes).
