### PR TITLE
refactor(dbt): expose _dbt_source_project on int_students__graduation_path_codes

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__graduation_path_codes.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__graduation_path_codes.sql
@@ -2,6 +2,7 @@ with
     students as (
         select
             e._dbt_source_relation,
+            e._dbt_source_project,
             e.students_dcid,
             e.studentid,
             e.student_number,
@@ -120,6 +121,7 @@ with
     lookup_table as (
         select
             s._dbt_source_relation,
+            s._dbt_source_project,
             s.students_dcid,
             s.studentid,
             s.student_number,
@@ -170,6 +172,7 @@ with
 
         select
             s._dbt_source_relation,
+            s._dbt_source_project,
             s.students_dcid,
             s.studentid,
             s.student_number,
@@ -358,6 +361,7 @@ with
     roster as (
         select
             l._dbt_source_relation,
+            l._dbt_source_project,
             l.students_dcid,
             l.studentid,
             l.student_number,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
@@ -10,6 +10,9 @@ models:
     columns:
       - name: _dbt_source_relation
         data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
       - name: students_dcid
         data_type: int64
       - name: studentsid


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Continues the producer-intermediate wave of the #3142 `_dbt_source_project`
migration (follow-on to #4516 / #4533). Exposes `_dbt_source_project` on
`int_students__graduation_path_codes` so its downstream consumers can later be
swapped off the `union_dataset_join_clause` macro.

`int_students__graduation_path_codes` is a join-target for two consumers that
still call the macro against it:

- `int_kippadb__roster` (its `dlm`/`d` alias, macro `se`/`d`)
- `rpt_powerschool__autocomm_students` (its `grad_path`/`g` alias, macro `se`/`g`)

Both stay on the macro for now; this PR only makes the column available so those
swaps become valid once this merges and rematerializes in prod.

## Approach

Pure pass-through — no re-derivation. `_dbt_source_project` is threaded from the
already-exposing upstream `int_extracts__student_enrollments_subjects` (aliased
`e`, which emits the column via `co.*` in prod) down the existing column chain:

- `students` CTE — `e._dbt_source_project`
- `lookup_table` CTE — `s._dbt_source_project` (both UNION ALL branches)
- `roster` CTE — `l._dbt_source_project`
- final `select r.*` carries it to output

This follows the repo's pass-through rule (`extract_source_project()` belongs
only at the union view; downstream join-targets select the materialized column
through). Behavior-preserving: purely additive column, no join logic changed.

`_dbt_source_project` reaches output via the direct `lookup_table -> roster`
path and never enters the downstream pivots (`unpivot_calcs` / `met_subject`
don't select it), so the model's `distinct_count(grad_eligibility by
student_number)` grain is unaffected (it is functionally determined by
`_dbt_source_relation` regardless).

## AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### dbt

- [x] Column resolution gate: `dbt build --empty --defer --favor-state --state <prod>`
      passes with 0 errors (validates `e`/`s`/`l._dbt_source_project` resolve
      against prod upstreams).
- [x] Pass-through, not re-derived — sourced from `int_extracts__student_enrollments_subjects`.
- [x] Not a breaking change — one additive column threaded through existing CTEs;
      no join predicate changed.
- [x] `properties.yml` gains the `_dbt_source_project` column entry (doc
      convention for a materialized column).
- [x] `trunk check --force` clean.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
