### PR TITLE
fix(google): retry transient errors on individual batch sub-requests in GoogleDirectoryResource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,13 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   path breaks — pass an absolute script path or run it from the main repo.
   Otherwise prefer absolute paths.
 
+- **Bash cwd does NOT persist across calls** — every Bash command (including
+  `run_in_background`) starts at the main repo root, so a prior `cd <worktree>`
+  does not carry over. Tools that resolve relative paths from cwd (`trunk check`
+  with relative paths, `pytest`) must include `cd <worktree> &&` in the SAME
+  command, or they silently operate on the main checkout's (unmodified) copies
+  and report a false "clean". Prefix with `pwd &&` to confirm the directory.
+
 - **Worktree Read/Edit/Write must target the worktree path**, not the main
   checkout: editing `/workspaces/teamster/<path>` instead of
   `/workspaces/teamster/.worktrees/<branch>/<path>` silently leaves the worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,9 @@ launcher. Package internals: see
 
 - **MCP outages**: If an MCP tool returns "server disconnected" or clearly
   impaired responses, surface to the user before working around with raw `gh` /
-  BigQuery calls.
+  BigQuery calls. Same if an EXPECTED MCP tool is absent from the deferred-tools
+  list (ToolSearch returns "No matching deferred tools") — flag it immediately
+  so the user can reconnect; do not silently fall back.
 
 - **MCP subprocess logs**: stdio MCP stderr captured at
   `~/.cache/claude-cli-nodejs/-workspaces-teamster/mcp-logs-<name>/<ts>.jsonl`.

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -246,3 +246,10 @@ the codespace). For a change to either, `py_compile` the edited files and import
 the affected submodule alone (e.g.
 `import teamster.code_locations.kipptaf.finalsite` or
 `teamster.code_locations.kippmiami.extracts`), not the `definitions` module.
+
+Importing a kipptaf **asset submodule** (e.g.
+`teamster.code_locations.kipptaf.google.directory.assets`) transitively imports
+`kipptaf.dbt` and needs the dbt manifest — absent in a fresh worktree, so a unit
+test importing it errors at collection (`FileNotFoundError: .../manifest.json`).
+Put unit-testable pure helpers in `libraries/` (imports cleanly), not a
+code-location asset module.

--- a/src/teamster/code_locations/kipptaf/google/directory/assets.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/assets.py
@@ -20,7 +20,10 @@ from teamster.core.asset_checks import (
     build_check_spec_avro_schema_valid,
     check_avro_schema_valid,
 )
-from teamster.libraries.google.directory.resources import GoogleDirectoryResource
+from teamster.libraries.google.directory.resources import (
+    GoogleDirectoryResource,
+    members_for_created_users,
+)
 
 key_prefix = [CODE_LOCATION, "google", "directory"]
 
@@ -202,20 +205,17 @@ def google_directory_user_create(
                 context.log.error(msg=ce)
                 errors.append(ce)
 
-            members_data = [
-                {
-                    "groupKey": u["groupKey"],
-                    "email": u["primaryEmail"],
-                    "delivery_settings": "DISABLED",
-                }
-                for u in valid_users
-            ]
+            # Only add users whose creation succeeded — a failed create leaves
+            # no account, so its member insert would fail with "resource not
+            # found" and double-count the same student in the error check.
+            members_data = members_for_created_users(valid_users, create_errors)
 
-            members_errors = google_directory.batch_insert_members(members_data)
+            if members_data:
+                members_errors = google_directory.batch_insert_members(members_data)
 
-            for me in members_errors:
-                context.log.error(msg=me)
-                errors.append(me)
+                for me in members_errors:
+                    context.log.error(msg=me)
+                    errors.append(me)
 
     yield Output(value=None)
     yield AssetCheckResult(

--- a/src/teamster/libraries/google/CLAUDE.md
+++ b/src/teamster/libraries/google/CLAUDE.md
@@ -23,6 +23,20 @@ wrapped via the module-level `_retryable_execute(request)` factory +
 `errors.HttpError` — 4xx client errors must not be retried. Transient codes:
 `{429, 500, 502, 503, 504}`.
 
+**Batch sub-request retry**: `BatchHttpRequest.execute()` never raises for an
+individual sub-request failure — it delivers the error to the `callback`, so the
+`backoff` wrapper alone only retries a failure of the whole batch envelope, not
+a per-sub-request 5xx. All four batch methods route through
+`_execute_batch_with_retry`, which re-submits only the transiently-failed
+(429/5xx) sub-requests in follow-up batches (bounded by `_MAX_BATCH_ATTEMPTS`);
+already-succeeded sub-requests are not re-sent (re-sending would 409).
+
+**`batch_insert_users` returns `list[dict]`** (`{"primaryEmail", "error"}`), NOT
+`list[str]` like the other three batch methods — the create asset needs the
+failed emails to skip group membership for uncreated users (via
+`members_for_created_users`), and the dict form keeps the create payload (which
+includes the password hash) out of logs and asset-check metadata.
+
 **409 conflict handling**: 409 is deliberately excluded from
 `_TRANSIENT_HTTP_CODES` because its meaning is method-specific: for
 `batch_insert_role_assignments` it means "entity already exists" (not

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -432,7 +432,7 @@ class GoogleDirectoryResource(ConfigurableResource):
             # _execute_batch_with_retry, so logging a traceback at ERROR here
             # would file false-positive GCP Error Reporting groups for transient
             # failures the retry layer recovers from.
-            self._log.warning(msg=(id, exception))
+            self._log.warning(msg=f"batch sub-request {id} failed: {exception}")
             self._exceptions.append((int(id) - 1, exception))
         else:
             self._log.info(
@@ -529,7 +529,7 @@ class GoogleDirectoryResource(ConfigurableResource):
             One ``{"primaryEmail": ..., "error": ...}`` dict per user whose
             creation ultimately failed (empty if all succeeded).
         """
-        errors = []
+        exceptions = []
 
         # You cannot create more than 10 users per domain per second using the
         # Directory API
@@ -545,7 +545,7 @@ class GoogleDirectoryResource(ConfigurableResource):
                 request_factory=lambda user: self._resource.users().insert(body=user),
             )
 
-            errors.extend(
+            exceptions.extend(
                 {"primaryEmail": item["primaryEmail"], "error": str(e)}
                 for item, e in failures
             )
@@ -553,7 +553,7 @@ class GoogleDirectoryResource(ConfigurableResource):
             if i < len(batches) - 1:
                 time.sleep(1)
 
-        return errors
+        return exceptions
 
     def _retry_update_user(self, user: dict) -> None:
         """Retry a single user update after a 409 conflict response."""

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -16,6 +16,10 @@ from teamster.core.utils.functions import chunk
 
 _TRANSIENT_HTTP_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 
+# Total attempts per batch (1 initial + retries) for sub-requests that fail with
+# a transient code. Matches dagster.backoff's default retry budget (1 + 4).
+_MAX_BATCH_ATTEMPTS: int = 5
+
 
 class _TransientHttpError(errors.HttpError):
     """``HttpError`` subclass raised only for retryable (5xx, 429) responses.
@@ -424,18 +428,92 @@ class GoogleDirectoryResource(ConfigurableResource):
             exception: Raised exception; ``None`` on success.
         """
         if exception is not None:
-            self._log.exception(msg=(id, exception))
+            # WARNING, not exception: batch sub-request failures are retried by
+            # _execute_batch_with_retry, so logging a traceback at ERROR here
+            # would file false-positive GCP Error Reporting groups for transient
+            # failures the retry layer recovers from.
+            self._log.warning(msg=(id, exception))
             self._exceptions.append((int(id) - 1, exception))
         else:
             self._log.info(
                 msg=" ".join([f"{k}={v}" for k, v in check.not_none(response).items()])
             )
 
+    def _execute_batch_with_retry(
+        self,
+        items: list[dict],
+        request_factory: Callable[[dict], object],
+    ) -> list[tuple[dict, Exception]]:
+        """Execute one batch, retrying only sub-requests that fail transiently.
+
+        A ``BatchHttpRequest`` never raises for an individual sub-request
+        failure — the result is delivered to :meth:`callback` and ``execute()``
+        returns normally — so wrapping ``execute()`` in :func:`backoff` retries
+        only a failure of the whole batch envelope, not a per-sub-request 5xx.
+        This helper adds sub-request-level retry: after each batch, sub-requests
+        that failed with a transient code (429, 5xx) are re-submitted in a
+        follow-up batch with exponential backoff, up to ``_MAX_BATCH_ATTEMPTS``
+        total attempts. Already-succeeded sub-requests are not re-sent.
+
+        Args:
+            items: Resource dicts for the batch.
+            request_factory: Builds the API request object for a single item.
+
+        Returns:
+            ``(item, exception)`` for each sub-request that ultimately failed —
+            either non-transient, or transient after exhausting retries.
+        """
+        pending = list(items)
+        failures: list[tuple[dict, Exception]] = []
+        delays = exponential_delay_generator()
+
+        for attempt in range(1, _MAX_BATCH_ATTEMPTS + 1):
+            self._exceptions = []
+
+            # trunk-ignore(pyright/reportAttributeAccessIssue)
+            batch_request = self._resource.new_batch_http_request(
+                callback=self.callback
+            )
+
+            for item in pending:
+                batch_request.add(request_factory(item))
+
+            # Retries a transient failure of the whole batch envelope; individual
+            # sub-request failures come back through self._exceptions below.
+            backoff(
+                fn=_retryable_execute(batch_request), retry_on=(_TransientHttpError,)
+            )
+
+            if not self._exceptions:
+                return failures
+
+            retryable = []
+            for ix, exc in self._exceptions:
+                item = pending[ix]
+
+                if (
+                    attempt < _MAX_BATCH_ATTEMPTS
+                    and isinstance(exc, errors.HttpError)
+                    and exc.resp.status in _TRANSIENT_HTTP_CODES
+                ):
+                    retryable.append(item)
+                else:
+                    failures.append((item, exc))
+
+            pending = retryable
+            if not pending:
+                break
+
+            time.sleep(next(delays))
+
+        return failures
+
     def batch_insert_users(self, users: list[dict]) -> list[str]:
         """Create multiple users in batches of 10.
 
-        Respects the 10-users-per-domain-per-second API limit. Each batch is
-        retried on transient errors (5xx, 429) with backoff.
+        Respects the 10-users-per-domain-per-second API limit. Each batch — and
+        each individual sub-request within it — is retried on transient errors
+        (5xx, 429) with backoff.
 
         Args:
             users: User resource dicts to create.
@@ -453,22 +531,13 @@ class GoogleDirectoryResource(ConfigurableResource):
         for i, batch in enumerate(batches):
             self._log.info(msg=f"Processing batch {i + 1}")
 
-            self._exceptions = []
-
-            # trunk-ignore(pyright/reportAttributeAccessIssue)
-            batch_request = self._resource.new_batch_http_request(
-                callback=self.callback
-            )
-
-            for user in batch:
+            failures = self._execute_batch_with_retry(
+                items=batch,
                 # trunk-ignore(pyright/reportAttributeAccessIssue)
-                batch_request.add(self._resource.users().insert(body=user))
-
-            backoff(
-                fn=_retryable_execute(batch_request), retry_on=(_TransientHttpError,)
+                request_factory=lambda user: self._resource.users().insert(body=user),
             )
 
-            exceptions.extend([f"{batch[ix]} {e}" for ix, e in self._exceptions])
+            exceptions.extend(f"{item} {e}" for item, e in failures)
 
             if i < len(batches) - 1:
                 time.sleep(1)
@@ -509,28 +578,17 @@ class GoogleDirectoryResource(ConfigurableResource):
         for i, batch in enumerate(batches):
             self._log.info(msg=f"Processing batch {i + 1}")
 
-            self._exceptions = []
-
-            # trunk-ignore(pyright/reportAttributeAccessIssue)
-            batch_request = self._resource.new_batch_http_request(
-                callback=self.callback
-            )
-
-            for user in batch:
-                batch_request.add(
+            failures = self._execute_batch_with_retry(
+                items=batch,
+                request_factory=lambda user: (
                     # trunk-ignore(pyright/reportAttributeAccessIssue)
                     self._resource.users().update(
                         userKey=user["primaryEmail"], body=user
                     )
-                )
-
-            backoff(
-                fn=_retryable_execute(batch_request), retry_on=(_TransientHttpError,)
+                ),
             )
 
-            for ix, e in self._exceptions:
-                user = batch[ix]
-
+            for user, e in failures:
                 if isinstance(e, errors.HttpError) and e.resp.status == 409:
                     try:
                         self._retry_update_user(user)
@@ -547,6 +605,9 @@ class GoogleDirectoryResource(ConfigurableResource):
     def batch_insert_members(self, members: list[dict]) -> list[str]:
         """Add multiple members to groups in batches of 40.
 
+        Each batch — and each individual sub-request within it — is retried on
+        transient errors (5xx, 429) with backoff.
+
         Args:
             members: Member resource dicts; each must include ``groupKey`` and
                 ``email``.
@@ -562,26 +623,17 @@ class GoogleDirectoryResource(ConfigurableResource):
         for i, batch in enumerate(batches):
             self._log.info(msg=f"Processing batch {i + 1}")
 
-            self._exceptions = []
-
-            # trunk-ignore(pyright/reportAttributeAccessIssue)
-            batch_request = self._resource.new_batch_http_request(
-                callback=self.callback
-            )
-
-            for member in batch:
-                batch_request.add(
+            failures = self._execute_batch_with_retry(
+                items=batch,
+                request_factory=lambda member: (
                     # trunk-ignore(pyright/reportAttributeAccessIssue)
                     self._resource.members().insert(
                         groupKey=member["groupKey"], body=member
                     )
-                )
-
-            backoff(
-                fn=_retryable_execute(batch_request), retry_on=(_TransientHttpError,)
+                ),
             )
 
-            exceptions.extend([f"{batch[ix]} {e}" for ix, e in self._exceptions])
+            exceptions.extend(f"{item} {e}" for item, e in failures)
 
             if i < len(batches) - 1:
                 time.sleep(1)
@@ -593,8 +645,9 @@ class GoogleDirectoryResource(ConfigurableResource):
     ) -> list[str]:
         """Create multiple role assignments in batches of 10.
 
-        Uses exponential backoff (rather than the default fixed delay) on
-        ``HttpError`` to handle quota exhaustion more gracefully.
+        Each batch — and each individual sub-request within it — is retried on
+        transient errors (5xx, 429) with exponential backoff to handle quota
+        exhaustion gracefully.
 
         Args:
             role_assignments: Role assignment resource dicts.
@@ -610,29 +663,18 @@ class GoogleDirectoryResource(ConfigurableResource):
         for i, batch in enumerate(batches):
             self._log.info(msg=f"Processing batch {i + 1}")
 
-            self._exceptions = []
-
-            # trunk-ignore(pyright/reportAttributeAccessIssue)
-            batch_request = self._resource.new_batch_http_request(
-                callback=self.callback
-            )
-
-            for role_assignment in batch:
-                batch_request.add(
+            failures = self._execute_batch_with_retry(
+                items=batch,
+                request_factory=lambda role_assignment: (
                     # trunk-ignore(pyright/reportAttributeAccessIssue)
                     self._resource.roleAssignments().insert(
                         customer=(customer or self.customer_id),
                         body=role_assignment,
                     )
-                )
-
-            backoff(
-                fn=_retryable_execute(batch_request),
-                retry_on=(_TransientHttpError,),
-                delay_generator=exponential_delay_generator(),
+                ),
             )
 
-            exceptions.extend([f"{batch[ix]} {e}" for ix, e in self._exceptions])
+            exceptions.extend(f"{item} {e}" for item, e in failures)
 
             if i < len(batches) - 1:
                 time.sleep(1)

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -508,20 +508,28 @@ class GoogleDirectoryResource(ConfigurableResource):
 
         return failures
 
-    def batch_insert_users(self, users: list[dict]) -> list[str]:
+    def batch_insert_users(self, users: list[dict]) -> list[dict]:
         """Create multiple users in batches of 10.
 
         Respects the 10-users-per-domain-per-second API limit. Each batch — and
         each individual sub-request within it — is retried on transient errors
         (5xx, 429) with backoff.
 
+        Unlike the sibling batch helpers (which return error strings), this
+        returns structured per-user errors. Callers use the returned emails to
+        skip follow-on group membership for users that were not created (see
+        ``members_for_created_users``), and the structured form keeps the create
+        payload — which includes the password hash — out of logs and
+        asset-check metadata.
+
         Args:
             users: User resource dicts to create.
 
         Returns:
-            Error strings for any failed requests.
+            One ``{"primaryEmail": ..., "error": ...}`` dict per user whose
+            creation ultimately failed (empty if all succeeded).
         """
-        exceptions = []
+        errors = []
 
         # You cannot create more than 10 users per domain per second using the
         # Directory API
@@ -537,12 +545,15 @@ class GoogleDirectoryResource(ConfigurableResource):
                 request_factory=lambda user: self._resource.users().insert(body=user),
             )
 
-            exceptions.extend(f"{item} {e}" for item, e in failures)
+            errors.extend(
+                {"primaryEmail": item["primaryEmail"], "error": str(e)}
+                for item, e in failures
+            )
 
             if i < len(batches) - 1:
                 time.sleep(1)
 
-        return exceptions
+        return errors
 
     def _retry_update_user(self, user: dict) -> None:
         """Retry a single user update after a 409 conflict response."""
@@ -680,3 +691,36 @@ class GoogleDirectoryResource(ConfigurableResource):
                 time.sleep(1)
 
         return exceptions
+
+
+def members_for_created_users(
+    users: list[dict], create_errors: list[dict]
+) -> list[dict]:
+    """Build group-membership payloads for users whose creation did not fail.
+
+    A user's group membership can only be added once the account exists, so a
+    user whose ``batch_insert_users`` call failed must be excluded — otherwise
+    the membership insert is guaranteed to fail with "resource not found".
+
+    Args:
+        users: The users passed to
+            :meth:`GoogleDirectoryResource.batch_insert_users`.
+        create_errors: The ``{"primaryEmail", "error"}`` dicts it returned for
+            users whose creation ultimately failed.
+
+    Returns:
+        :meth:`GoogleDirectoryResource.batch_insert_members` payloads
+        (``groupKey`` / ``email`` / ``delivery_settings``) for the users NOT
+        present in ``create_errors``.
+    """
+    failed_emails = {e["primaryEmail"] for e in create_errors}
+
+    return [
+        {
+            "groupKey": u["groupKey"],
+            "email": u["primaryEmail"],
+            "delivery_settings": "DISABLED",
+        }
+        for u in users
+        if u["primaryEmail"] not in failed_emails
+    ]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -82,6 +82,14 @@ uv run pytest tests/assets/test_assets_dbt.py                         # requires
   (BigQuery/GCS) auth is independent of 1Password and always works (dbt CLI, BQ
   client). `dagster definitions validate` likewise relies on the conftest
   bootstrap.
+- **Mixed live + mocked test files**:
+  `tests/resources/test_resource_google_directory.py` interleaves mocked unit
+  tests with **live-API** integration tests (bare names —
+  `test_batch_insert_users`, `test_list_users`, etc.) that mutate the REAL
+  Google directory (conftest bootstraps creds). Select mocked tests with
+  positive `-k` on suffix fragments; `pytest --deselect <file>::<bare>`
+  PREFIX-matches (silently drops same-prefix unit tests too), and
+  `-k "not <bare>"` substring-matches them.
 
 ## Hook security tests (`tests/hooks/`)
 

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -186,6 +186,8 @@ def test_batch_insert_users_collects_exception_from_failed_request():
     assert len(exceptions) == 1
     assert exceptions[0]["primaryEmail"] == "a@b.com"
     assert "error" in exceptions[0]
+    # 409 is non-transient: collected without a wasted follow-up batch.
+    assert mock_api.new_batch_http_request.call_count == 1
 
 
 def test_batch_insert_users_error_dict_omits_user_payload():
@@ -267,6 +269,45 @@ def test_batch_insert_users_records_transient_subrequest_after_exhausting_retrie
     assert len(exceptions) == 1
     assert exceptions[0]["primaryEmail"] == "a@b.com"
     assert 1 < mock_api.new_batch_http_request.call_count < 10
+
+
+def test_batch_insert_users_retries_only_the_failed_subrequest_in_a_mixed_batch():
+    # Item 0 succeeds and item 1 gets a transient 503: the retry batch must be
+    # built with only the failed item, never re-sending the succeeded one (which
+    # would 409 on recreate).
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    batches_built = []
+
+    responses_per_batch = [
+        [({"primaryEmail": "a@b.com"}, None), (None, transient)],  # attempt 1
+        [({"primaryEmail": "b@b.com"}, None)],  # retry: only the failed item
+    ]
+    batch_idx = [-1]
+
+    def new_batch(callback):
+        batch_idx[0] += 1
+        batch_responses = responses_per_batch[batch_idx[0]]
+        mock_batch = MagicMock()
+
+        def execute():
+            for i, (response, exception) in enumerate(batch_responses):
+                callback(str(i + 1), response, exception)
+
+        mock_batch.execute.side_effect = execute
+        batches_built.append(mock_batch)
+        return mock_batch
+
+    mock_api.new_batch_http_request.side_effect = new_batch
+
+    users = [{"primaryEmail": "a@b.com"}, {"primaryEmail": "b@b.com"}]
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_users(users)
+
+    assert exceptions == []
+    assert len(batches_built) == 2
+    assert batches_built[0].add.call_count == 2  # both items on the first attempt
+    assert batches_built[1].add.call_count == 1  # only the failed item retried
 
 
 # ── batch_update_users ────────────────────────────────────────────────────────

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -216,6 +216,40 @@ def test_batch_insert_users_sleeps_between_batches_not_after_last():
     mock_sleep.assert_called_once_with(1)
 
 
+def test_batch_insert_users_retries_transient_subrequest_and_succeeds():
+    # A transient 503 on an individual sub-request must be retried, not recorded
+    # as a permanent error. Regression: only the outer batch envelope was wrapped
+    # in backoff, but a sub-request failure is delivered to the callback and never
+    # raised out of execute(), so it was never retried.
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [
+            [(None, transient)],  # attempt 1: sub-request 503
+            [({"primaryEmail": "a@b.com"}, None)],  # retry: success
+        ]
+    )
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_users([{"primaryEmail": "a@b.com"}])
+    assert exceptions == []
+    assert mock_api.new_batch_http_request.call_count == 2
+
+
+def test_batch_insert_users_records_transient_subrequest_after_exhausting_retries():
+    # More failing attempts available than the retry budget; the helper must stop
+    # retrying and record the failure rather than loop forever.
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [[(None, transient)] for _ in range(10)]
+    )
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_users([{"primaryEmail": "a@b.com"}])
+    assert len(exceptions) == 1
+    assert "a@b.com" in exceptions[0]
+    assert 1 < mock_api.new_batch_http_request.call_count < 10
+
+
 # ── batch_update_users ────────────────────────────────────────────────────────
 
 
@@ -266,6 +300,23 @@ def test_batch_update_users_collects_exception_when_409_retry_also_fails():
     assert "a@b.com" in exceptions[0]
 
 
+def test_batch_update_users_retries_transient_subrequest_and_succeeds():
+    # Distinct from the 409 path: a transient 5xx on a sub-request is retried in
+    # a follow-up batch, not routed through the single-user 409 retry.
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [
+            [(None, transient)],
+            [({"primaryEmail": "a@b.com"}, None)],
+        ]
+    )
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_update_users([{"primaryEmail": "a@b.com"}])
+    assert exceptions == []
+    assert mock_api.new_batch_http_request.call_count == 2
+
+
 # ── batch_insert_members ──────────────────────────────────────────────────────
 
 
@@ -278,6 +329,23 @@ def test_batch_insert_members_returns_empty_on_all_success():
         resource.batch_insert_members([{"groupKey": "g@b.com", "email": "a@b.com"}])
         == []
     )
+
+
+def test_batch_insert_members_retries_transient_subrequest_and_succeeds():
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [
+            [(None, transient)],
+            [({"email": "a@b.com"}, None)],
+        ]
+    )
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_members(
+            [{"groupKey": "g@b.com", "email": "a@b.com"}]
+        )
+    assert exceptions == []
+    assert mock_api.new_batch_http_request.call_count == 2
 
 
 # ── batch_insert_role_assignments ─────────────────────────────────────────────
@@ -294,6 +362,23 @@ def test_batch_insert_role_assignments_returns_empty_on_all_success():
         )
         == []
     )
+
+
+def test_batch_insert_role_assignments_retries_transient_subrequest_and_succeeds():
+    resource, mock_api = _make_resource()
+    transient = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [
+            [(None, transient)],
+            [({"roleAssignmentId": "ra1"}, None)],
+        ]
+    )
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_role_assignments(
+            [{"assignedTo": "uid", "roleId": "rid", "scopeType": "CUSTOMER"}]
+        )
+    assert exceptions == []
+    assert mock_api.new_batch_http_request.call_count == 2
 
 
 # ── list_roles / list_role_assignments default params ─────────────────────────

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -10,6 +10,7 @@ from teamster.libraries.google.directory.resources import (
     GoogleDirectoryResource,
     _retryable_execute,
     _TransientHttpError,
+    members_for_created_users,
 )
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -183,7 +184,25 @@ def test_batch_insert_users_collects_exception_from_failed_request():
     )
     exceptions = resource.batch_insert_users([{"primaryEmail": "a@b.com"}])
     assert len(exceptions) == 1
-    assert "a@b.com" in exceptions[0]
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
+    assert "error" in exceptions[0]
+
+
+def test_batch_insert_users_error_dict_omits_user_payload():
+    # The returned error must not carry the user payload (e.g. the password
+    # hash) into logs / asset-check metadata — only the email and the message.
+    resource, mock_api = _make_resource()
+    err = _http_error(503, b"Backend Error")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [[(None, err)] for _ in range(10)]
+    )
+    user = {"primaryEmail": "a@b.com", "password": "deadbeefsecrethash"}
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_users([user])
+    assert len(exceptions) == 1
+    assert set(exceptions[0].keys()) == {"primaryEmail", "error"}
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
+    assert "deadbeefsecrethash" not in str(exceptions[0])
 
 
 def test_batch_insert_users_collects_all_exceptions_from_multi_failure_batch():
@@ -246,7 +265,7 @@ def test_batch_insert_users_records_transient_subrequest_after_exhausting_retrie
     with patch("teamster.libraries.google.directory.resources.time.sleep"):
         exceptions = resource.batch_insert_users([{"primaryEmail": "a@b.com"}])
     assert len(exceptions) == 1
-    assert "a@b.com" in exceptions[0]
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
     assert 1 < mock_api.new_batch_http_request.call_count < 10
 
 
@@ -404,6 +423,37 @@ def test_list_role_assignments_uses_max_results_200_and_items_key():
     assert data == [{"roleAssignmentId": "ra1"}]
     _, call_kwargs = mock_api.roleAssignments.return_value.list.call_args
     assert call_kwargs["maxResults"] == 200
+
+
+# ── members_for_created_users ─────────────────────────────────────────────────
+
+
+def _created_user(email: str) -> dict:
+    return {"primaryEmail": email, "groupKey": "g@x.org"}
+
+
+def _member(email: str) -> dict:
+    return {"groupKey": "g@x.org", "email": email, "delivery_settings": "DISABLED"}
+
+
+def test_members_for_created_users_all_succeeded():
+    users = [_created_user("a@x.org"), _created_user("b@x.org")]
+    assert members_for_created_users(users, []) == [
+        _member("a@x.org"),
+        _member("b@x.org"),
+    ]
+
+
+def test_members_for_created_users_skips_failed_create():
+    users = [_created_user("a@x.org"), _created_user("b@x.org")]
+    create_errors = [{"primaryEmail": "b@x.org", "error": "boom"}]
+    assert members_for_created_users(users, create_errors) == [_member("a@x.org")]
+
+
+def test_members_for_created_users_all_failed_returns_empty():
+    users = [_created_user("a@x.org")]
+    create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]
+    assert members_for_created_users(users, create_errors) == []
 
 
 def get_google_directory_resource() -> GoogleDirectoryResource:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this fixes spurious `zero_api_errors` alerts (and roughly a
one-day delay in account provisioning) from `GoogleDirectoryResource` batch
methods.

A `BatchHttpRequest` never raises for an individual sub-request failure — the
result is delivered to the callback and `execute()` returns normally — so the
existing `backoff(...)` wrapper only retried a failure of the whole batch
envelope. A transient 503 "Backend Error" on a single `users().insert()` was
therefore recorded as a permanent error, failing the `zero_api_errors` asset
check on `kipptaf/google/directory/user_create` and firing an alert, even
though a retry would very likely have succeeded. (Observed on prod run
`df2f8bec` for one student create.)

This adds a shared `_execute_batch_with_retry` helper that re-submits only the
transiently-failed (429 / 5xx) sub-requests in a follow-up batch with
exponential backoff, up to a bounded attempt count, and wires it into all four
batch methods: `batch_insert_users`, `batch_update_users`,
`batch_insert_members`, `batch_insert_role_assignments`. Already-succeeded
sub-requests are not re-sent (re-sending would return 409). The batch callback
now logs failures at WARNING instead of `exception`, so transients the retry
layer recovers from no longer file false-positive GCP Error Reporting groups.

Method-specific behavior is preserved: `batch_update_users` still retries 409
conflicts individually; a role-assignment 409 ("already exists") is still
treated as non-retryable.

**Also folded in (a follow-up noted on #4509):** the create asset built its
group-membership list from every attempted user, so a user whose create failed
still got a `members().insert` — guaranteed to fail (no account yet) and
double-counting the same student in the check. `batch_insert_users` now returns
structured per-user errors (`{"primaryEmail", "error"}`) instead of error
strings; a new library helper `members_for_created_users` builds membership
payloads only for users that were actually created; and the asset skips the
members call when none remain. The structured error form also keeps the create
payload (which includes the password hash) out of logs and check metadata — the
same payload that leaked into the alert that opened this issue.

Closes #4509.

## AI Assistance

Authored by Claude Code (Opus 4.8) via systematic-debugging plus TDD, directed
by @cbini. The root cause was verified against the `googleapiclient`
batch-execute source; the fix is covered by unit tests written test-first (each
new test was confirmed failing before the implementation landed).

## Self-review

### Dagster

- [x] Shared library resource + asset change, covered by mocked unit tests in
      `tests/resources/test_resource_google_directory.py` — 36 pass (5
      sub-request-retry, 1 no-payload-in-error, 3 `members_for_created_users`);
      no regressions. `dagster definitions validate` for kipptaf does not run in
      the codespace (credential specs resolve eagerly at import), but the
      library module imports cleanly, the asset module byte-compiles, and every
      mocked resource test passes.
- [x] No new integration; existing resource, Library + Config pattern
      unchanged.

## CI checks

- [ ] **Trunk** — `trunk check --force` on both changed files reports no issues
      locally; confirm the CI check.
- [ ] **dbt Cloud** — no dbt changes; expected trivial no-op.
- [ ] **Dagster Cloud** — confirm the branch deploy / deploy passes.
