### PR TITLE
fix(dbt): normalize Finalsite contact phone numbers

### DIFF
--- a/docs/superpowers/plans/2026-07-22-finalsite-phone-normalization.md
+++ b/docs/superpowers/plans/2026-07-22-finalsite-phone-normalization.md
@@ -1,0 +1,485 @@
+# Finalsite Contact Phone Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Normalize Finalsite contact phone numbers to a canonical E.164 form
+for all consumers, and format them to DeansList's "numbers or x" rule in the
+DeansList extract — de-garbling mojibake and salvaging malformed values without
+dropping anything.
+
+**Architecture:** A `clean_phone()` macro (finalsite package) normalizes each
+phone to E.164 (US `+1…`, international preserved, extensions appended) or
+passes through the de-garbled original; it is applied to the four phone columns
+in `int_finalsite__student_contacts`, so every downstream consumer inherits
+clean phones. `rpt_deanslist__family_contacts` then strips its phone columns to
+`[0-9x]`.
+
+**Tech Stack:** dbt (BigQuery), Jinja macro, dbt unit tests, trunk.
+
+## Global Constraints
+
+- Work in the worktree
+  `/workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization`.
+  Every `git`, `dbt`, Read/Edit/Write path targets that worktree.
+- Issue [#4498](https://github.com/TEAMSchools/teamster/issues/4498). Spec:
+  `docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md`.
+- The `clean_phone` E.164 logic below is already verified against BigQuery (14
+  representative cases pass) — implement it verbatim; do not redesign the regex.
+- Never emit NULL for a non-null input in `clean_phone` — unparseable values
+  pass through de-garbled so they stay visible.
+- SQL follows `src/dbt/CLAUDE.md` (BigQuery dialect, trailing commas, single
+  quotes, ST06 column order). Prefer inline `regexp_extract` over
+  `extract_code_location` is NOT relevant here.
+- `uv run` for all dbt. `int_finalsite__student_contacts` is a finalsite
+  **package** model — build/test it through a consuming district (`kippnewark`)
+  with `--defer`. Run `uv run dbt deps` in each project-dir first.
+- PII stays local — spot-check phone values only in the terminal, never in the
+  PR/issue/commit.
+
+---
+
+## File structure
+
+- Create: `src/dbt/finalsite/macros/clean_phone.sql` — the E.164 normalization
+  macro (single source of truth, reusable).
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`
+  — wrap the final union in an `all_contacts` CTE and apply `clean_phone()` to
+  `phone_mobile` / `phone_home` / `phone_work` / `phone_primary`.
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml`
+  — add a unit test covering the phone normalization.
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`
+  — strip `HomePhone` / `WorkPhone` / `CellPhone` to `[0-9x]`.
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`
+  — add phone assertions to the unit test.
+
+---
+
+## Task 1: `clean_phone` macro + apply in `int_finalsite__student_contacts`
+
+**Files:**
+
+- Create: `src/dbt/finalsite/macros/clean_phone.sql`
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml`
+
+**Interfaces:**
+
+- Produces: `clean_phone(column)` — a Jinja macro emitting a STRING expression.
+  Given a raw phone column, returns E.164 (`+1XXXXXXXXXX`, international
+  `+<cc>…`, extension `…x<ext>`) when confidently parseable, else the de-garbled
+  original. Never NULL for a non-null input.
+- `int_finalsite__student_contacts` keeps its 18-column output; only the four
+  phone columns' values change.
+
+- [ ] **Step 1: Create the macro**
+
+Create `src/dbt/finalsite/macros/clean_phone.sql` with exactly:
+
+```sql
+{% macro clean_phone(column) %}
+    {#-
+      Normalize a raw phone to E.164:
+        - US (bare 10, +1, or 11-digit leading 1, NANP-valid) -> +1XXXXXXXXXX
+        - explicit international (+<cc!=1> or 011<cc>)         -> +<cc><national>
+        - explicit x/ext extension                            -> append x<ext>
+      Anything not confidently parseable passes through the de-garbled original
+      (control chars stripped). Never returns NULL for a non-null input.
+    -#}
+    {%- set degarbled -%}
+        trim(regexp_replace({{ column }}, r'[^\x20-\x7E]', ''))
+    {%- endset -%}
+    {%- set ext -%}
+        regexp_extract(
+            {{ degarbled }}, r'(?i)(?:ext\.?|extension|x)\s*(\d{1,6})\s*$'
+        )
+    {%- endset -%}
+    {%- set main -%}
+        regexp_replace(
+            {{ degarbled }}, r'(?i)\s*(?:ext\.?|extension|x)\s*\d{1,6}\s*$', ''
+        )
+    {%- endset -%}
+    {%- set digits -%} regexp_replace({{ main }}, r'\D', '') {%- endset -%}
+    coalesce(
+        case
+            when
+                regexp_contains({{ main }}, r'^\s*\+')
+                and not regexp_contains({{ main }}, r'^\s*\+\s*1')
+                and length({{ digits }}) between 8 and 15
+            then '+' || {{ digits }}
+            when
+                starts_with({{ digits }}, '011')
+                and length({{ digits }}) between 11 and 18
+            then '+' || substr({{ digits }}, 4)
+            when
+                length({{ digits }}) = 10
+                and regexp_contains({{ digits }}, r'^[2-9]\d{2}[2-9]\d{6}$')
+            then '+1' || {{ digits }}
+            when
+                length({{ digits }}) = 11
+                and starts_with({{ digits }}, '1')
+                and regexp_contains(
+                    substr({{ digits }}, 2), r'^[2-9]\d{2}[2-9]\d{6}$'
+                )
+            then '+1' || substr({{ digits }}, 2)
+        end
+        || if({{ ext }} is not null, 'x' || {{ ext }}, ''),
+        {{ degarbled }}
+    )
+{% endmacro %}
+```
+
+The `coalesce(<case> || <ext-suffix>, degarbled)` returns the de-garbled
+original whenever the CASE is NULL (BigQuery `NULL || x` is NULL), giving the
+passthrough behavior without re-evaluating the CASE.
+
+- [ ] **Step 2: Wrap the union and apply the macro in the model**
+
+In
+`src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`,
+replace the final two-branch `SELECT … UNION ALL SELECT …` (the tail after the
+`emergency as (…)` CTE) with an `all_contacts` CTE plus a normalizing final
+select. The two union branches keep their existing 18 columns unchanged; only
+the final select changes:
+
+```sql
+    ),
+
+    all_contacts as (
+        select
+            finalsite_enrollment_id,
+            contact_slot,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            phone_daytime,
+            phone_primary,
+            home_address,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            is_emergency,
+        from contact_1
+
+        union all
+
+        select
+            finalsite_enrollment_id,
+            contact_slot,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            phone_daytime,
+            phone_primary,
+            home_address,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            is_emergency,
+        from emergency
+    )
+
+select
+    finalsite_enrollment_id,
+    contact_slot,
+    finalsite_contact_id,
+    contact_name,
+    contact_first_name,
+    contact_last_name,
+    relationship,
+    email,
+    phone_daytime,
+    home_address,
+    is_pickup,
+    is_custodial,
+    is_household_member,
+    is_emergency,
+
+    {{ clean_phone("phone_mobile") }} as phone_mobile,
+    {{ clean_phone("phone_home") }} as phone_home,
+    {{ clean_phone("phone_work") }} as phone_work,
+    {{ clean_phone("phone_primary") }} as phone_primary,
+from all_contacts
+```
+
+(`phone_daytime` is always NULL upstream, so it is left as a plain passthrough
+column, not cleaned. The four cleaned phones sort last per ST06 — plain columns
+first, then function-wrapped columns.)
+
+- [ ] **Step 3: Add the failing unit test**
+
+Append to
+`src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml`
+(top-level `unit_tests:` key). It drives a `contact_1` row whose Cell phone is
+garbled and whose Home phone is a bare-10; both must normalize to E.164. The
+emergency input is mocked empty.
+
+```yaml
+unit_tests:
+  - name: test_student_contacts_phone_normalization
+    description:
+      A contact_1 row with a control-char-garbled cell phone and a bare-10 home
+      phone normalizes both to E.164 (+1XXXXXXXXXX).
+    model: int_finalsite__student_contacts
+    given:
+      - input: ref("stg_finalsite__contact_relationships")
+        format: sql
+        rows: |
+          select
+            "stu1" as finalsite_enrollment_id,
+            "rel1" as relationship_id,
+            "con1" as rel_id,
+            "Jane Doe" as rel_name,
+            "parent" as rel_type,
+            true as is_primary,
+            true as is_financial
+      - input: ref("stg_finalsite__contacts")
+        format: sql
+        rows: |
+          select
+            "con1" as finalsite_enrollment_id,
+            "jane@example.com" as email,
+            "Jane" as first_name,
+            "Doe" as last_name,
+            code_points_to_string([8234])
+              || "+1 (862) 300" || code_points_to_string([8209]) || "7240"
+              || code_points_to_string([8236]) as phone_1_number,
+            "Cell" as phone_1_type,
+            "(929) 225-5670" as phone_2_number,
+            "Home" as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip
+      - input: ref("int_finalsite__contact_custom_attributes")
+        rows: []
+    expect:
+      format: sql
+      rows: |
+        select
+          "stu1" as finalsite_enrollment_id,
+          "contact_1" as contact_slot,
+          "con1" as finalsite_contact_id,
+          "Jane Doe" as contact_name,
+          "Jane" as contact_first_name,
+          "Doe" as contact_last_name,
+          "parent" as relationship,
+          "jane@example.com" as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          "+18623007240" as phone_mobile,
+          "+19292255670" as phone_home,
+          cast(null as string) as phone_work,
+          "+18623007240" as phone_primary
+```
+
+(`phone_primary` in the `contact_1` branch is `phone_1_number` — the garbled
+cell — so it normalizes to `+18623007240` too. Use `format: sql` for `expect` to
+control column types precisely; list all 18 output columns.)
+
+- [ ] **Step 4: Install deps and run the unit test — expect FAIL**
+
+```bash
+uv run dbt deps \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization/src/dbt/kippnewark
+
+uv run dbt test \
+  --select "int_finalsite__student_contacts,test_type:unit" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization/src/dbt/kippnewark \
+  --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kippnewark/target/prod
+```
+
+Expected before Steps 1-2 are applied: FAIL (phones not normalized). After Steps
+1-2: run again → PASS. (Author the test first, watch it fail against the
+unmodified model, then apply the macro + model change and watch it pass.)
+
+- [ ] **Step 5: Run the unit test — expect PASS**
+
+Re-run the Step 4 `dbt test` command. Expected: `PASS=1`.
+
+- [ ] **Step 6: Build the model against prod data and spot-check**
+
+```bash
+uv run dbt build \
+  --select int_finalsite__student_contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization/src/dbt/kippnewark \
+  --target dev --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kippnewark/target/prod
+```
+
+Expected: builds; existing tests pass. Then via the BigQuery MCP, query the
+dev-built table
+(`zz_<user>_kippnewark_finalsite.int_finalsite__student_contacts`) for a handful
+of previously-garbled emergency rows and confirm `phone_mobile` etc. are now
+`+1…` / passthrough (PII stays in the terminal). Confirm row count is unchanged
+vs prod.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/finalsite/macros/clean_phone.sql \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml \
+  </dev/null
+
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  add src/dbt/finalsite/macros/clean_phone.sql \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  commit -m "feat(finalsite): normalize contact phones to E.164 via clean_phone
+
+Refs #4498"
+```
+
+---
+
+## Task 2: DeansList "numbers or x" formatting
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`
+
+**Interfaces:**
+
+- Consumes: `int_finalsite__student_contacts.phone_home` / `phone_work` /
+  `phone_mobile`, now E.164 (from Task 1, via the kipptaf union).
+- Produces: `HomePhone` / `WorkPhone` / `CellPhone` containing only digits and
+  `x` (leading US `1` kept, extensions kept).
+
+- [ ] **Step 1: Apply the strip in the final select**
+
+In
+`src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql`,
+change the three phone projections in the final `SELECT` from plain passthrough
+to a `[0-9x]` strip (one level of nesting — `lower` inside `regexp_replace` — is
+allowed):
+
+```sql
+    regexp_replace(lower(c.phone_home), r'[^0-9x]', '') as `HomePhone`,
+    regexp_replace(lower(c.phone_work), r'[^0-9x]', '') as `WorkPhone`,
+    regexp_replace(lower(c.phone_mobile), r'[^0-9x]', '') as `CellPhone`,
+```
+
+Leave the other columns unchanged. Note the ST06 order: these become
+function-wrapped columns, so they must sort after the plain-column projections
+(`StudentID`, `ParentFirstName`, `ParentLastName`) — reorder the final `SELECT`
+so the three phones, `Email` passthrough, `Relationship`, and the
+`cast(null …) Language` follow the plain columns, phones grouped with the other
+function/expression columns. Confirm the exact ordering with `trunk check` in
+Step 4 and adjust to satisfy ST06.
+
+- [ ] **Step 2: Add phone assertions to the unit test**
+
+In
+`src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml`,
+edit the existing `test_family_contacts_emergency_numbering` unit test: give the
+`int_finalsite__student_contacts` mock input E.164-shaped phones and assert the
+stripped output. In the mock's `contact_1` row set
+`phone_home = '+19292255670'`, `phone_mobile = '+18623007240x216'`; in the
+`expect` rows for that student set `HomePhone: 9292255670`,
+`CellPhone: 18623007240x216` (unquoted — digits/`x` only), `WorkPhone: null`.
+Update the other expect rows' phone columns to the stripped form to match.
+
+- [ ] **Step 3: Run the rpt unit tests — expect PASS after Step 1**
+
+```bash
+uv run dbt test \
+  --select "rpt_deanslist__family_contacts,test_type:unit" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization/src/dbt/kipptaf \
+  --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: `PASS` for both unit tests. (Run once before Step 1's SQL edit to see
+the phone assertions fail, then after to see them pass.)
+
+- [ ] **Step 4: Build the rpt against prod data, lint**
+
+```bash
+uv run dbt build \
+  --select rpt_deanslist__family_contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization/src/dbt/kipptaf \
+  --target dev --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql \
+  src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml \
+  </dev/null
+```
+
+Expected: builds; tests pass (the `ParentLastName` warn is still expected).
+Query the dev-built view and confirm `HomePhone`/`WorkPhone`/`CellPhone` contain
+only `[0-9x]` (no `+`, parens, spaces).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  add src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql \
+  src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-finalsite-phone-normalization \
+  commit -m "feat(deanslist): format phones to numbers-or-x from E.164 canonical
+
+Refs #4498"
+```
+
+---
+
+## Post-implementation
+
+- Push and open a PR (`.github/pull_request_template.md` body, `Closes #4498`).
+- The `int_finalsite__student_contacts` change is value-only → kipptaf dbt Cloud
+  CI compiles unchanged; the `rpt_deanslist__family_contacts` change is
+  CI-exercised. After CI passes, fetch warnings
+  (`get_job_run_error(warning_only=true)`) — the `ParentLastName` warn is
+  expected.
+- Post-merge, district `int_finalsite__student_contacts` tables rebuild via
+  Dagster automation; normalized phones then flow to all consumers.
+
+## Self-review
+
+- **Spec coverage:** E.164 macro (Task 1 Step 1), applied at
+  `int_finalsite__student_contacts` on the four phone columns (Task 1 Step 2),
+  never-NULL passthrough (macro `coalesce`), DeansList `[0-9x]` strip (Task 2
+  Step 1), unit tests both layers, value-only rollout — all covered.
+- **No placeholders:** macro and both model edits are complete, BQ-verified SQL.
+- **Type consistency:** `clean_phone` returns STRING; phone columns stay STRING;
+  DeansList outputs STRING. Macro arg name is `column` throughout.

--- a/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
@@ -1,0 +1,93 @@
+# Finalsite Contact Phone Normalization — Design
+
+Issue: [#4498](https://github.com/TEAMSchools/teamster/issues/4498) (follow-up
+to [#4495](https://github.com/TEAMSchools/teamster/pull/4495))
+
+## Problem
+
+Finalsite emergency-contact phone values carry junk that flows through to the
+DeansList `contacts.txt` feed:
+
+- **Invisible Unicode control/formatting characters** — `U+202A`/`U+202C` bidi
+  wrappers, `U+00A0` non-breaking space, `U+2011` non-breaking hyphen (render as
+  `‚Ä™`/`¬†`/`‚Ä¨` mojibake). From parents pasting numbers out of a phone's
+  contacts app.
+- **Free-text** — labels ("Guardian Emergency Pickup"), the word "Mobile",
+  partials ("52771", "-4069").
+
+These live in the free-text emergency phone custom attributes
+(`emrg_N_phone_*`), so they affect only emergency slots — `contact_1` (from
+Finalsite's typed phone fields) is clean. The pattern is present across all four
+Finalsite instances, roughly proportional to volume: ~40 control-char and ~95
+free-text emergency mobiles network-wide.
+
+## Design
+
+### `clean_phone()` macro
+
+New macro in the finalsite package (`src/dbt/finalsite/macros/`). Normalizes a
+raw phone string to a canonical **10-digit US** string, or NULL when the value
+is not a usable phone:
+
+- Strip to digits (`regexp_replace(<col>, r'\D', '')`) — removes control chars,
+  formatting punctuation, and free-text labels.
+- If the result is 11 digits leading `1`, drop the `1`; if 10 digits, keep it;
+  otherwise NULL.
+
+Reasoning (from prod profiling of all phone values): ~94.8% are already 10
+digits, 1,778 are 11-digit-leading-`1`, and only ~61 network-wide are too-short
+/ 12+ / typos (NULLed — unusable). No meaningful international population to
+preserve.
+
+**No display formatting** (no parens/dashes) at this layer — a clean digit
+string is the most flexible canonical form; each extract formats for its own
+target. DeansList already ingests formatted numbers, so digits satisfy its "Only
+numbers or x" rule without locking in a presentation.
+
+Implementation note: to respect the repo's max-one-level-of-nesting /
+no-repeated-expression convention, stage `regexp_replace(<col>, r'\D', '')` as a
+named `*_digits` column in a CTE, then canonicalize that column — rather than
+repeating the `regexp_replace` inside the macro. The plan will settle the exact
+shape.
+
+### Placement — `int_finalsite__student_contacts`
+
+Apply `clean_phone()` to the four output phone columns (`phone_mobile`,
+`phone_home`, `phone_work`, `phone_primary`) in the finalsite package
+`int_finalsite__student_contacts` — the single point where the `contact_1` and
+emergency branches converge. `phone_daytime` is always NULL and is skipped.
+
+This is the earliest single chokepoint that catches every slot, and every
+downstream consumer inherits clean phones (DeansList
+`rpt_deanslist__family_contacts`, Focus `rpt_focus__*`, Clever
+`rpt_clever__students`, the contacts dimension / bridge). A pure
+`stg_finalsite__contacts` fix cannot reach the emergency phones — they live
+inside its `custom_attributes` array, not as scalar columns.
+
+## Rollout
+
+Value-only change to a finalsite package model (no column added/renamed), so
+kipptaf CI compiles unchanged and corrected values land after the next Dagster
+prod rebuild of the district `int_finalsite__student_contacts` tables. Validate
+locally via a consuming district build (e.g. `kippnewark`) with `--defer`.
+
+## Validation
+
+- Add a dbt unit test on `int_finalsite__student_contacts` (built via a district
+  project) mocking garbled / free-text / invalid phone inputs and asserting the
+  cleaned digit output (and NULL for unusable values).
+- Build `int_finalsite__student_contacts` locally with `--defer`; confirm row
+  counts are unchanged and spot-check known-garbled students before/after (PII
+  stays local).
+- Confirm downstream consumers still build (`rpt_focus__*`,
+  `rpt_clever__students`, `int_students__contacts`,
+  `rpt_deanslist__family_contacts`).
+
+## Out of scope
+
+- Formatting phones for display in any specific consumer (each extract owns its
+  format).
+- Fixing the data at the Finalsite source / data-entry side (this normalizes on
+  read).
+- Extension handling (`x1234`) and international numbers (negligible volume;
+  NULLed if not 10/11-digit US).

--- a/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
@@ -82,9 +82,19 @@ downstream consumer inherits normalized phones (DeansList
 `stg_finalsite__contacts` fix cannot reach the emergency phones — they live
 inside its `custom_attributes` array, not as scalar columns.
 
-Consumers that need a different presentation (e.g. DeansList strictly "numbers
-or x", or a display format) format from this E.164 canonical at their own
-extract layer.
+Consumers that need a different presentation format from this E.164 canonical at
+their own extract layer (see DeansList below).
+
+### DeansList extract formatting
+
+`rpt_deanslist__family_contacts` applies a final transform to its `HomePhone`,
+`WorkPhone`, and `CellPhone` columns: strip everything except digits and the
+extension marker `x` (`regexp_replace(lower(phone), r'[^0-9x]', '')`),
+satisfying the DeansList template's "Only numbers or x" rule. This keeps the US
+country-code `1` (`+18623007240` → `18623007240`), keeps extensions (`…x216`),
+and leaves international numbers as their country-code + national digits. It is
+a thin per-consumer format step over the shared E.164 canonical, not a second
+normalization.
 
 ## Data profile (rationale)
 
@@ -108,10 +118,12 @@ through by design.
 
 ## Rollout
 
-Value-only change to a finalsite package model (no column added / renamed), so
-kipptaf CI compiles unchanged and normalized values land after the next Dagster
-prod rebuild of the district `int_finalsite__student_contacts` tables. Validate
-locally via a consuming district build (e.g. `kippnewark`) with `--defer`.
+The `int_finalsite__student_contacts` change is value-only (no column added /
+renamed), so kipptaf CI compiles unchanged and normalized values land after the
+next Dagster prod rebuild of the district tables; validate locally via a
+consuming district build (e.g. `kippnewark`) with `--defer`. The
+`rpt_deanslist__family_contacts` formatting change is a kipptaf model, so dbt
+Cloud CI exercises it directly.
 
 ## Validation
 
@@ -126,12 +138,15 @@ locally via a consuming district build (e.g. `kippnewark`) with `--defer`.
 - Confirm downstream consumers still build (`rpt_focus__*`,
   `rpt_clever__students`, `int_students__contacts`,
   `rpt_deanslist__family_contacts`).
+- Confirm `rpt_deanslist__family_contacts` phone columns emit only digits and
+  `x` (no `+`, parens, or spaces) — the DeansList "numbers or x" requirement.
 
 ## Out of scope
 
 - Repairing malformed numbers (typo'd extra digits, concatenations) or adding a
   `+` to unmarked international numbers — passed through visibly for a consumer
   to flag.
-- Per-consumer display formatting (each extract formats from the E.164
-  canonical).
+- Reformatting phones for consumers other than DeansList (Focus, Clever, the
+  contacts dimension read the E.164 canonical as-is; they can format at their
+  own extract later if needed).
 - Fixing the data at the Finalsite source / data-entry side.

--- a/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md
@@ -6,49 +6,67 @@ to [#4495](https://github.com/TEAMSchools/teamster/pull/4495))
 ## Problem
 
 Finalsite emergency-contact phone values carry junk that flows through to the
-DeansList `contacts.txt` feed:
+DeansList `contacts.txt` feed (and other contact consumers):
 
 - **Invisible Unicode control/formatting characters** — `U+202A`/`U+202C` bidi
   wrappers, `U+00A0` non-breaking space, `U+2011` non-breaking hyphen (render as
   `‚Ä™`/`¬†`/`‚Ä¨` mojibake). From parents pasting numbers out of a phone's
   contacts app.
-- **Free-text** — labels ("Guardian Emergency Pickup"), the word "Mobile",
-  partials ("52771", "-4069").
+- **Free-text and malformed values** — labels ("Guardian Emergency Pickup"), the
+  word "Mobile", extensions ("ext. 2606"), typo'd extra digits, placeholder junk
+  ("00000000000"), and concatenated multiple numbers.
 
 These live in the free-text emergency phone custom attributes
 (`emrg_N_phone_*`), so they affect only emergency slots — `contact_1` (from
 Finalsite's typed phone fields) is clean. The pattern is present across all four
-Finalsite instances, roughly proportional to volume: ~40 control-char and ~95
-free-text emergency mobiles network-wide.
+Finalsite instances.
+
+Goal: normalize phone values to a consistent standard for **all** contact
+consumers (DeansList, Focus, Clever, the contacts dimension), not just
+DeansList.
 
 ## Design
 
 ### `clean_phone()` macro
 
 New macro in the finalsite package (`src/dbt/finalsite/macros/`). Normalizes a
-raw phone string to a canonical **10-digit US** string, or NULL when the value
-is not a usable phone:
+raw phone to canonical **E.164** when it parses confidently, otherwise returns
+the **de-garbled original** — it never returns NULL for a non-null input (a
+malformed value passes through visibly so a downstream consumer can flag it).
 
-- Strip to digits (`regexp_replace(<col>, r'\D', '')`) — removes control chars,
-  formatting punctuation, and free-text labels.
-- If the result is 11 digits leading `1`, drop the `1`; if 10 digits, keep it;
-  otherwise NULL.
+E.164 is the international standard (`+` + 1-3 digit country code + national
+number, max 15 digits), which handles US and international numbers uniformly.
 
-Reasoning (from prod profiling of all phone values): ~94.8% are already 10
-digits, 1,778 are 11-digit-leading-`1`, and only ~61 network-wide are too-short
-/ 12+ / typos (NULLed — unusable). No meaningful international population to
-preserve.
+Logic:
 
-**No display formatting** (no parens/dashes) at this layer — a clean digit
-string is the most flexible canonical form; each extract formats for its own
-target. DeansList already ingests formatted numbers, so digits satisfy its "Only
-numbers or x" rule without locking in a presentation.
+1. **De-garble** — strip non-printable / non-ASCII control characters and trim
+   (`regexp_replace(p, r'[^\x20-\x7E]', '')`). This alone fixes the mojibake.
+2. **Split an explicit extension** — if an `x` / `ext` / `extension` marker
+   followed by digits is present, hold the trailing digits as the extension and
+   parse the part before it as the number.
+3. **Classify the number:**
+   - **International** — leading `+` with a country code other than `1`, or an
+     `011` international-dial prefix (→ `+<cc>`), with a plausible 8-15 digit
+     length → emit `+<digits>` (E.164, preserved as entered — not NANP-forced).
+   - **US / NANP** — resolves to 10 NANP-valid digits (`[2-9]XX[2-9]XXXXXX`),
+     whether entered bare-10, `+1`-prefixed, or 11-digit leading `1` → emit
+     `+1XXXXXXXXXX`. NANP validation (`[2-9]` area and exchange) naturally
+     routes placeholders like `0000000000` to passthrough instead of a fake
+     `+10…`.
+   - **Otherwise** → passthrough the de-garbled original. This covers US numbers
+     with a typo'd extra digit, unmarked international numbers (a non-US country
+     code with no `+`), concatenated multiple numbers, and placeholder / junk
+     values — all preserved visibly rather than dropped or mis-normalized.
+4. On a confident parse, append `x<ext>` when an extension was split. The
+   passthrough branch returns the de-garbled original unchanged.
 
-Implementation note: to respect the repo's max-one-level-of-nesting /
-no-repeated-expression convention, stage `regexp_replace(<col>, r'\D', '')` as a
-named `*_digits` column in a CTE, then canonicalize that column — rather than
-repeating the `regexp_replace` inside the macro. The plan will settle the exact
-shape.
+Limitations (documented, acceptable):
+
+- **No `libphonenumber` in BigQuery** — this is a best-effort regex normalizer,
+  not a validating parser; it canonicalizes shape, it does not verify a country
+  code/length is real.
+- **Bare international without a `+`** is indistinguishable from US, so it falls
+  to passthrough rather than being mis-tagged `+1`.
 
 ### Placement — `int_finalsite__student_contacts`
 
@@ -58,36 +76,62 @@ Apply `clean_phone()` to the four output phone columns (`phone_mobile`,
 emergency branches converge. `phone_daytime` is always NULL and is skipped.
 
 This is the earliest single chokepoint that catches every slot, and every
-downstream consumer inherits clean phones (DeansList
+downstream consumer inherits normalized phones (DeansList
 `rpt_deanslist__family_contacts`, Focus `rpt_focus__*`, Clever
 `rpt_clever__students`, the contacts dimension / bridge). A pure
 `stg_finalsite__contacts` fix cannot reach the emergency phones — they live
 inside its `custom_attributes` array, not as scalar columns.
 
+Consumers that need a different presentation (e.g. DeansList strictly "numbers
+or x", or a display format) format from this E.164 canonical at their own
+extract layer.
+
+## Data profile (rationale)
+
+All phone values across the four instances (`phone_mobile` / `home` / `work` /
+`primary`):
+
+| signal                    | count  | disposition              |
+| ------------------------- | ------ | ------------------------ |
+| bare 10-digit             | 76,599 | US → `+1…`               |
+| leading `+1`              | 3,378  | US → `+1…`               |
+| bare 11-digit leading `1` | 347    | US → `+1…`               |
+| leading `+` non-`1`       | 127    | international → `+<cc>…` |
+| other                     | 162    | passthrough              |
+
+The 162-value "other" tail profiled into: US numbers with a typo'd extra digit
+(largest; recognizable US area codes), placeholder junk (all-zeros / all-nines /
+blank), unmarked international (`+20` Egypt, `+84` Vietnam, `+60` Malaysia,
+etc., entered without the `+`), concatenated multiple numbers, and explicit
+extensions. Only the extensions are confidently normalizable; the rest pass
+through by design.
+
 ## Rollout
 
-Value-only change to a finalsite package model (no column added/renamed), so
-kipptaf CI compiles unchanged and corrected values land after the next Dagster
+Value-only change to a finalsite package model (no column added / renamed), so
+kipptaf CI compiles unchanged and normalized values land after the next Dagster
 prod rebuild of the district `int_finalsite__student_contacts` tables. Validate
 locally via a consuming district build (e.g. `kippnewark`) with `--defer`.
 
 ## Validation
 
 - Add a dbt unit test on `int_finalsite__student_contacts` (built via a district
-  project) mocking garbled / free-text / invalid phone inputs and asserting the
-  cleaned digit output (and NULL for unusable values).
+  project) covering representative inputs: a garbled US number (control chars →
+  `+1…`), bare-10 and `+1` US, an international `+<cc>` number (preserved), an
+  explicit extension (`+1…xNNN`), a placeholder (passthrough), and a typo'd
+  extra-digit US number (passthrough).
 - Build `int_finalsite__student_contacts` locally with `--defer`; confirm row
-  counts are unchanged and spot-check known-garbled students before/after (PII
-  stays local).
+  counts are unchanged and spot-check known-garbled / international / extension
+  students before/after (PII stays local).
 - Confirm downstream consumers still build (`rpt_focus__*`,
   `rpt_clever__students`, `int_students__contacts`,
   `rpt_deanslist__family_contacts`).
 
 ## Out of scope
 
-- Formatting phones for display in any specific consumer (each extract owns its
-  format).
-- Fixing the data at the Finalsite source / data-entry side (this normalizes on
-  read).
-- Extension handling (`x1234`) and international numbers (negligible volume;
-  NULLed if not 10/11-digit US).
+- Repairing malformed numbers (typo'd extra digits, concatenations) or adding a
+  `+` to unmarked international numbers — passed through visibly for a consumer
+  to flag.
+- Per-consumer display formatting (each extract formats from the E.164
+  canonical).
+- Fixing the data at the Finalsite source / data-entry side.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -394,6 +394,20 @@ stale from the CI error's `compiled_code` `from` clause: a ref resolving to
 `zz_stg_*` was deferred to the stale staging copy; one resolving to
 `dbt_cloud_pr_*` was rebuilt on the PR branch.
 
+A value-only change that alters a value's **format** (e.g. raw phone → E.164) is
+schema-safe but can silently break downstream extracts with positional / format
+assumptions — the shared `int_finalsite__student_contacts` E.164 change broke
+`rpt_clever__students`' `left(regexp_replace(phone, '\W'), 10)` (it truncated
+the 11-digit `+1…`). Before reformatting a value at a shared model, grep
+consumers for `left(` / `substr(` / digit-count assumptions on that column — CI
+won't catch it (compiles fine; no error).
+
+A doc-only inline SQL comment on a heavily-consumed intermediate still marks it
+`state:modified`, fanning CI's `state:modified+` rebuild across its whole
+descendant graph and surfacing unrelated pre-existing warn-tests as noise. Put
+documentation notes in the properties `description` (doesn't mark modified), not
+an inline SQL comment, on hub models.
+
 ## Editing a `sources-kipp*.yml` schema fans out `state:modified+`
 
 Changing a source's schema (e.g. adding a `target=staging` branch) marks the

--- a/src/dbt/finalsite/macros/clean_phone.sql
+++ b/src/dbt/finalsite/macros/clean_phone.sql
@@ -1,0 +1,48 @@
+{% macro clean_phone(column) %}
+    {#-
+      Normalize a raw phone to E.164:
+        - US (bare 10, +1, or 11-digit leading 1, NANP-valid) -> +1XXXXXXXXXX
+        - explicit international (+<cc!=1> or 011<cc>)         -> +<cc><national>
+        - explicit x/ext extension                            -> append x<ext>
+      Anything not confidently parseable passes through the de-garbled original
+      (control chars stripped). Never returns NULL for a non-null input.
+    -#}
+    {%- set degarbled -%}
+        trim(regexp_replace({{ column }}, r'[^\x20-\x7E]', ''))
+    {%- endset -%}
+    {%- set ext -%}
+        regexp_extract(
+            {{ degarbled }}, r'(?i)(?:ext\.?|extension|x)\s*(\d{1,6})\s*$'
+        )
+    {%- endset -%}
+    {%- set main -%}
+        regexp_replace(
+            {{ degarbled }}, r'(?i)\s*(?:ext\.?|extension|x)\s*\d{1,6}\s*$', ''
+        )
+    {%- endset -%}
+    {%- set digits -%} regexp_replace({{ main }}, r'\D', '') {%- endset -%}
+    coalesce(
+        case
+            when
+                regexp_contains({{ main }}, r'^\s*\+')
+                and not regexp_contains({{ main }}, r'^\s*\+\s*1')
+                and length({{ digits }}) between 8 and 15
+            then '+' || {{ digits }}
+            when
+                starts_with({{ digits }}, '011')
+                and length({{ digits }}) between 11 and 18
+            then '+' || substr({{ digits }}, 4)
+            when
+                length({{ digits }}) = 10
+                and regexp_contains({{ digits }}, r'^[2-9]\d{2}[2-9]\d{6}$')
+            then '+1' || {{ digits }}
+            when
+                length({{ digits }}) = 11
+                and starts_with({{ digits }}, '1')
+                and regexp_contains(substr({{ digits }}, 2), r'^[2-9]\d{2}[2-9]\d{6}$')
+            then '+1' || substr({{ digits }}, 2)
+        end
+        || if({{ ext }} is not null, 'x' || {{ ext }}, ''),
+        {{ degarbled }}
+    )
+{% endmacro %}

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -281,6 +281,52 @@ with
             cast(null as string) as phone_daytime,
             cast(null as string) as home_address,
         from emergency_long
+    ),
+
+    all_contacts as (
+        select
+            finalsite_enrollment_id,
+            contact_slot,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            phone_daytime,
+            phone_primary,
+            home_address,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            is_emergency,
+        from contact_1
+
+        union all
+
+        select
+            finalsite_enrollment_id,
+            contact_slot,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            phone_daytime,
+            phone_primary,
+            home_address,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            is_emergency,
+        from emergency
     )
 
 select
@@ -292,37 +338,15 @@ select
     contact_last_name,
     relationship,
     email,
-    phone_mobile,
-    phone_home,
-    phone_work,
     phone_daytime,
-    phone_primary,
     home_address,
     is_pickup,
     is_custodial,
     is_household_member,
     is_emergency,
-from contact_1
 
-union all
-
-select
-    finalsite_enrollment_id,
-    contact_slot,
-    finalsite_contact_id,
-    contact_name,
-    contact_first_name,
-    contact_last_name,
-    relationship,
-    email,
-    phone_mobile,
-    phone_home,
-    phone_work,
-    phone_daytime,
-    phone_primary,
-    home_address,
-    is_pickup,
-    is_custodial,
-    is_household_member,
-    is_emergency,
-from emergency
+    {{ clean_phone("phone_mobile") }} as phone_mobile,
+    {{ clean_phone("phone_home") }} as phone_home,
+    {{ clean_phone("phone_work") }} as phone_work,
+    {{ clean_phone("phone_primary") }} as phone_primary,
+from all_contacts

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -154,3 +154,69 @@ models:
       - name: is_emergency
         data_type: boolean
         description: False for `contact_1`; true for every `emergency_*` slot.
+
+unit_tests:
+  - name: test_student_contacts_phone_normalization
+    description:
+      A contact_1 row with a control-char-garbled cell phone and a bare-10 home
+      phone normalizes both to E.164 (+1XXXXXXXXXX).
+    model: int_finalsite__student_contacts
+    given:
+      - input: ref('stg_finalsite__contact_relationships')
+        format: sql
+        rows: |
+          select
+            'stu1' as finalsite_enrollment_id,
+            'rel1' as relationship_id,
+            'con1' as rel_id,
+            'Jane Doe' as rel_name,
+            'parent' as rel_type,
+            true as is_primary,
+            true as is_financial
+      - input: ref('stg_finalsite__contacts')
+        format: sql
+        rows: |
+          select
+            'con1' as finalsite_enrollment_id,
+            'jane@example.com' as email,
+            'Jane' as first_name,
+            'Doe' as last_name,
+            code_points_to_string([8234])
+              || '+1 (862) 300'
+              || code_points_to_string([8209])
+              || '7240'
+              || code_points_to_string([8236]) as phone_1_number,
+            'Cell' as phone_1_type,
+            '(929) 225-5670' as phone_2_number,
+            'Home' as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip
+      - input: ref('int_finalsite__contact_custom_attributes')
+        rows: []
+    expect:
+      format: sql
+      rows: |
+        select
+          'stu1' as finalsite_enrollment_id,
+          'contact_1' as contact_slot,
+          'con1' as finalsite_contact_id,
+          'Jane Doe' as contact_name,
+          'Jane' as contact_first_name,
+          'Doe' as contact_last_name,
+          'parent' as relationship,
+          'jane@example.com' as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          '+18623007240' as phone_mobile,
+          '+19292255670' as phone_home,
+          cast(null as string) as phone_work,
+          '+18623007240' as phone_primary

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
@@ -29,7 +29,8 @@ with
             relationship,
             contact_type,
             contact_phone_type,
-            contact_phone,
+
+            regexp_replace(contact_phone, r'[^0-9]', '') as phone_digits,
         from
             contacts_base unpivot (
                 contact_phone for contact_phone_type
@@ -72,7 +73,9 @@ select
 
     format_date('%m/%d/%Y', sr.dob) as dob,
 
-    left(regexp_replace(c.contact_phone, r'\W', ''), 10) as contact_phone,
+    -- int_students__contacts carries E.164 (+1..., optional xNNN) for
+    -- Finalsite-sourced contacts; drop a leading US `1` and take 10 digits.
+    left(regexp_replace(c.phone_digits, r'^1', ''), 10) as contact_phone,
 
     if(sr.lep_status, 'Y', 'N') as ell_status,
     if(sr.spedlep in ('SPED', 'SPED SPEECH'), 'Y', 'N') as iep_status,

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -105,14 +105,14 @@ unit_tests:
             'Alice' as contact_first_name,
             'Johnson' as contact_last_name,
             'alice@example.com' as email,
-            '305-555-0100' as phone_home,
+            '+19292255670' as phone_home,
             cast(null as string) as phone_work,
-            '305-555-0101' as phone_mobile
+            '+18623007240x216' as phone_mobile
           union all
           select
             'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
             'Bob', 'Smith', cast(null as string), cast(null as string),
-            cast(null as string), '305-555-0200'
+            cast(null as string), '+13055550200'
           union all
           select
             'enr-001', 'kippnewark', 'emergency_2', 'aunt',
@@ -148,9 +148,9 @@ unit_tests:
             StudentID: 123456,
             ParentFirstName: Alice,
             ParentLastName: Johnson,
-            HomePhone: 305-555-0100,
+            HomePhone: "19292255670",
             WorkPhone: null,
-            CellPhone: 305-555-0101,
+            CellPhone: 18623007240x216,
             Email: alice@example.com,
             Relationship: parent,
             Language: null,
@@ -161,7 +161,7 @@ unit_tests:
             ParentLastName: Smith,
             HomePhone: null,
             WorkPhone: null,
-            CellPhone: 305-555-0200,
+            CellPhone: "13055550200",
             Email: null,
             Relationship: Emergency 1,
             Language: null,

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -4,12 +4,15 @@ with
             sc.contact_first_name,
             sc.contact_last_name,
             sc.email,
-            sc.phone_home,
-            sc.phone_work,
-            sc.phone_mobile,
             sc._dbt_source_project,
 
             safe_cast(xw.powerschool_student_number as int64) as student_number,
+
+            -- DeansList phone fields accept only digits and `x` (extension); strip
+            -- the E.164 canonical (leading `+`, etc.) to that shape.
+            regexp_replace(lower(sc.phone_home), r'[^0-9x]', '') as phone_home,
+            regexp_replace(lower(sc.phone_work), r'[^0-9x]', '') as phone_work,
+            regexp_replace(lower(sc.phone_mobile), r'[^0-9x]', '') as phone_mobile,
 
             case
                 sc.contact_slot

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -5,9 +5,6 @@ with
     -- to a PowerSchool student number. The crosswalk union also carries Miami's
     -- Focus contacts, but they never match here because
     -- int_finalsite__student_contacts unions only cutover regions.
-    -- Phone columns here are E.164-normalized upstream (clean_phone); the
-    -- powerschool branch below passes phones through raw, so this model's phone
-    -- columns are mixed-format by source region.
     finalsite as (
         select
             fc.contact_slot,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -5,6 +5,9 @@ with
     -- to a PowerSchool student number. The crosswalk union also carries Miami's
     -- Focus contacts, but they never match here because
     -- int_finalsite__student_contacts unions only cutover regions.
+    -- Phone columns here are E.164-normalized upstream (clean_phone); the
+    -- powerschool branch below passes phones through raw, so this model's phone
+    -- columns are mixed-format by source region.
     finalsite as (
         select
             fc.contact_slot,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -8,7 +8,9 @@ models:
       remaining region (Miami) sources from PowerSchool, mapping the priority-1
       contact to `contact_1` and the priority-3-and-higher emergency contacts to
       `emergency_1` through `emergency_4`. Feeds the contact pivot,
-      `dim_student_contact_persons`, and `bridge_student_contacts`.
+      `dim_student_contact_persons`, and `bridge_student_contacts`. Phone
+      columns carry E.164-normalized values from the Finalsite branch and raw
+      PowerSchool values from the Miami branch — mixed format by source region.
     config:
       materialized: table
     data_tests:


### PR DESCRIPTION
# Pull Request

Closes #4498

## Summary & Motivation

When merged, this normalizes Finalsite contact phone numbers to a canonical
**E.164** form for all consumers, and formats them to DeansList's "numbers or x"
rule in the DeansList extract. Finalsite emergency-contact phones (free-text
custom attributes) carry invisible Unicode control characters — surfacing as
`‚Ä™`/`¬†`/`‚Ä¨` mojibake in the DeansList feed (spotted after #4495) — plus
free-text labels, typo'd extra digits, and placeholder junk, across all four
Finalsite instances.

- New `clean_phone()` macro (finalsite package): de-garbles (strips control
  chars), then normalizes to E.164 — US → `+1XXXXXXXXXX`, explicit international
  (`+<cc!=1>` or `011`) preserved as `+<cc><national>`, explicit `x`/`ext`
  extension appended as `x<ext>`. NANP validation (`[2-9]` area/exchange) routes
  placeholders to passthrough. Anything not confidently parseable passes through
  the de-garbled original — it never returns NULL, so malformed values stay
  visible for a consumer to flag.
- Applied to the four phone columns in `int_finalsite__student_contacts`, so
  every downstream consumer (DeansList, Focus, Clever, the contacts dimension)
  inherits clean phones.
- `rpt_deanslist__family_contacts` strips `HomePhone`/`WorkPhone`/`CellPhone` to
  `[0-9x]` (11-digit US keeping the leading `1`, extensions kept) per the
  DeansList template.
- Fixes a downstream regression the shared E.164 change introduced (caught in
  review): `rpt_clever__students` derived its phone via
  `left(regexp_replace(phone, '\W'), 10)`, which truncated the 11-digit `+1…` to
  `1862300724`. It now strips to digits, drops a leading US `1`, and takes 10.
  The resulting mixed Finalsite-E.164 / PowerSchool-raw format is documented in
  `int_students__contacts`. `rpt_focus__*` is unaffected (reads
  `stg_finalsite__contacts` directly); no other consumer applies a phone-format
  assumption.

## AI Assistance

Claude Code (Opus 4.8) drove the diagnosis, spec, plan, and implementation.
Human-directed decisions: normalize at the shared layer for all consumers,
target E.164 (international-aware, not US-only), never drop/NULL a value
(passthrough malformed ones so a consumer follows up), and the DeansList output
form (11-digit US keeping the leading `1`, extensions kept).

## Self-review

### dbt

- [x] `clean_phone()` logic verified against BigQuery (14 representative cases:
      garbled US, `+1`, bare-10, 11-lead-1, international `+509`, `011` prefix,
      three extension formats, placeholder passthrough, typo passthrough,
      free-text extraction, NANP Caribbean `+1`).
- [x] `int_finalsite__student_contacts` unit test (garbled cell + bare-10 home →
      E.164) and `rpt_deanslist__family_contacts` unit tests (E.164 → `[0-9x]`,
      leading `1` and `x` kept) pass.
- [x] Built `int_finalsite__student_contacts` in Newark dev (26,985 rows):
      0 phones still garbled, 23,698 E.164 US, 4 E.164 international, 101
      passthrough, 3,179 null; row count unchanged. Built
      `rpt_deanslist__family_contacts` (30,288 rows): all three phone columns
      contain only `[0-9x]`.
- [x] `int_finalsite__student_contacts` change is value-only (no column
      added/renamed) — kipptaf CI compiles unchanged; normalized values land
      after the next Dagster prod rebuild. `rpt_deanslist__family_contacts` is a
      kipptaf model, CI-exercised.
- [x] No exposure or external-source change.

Design + plan:
`docs/superpowers/specs/2026-07-22-finalsite-phone-normalization-design.md`,
`docs/superpowers/plans/2026-07-22-finalsite-phone-normalization.md`.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes; the only warning is `ParentLastName` `not_null`
      (8 rows), the expected null-last-name emergency contacts.
- [ ] **Dagster Cloud** — branch deployment builds the finalsite + kipptaf
      changes.
