### PR TITLE
feat(extracts): refine lattice user extract (temp/part-time exclusion + demographics)

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -84,7 +84,7 @@ Lattice must match the source values exactly (e.g. "Latinx/Hispanic/Chicana(o)",
 - `gender` — self-reported gender identity from ADP, only visible to admins
 - `ethnicity` — race/ethnicity reporting category from ADP, only visible to
   admins
-- `birthdate` — employee date of birth from ADP
+- `birthdate` — employee date of birth from ADP, only visible to admins
 
 Not included:
 

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -1,0 +1,62 @@
+# Lattice User Extract — Who's Included
+
+This feed (`rpt_lattice__users`) decides which KTAF employees get a Lattice
+account. It draws from the staff roster (`int_people__staff_roster`) and applies
+the rules below. **An employee must clear _every_ gate to be included.**
+
+Keep this doc in sync with the model whenever the criteria change.
+
+## The short version
+
+Included = a current (or just-departed) employee, in an eligible business unit,
+who is **not** an intern, a temp, or a part-timer.
+
+## The gates in plain language
+
+### 1. Not an intern, temp, or part-timer
+
+- Their job title is not "Intern."
+- Their worker type is not a "Temporary" or "Part Time" classification.
+- As a backstop for mislabeling, anyone whose **job title** contains
+  "Temporary," "Part Time," or "Part-Time" is also excluded.
+- Employees with a **blank worker type are kept** — in practice these are
+  legitimate full-time staff, so we don't drop them.
+
+### 2. They belong to an eligible group
+
+Any one of these qualifies:
+
+- **KTAF central (KIPP TEAM and Family Schools Inc.)** — everyone.
+- **KIPP Paterson** — everyone.
+- **KIPP Miami** — only school/team leaders: job title contains "Director,"
+  "Head," "Leader," or "Dean," **or** their work location is "Room 11."
+- **Newark (TEAM Academy Charter School) or Camden (KIPP Cooper Norcross
+  Academy)** — only these operations roles:
+  - Director School Operations
+  - Director Campus Operations
+  - Managing Director of School Operations
+  - Managing Director of Operations
+- **Newark or Camden** — anyone in the **Technology** or **Marketing, Comms, and
+  Enrollment** department.
+
+### 3. Currently employed, or very recently departed
+
+Either one:
+
+- Their assignment status is "Active" or "Leave," **or**
+- They were terminated within the last 30 days.
+
+## Things worth remembering
+
+- **Newark and Camden are treated identically** — the same operations-title list
+  and the same two departments apply to both. They are the only regions with
+  role or department restrictions of that kind.
+- **Miami is the exception** — it is gated on a title keyword match plus one
+  hardcoded location ("Room 11"), rather than an explicit title or department
+  list.
+- **KTAF central and Paterson are wide open** — no role filter, so those two
+  always contribute the most people.
+- **Worker type is the primary signal for temps and part-timers**, not job
+  title. Most part-timers and temps have ordinary titles (Teacher, Counselor,
+  Registered Nurse, Office Manager), so the title check alone would miss them —
+  it is only a safety net.

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -11,12 +11,11 @@ Keep this doc in sync with the model whenever the criteria change.
 ### High level summary
 
 - **KTAF central and Paterson include everyone** — no role filter.
-- **Newark and Camden are treated identically** — the same operations-title list
-  and the same two departments apply to both. They are the only regions with
-  role or department restrictions of that kind.
-- **Miami is the exception** — it is gated on a title keyword match plus one
-  hardcoded location ("Room 11"), rather than an explicit title or department
-  list.
+- **Newark and Camden are treated identically** — operations leaders and two
+  departments (**Technology** or **Marketing, Comms, and Enrollment**) included.
+- **Miami includes additional leader roles** — gated on a title keyword match
+  plus one hardcoded location ("Room 11"), rather than an explicit title or
+  department list.
 - **Part-timers and temporary workers are excluded** - part-timers are excluded
   on ADP worker type; temps are excluded by job title. We intentionally do not
   exclude on the "Temporary" worker type right now, because full-time-temporary
@@ -61,29 +60,33 @@ Any one of these qualifies:
 Either one:
 
 - Their assignment status is "Active" or "Leave," **or**
-- They were terminated within the last 30 days.
+- They were terminated within the last 30 days. This is to deactivate terminated
+  users in Lattice, after 30 days they are dropped from the extract entirely.
 
 ## Lattice Fields Extract - What's Included
 
-The file is a CSV; each column header is the field name Lattice reads.
+The file is a CSV; each column header is the field name Lattice reads. **Gender
+and ethnicity** are sent verbatim from ADP, so the field options set up in
+Lattice must match the source values exactly (e.g. "Latinx/Hispanic/Chicana(o)",
+"Cis Woman"). A value can be blank when the employee has none recorded.
 
 - `external_user_id` — ADP employee number (the Lattice user ID)
 - `status` — Active or Inactive
-- `work_email`,
+- `work_email`
 - `manager_email`
-- `first_name`, `last_name`
-- `job_title`, `department`, `location`, `business_unit`
+- `first_name`
+- `last_name`
+- `job_title`
+- `department`
+- `location`
+- `business_unit`
 - `start_date`
-- `gender` — self-reported gender identity from ADP
-- `ethnicity` — race/ethnicity reporting category from ADP
+- `gender` — self-reported gender identity from ADP, only visible to admins
+- `ethnicity` — race/ethnicity reporting category from ADP, only visible to
+  admins
 - `birthdate` — employee date of birth from ADP
 
 Not included:
 
 - `tenure` - is a calculated field in Lattice
-- `pronouns` - not currently collected from staff
-
-**Gender and ethnicity** are sent verbatim from ADP, so the field options set up
-in Lattice must match the source values exactly (e.g.
-"Latinx/Hispanic/Chicana(o)", "Cis Woman"). A value can be blank when the
-employee has none recorded.
+- `pronouns` - not currently collected from staff, incomplete in ADP

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -20,8 +20,8 @@ who is **not** an intern, a temp, or a part-timer.
 - Anyone whose **job title** contains "Temporary," "Part Time," or "Part-Time"
   is excluded — this catches temps regardless of their worker type.
 - **Full-time temporary staff are currently kept**, pending a review of their
-  ADP records — that worker type is frequently a mislabel, so we don't
-  auto-remove them.
+  ADP records — that worker type might be a mislabel, so we don't auto-remove
+  them.
 - Employees with a **blank worker type are kept** — in practice these are
   legitimate full-time staff, so we don't drop them.
 
@@ -65,8 +65,7 @@ The file is a CSV; each column header is the field name Lattice reads.
 **Gender and ethnicity** are sent verbatim from ADP, so the field options set up
 in Lattice must match the source values exactly (e.g.
 "Latinx/Hispanic/Chicana(o)", "Cis Woman"). A value can be blank when the
-employee has none recorded. These are sensitive demographic attributes — changes
-to what we send should have People Ops sign-off.
+employee has none recorded.
 
 ## Things worth remembering
 
@@ -76,9 +75,8 @@ to what we send should have People Ops sign-off.
 - **Miami is the exception** — it is gated on a title keyword match plus one
   hardcoded location ("Room 11"), rather than an explicit title or department
   list.
-- **KTAF central and Paterson are wide open** — no role filter, so those two
-  always contribute the most people.
+- **KTAF central and Paterson include everyone** — no role filter.
 - **Part-timers are caught by worker type; temps are caught by job title.** We
   intentionally do not exclude on the "Temporary" worker type right now, because
-  full-time-temporary is frequently a mislabel in ADP — so a temp is dropped
-  only if their title says so. Revisit once the ADP records are cleaned up.
+  full-time-temporary might be mislabels in ADP — so a temp is dropped only if
+  their title says so.

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -49,6 +49,25 @@ Either one:
 - Their assignment status is "Active" or "Leave," **or**
 - They were terminated within the last 30 days.
 
+## What each row sends to Lattice
+
+The file is a CSV; each column header is the field name Lattice reads.
+
+- `external_user_id` — ADP employee number (the Lattice user ID)
+- `status` — Active or Inactive
+- `work_email`, `manager_email`
+- `first_name`, `last_name`
+- `job_title`, `department`, `location`, `business_unit`
+- `start_date`
+- `gender` — self-reported gender identity from ADP
+- `ethnicity` — race/ethnicity reporting category from ADP
+
+**Gender and ethnicity** are sent verbatim from ADP, so the field options set up
+in Lattice must match the source values exactly (e.g.
+"Latinx/Hispanic/Chicana(o)", "Cis Woman"). A value can be blank when the
+employee has none recorded. These are sensitive demographic attributes — changes
+to what we send should have People Ops sign-off.
+
 ## Things worth remembering
 
 - **Newark and Camden are treated identically** — the same operations-title list

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -13,12 +13,15 @@ who is **not** an intern, a temp, or a part-timer.
 
 ## The gates in plain language
 
-### 1. Not an intern, temp, or part-timer
+### 1. Not an intern, part-timer, or title-flagged temp
 
 - Their job title is not "Intern."
-- Their worker type is not a "Temporary" or "Part Time" classification.
-- As a backstop for mislabeling, anyone whose **job title** contains
-  "Temporary," "Part Time," or "Part-Time" is also excluded.
+- Their worker type is not a "Part Time" classification.
+- Anyone whose **job title** contains "Temporary," "Part Time," or "Part-Time"
+  is excluded — this catches temps regardless of their worker type.
+- **Full-time temporary staff are currently kept**, pending a review of their
+  ADP records — that worker type is frequently a mislabel, so we don't
+  auto-remove them.
 - Employees with a **blank worker type are kept** — in practice these are
   legitimate full-time staff, so we don't drop them.
 
@@ -56,7 +59,7 @@ Either one:
   list.
 - **KTAF central and Paterson are wide open** — no role filter, so those two
   always contribute the most people.
-- **Worker type is the primary signal for temps and part-timers**, not job
-  title. Most part-timers and temps have ordinary titles (Teacher, Counselor,
-  Registered Nurse, Office Manager), so the title check alone would miss them —
-  it is only a safety net.
+- **Part-timers are caught by worker type; temps are caught by job title.** We
+  intentionally do not exclude on the "Temporary" worker type right now, because
+  full-time-temporary is frequently a mislabel in ADP — so a temp is dropped
+  only if their title says so. Revisit once the ADP records are cleaned up.

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -1,17 +1,29 @@
 # Lattice User Extract — Who's Included
 
-This feed (`rpt_lattice__users`) decides which KTAF employees get a Lattice
-account. It draws from the staff roster (`int_people__staff_roster`) and applies
-the rules below. **An employee must clear _every_ gate to be included.**
+This feed (`rpt_lattice__users`) decides which employees get a Lattice account.
+It draws from the staff roster (`int_people__staff_roster`) and applies the
+rules below. **An employee must clear _every_ gate to be included.**
 
 Keep this doc in sync with the model whenever the criteria change.
 
-## The short version
+## High level summary
+
+- **KTAF central and Paterson include everyone** — no role filter.
+- **Newark and Camden are treated identically** — the same operations-title list
+  and the same two departments apply to both. They are the only regions with
+  role or department restrictions of that kind.
+- **Miami is the exception** — it is gated on a title keyword match plus one
+  hardcoded location ("Room 11"), rather than an explicit title or department
+  list.
+- **Part-timers and temporary workers are excluded** - part-timers are excluded
+  on ADP worker type; temps are excluded by job title. We intentionally do not
+  exclude on the "Temporary" worker type right now, because full-time-temporary
+  might be mislabels in ADP — so a temp is dropped only if their title says so.
+
+## Current inclusion criteria
 
 Included = a current (or just-departed) employee, in an eligible business unit,
 who is **not** an intern, a temp, or a part-timer.
-
-## The gates in plain language
 
 ### 1. Not an intern, part-timer, or title-flagged temp
 
@@ -49,7 +61,7 @@ Either one:
 - Their assignment status is "Active" or "Leave," **or**
 - They were terminated within the last 30 days.
 
-## What each row sends to Lattice
+## Lattice Fields Extract - What's Included
 
 The file is a CSV; each column header is the field name Lattice reads.
 
@@ -61,22 +73,9 @@ The file is a CSV; each column header is the field name Lattice reads.
 - `start_date`
 - `gender` — self-reported gender identity from ADP
 - `ethnicity` — race/ethnicity reporting category from ADP
+- `birthdate` — employee date of birth from ADP
 
 **Gender and ethnicity** are sent verbatim from ADP, so the field options set up
 in Lattice must match the source values exactly (e.g.
 "Latinx/Hispanic/Chicana(o)", "Cis Woman"). A value can be blank when the
 employee has none recorded.
-
-## Things worth remembering
-
-- **Newark and Camden are treated identically** — the same operations-title list
-  and the same two departments apply to both. They are the only regions with
-  role or department restrictions of that kind.
-- **Miami is the exception** — it is gated on a title keyword match plus one
-  hardcoded location ("Room 11"), rather than an explicit title or department
-  list.
-- **KTAF central and Paterson include everyone** — no role filter.
-- **Part-timers are caught by worker type; temps are caught by job title.** We
-  intentionally do not exclude on the "Temporary" worker type right now, because
-  full-time-temporary might be mislabels in ADP — so a temp is dropped only if
-  their title says so.

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -1,4 +1,4 @@
-# Lattice User Extract — Who's Included
+# Lattice Extract
 
 This feed (`rpt_lattice__users`) decides which employees get a Lattice account.
 It draws from the staff roster (`int_people__staff_roster`) and applies the
@@ -6,7 +6,9 @@ rules below. **An employee must clear _every_ gate to be included.**
 
 Keep this doc in sync with the model whenever the criteria change.
 
-## High level summary
+## Lattice User Extract — Who's Included
+
+### High level summary
 
 - **KTAF central and Paterson include everyone** — no role filter.
 - **Newark and Camden are treated identically** — the same operations-title list
@@ -20,12 +22,12 @@ Keep this doc in sync with the model whenever the criteria change.
   exclude on the "Temporary" worker type right now, because full-time-temporary
   might be mislabels in ADP — so a temp is dropped only if their title says so.
 
-## Current inclusion criteria
+### Current inclusion criteria
 
 Included = a current (or just-departed) employee, in an eligible business unit,
 who is **not** an intern, a temp, or a part-timer.
 
-### 1. Not an intern, part-timer, or title-flagged temp
+#### 1. Not an intern, part-timer, or title-flagged temp
 
 - Their job title is not "Intern."
 - Their worker type is not a "Part Time" classification.
@@ -37,7 +39,7 @@ who is **not** an intern, a temp, or a part-timer.
 - Employees with a **blank worker type are kept** — in practice these are
   legitimate full-time staff, so we don't drop them.
 
-### 2. They belong to an eligible group
+#### 2. They belong to an eligible group
 
 Any one of these qualifies:
 
@@ -54,7 +56,7 @@ Any one of these qualifies:
 - **Newark or Camden** — anyone in the **Technology** or **Marketing, Comms, and
   Enrollment** department.
 
-### 3. Currently employed, or very recently departed
+#### 3. Currently employed, or very recently departed
 
 Either one:
 
@@ -67,13 +69,19 @@ The file is a CSV; each column header is the field name Lattice reads.
 
 - `external_user_id` — ADP employee number (the Lattice user ID)
 - `status` — Active or Inactive
-- `work_email`, `manager_email`
+- `work_email`,
+- `manager_email`
 - `first_name`, `last_name`
 - `job_title`, `department`, `location`, `business_unit`
 - `start_date`
 - `gender` — self-reported gender identity from ADP
 - `ethnicity` — race/ethnicity reporting category from ADP
 - `birthdate` — employee date of birth from ADP
+
+Not included:
+
+- `tenure` - is a calculated field in Lattice
+- `pronouns` - not currently collected from staff
 
 **Gender and ethnicity** are sent verbatim from ADP, so the field options set up
 in Lattice must match the source values exactly (e.g.

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -49,6 +49,9 @@ models:
           canonical value), passed through verbatim. The Lattice field options
           must match these source values. Blank when none is recorded.
         data_type: string
+      - name: birthdate
+        description: Employee date of birth from ADP.
+        data_type: date
       - name: manager_email
         description: Work email address of the employee's direct manager.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -7,7 +7,8 @@ models:
       Camden staff in select Operations director roles or in the Technology or
       Marketing, Comms, and Enrollment departments. Interns are excluded. Covers
       staff who are Active or on Leave, plus any staff who met those same
-      criteria and were terminated within the past 30 days.
+      criteria and were terminated within the past 30 days. Includes staff
+      gender identity and race/ethnicity reporting category for Lattice.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.
@@ -35,6 +36,18 @@ models:
         data_type: date
       - name: department
         description: Employee home department name.
+        data_type: string
+      - name: gender
+        description: >
+          Employee self-reported gender identity from ADP, passed through
+          verbatim. The Lattice field options must match these source values.
+          Blank when the employee has no recorded gender identity.
+        data_type: string
+      - name: ethnicity
+        description: >
+          Employee race and ethnicity reporting category from ADP (a single
+          canonical value), passed through verbatim. The Lattice field options
+          must match these source values. Blank when none is recorded.
         data_type: string
       - name: manager_email
         description: Work email address of the employee's direct manager.

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -65,6 +65,7 @@ select
     s.home_department_name as department,
     s.gender_identity as gender,
     s.race_ethnicity_reporting as ethnicity,
+    s.birth_date as birthdate,
 
     m.work_email as manager_email,
 

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -4,6 +4,19 @@ with
         from {{ ref("int_people__staff_roster") }}
         where
             job_title <> 'Intern'
+            -- exclude temps and part-timers: worker_type_code is the primary
+            -- signal (nulls kept -- they are legitimate full-time staff); the
+            -- job_title checks are a fallback for HR mislabeling of the type
+            and (
+                worker_type_code is null
+                or not (
+                    contains_substr(worker_type_code, 'Temporary')
+                    or contains_substr(worker_type_code, 'Part Time')
+                )
+            )
+            and not contains_substr(job_title, 'Temporary')
+            and not contains_substr(job_title, 'Part Time')
+            and not contains_substr(job_title, 'Part-Time')
             and (
                 home_business_unit_name = 'KIPP TEAM and Family Schools Inc.'
                 or home_business_unit_name = 'KIPP Paterson'

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -4,15 +4,13 @@ with
         from {{ ref("int_people__staff_roster") }}
         where
             job_title <> 'Intern'
-            -- exclude temps and part-timers: worker_type_code is the primary
-            -- signal (nulls kept -- they are legitimate full-time staff); the
-            -- job_title checks are a fallback for HR mislabeling of the type
+            -- exclude part-timers plus anyone whose title names temp/part-time
+            -- work. Full Time - Temporary staff are kept pending an ADP review
+            -- (that worker type is frequently a mislabel); nulls kept as
+            -- legitimate full-time staff
             and (
                 worker_type_code is null
-                or not (
-                    contains_substr(worker_type_code, 'Temporary')
-                    or contains_substr(worker_type_code, 'Part Time')
-                )
+                or not contains_substr(worker_type_code, 'Part Time')
             )
             and not contains_substr(job_title, 'Temporary')
             and not contains_substr(job_title, 'Part Time')

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -63,6 +63,8 @@ select
     s.job_title,
     s.worker_hire_date_recent as `start_date`,
     s.home_department_name as department,
+    s.gender_identity as gender,
+    s.race_ethnicity_reporting as ethnicity,
 
     m.work_email as manager_email,
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will refine the Lattice user extract
(`rpt_lattice__users`) in two ways, and add a plain-language README documenting
the inclusion criteria and the fields sent.

**1. Exclude part-time and title-flagged temporary staff**

- Drops `worker_type_code` classifications containing "Part Time".
- Excludes anyone whose job title contains "Temporary", "Part Time", or
  "Part-Time" — catches temps regardless of worker type.
- **Full Time - Temporary staff are kept for now**, pending a review of their
  ADP records (that worker type may be a mislabel).
- **Blank worker types are kept** — in current data these are all legitimate
  full-time staff.
- Warehouse validation: 10 staff excluded from the current feed.

**2. Add demographic / profile fields**

- `gender` (from `gender_identity`, self-reported), `ethnicity` (from
  `race_ethnicity_reporting`), and `birthdate` (from `birth_date`) added as new
  columns, mapped to Lattice's Gender ID / Ethnicity / Birthdate fields.
- Gender and ethnicity ship verbatim; the corresponding Lattice field options
  are configured to match the source value sets.
- Validation on the current feed: gender and birthdate populated for all rows,
  ethnicity for most (remainder blank).
- **Pronouns were evaluated but not included** — the value exists only in ADP
  staging, is sparsely populated (~900 staff network-wide), and is not exposed
  in the staff roster, so it would require multi-model plumbing beyond this PR's
  scope.

> **Data-governance note:** this adds staff demographic attributes — gender,
> race/ethnicity, and **date of birth** (a direct identifier) — to an outbound
> third-party feed. Please confirm People Ops sign-off on sharing these with
> Lattice before merge.

### AI Assistance

Filter logic, source-column selection, warehouse validation, the field-option
lists, the Lattice field-list gap check, and the README were drafted by Claude
Code; the exclusion criteria, the decision to keep full-time-temporary staff
pending review, the demographic source choices, and the scope decisions were
specified by the requester.

## Self-review

### dbt

- Modifies an existing contracted model; adds three nullable columns (`gender`,
  `ethnicity`, `birthdate`) to the contract.
- **Not a breaking change:** additive columns plus a row filter — no renames or
  removals, so no downstream contract or exposure breakage.
- No external source changes, so no `stage_external_sources` needed.

## CI checks

- [x] **Trunk** — passes locally on all changed files.
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — pending.
