### PR TITLE
refactor(cube-mcp): move query guidance from instructions to tool descriptions

### DIFF
--- a/src/cube/mcp/CLAUDE.md
+++ b/src/cube/mcp/CLAUDE.md
@@ -24,7 +24,11 @@ data-team Codespaces via `npx mcp-remote`.
 ## When to edit
 
 - Tool descriptions or the FastMCP `instructions=` string: edit `server.py`.
-  Redeploy is required for changes to reach `claude.ai` users.
+  Redeploy is required for changes to reach `claude.ai` users. **Put
+  load-bearing model guidance in the per-tool docstrings, not `instructions=`**
+  — the `instructions=` block is dropped by the claude.ai connector and
+  truncated in Claude Code, whereas tool descriptions reach the model on every
+  surface (#4473). `instructions=` is now a slim orientation only.
 - Tool surface changes (add/remove tools): edit `server.py` and add tests in
   `tests/cube/test_mcp_server.py`.
 - Validate that an `instructions=`/tool change actually helps the model with the
@@ -75,6 +79,12 @@ Cloud Run service via `--set-secrets`).
 - **Cloud Run request timeout defaults to 300s** (no `--timeout` set). Claude
   Code's 60s per-tool ceiling is tighter for tool wall-clock; Cloud Run's
   governs the underlying connection.
+- **After a deploy that changes tool signatures or descriptions, refresh the
+  connector's tool list on the client.** claude.ai Custom Connector sessions
+  cache the tool list and keep serving the old schema indefinitely — a new
+  parameter or an edited description is invisible to the model until the user
+  reconnects / refreshes the connector (settings → the cube connector). The
+  server has the change immediately; the client does not (#4473).
 
 ## MCP SDK gotchas
 
@@ -126,7 +136,7 @@ Cloud Run service via `--set-secrets`).
 ## PII reminder
 
 Tools return Cube query results. Student views carry row-level student
-identifiers alongside aggregate-safe dimensions (see the FastMCP `instructions=`
-block in `server.py`). Never emit identifying values to PR comments, issues, or
-scheduled-agent outputs — only to the local conversation. See project CLAUDE.md
-PII reference.
+identifiers alongside aggregate-safe dimensions (see the PII note in the `load`
+tool docstring in `server.py`). Never emit identifying values to PR comments,
+issues, or scheduled-agent outputs — only to the local conversation. See project
+CLAUDE.md PII reference.

--- a/src/cube/mcp/eval/README.md
+++ b/src/cube/mcp/eval/README.md
@@ -1,7 +1,7 @@
 # Academic-year eval
 
-Measures whether the academic-year crosswalk in the FastMCP `instructions`
-string keeps the **wrong-year rate** near zero on Sonnet/Haiku, on top of the
+Measures whether the academic-year crosswalk in the `load` tool description
+keeps the **wrong-year rate** near zero on Sonnet/Haiku, on top of the
 `academic_year_label` dimension.
 
 The unit tests in `tests/cube/test_mcp_server.py` cover the dimensions and view
@@ -17,20 +17,23 @@ reps × 3 arms) the tool **never beat arm B**, and on the Family-2 trap it
 produced the off-by-one it existed to prevent — fed the bare end-year integer
 `2026`, it returned `SY27 (2026-2027)`, and only the model overriding the tool
 avoided a wrong answer. The tool was dropped (issue #4084 proposal #4, PR
-#4125); the crosswalk now lives inline in `instructions=`. This harness is
-retained as the A-vs-B regression guard for that crosswalk.
+#4125). The crosswalk lived inline in `instructions=` until #4473 moved it into
+the `load` tool description — a channel that reaches the model on every surface,
+where `instructions=` is dropped by the claude.ai connector and truncated in
+Claude Code. This harness is retained as the A-vs-B regression guard for that
+crosswalk.
 
 ## What it compares
 
-Two arms, holding the `meta` catalog (and its dimension descriptions) constant;
-only the academic-year crosswalk paragraph in the FastMCP `instructions` string
-changes. The instructions string is read from the real
-[`server.py`](../server.py), so the eval measures the shipped surface.
+Two arms, holding the `meta` catalog (and its dimension descriptions) and the
+slim `instructions` string constant; only the academic-year crosswalk paragraph
+in the `load` tool description changes. The tool descriptions are read from the
+real [`server.py`](../server.py), so the eval measures the shipped surface.
 
-| Arm              | instructions                                | isolates                   |
+| Arm              | `load` description                          | isolates                   |
 | ---------------- | ------------------------------------------- | -------------------------- |
 | `A_baseline`     | shipped, minus the crosswalk paragraph      | floor — descriptions alone |
-| `B_instructions` | the shipped branch as-is (inline crosswalk) | does the crosswalk help?   |
+| `B_descriptions` | the shipped branch as-is (inline crosswalk) | does the crosswalk help?   |
 
 `A` vs `B` shows whether the crosswalk paragraph buys correctness over the
 dimension descriptions alone.
@@ -66,7 +69,10 @@ they drive the model.
 | `run_eval_cc.py` | Claude Code subscription (logged-in `claude` binary) | Claude Agent SDK, run **hermetic** — cube instructions as the full system prompt, `tools=[]`, `strict_mcp_config=True`, `setting_sources=[]` |
 
 The two runners are methodologically equivalent (same clean "model + cube
-instructions + only cube tools" surface); they differ only in auth. The CC
+instructions + only cube tools" surface); they differ only in auth. The
+academic-year crosswalk under test rides in the `load` tool description (not the
+slim `instructions` system prompt), so both runners vary it per arm via the tool
+schema — the CC runner builds one in-process SDK server per arm for this. The CC
 runner **must** be hermetic: an earlier append-to-`claude_code`-preset version
 leaked into Bash, `ToolSearch`, sub-agents, and the **live claude.ai Cube
 connector** (it queried production Cube and returned pre-rename member names),
@@ -113,8 +119,8 @@ usage draws from a separate monthly Agent-SDK credit pool.
 
 ## Fidelity caveats
 
-- Drives the in-process tool schemas + instructions from `server.py`, not the
-  live Cloud Run connector. They share `server.py`, so behavior should match,
-  but the MCP transport itself is not exercised.
+- Drives the in-process tool descriptions + instructions from `server.py`, not
+  the live Cloud Run connector. They share `server.py`, so behavior should
+  match, but the MCP transport itself is not exercised.
 - The human Superset path (no model in the loop) is out of scope by construction
   — that is a data-model question, not an MCP one.

--- a/src/cube/mcp/eval/arms.py
+++ b/src/cube/mcp/eval/arms.py
@@ -1,25 +1,31 @@
 """Arm definitions for the academic-year eval.
 
 Two designs are compared, holding everything constant except the one variable
-under test: the academic-year crosswalk paragraph in the FastMCP
-``instructions`` string.
+under test: the academic-year crosswalk paragraph in the ``load`` tool
+description.
 
-    A_baseline      shipped instructions minus the "resolve it yourself"
-                    crosswalk paragraph — the floor: dimension descriptions
-                    alone.
-    B_instructions  the shipped branch as-is: instructions including the inline
-                    crosswalk with worked examples.
+    A_baseline      shipped tools minus the "resolve it yourself" crosswalk
+                    paragraph in load's description — the floor: the rest of
+                    the tool descriptions (and the academic-year dimension
+                    descriptions) alone.
+    B_descriptions  the shipped branch as-is: load's description including the
+                    inline crosswalk with worked examples.
 
-A model-in-the-loop eval (#4084, PR #4125) compared these against a third arm
-that added a deterministic ``resolve_academic_year`` tool. The tool never beat
-arm B and on the trap case produced the off-by-one it existed to prevent, so it
-was dropped; this harness is retained as the A-vs-B regression guard for the
-shipped crosswalk.
+The crosswalk moved from the FastMCP ``instructions`` string into the ``load``
+tool description (#4473) because ``instructions`` is an unreliable channel —
+absent on the claude.ai connector, truncated in Claude Code — while tool
+descriptions reach the model on every surface. This eval now measures that
+channel: it reads the tool descriptions from the real ``src/cube/mcp/server.py``
+and varies only the crosswalk paragraph; ``instructions`` is held constant
+(slim) across both arms.
 
-The instructions string is read from the real ``src/cube/mcp/server.py`` so the
-eval measures the shipped surface, not a hand-written approximation. Only the
-``load``/``meta``/``sql`` execution is stubbed (see harness.py) so no warehouse,
-auth, or PII is involved.
+A model-in-the-loop eval (#4084, PR #4125) also compared these against a third
+arm that added a deterministic ``resolve_academic_year`` tool. The tool never
+beat arm B and on the trap case produced the off-by-one it existed to prevent,
+so it was dropped; this harness is retained as the A-vs-B regression guard.
+
+Only the ``load``/``meta``/``sql`` execution is stubbed (see harness.py) so no
+warehouse, auth, or PII is involved.
 """
 
 import asyncio
@@ -33,14 +39,14 @@ from typing import Any
 _SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
 
 # Anchors that bracket the shipped "ACADEMIC YEAR — resolve it yourself ..."
-# crosswalk paragraph in the real instructions string. Removing the text between
-# them yields the crosswalk-free baseline instructions used by arm A.
+# crosswalk paragraph in the real load tool description. Removing the text
+# between them yields the crosswalk-free baseline description used by arm A.
 _CROSSWALK_ANCHOR = "ACADEMIC YEAR — resolve it yourself"
 _AFTER_ANCHOR = "Numeric values come back"
 
 # Fixed /meta payload. Carries the real academic-year dimension descriptions
 # (the crosswalk surface) so it is present in every arm; only the crosswalk
-# paragraph in the instructions string varies across arms.
+# paragraph in the load tool description varies across arms.
 _ACADEMIC_YEAR_DESC = (
     "KIPP academic year (July start). The calendar year in which the academic "
     "year begins (e.g., 2025 for the 2025-26 school year). For filtering by "
@@ -142,31 +148,43 @@ def _anthropic_tools(server: ModuleType) -> dict[str, dict[str, Any]]:
 
 
 def build_arms(server: ModuleType) -> dict[str, dict[str, Any]]:
-    """Return {arm_name: {"instructions": str, "tools": list[tool-dict]}}."""
+    """Return {arm_name: {"instructions": str, "tools": list[tool-dict]}}.
+
+    ``instructions`` is held constant (the shipped slim string) across arms; the
+    A-vs-B variable is the academic-year crosswalk paragraph in the ``load``
+    tool description, which arm A has removed.
+    """
     tools = _anthropic_tools(server)
     missing = {"meta", "load", "sql"} - set(tools)
     if missing:
         raise RuntimeError(f"server.py is missing expected tools: {sorted(missing)}")
 
-    base = server.mcp.instructions
-    start = base.find(_CROSSWALK_ANCHOR)
-    end = base.find(_AFTER_ANCHOR)
+    instructions = server.mcp.instructions or ""
+    load_desc = tools["load"]["description"]
+    start = load_desc.find(_CROSSWALK_ANCHOR)
+    end = load_desc.find(_AFTER_ANCHOR)
     if start == -1 or end == -1 or end < start:
         raise RuntimeError(
-            "Could not locate the academic-year crosswalk paragraph in "
-            "instructions; anchors may have changed — update "
+            "Could not locate the academic-year crosswalk paragraph in the "
+            "load tool description; anchors may have changed — update "
             "_CROSSWALK_ANCHOR/_AFTER_ANCHOR."
         )
-    no_crosswalk = base[:start] + base[end:]
+    load_no_crosswalk = load_desc[:start] + load_desc[end:]
 
-    query_tools = [tools["meta"], tools["load"], tools["sql"]]
+    def _tools_with_load(desc: str) -> list[dict[str, Any]]:
+        return [
+            tools["meta"],
+            {**tools["load"], "description": desc},
+            tools["sql"],
+        ]
+
     return {
         "A_baseline": {
-            "instructions": no_crosswalk,
-            "tools": query_tools,
+            "instructions": instructions,
+            "tools": _tools_with_load(load_no_crosswalk),
         },
-        "B_instructions": {
-            "instructions": base,
-            "tools": query_tools,
+        "B_descriptions": {
+            "instructions": instructions,
+            "tools": _tools_with_load(load_desc),
         },
     }

--- a/src/cube/mcp/eval/run_eval.py
+++ b/src/cube/mcp/eval/run_eval.py
@@ -48,8 +48,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--arms",
         nargs="+",
-        default=["A_baseline", "B_instructions"],
-        choices=["A_baseline", "B_instructions"],
+        default=["A_baseline", "B_descriptions"],
+        choices=["A_baseline", "B_descriptions"],
     )
     p.add_argument("--reps", type=int, default=DEFAULT_REPS)
     p.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
@@ -77,11 +77,13 @@ def do_dry_run(arms: dict[str, dict[str, Any]], prompts: list[dict[str, Any]]) -
     )
     for name, arm in arms.items():
         tool_names = [t["name"] for t in arm["tools"]]
-        has_crosswalk = "resolve it yourself" in arm["instructions"]
+        load_desc = next(t["description"] for t in arm["tools"] if t["name"] == "load")
+        has_crosswalk = "resolve it yourself" in load_desc
         print(f"=== {name} ===")
         print(f"  tools: {tool_names}")
         print(
-            f"  instructions: {len(arm['instructions'])} chars "
+            f"  instructions: {len(arm['instructions'])} chars; "
+            f"load description: {len(load_desc)} chars "
             f"(inline crosswalk: {has_crosswalk})"
         )
     print("\nDry run only — no API calls made.")
@@ -144,7 +146,7 @@ def main() -> None:
 
     if args.smoke:
         prompts = prompts[:1]
-        args.arms = ["B_instructions"]
+        args.arms = ["B_descriptions"]
         args.models = args.models[:1]
         args.reps = 1
 

--- a/src/cube/mcp/eval/run_eval_cc.py
+++ b/src/cube/mcp/eval/run_eval_cc.py
@@ -87,8 +87,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--arms",
         nargs="+",
-        default=["A_baseline", "B_instructions"],
-        choices=["A_baseline", "B_instructions"],
+        default=["A_baseline", "B_descriptions"],
+        choices=["A_baseline", "B_descriptions"],
     )
     p.add_argument("--reps", type=int, default=DEFAULT_REPS)
     p.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
@@ -198,8 +198,14 @@ def do_dry_run(
     for name in arm_names:
         arm = arm_defs[name]
         allowed = [f"mcp__cube__{n}" for n in _arm_tool_names(name)]
+        load_desc = next(t["description"] for t in arm["tools"] if t["name"] == "load")
+        has_crosswalk = "resolve it yourself" in load_desc
         print(f"=== {name} ===")
         print(f"  system-prompt (replace): {len(arm['instructions'])} chars")
+        print(
+            f"  load description: {len(load_desc)} chars "
+            f"(inline crosswalk: {has_crosswalk})"
+        )
         print(f"  allowed_tools: {allowed}")
     print("\nDry run only — no model calls made.")
 
@@ -212,22 +218,23 @@ async def sweep(
     prompts: list[dict[str, Any]],
     reps: int,
     concurrency: int,
-    tool_desc: dict[str, str],
+    tool_desc_by_arm: dict[str, dict[str, str]],
     out_path: Path,
 ) -> list[dict[str, Any]]:
     # trunk-ignore(pyright/reportMissingImports): claude-agent-sdk is a runtime --with dep
     from claude_agent_sdk import create_sdk_mcp_server
 
-    tools = _make_tools(tool_desc)
-    # One server object per arm (stateless tools, safe to share across runs).
-    arm_servers = {
-        name: create_sdk_mcp_server(
+    # One server per arm, built from THAT arm's tool descriptions. The A-vs-B
+    # variable (the academic-year crosswalk) now lives in the load description,
+    # so the servers must differ per arm — not just the system prompt.
+    arm_servers = {}
+    for name in arm_names:
+        arm_tools = _make_tools(tool_desc_by_arm[name])
+        arm_servers[name] = create_sdk_mcp_server(
             name="cube",
             version="1.0.0",
-            tools=[tools[n] for n in _arm_tool_names(name)],
+            tools=[arm_tools[n] for n in _arm_tool_names(name)],
         )
-        for name in arm_names
-    }
     semaphore = asyncio.Semaphore(concurrency)
 
     jobs = [
@@ -289,14 +296,15 @@ def main() -> None:
     args = parse_args()
     server = arms_mod.load_server()
     arm_defs = arms_mod.build_arms(server)
-    tool_desc = {
-        t["name"]: t["description"] for t in arm_defs["B_instructions"]["tools"]
+    tool_desc_by_arm = {
+        name: {t["name"]: t["description"] for t in arm_defs[name]["tools"]}
+        for name in arm_defs
     }
     prompts = load_prompts()
 
     if args.smoke:
         prompts = prompts[:1]
-        args.arms = ["B_instructions"]
+        args.arms = ["B_descriptions"]
         args.models = args.models[:1]
         args.reps = 1
     if args.limit:
@@ -315,7 +323,7 @@ def main() -> None:
             prompts=prompts,
             reps=args.reps,
             concurrency=args.concurrency,
-            tool_desc=tool_desc,
+            tool_desc_by_arm=tool_desc_by_arm,
             out_path=args.out,
         )
     )

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -226,67 +226,14 @@ mcp = FastMCP(
     "cube",
     instructions=(
         "Query the Cube semantic layer (KIPP TEAM & Family metrics, dimensions, "
-        "and views) via Cube Cloud's REST API.\n\n"
-        "Workflow: (1) call `meta` with no arguments once to discover available "
-        "view names — analyst-facing surfaces are views, e.g. `student_attendance_view` "
-        "(one view per student domain) or `staff_directory` / `staff_pii` (staff "
-        "domain, split by access tier); (2) call `meta` again with "
-        '`views=["<the-view-you-need>"]` to fetch just that view\'s measures '
-        "and dimensions — much smaller than the full catalog, prefer it once "
-        "you know which view(s) are relevant; (3) "
-        "build a Cube "
-        "query object (measures, dimensions, filters, timeDimensions, order, "
-        "limit) and call `load` to execute, or `sql` to inspect the compiled "
-        "SQL without running it. The query spec follows the Cube REST API.\n\n"
-        "Member naming: every measure/dimension is dotted `<view>.<member>` "
-        "(e.g. `student_attendance_view.count_students`). Bare names won't "
-        "resolve.\n\n"
-        "Filter operators are named, not SQL: `equals`, `notEquals`, `contains`, "
-        "`gt`/`gte`/`lt`/`lte`, `set`/`notSet`, `inDateRange`, `beforeDate`, "
-        "`afterDate`. SQL-style `=`/`IN`/`LIKE` won't parse. See "
-        "https://cube.dev/docs/product/apis-integrations/rest-api/query-format#filters-operators "
-        "for the full list.\n\n"
-        "Date dimensions: for a single date use `filters` with `equals`; for a "
-        "range or when you need `granularity` (day/week/month/etc.), use "
-        "`timeDimensions` with `dateRange`. Putting a date in the wrong place "
-        "either fails or silently drops the granularity.\n\n"
-        "Academic year convention: an academic_year value of 2025 means the "
-        "2025–26 school year (July 2025 – June 2026), not the year ending in "
-        "2025. This is the opposite of typical fiscal-year conventions where "
-        "FY2025 ends in 2025. When a user says 'this year' or 'current year', "
-        "use the academic_year value whose start year matches the current "
-        "calendar year (e.g. if today is May 2026, current academic_year = "
-        "2025). In attendance views, the academic year is exposed as "
-        "dates_academic_year (integer) and dates_academic_year_label "
-        "(string, e.g. '2025-2026'), both sourced from the date dimension.\n\n"
-        "ACADEMIC YEAR — resolve it yourself before building any query that "
-        "names a year:\n"
-        "- academic_year is the START year; 'SY' notation uses the END year.\n"
-        "- 'SY26' -> academic_year 2025, label '2025-2026' (SY end year minus "
-        "1).\n"
-        "- '2025-26', '2025-2026', 'AY2025' -> academic_year 2025, label "
-        "'2025-2026'.\n"
-        "- bare '2026' -> treat as the START year (academic_year 2026, label "
-        "'2026-2027'); if the user's wording implies SY / end-year, note the "
-        "other reading.\n"
-        "State your interpretation inline (e.g. 'Interpreting as the 2025-2026 "
-        "school year') before showing results, then proceed.\n\n"
-        "Numeric values come back as strings — cast to numeric before "
-        "comparing or arithmetic. Raw `==` / `<` compare lexicographically "
-        "(`'10' < '9'`).\n\n"
-        "PII defaults: student views (`student_attendance_view`, "
-        "`student_assessment_scores_view`, `student_enrollments_view`) carry "
-        "row-level student identifiers alongside aggregate-safe dimensions — "
-        "any scope-specific student group can see both; avoid pulling "
-        "identifier fields (student_key, full_name, birth_date, state/lea "
-        "IDs) unless drill-down is explicitly requested. Staff PII "
-        "(`staff_pii`, the six sensitive fields) is gated separately from "
-        "`staff_directory` (roster/employment). Never emit identifying "
-        "values to PR comments, issues, Slack, scheduled-agent outputs, or "
-        "any external surface — only to the local conversation.\n\n"
-        "Access is group-driven and default-deny: empty `meta` results or "
-        "`WHERE (1=0)` in `sql` output usually means the requester lacks the "
-        "required `cube-*` Workspace group, not a missing model."
+        "and views) via Cube Cloud's REST API. Start with the `meta` tool to "
+        "discover views, then build a query and call `load` to execute (or "
+        "`sql` to inspect the compiled SQL). The load-bearing query-construction "
+        "guidance — member naming, filter operators, date handling, the "
+        "academic-year convention, and PII handling — lives in the individual "
+        "`meta`/`load`/`sql` tool descriptions, which reach the model reliably "
+        "on every surface (unlike this instructions block, which some clients "
+        "drop or truncate)."
     ),
     **_fastmcp_kwargs,
 )
@@ -417,14 +364,20 @@ async def meta(
     Returns the catalog of views, measures, and dimensions queryable via `load`
     or `sql`.
 
-    Call with no arguments first to discover which views exist. Once you know
-    the view(s) you need, pass `views` to get back just their measures and
-    dimensions — a fraction of the full catalog's size, filtered client-side
-    from the same underlying `/meta` fetch (Cube's REST API doesn't take a
-    filter param, and its separate `/entities` endpoints need a differently
-    scoped token this server doesn't mint) — so it avoids exceeding a response
-    size budget on large models without any extra round trip once the full
-    catalog is cached.
+    Call with no arguments first to discover which views exist — analyst-facing
+    surfaces are views (e.g. `student_attendance_view`,
+    `student_assessment_scores_view`; staff is split into `staff_directory` and
+    `staff_pii` by access tier). Once you know the view(s) you need, pass
+    `views` to get back just their measures and dimensions — a fraction of the
+    full catalog's size, filtered client-side from the same underlying `/meta`
+    fetch (Cube's REST API doesn't take a filter param, and its separate
+    `/entities` endpoints need a differently scoped token this server doesn't
+    mint) — so it avoids exceeding a response size budget on large models
+    without any extra round trip once the full catalog is cached.
+
+    Access is group-driven and default-deny: an empty catalog (`cubes: []`)
+    usually means the requester lacks the required `cube-*` Workspace group, not
+    a missing model.
 
     Cached per (email, requested scope) for one hour (in-memory, with disk
     fallback across process restarts) — a filtered call never reads or writes
@@ -462,11 +415,47 @@ async def load(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
 
     The query object follows the Cube REST API spec (measures, dimensions,
     filters, timeDimensions, segments, order, limit, offset, total). Polls
-    automatically on Cube's 'Continue wait' long-polling response.
+    automatically on Cube's 'Continue wait' long-polling response. Discover
+    member names with the `meta` tool first.
+
+    Member naming: every measure/dimension is dotted `view.member` (e.g.
+    `student_attendance_view.count_students`). Bare names won't resolve.
+
+    Filter operators are named, not SQL: `equals`, `notEquals`, `contains`,
+    `gt`/`gte`/`lt`/`lte`, `set`/`notSet`, `inDateRange`, `beforeDate`,
+    `afterDate`. SQL-style `=`/`IN`/`LIKE` won't parse.
+
+    Date dimensions: for a single date use `filters` with `equals`; for a range
+    or when you need `granularity` (day/week/month/etc.), use `timeDimensions`
+    with `dateRange`. Putting a date in the wrong place either fails or silently
+    drops the granularity.
+
+    Academic year: an academic_year value of 2025 means the 2025-26 school year
+    (July 2025 - June 2026), not the year ending in 2025 — the opposite of
+    fiscal-year convention. When a user says 'this year'/'current year', use the
+    academic_year whose start year matches the current calendar year (e.g. in
+    May 2026, current academic_year = 2025). Exposed as `dates_academic_year`
+    (integer) and `dates_academic_year_label` (string, e.g. '2025-2026').
+
+    ACADEMIC YEAR — resolve it yourself before building any query that names a
+    year:
+    - academic_year is the START year; 'SY' notation uses the END year.
+    - 'SY26' -> academic_year 2025, label '2025-2026' (SY end year minus 1).
+    - '2025-26', '2025-2026', 'AY2025' -> academic_year 2025, label '2025-2026'.
+    - bare '2026' -> treat as the START year (academic_year 2026, label
+      '2026-2027'); if the user's wording implies SY / end-year, note the other
+      reading.
+    State your interpretation inline (e.g. 'Interpreting as the 2025-2026 school
+    year') before showing results, then proceed.
+
+    Numeric values come back as strings — cast to numeric before comparing or
+    doing arithmetic. Raw `==`/`<` compare lexicographically (`'10' < '9'`).
 
     PII: student view results carry row-level student identifiers alongside
-    aggregate-safe dimensions — keep identifying values (names, birth dates,
-    state/lea IDs) in the local conversation only.
+    aggregate-safe dimensions — avoid pulling identifier fields (student_key,
+    full_name, birth_date, state/lea IDs) unless drill-down is explicitly
+    requested, and keep any identifying values in the local conversation only
+    (never to PR comments, issues, Slack, or scheduled-agent outputs).
 
     Queries default to timezone UTC (mart dates are date-grain UTC); pass an
     explicit `timezone` only when wall-clock conversion is intended.
@@ -487,7 +476,14 @@ async def sql(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
     analytics query, without running it. Useful for debugging query shape,
     verifying access policies, or reviewing the compiled SQL before `load`.
 
+    Takes the same query object as `load` — see the `load` tool description for
+    member naming, filter operators, date handling, and the academic-year
+    convention.
+
     Response is wrapped: {"sql": {"status", "sql": [query-string, [params]], "query_type"}}.
+    A default-deny access result compiles to `WHERE (1 = 0)` plus
+    `rlsAccessDenied` — usually a missing `cube-*` Workspace group, not a schema
+    bug.
 
     Queries default to timezone UTC (mart dates are date-grain UTC); pass an
     explicit `timezone` only when wall-clock conversion is intended.

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -454,8 +454,11 @@ async def load(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
     PII: student view results carry row-level student identifiers alongside
     aggregate-safe dimensions — avoid pulling identifier fields (student_key,
     full_name, birth_date, state/lea IDs) unless drill-down is explicitly
-    requested, and keep any identifying values in the local conversation only
-    (never to PR comments, issues, Slack, or scheduled-agent outputs).
+    requested. Staff sensitive fields (personal contact, birth date,
+    demographics) live in `staff_pii`, gated separately from the open
+    `staff_directory` roster. Keep any identifying values — student or staff —
+    in the local conversation only, never to PR comments, issues, Slack, or
+    scheduled-agent outputs.
 
     Queries default to timezone UTC (mart dates are date-grain UTC); pass an
     explicit `timezone` only when wall-clock conversion is intended.


### PR DESCRIPTION
## Summary & Motivation

When merged, this moves the Cube MCP server's load-bearing model guidance out of the FastMCP `instructions=` string and into the individual `meta`/`load`/`sql` tool descriptions.

**Why:** `instructions=` is an unreliable delivery channel — it is dropped entirely on the claude.ai Custom Connector surface and truncated mid-paragraph in the Claude Code VSCode plugin (the cut-off point drops the academic-year resolution rules, the numeric-strings caveat, the PII defaults, and the access note). Per-tool descriptions reached the model in full on both surfaces.

**What moved (`server.py`):**

- `load` docstring now carries member naming, named filter operators, the `filters`-vs-`timeDimensions` date rule, the academic-year convention plus resolution rules, numeric-values-as-strings, and PII defaults.
- `sql` points to `load` for the shared query rules and gains the `WHERE (1 = 0)` = missing-group diagnostic.
- `meta` gains the empty-catalog = missing-group diagnostic.
- `instructions=` slimmed to a short orientation (no longer load-bearing).

**Eval retarget (`eval/`)** — the academic-year eval built its A/B arms by slicing the crosswalk out of the `instructions` string, so it had to move with the guidance:

- `arms.py` now slices the crosswalk out of the `load` tool description; `instructions` is held constant across arms. Renamed `B_instructions` to `B_descriptions`.
- `run_eval_cc.py` builds one in-process SDK server per arm from that arm's own descriptions (the A/B variable now lives in the tool schema, not the system prompt).
- `run_eval.py` plus `README.md` updated for the new channel and arm name.

**Docs (`CLAUDE.md`):** noted descriptions are the reliable channel; added a deploy-runbook line that connector sessions cache the tool list and need a client-side refresh after a signature/description change; fixed the stale PII pointer.

### Validation

- `uv run pytest tests/cube/` — 30 passed (tests assert transport/auth/cache/timezone, not doc text; unaffected).
- Both eval dry-runs confirm arm A drops the crosswalk (`load` description 2246 chars) and arm B keeps it (2823 chars) with `instructions` held constant across both.
- **Pre-merge gate (needs a human — the `claude` binary is not on the Codespace PATH):** run the model-in-the-loop academic-year eval and confirm `B_descriptions` holds the wrong-year rate near zero, especially on the Family-2 (SY-notation) trap:

```bash
unset ANTHROPIC_API_KEY
uv run --with claude-agent-sdk --with pyyaml python src/cube/mcp/eval/run_eval_cc.py --reps 5
```

## AI Assistance

Claude Code (Fable 5) authored the refactor and eval changes end-to-end. Human-directed: the decision to move the guidance came from cross-session observation of the connector dropping and Claude Code truncating the `instructions=` block.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply.

## CI checks

- [ ] **Trunk** — passes (ran `trunk check --force` locally on all 6 files: no issues).
- **dbt Cloud / Dagster Cloud** — not applicable: no `src/dbt/**` or Dagster code-location changes, and `deploy-cube-mcp` runs on merge to `main`, not on the PR.

Closes #4473