### PR TITLE
docs(extracts): confirm full-time temporary staff included in lattice extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -16,10 +16,11 @@ Keep this doc in sync with the model whenever the criteria change.
 - **Miami includes additional leader roles** — gated on a title keyword match
   plus one hardcoded location ("Room 11"), rather than an explicit title or
   department list.
-- **Part-timers and temporary workers are excluded** - part-timers are excluded
-  on ADP worker type; temps are excluded by job title. We intentionally do not
-  exclude on the "Temporary" worker type right now, because full-time-temporary
-  might be mislabels in ADP — so a temp is dropped only if their title says so.
+- **Part-timers are excluded; full-time temporary staff are included.**
+  Part-timers are dropped on ADP worker type. Full-time temporary workers are
+  kept — HR confirmed they are correctly classified and belong in Lattice — so
+  the "Temporary" worker type is not used to exclude. A job title that literally
+  names temporary or part-time work is still dropped as a backstop.
 
 ### Current inclusion criteria
 
@@ -32,9 +33,10 @@ who is **not** an intern, a temp, or a part-timer.
 - Their worker type is not a "Part Time" classification.
 - Anyone whose **job title** contains "Temporary," "Part Time," or "Part-Time"
   is excluded — this catches temps regardless of their worker type.
-- **Full-time temporary staff are currently kept**, pending a review of their
-  ADP records — that worker type might be a mislabel, so we don't auto-remove
-  them.
+- **Full-time temporary staff are included** — HR confirmed they are correctly
+  classified, so the "Temporary" worker type is not used to exclude. (The
+  job-title backstop above still applies, but no full-time temporary staff
+  currently carry such a title.)
 - Employees with a **blank worker type are kept** — in practice these are
   legitimate full-time staff, so we don't drop them.
 

--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -16,11 +16,8 @@ Keep this doc in sync with the model whenever the criteria change.
 - **Miami includes additional leader roles** — gated on a title keyword match
   plus one hardcoded location ("Room 11"), rather than an explicit title or
   department list.
-- **Part-timers are excluded; full-time temporary staff are included.**
-  Part-timers are dropped on ADP worker type. Full-time temporary workers are
-  kept — HR confirmed they are correctly classified and belong in Lattice — so
-  the "Temporary" worker type is not used to exclude. A job title that literally
-  names temporary or part-time work is still dropped as a backstop.
+- **Part-time permanent and temporary workers are excluded; full-time temporary
+  staff are included.**
 
 ### Current inclusion criteria
 
@@ -33,10 +30,9 @@ who is **not** an intern, a temp, or a part-timer.
 - Their worker type is not a "Part Time" classification.
 - Anyone whose **job title** contains "Temporary," "Part Time," or "Part-Time"
   is excluded — this catches temps regardless of their worker type.
-- **Full-time temporary staff are included** — HR confirmed they are correctly
-  classified, so the "Temporary" worker type is not used to exclude. (The
-  job-title backstop above still applies, but no full-time temporary staff
-  currently carry such a title.)
+- **Full-time temporary staff are included** — Managers confirmed they should be
+  included, so the "Temporary" worker type is not used to exclude (the job title
+  exclusion above still applies as a backstop).
 - Employees with a **blank worker type are kept** — in practice these are
   legitimate full-time staff, so we don't drop them.
 

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -5,8 +5,8 @@ with
         where
             job_title <> 'Intern'
             -- exclude part-timers plus anyone whose title names temp/part-time
-            -- work. Full Time - Temporary staff are kept pending an ADP review
-            -- (that worker type is frequently a mislabel); nulls kept as
+            -- work. Full Time - Temporary staff are kept (HR confirmed they are
+            -- correctly classified and belong in Lattice); nulls kept as
             -- legitimate full-time staff
             and (
                 worker_type_code is null


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request updates the Lattice extract wording to reflect
that **HR confirmed Full Time - Temporary staff are correctly classified and
belong in Lattice.**

- Updates the [README](src/dbt/kipptaf/models/extracts/lattice/README.md) (high-level
  summary and inclusion-criteria sections) to drop the earlier "kept pending an
  ADP review / possible mislabel" framing.
- Updates the matching filter comment in `rpt_lattice__users.sql` so the code
  and the README agree.

**No logic change.** Those staff were already retained by the filter (we
excluded only part-timers by worker type and title-flagged temps by job title),
so nothing about who lands in the feed changes — this is a wording/comment
correction only.

### AI Assistance

Wording drafted by Claude Code; the HR confirmation and the decision to update
both the doc and the code comment were directed by the requester.

## Self-review

### dbt

- Touches `rpt_lattice__users.sql` (a comment only) plus its README — no SQL
  logic, column, or contract change.
- CI will build the model because the `.sql` file changed; the resulting view is
  byte-identical in output.

## CI checks

- [x] **Trunk** — passes locally on both files.
- [ ] **dbt Cloud** — pending.
