### PR TITLE
docs(claude): record teacher-linkage session learnings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,7 +104,8 @@ evidence in `.claude/scratch/` and reference it. For non-Bash tools only Section
 **Non-Bash tool inputs are path-scanned too:** `TodoWrite` / `AskUserQuestion`
 text containing a bare `env` (or other sensitive-path token) trips "Cannot
 access sensitive path". Reword (`environment variable`; avoid cred-suffix tokens
-like `_KIPPMIAMI`).
+like `_KIPPMIAMI`). Also fires on `mcp__github__*` PR / issue bodies — prose
+like "staging env" / "dev env" is denied; write "environment".
 
 **Your own ad-hoc Bash self-blocks on `$UPPER_CASE`:** Rule 7 denies any Bash
 command expanding a non-allowlisted uppercase var — including one you define in

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -78,6 +78,12 @@ school_calendars) go in `cubes/conformed/`.
   resolutions: a compound join on the canonical path (see
   `student_attendance.yml` → `school_calendars`), or a degenerate FK with no
   declared join. Comment the choice.
+- **Second join to an already-role-played mart → fresh `sql_table` cube, not
+  `extends`.** To add a SECOND, differently-filtered join to a mart another cube
+  already reaches (e.g. a stint cube reaching "the current homeroom section" of
+  `dim_student_section_enrollments`), define a fresh `public: false`
+  `sql_table:` cube — NOT `extends` the existing one. `extends` inherits the
+  base's joins, forming a cycle with the new reverse join.
 - **Time dimensions** must cast to `TIMESTAMP` in the dim's `sql:` — but never
   reference a time dimension in a join `sql:`. Cube substitutes the
   query-timezone conversion (`convertTz`) into join predicates, so

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -336,6 +336,13 @@ Validate a newly-added data test against prod before pushing:
 `dbt test --select <model> --target dev --defer --state <prod manifest>` runs
 the compiled test SQL against the deferred prod relation — no dev build needed.
 
+A dev `--defer` build of a **table-materialized** mart can fail on a cross-mart
+`foreign_key` constraint ("Table X does not have Primary Key constraints") when
+the deferred prod parent's DDL lacks the rendered PK. To validate the model's
+logic (PK uniqueness, row counts) without building the parent, run its compiled
+SQL (`target/compiled/...`, refs already prod-resolved under `--favor-state`)
+against prod via the BQ MCP.
+
 ## Multi-line SQL in YAML `data_tests:` expressions
 
 Use literal block (`|`), not folded (`>-`). trunk-fmt reflows past 80 chars and

--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -207,6 +207,13 @@ Net mart row-count delta is typically `+N` where N is the residual fan-out — n
 `-N`. Adding an upstream `where` filter alongside doesn't drop PKs; it changes
 which rows the surviving PK joins to.
 
+The same applies to a final `dbt_utils.deduplicate` partitioned by the PK: it
+silently collapses ANY mid-chain fan-out (e.g. a coarse-key join to a non-unique
+lookup — the reporting-terms sheet isn't unique on `powerschool_term_id`), so
+removing or replacing it can surface a latent PK-uniqueness break from a source
+other than upstream dupes. Audit every join between the dedupe and the model
+grain before removing it.
+
 ## Verify source precision before R9 drops
 
 Staging cast chains (`cast(x as datetime)` → `cast(as date)`) and field names


### PR DESCRIPTION
## Summary and Motivation

When merged, this records four CLAUDE.md learnings from the #4485
teacher-linkage refactor session, so future sessions skip the same detours.
Docs-only — no code paths touched.

- **marts** (`models/marts/CLAUDE.md`) — a final `dbt_utils.deduplicate`
  partitioned by the PK silently masks a mid-chain join fan-out; audit the joins
  between the dedupe and the model grain before removing it. (A removed dedupe
  surfaced a latent reporting-terms fan-out this session.)
- **dbt** (`src/dbt/CLAUDE.md`) — a dev `--defer` build of a table-materialized
  mart can fail on a cross-mart `foreign_key` constraint; validate the model's
  logic via its compiled SQL against prod instead.
- **cube** (`src/cube/CLAUDE.md`) — a second, differently-filtered join to a
  mart another cube already role-plays needs a fresh `sql_table` cube, not
  `extends` (which inherits joins and forms a cycle).
- **hooks** (`.claude/CLAUDE.md`) — `mcp__github__*` PR / issue bodies are
  path-scanned; a bare sensitive-path token in prose is denied. Spell it out
  (write "environment", not the 3-letter form).

## AI Assistance

Learnings captured by Claude Code via the `revise-claude-md` skill; reviewed and
approved before applying.

## CI checks

- [ ] **Trunk** — markdownlint checked clean locally on all four files.
- [ ] **dbt Cloud** / **Dagster Cloud** — no-op (docs-only).