### PR TITLE
refactor(marts,cube): simplify student-teacher linkage per #4330 review

### DIFF
--- a/src/cube/model/cubes/staff/staff_homeroom_teacher.yml
+++ b/src/cube/model/cubes/staff/staff_homeroom_teacher.yml
@@ -1,27 +1,9 @@
 cubes:
-  # Role alias for staff, used as the homeroom-teacher join target on
-  # student_school_enrollments. Distinct role-play cube (like staff_manager) so
+  # Role alias for staff, the homeroom-teacher join target on
+  # student_homeroom_section (the current-homeroom section reached from
+  # student_school_enrollments). Distinct role-play cube (like staff_manager) so
   # the homeroom-teacher members can't collide with the lead-teacher role
-  # (staff_lead_teacher) when a view reaches both. Inherits staff's dimension
-  # definitions via extends (Cube's "derive specific cubes from base"
-  # pattern: extends merges member lists, sql: is fully replaced, not
-  # merged), but overrides sql: to project only the columns the
-  # student-side joins actually consume: staff_key (join key,
-  # student_school_enrollments.yml) and full_name/first_name/last_name (the
-  # only staff_homeroom_teacher.* members any view includes — see
-  # student_attendance_view.yml and student_enrollments_view.yml). staff's
-  # own sql: (SELECT s.*, ...) carries every dim_staff column, including
-  # birth_date/race/gender_identity, which also exist on the student side of
-  # these views — a SELECT * on a teacher-joined student view then errors
-  # "birth_date is ambiguous". Narrowing this cube's projection removes the
-  # duplicate columns entirely. See #4385.
+  # (staff_lead_teacher). Inherits all of staff's dimensions.
   - name: staff_homeroom_teacher
     extends: staff
     public: false
-    sql: |
-      SELECT
-        staff_key,
-        full_name,
-        first_name,
-        last_name
-      FROM kipptaf_marts.dim_staff

--- a/src/cube/model/cubes/staff/staff_lead_teacher.yml
+++ b/src/cube/model/cubes/staff/staff_lead_teacher.yml
@@ -2,26 +2,8 @@ cubes:
   # Role alias for staff, used as the lead-teacher join target on
   # student_section_enrollments. Distinct role-play cube (like staff_manager) so
   # the lead-teacher members can't collide with the homeroom-teacher role
-  # (staff_homeroom_teacher) when a view reaches both. Inherits staff's
-  # dimension definitions via extends (Cube's "derive specific cubes from
-  # base" pattern: extends merges member lists, sql: is fully replaced, not
-  # merged), but overrides sql: to project only the columns the
-  # student-side joins actually consume: staff_key (join key,
-  # student_section_enrollments.yml) and full_name/first_name/last_name
-  # (the only staff_lead_teacher.* members any view includes — see
-  # student_section_enrollments_view.yml and student_assessment_scores_view.yml).
-  # staff's own sql: (SELECT s.*, ...) carries every dim_staff column,
-  # including birth_date/race/gender_identity, which also exist on the
-  # student side of these views — a SELECT * on a teacher-joined student
-  # view then errors "birth_date is ambiguous". Narrowing this cube's
-  # projection removes the duplicate columns entirely. See #4385.
+  # (staff_homeroom_teacher) when a view reaches both. Inherits all of staff's
+  # dimensions.
   - name: staff_lead_teacher
     extends: staff
     public: false
-    sql: |
-      SELECT
-        staff_key,
-        full_name,
-        first_name,
-        last_name
-      FROM kipptaf_marts.dim_staff

--- a/src/cube/model/cubes/students/student_homeroom_section.yml
+++ b/src/cube/model/cubes/students/student_homeroom_section.yml
@@ -1,0 +1,44 @@
+cubes:
+  # Role alias of student_section_enrollments used to attach the homeroom
+  # teacher to the stint grain. student_school_enrollments joins this cube
+  # filtered to the student's current homeroom section (is_homeroom AND
+  # is_current_section_enrollment => one row per stint), so attendance and
+  # enrollment views surface the homeroom teacher without fanning out across a
+  # student's other classes. Kept separate from student_section_enrollments (not
+  # extends) so it carries no reverse join back to the stint — avoiding a join
+  # cycle — and so its staff_homeroom_teacher member names stay distinct from the
+  # section-grain lead-teacher join.
+  - name: student_homeroom_section
+    public: false
+    sql_table: kipptaf_marts.dim_student_section_enrollments
+
+    joins:
+      - name: staff_homeroom_teacher
+        sql:
+          "{staff_homeroom_teacher.staff_key} = {CUBE}.lead_teacher_staff_key"
+        relationship: many_to_one
+
+    dimensions:
+      - name: student_enrollment_key
+        description:
+          FK to student_school_enrollments — the stint this section is in.
+        sql: student_enrollment_key
+        type: string
+
+      - name: lead_teacher_staff_key
+        description: FK to staff — the homeroom section's teacher.
+        sql: lead_teacher_staff_key
+        type: string
+
+      - name: is_homeroom
+        description:
+          TRUE when this is a homeroom section (HR course-number prefix).
+        sql: is_homeroom
+        type: boolean
+
+      - name: is_current_section_enrollment
+        description: >-
+          TRUE for the current section enrollment among a student's sequential
+          same-course enrollments within an academic year.
+        sql: is_current_section_enrollment
+        type: boolean

--- a/src/cube/model/cubes/students/student_homeroom_section.yml
+++ b/src/cube/model/cubes/students/student_homeroom_section.yml
@@ -1,13 +1,12 @@
 cubes:
   # Role alias of student_section_enrollments used to attach the homeroom
   # teacher to the stint grain. student_school_enrollments joins this cube
-  # filtered to the student's current homeroom section (is_homeroom AND
-  # is_current_section_enrollment => one row per stint), so attendance and
-  # enrollment views surface the homeroom teacher without fanning out across a
-  # student's other classes. Kept separate from student_section_enrollments (not
-  # extends) so it carries no reverse join back to the stint — avoiding a join
-  # cycle — and so its staff_homeroom_teacher member names stay distinct from the
-  # section-grain lead-teacher join.
+  # filtered to the student's current homeroom section (is_current_homeroom =>
+  # one row per stint), so attendance and enrollment views surface the homeroom
+  # teacher without fanning out across a student's other classes. Kept separate
+  # from student_section_enrollments (not extends) so it carries no reverse join
+  # back to the stint — avoiding a join cycle — and so its staff_homeroom_teacher
+  # member names stay distinct from the section-grain lead-teacher join.
   - name: student_homeroom_section
     public: false
     sql_table: kipptaf_marts.dim_student_section_enrollments
@@ -30,15 +29,9 @@ cubes:
         sql: lead_teacher_staff_key
         type: string
 
-      - name: is_homeroom
-        description:
-          TRUE when this is a homeroom section (HR course-number prefix).
-        sql: is_homeroom
-        type: boolean
-
-      - name: is_current_section_enrollment
+      - name: is_current_homeroom
         description: >-
-          TRUE for the current section enrollment among a student's sequential
-          same-course enrollments within an academic year.
-        sql: is_current_section_enrollment
+          TRUE for the student's single current homeroom section within a stint
+          — one row per stint, so the homeroom-teacher join does not fan out.
+        sql: is_current_homeroom
         type: boolean

--- a/src/cube/model/cubes/students/student_school_enrollments.yml
+++ b/src/cube/model/cubes/students/student_school_enrollments.yml
@@ -18,17 +18,19 @@ cubes:
           {CUBE}.student_enrollment_key
         relationship: one_to_one
 
-      # Homeroom teacher. Lives on this stint-grain dim so stint-based facts
-      # (attendance, enrollment) join it many_to_one with no fan-out — the
-      # section-grain dim can't serve it without fanning out across every class.
-      # Joins the staff_homeroom_teacher role-play cube (extends staff) so its
-      # members can't collide with the lead-teacher staff join on
-      # student_section_enrollments. many_to_one — one homeroom lead per
-      # enrollment after dbt resolution, so no fan-out.
-      - name: staff_homeroom_teacher
+      # Homeroom teacher, via the student's current homeroom section. Joins
+      # student_homeroom_section (a role alias of student_section_enrollments)
+      # filtered to the current homeroom (is_homeroom AND
+      # is_current_section_enrollment => one section per stint), so the homeroom
+      # teacher surfaces without fanning out across the student's other classes.
+      # The teacher name comes from that cube's staff_homeroom_teacher join.
+      - name: student_homeroom_section
         sql: >
-          {staff_homeroom_teacher.staff_key} = {CUBE}.homeroom_teacher_staff_key
-        relationship: many_to_one
+          {student_homeroom_section.student_enrollment_key} =
+          {CUBE}.student_enrollment_key AND
+          {student_homeroom_section.is_homeroom} AND
+          {student_homeroom_section.is_current_section_enrollment}
+        relationship: one_to_one
 
     dimensions:
       - name: student_enrollment_key
@@ -103,12 +105,6 @@ cubes:
         sql: is_retained_year
         type: boolean
         public: true
-
-      # Degenerate FK to staff — homeroom teacher name comes via the staff join.
-      - name: homeroom_teacher_staff_key
-        description: FK to staff — the student's homeroom/advisory Lead Teacher.
-        sql: homeroom_teacher_staff_key
-        type: string
 
     measures:
       - name: count_enrollments

--- a/src/cube/model/cubes/students/student_school_enrollments.yml
+++ b/src/cube/model/cubes/students/student_school_enrollments.yml
@@ -20,16 +20,15 @@ cubes:
 
       # Homeroom teacher, via the student's current homeroom section. Joins
       # student_homeroom_section (a role alias of student_section_enrollments)
-      # filtered to the current homeroom (is_homeroom AND
-      # is_current_section_enrollment => one section per stint), so the homeroom
-      # teacher surfaces without fanning out across the student's other classes.
-      # The teacher name comes from that cube's staff_homeroom_teacher join.
+      # filtered to the current homeroom (is_current_homeroom => one section per
+      # stint), so the homeroom teacher surfaces without fanning out across the
+      # student's other classes. The teacher name comes from that cube's
+      # staff_homeroom_teacher join.
       - name: student_homeroom_section
         sql: >
           {student_homeroom_section.student_enrollment_key} =
           {CUBE}.student_enrollment_key AND
-          {student_homeroom_section.is_homeroom} AND
-          {student_homeroom_section.is_current_section_enrollment}
+          {student_homeroom_section.is_current_homeroom}
         relationship: one_to_one
 
     dimensions:

--- a/src/cube/model/cubes/students/student_section_enrollments.yml
+++ b/src/cube/model/cubes/students/student_section_enrollments.yml
@@ -100,15 +100,19 @@ cubes:
         sql: lead_teacher_staff_key
         type: string
 
-      - name: teacher_role
-        description: Role of the resolved teacher (always Lead Teacher here).
-        sql: teacher_role
-        type: string
+      - name: is_homeroom
+        description:
+          TRUE when this is a homeroom section (HR course-number prefix).
+        sql: is_homeroom
+        type: boolean
         public: true
 
-      - name: is_homeroom
-        description: TRUE when this is an HR-credit (homeroom/advisory) section.
-        sql: is_homeroom
+      - name: is_current_section_enrollment
+        description: >-
+          TRUE for the most-recent section enrollment among a student's
+          sequential enrollments in the same course within an academic year.
+          Filter with is_homeroom to select the current homeroom section.
+        sql: is_current_section_enrollment
         type: boolean
         public: true
 

--- a/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
+++ b/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
@@ -82,7 +82,6 @@ views:
           - is_dropped_section
           - is_dropped_course
           - lead_teacher_staff_key
-          - teacher_role
 
       - join_path: student_assessment_scores.student_section_enrollments.staff_lead_teacher
         prefix: true
@@ -245,7 +244,6 @@ views:
         - name: Teacher
           members:
             - lead_teacher_staff_key
-            - teacher_role
             - staff_lead_teacher_full_name
             - staff_lead_teacher_first_name
             - staff_lead_teacher_last_name

--- a/src/cube/model/views/student_attendance/student_attendance_view.yml
+++ b/src/cube/model/views/student_attendance/student_attendance_view.yml
@@ -111,9 +111,8 @@ views:
           - entry_date
           - exit_date
           - is_retained_year
-          - homeroom_teacher_staff_key
 
-      - join_path: student_attendance.student_school_enrollments.staff_homeroom_teacher
+      - join_path: student_attendance.student_school_enrollments.student_homeroom_section.staff_homeroom_teacher
         prefix: true
         includes:
           - full_name
@@ -235,7 +234,6 @@ views:
             - is_retained_year
         - name: Teacher
           members:
-            - homeroom_teacher_staff_key
             - staff_homeroom_teacher_full_name
             - staff_homeroom_teacher_first_name
             - staff_homeroom_teacher_last_name
@@ -255,8 +253,8 @@ views:
       # holds exactly one student-<scope> group (buildGroups); none => no group =>
       # default-deny. row_level uses this view's flat location member names (see
       # the includes/folders below), not cube-qualified paths.
-      # Teacher fields (staff_homeroom_teacher_* names, homeroom_teacher_staff_key)
-      # ride the wildcard include — staff-directory-tier info, not student PII.
+      # Teacher fields (staff_homeroom_teacher_* names) ride the wildcard
+      # include — staff-directory-tier info, not student PII.
       - group: student-region
         member_level:
           includes: "*"

--- a/src/cube/model/views/students/student_enrollments_view.yml
+++ b/src/cube/model/views/students/student_enrollments_view.yml
@@ -65,9 +65,8 @@ views:
           - grade_level
           - graduation_year
           - is_retained_year
-          - homeroom_teacher_staff_key
 
-      - join_path: student_enrollments.student_school_enrollments.staff_homeroom_teacher
+      - join_path: student_enrollments.student_school_enrollments.student_homeroom_section.staff_homeroom_teacher
         prefix: true
         includes:
           - full_name
@@ -142,7 +141,6 @@ views:
             - is_latest_record
         - name: Teacher
           members:
-            - homeroom_teacher_staff_key
             - staff_homeroom_teacher_full_name
             - staff_homeroom_teacher_first_name
             - staff_homeroom_teacher_last_name
@@ -152,8 +150,8 @@ views:
       # holds exactly one student-<scope> group (buildGroups); none => no group =>
       # default-deny. row_level uses this view's flat location member names (see
       # the includes/folders below), not cube-qualified paths.
-      # Teacher fields (staff_homeroom_teacher_* names, homeroom_teacher_staff_key)
-      # ride the wildcard include — staff-directory-tier info, not student PII.
+      # Teacher fields (staff_homeroom_teacher_* names) ride the wildcard
+      # include — staff-directory-tier info, not student PII.
       - group: student-region
         member_level:
           includes: "*"

--- a/src/cube/model/views/students/student_section_enrollments_view.yml
+++ b/src/cube/model/views/students/student_section_enrollments_view.yml
@@ -21,7 +21,7 @@ views:
           - is_dropped_section
           - is_dropped_course
           - is_homeroom
-          - teacher_role
+          - is_current_section_enrollment
           - lead_teacher_staff_key
 
       - join_path: student_section_enrollments.staff_lead_teacher
@@ -93,7 +93,6 @@ views:
         - name: Teacher
           members:
             - lead_teacher_staff_key
-            - teacher_role
             - staff_lead_teacher_full_name
             - staff_lead_teacher_first_name
             - staff_lead_teacher_last_name
@@ -141,6 +140,7 @@ views:
             - entry_date
             - exit_date
             - is_homeroom
+            - is_current_section_enrollment
             - is_dropped_section
             - is_dropped_course
             - grade_level

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -30,7 +30,6 @@ vars:
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
   current_academic_year: 2026
   current_fiscal_year: 2027
-  homeroom_credit_types: [HR, Advisory]
 
 models:
   kipptaf:

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_enrollments.sql
@@ -1,123 +1,30 @@
-with
-    homeroom_sections as (
-        select
-            cc.cc_studentid,
-            cc.cc_yearid,
-            cc.sections_schoolid,
-            cc._dbt_source_project,
-            cc.cc_dateenrolled,
-            cc.cc_dateleft,
-
-            {{
-                dbt_utils.generate_surrogate_key(
-                    ["cc.sections_dcid", "cc._dbt_source_project"]
-                )
-            }} as course_section_key,
-        from {{ ref("base_powerschool__course_enrollments") }} as cc
-        where
-            -- Credit-type test is duplicated in
-            -- dim_student_section_enrollments.sql (is_homeroom column), which
-            -- flags homeroom sections independently to avoid a build cycle.
-            -- Both read the var("homeroom_credit_types") list.
-            cc.courses_credittype
-            in ({{ "'" ~ (var("homeroom_credit_types") | join("', '")) ~ "'" }})
-            and not cc.is_dropped_section
-            and not cc.is_dropped_course
-    ),
-
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    homeroom_teacher as (
-        select
-            hs.cc_dateenrolled,
-
-            bcst.effective_start_date,
-            bcst.staff_key as homeroom_teacher_staff_key,
-
-            {{
-                dbt_utils.generate_surrogate_key(
-                    [
-                        "s.student_number",
-                        "s._dbt_source_project",
-                        "s.academic_year",
-                        "s.entrydate",
-                    ]
-                )
-            }} as student_enrollment_key,
-        from homeroom_sections as hs
-        inner join
-            {{ ref("int_powerschool__student_enrollment_union") }} as s
-            on hs.cc_studentid = s.studentid
-            and hs.sections_schoolid = s.schoolid
-            and hs.cc_yearid = s.yearid
-            and hs._dbt_source_project = s._dbt_source_project
-            and hs.cc_dateenrolled >= s.entrydate
-            and hs.cc_dateenrolled < s.exitdate
-        left join
-            {{ ref("bridge_course_section_teachers") }} as bcst
-            on hs.course_section_key = bcst.course_section_key
-            and bcst.`role` = 'Lead Teacher'
-            and bcst.effective_start_date
-            < coalesce(hs.cc_dateleft, cast('9999-12-31' as date))
-            and hs.cc_dateenrolled
-            < coalesce(bcst.effective_end_date, cast('9999-12-31' as date))
-    ),
-
-    homeroom_resolved as (
-        {{
-            dbt_utils.deduplicate(
-                relation="homeroom_teacher",
-                partition_by="student_enrollment_key",
-                order_by="cc_dateenrolled desc, effective_start_date desc, homeroom_teacher_staff_key asc",
-            )
-        }}
-    ),
-
-    enrollments as (
-        select
-            {{
-                dbt_utils.generate_surrogate_key(
-                    [
-                        "enr.student_number",
-                        "enr._dbt_source_project",
-                        "enr.academic_year",
-                        "enr.entrydate",
-                    ]
-                )
-            }} as student_enrollment_key,
-
-            {{ dbt_utils.generate_surrogate_key(["enr.student_number"]) }}
-            as student_key,
-
-            sch.location_key,
-
-            enr.entrydate as entry_date_key,
-            enr.exitdate as exit_date_key,
-
-            enr.academic_year,
-            enr.grade_level,
-            enr.cohort_primary as graduation_year,
-            enr.is_retained_year,
-            enr.year_in_network,
-        from {{ ref("int_powerschool__student_enrollment_union") }} as enr
-        left join
-            {{ ref("stg_powerschool__schools") }} as sch
-            on enr.schoolid = sch.school_number
-            and enr._dbt_source_project = sch._dbt_source_project
-    )
-
 select
-    e.student_enrollment_key,
-    e.student_key,
-    e.location_key,
-    e.entry_date_key,
-    e.exit_date_key,
-    e.academic_year,
-    e.grade_level,
-    e.graduation_year,
-    e.is_retained_year,
-    e.year_in_network,
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "enr.student_number",
+                "enr._dbt_source_project",
+                "enr.academic_year",
+                "enr.entrydate",
+            ]
+        )
+    }} as student_enrollment_key,
 
-    hr.homeroom_teacher_staff_key,
-from enrollments as e
+    {{ dbt_utils.generate_surrogate_key(["enr.student_number"]) }} as student_key,
+
+    sch.location_key,
+
+    enr.entrydate as entry_date_key,
+    enr.exitdate as exit_date_key,
+
+    enr.academic_year,
+    enr.grade_level,
+    enr.cohort_primary as graduation_year,
+    enr.is_retained_year,
+    enr.year_in_network,
+
+from {{ ref("int_powerschool__student_enrollment_union") }} as enr
 left join
-    homeroom_resolved as hr on e.student_enrollment_key = hr.student_enrollment_key
+    {{ ref("stg_powerschool__schools") }} as sch
+    on enr.schoolid = sch.school_number
+    and enr._dbt_source_project = sch._dbt_source_project

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -26,7 +26,8 @@ with
             cc.region,
             cc.is_dropped_section,
             cc.is_dropped_course,
-            cc.courses_credittype,
+            cc.cc_course_number,
+            cc.teachernumber,
 
             enr._dbt_source_project as enr_source_project,
             enr.student_number as enr_student_number,
@@ -70,7 +71,8 @@ with
             er.cc_dateleft,
             er.is_dropped_section,
             er.is_dropped_course,
-            er.courses_credittype,
+            er.cc_course_number,
+            er.teachernumber,
             er.enr_source_project,
             er.enr_student_number,
             er.enr_academic_year,
@@ -78,7 +80,7 @@ with
 
             rt.`type` as rt_type,
             rt.code as rt_code,
-            rt.name as rt_name,
+            rt.`name` as rt_name,
             rt.start_date as rt_start_date,
             rt.region as rt_region,
             rt.school_id as rt_school_id,
@@ -91,6 +93,7 @@ with
             and rt.`type` = 'RT'
     ),
 
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     section_enrollments as (
         select
             cc_academic_year as academic_year,
@@ -98,7 +101,10 @@ with
             cc_dateleft as exit_date,
             is_dropped_section,
             is_dropped_course,
-            courses_credittype,
+            cc_course_number,
+            teachernumber,
+            enr_source_project,
+            enr_student_number,
 
             {{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
             as student_section_enrollment_key,
@@ -143,58 +149,69 @@ with
         from course_enrollments_joined
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    lead_teacher_overlap as (
-        select
-            se.student_section_enrollment_key,
-
-            bcst.staff_key as lead_teacher_staff_key,
-            bcst.`role` as teacher_role,
-            bcst.effective_start_date,
-        from section_enrollments as se
-        left join
-            {{ ref("bridge_course_section_teachers") }} as bcst
-            on se.course_section_key = bcst.course_section_key
-            and bcst.`role` = 'Lead Teacher'
-            and bcst.effective_start_date
-            < coalesce(se.exit_date, cast('9999-12-31' as date))
-            and se.entry_date
-            < coalesce(bcst.effective_end_date, cast('9999-12-31' as date))
-    ),
-
-    lead_teacher_resolved as (
+    -- Reporting terms are not unique on (powerschool_term_id, school, region) —
+    -- one term id maps to several reporting quarters — so the term join fans a
+    -- section enrollment across quarters. Collapse to one row per PK (the model
+    -- grain); term_key resolves to a single deterministic quarter, as before.
+    section_enrollments_deduped as (
         {{
             dbt_utils.deduplicate(
-                relation="lead_teacher_overlap",
+                relation="section_enrollments",
                 partition_by="student_section_enrollment_key",
-                order_by="effective_start_date desc, lead_teacher_staff_key asc",
+                order_by="term_key asc",
             )
         }}
+    ),
+
+    section_enrollments_resolved as (
+        select
+            se.academic_year,
+            se.entry_date,
+            se.exit_date,
+            se.is_dropped_section,
+            se.is_dropped_course,
+            se.cc_course_number,
+            se.student_section_enrollment_key,
+            se.course_section_key,
+            se.student_enrollment_key,
+            se.term_key,
+
+            if(
+                sr.employee_number is not null,
+                {{ dbt_utils.generate_surrogate_key(["sr.employee_number"]) }},
+                cast(null as string)
+            ) as lead_teacher_staff_key,
+
+            row_number() over (
+                partition by
+                    se.enr_student_number,
+                    se.enr_source_project,
+                    se.academic_year,
+                    se.cc_course_number
+                order by
+                    (se.is_dropped_section or se.is_dropped_course) asc,
+                    coalesce(se.exit_date, cast('9999-12-31' as date)) desc,
+                    se.entry_date desc,
+                    se.student_section_enrollment_key asc
+            ) as course_enrollment_rank,
+        from section_enrollments_deduped as se
+        left join
+            {{ ref("int_people__staff_roster") }} as sr
+            on se.teachernumber = sr.powerschool_teacher_number
     )
 
 select
-    se.academic_year,
-    se.entry_date,
-    se.exit_date,
-    se.is_dropped_section,
-    se.is_dropped_course,
-    se.student_section_enrollment_key,
-    se.course_section_key,
-    se.student_enrollment_key,
-    se.term_key,
+    academic_year,
+    entry_date,
+    exit_date,
+    is_dropped_section,
+    is_dropped_course,
+    student_section_enrollment_key,
+    course_section_key,
+    student_enrollment_key,
+    term_key,
+    lead_teacher_staff_key,
 
-    ltr.lead_teacher_staff_key,
-    ltr.teacher_role,
-
-    -- Credit-type test is duplicated in dim_student_enrollments.sql
-    -- (homeroom_sections CTE), which resolves the homeroom teacher independently
-    -- to avoid a build cycle. Both read the var("homeroom_credit_types") list.
-    coalesce(
-        se.courses_credittype
-        in ({{ "'" ~ (var("homeroom_credit_types") | join("', '")) ~ "'" }}),
-        false
-    ) as is_homeroom,
-from section_enrollments as se
-left join
-    lead_teacher_resolved as ltr
-    on se.student_section_enrollment_key = ltr.student_section_enrollment_key
+    coalesce(cc_course_number like 'HR%', false) as is_homeroom,
+    (course_enrollment_rank = 1) as is_current_section_enrollment,
+from section_enrollments_resolved

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -106,6 +106,8 @@ with
             enr_source_project,
             enr_student_number,
 
+            coalesce(cc_course_number like 'HR%', false) as is_homeroom,
+
             {{ dbt_utils.generate_surrogate_key(["cc_dcid", "_dbt_source_project"]) }}
             as student_section_enrollment_key,
 
@@ -153,6 +155,7 @@ with
     -- one term id maps to several reporting quarters — so the term join fans a
     -- section enrollment across quarters. Collapse to one row per PK (the model
     -- grain); term_key resolves to a single deterministic quarter, as before.
+    -- TODO(#4484): resolve term_key to the enrollment's actual quarter by date.
     section_enrollments_deduped as (
         {{
             dbt_utils.deduplicate(
@@ -170,7 +173,7 @@ with
             se.exit_date,
             se.is_dropped_section,
             se.is_dropped_course,
-            se.cc_course_number,
+            se.is_homeroom,
             se.student_section_enrollment_key,
             se.course_section_key,
             se.student_enrollment_key,
@@ -194,6 +197,19 @@ with
                     se.entry_date desc,
                     se.student_section_enrollment_key asc
             ) as course_enrollment_rank,
+
+            -- The current homeroom section per stint: rank homeroom rows within
+            -- the enrollment stint and keep the most recent, so at most one
+            -- current homeroom exists per stint even when a student carries
+            -- concurrent HR sections (a data-quality case; deduped to latest).
+            row_number() over (
+                partition by se.student_enrollment_key, se.is_homeroom
+                order by
+                    (se.is_dropped_section or se.is_dropped_course) asc,
+                    coalesce(se.exit_date, cast('9999-12-31' as date)) desc,
+                    se.entry_date desc,
+                    se.student_section_enrollment_key asc
+            ) as homeroom_rank,
         from section_enrollments_deduped as se
         left join
             {{ ref("int_people__staff_roster") }} as sr
@@ -206,12 +222,13 @@ select
     exit_date,
     is_dropped_section,
     is_dropped_course,
+    is_homeroom,
     student_section_enrollment_key,
     course_section_key,
     student_enrollment_key,
     term_key,
     lead_teacher_staff_key,
 
-    coalesce(cc_course_number like 'HR%', false) as is_homeroom,
     (course_enrollment_rank = 1) as is_current_section_enrollment,
+    (is_homeroom and homeroom_rank = 1) as is_current_homeroom,
 from section_enrollments_resolved

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -4,9 +4,8 @@ models:
       Student enrollment dimension. One row per student x school x academic year
       enrollment record. Each re-enrollment within a year is a distinct record
       identified by entrydate. Entry and exit dates bound each enrollment
-      period. FK to dim_students, dim_locations, dim_dates (role-playing via
-      entry_date_key and exit_date_key), and dim_staff via
-      homeroom_teacher_staff_key.
+      period. FK to dim_students, dim_locations, and dim_dates (role-playing via
+      entry_date_key and exit_date_key).
     columns:
       - name: student_enrollment_key
         data_type: string
@@ -39,28 +38,6 @@ models:
               arguments:
                 to: ref('dim_students')
                 field: student_key
-
-      - name: homeroom_teacher_staff_key
-        data_type: string
-        description: >-
-          Staff key of the student's homeroom/advisory Lead Teacher for this
-          enrollment stint — the Lead Teacher of the stint's HR-credit section,
-          resolved from HR-credit course enrollments joined to the
-          section-teacher bridge and deduplicated to the most-recent on a
-          mid-year homeroom change. FK to dim_staff. Null when the stint has no
-          resolvable HR section lead.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
-            warn_unenforced: false
-        data_tests:
-          - relationships:
-              arguments:
-                to: ref('dim_staff')
-                field: staff_key
-
       - name: location_key
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -38,7 +38,9 @@ models:
             warn_unsupported: false
             warn_unenforced: false
         data_tests:
-          - unique
+          - unique:
+              config:
+                severity: error
           - not_null
 
       - name: student_enrollment_key
@@ -133,15 +135,27 @@ models:
         data_type: boolean
         description: >-
           TRUE when the section is a homeroom section, identified by an HR
-          course-number prefix. Never null — any other course is FALSE. Combine
-          with is_current_section_enrollment to resolve a student's single
-          current homeroom teacher.
+          course-number prefix. Never null — any other course is FALSE. To
+          resolve a student's single current homeroom section and its teacher,
+          use is_current_homeroom.
 
       - name: is_current_section_enrollment
         data_type: boolean
         description: >-
           TRUE for the current section enrollment among a student's sequential
           enrollments in the same course within an academic year — the
-          most-recent, non-dropped enrollment. Never null. For homeroom, combine
-          with is_homeroom to select the student's single current homeroom
-          section and its lead teacher.
+          most-recent enrollment, ranking active enrollments ahead of dropped
+          ones. Never null; an all-dropped course still resolves one current
+          row. General across all courses — for the homeroom teacher use
+          is_current_homeroom, which collapses concurrent homerooms to one per
+          stint.
+
+      - name: is_current_homeroom
+        data_type: boolean
+        description: >-
+          TRUE for the student's single current homeroom section within an
+          enrollment stint — the most-recent homeroom among any sequential or
+          concurrent homeroom enrollments. Never null; FALSE for non-homeroom
+          sections. Guarantees one homeroom section per stint, so the homeroom
+          teacher resolves without fan-out even in the rare data-quality case of
+          concurrent homerooms (deduped to the most recent).

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -12,12 +12,10 @@ models:
       - name: lead_teacher_staff_key
         data_type: string
         description: >-
-          Staff key of the section's Lead Teacher, resolved from
-          bridge_course_section_teachers by course_section_key with a date
-          overlap of the teacher assignment window and the section enrollment,
-          deduplicated to the most-recent lead on a mid-year handoff. FK to
-          dim_staff. Null when the section has no Lead Teacher assignment
-          overlapping the enrollment (expected for a minority of rows).
+          Staff key of the section's lead teacher — the section's teacher of
+          record, resolved to a staff member via the staff roster. FK to
+          dim_staff. Null when the section's teacher does not resolve to a staff
+          record.
         constraints:
           - type: foreign_key
             to: ref('dim_staff')
@@ -131,17 +129,19 @@ models:
           meaning the entire course was abandoned rather than just a section
           transfer.
 
-      - name: teacher_role
-        data_type: string
-        description: >-
-          Role name of the resolved teacher from the section-teacher bridge.
-          Always Lead Teacher in this dimension (co-teacher and other roles are
-          not surfaced here). Null when no lead teacher resolved.
-
       - name: is_homeroom
         data_type: boolean
         description: >-
-          TRUE when the section's credit type is HR or Advisory (the homeroom /
-          advisory sections). Never null — a null or other credit type is FALSE.
-          The same HR / Advisory rule identifies each student's homeroom teacher
-          (the homeroom_teacher_staff_key on the enrollment dimension).
+          TRUE when the section is a homeroom section, identified by an HR
+          course-number prefix. Never null — any other course is FALSE. Combine
+          with is_current_section_enrollment to resolve a student's single
+          current homeroom teacher.
+
+      - name: is_current_section_enrollment
+        data_type: boolean
+        description: >-
+          TRUE for the current section enrollment among a student's sequential
+          enrollments in the same course within an academic year — the
+          most-recent, non-dropped enrollment. Never null. For homeroom, combine
+          with is_homeroom to select the student's single current homeroom
+          section and its lead teacher.

--- a/src/dbt/kipptaf/models/people/intermediate/properties/int_people__staff_roster.yml
+++ b/src/dbt/kipptaf/models/people/intermediate/properties/int_people__staff_roster.yml
@@ -221,6 +221,8 @@ models:
       - name: reports_to_mail
         data_type: string
       - name: powerschool_teacher_number
+        data_tests:
+          - unique
         data_type: string
       - name: reports_to_employee_number
         data_type: int64


### PR DESCRIPTION
## Summary and Motivation

Reworks the student-teacher linkage from #4330 per code review — a net
simplification (14 files, +195/-293). Stacked on
`cristinabaldor/feat/claude-student-teacher-manager-cube-linkage`; intended to be
folded into #4330 before merge.

**dbt — `dim_student_section_enrollments`**

- Lead teacher resolves from the section `teachernumber` via
  `int_people__staff_roster` (`staff_key`), replacing the
  `bridge_course_section_teachers` join, date-overlap, dedupe, and
  `teacher_role`. `teachernumber` is globally unique in the roster, so the join
  is fan-safe.
- `is_homeroom` redefined to the `HR`-prefixed course-number rule (matching
  `int_powerschool__advisory`); credit type is not a reliable signal. The
  `homeroom_credit_types` var is removed.
- New general `is_current_section_enrollment` flag — the most-recent section
  enrollment per (student, course, academic_year). Homeroom resolves to one
  section per stint via `is_homeroom AND is_current_section_enrollment` (3 DQ
  stints network-wide carry two concurrent HR courses — flagged, not blocked).

**dbt — `dim_student_enrollments`**: the `homeroom_teacher_staff_key` derivation
is reverted. Homeroom teacher now lives at the section grain.

**Reporting-term handling (status quo — not fixed here)**: removing the old
dedupe surfaced a pre-existing fan-out — one PowerSchool term id maps to several
reporting quarters. This PR preserves the original behavior: collapse to one row
per PK, so `term_key` stays a single arbitrary quarter for the ~140 coarse term
ids (unchanged from prod, now deterministic instead of build-nondeterministic).
The real fix is tracked in #4484.

**Cube**

- `staff_lead_teacher` / `staff_homeroom_teacher` become plain `extends: staff`
  (inline sql removed).
- New `student_homeroom_section` role cube reads the section mart;
  `student_school_enrollments` joins it filtered to the current homeroom section,
  so attendance and enrollment views surface the homeroom teacher `many_to_one`.
- Views drop `teacher_role`; the roster view exposes
  `is_current_section_enrollment`.

## AI Assistance

Implemented with Claude Code. Human-directed: the sourcing decision (section
`teachernumber` vs the bridge), the homeroom definition, the general
current-enrollment flag, and the Cube topology.

## Self-review — dbt

- [x] Properties `.yml` updated for both changed models.
- [x] Validated against prod (compiled model): PK unique, lead-teacher FK 95.1%
      populated, homeroom resolves to one section per stint (3 DQ).

## Validation still needed

- [ ] **Cube dev-server validation** — the homeroom join topology (new
      `student_homeroom_section` cube + filtered join) cannot be validated
      locally. Spin up the branch staging environment and confirm the four
      student views compile and attendance-by-homeroom-teacher returns rows.
- [ ] **Docs** — the #4330 spec/plan still describe the original approach
      (bridge, credit-type homeroom, homeroom on the enrollment dim). Reconcile
      when folding this in.

## CI checks

- [ ] **Trunk** — expected clean (checked locally).
- [ ] **dbt Cloud** — runs on this stacked PR.
- [ ] **Dagster Cloud** — not triggered (no Dagster paths changed).
- Note: `claude-code-review` does not auto-run on a stacked PR (base is not
  `main`).

Refs #4330
Refs #4484