### PR TITLE
feat(dbt): add emergency contacts to DeansList family contacts export

### DIFF
--- a/docs/superpowers/plans/2026-07-21-deanslist-emergency-contacts.md
+++ b/docs/superpowers/plans/2026-07-21-deanslist-emergency-contacts.md
@@ -1,0 +1,418 @@
+# DeansList Family Contacts — Add Emergency Contacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add emergency contacts to the DeansList `contacts.txt` feed, numbered
+`Emergency 1`–`Emergency 4` in the `Relationship` column, while the primary
+parent keeps its real relationship.
+
+**Architecture:** One kipptaf-only reporting view change. Drop the
+`contact_slot = 'contact_1'` filter in `rpt_deanslist__family_contacts` so all
+Finalsite contact slots flow through, and derive the `Relationship` value from
+`contact_slot`. Swap the row-grain uniqueness test to
+`(StudentID, Relationship)`. A new dbt unit test drives the change (TDD).
+
+**Tech Stack:** dbt (BigQuery), dbt_utils, dbt unit tests, trunk (sqlfluff +
+prettier + yamllint).
+
+## Global Constraints
+
+- Work in the worktree
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts`.
+  Every `git`, `dbt`, Read/Edit/Write path targets that worktree.
+- Issue: [#4478](https://github.com/TEAMSchools/teamster/issues/4478). Spec:
+  `docs/superpowers/specs/2026-07-21-deanslist-emergency-contacts-design.md`.
+- Nine DeansList template columns only — do NOT add a tenth column to the feed.
+  `contact_slot` is used only inside the `Relationship` `CASE`; it is not
+  projected.
+- SQL follows `src/dbt/CLAUDE.md`: BigQuery dialect, trailing commas, single
+  quotes, max one level of function nesting, no `QUALIFY`/`ORDER BY`,
+  backtick-quoted output aliases, computed values derived as named CTE columns.
+- YAML `description:` scalars must not contain `": "` (colon-space) or start
+  with a backtick. Unit-test `given`/`expect` scalars stay UNQUOTED unless a
+  quote is needed to preserve the string type.
+- `uv run` for all dbt; never bare `dbt`. Do not run `trunk fmt`/`trunk check`
+  by hand except the explicit `trunk check` step below.
+
+---
+
+## File structure
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`
+  — the reporting view. Drops the slot filter; adds the numbered-`Relationship`
+  `CASE`; renames the `parent_contacts` CTE to `contacts`.
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`
+  — swaps the `StudentID` `unique` test for a model-level
+  `unique_combination_of_columns([StudentID, Relationship])` (error), updates
+  the model + `Relationship` descriptions, and adds the unit test.
+
+No other files. All upstream columns already exist in prod, so there is no
+district, source-schema, staging-seed, or Dagster/Python change.
+
+---
+
+## Task 1: Add emergency contacts, numbered and grain-tested
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`
+
+**Interfaces:**
+
+- Consumes (unchanged, already in prod): `int_finalsite__student_contacts`
+  (`finalsite_enrollment_id`, `_dbt_source_project`, `contact_slot`,
+  `relationship`, `contact_first_name`, `contact_last_name`, `email`,
+  `phone_home`, `phone_work`, `phone_mobile`);
+  `int_finalsite__contact_id_attributes` (`finalsite_enrollment_id`,
+  `_dbt_source_project`, `powerschool_student_number`);
+  `stg_powerschool__students` (`student_number`, `enroll_status`,
+  `_dbt_source_relation`).
+- Produces: the `contacts.txt` feed shape — columns `StudentID` (int64),
+  `ParentFirstName`, `ParentLastName`, `HomePhone`, `WorkPhone`, `CellPhone`,
+  `Email`, `Relationship`, `Language` (all string). Grain: one row per
+  `(StudentID, Relationship)`.
+
+- [ ] **Step 1: Add the failing unit test to the properties yml**
+
+Append this `unit_tests:` block to the end of
+`src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`
+(top-level key, sibling of `models:`):
+
+```yaml
+unit_tests:
+  - name: test_family_contacts_emergency_numbering
+    description:
+      One student with a primary parent plus two emergency contacts. Asserts the
+      primary parent keeps its Finalsite relationship, each emergency slot is
+      relabeled Emergency N by slot number, and all three contacts are emitted
+      for the enrolled student.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Alice' as contact_first_name,
+            'Johnson' as contact_last_name,
+            'alice@example.com' as email,
+            '305-555-0100' as phone_home,
+            cast(null as string) as phone_work,
+            '305-555-0101' as phone_mobile
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
+            'Bob', 'Smith', cast(null as string), cast(null as string),
+            cast(null as string), '305-555-0200'
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_2', 'aunt',
+            'Carol', 'Diaz', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            '123456' as powerschool_student_number
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            123456 as student_number,
+            0 as enroll_status,
+            'kippnewark_powerschool' as _dbt_source_relation
+    expect:
+      rows:
+        - {
+            StudentID: 123456,
+            ParentFirstName: Alice,
+            ParentLastName: Johnson,
+            Relationship: parent,
+            HomePhone: 305-555-0100,
+            CellPhone: 305-555-0101,
+            Email: alice@example.com,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Bob,
+            ParentLastName: Smith,
+            Relationship: Emergency 1,
+            CellPhone: 305-555-0200,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Carol,
+            ParentLastName: Diaz,
+            Relationship: Emergency 2,
+          }
+```
+
+Rationale for `format: sql` on every input: it provides exactly the columns the
+model reads and avoids dbt schema introspection of the real relations (per
+`src/dbt/CLAUDE.md`). Columns omitted from an `expect` row are compared as null.
+The `_dbt_source_relation` value `kippnewark_powerschool` makes
+`extract_code_location` resolve to `kippnewark`, matching the finalsite rows'
+`_dbt_source_project`.
+
+- [ ] **Step 2: Ensure worktree deps, then run the unit test to verify it
+      fails**
+
+The current model still filters `contact_slot = 'contact_1'`, so the two
+emergency rows drop and the model returns one row against three expected.
+
+Run:
+
+```bash
+uv run dbt deps \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts/src/dbt/kipptaf
+
+uv run dbt test \
+  --select "rpt_deanslist__family_contacts,test_type:unit" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts/src/dbt/kipptaf \
+  --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: FAIL — the unit test reports a row-count / value difference (1 actual
+row vs 3 expected). If instead it errors on profiles, add
+`--profiles-dir /workspaces/teamster/.dbt`.
+
+- [ ] **Step 3: Rewrite the model SQL**
+
+Replace the entire contents of
+`src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`
+with:
+
+```sql
+with
+    contacts as (
+        select
+            sc.contact_first_name,
+            sc.contact_last_name,
+            sc.email,
+            sc.phone_home,
+            sc.phone_work,
+            sc.phone_mobile,
+            sc._dbt_source_project,
+
+            safe_cast(xw.powerschool_student_number as int64) as student_number,
+
+            case sc.contact_slot
+                when 'emergency_1'
+                then 'Emergency 1'
+                when 'emergency_2'
+                then 'Emergency 2'
+                when 'emergency_3'
+                then 'Emergency 3'
+                when 'emergency_4'
+                then 'Emergency 4'
+                else sc.relationship
+            end as relationship,
+        from {{ ref("int_finalsite__student_contacts") }} as sc
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as xw
+            on sc.finalsite_enrollment_id = xw.finalsite_enrollment_id
+            and sc._dbt_source_project = xw._dbt_source_project
+        where
+            sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
+            and xw.powerschool_student_number is not null
+    ),
+
+    enrolled_students as (
+        select
+            student_number,
+
+            {{ extract_code_location("stg_powerschool__students") }}
+            as _dbt_source_project,
+        from {{ ref("stg_powerschool__students") }}
+        where enroll_status = 0
+    )
+
+select
+    c.student_number as `StudentID`,
+    c.contact_first_name as `ParentFirstName`,
+    c.contact_last_name as `ParentLastName`,
+    c.phone_home as `HomePhone`,
+    c.phone_work as `WorkPhone`,
+    c.phone_mobile as `CellPhone`,
+    c.email as `Email`,
+    c.relationship as `Relationship`,
+
+    cast(null as string) as `Language`,
+from contacts as c
+inner join
+    enrolled_students as s
+    on c.student_number = s.student_number
+    and c._dbt_source_project = s._dbt_source_project
+```
+
+Changes vs. the current file: `contact_slot = 'contact_1'` filter removed; `CTE`
+renamed `parent_contacts` → `contacts` and its alias `pc` → `c`; the passthrough
+`sc.relationship` replaced by the `CASE`. (sqlfmt will collapse the
+`when … then …` lines at commit; either layout is acceptable.)
+
+- [ ] **Step 4: Update the properties yml — uniqueness test and descriptions**
+
+In
+`src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`:
+
+Replace the model `description` (lines 3–9 in the current file) with:
+
+```yaml
+description:
+  DeansList nightly Family Contacts import (`contacts.txt`) for the NJ regions —
+  one row per Finalsite contact for each currently enrolled student, covering
+  the primary parent (`contact_1`, the relationship flagged primary, falling
+  back to financial) plus emergency contacts (`emergency_1` through
+  `emergency_4`). Emergency contacts carry a numbered `Emergency N` relationship
+  so Ops can exclude them from DeansList guardian messaging; the primary parent
+  keeps its real Finalsite relationship. Column names match the DeansList import
+  template headers exactly. Delivered by the Dagster asset
+  `kipptaf/extracts/deanslist/contacts_txt`.
+```
+
+Immediately after the model `description` and before `columns:`, add the
+model-level grain test:
+
+```yaml
+data_tests:
+  - dbt_utils.unique_combination_of_columns:
+      arguments:
+        combination_of_columns:
+          - StudentID
+          - Relationship
+      config:
+        severity: error
+```
+
+On the `StudentID` column, remove the `unique` test but keep `not_null` (error).
+The column's `data_tests:` becomes:
+
+```yaml
+data_tests:
+  - not_null:
+      config:
+        severity: error
+```
+
+Replace the `Relationship` column `description` with:
+
+```yaml
+description:
+  Relationship of the contact to the student. For the primary parent
+  (`contact_1`) this is the Finalsite `rel_type` (`parent`, `stepparent`,
+  `guardian`, `grandparent`, etc.). For emergency contacts this is `Emergency
+  N`, numbered by the Finalsite emergency slot (`emergency_1` through
+  `emergency_4`).
+```
+
+Leave `ParentFirstName`, `ParentLastName`, phones, `Email`, and `Language`
+columns and their tests unchanged (`ParentLastName` `not_null` stays at the
+project-default warn).
+
+- [ ] **Step 5: Run the unit test to verify it passes**
+
+Run:
+
+```bash
+uv run dbt test \
+  --select "rpt_deanslist__family_contacts,test_type:unit" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts/src/dbt/kipptaf \
+  --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS (1 unit test).
+
+- [ ] **Step 6: Build the view against prod data and run the data tests**
+
+Run:
+
+```bash
+uv run dbt build \
+  --select rpt_deanslist__family_contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts/src/dbt/kipptaf \
+  --target dev --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: the view builds in the dev schema and every test PASSES — in
+particular `unique_combination_of_columns(StudentID, Relationship)` (error) and
+`not_null` on `StudentID` (error). `ParentLastName` `not_null` may WARN (~8
+rows); that is expected and acceptable.
+
+- [ ] **Step 7: Confirm the built view's shape (row count and grain)**
+
+Query the dev-built view via the BigQuery MCP (schema is
+`zz_<github_user>_kipptaf_extracts`; find it with the SCHEMATA query in
+`src/dbt/CLAUDE.md` if unsure). Confirm ~30,478 rows, that `Relationship`
+`Emergency N` values appear, and `(StudentID, Relationship)` is unique
+(`count(*) = count(distinct format('%T|%T', StudentID, Relationship))`). Do not
+copy any PII values into the commit, PR, or issue.
+
+- [ ] **Step 8: Lint the changed files**
+
+Run (from inside the worktree; the `trunk` binary lives only in the main repo):
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts \
+  && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql \
+  src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml \
+  </dev/null
+```
+
+Expected: No issues (sqlfluff, yamllint, prettier). Fix any findings inline and
+re-run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts \
+  add \
+  src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql \
+  src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-deanslist-emergency-contacts \
+  commit -m "feat(deanslist): add emergency contacts to family contacts export
+
+Closes #4478"
+```
+
+---
+
+## Post-implementation
+
+- Push the branch and open a PR with `.github/pull_request_template.md` as the
+  body; the PR body should `Closes #4478`.
+- dbt Cloud CI rebuilds the `rpt` view under `state:modified+`. After CI passes,
+  fetch warnings with `get_job_run_error(warning_only=true)` — a
+  `ParentLastName` `not_null` warn (~8 rows) is expected, not a regression.
+- Post-merge: Dagster rematerializes the view and the `contacts_txt` extract
+  asset emits the wider `contacts.txt` on the next nightly run.
+
+## Self-review notes
+
+- **Spec coverage:** drop filter (Step 3), numbered `Emergency N` (Step 3 CASE),
+  `(StudentID, Relationship)` error-level uniqueness (Step 4), `ParentLastName`
+  stays warn (Step 4), descriptions updated (Step 4), kipptaf-only single PR
+  (file structure). All covered.
+- **No placeholders:** every step has exact paths, code, commands, expected
+  output.
+- **Type consistency:** `StudentID` int64 (from `safe_cast(... as int64)`);
+  `Relationship` string (CASE branches + `rel_type` are all string); unit-test
+  `powerschool_student_number` supplied as string `'123456'` and cast to
+  `123456`.

--- a/docs/superpowers/specs/2026-07-21-deanslist-emergency-contacts-design.md
+++ b/docs/superpowers/specs/2026-07-21-deanslist-emergency-contacts-design.md
@@ -1,0 +1,150 @@
+# DeansList Family Contacts Extract — Add Emergency Contacts — Design
+
+Issue: [#4478](https://github.com/TEAMSchools/teamster/issues/4478)
+
+## Background
+
+The DeansList nightly `contacts.txt` feed (`rpt_deanslist__family_contacts`,
+shipped in [#4400](https://github.com/TEAMSchools/teamster/issues/4400)) sends
+one row per currently enrolled NJ student: their single `contact_1` (the
+Finalsite primary → financial parent pick). Emergency contacts were explicitly
+out of scope then. This change adds them.
+
+The upstream `int_finalsite__student_contacts` already carries the emergency
+rows in prod today: `contact_slot` ∈ (`contact_1`, `emergency_1` …
+`emergency_4`), a boolean `is_emergency`, a per-row `relationship`, split
+`contact_first_name` / `contact_last_name`, phones, and email. So no upstream or
+district work is required — only the kipptaf `rpt` view and its properties
+change.
+
+## Goal
+
+Include emergency contacts alongside the primary parent in the DeansList
+`contacts.txt` feed for the NJ regions (Newark, Camden, Paterson), with each
+emergency slot numbered so Ops can distinguish (and exclude from guardian
+messaging) the emergency rows.
+
+## Requirements
+
+- Emit every populated contact slot per enrolled NJ student: `contact_1` plus
+  any of `emergency_1` … `emergency_4`.
+- `Relationship` values: `contact_1` keeps its Finalsite `rel_type` (`parent`,
+  `guardian`, etc.); each emergency slot is labeled `Emergency N`, where `N` is
+  the slot number (`emergency_1` → `Emergency 1`).
+- Grain `(StudentID, Relationship)` is unique, enforced at severity error.
+- No change to the nine DeansList template columns, the file name, or the
+  nightly schedule.
+- Currently enrolled students only (`enroll_status = 0`) — unchanged.
+
+## Design
+
+### Model — `rpt_deanslist__family_contacts.sql`
+
+- Drop the `sc.contact_slot = 'contact_1'` filter; keep the NJ-region pin
+  (`_dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')`) and
+  `xw.powerschool_student_number is not null`.
+- Rename the `parent_contacts` CTE to `contacts` — it is no longer parent-only.
+- Derive `Relationship` in that CTE with a `CASE` on `contact_slot`, replacing
+  the passthrough `sc.relationship`:
+
+  ```sql
+  case sc.contact_slot
+      when 'emergency_1' then 'Emergency 1'
+      when 'emergency_2' then 'Emergency 2'
+      when 'emergency_3' then 'Emergency 3'
+      when 'emergency_4' then 'Emergency 4'
+      else sc.relationship
+  end as relationship,
+  ```
+
+- `contact_slot` is referenced only inside the `CASE`; it is not projected into
+  the feed (the nine template columns are unchanged).
+- All other columns, the `enrolled_students` join, and the final `SELECT` are
+  unchanged.
+
+### Properties — `properties/rpt_deanslist__family_contacts.yml`
+
+- Remove the standalone `unique` test from `StudentID`; keep its `not_null`
+  (error).
+- Add a model-level test:
+
+  ```yaml
+  data_tests:
+    - dbt_utils.unique_combination_of_columns:
+        arguments:
+          combination_of_columns:
+            - StudentID
+            - Relationship
+        config:
+          severity: error
+  ```
+
+- Update the model `description` (emergency contacts are now included and
+  numbered) and the `Relationship` column `description` (`contact_1` carries the
+  Finalsite `rel_type`; emergency slots carry `Emergency N`).
+- `ParentLastName` `not_null` stays at warn — it flags the small number of
+  emergency rows with a null last name (DeansList requires the field, so the
+  warning is the correct signal to Ops rather than a hard failure).
+
+## Grain and uniqueness
+
+`(StudentID, Relationship)` is a genuine unique key:
+
+- The upstream grain is `(student, contact_slot)` — each slot occurs at most
+  once per student.
+- Every emergency slot maps 1:1 to a distinct `Emergency N` label, and a student
+  has exactly one `contact_1` row whose `rel_type` is never an `Emergency N`
+  string. So no two rows for a student share a `Relationship` value.
+
+Verified against prod: `(StudentID, Relationship)` is unique at 30,478 / 30,478
+rows. `Relationship` is never null.
+
+Only three students network-wide have a slot gap (an `emergency_N` present with
+`emergency_(N-1)` absent), so numbering by slot is effectively dense. Those
+students get a harmless label gap (e.g. `Emergency 1` and `Emergency 3`).
+Numbering by slot keeps the SQL a plain `CASE` and avoids a window function to
+re-rank.
+
+### Prod data profile (current)
+
+| `contact_slot` | rows  | null last name | rows w/ no phone or email |
+| -------------- | ----- | -------------- | ------------------------- |
+| `contact_1`    | 9,685 | 0              | 4                         |
+| `emergency_1`  | 9,107 | 3              | 167                       |
+| `emergency_2`  | 8,818 | 4              | 311                       |
+| `emergency_3`  | 2,094 | 1              | 49                        |
+| `emergency_4`  | 774   | 0              | 21                        |
+
+Total after the change: ~30,478 rows over 9,685 students (~3× the current feed).
+
+## Rollout
+
+Single kipptaf-only PR, two files (`rpt_deanslist__family_contacts.sql` and its
+properties yml). No district, source-schema, staging-seed, or Dagster/Python
+changes — every upstream column already exists in prod, so there is no
+cross-project seeding step (unlike #4400).
+
+dbt Cloud CI rebuilds the `rpt` view under `state:modified+`. Post-merge,
+Dagster rematerializes the view and the existing `contacts_txt` extract asset
+emits the wider file on the next nightly run (1:25 AM). No change to the extract
+config, transport, or schedule.
+
+## Validation
+
+- Build the `rpt` model locally against the district projects with `--defer`;
+  confirm ~30,478 rows, `(StudentID, Relationship)` uniqueness, correct
+  `Emergency N` labels, and `contact_1` rows retaining their real relationship.
+  Spot-check a handful of students against Finalsite (PII stays local — never in
+  the PR).
+- Post-deploy: confirm `contacts.txt` on the DeansList SFTP now carries the
+  emergency rows.
+
+## Out of scope
+
+- Deduplicating a person who is both the primary parent and an emergency contact
+  (633 students). Per Ops decision these ship as separate rows; the numbered
+  `Relationship` keeps them distinct on the DeansList side.
+- Densely re-ranking emergency numbers across the three slot-gap students.
+- Miami (still PowerSchool-sourced for contacts), other DeansList template
+  files, populating `Language`, and phone-number formatting
+  (`only numbers or x`).

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -414,6 +414,11 @@ found inside <alias>"), not just relationships tests.
 upstream to prod regardless of stale dev copies — cleaner than enumerating
 parents in `--select`.
 
+Conversely, to validate a consumer of a NEW column on an unmerged upstream,
+`--select` BOTH: `--favor-state` resolves the unselected upstream to prod (which
+lacks the column) and the consumer build fails; selecting the upstream builds it
+into dev with the column first.
+
 Also manifests as false row-count / row-presence deltas (not just
 `relationships`/PK tests): a stale dev `int_people__staff_roster` missing recent
 hires makes a dev-built rpt look like it dropped rows. Confirm which upstreams
@@ -705,6 +710,11 @@ After a column/contract rename, run the WHOLE directory's unit tests
 not just the changed model — sibling models mock the same `ref()`/`source()`, so
 their `given`/`expect` rows break on the same rename and CI catches what a
 single-model run misses.
+
+Every `expect` row must list the **same columns** — dbt builds them as
+`UNION ALL` and does NOT null-fill omitted keys, so uneven rows fail with
+`Queries in UNION ALL have mismatched column count`. Put every asserted column
+in every row, `null` for empties.
 
 ### Date-range joins
 

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -70,6 +70,13 @@ Produce `_dbt_source_project` on a union model with
 `from union_relations` (the `union_relations` CTE wrapping
 `dbt_utils.union_relations`).
 
+Prefer inline `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` over the
+`extract_code_location` macro when the union view is `select *` with an `AM04`
+trunk-ignore, or is mocked in a dbt unit test: the macro form makes AM04 stop
+firing (`trunk/ignore-does-nothing`), and its table-name qualifier breaks unit
+tests (`Unrecognized name` after dbt renames the mocked ref). Siblings
+`stg_powerschool__courses` / `stg_powerschool__studentcorefields` use inline.
+
 ### Selecting from `dbt_utils.star()` models
 
 `base_` models using `star()` resolve columns from BigQuery at run time, not

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -88,10 +88,10 @@ models:
 unit_tests:
   - name: test_family_contacts_emergency_numbering
     description:
-      One student with a primary parent plus two emergency contacts. Asserts the
-      primary parent keeps its Finalsite relationship, each emergency slot is
-      relabeled Emergency N by slot number, and all three contacts are emitted
-      for the enrolled student.
+      One enrolled student with a primary parent plus all four emergency slots.
+      Asserts the primary parent keeps its Finalsite relationship and each
+      emergency slot is relabeled Emergency N by slot number (exercising every
+      case branch).
     model: rpt_deanslist__family_contacts
     given:
       - input: ref('int_finalsite__student_contacts')
@@ -117,6 +117,16 @@ unit_tests:
           select
             'enr-001', 'kippnewark', 'emergency_2', 'aunt',
             'Carol', 'Diaz', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_3', 'uncle',
+            'Dan', 'Evans', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_4', 'neighbor',
+            'Erin', 'Fox', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
@@ -165,5 +175,102 @@ unit_tests:
             CellPhone: null,
             Email: null,
             Relationship: Emergency 2,
+            Language: null,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Dan,
+            ParentLastName: Evans,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: Emergency 3,
+            Language: null,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Erin,
+            ParentLastName: Fox,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: Emergency 4,
+            Language: null,
+          }
+
+  - name: test_family_contacts_excludes_ineligible
+    description:
+      Locks the eligibility filters. Three primary-parent contacts, each valid
+      but for one disqualifier — a non-NJ region (Miami), a non-enrolled student
+      (enroll_status != 0), and a null PowerSchool crosswalk — plus one fully
+      eligible NJ student. Only the eligible student is emitted.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-ok' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Gina' as contact_first_name,
+            'Hill' as contact_last_name,
+            cast(null as string) as email,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_work,
+            cast(null as string) as phone_mobile
+          union all
+          select
+            'enr-mia', 'kippmiami', 'contact_1', 'parent',
+            'Hank', 'Ito', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-unenr', 'kippnewark', 'contact_1', 'parent',
+            'Ivy', 'Jones', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-noxwalk', 'kippnewark', 'contact_1', 'parent',
+            'Kim', 'Lee', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-ok' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            '200001' as powerschool_student_number
+          union all
+          select 'enr-mia', 'kippmiami', '200002'
+          union all
+          select 'enr-unenr', 'kippnewark', '200003'
+          union all
+          select 'enr-noxwalk', 'kippnewark', cast(null as string)
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            200001 as student_number,
+            0 as enroll_status,
+            'kippnewark_powerschool' as _dbt_source_relation
+          union all
+          select 200002, 0, 'kippmiami_powerschool'
+          union all
+          select 200003, 2, 'kippnewark_powerschool'
+    expect:
+      rows:
+        - {
+            StudentID: 200001,
+            ParentFirstName: Gina,
+            ParentLastName: Hill,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: parent,
             Language: null,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -2,11 +2,22 @@ models:
   - name: rpt_deanslist__family_contacts
     description:
       DeansList nightly Family Contacts import (`contacts.txt`) for the NJ
-      regions — one row per currently enrolled student carrying their single
-      Finalsite parent contact (`contact_1` — the relationship flagged primary,
-      falling back to financial). Emergency contacts are excluded. Column names
-      match the DeansList import template headers exactly. Delivered by the
-      Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
+      regions — one row per Finalsite contact for each currently enrolled
+      student, covering the primary parent (`contact_1`, the relationship
+      flagged primary, falling back to financial) plus emergency contacts
+      (`emergency_1` through `emergency_4`). Emergency contacts carry a numbered
+      `Emergency N` relationship so Ops can exclude them from DeansList guardian
+      messaging; the primary parent keeps its real Finalsite relationship.
+      Column names match the DeansList import template headers exactly.
+      Delivered by the Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - StudentID
+              - Relationship
+          config:
+            severity: error
     columns:
       - name: StudentID
         data_type: int64
@@ -14,9 +25,6 @@ models:
           PowerSchool student number, from the Finalsite contact's
           `powerschool_student_number` id attribute.
         data_tests:
-          - unique:
-              config:
-                severity: error
           - not_null:
               config:
                 severity: error
@@ -39,8 +47,11 @@ models:
       - name: Relationship
         data_type: string
         description:
-          Relationship to the student (`parent`, `stepparent`, `guardian`,
-          `grandparent`, etc.) — Finalsite `rel_type`.
+          Relationship of the contact to the student. For the primary parent
+          (`contact_1`) this is the Finalsite `rel_type` (`parent`,
+          `stepparent`, `guardian`, `grandparent`, etc.). For emergency contacts
+          this is `Emergency N`, numbered by the Finalsite emergency slot
+          (`emergency_1` through `emergency_4`).
         data_tests:
           - not_null
       - name: HomePhone
@@ -73,3 +84,86 @@ models:
           Always null — the header is required by the DeansList template, but
           Finalsite parent-language data is not maintained reliably enough to
           send.
+
+unit_tests:
+  - name: test_family_contacts_emergency_numbering
+    description:
+      One student with a primary parent plus two emergency contacts. Asserts the
+      primary parent keeps its Finalsite relationship, each emergency slot is
+      relabeled Emergency N by slot number, and all three contacts are emitted
+      for the enrolled student.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Alice' as contact_first_name,
+            'Johnson' as contact_last_name,
+            'alice@example.com' as email,
+            '305-555-0100' as phone_home,
+            cast(null as string) as phone_work,
+            '305-555-0101' as phone_mobile
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
+            'Bob', 'Smith', cast(null as string), cast(null as string),
+            cast(null as string), '305-555-0200'
+          union all
+          select
+            'enr-001', 'kippnewark', 'emergency_2', 'aunt',
+            'Carol', 'Diaz', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-001' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            '123456' as powerschool_student_number
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            123456 as student_number,
+            0 as enroll_status,
+            'kippnewark_powerschool' as _dbt_source_relation
+    expect:
+      rows:
+        - {
+            StudentID: 123456,
+            ParentFirstName: Alice,
+            ParentLastName: Johnson,
+            HomePhone: 305-555-0100,
+            WorkPhone: null,
+            CellPhone: 305-555-0101,
+            Email: alice@example.com,
+            Relationship: parent,
+            Language: null,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Bob,
+            ParentLastName: Smith,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: 305-555-0200,
+            Email: null,
+            Relationship: Emergency 1,
+            Language: null,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Carol,
+            ParentLastName: Diaz,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: Emergency 2,
+            Language: null,
+          }

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -141,7 +141,7 @@ unit_tests:
           select
             123456 as student_number,
             0 as enroll_status,
-            'kippnewark_powerschool' as _dbt_source_relation
+            'kippnewark' as _dbt_source_project
     expect:
       rows:
         - {
@@ -256,11 +256,11 @@ unit_tests:
           select
             200001 as student_number,
             0 as enroll_status,
-            'kippnewark_powerschool' as _dbt_source_relation
+            'kippnewark' as _dbt_source_project
           union all
-          select 200002, 0, 'kippmiami_powerschool'
+          select 200002, 0, 'kippmiami'
           union all
-          select 200003, 2, 'kippnewark_powerschool'
+          select 200003, 2, 'kippnewark'
     expect:
       rows:
         - {

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -31,18 +31,6 @@ with
         where
             sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
             and xw.powerschool_student_number is not null
-    ),
-
-    enrolled_students as (
-        -- _dbt_source_project derived inline rather than via extract_code_location
-        -- so this CTE stays unit-testable: the macro qualifies _dbt_source_relation
-        -- by table name, which dbt unit tests rename to the mock relation.
-        select
-            student_number,
-
-            regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
-        from {{ ref("stg_powerschool__students") }}
-        where enroll_status = 0
     )
 
 select
@@ -58,6 +46,7 @@ select
     cast(null as string) as `Language`,
 from contacts as c
 inner join
-    enrolled_students as s
+    {{ ref("stg_powerschool__students") }} as s
     on c.student_number = s.student_number
     and c._dbt_source_project = s._dbt_source_project
+    and s.enroll_status = 0

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -1,5 +1,5 @@
 with
-    parent_contacts as (
+    contacts as (
         select
             sc.contact_first_name,
             sc.contact_last_name,
@@ -7,44 +7,57 @@ with
             sc.phone_home,
             sc.phone_work,
             sc.phone_mobile,
-            sc.relationship,
             sc._dbt_source_project,
 
             safe_cast(xw.powerschool_student_number as int64) as student_number,
+
+            case
+                sc.contact_slot
+                when 'emergency_1'
+                then 'Emergency 1'
+                when 'emergency_2'
+                then 'Emergency 2'
+                when 'emergency_3'
+                then 'Emergency 3'
+                when 'emergency_4'
+                then 'Emergency 4'
+                else sc.relationship
+            end as relationship,
         from {{ ref("int_finalsite__student_contacts") }} as sc
         inner join
             {{ ref("int_finalsite__contact_id_attributes") }} as xw
             on sc.finalsite_enrollment_id = xw.finalsite_enrollment_id
             and sc._dbt_source_project = xw._dbt_source_project
         where
-            sc.contact_slot = 'contact_1'
-            and sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
+            sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
             and xw.powerschool_student_number is not null
     ),
 
     enrolled_students as (
+        -- _dbt_source_project derived inline rather than via extract_code_location
+        -- so this CTE stays unit-testable: the macro qualifies _dbt_source_relation
+        -- by table name, which dbt unit tests rename to the mock relation.
         select
             student_number,
 
-            {{ extract_code_location("stg_powerschool__students") }}
-            as _dbt_source_project,
+            regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
         from {{ ref("stg_powerschool__students") }}
         where enroll_status = 0
     )
 
 select
-    pc.student_number as `StudentID`,
-    pc.contact_first_name as `ParentFirstName`,
-    pc.contact_last_name as `ParentLastName`,
-    pc.phone_home as `HomePhone`,
-    pc.phone_work as `WorkPhone`,
-    pc.phone_mobile as `CellPhone`,
-    pc.email as `Email`,
-    pc.relationship as `Relationship`,
+    c.student_number as `StudentID`,
+    c.contact_first_name as `ParentFirstName`,
+    c.contact_last_name as `ParentLastName`,
+    c.phone_home as `HomePhone`,
+    c.phone_work as `WorkPhone`,
+    c.phone_mobile as `CellPhone`,
+    c.email as `Email`,
+    c.relationship as `Relationship`,
 
     cast(null as string) as `Language`,
-from parent_contacts as pc
+from contacts as c
 inner join
     enrolled_students as s
-    on pc.student_number = s.student_number
-    and pc._dbt_source_project = s._dbt_source_project
+    on c.student_number = s.student_number
+    and c._dbt_source_project = s._dbt_source_project

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__students.sql
@@ -13,6 +13,6 @@ with
     )
 
 -- trunk-ignore(sqlfluff/AM04): union_relations produces an unknown column count
-select *,
+select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project,
 from union_relations
 where dcid >= 1


### PR DESCRIPTION
# Pull Request

Closes #4478

## Summary & Motivation

When merged, this adds emergency contacts to the DeansList `contacts.txt` feed
(`rpt_deanslist__family_contacts`) for the NJ regions (Newark, Camden,
Paterson). The feed shipped in #4400 with the primary parent (`contact_1`) only;
this includes the emergency slots (`emergency_1` through `emergency_4`) too.

- Drops the `contact_slot = 'contact_1'` filter so all slots flow through
  (~30.5k rows over ~9.9k students, up from ~9.7k single-contact rows).
- Numbers the emergency relationships: `Relationship` becomes `Emergency 1`
  through `Emergency 4` for the emergency slots; `contact_1` keeps its real
  Finalsite relationship (`parent`/`guardian`/etc.). This lets Ops exclude
  emergency contacts from DeansList guardian messaging (the Family Contacts
  template requires non-guardian relationships to be specified).
- Replaces the standalone `StudentID` `unique` test with
  `dbt_utils.unique_combination_of_columns([StudentID, Relationship])` at
  severity error — the new row grain, verified unique against prod
  (30,559 / 30,559).
- Adds two dbt unit tests: emergency numbering (all four slots) and the
  eligibility filters (non-NJ region, `enroll_status != 0`, null crosswalk).

Scope: kipptaf-only, three files — the `rpt` model, its properties/unit tests,
and `stg_powerschool__students` (see reviewer notes). No district,
source-schema, staging-seed, or Dagster/Python change; every finalsite column
already exists in prod. Note: adding a column to `stg_powerschool__students`
fans `state:modified+` out to its downstream consumers, so this CI run rebuilds
a large graph.

Design and plan:

- `docs/superpowers/specs/2026-07-21-deanslist-emergency-contacts-design.md`
- `docs/superpowers/plans/2026-07-21-deanslist-emergency-contacts.md`

Reviewer notes:

- Adds `_dbt_source_project` to `stg_powerschool__students` (matching the sibling
  powerschool union views) and joins the `rpt` directly on it, with
  `enroll_status` as a join predicate — no `enrolled_students` CTE. The stg
  column uses inline `regexp_extract` rather than the `extract_code_location`
  macro: the macro form leaves a dead `AM04` ignore
  (`trunk/ignore-does-nothing`), while inline matches `stg_powerschool__courses`
  and `stg_powerschool__studentcorefields`.
- `ParentLastName` `not_null` stays at warn and flags the handful of emergency
  rows (7 in prod today) with a null last name (DeansList requires the field;
  the warning surfaces the gap to Ops without failing the build).

## AI Assistance

Claude Code (Opus 4.8) drove the investigation, spec, plan, and implementation.
Human-directed decisions: ship every contact slot as-is (rather than deduping a
person listed as both the primary parent and an emergency contact), number the
emergency relationships, enforce uniqueness on `StudentID` plus `Relationship`,
and derive the join region from a new `_dbt_source_project` column on
`stg_powerschool__students`.

## Self-review

### dbt

- [x] Properties file updated for the modified model
      (`rpt_deanslist__family_contacts.yml`) — model and `Relationship`
      descriptions plus the new grain test.
- [x] No exposure change — the DeansList `contacts.txt` consumer already exists
      from #4400 and the column set is unchanged.
- [x] **Not a breaking change** — same nine template columns; the
      `stg_powerschool__students` change is purely additive (one new column). No
      downstream dbt exposure consumes this outbound extract.
- [x] No external-source change (all upstreams already in prod).

Validated locally (`--target dev --defer --favor-state`): both unit tests pass;
`unique_combination_of_columns(StudentID, Relationship)` and `not_null` on
`StudentID` / `Relationship` pass at error; `ParentLastName` warns on 7 rows as
expected.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes. Three log warnings are pre-existing breaking-change
      comparisons on unrelated models (`rpt_lattice__users`, `dim_staff`,
      `dim_student_section_enrollments`), surfaced by the widened
      `state:modified+` selection — not introduced by this PR.
- [ ] **Dagster Cloud** — not triggered (`pull_request` paths exclude
      `src/dbt/**`).
