### PR TITLE
refactor(dbt): swap union_dataset_join_clause for _dbt_source_project in tableau reports

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__academic_goals_rollup.sql
@@ -80,11 +80,11 @@ with
         inner join
             {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
             on f.student_id = suf.fleid
-            and {{ union_dataset_join_clause(left_alias="f", right_alias="suf") }}
+            and f._dbt_source_project = suf._dbt_source_project
         inner join
             {{ ref("stg_powerschool__students") }} as s
             on suf.studentsdcid = s.dcid
-            and {{ union_dataset_join_clause(left_alias="suf", right_alias="s") }}
+            and suf._dbt_source_project = s._dbt_source_project
             and s.grade_level >= 4
         where
             f.assessment_name = 'FAST'
@@ -114,11 +114,11 @@ with
         inner join
             {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
             on f.student_id = suf.fleid
-            and {{ union_dataset_join_clause(left_alias="f", right_alias="suf") }}
+            and f._dbt_source_project = suf._dbt_source_project
         inner join
             {{ ref("stg_powerschool__students") }} as s
             on suf.studentsdcid = s.dcid
-            and {{ union_dataset_join_clause(left_alias="suf", right_alias="s") }}
+            and suf._dbt_source_project = s._dbt_source_project
             and s.grade_level = 3
         where
             f.assessment_name = 'FAST'
@@ -299,7 +299,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as cc
             on co.studentid = cc.cc_studentid
             and co.yearid = cc.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="cc") }}
+            and co._dbt_source_project = cc._dbt_source_project
             and co.illuminate_subject_area = cc.illuminate_subject_area
             and not cc.is_dropped_section
             and cc.rn_student_year_illuminate_subject_desc = 1
@@ -367,7 +367,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as cc
             on co.studentid = cc.cc_studentid
             and co.yearid = cc.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="cc") }}
+            and co._dbt_source_project = cc._dbt_source_project
             and co.illuminate_subject_area = cc.illuminate_subject_area
             and not cc.is_dropped_section
             and cc.rn_student_year_illuminate_subject_desc = 1
@@ -433,7 +433,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as cc
             on co.studentid = cc.cc_studentid
             and co.yearid = cc.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="cc") }}
+            and co._dbt_source_project = cc._dbt_source_project
             and co.illuminate_subject_area = cc.illuminate_subject_area
             and not cc.is_dropped_section
             and cc.rn_student_year_illuminate_subject_desc = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assessment_dashboard.sql
@@ -59,7 +59,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.subject_area = enr.illuminate_subject_area
             and not enr.is_dropped_section
             and enr.rn_student_year_illuminate_subject_desc = 1
@@ -131,7 +131,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.discipline = enr.discipline
             and not enr.is_dropped_section
             and enr.rn_student_year_illuminate_subject_desc = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assignment_checks.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assignment_checks.sql
@@ -23,7 +23,7 @@ inner join
     {{ ref("int_powerschool__gradebook_assignments") }} as a
     on b.sections_dcid = a.sectionsdcid
     and a.duedate between b.week_start_monday and b.week_end_sunday
-    and {{ union_dataset_join_clause(left_alias="b", right_alias="a") }}
+    and b._dbt_source_project = a._dbt_source_project
 where
     b.region_school_level not in ('CamdenES', 'NewarkES')
     and b.scaffold_name = 'teacher_scaffold'

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__attendance_chronic_absenteeism_log.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__attendance_chronic_absenteeism_log.sql
@@ -17,12 +17,12 @@ with
             {{ ref("stg_powerschool__attendance") }} as att
             on co.studentid = att.studentid
             and att.att_date between co.entrydate and co.exitdate
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="att") }}
+            and co._dbt_source_project = att._dbt_source_project
             and att.att_mode_code = 'ATT_ModeDaily'
         inner join
             {{ ref("stg_powerschool__attendance_code") }} as ac
             on att.attendance_codeid = ac.id
-            and {{ union_dataset_join_clause(left_alias="att", right_alias="ac") }}
+            and att._dbt_source_project = ac._dbt_source_project
             and ac.att_code like 'A%'  -- change to exclude AE
         where
             co.academic_year = {{ var("current_academic_year") }}
@@ -65,5 +65,5 @@ left join
     {{ ref("int_deanslist__comm_log") }} as cl
     on ac.student_number = cl.student_school_id
     and ac.academic_year = cl.academic_year
-    and {{ union_dataset_join_clause(left_alias="ac", right_alias="cl") }}
+    and ac._dbt_source_project = cl._dbt_source_project
     and cl.reason like 'Chronic%'

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__attendance_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__attendance_dashboard.sql
@@ -58,7 +58,7 @@ with
             on ad.studentid = co.studentid
             and ad.schoolid = co.schoolid
             and ad.calendardate between co.entrydate and co.exitdate
-            and {{ union_dataset_join_clause(left_alias="ad", right_alias="co") }}
+            and ad._dbt_source_project = co._dbt_source_project
         left join
             overall_filters as f
             on co.academic_year = f.academic_year

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_de.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_de.sql
@@ -22,11 +22,11 @@ from {{ ref("stg_powerschool__storedgrades") }} as sg
 left join
     {{ ref("stg_powerschool__students") }} as s
     on sg.studentid = s.id
-    and {{ union_dataset_join_clause(left_alias="sg", right_alias="s") }}
+    and sg._dbt_source_project = s._dbt_source_project
 left join
     {{ ref("stg_powerschool__u_storedgrades_de") }} as de
     on sg.dcid = de.storedgradesdcid
-    and {{ union_dataset_join_clause(left_alias="sg", right_alias="de") }}
+    and sg._dbt_source_project = de._dbt_source_project
     and de.de_course_name is not null
 -- TODO: establish storecode policy for DE grades as institutions now submit
 -- twice yearly (fall → Q2, spring → ?). If spring grades land on Y1 in the

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_historic.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_historic.sql
@@ -77,7 +77,7 @@ with
             on e.studentid = s.cc_studentid
             and e.academic_year = s.cc_academic_year
             and e.powerschool_credittype = s.courses_credittype
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
+            and e._dbt_source_project = s._dbt_source_project
             and s.rn_course_number_year = 1
             and not s.is_dropped_section
             and s.courses_course_name in (
@@ -92,7 +92,7 @@ with
             on s.cc_academic_year = ec.cc_academic_year
             and s.students_student_number = ec.student_number
             and s.courses_course_name = ec.courses_course_name_expected
-            and {{ union_dataset_join_clause(left_alias="s", right_alias="ec") }}
+            and s._dbt_source_project = ec._dbt_source_project
         where e.rn_year = 1 and e.school_level = 'HS'
     ),
 

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__community_service.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__community_service.sql
@@ -29,7 +29,7 @@ from {{ ref("int_extracts__student_enrollments") }} as co
 left join
     {{ ref("stg_deanslist__behavior") }} as b
     on co.student_number = b.student_school_id
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="b") }}
+    and co._dbt_source_project = b._dbt_source_project
     and b.behavior_category in ('Community Service', 'Community Service Hours')
     and b.behavior_date between co.entrydate and co.exitdate
 left join

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__consequence_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__consequence_dashboard.sql
@@ -71,7 +71,7 @@ left join
     {{ ref("int_deanslist__incidents__penalties") }} as dli
     on co.student_number = dli.student_school_id
     and co.academic_year = dli.create_ts_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="dli") }}
+    and co._dbt_source_project = dli._dbt_source_project
 left join
     {{ ref("stg_google_sheets__reporting__terms") }} as d
     on co.schoolid = d.school_id
@@ -81,5 +81,5 @@ left join
     suspension_att as att
     on co.studentid = att.studentid
     and co.academic_year = att.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="att") }}
+    and co._dbt_source_project = att._dbt_source_project
 where co.rn_year = 1 and co.academic_year >= {{ var("current_academic_year") - 1 }}

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__crdc_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__crdc_roster.sql
@@ -3,7 +3,7 @@ with
         select student_number, is_retained_year,
         from {{ ref("int_extracts__student_enrollments") }}
         where
-            /* submission is always for the previous school year, but retention is 
+            /* submission is always for the previous school year, but retention is
             tracked only on the submission year + 1 (current academic year) */
             academic_year = {{ var("current_academic_year") }}
             and rn_year = 1
@@ -15,6 +15,7 @@ with
     enrollment as (
         select
             e._dbt_source_relation,
+            e._dbt_source_project,
             e.academic_year,
             e.region,
             e.schoolid,
@@ -102,6 +103,7 @@ with
     custom_schedule as (
         select
             c._dbt_source_relation,
+            c._dbt_source_project,
             c.cc_academic_year,
             c.cc_schoolid,
 
@@ -171,7 +173,7 @@ with
             on c.cc_academic_year = g.academic_year
             and c.sections_id = g.sectionid
             and c.cc_studentid = g.studentid
-            and {{ union_dataset_join_clause(left_alias="c", right_alias="g") }}
+            and c._dbt_source_project = g._dbt_source_project
             and g.storecode = 'Y1'
         left join
             {{ ref("stg_google_sheets__crdc__sced_code_crosswalk") }} as x
@@ -186,6 +188,7 @@ with
         -- credit recovery courses, which only exist in storedgrades
         select
             _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             schoolid,
 
@@ -561,7 +564,7 @@ from enrollment as e
 inner join
     final_schedule as f
     on e.studentid = f.cc_studentid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="f") }}
+    and e._dbt_source_project = f._dbt_source_project
     and f.crdc_question_section = 'PENR-6'
 where
     -- timeframe is any part of the year + summer

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ddi_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ddi_dashboard.sql
@@ -143,7 +143,7 @@ with
             on co.studentid = cc.cc_studentid
             and co.yearid = cc.cc_yearid
             and r.subject_area = cc.illuminate_subject_area
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="cc") }}
+            and co._dbt_source_project = cc._dbt_source_project
             and not cc.is_dropped_section
             and cc.rn_student_year_illuminate_subject_desc = 1
         left join

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__dibels_dashboard.sql
@@ -137,7 +137,7 @@ left join
     on s.academic_year = c.cc_academic_year
     and s.schoolid = c.cc_schoolid
     and s.student_number = c.students_student_number
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="c") }}
+    and s._dbt_source_project = c._dbt_source_project
     and c.rn_course_number_year = 1
     and not c.is_dropped_section
     and c.cc_section_number not like '%SC%'
@@ -324,7 +324,7 @@ left join
     on s.academic_year = c.cc_academic_year
     and s.schoolid = c.cc_schoolid
     and s.student_number = c.students_student_number
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="c") }}
+    and s._dbt_source_project = c._dbt_source_project
     and c.rn_course_number_year = 1
     and not c.is_dropped_section
     and c.cc_section_number not like '%SC%'

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_analysis.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_analysis.sql
@@ -60,5 +60,5 @@ left join
     on sr.studentid = gt.studentid
     and sr.yearid = gt.yearid
     and sr.schoolid = gt.schoolid
-    and {{ union_dataset_join_clause(left_alias="sr", right_alias="gt") }}
+    and sr._dbt_source_project = gt._dbt_source_project
 where sr.school_level in ('MS', 'HS') and sr.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_assignments.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_assignments.sql
@@ -42,22 +42,22 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as co
     on enr.cc_studentid = co.studentid
     and enr.cc_yearid = co.yearid
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="co") }}
+    and enr._dbt_source_project = co._dbt_source_project
     and co.rn_year = 1
 inner join
     {{ ref("int_powerschool__section_grade_config") }} as gb
     on enr.sections_dcid = gb.sections_dcid
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="gb") }}
+    and enr._dbt_source_project = gb._dbt_source_project
     and gb.grading_formula_weighting_type = 'Total_Points'
 left join
     {{ ref("int_powerschool__gradebook_assignments") }} as a
     on gb.sections_dcid = a.sectionsdcid
     and a.duedate between gb.term_start_date and gb.term_end_date
-    and {{ union_dataset_join_clause(left_alias="gb", right_alias="a") }}
+    and gb._dbt_source_project = a._dbt_source_project
 left join
     {{ ref("stg_powerschool__assignmentscore") }} as s
     on a.assignmentsectionid = s.assignmentsectionid
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="s") }}
+    and a._dbt_source_project = s._dbt_source_project
     and enr.students_dcid = s.studentsdcid
 where enr.cc_academic_year = {{ var("current_academic_year") }}
 
@@ -107,22 +107,22 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as co
     on enr.cc_studentid = co.studentid
     and enr.cc_yearid = co.yearid
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="co") }}
+    and enr._dbt_source_project = co._dbt_source_project
     and co.rn_year = 1
 inner join
     {{ ref("int_powerschool__section_grade_config") }} as gb
     on enr.sections_dcid = gb.sections_dcid
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="gb") }}
+    and enr._dbt_source_project = gb._dbt_source_project
     and gb.grading_formula_weighting_type != 'Total_Points'
 left join
     {{ ref("int_powerschool__gradebook_assignments") }} as a
     on gb.sections_dcid = a.sectionsdcid
     and gb.category_id = a.category_id
     and a.duedate between gb.term_start_date and gb.term_end_date
-    and {{ union_dataset_join_clause(left_alias="gb", right_alias="a") }}
+    and gb._dbt_source_project = a._dbt_source_project
 left join
     {{ ref("stg_powerschool__assignmentscore") }} as s
     on a.assignmentsectionid = s.assignmentsectionid
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="s") }}
+    and a._dbt_source_project = s._dbt_source_project
     and enr.students_dcid = s.studentsdcid
 where enr.cc_academic_year = {{ var("current_academic_year") }}

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_dashboard.sql
@@ -49,7 +49,7 @@ with
             on enr.cc_studentid = f.studentid
             and enr.cc_academic_year = f.academic_year
             and enr.courses_credittype = f.powerschool_credittype
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="f") }}
+            and enr._dbt_source_project = f._dbt_source_project
             and f.rn_year = 1
         where enr.rn_course_number_year = 1 and not enr.is_dropped_section
     )
@@ -124,19 +124,19 @@ left join
     {{ ref("base_powerschool__final_grades") }} as gr
     on co.studentid = gr.studentid
     and co.yearid = gr.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gr") }}
+    and co._dbt_source_project = gr._dbt_source_project
     and gr.termbin_start_date <= current_date('{{ var("local_timezone") }}')
 left join
     {{ ref("stg_powerschool__pgfinalgrades") }} as pgf
     on gr.studentid = pgf.studentid
     and gr.sectionid = pgf.sectionid
     and gr.storecode = pgf.finalgradename
-    and {{ union_dataset_join_clause(left_alias="gr", right_alias="pgf") }}
+    and gr._dbt_source_project = pgf._dbt_source_project
 left join
     section_teacher as st
     on co.studentid = st.studentid
     and co.yearid = st.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="st") }}
+    and co._dbt_source_project = st._dbt_source_project
     and gr.course_number = st.course_number
 where co.academic_year = {{ var("current_academic_year") }}
 
@@ -212,21 +212,21 @@ left join
     {{ ref("base_powerschool__final_grades") }} as gr
     on co.studentid = gr.studentid
     and co.yearid = gr.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gr") }}
+    and co._dbt_source_project = gr._dbt_source_project
     and gr.termbin_is_current
     and gr.termbin_start_date <= current_date('{{ var("local_timezone") }}')
 left join
     {{ ref("stg_powerschool__storedgrades") }} as y1
     on co.studentid = y1.studentid
     and co.academic_year = y1.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="y1") }}
+    and co._dbt_source_project = y1._dbt_source_project
     and gr.course_number = y1.course_number
     and y1.storecode = 'Y1'
 left join
     section_teacher as st
     on co.studentid = st.studentid
     and co.yearid = st.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="st") }}
+    and co._dbt_source_project = st._dbt_source_project
     and gr.course_number = st.course_number
 where co.academic_year = {{ var("current_academic_year") }}
 
@@ -303,13 +303,13 @@ left join
     {{ ref("int_powerschool__category_grades") }} as cg
     on co.studentid = cg.studentid
     and co.yearid = cg.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="cg") }}
+    and co._dbt_source_project = cg._dbt_source_project
     and cg.storecode_type != 'Q'
 left join
     section_teacher as st
     on co.studentid = st.studentid
     and co.yearid = st.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="st") }}
+    and co._dbt_source_project = st._dbt_source_project
     and cg.course_number = st.course_number
 where co.academic_year = {{ var("current_academic_year") }}
 
@@ -382,7 +382,7 @@ left join
     {{ ref("int_powerschool__category_grades") }} as cy
     on co.studentid = cy.studentid
     and co.yearid = cy.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="cy") }}
+    and co._dbt_source_project = cy._dbt_source_project
     and cy.storecode_type != 'Q'
     and current_date('{{ var("local_timezone") }}')
     between cy.termbin_start_date and cy.termbin_end_date
@@ -390,7 +390,7 @@ left join
     section_teacher as st
     on co.studentid = st.studentid
     and co.yearid = st.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="st") }}
+    and co._dbt_source_project = st._dbt_source_project
     and cy.course_number = st.course_number
 where co.academic_year = {{ var("current_academic_year") }}
 
@@ -458,14 +458,14 @@ left join
     {{ ref("stg_powerschool__storedgrades") }} as sg
     on co.studentid = sg.studentid
     and co.academic_year = sg.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="sg") }}
+    and co._dbt_source_project = sg._dbt_source_project
     and sg.storecode = 'Y1'
     and sg.course_number is not null
 left join
     section_teacher as st
     on co.studentid = st.studentid
     and co.yearid = st.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="st") }}
+    and co._dbt_source_project = st._dbt_source_project
     and sg.course_number = st.course_number
 where co.academic_year < {{ var("current_academic_year") }}
 
@@ -541,12 +541,12 @@ left join
     student_roster as co
     on tr.studentid = co.studentid
     and tr.schoolid = co.schoolid
-    and {{ union_dataset_join_clause(left_alias="tr", right_alias="co") }}
+    and tr._dbt_source_project = co._dbt_source_project
     and tr.academic_year = co.academic_year
 left join
     student_roster as e1
     on tr.studentid = e1.studentid
     and tr.schoolid = e1.schoolid
-    and {{ union_dataset_join_clause(left_alias="tr", right_alias="e1") }}
+    and tr._dbt_source_project = e1._dbt_source_project
     and e1.year_in_school = 1
 where tr.storecode = 'Y1' and tr.course_number is null

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
@@ -2,6 +2,7 @@ with
     term as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             schoolid,
             yearid,
 
@@ -20,6 +21,7 @@ with
 
         select
             _dbt_source_relation,
+            _dbt_source_project,
             schoolid,
             yearid,
 
@@ -39,6 +41,7 @@ with
     student_roster as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.studentid,
             enr.student_number,
             enr.student_name,
@@ -110,21 +113,21 @@ with
             term
             on enr.schoolid = term.schoolid
             and enr.yearid = term.yearid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="term") }}
+            and enr._dbt_source_project = term._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gtq
             on enr.studentid = gtq.studentid
             and enr.yearid = gtq.yearid
             and enr.schoolid = gtq.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gtq") }}
+            and enr._dbt_source_project = gtq._dbt_source_project
             and term.quarter = gtq.term_name
-            and {{ union_dataset_join_clause(left_alias="term", right_alias="gtq") }}
+            and term._dbt_source_project = gtq._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gty
             on enr.studentid = gty.studentid
             and enr.yearid = gty.yearid
             and enr.schoolid = gty.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gty") }}
+            and enr._dbt_source_project = gty._dbt_source_project
             and gty.is_current
         where enr.rn_year = 1 and not enr.is_out_of_district and enr.enroll_status != -1
     ),
@@ -132,6 +135,7 @@ with
     course_enrollments as (
         select
             m._dbt_source_relation,
+            m._dbt_source_project,
             m.cc_studentid as studentid,
             m.cc_yearid as yearid,
             m.cc_course_number as course_number,
@@ -157,7 +161,7 @@ with
             on m.cc_studentid = f.studentid
             and m.cc_academic_year = f.academic_year
             and m.courses_credittype = f.powerschool_credittype
-            and {{ union_dataset_join_clause(left_alias="m", right_alias="f") }}
+            and m._dbt_source_project = f._dbt_source_project
             and f.rn_year = 1
         left join
             {{ ref("int_people__staff_roster") }} as r
@@ -182,6 +186,7 @@ with
     y1_historical as (
         select
             tr._dbt_source_relation,
+            tr._dbt_source_project,
             tr.studentid,
             tr.academic_year,
             tr.yearid,
@@ -212,13 +217,14 @@ with
             and tr.academic_year = co.academic_year
             and tr.schoolid = co.schoolid
             and tr.storecode = co.`quarter`
-            and {{ union_dataset_join_clause(left_alias="tr", right_alias="co") }}
+            and tr._dbt_source_project = co._dbt_source_project
         where tr.storecode = 'Y1'
     ),
 
     quarter_and_ip_y1_grades as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             schoolid,
@@ -254,6 +260,7 @@ with
 
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             schoolid,
@@ -289,6 +296,7 @@ with
     category_grades as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             yearid,
             schoolid,
             studentid,
@@ -447,29 +455,29 @@ left join
     course_enrollments as ce
     on s.studentid = ce.studentid
     and s.yearid = ce.yearid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="ce") }}
+    and s._dbt_source_project = ce._dbt_source_project
 left join
     y1_historical as y1h
     on s.studentid = y1h.studentid
     and s.yearid = y1h.yearid
     and s.`quarter` = y1h.storecode
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="y1h") }}
+    and s._dbt_source_project = y1h._dbt_source_project
     and ce.course_number = y1h.course_number
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="y1h") }}
+    and ce._dbt_source_project = y1h._dbt_source_project
 left join
     quarter_and_ip_y1_grades as qy1
     on s.studentid = qy1.studentid
     and s.yearid = qy1.yearid
     and s.`quarter` = qy1.`quarter`
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="qy1") }}
+    and s._dbt_source_project = qy1._dbt_source_project
     and ce.sectionid = qy1.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="qy1") }}
+    and ce._dbt_source_project = qy1._dbt_source_project
 left join
     category_grades as c
     on s.studentid = c.studentid
     and s.yearid = c.yearid
     and s.`quarter` = c.term
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="c") }}
+    and s._dbt_source_project = c._dbt_source_project
     and ce.sectionid = c.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="c") }}
+    and ce._dbt_source_project = c._dbt_source_project
 where s.quarter_start_date <= current_date('{{ var("local_timezone") }}')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__graduation_requirements.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__graduation_requirements.sql
@@ -60,7 +60,7 @@ left join
     {{ ref("base_powerschool__course_enrollments") }} as s
     on e.studentid = s.cc_studentid
     and e.academic_year = s.cc_academic_year
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
+    and e._dbt_source_project = s._dbt_source_project
     and s.courses_course_name like 'College and Career%'
     and s.rn_course_number_year = 1
     and not s.is_dropped_section

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__home_instruction.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__home_instruction.sql
@@ -128,5 +128,5 @@ left join
     and co.academic_year = sp.academic_year
     and dl.hi_start_date between sp.enter_date and sp.exit_date
     and sp.specprog_name = 'Home Instruction'
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="sp") }}
+    and co._dbt_source_project = sp._dbt_source_project
 where co.grade_level != 99

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__home_instruction_queue.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__home_instruction_queue.sql
@@ -41,7 +41,7 @@ inner join
     {{ ref("int_deanslist__incidents") }} as dli
     on co.student_number = dli.student_school_id
     and co.academic_year = dli.create_ts_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="dli") }}
+    and co._dbt_source_project = dli._dbt_source_project
     and (dli.category = 'TX - HI Request (admin only)' or dli.hi_start_date is not null)
 inner join
     {{ ref("stg_google_sheets__reporting__terms") }} as d

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__hs_early_warning_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__hs_early_warning_dashboard.sql
@@ -2,6 +2,7 @@ with
     suspension as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_school_id,
             create_ts_academic_year,
 
@@ -9,7 +10,11 @@ with
             sum(num_days) as suspension_days,
         from {{ ref("int_deanslist__incidents__penalties") }}
         where is_suspension
-        group by student_school_id, create_ts_academic_year, _dbt_source_relation
+        group by
+            student_school_id,
+            create_ts_academic_year,
+            _dbt_source_relation,
+            _dbt_source_project
     )
 
 select
@@ -80,24 +85,24 @@ left join
     {{ ref("base_powerschool__final_grades") }} as gr
     on co.studentid = gr.studentid
     and co.yearid = gr.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gr") }}
+    and co._dbt_source_project = gr._dbt_source_project
     and dt.name = gr.storecode
     and gr.exclude_from_gpa = 0
 left join
     {{ ref("base_powerschool__sections") }} as si
     on gr.sectionid = si.sections_id
-    and {{ union_dataset_join_clause(left_alias="gr", right_alias="si") }}
+    and gr._dbt_source_project = si._dbt_source_project
 left join
     {{ ref("int_powerschool__gpa_term") }} as gpa
     on co.studentid = gpa.studentid
     and co.yearid = gpa.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
     and dt.name = gpa.term_name
 left join
     suspension as sus
     on co.student_number = sus.student_school_id
     and co.academic_year = sus.create_ts_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="sus") }}
+    and co._dbt_source_project = sus._dbt_source_project
 where
     co.academic_year = {{ var("current_academic_year") }}
     and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__iready_apm.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__iready_apm.sql
@@ -117,7 +117,7 @@ left join
     and co.yearid = cr.cc_yearid
     and co.schoolid = cr.cc_schoolid
     and co.powerschool_credittype = cr.courses_credittype
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="cr") }}
+    and co._dbt_source_project = cr._dbt_source_project
     and not cr.is_dropped_section
     and cr.rn_credittype_year = 1
 left join

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__miami_k2_iready.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__miami_k2_iready.sql
@@ -49,7 +49,7 @@ left join
     {{ ref("base_powerschool__course_enrollments") }} as e
     on co.student_number = e.students_student_number
     and co.academic_year = e.cc_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="e") }}
+    and co._dbt_source_project = e._dbt_source_project
     and subj.ps_credittype = e.courses_credittype
     and not e.is_dropped_section
     and e.rn_credittype_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__mtss_rti.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__mtss_rti.sql
@@ -146,7 +146,7 @@ with
             on co.studentid = g.studentid
             and co.schoolid = g.schoolid
             and co.yearid = g.yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="g") }}
+            and co._dbt_source_project = g._dbt_source_project
             and g.is_current
         left join
             {{ ref("int_deanslist__referral_suspension_rollup") }} as sr

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__nj_school_register.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__nj_school_register.sql
@@ -4,6 +4,7 @@ with
             studentid,
             yearid,
             _dbt_source_relation,
+            _dbt_source_project,
 
             sum(attendancevalue) as n_att,
             sum(membershipvalue) as n_mem,
@@ -16,7 +17,7 @@ with
             ) as n_mem_ytd,
         from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }}
         where membershipvalue = 1
-        group by studentid, yearid, _dbt_source_relation
+        group by studentid, yearid, _dbt_source_relation, _dbt_source_project
     )
 
 select
@@ -48,11 +49,11 @@ inner join
     att_mem as sub
     on co.studentid = sub.studentid
     and co.yearid = sub.yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="sub") }}
+    and co._dbt_source_project = sub._dbt_source_project
 left join
     {{ ref("int_powerschool__calendar_rollup") }} as d
     on co.schoolid = d.schoolid
     and co.yearid = d.yearid
     and co.track = d.track
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="d") }}
+    and co._dbt_source_project = d._dbt_source_project
 where co.rn_year = 1 and co.region != 'Miami' and co.grade_level != 99

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_behavior.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_behavior.sql
@@ -2,6 +2,7 @@ with
     behaviors as (
         select
             b._dbt_source_relation,
+            b._dbt_source_project,
             b.dl_said,
             b.school_name,
             b.student_school_id,
@@ -63,7 +64,7 @@ with
         inner join
             {{ ref("int_powerschool__calendar_week") }} as w
             on b.behavior_date between w.week_start_monday and w.week_end_sunday
-            and {{ union_dataset_join_clause(left_alias="w", right_alias="b") }}
+            and w._dbt_source_project = b._dbt_source_project
             and lc.location_powerschool_school_id = w.schoolid
         where
             b.behavior_category in (
@@ -86,6 +87,7 @@ with
     behavior_aggregation as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_school_id,
             behavior,
             behavior_category,
@@ -102,6 +104,7 @@ with
         from behaviors
         group by
             _dbt_source_relation,
+            _dbt_source_project,
             student_school_id,
             behavior,
             behavior_category,
@@ -166,7 +169,7 @@ left join
     on co.student_number = b.student_school_id
     and co.academic_year = b.academic_year
     and co.week_start_monday = b.week_start_monday
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="b") }}
+    and co._dbt_source_project = b._dbt_source_project
 left join
     {{ ref("int_deanslist__behavior_incentive_by_term") }} as bi
     on co.student_number = bi.student_school_id

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__power_standards.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__power_standards.sql
@@ -78,7 +78,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.subject_area = enr.illuminate_subject_area
             and enr.rn_student_year_illuminate_subject_desc = 1
             and not enr.is_dropped_section
@@ -145,7 +145,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.subject_area = enr.illuminate_subject_area
             and not enr.is_dropped_section
             and enr.rn_student_year_illuminate_subject_desc = 1
@@ -230,7 +230,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.subject_area = enr.illuminate_subject_area
             and enr.rn_student_year_illuminate_subject_desc = 1
             and not enr.is_dropped_section
@@ -314,7 +314,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as enr
             on co.studentid = enr.cc_studentid
             and co.yearid = enr.cc_yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+            and co._dbt_source_project = enr._dbt_source_project
             and asr.subject_area = enr.illuminate_subject_area
             and enr.rn_student_year_illuminate_subject_desc = 1
             and not enr.is_dropped_section

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__qbl.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__qbl.sql
@@ -87,7 +87,7 @@ left join
     {{ ref("base_powerschool__course_enrollments") }} as enr
     on co.studentid = enr.cc_studentid
     and co.yearid = enr.cc_yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+    and co._dbt_source_project = enr._dbt_source_project
     and asr.subject_area = enr.illuminate_subject_area
     and not enr.is_dropped_section
     and enr.rn_student_year_illuminate_subject_desc = 1
@@ -192,7 +192,7 @@ left join
     {{ ref("base_powerschool__course_enrollments") }} as enr
     on co.studentid = enr.cc_studentid
     and co.yearid = enr.cc_yearid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="enr") }}
+    and co._dbt_source_project = enr._dbt_source_project
     and asr.subject_area = enr.illuminate_subject_area
     and not enr.is_dropped_section
     and enr.rn_student_year_illuminate_subject_desc = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__school_culture_dashboard_nj.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__school_culture_dashboard_nj.sql
@@ -84,7 +84,7 @@ left join
     {{ ref("int_deanslist__incidents__penalties") }} as dlp
     on co.student_number = dlp.student_school_id
     and co.academic_year = dlp.create_ts_academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="dlp") }}
+    and co._dbt_source_project = dlp._dbt_source_project
     and dlp.is_active
 left join
     {{ ref("stg_google_sheets__reporting__terms") }} as d
@@ -95,7 +95,7 @@ left join
     suspension_att as att
     on co.studentid = att.studentid
     and co.academic_year = att.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="att") }}
+    and co._dbt_source_project = att._dbt_source_project
 where
     co.rn_year = 1
     and co.region in ('Newark', 'Camden')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_testing_accomodations.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_testing_accomodations.sql
@@ -2,6 +2,7 @@ with
     accommodations_unpivot as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentsdcid,
             asmt_exclude_ela,
             asmt_exclude_math,
@@ -82,7 +83,7 @@ from {{ ref("int_extracts__student_enrollments") }} as co
 left join
     accommodations_unpivot as ac
     on co.students_dcid = ac.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="ac") }}
+    and co._dbt_source_project = ac._dbt_source_project
 where
     co.academic_year = {{ var("current_academic_year") }}
     and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_attrition_over_time_v1.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_attrition_over_time_v1.sql
@@ -52,13 +52,13 @@ from {{ ref("int_extracts__student_enrollments") }} as y1
 inner join
     {{ ref("stg_powerschool__students") }} as s
     on y1.student_number = s.student_number
-    and {{ union_dataset_join_clause(left_alias="y1", right_alias="s") }}
+    and y1._dbt_source_project = s._dbt_source_project
 left join
     {{ ref("int_extracts__student_enrollments") }} as y2
     on y1.student_number = y2.student_number
     and y1.academic_year = (y2.academic_year - 1)
     and date(y2.academic_year, 10, 1) between y2.entrydate and y2.exitdate
-    and {{ union_dataset_join_clause(left_alias="y1", right_alias="y2") }}
+    and y1._dbt_source_project = y2._dbt_source_project
 inner join
     attrition_dates as d
     on y1.academic_year = d.attrition_year

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -2,6 +2,7 @@ with
     term as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             schoolid,
             yearid,
 
@@ -23,6 +24,7 @@ with
 
         select
             _dbt_source_relation,
+            _dbt_source_project,
             schoolid,
             yearid,
 
@@ -76,6 +78,7 @@ with
     student_roster as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.studentid,
             enr.student_number,
             enr.student_name,
@@ -169,21 +172,21 @@ with
             term
             on enr.schoolid = term.schoolid
             and enr.yearid = term.yearid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="term") }}
+            and enr._dbt_source_project = term._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gtq
             on enr.studentid = gtq.studentid
             and enr.yearid = gtq.yearid
             and enr.schoolid = gtq.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gtq") }}
+            and enr._dbt_source_project = gtq._dbt_source_project
             and term.quarter = gtq.term_name
-            and {{ union_dataset_join_clause(left_alias="term", right_alias="gtq") }}
+            and term._dbt_source_project = gtq._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gty
             on enr.studentid = gty.studentid
             and enr.yearid = gty.yearid
             and enr.schoolid = gty.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gty") }}
+            and enr._dbt_source_project = gty._dbt_source_project
             and gty.is_current
         /* gc join gated to the current year in ON: prior-year rows keep NULL
            cumulative/needed columns (as-of-today measures) */
@@ -191,7 +194,7 @@ with
             {{ ref("int_powerschool__gpa_cumulative") }} as gc
             on enr.studentid = gc.studentid
             and enr.schoolid = gc.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gc") }}
+            and enr._dbt_source_project = gc._dbt_source_project
             and enr.academic_year = {{ var("current_academic_year") }}
         /* lookback is current-year only by construction (yearid in the join
            key), so prior-year rows read NULL naturally */
@@ -200,7 +203,7 @@ with
             on enr.studentid = lb.studentid
             and enr.schoolid = lb.schoolid
             and enr.yearid = lb.yearid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="lb") }}
+            and enr._dbt_source_project = lb._dbt_source_project
         /* both comparison joins are current-year-only (as-of columns), gated
            in ON so prior-year rows keep NULLs */
         left join
@@ -208,7 +211,7 @@ with
             on enr.studentid = gpq.studentid
             and enr.yearid = gpq.yearid
             and enr.schoolid = gpq.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="gpq") }}
+            and enr._dbt_source_project = gpq._dbt_source_project
             and term.prior_quarter = gpq.term_name
             and enr.academic_year = {{ var("current_academic_year") }}
         left join
@@ -236,6 +239,7 @@ with
     course_enrollments as (
         select
             m._dbt_source_relation,
+            m._dbt_source_project,
             m.cc_studentid as studentid,
             m.cc_yearid as yearid,
             m.cc_course_number as course_number,
@@ -260,7 +264,7 @@ with
             on m.cc_studentid = f.studentid
             and m.cc_academic_year = f.academic_year
             and m.courses_credittype = f.powerschool_credittype
-            and {{ union_dataset_join_clause(left_alias="m", right_alias="f") }}
+            and m._dbt_source_project = f._dbt_source_project
             and f.rn_year = 1
         left join
             {{ ref("int_people__staff_roster") }} as r
@@ -285,6 +289,7 @@ with
     y1_final_grades as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             course_number,
@@ -306,6 +311,7 @@ with
         /* current year: live gradebook */
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             course_number,
@@ -336,6 +342,7 @@ with
         /* current year: in-progress Y1 row */
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             course_number,
@@ -368,6 +375,7 @@ with
            branch does for the current year) */
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
             course_number,
@@ -397,6 +405,7 @@ with
     category_grades as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             yearid,
             schoolid,
             studentid,
@@ -568,29 +577,29 @@ left join
     course_enrollments as ce
     on s.studentid = ce.studentid
     and s.yearid = ce.yearid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="ce") }}
+    and s._dbt_source_project = ce._dbt_source_project
 left join
     y1_final_grades as y1f
     on s.studentid = y1f.studentid
     and s.yearid = y1f.yearid
     and s.`quarter` = y1f.storecode
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="y1f") }}
+    and s._dbt_source_project = y1f._dbt_source_project
     and ce.course_number = y1f.course_number
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="y1f") }}
+    and ce._dbt_source_project = y1f._dbt_source_project
 left join
     quarter_grades as qg
     on s.studentid = qg.studentid
     and s.yearid = qg.yearid
     and s.`quarter` = qg.`quarter`
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="qg") }}
+    and s._dbt_source_project = qg._dbt_source_project
     and ce.course_number = qg.course_number
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="qg") }}
+    and ce._dbt_source_project = qg._dbt_source_project
 left join
     category_grades as c
     on s.studentid = c.studentid
     and s.yearid = c.yearid
     and s.`quarter` = c.term
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="c") }}
+    and s._dbt_source_project = c._dbt_source_project
     and ce.sectionid = c.sectionid
-    and {{ union_dataset_join_clause(left_alias="ce", right_alias="c") }}
+    and ce._dbt_source_project = c._dbt_source_project
 where s.quarter_start_date <= current_date('{{ var("local_timezone") }}')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_info_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_info_audit.sql
@@ -1,25 +1,35 @@
 with
     studentrace_agg as (
-        select _dbt_source_relation, studentid, string_agg(racecd) as racecd,
+        select
+            _dbt_source_relation,
+            _dbt_source_project,
+            studentid,
+            string_agg(racecd) as racecd,
         from {{ ref("stg_powerschool__studentrace") }}
-        group by studentid, _dbt_source_relation
+        group by studentid, _dbt_source_relation, _dbt_source_project
     ),
 
     course_enrollment_count as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             students_student_number,
             cc_academic_year,
 
             count(cc_sectionid) as sectionid_count,
         from {{ ref("base_powerschool__course_enrollments") }}
         where not is_dropped_section
-        group by _dbt_source_relation, students_student_number, cc_academic_year
+        group by
+            _dbt_source_relation,
+            _dbt_source_project,
+            students_student_number,
+            cc_academic_year
     ),
 
     student_enrollments as (
         select
             se._dbt_source_relation,
+            se._dbt_source_project,
             se.student_number,
             se.state_studentnumber,
             se.student_name as lastfirst,
@@ -92,17 +102,17 @@ with
             {{ ref("stg_powerschool__fte") }} as fte
             on se.schoolid = fte.schoolid
             and se.yearid = fte.yearid
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="fte") }}
+            and se._dbt_source_project = fte._dbt_source_project
             and fte.name like 'Full Time Student%'
         left join
             studentrace_agg as r
             on se.studentid = r.studentid
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="r") }}
+            and se._dbt_source_project = r._dbt_source_project
         left join
             course_enrollment_count as cec
             on se.student_number = cec.students_student_number
             and se.academic_year = cec.cc_academic_year
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="cec") }}
+            and se._dbt_source_project = cec._dbt_source_project
         where
             se.academic_year = {{ var("current_academic_year") }}
             and se.schoolid != 999999
@@ -112,6 +122,7 @@ with
     cc_lag as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studyear,
             course_number,
             dateleft,
@@ -127,6 +138,7 @@ with
     enr_dupes as (
         select
             cc._dbt_source_relation,
+            cc._dbt_source_project,
             cc.cc_academic_year,
             cc.cc_course_number,
             cc.cc_dateenrolled,
@@ -138,7 +150,7 @@ with
             cc_lag as cco
             on cc.cc_studyear = cco.studyear
             and cc.cc_course_number = cco.course_number
-            and {{ union_dataset_join_clause(left_alias="cc", right_alias="cco") }}
+            and cc._dbt_source_project = cco._dbt_source_project
             and cco.dateleft <= cco.dateleft_prev
     )
 
@@ -326,5 +338,5 @@ inner join
     enr_dupes as ceo
     on se.student_number = ceo.students_student_number
     and se.academic_year = ceo.cc_academic_year
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="ceo") }}
+    and se._dbt_source_project = ceo._dbt_source_project
 where se.enroll_status = 0

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__suspension_over_time.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__suspension_over_time.sql
@@ -2,6 +2,7 @@ with
     suspension_dates as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_school_id as student_number,
             create_ts_academic_year as academic_year,
 
@@ -16,7 +17,11 @@ with
             ) as first_suspension_date_oss,
         from {{ ref("int_deanslist__incidents__penalties") }}
         where is_suspension
-        group by _dbt_source_relation, student_school_id, create_ts_academic_year
+        group by
+            _dbt_source_relation,
+            _dbt_source_project,
+            student_school_id,
+            create_ts_academic_year
     )
 
 select
@@ -81,7 +86,7 @@ left join
     suspension_dates as s
     on co.student_number = s.student_number
     and co.academic_year = s.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="s") }}
+    and co._dbt_source_project = s._dbt_source_project
 left join
     {{ ref("int_deanslist__incidents__penalties") }} as sd
     on co.student_number = sd.student_school_id


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR advances **Batch 2** (consumer join swaps) of the #3142 `_dbt_source_project` migration — the first directory-scoped PR of that batch.

Following Batch 1 (producer backfill, #4503–#4505) and the join-target intermediates (#4516, now merged and materialized in prod), this swaps the `union_dataset_join_clause` macro for the direct materialized-column equality `a._dbt_source_project = b._dbt_source_project` across the `rpt_tableau__*` report family.

The change is **behavior-preserving**: `_dbt_source_project` equals `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` by construction (it is derived by that exact expression at the union view), so the new predicate is algebraically identical to the macro it replaces — just without the per-join `regexp_extract`.

**Scope:** 33 files under `models/extracts/tableau/`, 124 macro calls swapped:

- **23 enabled (view) models** — column-resolution gate verified (see Self-review).
- **10 statically-disabled models** (`enabled: false` in properties.yml, unconditional — they never build in dev, staging, or prod) — mechanical swap only, parse-verified. Swapped now so Batch 3 can delete the macro with zero residual call sites. Same apply-but-unverifiable convention as the disabled scaffolds in #4516.

Where a consuming CTE selected explicit columns (it already projected `_dbt_source_relation` for the old macro but not `_dbt_source_project`), the column was threaded through alongside `_dbt_source_relation` from the same source — no new derivation, no `extract_source_project()` re-introduced downstream.

### Deferred to a follow-up PR

Two enabled models were left on the macro (reverted) because a join operand does not yet expose `_dbt_source_project` and needs a producer fix first:

- `rpt_tableau__ops_dashboard` — joins `int_finance__enrollment_targets`, a hand-built non-union intermediate that builds `_dbt_source_relation` via `concat`, so the column was never materialized on it.
- `rpt_tableau__state_assessments_dashboard` — joins `int_pearson__student_list_report`, which drops the column its `stg_pearson__student_list_report` source carries.

Both intermediates will get the column in a follow-up (analogous to the #4516 join-target work), after which their consumers can be swapped.

### Note on line counts

Four files (`rpt_tableau__crdc_roster`, `rpt_tableau__assignment_checks`, `rpt_tableau__college_assessment_dashboard_de`, `rpt_tableau__college_assessment_dashboard_historic`) were CRLF on `main` and normalize to LF here (sqlfmt does this at commit regardless), inflating their diffs. **Review with whitespace hidden.**

## AI Assistance

AI-assisted (Claude Code), human-directed. The swap is mechanical; the producer-gate verification (which CTEs needed the column threaded, which two models to defer) was driven by an `--empty` gate build against prod upstreams.

## Self-review

### dbt

- [x] No new models — no properties/exposure files needed. These are existing reporting views; the swap changes join predicates only, not model output columns.
- [x] **Not a breaking change** — no contracted column renamed or removed; join-predicate-only edits.
- [x] No external sources changed.
- [x] Column-resolution gate: all 23 enabled models pass `dbt build --empty --defer --favor-state --state <prod>` (validates every `_dbt_source_project` reference resolves against prod upstreams, no data scanned). Behavior equivalence holds by algebraic identity.
- [x] `trunk check --force` clean on all 33 files.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
