### PR TITLE
refactor(dbt): backfill _dbt_source_project on pearson + fldoe union views (#3142)

### DIFF
--- a/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fast_standard_performance_unpivot.sql
+++ b/src/dbt/kipptaf/models/fldoe/intermediate/int_fldoe__fast_standard_performance_unpivot.sql
@@ -1,7 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippmiami_fldoe", "int_fldoe__fast_standard_performance_unpivot")
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippmiami_fldoe",
+                        "int_fldoe__fast_standard_performance_unpivot",
+                    )
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__student_list_report.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__student_list_report.sql
@@ -1,9 +1,18 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", "stg_pearson__student_list_report"),
-            source("kippcamden_pearson", "stg_pearson__student_list_report"),
-            source("kipppaterson_pearson", "stg_pearson__student_list_report"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", "stg_pearson__student_list_report"),
+                    source("kippcamden_pearson", "stg_pearson__student_list_report"),
+                    source(
+                        "kipppaterson_pearson", "stg_pearson__student_list_report"
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/pearson/staging/stg_pearson__student_test_update.sql
+++ b/src/dbt/kipptaf/models/pearson/staging/stg_pearson__student_test_update.sql
@@ -1,8 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_pearson", "stg_pearson__student_test_update"),
-            source("kippcamden_pearson", "stg_pearson__student_test_update"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_pearson", "stg_pearson__student_test_update"),
+                    source("kippcamden_pearson", "stg_pearson__student_test_update"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations


### PR DESCRIPTION
## Summary and Motivation

When merged, this wraps the 3 cross-district state-assessment union views to expose `_dbt_source_project` — Batch 1b-2 of #3142. **Stacked on #4503** (powerschool); merge order: #4502 → #4503 → this.

- `stg_pearson__student_list_report`, `stg_pearson__student_test_update` (union Newark/Camden/Paterson pearson)
- `int_fldoe__fast_standard_performance_unpivot` (Miami fldoe)

## Scope correction (illuminate excluded)

The plan listed illuminate under 1b-2, but illuminate union views are **not cross-district** — their `_dbt_source_relation` unions non-region dimensions:

- `int_illuminate__agg_student_responses` → response-type (standard vs group)
- `int_illuminate__repository_data` → repository IDs
- `stg_illuminate__national_assessments__psat` → assessment years (2023/2024)

A region regex on those yields null, so they are correctly **excluded**. The backfill rule is "every cross-district union view," not literally every `union_relations` view. Several other candidates in the original 63-model list need the same region-vs-not check before backfilling.

## Verification

`dbt build --target dev --defer`: **PASS=3, ERROR=0**. `_dbt_source_project` resolves to `kippmiami` (fldoe) and `kippnewark` / `kippcamden` / `kipppaterson` (pearson).

## AI Assistance

Authored by Claude Code (Opus 4.8), human-directed.

## Note

Stacked PR (base is a feature branch) — `claude-code-review` does not auto-run; request via `@claude` or manually.

Refs #3142