### PR TITLE
refactor(dbt): add _dbt_source_project to join-target intermediates (#3142)

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_student_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_student_scaffold.sql
@@ -7,8 +7,7 @@ with
             sectionid,
             storecode,
             percent_grade as category_quarter_percent_grade,
-
-            {{ extract_source_project() }} as _dbt_source_project,
+            _dbt_source_project,
 
             round(
                 avg(percent_grade) over (
@@ -32,13 +31,12 @@ with
             studentid,
             sectionid,
             storecode,
+            _dbt_source_project,
             termbin_start_date,
             term_percent_grade_adjusted as quarter_course_percent_grade,
             term_grade_points as quarter_course_grade_points,
             citizenship as quarter_conduct,
             comment_value as quarter_comment_value,
-
-            {{ extract_source_project() }} as _dbt_source_project,
 
             'current_year' as grades_type,
 
@@ -53,13 +51,12 @@ with
             studentid,
             sectionid,
             storecode,
+            _dbt_source_project,
             null as termbin_start_date,
             `percent` as quarter_course_percent_grade,
             gpa_points as quarter_course_grade_points,
             behavior as quarter_conduct,
             comment_value as quarter_comment_value,
-
-            {{ extract_source_project() }} as _dbt_source_project,
 
             'last_year' as grades_type,
 
@@ -108,6 +105,7 @@ select
     s.is_student_athlete,
     s.`ada`,
     s.ada_above_or_at_80,
+    s._dbt_source_project,
 
     ce.cc_sectionid as sectionid,
     ce.cc_course_number as course_number,
@@ -148,8 +146,6 @@ select
     qg.quarter_course_grade_points,
     qg.quarter_conduct,
     qg.quarter_comment_value,
-
-    {{ extract_source_project("s") }} as _dbt_source_project,
 
     'student_scaffold' as scaffold_name,
 
@@ -329,6 +325,7 @@ select
     s.is_student_athlete,
     s.`ada`,
     s.ada_above_or_at_80,
+    s._dbt_source_project,
 
     ce.cc_sectionid as sectionid,
     ce.cc_course_number as course_number,
@@ -368,8 +365,6 @@ select
     qg.quarter_course_grade_points,
     qg.quarter_conduct,
     qg.quarter_comment_value,
-
-    {{ extract_source_project("s") }} as _dbt_source_project,
 
     'student_category_scaffold' as scaffold_name,
 

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_student_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_student_scaffold.sql
@@ -8,6 +8,8 @@ with
             storecode,
             percent_grade as category_quarter_percent_grade,
 
+            {{ extract_source_project() }} as _dbt_source_project,
+
             round(
                 avg(percent_grade) over (
                     partition by _dbt_source_relation, studentid, yearid, storecode
@@ -36,6 +38,8 @@ with
             citizenship as quarter_conduct,
             comment_value as quarter_comment_value,
 
+            {{ extract_source_project() }} as _dbt_source_project,
+
             'current_year' as grades_type,
 
         from {{ ref("base_powerschool__final_grades") }}
@@ -54,6 +58,8 @@ with
             gpa_points as quarter_course_grade_points,
             behavior as quarter_conduct,
             comment_value as quarter_comment_value,
+
+            {{ extract_source_project() }} as _dbt_source_project,
 
             'last_year' as grades_type,
 
@@ -142,6 +148,8 @@ select
     qg.quarter_course_grade_points,
     qg.quarter_conduct,
     qg.quarter_comment_value,
+
+    {{ extract_source_project("s") }} as _dbt_source_project,
 
     'student_scaffold' as scaffold_name,
 
@@ -256,23 +264,23 @@ inner join
     {{ ref("base_powerschool__course_enrollments") }} as ce
     on s.studentid = ce.cc_studentid
     and s.yearid = ce.terms_yearid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="ce") }}
+    and s._dbt_source_project = ce._dbt_source_project
     and not ce.is_dropped_section
     and ce.sections_no_of_students != 0
 inner join
     {{ ref("int_tableau__gradebook_audit_teacher_scaffold") }} as sec
     on ce.terms_yearid = sec.yearid
     and ce.cc_sectionid = sec.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="sec") }}
+    and ce._dbt_source_project = sec._dbt_source_project
     and sec.scaffold_name = 'teacher_scaffold'
 left join
     quarter_course_grades as qg
     on ce.terms_yearid = qg.yearid
     and ce.cc_studentid = qg.studentid
     and ce.cc_sectionid = qg.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="qg") }}
+    and ce._dbt_source_project = qg._dbt_source_project
     and sec.quarter = qg.storecode
-    and {{ union_dataset_join_clause(left_alias="sec", right_alias="qg") }}
+    and sec._dbt_source_project = qg._dbt_source_project
     and qg.termbin_start_date <= current_date('{{ var("local_timezone") }}')
     and qg.grades_type = 'current_year'
 where
@@ -361,6 +369,8 @@ select
     qg.quarter_conduct,
     qg.quarter_comment_value,
 
+    {{ extract_source_project("s") }} as _dbt_source_project,
+
     'student_category_scaffold' as scaffold_name,
 
     ge.assignment_category_name,
@@ -428,14 +438,14 @@ inner join
     {{ ref("base_powerschool__course_enrollments") }} as ce
     on s.studentid = ce.cc_studentid
     and s.yearid = ce.terms_yearid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="ce") }}
+    and s._dbt_source_project = ce._dbt_source_project
     and not ce.is_dropped_section
     and ce.sections_no_of_students != 0
 inner join
     {{ ref("int_tableau__gradebook_audit_teacher_scaffold") }} as sec
     on ce.terms_yearid = sec.yearid
     and ce.cc_sectionid = sec.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="sec") }}
+    and ce._dbt_source_project = sec._dbt_source_project
     and sec.scaffold_name = 'teacher_category_scaffold'
 inner join
     {{ ref("stg_google_sheets__gradebook_expectations_assignments") }} as ge
@@ -450,9 +460,9 @@ left join
     on ce.terms_yearid = qg.yearid
     and ce.cc_studentid = qg.studentid
     and ce.cc_sectionid = qg.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="qg") }}
+    and ce._dbt_source_project = qg._dbt_source_project
     and sec.quarter = qg.storecode
-    and {{ union_dataset_join_clause(left_alias="sec", right_alias="qg") }}
+    and sec._dbt_source_project = qg._dbt_source_project
     and qg.termbin_start_date <= current_date('{{ var("local_timezone") }}')
     and qg.grades_type = 'current_year'
 left join
@@ -460,7 +470,7 @@ left join
     on ce.terms_yearid = cg.yearid
     and ce.cc_studentid = cg.studentid
     and ce.cc_sectionid = cg.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="cg") }}
+    and ce._dbt_source_project = cg._dbt_source_project
     and ge.assignment_category_term = cg.storecode
 where
     s.academic_year = {{ var("current_academic_year") }}

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
@@ -21,6 +21,8 @@ with
 
             r.sam_account_name as teacher_tableau_username,
 
+            {{ extract_source_project("s") }} as _dbt_source_project,
+
             if(
                 s.school_abbreviation = 'Sumner' and s.sections_grade_level >= 5,
                 'MS',
@@ -85,6 +87,8 @@ with
             l.school_leader_preferred_name_lastfirst as school_leader,
             l.school_leader_sam_account_name as school_leader_tableau_username,
 
+            {{ extract_source_project("t") }} as _dbt_source_project,
+
             cast(t.academic_year as string)
             || '-'
             || right(cast(t.academic_year + 1 as string), 2) as academic_year_display,
@@ -97,13 +101,13 @@ with
         inner join
             {{ ref("stg_powerschool__schools") }} as sch
             on t.schoolid = sch.school_number
-            and {{ union_dataset_join_clause(left_alias="t", right_alias="sch") }}
+            and t._dbt_source_project = sch._dbt_source_project
         inner join
             {{ ref("int_powerschool__calendar_week") }} as cw
             on t.yearid = cw.yearid
             and t.schoolid = cw.schoolid
             and t.term = cw.quarter
-            and {{ union_dataset_join_clause(left_alias="t", right_alias="cw") }}
+            and t._dbt_source_project = cw._dbt_source_project
         left join
             {{ ref("int_people__leadership_crosswalk") }} as l
             on t.schoolid = l.home_work_location_powerschool_school_id
@@ -150,6 +154,8 @@ with
             sec.teacher_number,
             sec.teacher_name,
             sec.teacher_tableau_username,
+
+            {{ extract_source_project("tw") }} as _dbt_source_project,
 
             concat(
                 tw.region, coalesce(sec.school_level_alt, tw.school_level)
@@ -207,7 +213,7 @@ with
             on tw.schoolid = sec.schoolid
             and tw.yearid = sec.terms_yearid
             and tw.week_end_date between sec.terms_firstday and sec.terms_lastday
-            and {{ union_dataset_join_clause(left_alias="tw", right_alias="sec") }}
+            and tw._dbt_source_project = sec._dbt_source_project
         where sec.academic_year = {{ var("current_academic_year") }}
     ),
 

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/int_tableau__gradebook_audit_teacher_scaffold.sql
@@ -18,10 +18,9 @@ with
             s.is_ap_course,
             s.teachernumber as teacher_number,
             s.teacher_lastfirst as teacher_name,
+            s._dbt_source_project,
 
             r.sam_account_name as teacher_tableau_username,
-
-            {{ extract_source_project("s") }} as _dbt_source_project,
 
             if(
                 s.school_abbreviation = 'Sumner' and s.sections_grade_level >= 5,
@@ -70,6 +69,7 @@ with
             t.term_start_date as quarter_start_date,
             t.term_end_date as quarter_end_date,
             t.is_current_term,
+            t._dbt_source_project,
 
             sch.abbreviation as school,
 
@@ -86,8 +86,6 @@ with
             l.head_of_school_preferred_name_lastfirst as hos,
             l.school_leader_preferred_name_lastfirst as school_leader,
             l.school_leader_sam_account_name as school_leader_tableau_username,
-
-            {{ extract_source_project("t") }} as _dbt_source_project,
 
             cast(t.academic_year as string)
             || '-'
@@ -141,6 +139,7 @@ with
             tw.hos,
             tw.school_leader,
             tw.school_leader_tableau_username,
+            tw._dbt_source_project,
 
             sec.sections_dcid,
             sec.sectionid,
@@ -154,8 +153,6 @@ with
             sec.teacher_number,
             sec.teacher_name,
             sec.teacher_tableau_username,
-
-            {{ extract_source_project("tw") }} as _dbt_source_project,
 
             concat(
                 tw.region, coalesce(sec.school_level_alt, tw.school_level)

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
@@ -6,6 +6,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: academic_year
         data_type: int64
       - name: academic_year_display

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_teacher_scaffold.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_teacher_scaffold.yml
@@ -6,6 +6,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: schoolid
         data_type: int64
       - name: yearid

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_rollup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_rollup.sql
@@ -5,6 +5,8 @@ select
     schoolid,
     storecode,
 
+    {{ extract_source_project() }} as _dbt_source_project,
+
     sum(potential_credit_hours) as enrolled_credit_hours,
 
     sum(if(y1_letter_grade_adjusted in ('F', 'F*'), 1, 0)) as n_failing,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_rollup.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__final_grades_rollup.sql
@@ -4,8 +4,7 @@ select
     academic_year,
     schoolid,
     storecode,
-
-    {{ extract_source_project() }} as _dbt_source_project,
+    _dbt_source_project,
 
     sum(potential_credit_hours) as enrolled_credit_hours,
 
@@ -23,4 +22,10 @@ select
         if(y1_letter_grade_adjusted not in ('F', 'F*'), potential_credit_hours, null)
     ) as projected_credits_y1_term,
 from {{ ref("base_powerschool__final_grades") }}
-group by _dbt_source_relation, studentid, academic_year, schoolid, storecode
+group by
+    _dbt_source_relation,
+    studentid,
+    academic_year,
+    schoolid,
+    storecode,
+    _dbt_source_project

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_lookback.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_lookback.sql
@@ -49,6 +49,8 @@ select
     schoolid,
     yearid,
 
+    {{ extract_source_project() }} as _dbt_source_project,
+
     max(if(days_prior = 7, gpa_y1, null)) as gpa_y1_1_week_prior,
     max(if(days_prior = 14, gpa_y1, null)) as gpa_y1_2_week_prior,
     max(if(days_prior = 28, gpa_y1, null)) as gpa_y1_4_week_prior,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_pivot.sql
@@ -32,6 +32,8 @@ select
     gpa_y1_q2,
     gpa_y1_q3,
     gpa_y1_q4,
+
+    {{ extract_source_project() }} as _dbt_source_project,
 from
     gpa pivot (
         max(gpa_term) as gpa_term,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_pivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_pivot.sql
@@ -1,6 +1,13 @@
 with
     gpa as (
-        select _dbt_source_relation, studentid, yearid, term_name, gpa_term, gpa_y1,
+        select
+            _dbt_source_relation,
+            studentid,
+            yearid,
+            term_name,
+            gpa_term,
+            gpa_y1,
+            _dbt_source_project,
         from {{ ref("int_powerschool__gpa_term") }}
 
         union all
@@ -12,6 +19,7 @@ with
             'CUR' as term_name,
             gpa_term,
             gpa_y1,
+            _dbt_source_project,
         from {{ ref("int_powerschool__gpa_term") }}
         where is_current
     )
@@ -32,8 +40,7 @@ select
     gpa_y1_q2,
     gpa_y1_q3,
     gpa_y1_q4,
-
-    {{ extract_source_project() }} as _dbt_source_project,
+    _dbt_source_project,
 from
     gpa pivot (
         max(gpa_term) as gpa_term,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpnode.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpnode.sql
@@ -12,6 +12,8 @@ select
     d.name as discipline_name,
     d.creditcapacity as discipline_credit_capacity,
 
+    {{ extract_source_project("p") }} as _dbt_source_project,
+
     coalesce(s.id, d.id) as subject_id,
     coalesce(s.name, d.name) as subject_name,
     coalesce(s.creditcapacity, d.creditcapacity) as subject_credit_capacity,
@@ -19,13 +21,13 @@ from {{ ref("stg_powerschool__gpnode") }} as p
 inner join
     {{ ref("stg_powerschool__gpnode") }} as o
     on p.id = o.parentid
-    and {{ union_dataset_join_clause(left_alias="p", right_alias="o") }}
+    and p._dbt_source_project = o._dbt_source_project
 inner join
     {{ ref("stg_powerschool__gpnode") }} as d
     on o.id = d.parentid
-    and {{ union_dataset_join_clause(left_alias="o", right_alias="d") }}
+    and o._dbt_source_project = d._dbt_source_project
 left join
     {{ ref("stg_powerschool__gpnode") }} as s
     on d.id = s.parentid
-    and {{ union_dataset_join_clause(left_alias="d", right_alias="s") }}
+    and d._dbt_source_project = s._dbt_source_project
 where p.parentid is null

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpnode.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpnode.sql
@@ -5,14 +5,13 @@ select
     p.gpversionid as plan_gpversionid,
     p.parentid as plan_parentid,
     p.name as plan_name,
+    p._dbt_source_project,
 
     o.creditcapacity as plan_credit_capacity,
 
     d.id as discipline_id,
     d.name as discipline_name,
     d.creditcapacity as discipline_credit_capacity,
-
-    {{ extract_source_project("p") }} as _dbt_source_project,
 
     coalesce(s.id, d.id) as subject_id,
     coalesce(s.name, d.name) as subject_name,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpprogress_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpprogress_grades.sql
@@ -11,6 +11,7 @@ with
             gpn.plan_credit_capacity,
             gpn.discipline_credit_capacity,
             gpn.subject_credit_capacity,
+            gpn._dbt_source_project,
 
             sub.studentsdcid,
 
@@ -27,8 +28,6 @@ with
             sg.potentialcrhrs as official_potential_credits,
             sg.potentialcrhrs as potential_credits,
             sg.is_transfer_grade,
-
-            {{ extract_source_project("gpn") }} as _dbt_source_project,
 
             'Earned' as credit_status,
 
@@ -63,6 +62,7 @@ with
             gpn.plan_credit_capacity,
             gpn.discipline_credit_capacity,
             gpn.subject_credit_capacity,
+            gpn._dbt_source_project,
 
             sub.studentsdcid,
 
@@ -80,8 +80,6 @@ with
             sub.enrolledcredits as potential_credits,
 
             false as is_transfer_grade,
-
-            {{ extract_source_project("gpn") }} as _dbt_source_project,
 
             'Enrolled' as credit_status,
 
@@ -134,6 +132,7 @@ select
     g.is_transfer_grade,
     g.credit_status,
     g.earned_credits,
+    g._dbt_source_project,
 
     sp.enrolledcredits as plan_enrolled_credits,
     sp.requestedcredits as plan_requested_credits,
@@ -149,8 +148,6 @@ select
     ss.requestedcredits as subject_requested_credits,
     ss.earnedcredits as subject_earned_credits,
     ss.waivedcredits as subject_waived_credits,
-
-    {{ extract_source_project("g") }} as _dbt_source_project,
 
     coalesce(sp.requiredcredits, g.plan_credit_capacity) as plan_required_credits,
     coalesce(

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpprogress_grades.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpprogress_grades.sql
@@ -28,6 +28,8 @@ with
             sg.potentialcrhrs as potential_credits,
             sg.is_transfer_grade,
 
+            {{ extract_source_project("gpn") }} as _dbt_source_project,
+
             'Earned' as credit_status,
 
             coalesce(sg.earnedcrhrs, 0.0) as earned_credits,
@@ -37,15 +39,15 @@ with
             {{ ref("stg_powerschool__gpprogresssubject") }} as sub
             on gpn.subject_id = sub.gpnodeid
             and gpn.nodetype = sub.nodetype
-            and {{ union_dataset_join_clause(left_alias="gpn", right_alias="sub") }}
+            and gpn._dbt_source_project = sub._dbt_source_project
         inner join
             {{ ref("stg_powerschool__gpprogresssubjectearned") }} as se
             on sub.id = se.gpprogresssubjectid
-            and {{ union_dataset_join_clause(left_alias="sub", right_alias="se") }}
+            and sub._dbt_source_project = se._dbt_source_project
         inner join
             {{ ref("stg_powerschool__storedgrades") }} as sg
             on se.storedgradesdcid = sg.dcid
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="sg") }}
+            and se._dbt_source_project = sg._dbt_source_project
             and sg.storecode = 'Y1'
 
         union all
@@ -79,6 +81,8 @@ with
 
             false as is_transfer_grade,
 
+            {{ extract_source_project("gpn") }} as _dbt_source_project,
+
             'Enrolled' as credit_status,
 
             if(
@@ -90,15 +94,15 @@ with
             {{ ref("stg_powerschool__gpprogresssubject") }} as sub
             on gpn.subject_id = sub.gpnodeid
             and gpn.nodetype = sub.nodetype
-            and {{ union_dataset_join_clause(left_alias="gpn", right_alias="sub") }}
+            and gpn._dbt_source_project = sub._dbt_source_project
         inner join
             {{ ref("stg_powerschool__gpprogresssubjectenrolled") }} as se
             on sub.id = se.gpprogresssubjectid
-            and {{ union_dataset_join_clause(left_alias="sub", right_alias="se") }}
+            and sub._dbt_source_project = se._dbt_source_project
         inner join
             {{ ref("base_powerschool__final_grades") }} as fg
             on se.ccdcid = fg.cc_dcid
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="fg") }}
+            and se._dbt_source_project = fg._dbt_source_project
             and fg.academic_year = {{ var("current_academic_year") }}
             and fg.termbin_is_current
     )
@@ -146,6 +150,8 @@ select
     ss.earnedcredits as subject_earned_credits,
     ss.waivedcredits as subject_waived_credits,
 
+    {{ extract_source_project("g") }} as _dbt_source_project,
+
     coalesce(sp.requiredcredits, g.plan_credit_capacity) as plan_required_credits,
     coalesce(
         sd.requiredcredits, g.discipline_credit_capacity
@@ -157,14 +163,14 @@ left join
     {{ ref("stg_powerschool__gpprogresssubject") }} as sp
     on g.plan_id = sp.gpnodeid
     and g.studentsdcid = sp.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="g", right_alias="sp") }}
+    and g._dbt_source_project = sp._dbt_source_project
 left join
     {{ ref("stg_powerschool__gpprogresssubject") }} as sd
     on g.discipline_id = sd.gpnodeid
     and g.studentsdcid = sd.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="g", right_alias="sd") }}
+    and g._dbt_source_project = sd._dbt_source_project
 left join
     {{ ref("stg_powerschool__gpprogresssubject") }} as ss
     on g.subject_id = ss.gpnodeid
     and g.studentsdcid = ss.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="g", right_alias="ss") }}
+    and g._dbt_source_project = ss._dbt_source_project

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__s_nj_stu_x_unpivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__s_nj_stu_x_unpivot.sql
@@ -4,6 +4,8 @@ select
     name_column,
     values_column,
 
+    {{ extract_source_project() }} as _dbt_source_project,
+
     if(values_column = 'N', true, false) as is_portfolio_eligible,
     if(values_column = 'M', true, false) as is_iep_eligible,
     if(values_column in ('M', 'N'), true, false) as met_requirement,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__s_nj_stu_x_unpivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__s_nj_stu_x_unpivot.sql
@@ -3,8 +3,7 @@ select
     studentsdcid,
     name_column,
     values_column,
-
-    {{ extract_source_project() }} as _dbt_source_project,
+    _dbt_source_project,
 
     if(values_column = 'N', true, false) as is_portfolio_eligible,
     if(values_column = 'M', true, false) as is_iep_eligible,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__final_grades_rollup.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__final_grades_rollup.yml
@@ -1,0 +1,58 @@
+models:
+  - name: int_powerschool__final_grades_rollup
+    description:
+      Per-student, per-store-code rollup of final grades from
+      `base_powerschool__final_grades`, aggregating enrolled credit hours and
+      failing-grade counts (overall and core-subject) used by downstream
+      promotion and GPA reporting.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - _dbt_source_project
+              - studentid
+              - academic_year
+              - schoolid
+              - storecode
+    columns:
+      - name: _dbt_source_relation
+        data_type: string
+        description: Source relation identifier for union models.
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
+      - name: studentid
+        data_type: int64
+        description:
+          The internal number and ID of the associated Students record.
+      - name: academic_year
+        data_type: int64
+        description: The academic year the final grades were stored in.
+      - name: schoolid
+        data_type: int64
+        description: The School_Number of the associated Schools record.
+      - name: storecode
+        data_type: string
+        description:
+          The stored final-grade term identifier (for example Q1 or Y1) the
+          grades roll up to.
+      - name: enrolled_credit_hours
+        data_type: float64
+        description:
+          Total potential credit hours across the student's stored grades for
+          the store code.
+      - name: n_failing
+        data_type: int64
+        description:
+          Count of stored grades with a failing adjusted Y1 letter grade (F or
+          F*).
+      - name: n_failing_core
+        data_type: int64
+        description:
+          Count of failing stored grades limited to core credit types (ENG,
+          MATH, SCI, and SOC).
+      - name: projected_credits_y1_term
+        data_type: float64
+        description:
+          Sum of potential credit hours for stored grades that are not failing,
+          used to project credits earned.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_lookback.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_lookback.yml
@@ -24,6 +24,9 @@ models:
       - name: _dbt_source_relation
         data_type: string
         description: dbt-generated relation of the originating district model.
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_pivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_pivot.yml
@@ -12,6 +12,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpnode.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpnode.yml
@@ -17,6 +17,9 @@ models:
       - name: _dbt_source_relation
         description: Source relation identifier for union models.
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: nodetype
         description:
           PowerSchool node type code; used to match gpprogresssubject records to

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpprogress_grades.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpprogress_grades.yml
@@ -22,6 +22,9 @@ models:
       - name: _dbt_source_relation
         description: Source relation identifier for union models.
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: plan_id
         description: gpnode.id for the grad plan root node.
         data_type: int64

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__s_nj_stu_x_unpivot.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__s_nj_stu_x_unpivot.yml
@@ -5,6 +5,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentsdcid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects_weeks.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects_weeks.sql
@@ -306,6 +306,8 @@ select
     cw.is_current_week_mon_sun,
     cw.date_count,
 
+    {{ extract_source_project("co") }} as _dbt_source_project,
+
     if(
         cw.week_start_monday between co.entrydate and co.exitdate, true, false
     ) as is_enrolled_week,

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects_weeks.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects_weeks.sql
@@ -294,6 +294,7 @@ select
     co.is_low_25_fl,
     co.is_exempt_state_testing,
     co.mtss_enrollment,
+    co._dbt_source_project,
 
     cw.week_start_monday,
     cw.week_end_sunday,
@@ -305,8 +306,6 @@ select
     cw.week_number_quarter,
     cw.is_current_week_mon_sun,
     cw.date_count,
-
-    {{ extract_source_project("co") }} as _dbt_source_project,
 
     if(
         cw.week_start_monday between co.entrydate and co.exitdate, true, false

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
@@ -5,6 +5,8 @@ with
             yearid,
             studentid,
 
+            {{ extract_source_project() }} as _dbt_source_project,
+
             sum(earnedcrhrs) as py_credits,
 
             if(sum(earnedcrhrs) >= 30, true, false) as met_py_credits,
@@ -20,6 +22,8 @@ with
             _dbt_source_relation,
             yearid,
             studentid,
+
+            {{ extract_source_project() }} as _dbt_source_project,
 
             if(
                 sum(if(y1_letter_grade_adjusted in ('F', 'F*'), 1, 0)) = 0, true, false
@@ -80,20 +84,20 @@ with
             {{ ref("int_powerschool__gpa_term_pivot") }} as gpa
             on e.studentid = gpa.studentid
             and e.yearid = gpa.yearid
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="gpa") }}
+            and e._dbt_source_project = gpa._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term_pivot") }} as gpapy
             on e.studentid = gpapy.studentid
             and e.yearid = (gpapy.yearid + 1)
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="gpapy") }}
+            and e._dbt_source_project = gpapy._dbt_source_project
         left join
             py_credits as pyc
             on e.studentid = pyc.studentid
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="pyc") }}
+            and e._dbt_source_project = pyc._dbt_source_project
         left join
             cy_credits as cyc
             on e.studentid = cyc.studentid
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="cyc") }}
+            and e._dbt_source_project = cyc._dbt_source_project
         where
             e.academic_year = {{ var("current_academic_year") }}
             and e.rn_year = 1
@@ -129,6 +133,8 @@ select
     met_cy_credits,
     is_first_time_ninth,
     is_age_eligible,
+
+    {{ extract_source_project() }} as _dbt_source_project,
 
     case
         when not is_age_eligible

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
@@ -4,8 +4,7 @@ with
             _dbt_source_relation,
             yearid,
             studentid,
-
-            {{ extract_source_project() }} as _dbt_source_project,
+            _dbt_source_project,
 
             sum(earnedcrhrs) as py_credits,
 
@@ -14,7 +13,7 @@ with
         from {{ ref("stg_powerschool__storedgrades") }}
         where
             storecode = 'Y1' and academic_year = {{ var("current_academic_year") - 1 }}
-        group by _dbt_source_relation, yearid, studentid
+        group by _dbt_source_relation, yearid, studentid, _dbt_source_project
     ),
 
     cy_credits as (
@@ -22,8 +21,7 @@ with
             _dbt_source_relation,
             yearid,
             studentid,
-
-            {{ extract_source_project() }} as _dbt_source_project,
+            _dbt_source_project,
 
             if(
                 sum(if(y1_letter_grade_adjusted in ('F', 'F*'), 1, 0)) = 0, true, false
@@ -31,7 +29,7 @@ with
 
         from {{ ref("base_powerschool__final_grades") }}
         where storecode = 'Q2'
-        group by _dbt_source_relation, yearid, studentid
+        group by _dbt_source_relation, yearid, studentid, _dbt_source_project
     ),
 
     base as (
@@ -53,6 +51,7 @@ with
             e.ada_weighted_semester_s1 as cy_weighted_s1_ada,
             e.ada_unweighted_year_prev as py_y1_unweighted_ada,
             e.ada_weighted_year_prev as py_y1_weighted_ada,
+            e._dbt_source_project,
 
             gpa.gpa_term_q1 as cy_q1_gpa,
             gpa.gpa_y1_q2 as cy_s1_gpa,
@@ -133,8 +132,7 @@ select
     met_cy_credits,
     is_first_time_ninth,
     is_age_eligible,
-
-    {{ extract_source_project() }} as _dbt_source_project,
+    _dbt_source_project,
 
     case
         when not is_age_eligible

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects_weeks.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects_weeks.yml
@@ -5,6 +5,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__athletic_eligibility.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__athletic_eligibility.yml
@@ -4,6 +4,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
 
       - name: academic_year
         data_type: int64


### PR DESCRIPTION
## Summary and Motivation

When merged, this PR completes **Wave 1** of the #3142 migration from the `union_dataset_join_clause` macro to a materialized `_dbt_source_project` column.

It adds `_dbt_source_project` to the output of 10 intermediate models that are join targets for downstream consumers but did not yet expose the column, and swaps those models' own internal `union_dataset_join_clause` calls to plain column equality (`a._dbt_source_project = b._dbt_source_project`).

The change is **behavior-preserving**: `extract_source_project()` derives exactly the same `regexp_extract(_dbt_source_relation, ...)` region code the macro produced.

This unblocks **Wave 2** (the reporting-leaf swaps), which need these intermediates to expose the column before they can join on it.

Models (all intermediate, no contract enforcement):

- `int_extracts__student_enrollments_subjects_weeks`
- `int_powerschool__final_grades_rollup`, `int_powerschool__gpa_term_lookback`, `int_powerschool__gpa_term_pivot`, `int_powerschool__gpnode`, `int_powerschool__gpprogress_grades`, `int_powerschool__s_nj_stu_x_unpivot`
- `int_students__athletic_eligibility`
- `int_tableau__gradebook_audit_student_scaffold`, `int_tableau__gradebook_audit_teacher_scaffold` (both `enabled: false` dead code; edited only so Batch 3 can delete the macro without a parse error)

Note: 3 files were CRLF on `main` and are normalized to LF here (sqlfmt does this at commit anyway), which inflates their line counts. **Review with whitespace hidden.**

## AI Assistance

AI-assisted (Claude Code), human-directed. The scope (which models need the column) was derived by resolving every macro call's join aliases against the prod schema; the 8 enabled models were built with `--target dev --defer` and confirmed to populate `_dbt_source_project` with real region codes. The 2 disabled scaffolds are parse-validated only.

## Self-review (dbt)

- [x] No new models; no properties/exposure changes needed (intermediate layer, no contract).
- [x] No contracted column renames/removals — purely additive column plus algebraically-equivalent join-predicate swaps.
- [x] No external sources changed.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
