### PR TITLE
refactor(dbt): swap union_dataset_join_clause for _dbt_source_project in extracts reports

### DIFF
--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
@@ -10,7 +10,7 @@ from {{ ref("stg_powerschool__cc") }} as cc
 inner join
     {{ ref("stg_powerschool__students") }} as s
     on cc.studentid = s.id
-    and {{ union_dataset_join_clause(left_alias="cc", right_alias="s") }}
+    and cc._dbt_source_project = s._dbt_source_project
     and s.enroll_status in (0, -1)
 where
     cc.dateleft >= current_date('{{ var("local_timezone") }}')

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
@@ -77,16 +77,16 @@ with
         inner join
             {{ ref("stg_powerschool__sectionteacher") }} as st
             on sec.sections_id = st.sectionid
-            and {{ union_dataset_join_clause(left_alias="sec", right_alias="st") }}
+            and sec._dbt_source_project = st._dbt_source_project
         inner join
             {{ ref("stg_powerschool__roledef") }} as r
             on st.roleid = r.id
-            and {{ union_dataset_join_clause(left_alias="st", right_alias="r") }}
+            and st._dbt_source_project = r._dbt_source_project
         inner join
             {{ ref("int_powerschool__teachers") }} as t
             on st.teacherid = t.id
             and sec.sections_schoolid = t.schoolid
-            and {{ union_dataset_join_clause(left_alias="st", right_alias="t") }}
+            and st._dbt_source_project = t._dbt_source_project
         where
             sec.terms_yearid = ({{ var("current_academic_year") - 1990 }})
             and sec._dbt_source_relation not like '%kipppaterson%'

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__designations.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__designations.sql
@@ -2,6 +2,7 @@ with
     student_enrollments as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_number,
             studentid,
             yearid,
@@ -47,13 +48,13 @@ with
             {{ ref("int_powerschool__gpa_term") }} as gpa
             on co.studentid = gpa.studentid
             and co.yearid = gpa.yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+            and co._dbt_source_project = gpa._dbt_source_project
             and rt.name = gpa.term_name
         left join
             {{ ref("int_powerschool__final_grades_rollup") }} as ps
             on co.studentid = ps.studentid
             and co.academic_year = ps.academic_year
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="ps") }}
+            and co._dbt_source_project = ps._dbt_source_project
             and rt.name = ps.storecode
     )
 
@@ -63,7 +64,7 @@ inner join
     {{ ref("int_powerschool__spenrollments") }} as sp
     on co.studentid = sp.studentid
     and co.academic_year = sp.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="sp") }}
+    and co._dbt_source_project = sp._dbt_source_project
     and sp.is_current
     and sp.specprog_name in (
         'Counseling Services',

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__final_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__final_grades.sql
@@ -3,6 +3,7 @@ with
     enr as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.cc_studentid,
             enr.cc_yearid,
             enr.cc_academic_year,
@@ -48,6 +49,7 @@ with
     enr_fg as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.students_student_number,
             enr.cc_studentid,
             enr.cc_yearid,
@@ -119,7 +121,7 @@ with
             and enr.cc_yearid = fg.yearid
             and enr.cc_course_number = fg.course_number
             and enr.term_name = fg.storecode
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="fg") }}
+            and enr._dbt_source_project = fg._dbt_source_project
     )
 
 select
@@ -244,14 +246,14 @@ left join
     and enr.cc_schoolid = cat.schoolid
     and enr.term_code = cat.reporting_term
     and enr.cc_course_number = cat.course_number
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="cat") }}
+    and enr._dbt_source_project = cat._dbt_source_project
 left join
     {{ ref("int_powerschool__category_grades_pivot") }} as kctz
     on enr.cc_studentid = kctz.studentid
     and enr.cc_yearid = kctz.yearid
     and enr.cc_schoolid = cat.schoolid
     and enr.term_name = kctz.reporting_term
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="kctz") }}
+    and enr._dbt_source_project = kctz._dbt_source_project
     and kctz.course_number = 'HR'
     and left(enr.sections_section_number, 1) = '0'
 left join
@@ -259,12 +261,12 @@ left join
     on enr.cc_studentid = comm.studentid
     and enr.cc_sectionid = comm.sectionid
     and enr.term_name = comm.finalgradename
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="comm") }}
+    and enr._dbt_source_project = comm._dbt_source_project
 left join
     {{ ref("stg_powerschool__storedgrades") }} as sgy1
     on enr.cc_studentid = sgy1.studentid
     and enr.cc_academic_year = sgy1.academic_year
     and enr.cc_course_number = sgy1.course_number
-    and {{ union_dataset_join_clause(left_alias="enr", right_alias="sgy1") }}
+    and enr._dbt_source_project = sgy1._dbt_source_project
     and enr.term_name = 'Q4'
     and sgy1.storecode = 'Y1'

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__hs_transcript_programs.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__hs_transcript_programs.sql
@@ -10,7 +10,7 @@ from {{ ref("stg_powerschool__students") }} as s
 inner join
     {{ ref("int_powerschool__spenrollments") }} as sp
     on s.id = sp.studentid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="sp") }}
+    and s._dbt_source_project = sp._dbt_source_project
     and sp.specprog_name like 'High School%'
     and sp.rn_student_program_year_desc = 1
 where s.grade_level >= 9  /* needs to include grade_level = 99 */

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__state_test_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__state_test_scores.sql
@@ -46,5 +46,5 @@ from {{ ref("stg_powerschool__students") }} as co
 inner join
     {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
     on co.dcid = suf.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="suf") }}
+    and co._dbt_source_project = suf._dbt_source_project
 inner join {{ ref("stg_fldoe__fast") }} as fl on suf.fleid = fl.student_id

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__student_misc.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__student_misc.sql
@@ -1,6 +1,6 @@
 with
     ug_school as (
-        select studentid, schoolid, _dbt_source_relation,
+        select studentid, schoolid, _dbt_source_relation, _dbt_source_project,
         from {{ ref("int_extracts__student_enrollments") }}
         where rn_undergrad = 1 and grade_level != 99
     ),
@@ -10,16 +10,18 @@ with
             studentid,
             schoolid,
             _dbt_source_relation,
+            _dbt_source_project,
 
             min(entrydate) as school_entrydate,
             max(exitdate) as school_exitdate,
         from {{ ref("int_extracts__student_enrollments") }}
-        group by studentid, schoolid, _dbt_source_relation
+        group by studentid, schoolid, _dbt_source_relation, _dbt_source_project
     ),
 
     students as (
         select
             co._dbt_source_relation,
+            co._dbt_source_project,
             co.studentid,
             co.student_number,
             co.state_studentnumber as `SID`,
@@ -87,24 +89,24 @@ with
         inner join
             ug_school as ug
             on co.studentid = ug.studentid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="ug") }}
+            and co._dbt_source_project = ug._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gpa
             on co.studentid = gpa.studentid
             and co.yearid = gpa.yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+            and co._dbt_source_project = gpa._dbt_source_project
             and gpa.is_current
         left join
             {{ ref("stg_powerschool__schools") }} as sch
             on co.schoolid = sch.school_number
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="sch") }}
+            and co._dbt_source_project = sch._dbt_source_project
         where co.academic_year = {{ var("current_academic_year") }} and co.rn_year = 1
     )
 
-select co.*, ed.school_entrydate, ed.school_exitdate,
+select co.* except (_dbt_source_project), ed.school_entrydate, ed.school_exitdate,
 from students as co
 left join
     enroll_dates as ed
     on co.studentid = ed.studentid
     and co.schoolid = ed.schoolid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="ed") }}
+    and co._dbt_source_project = ed._dbt_source_project

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_gpas.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_gpas.sql
@@ -15,10 +15,10 @@ with
         inner join
             {{ ref("stg_powerschool__students") }} as s
             on sg.studentid = s.id
-            and {{ union_dataset_join_clause(left_alias="sg", right_alias="s") }}
+            and sg._dbt_source_project = s._dbt_source_project
         left outer join
             {{ ref("int_powerschool__gradescaleitem_lookup") }} as suw
-            on {{ union_dataset_join_clause(left_alias="sg", right_alias="suw") }}
+            on sg._dbt_source_project = suw._dbt_source_project
             and sg.percent between suw.min_cutoffpercentage and suw.max_cutoffpercentage
             and sg.gradescale_name_unweighted = suw.gradescale_name
         where sg.storecode = 'Y1' and sg.excludefromgpa = 0

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__transcript_grades.sql
@@ -22,7 +22,7 @@ with
         inner join
             {{ ref("stg_powerschool__students") }} as s
             on sg.studentid = s.id
-            and {{ union_dataset_join_clause(left_alias="sg", right_alias="s") }}
+            and sg._dbt_source_project = s._dbt_source_project
         where ifnull(sg.excludefromtranscripts, 0) = 0 and sg.storecode = 'Y1'
 
         union all
@@ -53,18 +53,18 @@ with
         inner join
             {{ ref("base_powerschool__final_grades") }} as fg
             on s.id = fg.studentid
-            and {{ union_dataset_join_clause(left_alias="s", right_alias="fg") }}
+            and s._dbt_source_project = fg._dbt_source_project
             and fg.exclude_from_gpa = 0
             and current_date('{{ var("local_timezone") }}')
             between fg.termbin_start_date and fg.termbin_end_date
         inner join
             {{ ref("stg_powerschool__courses") }} as c
             on c.course_number = fg.course_number
-            and {{ union_dataset_join_clause(left_alias="c", right_alias="fg") }}
+            and c._dbt_source_project = fg._dbt_source_project
         inner join
             {{ ref("stg_powerschool__schools") }} as sch
             on s.schoolid = sch.school_number
-            and {{ union_dataset_join_clause(left_alias="s", right_alias="sch") }}
+            and s._dbt_source_project = sch._dbt_source_project
         where s.grade_level >= 5
     )
 

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__absence_streak_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__absence_streak_roster.sql
@@ -23,12 +23,12 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as co
     on st.studentid = co.studentid
     and st.yearid = co.yearid
-    and {{ union_dataset_join_clause(left_alias="st", right_alias="co") }}
+    and st._dbt_source_project = co._dbt_source_project
 left join
     {{ ref("int_deanslist__comm_log") }} as c
     on co.student_number = c.student_school_id
     and c.call_date between st.streak_start_date and st.streak_end_date
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="c") }}
+    and co._dbt_source_project = c._dbt_source_project
     and c.reason like 'Att:%'
 where
     st.att_code in ('A', 'AD', 'M')

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
@@ -42,7 +42,7 @@ left join
     {{ ref("int_students__athletic_eligibility") }} as a
     on e.academic_year = a.academic_year
     and e.student_number = a.student_number
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="a") }}
+    and e._dbt_source_project = a._dbt_source_project
 where
     e.academic_year = {{ var("current_academic_year") }}
     and e.grade_level >= 5

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__award_ceremony_gpa.sql
@@ -19,7 +19,7 @@ with
         inner join
             {{ ref("base_powerschool__student_enrollments") }} as co
             on sg.studentid = co.studentid
-            and {{ union_dataset_join_clause(left_alias="sg", right_alias="co") }}
+            and sg._dbt_source_project = co._dbt_source_project
             and sg.schoolid = co.schoolid
             and co.grade_level >= 9
             and co.rn_year = 1
@@ -53,7 +53,7 @@ with
         inner join
             {{ ref("base_powerschool__student_enrollments") }} as co
             on fg.studentid = co.studentid
-            and {{ union_dataset_join_clause(left_alias="fg", right_alias="co") }}
+            and fg._dbt_source_project = co._dbt_source_project
             and fg.schoolid = co.schoolid
             and fg.academic_year = co.academic_year
             and co.grade_level >= 9

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_offerings.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_offerings.sql
@@ -16,7 +16,7 @@ with
             {{ ref("base_powerschool__course_enrollments") }} as s
             on e.academic_year = s.cc_academic_year
             and e.studentid = s.cc_studentid
-            and {{ union_dataset_join_clause(left_alias="e", right_alias="s") }}
+            and e._dbt_source_project = s._dbt_source_project
             and s.rn_course_number_year = 1
             and s.is_ap_course
             and not s.is_dropped_section

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_enrollment.sql
@@ -217,7 +217,7 @@ with
             on c.cc_academic_year = g.academic_year
             and c.sections_id = g.sectionid
             and c.cc_studentid = g.studentid
-            and {{ union_dataset_join_clause(left_alias="c", right_alias="g") }}
+            and c._dbt_source_project = g._dbt_source_project
             and g.storecode = 'Y1'
         left join
             {{ ref("stg_google_sheets__crdc__sced_code_crosswalk") }} as x

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_flags_report.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_flags_report.sql
@@ -18,7 +18,7 @@ with
             {{ ref("base_powerschool__student_enrollments") }} as e
             on g.studentid = e.studentid
             and g.schoolid = e.schoolid
-            and {{ union_dataset_join_clause(left_alias="g", right_alias="e") }}
+            and g._dbt_source_project = e._dbt_source_project
         where
             e.academic_year = {{ var("current_academic_year") }}
             and e.enroll_status = 0

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
@@ -33,19 +33,19 @@ with
             and co.yearid = y.yearid
             and co.schoolid = y.schoolid
             and y.is_current
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="y") }}
+            and co._dbt_source_project = y._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gpa
             on co.studentid = gpa.studentid
             and co.yearid = gpa.yearid
             and term = gpa.term_name
             and co.schoolid = gpa.schoolid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+            and co._dbt_source_project = gpa._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_cumulative") }} as gc
             on co.studentid = gc.studentid
             and co.schoolid = gc.schoolid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="gc") }}
+            and co._dbt_source_project = gc._dbt_source_project
         where
             co.academic_year = {{ var("current_academic_year") }}
             and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__grad_plan_tracking.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__grad_plan_tracking.sql
@@ -77,7 +77,7 @@ from {{ ref("int_extracts__student_enrollments") }} as e
 inner join
     {{ ref("int_powerschool__gpprogress_grades") }} as g
     on e.students_dcid = g.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="e", right_alias="g") }}
+    and e._dbt_source_project = g._dbt_source_project
     and g.plan_name in ('NJ State Diploma', 'HS Distinction Diploma')
 where
     e.academic_year = {{ var("current_academic_year") }}

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
@@ -2,6 +2,7 @@ with
     fast_concat as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_id,
             academic_year,
 
@@ -13,6 +14,7 @@ with
     fast_pivot as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             student_id,
             academic_year,
             ela_pm1,
@@ -73,18 +75,18 @@ left join
     fast_pivot as fp
     on co.state_studentnumber = fp.student_id
     and co.academic_year = fp.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="fp") }}
+    and co._dbt_source_project = fp._dbt_source_project
 left join
     fast_pivot as fp_prev
     on co.state_studentnumber = fp_prev.student_id
     and co.academic_year - 1 = fp_prev.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="fp_prev") }}
+    and co._dbt_source_project = fp_prev._dbt_source_project
 left join
     {{ ref("int_powerschool__gpa_term") }} as gpa
     on co.studentid = gpa.studentid
     and co.yearid = gpa.yearid
     and co.schoolid = gpa.schoolid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
 where
     co.rn_year = 1
     and co.region = 'Miami'

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__mtss_rti.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__mtss_rti.sql
@@ -118,7 +118,7 @@ with
             on co.studentid = g.studentid
             and co.schoolid = g.schoolid
             and co.yearid = g.yearid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="g") }}
+            and co._dbt_source_project = g._dbt_source_project
             and g.is_current
         left join
             {{ ref("int_deanslist__referral_suspension_rollup") }} as sr

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nj_state_test_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nj_state_test_roster.sql
@@ -104,7 +104,7 @@ with
         left join
             {{ ref("stg_powerschool__s_nj_stu_x") }} as nj
             on co.students_dcid = nj.studentsdcid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="nj") }}
+            and co._dbt_source_project = nj._dbt_source_project
         where
             co.academic_year = {{ var("current_academic_year") }}
             and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__school_metrics_extract.sql
@@ -414,6 +414,7 @@ with
     section_enrollments as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.cc_studentid,
             enr.cc_yearid,
             enr.cc_sectionid,
@@ -447,7 +448,13 @@ with
     -- section records still resolve to a school/region even when their latest
     -- enrollment row has enroll_status != 0.
     section_school_context as (
-        select distinct _dbt_source_relation, studentid, schoolid, school, region,
+        select distinct
+            _dbt_source_relation,
+            _dbt_source_project,
+            studentid,
+            schoolid,
+            school,
+            region,
         from {{ ref("int_extracts__student_enrollments") }}
         where academic_year = {{ var("current_academic_year") }} and grade_level <= 8
     ),
@@ -455,6 +462,7 @@ with
     section_teacher_manager_raw as (
         select
             enr._dbt_source_relation,
+            enr._dbt_source_project,
             enr.cc_sectionid,
 
             sr.formatted_name as teacher_name,
@@ -464,7 +472,7 @@ with
         left join
             {{ ref("base_powerschool__sections") }} as sec
             on enr.cc_sectionid = sec.sections_id
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="sec") }}
+            and enr._dbt_source_project = sec._dbt_source_project
         left join
             {{ ref("int_people__staff_roster") }} as sr
             on sec.teachernumber = sr.powerschool_teacher_number
@@ -502,16 +510,16 @@ with
             on enr.cc_studentid = fg.studentid
             and enr.cc_yearid = fg.yearid
             and enr.cc_sectionid = fg.sectionid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="fg") }}
+            and enr._dbt_source_project = fg._dbt_source_project
         inner join
             section_school_context as sc
             on enr.cc_studentid = sc.studentid
             and enr.cc_schoolid = sc.schoolid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="sc") }}
+            and enr._dbt_source_project = sc._dbt_source_project
         left join
             section_teacher_manager as stm
             on enr.cc_sectionid = stm.cc_sectionid
-            and {{ union_dataset_join_clause(left_alias="enr", right_alias="stm") }}
+            and enr._dbt_source_project = stm._dbt_source_project
         -- storecode filter on right-side column makes the fg LEFT JOIN an
         -- effective INNER JOIN: sections with no final-grade records are
         -- silently excluded. This is intentional — failure rate is undefined

--- a/src/dbt/kipptaf/models/extracts/littlesis/rpt_littlesis__enrollments.sql
+++ b/src/dbt/kipptaf/models/extracts/littlesis/rpt_littlesis__enrollments.sql
@@ -38,7 +38,7 @@ inner join
 inner join
     {{ ref("stg_powerschool__schools") }} as sch
     on sec.sections_schoolid = sch.school_number
-    and {{ union_dataset_join_clause(left_alias="sec", right_alias="sch") }}
+    and sec._dbt_source_project = sch._dbt_source_project
 inner join staff_roster as scw on sec.teachernumber = scw.powerschool_teacher_number
 where
     sec.cc_academic_year = {{ var("current_academic_year") }}

--- a/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_teachers.sql
@@ -71,7 +71,7 @@ with
         left join
             {{ ref("stg_powerschool__userscorefields") }} as ucf
             on u.dcid = ucf.usersdcid
-            and {{ union_dataset_join_clause(left_alias="u", right_alias="ucf") }}
+            and u._dbt_source_project = ucf._dbt_source_project
         /* import terminated staff up to 2 weeks after termination date */
         where sr.days_after_termination <= 14
 

--- a/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__dibels_pm_expectations.sql
+++ b/src/dbt/kipptaf/models/google/sheets/intermediate/int_google_sheets__dibels_pm_expectations.sql
@@ -15,7 +15,7 @@ with
             {{ ref("stg_powerschool__calendar_day") }} as c
             on s.school_number = c.schoolid
             and c.insession = 1
-            and {{ union_dataset_join_clause(left_alias="s", right_alias="c") }}
+            and s._dbt_source_project = c._dbt_source_project
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as t
             on s.schoolcity = t.region


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR continues **Batch 2** (consumer join swaps) of the #3142 `_dbt_source_project` migration — the second directory-scoped PR, covering the **extracts reporting layer**: gsheets, deanslist, clever, powerschool autocomm, and littlesis.

It swaps the `union_dataset_join_clause` macro for the direct materialized-column equality `a._dbt_source_project = b._dbt_source_project`. Behavior-preserving: `_dbt_source_project` equals `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` by construction, so the new predicate is algebraically identical to the macro.

**Scope:** 24 files, 50 macro calls swapped. All build-verified (see Self-review).

Where a consuming CTE selected explicit columns (it already projected `_dbt_source_relation` for the old macro), `_dbt_source_project` was threaded through alongside it from the same source — no re-derivation.

One contract-specific case: `rpt_deanslist__student_misc` needed `_dbt_source_project` threaded into its `co` CTE for the join, but its final `select co.*` would then emit the column, which is not in the model contract. Kept it out of the output with `select co.* except (_dbt_source_project)` (the same idiom used for `source_file_name` in staging) — the internal join key is used but not surfaced, so the contracted output is unchanged.

### Deferred to a follow-up PR

Two reports were left on the macro (fully reverted) because a join operand does not yet expose `_dbt_source_project` and needs a producer fix first:

- `rpt_powerschool__autocomm_students` — joins `int_students__graduation_path_codes`, which does not project the column.
- `rpt_deanslist__promo_status` — joins `int_powerschool__log`, which projects `_dbt_source_relation` only.

Both producers will get the column in a follow-up, after which these two consumers can be swapped atomically.

### Note on line counts

Two files (`rpt_gsheets__gpa_flags_report`, `int_google_sheets__dibels_pm_expectations`) were CRLF on `main` and normalize to LF here (sqlfmt does this at commit regardless), inflating their diffs. **Review with whitespace hidden.**

## AI Assistance

AI-assisted (Claude Code), human-directed. The swap is mechanical; column-threading and the two deferrals were driven by an `--empty` gate build against prod upstreams.

## Self-review

### dbt

- [x] No new models; the swap changes join predicates only. `rpt_deanslist__student_misc` keeps its contracted output identical (the threaded column is `except`-ed out).
- [x] **Not a breaking change** — no contracted column renamed or removed.
- [x] No external sources changed.
- [x] Column-resolution gate: the changed set passes `dbt build --empty --defer --favor-state --state <prod>` with 0 errors (every `_dbt_source_project` reference resolves against prod upstreams, no data scanned; contracts enforced under `--empty`). Behavior equivalence holds by algebraic identity.
- [x] `trunk check --force` clean (no new issues) on all 24 files.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
