### PR TITLE
refactor(dbt): backfill _dbt_source_project on deanslist/overgrad/finalsite/titan union views (#3142)

### DIFF
--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__attachments.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__incidents__attachments.sql
@@ -1,10 +1,28 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", "int_deanslist__incidents__attachments"),
-            source("kippcamden_deanslist", "int_deanslist__incidents__attachments"),
-            source("kippmiami_deanslist", "int_deanslist__incidents__attachments"),
-            source("kipppaterson_deanslist", "int_deanslist__incidents__attachments"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnewark_deanslist",
+                        "int_deanslist__incidents__attachments",
+                    ),
+                    source(
+                        "kippcamden_deanslist",
+                        "int_deanslist__incidents__attachments",
+                    ),
+                    source(
+                        "kippmiami_deanslist", "int_deanslist__incidents__attachments"
+                    ),
+                    source(
+                        "kipppaterson_deanslist",
+                        "int_deanslist__incidents__attachments",
+                    ),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__students__custom_fields__pivot.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/int_deanslist__students__custom_fields__pivot.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", model.name),
-            source("kippcamden_deanslist", model.name),
-            source("kippmiami_deanslist", model.name),
-            source("kipppaterson_deanslist", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_deanslist", model.name),
+                    source("kippcamden_deanslist", model.name),
+                    source("kippmiami_deanslist", model.name),
+                    source("kipppaterson_deanslist", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/deanslist/api/staging/properties/stg_deanslist__behavior.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/properties/stg_deanslist__behavior.yml
@@ -12,6 +12,8 @@ models:
                 field: name
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: assignment
         data_type: string
       - name: behavior

--- a/src/dbt/kipptaf/models/deanslist/api/staging/properties/stg_deanslist__terms.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/properties/stg_deanslist__terms.yml
@@ -5,6 +5,8 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: stored_grades
         data_type: boolean
       - name: start_date_timezone_type

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__behavior.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__behavior.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", "stg_deanslist__behavior"),
-            source("kippcamden_deanslist", "stg_deanslist__behavior"),
-            source("kippmiami_deanslist", "stg_deanslist__behavior"),
-            source("kipppaterson_deanslist", "stg_deanslist__behavior"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_deanslist", "stg_deanslist__behavior"),
+                    source("kippcamden_deanslist", "stg_deanslist__behavior"),
+                    source("kippmiami_deanslist", "stg_deanslist__behavior"),
+                    source("kipppaterson_deanslist", "stg_deanslist__behavior"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__terms.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__terms.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", "stg_deanslist__terms"),
-            source("kippcamden_deanslist", "stg_deanslist__terms"),
-            source("kippmiami_deanslist", "stg_deanslist__terms"),
-            source("kipppaterson_deanslist", "stg_deanslist__terms"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_deanslist", "stg_deanslist__terms"),
+                    source("kippcamden_deanslist", "stg_deanslist__terms"),
+                    source("kippmiami_deanslist", "stg_deanslist__terms"),
+                    source("kipppaterson_deanslist", "stg_deanslist__terms"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__users.sql
+++ b/src/dbt/kipptaf/models/deanslist/api/staging/stg_deanslist__users.sql
@@ -1,10 +1,17 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_deanslist", "stg_deanslist__users"),
-            source("kippcamden_deanslist", "stg_deanslist__users"),
-            source("kippmiami_deanslist", "stg_deanslist__users"),
-            source("kipppaterson_deanslist", "stg_deanslist__users"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_deanslist", "stg_deanslist__users"),
+                    source("kippcamden_deanslist", "stg_deanslist__users"),
+                    source("kippmiami_deanslist", "stg_deanslist__users"),
+                    source("kipppaterson_deanslist", "stg_deanslist__users"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/finalsite/staging/properties/stg_finalsite__status_report.yml
+++ b/src/dbt/kipptaf/models/finalsite/staging/properties/stg_finalsite__status_report.yml
@@ -10,6 +10,8 @@ models:
                 field: name
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
       - name: finalsite_enrollment_id
         data_type: string
       - name: _dagster_partition_key

--- a/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__status_report.sql
+++ b/src/dbt/kipptaf/models/finalsite/staging/stg_finalsite__status_report.sql
@@ -21,6 +21,8 @@ select
 
     initcap(regexp_extract(_dbt_source_relation, r'kipp(\w+)_')) as region,
 
+    {{ extract_source_project() }} as _dbt_source_project,
+
     if(
         application_grade in ('K', 'Kindergarten'),
         0,

--- a/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__admissions.sql
+++ b/src/dbt/kipptaf/models/overgrad/intermediate/int_overgrad__admissions.sql
@@ -97,5 +97,7 @@ select
     u.status as university_status,
     u.city as university_city,
     u.state as university_state,
+
+    {{ extract_source_project("ur") }} as _dbt_source_project,
 from union_relations as ur
 inner join {{ ref("stg_overgrad__universities") }} as u on ur.university__id = u.id

--- a/src/dbt/kipptaf/models/overgrad/staging/stg_overgrad__admissions.sql
+++ b/src/dbt/kipptaf/models/overgrad/staging/stg_overgrad__admissions.sql
@@ -1,8 +1,15 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_overgrad", "stg_overgrad__admissions"),
-            source("kippcamden_overgrad", "stg_overgrad__admissions"),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_overgrad", "stg_overgrad__admissions"),
+                    source("kippcamden_overgrad", "stg_overgrad__admissions"),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/titan/staging/stg_titan__income_form_data.sql
+++ b/src/dbt/kipptaf/models/titan/staging/stg_titan__income_form_data.sql
@@ -1,7 +1,14 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnewark_titan", model.name),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippnewark_titan", model.name),
+                ]
+            )
+        }}
     )
-}}
+
+-- trunk-ignore(sqlfluff/AM04): union_relations resolves columns at run time
+select *, {{ extract_source_project() }} as _dbt_source_project,
+from union_relations


### PR DESCRIPTION
## Summary and Motivation

Backfills `_dbt_source_project` onto the 9 remaining cross-district region union views — Batch 1b-3 of #3142, completing the Batch 1b producer backfill. **Stacked on #4504**; merge order: #4502 → #4503 → #4504 → this.

- deanslist (5), overgrad (2), finalsite (1), titan (1)
- 7 pure-inline unions wrapped; `int_overgrad__admissions` and `stg_finalsite__status_report` got the column in their existing select (overgrad uses the qualified `extract_source_project("ur")` since it joins a lookup)
- documented the column in the 3 ymls that document `_dbt_source_relation`

## Scope note

`zendesk` (unions current + archive) and `schoolmint_grow__generic_tags` (unions tag-types) are **excluded** as non-region unions, consistent with illuminate in 1b-2.

## Verification

`overgrad` / `finalsite` / `titan` build PASS; `_dbt_source_project` resolves to correct regions (finalsite covers all four: Camden/Miami/Newark/Paterson). The 2 deanslist models fail the local dev build only on a missing dev source copy (`zz_cbini_kipppaterson_deanslist`) — environmental, not a code issue; they compile clean and use the same wrap as the verified titan model.

## AI Assistance

Authored by Claude Code (Opus 4.8), human-directed.

## Note

Stacked PR — `claude-code-review` does not auto-run; request via `@claude` or manually. Also: `finalsite` is a cross-region union; dbt Cloud CI may need staged copies of the finalsite regional sources (see kipptaf CLAUDE.md) if it fails on the union wrapper.

Refs #3142