### PR TITLE
ci(deploy): fix push-path drift and harden workflow jobs

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -9,7 +9,6 @@ on:
       - src/**
       - tests/**
       - scripts/**
-      - mcp/**
       - "!**/*.md"
 
 jobs:
@@ -17,6 +16,7 @@ jobs:
     if: github.actor != 'dependabot[bot]' && !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -20,6 +20,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dagster-cloud-deploy.yaml
+++ b/.github/workflows/dagster-cloud-deploy.yaml
@@ -48,6 +48,7 @@ jobs:
   prerun:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_AGENT_TOKEN }}
     outputs:
@@ -70,6 +71,7 @@ jobs:
           - linux-amd64
           - linux-arm64
     runs-on: teamschools-${{ matrix.runner }}
+    timeout-minutes: 60
     steps:
       - name: Prepare
         run: |
@@ -133,6 +135,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - prerun
       - build
@@ -174,6 +177,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - prerun
       - build

--- a/.github/workflows/deploy-cube-mcp.yaml
+++ b/.github/workflows/deploy-cube-mcp.yaml
@@ -33,6 +33,7 @@ jobs:
   deploy:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/deploy-prod-kippcamden.yaml
+++ b/.github/workflows/deploy-prod-kippcamden.yaml
@@ -29,12 +29,12 @@ on:
       - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/edplan/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/google/drive/resources.py
       - src/teamster/libraries/overgrad/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/odbc/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**
       - src/teamster/libraries/titan/**
@@ -51,12 +51,12 @@ on:
       - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/edplan/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/google/drive/resources.py
       - src/teamster/libraries/overgrad/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/odbc/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**
       - src/teamster/libraries/titan/**

--- a/.github/workflows/deploy-prod-kippnewark.yaml
+++ b/.github/workflows/deploy-prod-kippnewark.yaml
@@ -33,13 +33,13 @@ on:
       - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/edplan/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/google/drive/resources.py
       - src/teamster/libraries/iready/**
       - src/teamster/libraries/overgrad/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/odbc/**
       - src/teamster/libraries/renlearn/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**
@@ -59,12 +59,12 @@ on:
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/dbt/**
       - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/edplan/**
       - src/teamster/libraries/google/drive/resources.py
       - src/teamster/libraries/iready/**
       - src/teamster/libraries/overgrad/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/odbc/**
       - src/teamster/libraries/renlearn/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**

--- a/.github/workflows/deploy-prod-kipppaterson.yaml
+++ b/.github/workflows/deploy-prod-kipppaterson.yaml
@@ -16,6 +16,7 @@ on:
       - Dockerfile
       - uv.lock
       - src/dbt/amplify/**
+      - src/dbt/deanslist/**
       - src/dbt/finalsite/**
       - src/dbt/kipppaterson/**
       - src/dbt/pearson/**
@@ -24,10 +25,12 @@ on:
       - src/teamster/core/**
       - src/teamster/libraries/amplify/**
       - src/teamster/libraries/couchdrop/**
+      - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
+      - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/sftp/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**
       - "!**/CLAUDE.md"
@@ -41,10 +44,12 @@ on:
       - src/teamster/core/**
       - src/teamster/libraries/amplify/**
       - src/teamster/libraries/couchdrop/**
+      - src/teamster/libraries/extracts/**
       - src/teamster/libraries/dbt/**
+      - src/teamster/libraries/deanslist/**
+      - src/teamster/libraries/dlt/**
       - src/teamster/libraries/finalsite/**
       - src/teamster/libraries/pearson/**
-      - src/teamster/libraries/powerschool/sis/sftp/**
       - src/teamster/libraries/sftp/**
       - src/teamster/libraries/ssh/**
       - "!**/CLAUDE.md"

--- a/.github/workflows/mkdocs-gh-deploy.yaml
+++ b/.github/workflows/mkdocs-gh-deploy.yaml
@@ -14,10 +14,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -19,6 +19,7 @@ jobs:
     name: Trunk Check Runner
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       checks: write # For trunk to post annotations
       contents: read # For repo checkout


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this PR fixes deploy push-path drift and hardens the GitHub Actions workflows. It came out of a full review of `.github/workflows/`; every finding below was verified against the code before editing.

**Critical — push-path drift** (silently strands a prod district on stale code when a shared path changes; same class as #4175 and #4216/#4219):

- `deploy-prod-kipppaterson.yaml`: add `src/dbt/deanslist/**`. Paterson's `packages.yml` declares `../deanslist`, but the dbt package was missing from its push paths.
- `deploy-prod-kippcamden.yaml`, `deploy-prod-kippnewark.yaml`, `deploy-prod-kipppaterson.yaml`: add `src/teamster/libraries/dlt/**`. All three import `teamster.libraries.dlt.powerschool` since the PowerSchool SIS to dlt migration, but only kippmiami listed the path.
- `deploy-prod-kipppaterson.yaml`: add `src/teamster/libraries/deanslist/**` and `src/teamster/libraries/extracts/**`. Both are imported by Paterson; neither was listed.

**Cleanup and hardening:**

- Drop the orphaned `powerschool/sis/{odbc,sftp}/**` library paths from Camden/Newark/Paterson (verified: no importers remain repo-wide after the dlt migration).
- Add `timeout-minutes` backstops to every job that can take one. The `deploy-prod-*` jobs are reusable-workflow calls and cannot, so the deploy-pipeline backstops live in `dagster-cloud-deploy.yaml` (prerun 5, build 60, merge 15, deploy 30).
- Add a `concurrency` group to `mkdocs-gh-deploy.yaml` (it force-pushes `gh-pages`).
- Remove the dead `mcp/**` path filter from `claude-code-review.yaml` — there is no top-level `mcp/`; the MCP code lives under `src/cube/mcp`, already covered by `src/**`.

**Deferred to follow-ups** (not in this PR): the automated push-path drift-guard CI check, and the `upload-artifact` v7 / `download-artifact` v8 major-version skew (both already SHA-pinned and Dependabot-managed).

## AI Assistance

AI-assisted (Claude Code): reviewed the workflows, verified each finding against the code (`packages.yml` locals, library imports, repo-wide importer greps), and made the edits. Human-directed: the review scope and the decision to defer the drift-guard to a separate PR.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [x] Claude Code Review: note that `claude-code-review` only triggers on `src/`, `tests/`, `scripts/` changes, so it will not auto-run on this `.github/`-only PR.

## CI checks

- [x] Trunk — passes (`trunk check --force` run locally on all 9 files: no issues).
- [ ] Dagster Cloud — not triggered while this PR is a draft. `dagster-cloud-deploy.yaml` is a shared `pull_request` path for all five locations, so marking this ready-for-review will fan out branch-deploy builds to all five.
