### PR TITLE
refactor(dbt): expose _dbt_source_project on int_powerschool__log and int_pearson__student_list_report

### DIFF
--- a/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__student_list_report.sql
+++ b/src/dbt/kipptaf/models/pearson/intermediate/int_pearson__student_list_report.sql
@@ -2,6 +2,7 @@ with
     scores as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             state_student_identifier,
             local_student_identifier,

--- a/src/dbt/kipptaf/models/pearson/intermediate/properties/int_pearson__student_list_report.yml
+++ b/src/dbt/kipptaf/models/pearson/intermediate/properties/int_pearson__student_list_report.yml
@@ -21,6 +21,10 @@ models:
         data_type: string
         description: Source relation identifier from dbt_utils.union_relations.
 
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
+
       - name: academic_year
         data_type: int64
         description: Academic year the assessment was administered.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__log.sql
@@ -1,5 +1,6 @@
 select
     log._dbt_source_relation,
+    log._dbt_source_project,
     log.studentid,
     log.dcid,
     log.logtypeid,
@@ -13,4 +14,4 @@ inner join
     {{ ref("stg_powerschool__gen") }} as gen
     on log.logtypeid = gen.id
     and gen.cat = 'logtype'
-    and {{ union_dataset_join_clause(left_alias="log", right_alias="gen") }}
+    and log._dbt_source_project = gen._dbt_source_project

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__log.yml
@@ -5,6 +5,9 @@ models:
         data_type: int64
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: studentid
         data_type: int64
       - name: logtypeid


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR starts the **producer-intermediate wave** of the #3142 `_dbt_source_project` migration — a follow-on to #4516 that exposes the column on more join-target intermediates so their downstream consumers can be swapped off the `union_dataset_join_clause` macro.

It handles the two cleanly-independent **deferred-report blockers** (their upstreams already expose `_dbt_source_project` in prod):

- **`int_powerschool__log`** — passes the column through from `stg_powerschool__log` (`log._dbt_source_project`) and swaps its own internal macro join to `log._dbt_source_project = gen._dbt_source_project`. Unblocks `rpt_deanslist__promo_status`.
- **`int_pearson__student_list_report`** — threads `_dbt_source_project` through the `scores` CTE from `stg_pearson__student_list_report` (the final `select *` carries it to output). Unblocks `rpt_tableau__state_assessments_dashboard`.

Behavior-preserving: `_dbt_source_project` equals `regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` by construction, so the `int_powerschool__log` join swap is algebraically identical to the macro; the pearson change is purely additive (a column that was dropped by an explicit-column re-select is restored).

Each model's properties.yml gains a `_dbt_source_project` column entry (the doc convention for a materialized column).

## AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### dbt

- [x] Both models now **expose** `_dbt_source_project` in their output — verified against `INFORMATION_SCHEMA.COLUMNS` on the dev-built views, not just a successful compile.
- [x] `int_powerschool__log` internal macro swap is algebraically identical (both operands are cross-district powerschool unions that carry the column in prod).
- [x] Not a breaking change — additive column plus one equivalent join-predicate swap.
- [x] Column-resolution gate: `dbt build --empty --defer --favor-state --state <prod>` passes with 0 errors.
- [x] `trunk check --force` clean on all 4 files.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
