### PR TITLE
fix(finalsite): retry transient gateway 5xx (502/503/504)

### DIFF
--- a/src/teamster/libraries/finalsite/api/resources.py
+++ b/src/teamster/libraries/finalsite/api/resources.py
@@ -16,6 +16,16 @@ from tenacity import (
 )
 
 
+def _is_transient_status(status_code: int) -> bool:
+    """Return True for HTTP status codes treated as transient (worth retrying).
+
+    A bare gateway ``403`` (the shared-egress throttle signature) and any ``5xx``
+    gateway/upstream fault. Centralized so the retry decision (``_is_retryable``)
+    and the log-severity decision (``_request``'s error handler) cannot drift.
+    """
+    return status_code == 403 or status_code >= 500
+
+
 def _is_retryable(exception: BaseException) -> bool:
     """Return True for transient faults worth a bounded retry.
 
@@ -41,10 +51,7 @@ def _is_retryable(exception: BaseException) -> bool:
     return (
         isinstance(exception, HTTPError)
         and exception.response is not None
-        and (
-            exception.response.status_code == 403
-            or exception.response.status_code >= 500
-        )
+        and _is_transient_status(exception.response.status_code)
     )
 
 
@@ -113,7 +120,7 @@ class FinalsiteResource(ConfigurableResource):
             # log at WARNING, not ERROR, so the retry layer's recovered attempts
             # don't file false-positive GCP Error Reporting groups, then re-raise
             # for tenacity to retry with backoff.
-            if response.status_code == 403 or response.status_code >= 500:
+            if _is_transient_status(response.status_code):
                 self._log.warning(
                     f"Transient {response.status_code} on {method} {path}: "
                     f"{response.text.strip()[:200]}"

--- a/src/teamster/libraries/finalsite/api/resources.py
+++ b/src/teamster/libraries/finalsite/api/resources.py
@@ -19,17 +19,21 @@ from tenacity import (
 def _is_retryable(exception: BaseException) -> bool:
     """Return True for transient faults worth a bounded retry.
 
-    Two cases are retried:
+    Retried cases:
 
+    - A connection error or connect/read timeout against the gateway.
     - A bare gateway ``403``. All four districts' contacts pulls fire
       simultaneously from one shared egress IP, so the Finalsite gateway returns
       a ``403`` (not a ``429``) once the concurrent load trips its per-source
       ceiling. The ``finalsite_api`` concurrency pool is the root-cause fix; this
       is defense-in-depth for a transient ``403``.
-    - A connection error or connect/read timeout against the gateway.
+    - Any ``5xx``. Gateway/upstream faults (``502 Bad Gateway``,
+      ``503 Service Unavailable``, ``504 Gateway Timeout``) are transient and
+      clear on retry, so a single mid-pagination blip must not fail the whole
+      ~20-minute pull and force a full re-run.
 
     A ``429`` never reaches here — it is handled in-band (sleep on ``Retry-After``
-    then retry). Other ``4xx``/``5xx`` are deterministic and fail fast.
+    then retry). Other ``4xx`` are deterministic client errors and fail fast.
     """
     if isinstance(exception, (RequestsConnectionError, Timeout)):
         return True
@@ -37,7 +41,10 @@ def _is_retryable(exception: BaseException) -> bool:
     return (
         isinstance(exception, HTTPError)
         and exception.response is not None
-        and exception.response.status_code == 403
+        and (
+            exception.response.status_code == 403
+            or exception.response.status_code >= 500
+        )
     )
 
 
@@ -102,9 +109,14 @@ class FinalsiteResource(ConfigurableResource):
 
                 return self._request(method=method, path=path, id=id, **kwargs)
 
-            if response.status_code == 403:
+            # A shared-gateway 403 and any 5xx are transient (see _is_retryable):
+            # log at WARNING, not ERROR, so the retry layer's recovered attempts
+            # don't file false-positive GCP Error Reporting groups, then re-raise
+            # for tenacity to retry with backoff.
+            if response.status_code == 403 or response.status_code >= 500:
                 self._log.warning(
-                    f"Forbidden (403) on {method} {path}: {response.text.strip()[:200]}"
+                    f"Transient {response.status_code} on {method} {path}: "
+                    f"{response.text.strip()[:200]}"
                 )
                 raise
 

--- a/tests/resources/test_resource_finalsite.py
+++ b/tests/resources/test_resource_finalsite.py
@@ -131,6 +131,54 @@ def test_request_exhausts_on_persistent_403(monkeypatch: pytest.MonkeyPatch):
     assert calls["n"] == 5
 
 
+def test_request_retries_on_gateway_5xx(monkeypatch: pytest.MonkeyPatch):
+    """A transient gateway 5xx mid-pagination is retried and recovers.
+
+    The Finalsite gateway returns a 502 Bad Gateway (also 503/504) when its
+    upstream briefly has no healthy backend. Like the shared-egress 403 and
+    network faults, this is transient, so a bounded backoff must retry rather
+    than fail the whole pull. Regression for prod run 7e56efa7.
+    """
+    monkeypatch.setattr(FinalsiteResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(502, text="502 Bad Gateway")
+        return _FakeResponse(200, {"ok": True})
+
+    finalsite = _build_offline_resource(request_fn)
+
+    response = finalsite._request(method="GET", path="contacts", id=None)
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_exhausts_on_persistent_5xx(monkeypatch: pytest.MonkeyPatch):
+    """A persistent 5xx is retried up to the cap, then re-raises the HTTPError.
+
+    A gateway fault that never clears must still surface as the original
+    ``HTTPError`` and fail the run rather than retry unbounded.
+    """
+    monkeypatch.setattr(FinalsiteResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(503, text="503 Service Unavailable")
+
+    finalsite = _build_offline_resource(request_fn)
+
+    with pytest.raises(HTTPError):
+        finalsite._request(method="GET", path="contacts", id=None)
+
+    assert calls["n"] == 5
+
+
 def test_request_retries_on_network_faults(monkeypatch: pytest.MonkeyPatch):
     """A connect/read timeout or connection error is retried.
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will make `FinalsiteResource` retry transient
> gateway `5xx` responses in-process, instead of failing the whole contacts pull
> on the first one.

**Root cause.** Prod run
[`7e56efa7`](https://kipptaf.dagster.cloud/prod/runs/7e56efa7-c8d9-4d1c-8018-00cc62311aaa)
failed materializing `kippnewark/finalsite/contacts` on a mid-pagination
`502 Bad Gateway` from the Finalsite vendor gateway. `FinalsiteResource._is_retryable`
only retried a shared-egress `403` and network faults; every `5xx` fell through
to fail-fast. The Dagster run-level auto-retry then re-ran the entire
~20-minute pull from scratch and succeeded — confirming the `502` was transient,
and that an in-process retry would have absorbed it in seconds without the full
re-run or the false-positive alert.

**Change.**

- `_is_retryable` now also retries any `5xx` (`status_code >= 500`) — matching
  the ADP reference resource, which already treats `5xx` as transient. A single
  `502`/`503`/`504` mid-pagination is now absorbed by the in-process `tenacity`
  retry (5 attempts, exponential-jitter backoff) rather than failing the run.
- The `except HTTPError` block logs `403`/`5xx` at `WARNING` instead of `ERROR`,
  so the retry layer's recovered attempts don't file false-positive GCP Error
  Reporting groups (per the repo retry-logging convention).

## AI Assistance

Authored by Claude Code via the systematic-debugging workflow: diagnosis from
the run's error chain, a failing test first (TDD), then the fix. Human-directed:
the decision to fix, scope, and review.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster

- [x] Unit tests pass: `uv run pytest tests/resources/test_resource_finalsite.py`
      — 7 offline tests (new `502`-retry + persistent-`5xx`-exhaust, plus the
      existing `403`/`404`/`429`/network-fault cases); the `404` case confirms
      deterministic `4xx` still fails fast. Trunk clean on both changed files.
- [ ] `dagster definitions validate` / `tests/test_dagster_definitions.py` not
      run locally — the codespace raises env-var false errors (per repo
      convention), and this is a self-contained library-resource edit with no
      import or signature changes. Dagster Cloud CI will validate on the PR.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — n/a (no dbt changes).
- [ ] **Dagster Cloud** — passes or not triggered.
