### PR TITLE
refactor(dbt): backfill _dbt_source_project on powerschool union views (#3142)

### DIFF
--- a/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_teachers.sql
@@ -67,7 +67,7 @@ with
             {{ ref("stg_powerschool__users") }} as u
             on sr.powerschool_teacher_number = u.teachernumber
             and sr.home_work_location_powerschool_school_id = u.homeschoolid
-            and sr.home_work_location_dagster_code_location = u.dagster_code_location
+            and sr.home_work_location_dagster_code_location = u._dbt_source_project
         left join
             {{ ref("stg_powerschool__userscorefields") }} as ucf
             on u.dcid = ucf.usersdcid
@@ -95,7 +95,7 @@ with
         left join
             {{ ref("stg_powerschool__users") }} as u
             on sr.powerschool_teacher_number = u.teachernumber
-            and sr.home_work_location_dagster_code_location = u.dagster_code_location
+            and sr.home_work_location_dagster_code_location = u._dbt_source_project
         where sr.days_after_termination <= 14 and u.dcid is null
     ),
 

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__calendar_rollup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__calendar_rollup.sql
@@ -1,10 +1,25 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__calendar_rollup"),
-            source("kippcamden_powerschool", "int_powerschool__calendar_rollup"),
-            source("kippmiami_powerschool", "int_powerschool__calendar_rollup"),
-            source("kipppaterson_powerschool", "int_powerschool__calendar_rollup"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "int_powerschool__calendar_rollup"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "int_powerschool__calendar_rollup"
+                    ),
+                    source(
+                        "kippmiami_powerschool", "int_powerschool__calendar_rollup"
+                    ),
+                    source(
+                        "kipppaterson_powerschool", "int_powerschool__calendar_rollup"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__category_grades_pivot.sql
@@ -1,13 +1,25 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source(
-                "kippnewark_powerschool", "int_powerschool__category_grades_pivot"
-            ),
-            source(
-                "kippcamden_powerschool", "int_powerschool__category_grades_pivot"
-            ),
-            source("kippmiami_powerschool", "int_powerschool__category_grades_pivot"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "int_powerschool__category_grades_pivot",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "int_powerschool__category_grades_pivot",
+                    ),
+                    source(
+                        "kippmiami_powerschool",
+                        "int_powerschool__category_grades_pivot",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__district_entry_date.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__district_entry_date.sql
@@ -1,12 +1,29 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__district_entry_date"),
-            source("kippcamden_powerschool", "int_powerschool__district_entry_date"),
-            source("kippmiami_powerschool", "int_powerschool__district_entry_date"),
-            source(
-                "kipppaterson_powerschool", "int_powerschool__district_entry_date"
-            ),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "int_powerschool__district_entry_date",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "int_powerschool__district_entry_date",
+                    ),
+                    source(
+                        "kippmiami_powerschool",
+                        "int_powerschool__district_entry_date",
+                    ),
+                    source(
+                        "kipppaterson_powerschool",
+                        "int_powerschool__district_entry_date",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_pivot.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradescaleitem_lookup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gradescaleitem_lookup.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__section_grade_config.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__section_grade_config.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__teachers.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__teachers.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "int_powerschool__teachers"),
-            source("kippcamden_powerschool", "int_powerschool__teachers"),
-            source("kippmiami_powerschool", "int_powerschool__teachers"),
-            source("kipppaterson_powerschool", "int_powerschool__teachers"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "int_powerschool__teachers"),
+                    source("kippcamden_powerschool", "int_powerschool__teachers"),
+                    source("kippmiami_powerschool", "int_powerschool__teachers"),
+                    source("kipppaterson_powerschool", "int_powerschool__teachers"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__calendar_rollup.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__calendar_rollup.yml
@@ -5,6 +5,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: schoolid
         data_type: int64
         description: The School_Number of the associated Schools record.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__category_grades_pivot.yml
@@ -3,6 +3,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__district_entry_date.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__district_entry_date.yml
@@ -5,6 +5,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__final_grades_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__final_grades_pivot.yml
@@ -3,6 +3,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradescaleitem_lookup.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradescaleitem_lookup.yml
@@ -5,6 +5,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: gradescaleid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__section_grade_config.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__section_grade_config.yml
@@ -3,6 +3,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: sections_dcid
         data_type: int64
       - name: grade_formula_set_id

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__teachers.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__teachers.yml
@@ -5,6 +5,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: lastfirst
         data_type: string
         description: Last, First, Mi. Indexed.

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__log.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__log.yml
@@ -16,5 +16,7 @@ models:
         data_type: string
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__users.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__users.yml
@@ -141,5 +141,5 @@ models:
         data_type: int64
       - name: _dbt_source_relation
         data_type: string
-      - name: dagster_code_location
+      - name: _dbt_source_project
         data_type: string

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__attendance.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__attendance.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__attendance"),
-            source("kippcamden_powerschool", "stg_powerschool__attendance"),
-            source("kippmiami_powerschool", "stg_powerschool__attendance"),
-            source("kipppaterson_powerschool", "stg_powerschool__attendance"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__attendance"),
+                    source("kippcamden_powerschool", "stg_powerschool__attendance"),
+                    source("kippmiami_powerschool", "stg_powerschool__attendance"),
+                    source("kipppaterson_powerschool", "stg_powerschool__attendance"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__attendance_code.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__attendance_code.sql
@@ -1,10 +1,25 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__attendance_code"),
-            source("kippcamden_powerschool", "stg_powerschool__attendance_code"),
-            source("kippmiami_powerschool", "stg_powerschool__attendance_code"),
-            source("kipppaterson_powerschool", "stg_powerschool__attendance_code"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "stg_powerschool__attendance_code"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "stg_powerschool__attendance_code"
+                    ),
+                    source(
+                        "kippmiami_powerschool", "stg_powerschool__attendance_code"
+                    ),
+                    source(
+                        "kipppaterson_powerschool", "stg_powerschool__attendance_code"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__cc.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__cc.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__cc"),
-            source("kippcamden_powerschool", "stg_powerschool__cc"),
-            source("kippmiami_powerschool", "stg_powerschool__cc"),
-            source("kipppaterson_powerschool", "stg_powerschool__cc"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__cc"),
+                    source("kippcamden_powerschool", "stg_powerschool__cc"),
+                    source("kippmiami_powerschool", "stg_powerschool__cc"),
+                    source("kipppaterson_powerschool", "stg_powerschool__cc"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__fte.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__fte.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__fte"),
-            source("kippcamden_powerschool", "stg_powerschool__fte"),
-            source("kippmiami_powerschool", "stg_powerschool__fte"),
-            source("kipppaterson_powerschool", "stg_powerschool__fte"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__fte"),
+                    source("kippcamden_powerschool", "stg_powerschool__fte"),
+                    source("kippmiami_powerschool", "stg_powerschool__fte"),
+                    source("kipppaterson_powerschool", "stg_powerschool__fte"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gen.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gen.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__gen"),
-            source("kippcamden_powerschool", "stg_powerschool__gen"),
-            source("kippmiami_powerschool", "stg_powerschool__gen"),
-            source("kipppaterson_powerschool", "stg_powerschool__gen"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__gen"),
+                    source("kippcamden_powerschool", "stg_powerschool__gen"),
+                    source("kippmiami_powerschool", "stg_powerschool__gen"),
+                    source("kipppaterson_powerschool", "stg_powerschool__gen"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpnode.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpnode.sql
@@ -1,8 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubject.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubject.sql
@@ -1,8 +1,19 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__gpprogresssubject"),
-            source("kippcamden_powerschool", "stg_powerschool__gpprogresssubject"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "stg_powerschool__gpprogresssubject"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "stg_powerschool__gpprogresssubject"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubjectearned.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubjectearned.sql
@@ -1,12 +1,21 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source(
-                "kippnewark_powerschool", "stg_powerschool__gpprogresssubjectearned"
-            ),
-            source(
-                "kippcamden_powerschool", "stg_powerschool__gpprogresssubjectearned"
-            ),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "stg_powerschool__gpprogresssubjectearned",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "stg_powerschool__gpprogresssubjectearned",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubjectenrolled.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__gpprogresssubjectenrolled.sql
@@ -1,12 +1,21 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source(
-                "kippnewark_powerschool", "stg_powerschool__gpprogresssubjectenrolled"
-            ),
-            source(
-                "kippcamden_powerschool", "stg_powerschool__gpprogresssubjectenrolled"
-            ),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool",
+                        "stg_powerschool__gpprogresssubjectenrolled",
+                    ),
+                    source(
+                        "kippcamden_powerschool",
+                        "stg_powerschool__gpprogresssubjectenrolled",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__log.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__log.sql
@@ -14,6 +14,8 @@ with
 select
     *,
 
+    {{ extract_source_project() }} as _dbt_source_project,
+
     {{
         date_to_fiscal_year(
             date_field="entry_date", start_month=7, year_source="start"

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__pgfinalgrades.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__pgfinalgrades.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__roledef.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__roledef.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_stu_x.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__s_stu_x.sql
@@ -1,8 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__s_stu_x"),
-            source("kippcamden_powerschool", "stg_powerschool__s_stu_x"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__s_stu_x"),
+                    source("kippcamden_powerschool", "stg_powerschool__s_stu_x"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__sectionteacher.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__sectionteacher.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studentrace.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studentrace.sql
@@ -1,8 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studenttest.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studenttest.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studenttestscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__studenttestscore.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__terms.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__terms.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__terms"),
-            source("kippcamden_powerschool", "stg_powerschool__terms"),
-            source("kippmiami_powerschool", "stg_powerschool__terms"),
-            source("kipppaterson_powerschool", "stg_powerschool__terms"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", "stg_powerschool__terms"),
+                    source("kippcamden_powerschool", "stg_powerschool__terms"),
+                    source("kippmiami_powerschool", "stg_powerschool__terms"),
+                    source("kipppaterson_powerschool", "stg_powerschool__terms"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__test.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__test.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__testscore.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__testscore.sql
@@ -1,9 +1,16 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", model.name),
-            source("kippcamden_powerschool", model.name),
-            source("kippmiami_powerschool", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_powerschool", model.name),
+                    source("kippcamden_powerschool", model.name),
+                    source("kippmiami_powerschool", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_storedgrades_de.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_storedgrades_de.sql
@@ -1,8 +1,19 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__u_storedgrades_de"),
-            source("kippcamden_powerschool", "stg_powerschool__u_storedgrades_de"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "stg_powerschool__u_storedgrades_de"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "stg_powerschool__u_storedgrades_de"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__users.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__users.sql
@@ -12,6 +12,6 @@ with
         }}
     )
 
--- trunk-ignore(sqlfluff/AM04)
-select *, regexp_extract(_dbt_source_relation, r'(kipp\w+)_') as dagster_code_location,
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
 from union_relations

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__userscorefields.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__userscorefields.sql
@@ -1,9 +1,22 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_powerschool", "stg_powerschool__userscorefields"),
-            source("kippcamden_powerschool", "stg_powerschool__userscorefields"),
-            source("kippmiami_powerschool", "stg_powerschool__userscorefields"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_powerschool", "stg_powerschool__userscorefields"
+                    ),
+                    source(
+                        "kippcamden_powerschool", "stg_powerschool__userscorefields"
+                    ),
+                    source(
+                        "kippmiami_powerschool", "stg_powerschool__userscorefields"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations


### PR DESCRIPTION
## Summary and Motivation

When merged, this PR backfills `_dbt_source_project` onto every kipptaf powerschool `union_relations` view — Batch 1b-1 of #3142. **Stacked on the kickoff PR #4502** (the macro rename); merge that first.

Changes (30 producers):

- **28 pure-inline union views** (`{{ dbt_utils.union_relations(...) }}` with no select wrapper) were wrapped in a `union_relations` CTE plus `select *, {{ extract_source_project() }} as _dbt_source_project`.
- **`stg_powerschool__log`** — column added to its existing select.
- **`stg_powerschool__users`** — already derived the region under the name `dagster_code_location`; renamed to `_dbt_source_project` (and switched inline `regexp_extract` to the macro). Its only consumer, `rpt_powerschool__autocomm_teachers`, was updated to join on `u._dbt_source_project`.
- Documented the new column in the 8 ymls that already document `_dbt_source_relation`. Only `stg_powerschool__users` is contract-enforced; its `properties.yml` column list was updated accordingly.

## Verification

Local `dbt build --target dev --defer` of `stg_powerschool__users`, `stg_powerschool__log`, `int_powerschool__teachers`, `int_powerschool__calendar_rollup`, and `rpt_powerschool__autocomm_teachers`: **PASS=6, ERROR=0**. The `users` contract check and the `autocomm_teachers` uniqueness test both pass. `_dbt_source_project` resolves to `kippnewark` / `kippcamden` / `kippmiami` / `kipppaterson`.

## AI Assistance

Authored by Claude Code (Opus 4.8), human-directed (the wrap-vs-add and rename decisions were made by the reviewer).

## Note

Stacked PR (base is a feature branch), so `claude-code-review` does not auto-run — request review via an `@claude` comment or manually.

Refs #3142