### PR TITLE
refactor(dbt): kickoff #3142 source-project sweep (spec, plan, macro rename)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-dbt-source-project-completion.md
+++ b/docs/superpowers/plans/2026-07-22-dbt-source-project-completion.md
@@ -1,0 +1,446 @@
+# `_dbt_source_project` Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish #3142 — every `union_relations` view exposes
+`_dbt_source_project`, every `union_dataset_join_clause` call is replaced by a
+`_dbt_source_project` equality, and the macro is deleted.
+
+**Architecture:** A behavior-preserving refactor in three dependency-ordered
+batches: (1) rename the producer macro and backfill the column on every union
+view, (2) swap consumer joins directory-by-directory, (3) delete the legacy
+macro and update docs. Each lettered sub-step is its own PR.
+
+**Tech Stack:** dbt (BigQuery), Jinja macros, dbt contracts, sqlfluff/trunk.
+
+## Global Constraints
+
+- Spec:
+  `docs/superpowers/specs/2026-07-22-dbt-source-project-completion-design.md`.
+- Macro signature: `extract_source_project(relation="")` — qualified when an
+  alias is passed, unqualified when omitted.
+- **Producer gate:** a consumer join may be swapped only after **both** joined
+  union views expose `_dbt_source_project`. Batch 1 fully precedes Batch 2;
+  Batch 2 fully precedes Batch 3.
+- **Carve-out sources** (iReady, renlearn, amplify mClass) resolve
+  `_dbt_source_project` from
+  `int_people__location_crosswalk.location_dagster_code_location`, NOT the
+  regex.
+- Contract-enforced layers (`staging/`, `marts/`) require the new column in the
+  model's `properties.yml`; intermediate/`base` do not.
+- All work happens in the worktree
+  `/workspaces/teamster/.worktrees/cbini/refactor/claude-source-project-sweep`
+  on branch `cbini/refactor/claude-source-project-sweep`. Use
+  `git -C <worktree>` and run dbt with
+  `--project-dir <worktree>/src/dbt/kipptaf`.
+- Run `uv run dbt deps --project-dir <worktree>/src/dbt/kipptaf` once in a fresh
+  worktree before any build.
+- `--target prod` dbt runs are classifier-blocked; use `--target dev --defer`
+  with `--state /workspaces/teamster/src/dbt/kipptaf/target/prod` (absolute).
+- Lint before every push:
+  `/workspaces/teamster/.trunk/tools/trunk check --force` the changed files, run
+  with cwd set to the worktree.
+- Commit trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. PR
+  bodies ref `#3142`.
+
+---
+
+## Transformation patterns (referenced by every task)
+
+**Pattern R — rename (Batch 1a):** `extract_code_location(X)` →
+`extract_source_project(X)`; `extract_code_location(table="X")` →
+`extract_source_project(relation="X")`; the macro definition is renamed and
+gains the optional arg. No other change.
+
+**Pattern P — producer add (Batch 1b):** in a union view's final `select`, add
+the column. Prefer the no-arg form in bare-`select *` / AM04 / unit-tested
+views:
+
+```sql
+-- select-* view (keep the AM04 trunk-ignore already present)
+select *, extract_source_project() as _dbt_source_project,
+from union_relations
+```
+
+```sql
+-- explicit / qualified-star view
+select ur.*, extract_source_project("ur") as _dbt_source_project,
+from union_relations as ur
+```
+
+**Pattern I — inline → macro (Batch 1b):** replace an inline
+`regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as _dbt_source_project`
+with `extract_source_project() as _dbt_source_project` (or the qualified form if
+the inline was qualified).
+
+**Pattern X — crosswalk (Batch 1c):** the model must join
+`int_people__location_crosswalk` on its school/location column and project:
+
+```sql
+lc.location_dagster_code_location as _dbt_source_project,
+```
+
+If the model lacks a location join, add it
+(`left join {{ ref("int_people__location_crosswalk") }} as lc on <school> = lc.location_name`).
+
+**Pattern S — consumer swap (Batch 2):** in a join clause, replace the macro:
+
+```sql
+-- before
+inner join {{ ref("other_union_model") }} as b
+    on a.id = b.id
+    and {{ union_dataset_join_clause(left_alias="a", right_alias="b") }}
+
+-- after
+inner join {{ ref("other_union_model") }} as b
+    on a.id = b.id
+    and a._dbt_source_project = b._dbt_source_project
+```
+
+If alias `a` or `b` does not yet expose `_dbt_source_project`, add it to that
+CTE's `select` first (it originates from the union view fixed in Batch 1).
+
+**Pattern C — contract column:** for a contracted producer/consumer, add to
+`properties.yml`:
+
+```yaml
+- name: _dbt_source_project
+  data_type: string
+  description: KIPP region code location derived from the source relation.
+```
+
+---
+
+## Batch 1a — Rename the macro (1 PR)
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/macros/utils.sql` (macro def)
+- Modify: all files calling `extract_code_location` (~45 producer sites + 2
+  non-producer sites `int_students__fldoe_fte.sql`,
+  `qa_edplan__powerschool_mismatch.sql`)
+
+**Interfaces:**
+
+- Produces: macro `extract_source_project(relation="")`.
+
+- [ ] **Step 1: Rewrite the macro definition**
+
+```sql
+{% macro extract_source_project(relation="") %}
+    regexp_extract(
+        {% if relation %}{{ relation }}.{% endif %}_dbt_source_relation,
+        r'(kipp\w+)_'
+    )
+{% endmacro %}
+```
+
+(Delete the old `extract_code_location` macro. Leave `union_dataset_join_clause`
+and `extract_region` untouched — `union_dataset_join_clause` still references
+the old name, so update its body to call `extract_source_project`.)
+
+- [ ] **Step 2: Sweep all call sites** — replace `extract_code_location(` with
+      `extract_source_project(` and the keyword `table=` with `relation=`:
+
+Run (from worktree):
+
+```bash
+grep -rl 'extract_code_location' src/dbt/kipptaf --include='*.sql' \
+  | xargs sed -i 's/extract_code_location(table=/extract_source_project(relation=/g; s/extract_code_location(/extract_source_project(/g'
+```
+
+- [ ] **Step 3: Verify no references remain**
+
+Run: `grep -rn 'extract_code_location' src/dbt/kipptaf` → Expected: only the
+docs/CLAUDE.md prose (fixed in Batch 3); **0** in `*.sql`.
+
+- [ ] **Step 4: Compile to confirm identical render**
+
+Run: `uv run dbt parse --project-dir src/dbt/kipptaf --target dev` Expected:
+parses with no macro-resolution errors.
+
+- [ ] **Step 5: Lint**
+
+Run: `/workspaces/teamster/.trunk/tools/trunk check --force <changed .sql>` (cwd
+= worktree). Expected: no new issues.
+
+- [ ] **Step 6: Commit + push + PR**
+
+```bash
+git -C <worktree> add -u
+git -C <worktree> commit -m "refactor(dbt): rename extract_code_location to extract_source_project (#3142)"
+git -C <worktree> push
+```
+
+PR body: "Mechanical rename, behavior-preserving. Refs #3142."
+
+---
+
+## Batch 1b — Backfill regex-producers (3 PRs)
+
+All 53 regex-producers apply **Pattern P** (or **Pattern I** for the 9 inline
+copies), plus **Pattern C** for the `staging*` ones. **Skip disabled
+integrations** — they will not build: `adp/workforce_now/fivetran/*` and
+`illuminate/fivetran/*` (per `kipptaf/CLAUDE.md` disabled list). Apply the macro
+to them for consistency but note in the PR they are unverifiable locally.
+
+### PR 1b-1 — powerschool (30 files)
+
+**Files (Modify SQL + `properties.yml` for `stg_*`):**
+`int_powerschool__calendar_rollup`, `int_powerschool__category_grades_pivot`,
+`int_powerschool__district_entry_date`, `int_powerschool__final_grades_pivot`,
+`int_powerschool__gradescaleitem_lookup`,
+`int_powerschool__section_grade_config`, `int_powerschool__teachers`,
+`stg_powerschool__attendance`, `stg_powerschool__attendance_code`,
+`stg_powerschool__cc`, `stg_powerschool__fte`, `stg_powerschool__gen`,
+`stg_powerschool__gpnode`, `stg_powerschool__gpprogresssubject`,
+`stg_powerschool__gpprogresssubjectearned`,
+`stg_powerschool__gpprogresssubjectenrolled`, `stg_powerschool__log`,
+`stg_powerschool__pgfinalgrades`, `stg_powerschool__roledef`,
+`stg_powerschool__s_stu_x`, `stg_powerschool__sectionteacher`,
+`stg_powerschool__studentrace`, `stg_powerschool__studenttest`,
+`stg_powerschool__studenttestscore`, `stg_powerschool__terms`,
+`stg_powerschool__test`, `stg_powerschool__testscore`,
+`stg_powerschool__u_storedgrades_de`, `stg_powerschool__users`,
+`stg_powerschool__userscorefields`
+
+- [ ] **Step 1:** Apply Pattern P to each SQL (Pattern I where inline already
+      exists), Pattern C to each `stg_*` `properties.yml`. Inspect each: if it
+      is a bare `select *` with an AM04 trunk-ignore, use
+      `extract_source_project()` (no arg); if `select ur.*`/explicit, use
+      `extract_source_project("ur")`.
+- [ ] **Step 2: Build + verify column present, row count unchanged**
+
+```bash
+uv run dbt build --project-dir src/dbt/kipptaf --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select stg_powerschool__cc stg_powerschool__terms int_powerschool__teachers  # (repeat/expand for the set)
+```
+
+Expected: all build; `_dbt_source_project` populated with `kipp*` values;
+per-model row count equals prod baseline.
+
+- [ ] **Step 3: Lint** the changed `.sql`/`.yml`.
+- [ ] **Step 4: Commit + push + PR**
+      (`refactor(dbt): add _dbt_source_project to powerschool union views (#3142)`).
+
+### PR 1b-2 — assessment sources (illuminate-dlt + pearson + fldoe)
+
+**Files:** `int_illuminate__agg_student_responses` (dlt),
+`int_illuminate__repository_data`, `stg_illuminate__national_assessments__psat`,
+`stg_pearson__student_list_report`, `stg_pearson__student_test_update`,
+`int_fldoe__fast_standard_performance_unpivot`. (Disabled,
+apply-but-unverifiable: `int_illuminate__agg_student_responses` (fivetran),
+`stg_illuminate__aptest`, `stg_illuminate__psat`, `stg_illuminate__psat89`.)
+
+- [ ] Steps as PR 1b-1 (Patterns P/I + C), building the enabled models.
+
+### PR 1b-3 — misc sources (deanslist + overgrad + finalsite + schoolmint + titan + zendesk)
+
+**Files:** `int_deanslist__incidents__attachments`,
+`int_deanslist__students__custom_fields__pivot`, `stg_deanslist__behavior`,
+`stg_deanslist__terms`, `stg_deanslist__users`, `int_overgrad__admissions`,
+`stg_overgrad__admissions`, `stg_finalsite__status_report`,
+`stg_schoolmint_grow__generic_tags`, `stg_titan__income_form_data`,
+`int_zendesk__ticket_metrics_union`. (Disabled, apply-but-unverifiable:
+`int_adp_workforce_now__person_communication_pivot`,
+`int_adp_workforce_now__worker_organizational_unit_pivot`.)
+
+- [ ] Steps as PR 1b-1.
+
+---
+
+## Batch 1c — Crosswalk carve-out (1 PR)
+
+**Files (all apply Pattern X + Pattern C for `stg_*`):**
+
+- iReady: `int_iready__instruction_by_lesson`,
+  `int_iready__instruction_by_lesson_pro`,
+  `int_iready__instructional_usage_data`,
+  `int_iready__personalized_instruction_unpivot`,
+  `stg_iready__personalized_instruction_summary`
+- renlearn: `stg_renlearn__fast_star`, `stg_renlearn__star_dashboard_standards`
+- amplify mClass: `stg_amplify__mclass__sftp__benchmark_student_summary`,
+  `stg_amplify__mclass__sftp__pm_student_summary`,
+  `stg_amplify__mclass__sftp__pm_student_summary_aimline`
+- Reference (already crosswalk-resolved, normalize pattern to match):
+  `stg_renlearn__star`, `int_iready__diagnostic_results`,
+  `int_amplify__mclass__benchmark_student_summary`,
+  `int_amplify__mclass__pm_student_summary`
+
+- [ ] **Step 1: Verify each unions a shared/non-region relation** — confirm the
+      model unions a `kippnj_*` source (iReady/renlearn) or a method-keyed union
+      (amplify). If a listed model instead unions region-bearing relations, use
+      Pattern P/I (macro) rather than Pattern X.
+- [ ] **Step 2:** Apply Pattern X (add the `int_people__location_crosswalk` join
+      where absent; project
+      `location_dagster_code_location as _dbt_source_project`). Add Pattern C to
+      the `stg_*` `properties.yml`.
+- [ ] **Step 3: Build + verify home region** — a Newark iReady/renlearn row
+      reads `kippnewark` (NOT `kippnj`); a Camden row reads `kippcamden`; row
+      counts match prod.
+
+```bash
+uv run dbt build --project-dir src/dbt/kipptaf --target dev --defer \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --select stg_renlearn__fast_star int_iready__instruction_by_lesson
+```
+
+- [ ] **Step 4: Lint. Step 5: Commit + push + PR**
+      (`refactor(dbt): resolve _dbt_source_project via crosswalk for iready/renlearn/amplify (#3142)`).
+
+---
+
+## Batch 2 — Consumer join swaps (Pattern S), by directory
+
+**Gate:** run this only after all Batch 1 PRs merge. Before each PR, for every
+`union_dataset_join_clause` call in its files, confirm both aliased CTEs expose
+`_dbt_source_project` (grep the compiled SQL); if not, thread it through the
+CTE.
+
+Common per-PR cycle for each task below:
+
+- [ ] Apply Pattern S to every `union_dataset_join_clause` in the file set;
+      thread the column through CTEs as needed; add Pattern C for contracted
+      models.
+- [ ] Build the changed models `--target dev --defer`; confirm **row count and
+      distinct-key count equal the prod baseline** (algebraic identity → exact
+      match).
+- [ ] Lint; commit; push; PR
+      (`refactor(dbt): swap union_dataset_join_clause in <dir> (#3142)`).
+
+### PR 2a-1 — tableau gradebook family
+
+`rpt_tableau__gradebook_dashboard`, `rpt_tableau__gradebook_assignments`,
+`rpt_tableau__gradebook_gpa`, `rpt_tableau__assignment_checks`,
+`rpt_tableau__student_course_grades`, `rpt_tableau__qbl`.
+
+### PR 2a-2 — tableau assessment/state family
+
+`rpt_tableau__state_assessments_dashboard`, `rpt_tableau__assessment_dashboard`,
+`rpt_tableau__ddi_dashboard`, `rpt_tableau__college_assessment_dashboard_de`,
+`rpt_tableau__college_assessment_dashboard_historic`,
+`rpt_tableau__state_testing_accomodations`, `rpt_tableau__power_standards`,
+`rpt_tableau__academic_goals_rollup`, `rpt_tableau__iready_apm`,
+`rpt_tableau__miami_k2_iready`, `rpt_tableau__dibels_dashboard`,
+`rpt_tableau__graduation_requirements`.
+
+### PR 2a-3 — tableau attendance/culture/misc family
+
+`rpt_tableau__attendance_dashboard`,
+`rpt_tableau__attendance_chronic_absenteeism_log`,
+`rpt_tableau__suspension_over_time`, `rpt_tableau__consequence_dashboard`,
+`rpt_tableau__okrts_behavior`, `rpt_tableau__school_culture_dashboard_nj`,
+`rpt_tableau__mtss_rti`, `rpt_tableau__community_service`,
+`rpt_tableau__home_instruction`, `rpt_tableau__home_instruction_queue`,
+`rpt_tableau__hs_early_warning_dashboard`, `rpt_tableau__crdc_roster`,
+`rpt_tableau__nj_school_register`, `rpt_tableau__gpa_analysis`,
+`rpt_tableau__student_info_audit`,
+`rpt_tableau__student_attrition_over_time_v1`, `rpt_tableau__ops_dashboard`.
+
+### PR 2b — tableau intermediate
+
+`int_tableau__gradebook_audit_student_scaffold`,
+`int_tableau__gradebook_audit_teacher_scaffold`,
+`int_tableau__gradebook_audit_categories_teacher`,
+`int_tableau__gradebook_audit_assignments_teacher`,
+`int_tableau__gradebook_audit_assignments_student`,
+`int_tableau__state_assessments_demographic_comps`.
+
+### PR 2c — extracts/google (12)
+
+`rpt_gsheets__nj_state_test_roster`, `rpt_gsheets__athletic_eligibility`,
+`rpt_gsheets__kippfwd_miami_roster`, `rpt_gsheets__csgf_hs_enrollment`,
+`rpt_gsheets__csgf_hs_ap_offerings`, `rpt_gsheets__grad_plan_tracking`,
+`rpt_gsheets__award_ceremony_gpa`, `rpt_gsheets__mtss_rti`,
+`rpt_gsheets__absence_streak_roster`, `rpt_gsheets__school_metrics_extract`,
+`rpt_gsheets__gpa_roster`, `rpt_gsheets__gpa_flags_report`,
+`int_google_sheets__dibels_pm_expectations` (13 incl. the intermediate).
+
+### PR 2d — extracts/deanslist + clever + powerschool + littlesis (13)
+
+`rpt_deanslist__promo_status`, `rpt_deanslist__student_misc`,
+`rpt_deanslist__transcript_gpas`, `rpt_deanslist__final_grades`,
+`rpt_deanslist__hs_transcript_programs`, `rpt_deanslist__state_test_scores`,
+`rpt_deanslist__designations`, `rpt_deanslist__transcript_grades`,
+`rpt_clever__enrollments`, `rpt_clever__sections`,
+`rpt_powerschool__autocomm_students`, `rpt_powerschool__autocomm_teachers`,
+`rpt_littlesis__enrollments`.
+
+### PR 2e — non-extract consumers (18)
+
+`int_students__contacts`, `int_students__athletic_eligibility`,
+`int_extracts__student_enrollments_subjects`,
+`int_assessments__course_enrollments`, `int_kippadb__roster`,
+`int_powerschool__state_assessments_transfer_scores`, `int_powerschool__log`,
+`int_powerschool__ps_adaadm_daily_ctod`, `int_powerschool__gpnode`,
+`int_powerschool__gpprogress_grades`, `base_powerschool__sections`,
+`int_reporting__promotional_status`, `int_topline__gpa_term_weekly`,
+`int_topline__iready_diagnostic_weekly`, `int_topline__gpa_cumulative_weekly`,
+`bridge_course_section_teachers`, `fct_family_communications`, `dim_students`.
+
+**Ordering within 2e:** some of these are themselves union producers feeding
+others (`int_powerschool__gpnode` → `int_powerschool__gpprogress_grades` →
+`int_topline__gpa_term_weekly`). Do producer models before their consumers
+within the PR; keep each model's own swap atomic.
+
+### PR 2f — qa + tests + analyses (5)
+
+`qa_powerschool__transfer_records`, `qa_edplan__powerschool_mismatch`,
+`test_incorrect_student_number_pearson`,
+`collegeboard_ap_tiered_crosswalk_match`,
+`collegeboard_ap_downstream_lineage_root_cause`. (Also convert the 2
+non-producer `extract_source_project` filter/alias sites in
+`int_students__fldoe_fte` — done in 2e with `int_students__` — and
+`qa_edplan__powerschool_mismatch` to plain `_dbt_source_project` refs.)
+
+---
+
+## Batch 3 — Macro removal + docs (1 PR)
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/macros/utils.sql` (delete
+  `union_dataset_join_clause`)
+- Modify: `src/dbt/kipptaf/CLAUDE.md`, `src/dbt/kipptaf/models/marts/CLAUDE.md`
+- Verify: the 7 half-migrated files carry no residual macro call
+
+- [ ] **Step 1: Confirm 0 call sites**
+
+Run: `grep -rn 'union_dataset_join_clause' src/dbt/kipptaf --include='*.sql'`
+Expected: **0** results.
+
+- [ ] **Step 2: Delete the macro** from `utils.sql`.
+- [ ] **Step 3: Rewrite the docs** — in `kipptaf/CLAUDE.md`, replace the
+      `union_dataset_join_clause (critical)` section with the new rule: "Union
+      views expose `_dbt_source_project` via `extract_source_project()`; join on
+      it directly. Exception: crosswalk-resolved sources
+      (iReady/renlearn/amplify mClass) derive it from
+      `int_people__location_crosswalk`." Remove the "prefer inline" guidance.
+      Update the `marts/CLAUDE.md` hash-and-join note.
+- [ ] **Step 4: Reconcile half-migrated files** — grep the 7 files; ensure none
+      still calls the macro (all should have been swapped in Batch 2).
+- [ ] **Step 5: Compile** (`dbt parse --target dev`) — Expected: no
+      `union_dataset_join_clause` resolution errors (proves nothing still calls
+      it).
+- [ ] **Step 6: Lint** (include the `*.md`:
+      `trunk check --force --no-fix </dev/null <files>`).
+- [ ] **Step 7: Commit + push + PR**
+      (`refactor(dbt): remove union_dataset_join_clause macro; update docs (closes #3142)`).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** macro rename (1a) ✓, backfill all 124 = 61 existing + 63
+  new split regex(1b)/carve-out(1c) ✓, inline→macro ✓, consumer swaps all 263/90
+  files (2a-2f) ✓, macro delete + docs (3) ✓, contract columns (Pattern C) ✓,
+  carve-out (1c) ✓, half-migrated reconciliation (3) ✓.
+- **Producer gate** enforced by batch ordering + the pre-swap compiled-SQL
+  check.
+- **Disabled integrations** (adp/illuminate Fivetran) flagged as
+  apply-but-unverifiable, not silently skipped.

--- a/docs/superpowers/specs/2026-07-22-dbt-source-project-completion-design.md
+++ b/docs/superpowers/specs/2026-07-22-dbt-source-project-completion-design.md
@@ -1,0 +1,249 @@
+# Complete #3142: `_dbt_source_project` everywhere, retire `union_dataset_join_clause`
+
+Design spec for finishing the refactor started in
+[#3142](https://github.com/TEAMSchools/teamster/issues/3142) and partially
+landed in PR #4024 (assessment domain).
+
+## Problem
+
+Cross-district union models in `kipptaf` carry a `_dbt_source_relation` column
+(added by `dbt_utils.union_relations`) whose value includes the full schema plus
+table name, so it is unsafe to join two union-derived relations on it directly.
+The legacy workaround is the `union_dataset_join_clause` macro, which runs
+`regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` on **both** sides of
+**every** join, at query time.
+
+The intended fix — materialize the extraction once per union model as a
+`_dbt_source_project` column and join on it directly — was started but stalled.
+The column-materialization groundwork is roughly half done; the join swap, the
+macro removal, and the macro rename are almost entirely outstanding.
+
+## Current state (measured 2026-07-22)
+
+- `union_dataset_join_clause`: **263** call sites across **90**
+  model/test/analysis files (plus the definition in `macros/utils.sql`). Down
+  only ~5 from the original 268 baseline.
+- `union_relations` producers: **124** total; **61** already project
+  `_dbt_source_project`, **63** do not.
+- Of the 61 producers that carry the column, region-extraction is forked across
+  three idioms: **45** derive it via the `extract_code_location` macro, **9**
+  via inline `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')`, and a
+  handful resolve it from `int_people__location_crosswalk` instead of the
+  relation (see _Region carve-out_ below).
+- **7** files are half-migrated — they carry both `_dbt_source_project` and a
+  live `union_dataset_join_clause` call: `int_assessments__course_enrollments`,
+  `rpt_tableau__student_course_grades`, `bridge_course_section_teachers`,
+  `fct_family_communications`, `base_powerschool__sections`,
+  `int_powerschool__ps_adaadm_daily_ctod`, `int_students__contacts`.
+
+## Design decisions
+
+### Producer macro: rename, optional arg
+
+Rename `extract_code_location` to `extract_source_project`, with an **optional**
+relation argument that defaults to the unqualified form:
+
+```sql
+{% macro extract_source_project(relation="") %}
+    regexp_extract(
+        {% if relation %}{{ relation }}.{% endif %}_dbt_source_relation,
+        r'(kipp\w+)_'
+    )
+{% endmacro %}
+```
+
+- Called **with** an alias (`extract_source_project("wc")`) it renders the
+  qualified form — defensive in a `SELECT` that joins several relations, and
+  robust if a producer ever has two `_dbt_source_relation` columns in scope.
+- Called **with no arg** (`extract_source_project()`) it renders the unqualified
+  `regexp_extract(_dbt_source_relation, ...)`. This is the **exact string** that
+  `stg_powerschool__courses`, `stg_powerschool__students`,
+  `stg_powerschool__studentcorefields`, `stg_powerschool__s_nj_stu_x`,
+  `stg_titan__person_data`, and `int_edplan__njsmart_powerschool_union` already
+  use inline today — all bare `select *` + AM04 views, all green in CI. So it is
+  AM04-clean and unit-test-safe (the old table qualifier was the only reason
+  inline was ever preferred; omitting it in `select *` / unit-tested views
+  reproduces the proven-safe form).
+
+The qualifier existed **only** because the macro was also used in join clauses,
+where `a.` and `b.` must be disambiguated. This refactor deletes every join
+usage, so the arg reverts to a defensive, optional convenience.
+
+Apply the macro to every `union_relations` view whose warehouse schema prefix
+**is** the home region (~118 views): backfill those missing the column, and
+convert the 9 inline copies to the macro. Contracted producers (`staging/`,
+`marts/`) also add the new column to their `properties.yml`.
+
+### Region carve-out: crosswalk-resolved sources
+
+A minority of union sources cannot derive region from a regex on
+`_dbt_source_relation`, because the raw relation is wrong or meaningless for
+region. These resolve `_dbt_source_project` from
+`int_people__location_crosswalk.location_dagster_code_location` instead, and the
+macro must **not** be forced onto them:
+
+- **iReady** (`int_iready__*`) — Newark, Camden, and Paterson all land in the
+  shared `kippnj_iready` schema, so the regex yields `kippnj`, not the home
+  region.
+- **renlearn** (`stg_renlearn__star`) — shared `kippnj_renlearn` schema.
+- **amplify mClass** (`int_amplify__mclass__*`) — the union column encodes SFTP
+  vs API delivery method (and is renamed `_dbt_source_relation_2`), not region.
+
+These stay crosswalk-resolved and are normalized to one crosswalk-direct pattern
+(`location_dagster_code_location as _dbt_source_project`). Several of the 63
+backfill-pending views fall here (the other iReady models, the amplify SFTP
+staging models); they need a crosswalk join added, not a macro call. The
+CLAUDE.md rule documents this exception explicitly.
+
+### Consumer joins
+
+Replace every `union_dataset_join_clause(a, b)` call with
+`a._dbt_source_project = b._dbt_source_project`, threading `_dbt_source_project`
+through the consumer's own CTEs so both aliases expose it. The two non-producer
+`extract_code_location` sites become plain column references:
+
+- `int_students__fldoe_fte` — `extract_code_location("att") = 'kippmiami'`
+  becomes `att._dbt_source_project = 'kippmiami'`.
+- `qa_edplan__powerschool_mismatch` —
+  `extract_code_location(table="s") as code_location` becomes
+  `s._dbt_source_project as code_location`.
+
+### Cleanup
+
+- Delete `union_dataset_join_clause` from `macros/utils.sql` (only after 0 call
+  sites remain).
+- **Reverse** the `kipptaf/CLAUDE.md` guidance: the current "prefer inline
+  `regexp_extract` in `select *` / unit-test views" rule becomes "always use
+  `extract_source_project()` on `union_relations` views, except the
+  crosswalk-resolved sources named above." Update the
+  `union_dataset_join_clause (critical)` section and the `marts/CLAUDE.md`
+  hash-and-join note.
+
+### Enforcement
+
+Convention only — apply the macro everywhere (outside the carve-out) and
+document it as the rule. No automated CI guard. A source-level guard cannot
+distinguish macro from inline anyway (they compile identically), and a
+data-level guard would only assert the column exists, not how it was derived.
+
+## The invariant (why every swap is safe)
+
+`union_dataset_join_clause(a, b)` expands to:
+
+```sql
+regexp_extract(a._dbt_source_relation, r'(kipp\w+)_')
+= regexp_extract(b._dbt_source_relation, r'(kipp\w+)_')
+```
+
+`_dbt_source_project` is defined as
+`regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` (or, for carve-out
+sources, the crosswalk equivalent — which is what the old macro also resolved to
+for those rows). So `a._dbt_source_project = b._dbt_source_project` is
+byte-identical in result — **provided both `a` and `b` expose the column.** That
+single prerequisite makes each swap a provably behavior-preserving refactor,
+verifiable by row equality rather than judgment.
+
+## Batch sequence
+
+Dependency-layer first (producers before the consumers that join on them), then
+by directory. Each lettered sub-step is its own PR — 1a standalone, 1b split per
+source group, 1c standalone, each `2x` per directory, 3 standalone — with the
+producer-gate ordering enforced across them (1 before 2, 2 before 3). The
+implementation plan enumerates the exact file list per PR.
+
+```text
+Batch 1 — MACRO RENAME + PRODUCER BACKFILL (kipptaf-only, self-contained)
+  1a Rename extract_code_location -> extract_source_project (optional relation arg,
+     default unqualified) across the macro def + all existing call sites.
+     Front-loaded and behavior-preserving, so every later batch writes the final name.
+  1b Regex-producers (schema prefix = home region, ~118 views): add extract_source_project()
+     to those still missing the column; convert the 9 inline copies to the macro.
+     Grouped by source: powerschool (~30) / deanslist / illuminate / pearson / amplify(api) /
+     overgrad / fldoe / titan / adp / zendesk.
+  1c Crosswalk carve-out (iReady / renlearn / amplify mClass): resolve _dbt_source_project
+     from int_people__location_crosswalk.location_dagster_code_location, normalized to one
+     crosswalk-direct pattern. Add the crosswalk join where a backfill-pending model lacks it.
+  Contracted producers add the column to properties.yml.
+
+Batch 2 — CONSUMER JOIN SWAPS, by directory (only after Batch 1 lands the columns)
+    2a extracts/tableau rpt_ (41 files -> 2-3 sub-PRs: gradebook / assessment+state / attendance+culture+misc)
+    2b extracts/tableau/intermediate (gradebook_audit scaffolds)
+    2c extracts/google (12)
+    2d extracts/deanslist (8) + clever (2) + powerschool (2) + littlesis (1)
+    2e non-extract: powerschool/intermediate (5), topline/intermediate (3),
+       students/intermediate (3), marts (3), assessments/intermediate (1),
+       kippadb/intermediate (1), reporting/intermediate (1), google/sheets (1)
+    2f qa + tests + analyses (5)
+  Each swap threads _dbt_source_project through the consumer's CTEs so aliases resolve.
+
+Batch 3 — MACRO REMOVAL + DOCS (only after 0 union_dataset_join_clause call sites remain)
+  - Delete union_dataset_join_clause from utils.sql
+  - Reverse kipptaf/CLAUDE.md guidance (incl. the carve-out exception); update marts/CLAUDE.md
+  - Reconcile the 7 half-migrated files for stragglers
+```
+
+Note: some intermediates are **both** a producer to fix in Batch 1 and a
+consumer to swap in Batch 2 (e.g. `int_powerschool__gpprogress_grades`).
+Multi-level chains (`stg_powerschool__gpnode` to
+`int_powerschool__gpprogress_grades` to `int_topline__gpa_term_weekly`) thread
+the column through each level; the implementation plan sequences these
+producer-first.
+
+## Verification per batch
+
+Because each swap is algebraically identical, verification targets equality, not
+plausibility:
+
+1. Dev `--defer` build of each touched model against a fresh prod baseline;
+   compare row counts and distinct-key counts. Watch for stale-dev-shadow false
+   positives (a stale dev parent produces phantom row/relationships deltas — see
+   `src/dbt/CLAUDE.md`).
+1. CI `state:modified+` relationships and uniqueness tests stay green.
+1. Before each swap, grep the compiled SQL to confirm both aliases expose
+   `_dbt_source_project` (the invariant prerequisite).
+1. `dbt parse` / `compile` to confirm the swapped SQL renders.
+1. For carve-out sources, spot-check that `_dbt_source_project` holds the home
+   region (e.g. a Newark iReady row reads `kippnewark`, not `kippnj`).
+
+## Risks and gotchas
+
+- **Producer gate.** Swapping a consumer before its producer carries the column
+  fails with `Name _dbt_source_project not found`. Strict Batch 1 -> Batch 2
+  ordering prevents this.
+- **Carve-out mis-derivation.** Mechanically adding `extract_source_project()`
+  to a shared-schema source (iReady / renlearn) assigns every NJ row `kippnj`
+  and silently breaks region attribution. Batch 1c must use the crosswalk for
+  these.
+- **Multi-level chains.** The column must be threaded through every intermediate
+  level, not just the leaf producer.
+- **Contracted models.** Adding the column to a `staging/`, `marts/`, or `rpt_`
+  model requires the matching `properties.yml` column entry, or contract
+  enforcement fails at build.
+- **Half-migrated files.** The 7 files carrying both idioms must be reconciled,
+  not double-processed.
+- **Refactor regex sweeps include `*.md`.** The rename and removal touch
+  `kipptaf/CLAUDE.md`, `marts/CLAUDE.md`, and this spec — include Markdown in
+  any identifier sweep.
+
+## Out of scope
+
+- Removing or renaming `_dbt_source_relation` itself — it stays; models may
+  still select or carry it.
+- The `extract_region` macro (line 9 of `utils.sql`) — it reads
+  `_dbt_source_project` to derive region and is unaffected.
+- Any automated enforcement mechanism (decided: convention only).
+
+## Acceptance criteria
+
+- [ ] Every `union_relations` view projects `_dbt_source_project`: the ~118
+      schema-prefix-is-region views via `extract_source_project()` (0 inline
+      `regexp_extract(_dbt_source_relation, ...)` producer copies remain); the
+      carve-out sources via the crosswalk.
+- [ ] 0 `union_dataset_join_clause` call sites remain; the macro is deleted from
+      `macros/utils.sql`.
+- [ ] `extract_code_location` is renamed to `extract_source_project` (optional
+      arg); the 2 non-producer sites are plain column refs.
+- [ ] `kipptaf/CLAUDE.md` and `marts/CLAUDE.md` reflect the macro-everywhere
+      rule and the crosswalk carve-out.
+- [ ] All cross-mart relationships and uniqueness tests stay at their current
+      severity with 0 new failures; CI green.

--- a/src/dbt/kipptaf/macros/utils.sql
+++ b/src/dbt/kipptaf/macros/utils.sql
@@ -1,9 +1,11 @@
-{% macro extract_code_location(table) %}
-    regexp_extract({{ table }}._dbt_source_relation, r'(kipp\w+)_')
+{% macro extract_source_project(relation="") %}
+    regexp_extract(
+        {% if relation %}{{ relation }}.{% endif %}_dbt_source_relation, r'(kipp\w+)_'
+    )
 {% endmacro %}
 
 {% macro union_dataset_join_clause(left_alias, right_alias) %}
-    {{ extract_code_location(left_alias) }} = {{ extract_code_location(right_alias) }}
+    {{ extract_source_project(left_alias) }} = {{ extract_source_project(right_alias) }}
 {% endmacro %}
 
 {% macro extract_region(table) %}

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -122,7 +122,7 @@ models:
           Dagster code-location prefix derived from region (e.g. kippnewark,
           kippcamden, kippmiami, kipppaterson). Carried into downstream hashes
           so consumers join/hash on a stable column rather than re-deriving via
-          concat(region) or extract_code_location() at each call.
+          concat(region) or extract_source_project() at each call.
       - name: student_assessment_id
         data_type: int64
       - name: date_taken

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__comm_log.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__comm_log.sql
@@ -12,5 +12,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents.sql
@@ -23,7 +23,7 @@ with
         from union_relations
     )
 
-select u.*, {{ extract_code_location("u") }} as _dbt_source_project, loc.location_key,
+select u.*, {{ extract_source_project("u") }} as _dbt_source_project, loc.location_key,
 from sanitized as u
 left join
     {{ ref("stg_google_sheets__people__locations") }} as loc

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__penalties.sql
@@ -31,5 +31,5 @@ with
         from union_relations
     )
 
-select *, {{ extract_code_location("sanitized") }} as _dbt_source_project,
+select *, {{ extract_source_project("sanitized") }} as _dbt_source_project,
 from sanitized

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__roster_assignments.sql
@@ -20,5 +20,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/edplan/qa/qa_edplan__powerschool_mismatch.sql
+++ b/src/dbt/kipptaf/models/edplan/qa/qa_edplan__powerschool_mismatch.sql
@@ -36,7 +36,7 @@ with
 
             ep.nj_se_parentalconsentobtained,
 
-            {{ extract_code_location(table="s") }} as code_location,
+            {{ extract_source_project(relation="s") }} as code_location,
         from {{ ref("stg_powerschool__students") }} as s
         inner join
             {{ ref("stg_powerschool__studentcorefields") }} as scf
@@ -64,7 +64,7 @@ with
 
             ep.nj_se_parentalconsentobtained,
 
-            {{ extract_code_location(table="ep") }} as code_location,
+            {{ extract_source_project(relation="ep") }} as code_location,
         from edplan_deduplicate as ep
         left join
             {{ ref("stg_powerschool__students") }} as s

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_custom_attributes.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_custom_attributes.sql
@@ -15,5 +15,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_id_attributes.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_id_attributes.sql
@@ -30,5 +30,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_lifecycle.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_lifecycle.sql
@@ -20,5 +20,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__student_contacts.sql
@@ -20,5 +20,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__contact_relationships.sql
+++ b/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__contact_relationships.sql
@@ -14,5 +14,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__contacts.sql
@@ -12,5 +12,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__all_assessments.sql
@@ -60,7 +60,7 @@ select
     fl.test_date,
     fl.student_number,
 
-    {{ extract_code_location("fl") }} as _dbt_source_project,
+    {{ extract_source_project("fl") }} as _dbt_source_project,
 
     cw1.sublevel_number,
     cw1.sublevel_name,

--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fte_pivot.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fte_pivot.sql
@@ -7,5 +7,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/properties/int_fldoe__all_assessments.yml
@@ -26,7 +26,7 @@ models:
       - name: _dbt_source_project
         data_type: string
         description: >-
-          Dagster code-location identifier derived via extract_code_location()
+          Dagster code-location identifier derived via extract_source_project()
           from _dbt_source_relation; identifies the district source project
           (e.g. kippmiami).
 

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__eoc.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__eoc.yml
@@ -77,8 +77,8 @@ models:
         data_type: boolean
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — 'kippmiami'.
+          Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: grade_level
         data_type: int64
         description: Cast from enrolled_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fast.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fast.yml
@@ -75,8 +75,8 @@ models:
         data_type: boolean
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — 'kippmiami'.
+          Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: grade_level
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fsa.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__fsa.yml
@@ -91,8 +91,8 @@ models:
         data_type: string
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — 'kippmiami'.
+          Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: grade_level
         data_type: int64
         description: Cast from test_grade (per-source grade representation).

--- a/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__science.yml
+++ b/src/dbt/kipptaf/models/fldoe/staging/properties/stg_fldoe__science.yml
@@ -71,8 +71,8 @@ models:
         data_type: string
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — 'kippmiami'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — 'kippmiami'.
+          Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: grade_level
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__eoc.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__eoc.sql
@@ -10,7 +10,7 @@ with
 select
     *,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     cast(enrolled_grade as int) as grade_level,
 from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fast.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fast.sql
@@ -10,7 +10,7 @@ with
 select
     *,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     cast(assessment_grade as int) as grade_level,
 from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fsa.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__fsa.sql
@@ -10,7 +10,7 @@ with
 select
     *,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     cast(test_grade as int) as grade_level,
 from union_relations

--- a/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__science.sql
+++ b/src/dbt/kipptaf/models/fldoe/staging/stg_fldoe__science.sql
@@ -10,7 +10,7 @@ with
 select
     *,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     cast(assessment_grade as int) as grade_level,
 from union_relations

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
@@ -127,7 +127,7 @@ select
 
     right(rt.code, 1) as round_number,
 
-    {{ extract_code_location("wc") }} as _dbt_source_project,
+    {{ extract_source_project("wc") }} as _dbt_source_project,
 
     case
         when wc.overall_relative_placement_int <= 2

--- a/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__students.sql
@@ -38,7 +38,7 @@ select
     c.second_choice_school,
     c.third_choice_school,
 
-    {{ extract_code_location("ur") }} as _dbt_source_project,
+    {{ extract_source_project("ur") }} as _dbt_source_project,
 
 from union_relations as ur
 left join choices_pivot as c on ur.id = c.student__id

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njgpa.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njgpa.yml
@@ -18,9 +18,8 @@ models:
         description: Normalized from `period` ('FallBlock' → 'Fall').
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
-          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — e.g.,
+          'kippnewark' / 'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: test_date
         data_type: date
         description:

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla.yml
@@ -18,9 +18,8 @@ models:
         description: Normalized from `period` ('FallBlock' → 'Fall').
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
-          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — e.g.,
+          'kippnewark' / 'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: test_date
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla_science.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__njsla_science.yml
@@ -18,9 +18,8 @@ models:
         description: Normalized from `period` ('FallBlock' → 'Fall').
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
-          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — e.g.,
+          'kippnewark' / 'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: test_date
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__parcc.yml
+++ b/src/dbt/kipptaf/models/pearson/staging/properties/stg_pearson__parcc.yml
@@ -18,9 +18,8 @@ models:
         description: Normalized from `period` ('FallBlock' → 'Fall').
       - name: _dbt_source_project
         data_type: string
-        description: Source project
-          (extract_code_location(_dbt_source_relation)) — e.g., 'kippnewark' /
-          'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
+        description: Source project (extract_source_project()) — e.g.,
+          'kippnewark' / 'kippcamden'. Per #3142, materialized at the union model so consumers don't re-derive per-call.
       - name: test_date
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njgpa.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njgpa.sql
@@ -19,7 +19,7 @@ select
 
     if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     case
         testcode

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla.sql
@@ -20,7 +20,7 @@ select
 
     if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     case
         testcode

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla_science.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__njsla_science.sql
@@ -20,7 +20,7 @@ select
 
     if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     case
         testcode

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__parcc.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__parcc.sql
@@ -19,7 +19,7 @@ select
 
     if(`period` = 'FallBlock', 'Fall', `period`) as administration_period,
 
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
     case
         testcode

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__course_enrollments.sql
@@ -25,7 +25,7 @@ with
     ),
 
     add_dbt_field as (
-        select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+        select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
         from union_relations as ur
     )
 

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__final_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__final_grades.sql
@@ -11,5 +11,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__sections.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__sections.sql
@@ -14,7 +14,7 @@ with
 
 select
     ur.*,
-    {{ extract_code_location("ur") }} as _dbt_source_project,
+    {{ extract_source_project("ur") }} as _dbt_source_project,
     if(cx.ap_course_subject is not null, true, false) as is_ap_course,
 from union_relations as ur
 left join

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada.sql
@@ -12,5 +12,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__attendance_streak.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__attendance_streak.sql
@@ -21,5 +21,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__calendar_week.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__calendar_week.sql
@@ -21,5 +21,5 @@ with
 select
     *,
     initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
-    {{ extract_code_location("union_relations") }} as _dbt_source_project,
+    {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades.sql
@@ -28,7 +28,7 @@ with
 select
     ur.*,
 
-    {{ extract_code_location("ur") }} as _dbt_source_project,
+    {{ extract_source_project("ur") }} as _dbt_source_project,
 
     ur.yearid + 1990 as academic_year,
 

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__contacts.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__contacts.sql
@@ -13,5 +13,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative.sql
@@ -14,7 +14,7 @@ with
 select
     ur.*,
 
-    {{ extract_code_location("ur") }} as _dbt_source_project,
+    {{ extract_source_project("ur") }} as _dbt_source_project,
 
     case
         when ur.cumulative_y1_gpa_unweighted >= 3.00

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative_year.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_cumulative_year.sql
@@ -11,5 +11,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term.sql
@@ -11,5 +11,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradebook_assignments.sql
@@ -24,6 +24,6 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__spenrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__spenrollments.sql
@@ -18,5 +18,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__teacher_grade_levels.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__teacher_grade_levels.sql
@@ -20,5 +20,5 @@ with
         }}
     )
 
-select *, {{ extract_code_location("union_relations") }} as _dbt_source_project,
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__terms.sql
@@ -12,6 +12,6 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__assignmentscore.sql
@@ -12,5 +12,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__calendar_day.sql
@@ -17,7 +17,7 @@ with
 select
     ur.* except (date_value),
 
-    {{ extract_code_location("ur") }} as _dbt_source_project,
+    {{ extract_source_project("ur") }} as _dbt_source_project,
 
     if(ur.date_value < date '2000-01-01', null, ur.date_value) as date_value,
 

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_crs_x.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_crs_x.sql
@@ -11,5 +11,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_ren_x.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_nj_ren_x.sql
@@ -11,5 +11,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__schools.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__schools.sql
@@ -12,7 +12,7 @@ with
         }}
     )
 
-select u.*, {{ extract_code_location("u") }} as _dbt_source_project, loc.location_key,
+select u.*, {{ extract_source_project("u") }} as _dbt_source_project, loc.location_key,
 from unioned as u
 left join
     {{ ref("stg_google_sheets__people__locations") }} as loc

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__storedgrades.sql
@@ -31,7 +31,7 @@ select
 
     if(l.location_name is null, true, false) as is_transfer_grade,
 
-    {{ extract_code_location("u") }} as _dbt_source_project,
+    {{ extract_source_project("u") }} as _dbt_source_project,
 
 from union_relations as u
 left join

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
@@ -30,7 +30,7 @@ with
             whomodified,
             whenmodified,
 
-            {{ extract_code_location("union_relations") }} as _dbt_source_project,
+            {{ extract_source_project("union_relations") }} as _dbt_source_project,
 
         from union_relations
     ),

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_studentsuserfields.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_studentsuserfields.sql
@@ -24,5 +24,5 @@ with
         }}
     )
 
-select ur.*, {{ extract_code_location("ur") }} as _dbt_source_project,
+select ur.*, {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__fldoe_fte.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__fldoe_fte.sql
@@ -16,7 +16,7 @@ with
             and att.calendardate between fte.start_date and fte.end_date
             and fte.type = 'FTE'
         where
-            {{ extract_code_location("att") }} = 'kippmiami'
+            {{ extract_source_project("att") }} = 'kippmiami'
             and att.membershipvalue = 1
             and att.attendancevalue = 1
         group by att._dbt_source_relation, att.studentid, att.yearid, fte.name


### PR DESCRIPTION
## Summary and Motivation

When merged, this PR kicks off completion of #3142 (replace `union_dataset_join_clause` with a materialized `_dbt_source_project` column). It adds:

- The design spec and implementation plan under `docs/superpowers/`.
- Batch 1a: a mechanical, behavior-preserving rename of the `extract_code_location` macro to `extract_source_project`, now with an optional `relation` arg (default unqualified). `union_dataset_join_clause` is repointed at the new name (it is removed entirely in the final batch).

Verified byte-identical via `dbt compile` — both the producer arg-form and the consumer join-clause path render the same `regexp_extract(...)`. Also normalizes one CRLF file to LF.

Subsequent batches (producer backfill, consumer swaps, macro removal) stack on this branch as separate PRs per the plan.

## AI Assistance

Authored by Claude Code (Opus 4.8), human-directed. The human reviewer decided the design: optional-arg vs argument-less macro, the iReady/renlearn/amplify crosswalk carve-out, convention-only enforcement, and the stacked-PR structure.

## Self-review

### dbt

- [x] Rename is behavior-preserving — no model logic, columns, or contracts changed
- [x] No new models (docs plus macro rename only)
- [x] No external-source changes

## CI checks

- [ ] Trunk
- [ ] dbt Cloud

Refs #3142