### PR TITLE
refactor(dbt): expose _dbt_source_project on int_finance__enrollment_targets

### DIFF
--- a/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
+++ b/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
@@ -18,7 +18,7 @@ select
     sch._dbt_source_project,
 
     '`{{ target.database }}`.`'
-    || regexp_extract(sch._dbt_source_relation, r'(kipp\w+)_')
+    || sch._dbt_source_project
     || '_powerschool'
     || '`.`base_powerschool__student_enrollments`' as _dbt_source_relation,
 from {{ ref("stg_google_sheets__finance__enrollment_targets") }} as et

--- a/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
+++ b/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
@@ -15,6 +15,8 @@ select
     et.lep_only_ratio,
     et.sped_ratio,
 
+    sch._dbt_source_project,
+
     '`{{ target.database }}`.`'
     || regexp_extract(sch._dbt_source_relation, r'(kipp\w+)_')
     || '_powerschool'

--- a/src/dbt/kipptaf/models/finance/intermediate/properties/int_finance__enrollment_targets.yml
+++ b/src/dbt/kipptaf/models/finance/intermediate/properties/int_finance__enrollment_targets.yml
@@ -1,0 +1,52 @@
+models:
+  - name: int_finance__enrollment_targets
+    description: >-
+      Financial-model enrollment targets by school, grade level, and academic
+      year, sourced from the finance enrollment-targets Google Sheet and joined
+      to PowerSchool schools to resolve the source district.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - academic_year
+              - schoolid
+              - grade_level
+    columns:
+      - name: _dbt_source_relation
+        data_type: string
+        description: >-
+          Synthesized relation path referencing the source district's
+          base_powerschool__student_enrollments, used for cross-district joins.
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
+      - name: fiscal_year
+        data_type: int64
+      - name: academic_year
+        data_type: int64
+      - name: region
+        data_type: string
+      - name: schoolid
+        data_type: int64
+      - name: school_name
+        data_type: string
+      - name: grade_level
+        data_type: int64
+      - name: target_enrollment
+        data_type: int64
+      - name: adjustment
+        data_type: int64
+      - name: attrition_factor
+        data_type: float64
+      - name: financial_model_enrollment
+        data_type: float64
+      - name: grade_band_ratio
+        data_type: float64
+      - name: at_risk_and_lep_ratio
+        data_type: float64
+      - name: at_risk_only_ratio
+        data_type: float64
+      - name: lep_only_ratio
+        data_type: float64
+      - name: sped_ratio
+        data_type: float64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Producer-intermediate wave of the #3142 `_dbt_source_project` migration (follows
#4516 / #4533 / #4537). Exposes `_dbt_source_project` on
`int_finance__enrollment_targets` so its downstream consumer can later be swapped
off the `union_dataset_join_clause` macro.

Consumer still on the macro (not touched here): `rpt_tableau__ops_dashboard` (its
`target_union` -> `t` alias, macro `se`/`t`).

## Approach

`int_finance__enrollment_targets` already synthesizes a `_dbt_source_relation`
from `regexp_extract(sch._dbt_source_relation, ...)`. This adds the matching
materialized `_dbt_source_project` as a pass-through from
`stg_powerschool__schools` (`sch._dbt_source_project`), which equals that same
region by construction — so the exposed column and the synthetic relation stay
consistent.

Also adds a `properties.yml` (the model had none): model description, a grain
uniqueness test, and the `_dbt_source_project` doc entry.

## Verification

- Built into dev against prod-deferred upstreams (reads the finance sheet live
  via ADC): the view creates and `sch._dbt_source_project` resolves.
- Grain confirmed empirically: 641 rows, `(academic_year, schoolid,
  grade_level)` is exactly unique (no fan-out on the `et.schoolid =
  sch.school_number` join), and `_dbt_source_project` is never null (3
  districts). The `dbt_utils.unique_combination_of_columns` test passes on real
  data.

## Scope note

The finance-modeling columns (`grade_band_ratio`, `at_risk_and_lep_ratio`,
`attrition_factor`, etc.) are listed name + type only, mirroring the staging
source yml (`stg_google_sheets__finance__enrollment_targets`), which carries no
column descriptions. Prose descriptions for those need finance-domain input and
are out of scope for this migration PR.

## AI Assistance

AI-assisted (Claude Code), human-directed.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
