### PR TITLE
docs(cube-mcp): make aggregation-grain behavior explicit in tool descriptions

### DIFF
--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -89,6 +89,18 @@ school_calendars) go in `cubes/conformed/`.
 - **`meta.folders` is the only Cube-rendered `meta.*` key.** Put guidance in
   `description:`, not `meta.usage` / `meta.synonyms` / etc. — those land in
   `/v1/meta` but Cube Cloud and the chat agent don't read them.
+- **Measure grain: query-time vs pre-agg.** At query time Cube recomputes every
+  measure fresh at the requested grain — including `count_distinct` (a valid
+  distinct count at any grain). A description's "non-additive" note is a
+  **pre-aggregation rollup** property, NOT a query-time-grain hazard; don't let
+  it read as "unsafe to drop a dimension." The real drop-a-dimension trap is
+  **semantic**: measures that recompute mathematically but are meaningful only
+  within a comparable scope (`avg_scale_score` / `avg_percent_correct` pooled
+  across incompatible assessment sources). Give such scope-bound measures a
+  leading `Grain: ... meaningful only within {scope} ... silent-failure trap`
+  clause in `description:` (#4476). No schema field enforces this — a
+  `reaggregatable` boolean was rejected because "scope-bound" isn't
+  machine-detectable; it's a review-checked convention.
 - **Folders group dimensions only.** Cube Cloud separates measures natively;
   don't list measures under `members:`.
 - **Folder member naming.** Bare for top-cube members; `<prefix>_<member>` for

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -379,6 +379,13 @@ async def meta(
     usually means the requester lacks the required `cube-*` Workspace group, not
     a missing model.
 
+    Grain/scope: each measure's description states any scope it must stay within
+    to remain meaningful. Some measures recompute at any query grain but are only
+    meaningful pooled within a comparable scope (e.g. one assessment source);
+    coarsening past that silently returns a valid-looking but meaningless value
+    (not an error) — see the `load` tool's grain rule before dropping a
+    dimension.
+
     Cached per (email, requested scope) for one hour (in-memory, with disk
     fallback across process restarts) — a filtered call never reads or writes
     the full-catalog cache entry, or another view-set's, though it does reuse
@@ -417,6 +424,28 @@ async def load(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
     filters, timeDimensions, segments, order, limit, offset, total). Polls
     automatically on Cube's 'Continue wait' long-polling response. Discover
     member names with the `meta` tool first.
+
+    Grain: the dimensions you pass set the aggregation grain, and every measure
+    is recomputed fresh at that grain — it is NOT a finer result with columns
+    hidden. Dropping a dimension from a previous query re-aggregates the measure
+    over everything the filters still match, changing what the number means, not
+    just which columns come back. (This includes count_distinct measures like
+    count_students: at a coarser grain Cube computes a correct distinct count
+    for that grain — the "non-additive" note on some measures refers to
+    pre-aggregation rollup, not query-time grain.)
+
+    Example — same filters, two grains: dimensions [is_iep, module_code,
+    academic_year] returns one mastery rate per (IEP status x module x year)
+    cell; dropping to dimensions [is_iep] returns one pooled rate per IEP status
+    across every module and year the filters matched. Same underlying rows,
+    re-aggregated — not the first result with columns removed.
+
+    Silent-failure risk: a few measures recompute mathematically at any grain
+    but are meaningful only within a comparable scope — e.g. avg_scale_score and
+    avg_percent_correct pool across incompatible assessment sources/subjects to
+    produce a valid-looking but meaningless number. This does not raise an
+    error; check the measure's own description for the scope it is valid within
+    before coarsening.
 
     Member naming: every measure/dimension is dotted `view.member` (e.g.
     `student_attendance_view.count_students`). Bare names won't resolve.

--- a/src/cube/mcp/server.py
+++ b/src/cube/mcp/server.py
@@ -434,11 +434,12 @@ async def load(ctx: Context, query: dict[str, Any]) -> dict[str, Any]:
     for that grain — the "non-additive" note on some measures refers to
     pre-aggregation rollup, not query-time grain.)
 
-    Example — same filters, two grains: dimensions [is_iep, module_code,
-    academic_year] returns one mastery rate per (IEP status x module x year)
-    cell; dropping to dimensions [is_iep] returns one pooled rate per IEP status
-    across every module and year the filters matched. Same underlying rows,
-    re-aggregated — not the first result with columns removed.
+    Example — same filters and measure (pct_proficient), two grains: dimensions
+    [is_iep, module_code, academic_year] returns one proficiency rate per (IEP
+    status x module x year) cell; dropping to dimensions [is_iep] returns one
+    pooled rate per IEP status across every module and year the filters matched.
+    Same underlying rows, re-aggregated — not the first result with columns
+    removed.
 
     Silent-failure risk: a few measures recompute mathematically at any grain
     but are meaningful only within a comparable scope — e.g. avg_scale_score and

--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -184,9 +184,11 @@ cubes:
 
       - name: avg_percent_correct
         description: >-
-          Average percent correct. Internal-effective (null for state) — filter
-          by subject/standard for a meaningful value. Built from additive
-          primitives so pre-aggregations roll it up.
+          Grain: recomputes at any query grain, but meaningful only within a
+          single subject/standard — pooling percent-correct across assessments
+          is a silent-failure trap (numerically valid, semantically
+          meaningless). Average percent correct, internal-effective (null for
+          state), built from additive primitives so pre-aggregations roll it up.
         sql: "{_sum_percent_correct} / NULLIF({_count_percent_correct}, 0)"
         type: number
         public: true
@@ -210,10 +212,11 @@ cubes:
 
       - name: avg_scale_score
         description: >-
-          Average scale score. Only meaningful within a single
-          assessment/subject/grade/source — scales are not comparable across
-          sources. Built from additive primitives so pre-aggregations roll it
-          up.
+          Grain: recomputes at any query grain, but meaningful only within a
+          single assessment source/subject/grade — scale scores are not
+          comparable across sources, so pooling them is a silent-failure trap
+          (numerically valid, semantically meaningless). Average scale score,
+          built from additive primitives so pre-aggregations roll it up.
         sql: "{_sum_scale_score} / NULLIF({_count_scale_score}, 0)"
         type: number
         public: true


### PR DESCRIPTION
## Summary & Motivation

When merged, a model calling the Cube MCP for the first time can determine, without trial and error, whether it's safe to drop a dimension to change grain — and understands that a coarser query re-aggregates rather than hiding a column. Description-only change, no code logic.

Motivated by live-session friction: a model couldn't tell whether dropping a dimension was safe for a given measure, and treated a coarser query as a finer one with a column hidden.

**What changed (2 files):**

- `src/cube/mcp/server.py` `load` docstring: a grain rule (dimensions set the grain; measures recompute fresh at that grain, not hide columns; dropping a dimension re-aggregates and changes meaning), a compact before/after example, and a silent-failure warning scoped to the real trap.
- `src/cube/mcp/server.py` `meta` docstring: one paragraph pointing at each measure's scope note and naming the silent-failure class.
- `src/cube/model/cubes/student_assessments/student_assessment_scores.yml`: a standardized leading "Grain:" clause on `avg_scale_score` and `avg_percent_correct` — the two measures that recompute mathematically at any grain but are meaningful only within a comparable scope.

**Reframe (the feedback was one model's wishlist, taken with a grain of salt):** the docs use "measures recompute at the requested grain; the trap is semantic pooling of a scope-bound measure" rather than the original "additive vs non-additive" framing, which conflates pre-aggregation rollup with query-time grain. `count_distinct` measures (e.g. `count_students`) recompute a correct distinct count at any query grain; that clarification lives once in the grain rule.

**Rejected as out of scope:** a structured `reaggregatable` metadata field on every measure — YAGNI for an LLM-only consumer that reads descriptions fine, and a single boolean can't express the `avg_scale_score` conditional (mathematically re-aggregatable, semantically scope-bound). The standardized description clause delivers the same at-a-glance signal.

## AI Assistance

Claude Code (Fable 5) authored the change end-to-end. Human-directed: the request originated from a live Sonnet session's feedback, which the user explicitly flagged to treat skeptically — the reframe and the scope-down (dropping the structured field) came out of that review.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR.

## CI checks

- [ ] **Trunk** — passes (ran `trunk check --force` locally on both files: no issues).
- **dbt Cloud / Dagster Cloud** — not applicable: no `src/dbt/**` or Dagster code-location changes. `src/cube/mcp/**` deploys on merge to `main`, and the Cube model redeploys via Cube Cloud on merge — neither runs on the PR.

## Validation

- `uv run pytest tests/cube/` — 30 passed (tests assert transport/auth/cache/timezone, not doc text).
- Edited cube YAML parses cleanly; both measure descriptions fold to the intended single-line text.

Closes #4476