### PR TITLE
refactor(dbt): swap union_dataset_join_clause in big-fanout intermediates

### DIFF
--- a/docs/superpowers/plans/2026-07-22-dbt-source-project-completion.md
+++ b/docs/superpowers/plans/2026-07-22-dbt-source-project-completion.md
@@ -398,6 +398,71 @@ non-producer `extract_source_project` filter/alias sites in
 `int_students__fldoe_fte` — done in 2e with `int_students__` — and
 `qa_edplan__powerschool_mismatch` to plain `_dbt_source_project` refs.)
 
+### Revised cut for the remaining work (2026-07-24)
+
+The directory cut above (`2a-1` … `2f`) is **superseded** for whatever is still
+unswapped. It was sized when Batch 1 producers had not merged and ~80 files were
+in flight; that ordering constraint is gone, so every remaining change is
+self-contained within its own file. The binding constraints now are (a) whether
+a file can be build-verified and (b) descendant fan-out, which sets CI cost.
+Counts below come from the prod manifest `child_map`.
+
+#### PR A — big-fanout intermediates
+
+`int_students__contacts`, `int_powerschool__ps_adaadm_daily_ctod`,
+`int_extracts__student_enrollments_subjects`, `int_kippadb__roster`,
+`int_reporting__promotional_status`, `base_powerschool__sections`.
+
+CTE threading plus two union-derive restructures (`base_powerschool__sections`,
+`int_powerschool__ps_adaadm_daily_ctod`) whose join alias reads the raw
+`union_relations` CTE, so `_dbt_source_project` must be derived in a CTE between
+the union and the join. Combined `state:modified+` is **174** models versus
+**410** split per-model — `int_powerschool__ps_adaadm_daily_ctod` (157) and
+`int_students__contacts` (155) alone share 151 descendants, so the other four
+cost `+17`.
+
+#### PR B — leaves (reports, marts, singular test)
+
+`rpt_deanslist__promo_status`, `rpt_powerschool__autocomm_students`,
+`rpt_tableau__state_assessments_dashboard`, `rpt_tableau__ops_dashboard`,
+`int_finance__enrollment_targets`, `bridge_course_section_teachers`,
+`dim_students`, `fct_family_communications`,
+`test_incorrect_student_number_pearson`.
+
+Combined `state:modified+` is **32** versus 35 split — the four reports have
+zero descendant models each. `rpt_tableau__ops_dashboard` additionally drops the
+synthetic `_dbt_source_relation` from `int_finance__enrollment_targets` and
+rewrites `target_union` / `targets` / the join to `_dbt_source_project`,
+including turning its regexp region filter into
+`_dbt_source_project in ('kippnewark', 'kippmiami')`; verify `cal` exposes the
+column first. Marts are contract-enforced — apply Pattern C.
+
+#### PR C — topline (snapshot-derive, not a swap)
+
+`int_topline__gpa_cumulative_weekly`, `int_topline__gpa_term_weekly`,
+`int_topline__iready_diagnostic_weekly`. Combined `state:modified+` is 7. Kept
+standalone because it is the only remaining group where correctness is not
+mechanical — see the corrected snapshot note below.
+
+#### PR D — unverifiable / stale pass
+
+`int_tableau__gradebook_audit_assignments_student`,
+`int_tableau__gradebook_audit_assignments_teacher`,
+`int_tableau__gradebook_audit_categories_teacher`,
+`qa_edplan__powerschool_mismatch`, `qa_powerschool__transfer_records`,
+`collegeboard_ap_tiered_crosswalk_match`,
+`collegeboard_ap_downstream_lineage_root_cause`.
+
+All seven are disabled models or analyses — no build-time column resolution, so
+a mechanical swap ships latent errors (this is how #4543 nearly shipped
+`asg._dbt_source_project` against a CTE carrying only `_dbt_source_relation`).
+The three gradebook models are additionally stale: their producer
+`int_powerschool__gradebook_assignments_scores` no longer exposes
+`_dbt_source_relation` at all. Investigate-or-delete, not swap. **This gates
+Batch 3.**
+
+PRs A, B and C touch disjoint files and can run in parallel.
+
 ---
 
 ## Batch 3 — Macro removal + docs (1 PR)
@@ -487,11 +552,22 @@ region-relevant models (`stg_renlearn__star`, `int_iready__diagnostic_results`,
 
 **Batch 1 (producer backfill) is complete** across PRs #4503 / #4504 / #4505.
 
-**Batch 2 gating (stronger than stated):** a consumer whose join alias reads a
-**snapshot** (e.g. `int_topline__gpa_term_weekly` reads
-`snapshot_powerschool__gpa_term`) cannot expose `_dbt_source_project` on that
-side until the producer PR **merges and the snapshot re-runs in prod** — so
-Batch 2 is gated on Batch 1 _merging_, not just the branch carrying the columns.
+**Batch 2 gating — CORRECTED 2026-07-24.** An earlier revision of this plan said
+a snapshot-fed consumer is merely gated on the producer PR merging and the
+snapshot re-running in prod. That is wrong, and waiting makes the failure
+_silent_ instead of loud. A `check`-strategy snapshot only writes columns onto
+rows it touches, so adding `_dbt_source_project` upstream never backfills
+history. Measured against prod: `snapshot_powerschool__gpa_term` does not carry
+the column at all (a swap there fails the build — loud), while
+`snapshot_powerschool__gpa_cumulative` does carry it with 2,151,864 of 2,178,255
+rows NULL (98.8%; only rows written since 2026-06-24 are populated). So a plain
+swap on `int_topline__gpa_cumulative_weekly` compiles, builds green, passes the
+`--empty` gate, and silently drops 98.8% of the join — the algebraic identity
+this migration rests on does not hold across snapshot history. Snapshot-fed
+consumers must **derive** `_dbt_source_project` from the snapshot's
+`_dbt_source_relation` in the CTE (the documented exception in
+`src/dbt/kipptaf/CLAUDE.md`). Only `int_topline__gpa_cumulative_weekly` and
+`int_topline__gpa_term_weekly` are snapshot-fed; no other remaining consumer is.
 
 **Two recurring build-only bugs** (both lint/parse-clean, fail at BigQuery
 build):

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
@@ -2,6 +2,7 @@ with
     es_grad as (
         select
             co._dbt_source_relation,
+            co._dbt_source_project,
             co.student_number,
 
             s.abbreviation as entry_school,
@@ -18,16 +19,25 @@ with
         inner join
             {{ ref("stg_powerschool__schools") }} as s
             on co.entry_schoolid = s.school_number
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="s") }}
+            and co._dbt_source_project = s._dbt_source_project
         where co.rn_year = 1
-        group by co._dbt_source_relation, co.student_number, s.abbreviation
+        group by
+            co._dbt_source_relation,
+            co._dbt_source_project,
+            co.student_number,
+            s.abbreviation
     ),
 
     dlm as (
-        select _dbt_source_relation, student_number, max(pathway_option) as dlm,
+        select
+            _dbt_source_relation,
+            _dbt_source_project,
+            student_number,
+
+            max(pathway_option) as dlm,
         from {{ ref("int_students__graduation_path_codes") }}
         where rn_discipline_distinct = 1 and final_grad_path_code = 'M'
-        group by _dbt_source_relation, student_number
+        group by _dbt_source_relation, _dbt_source_project, student_number
     ),
 
     tier as (
@@ -334,15 +344,15 @@ with
         left join
             {{ ref("int_overgrad__students") }} as os
             on se.salesforce_id = os.external_student_id
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="os") }}
+            and se._dbt_source_project = os._dbt_source_project
         left join
             es_grad as e
             on se.student_number = e.student_number
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="e") }}
+            and se._dbt_source_project = e._dbt_source_project
         left join
             dlm as d
             on se.student_number = d.student_number
-            and {{ union_dataset_join_clause(left_alias="se", right_alias="d") }}
+            and se._dbt_source_project = d._dbt_source_project
         left join tier as t on se.salesforce_id = t.contact and t.rn_tier_recent = 1
         left join
             military as mil on c.contact_id = mil.contact and mil.rn_enlistment = 1

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__sections.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__sections.sql
@@ -10,14 +10,16 @@ with
                 ]
             )
         }}
+    ),
+
+    sections as (
+        select *, {{ extract_source_project() }} as _dbt_source_project,
+        from union_relations
     )
 
-select
-    ur.*,
-    {{ extract_source_project("ur") }} as _dbt_source_project,
-    if(cx.ap_course_subject is not null, true, false) as is_ap_course,
-from union_relations as ur
+select sec.*, if(cx.ap_course_subject is not null, true, false) as is_ap_course,
+from sections as sec
 left join
     {{ ref("stg_powerschool__s_nj_crs_x") }} as cx
-    on ur.courses_dcid = cx.coursesdcid
-    and {{ union_dataset_join_clause(left_alias="ur", right_alias="cx") }}
+    on sec.courses_dcid = cx.coursesdcid
+    and sec._dbt_source_project = cx._dbt_source_project

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
@@ -24,9 +24,15 @@ with
         }}
     ),
 
+    memberships as (
+        select *, {{ extract_source_project() }} as _dbt_source_project,
+        from union_relations
+    ),
+
     calcs as (
         select
             mem._dbt_source_relation,
+            mem._dbt_source_project,
             mem.studentid,
             mem.student_number,
             mem.schoolid,
@@ -51,10 +57,6 @@ with
             cw.week_start_monday,
             cw.week_end_sunday,
             cw.week_number_academic_year,
-
-            regexp_extract(
-                mem._dbt_source_relation, r'(kipp\w+)_'
-            ) as _dbt_source_project,
 
             abs(mem.attendancevalue - 1) as is_absent,
 
@@ -83,13 +85,13 @@ with
             mem.calendardate
             <= current_date('{{ var("local_timezone") }}') as is_realized,
 
-        from union_relations as mem
+        from memberships as mem
         inner join
             {{ ref("int_powerschool__terms") }} as t
             on mem.yearid = t.yearid
             and mem.schoolid = t.schoolid
             and mem.calendardate between t.term_start_date and t.term_end_date
-            and {{ union_dataset_join_clause(left_alias="mem", right_alias="t") }}
+            and mem._dbt_source_project = t._dbt_source_project
         inner join
             {{ ref("int_powerschool__calendar_week") }} as cw
             on mem.yearid = cw.yearid

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
@@ -97,6 +97,7 @@ with
             on mem.yearid = cw.yearid
             and mem.schoolid = cw.schoolid
             and mem.calendardate between cw.week_start_monday and cw.week_end_sunday
+            and mem._dbt_source_project = cw._dbt_source_project
     ),
 
     anchors as (

--- a/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__promotional_status.sql
+++ b/src/dbt/kipptaf/models/reporting/intermediate/int_reporting__promotional_status.sql
@@ -2,6 +2,7 @@ with
     attendance as (
         select
             mem._dbt_source_relation,
+            mem._dbt_source_project,
             mem.studentid,
             mem.yearid,
 
@@ -19,7 +20,7 @@ with
             ) as n_absences_y1_running_non_susp_no_tardy,
 
             case
-                regexp_extract(mem._dbt_source_relation, r'(kipp\w+)_')
+                mem._dbt_source_project
                 when 'kippnewark'
                 then 27
                 when 'kippcamden'
@@ -27,13 +28,9 @@ with
             end as hs_at_risk_absences,
 
             case
-                when
-                    regexp_extract(mem._dbt_source_relation, r'(kipp\w+)_')
-                    = 'kippnewark'
+                when mem._dbt_source_project = 'kippnewark'
                 then 6 * safe_cast(right(rt.name, 1) as int)
-                when
-                    regexp_extract(mem._dbt_source_relation, r'(kipp\w+)_')
-                    = 'kippcamden'
+                when mem._dbt_source_project = 'kippcamden'
                 then 9 * safe_cast(right(rt.name, 1) as int)
             end as hs_off_track_absences,
         from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }} as mem
@@ -47,12 +44,18 @@ with
         where
             mem.membershipvalue = 1
             and mem.calendardate <= current_date('{{ var("local_timezone") }}')
-        group by mem._dbt_source_relation, mem.yearid, mem.studentid, rt.name
+        group by
+            mem._dbt_source_relation,
+            mem._dbt_source_project,
+            mem.yearid,
+            mem.studentid,
+            rt.name
     ),
 
     credits as (
         select
             fg._dbt_source_relation,
+            fg._dbt_source_project,
             fg.studentid,
             fg.academic_year,
             fg.storecode,
@@ -68,7 +71,7 @@ with
             {{ ref("int_powerschool__gpa_cumulative") }} as gc
             on fg.studentid = gc.studentid
             and fg.schoolid = gc.schoolid
-            and {{ union_dataset_join_clause(left_alias="fg", right_alias="gc") }}
+            and fg._dbt_source_project = gc._dbt_source_project
     ),
 
     iready_dr as (
@@ -164,6 +167,7 @@ with
     ps_log as (
         select
             lg._dbt_source_relation,
+            lg._dbt_source_project,
             lg.studentid,
             lg.academic_year,
             lg.entry_date,
@@ -181,6 +185,7 @@ with
     exempt_override as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             academic_year,
             entry_date,
@@ -197,6 +202,7 @@ with
     force_retention as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             academic_year,
             entry_date,
@@ -501,13 +507,13 @@ with
             on co.studentid = att.studentid
             and co.yearid = att.yearid
             and rt.name = att.term_name
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="att") }}
+            and co._dbt_source_project = att._dbt_source_project
         left join
             credits as c
             on co.studentid = c.studentid
             and co.academic_year = c.academic_year
             and rt.name = c.storecode
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="c") }}
+            and co._dbt_source_project = c._dbt_source_project
         left join
             iready as ir
             on co.student_number = ir.student_id
@@ -526,17 +532,17 @@ with
         left join
             {{ ref("stg_powerschool__s_nj_stu_x") }} as nj
             on co.students_dcid = nj.studentsdcid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="nj") }}
+            and co._dbt_source_project = nj._dbt_source_project
         left join
             exempt_override as lg
             on co.studentid = lg.studentid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="lg") }}
+            and co._dbt_source_project = lg._dbt_source_project
             and co.academic_year = lg.academic_year
             and lg.rn_log = 1
         left join
             force_retention as fr
             on co.studentid = fr.studentid
-            and {{ union_dataset_join_clause(left_alias="co", right_alias="fr") }}
+            and co._dbt_source_project = fr._dbt_source_project
             and co.academic_year = fr.academic_year
             and fr.rn_log = 1
         where co.rn_year = 1

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments_subjects.sql
@@ -37,6 +37,7 @@ with
     intervention_nj as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             academic_year,
 
@@ -51,6 +52,7 @@ with
     prev_yr_state_test as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             localstudentidentifier,
             is_proficient,
 
@@ -67,6 +69,7 @@ with
 
         select
             _dbt_source_relation,
+            _dbt_source_project,
 
             null as localstudentidentifier,
 
@@ -101,6 +104,7 @@ with
     magoosh_exempt as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             students_student_number as student_number,
             cc_academic_year as academic_year,
 
@@ -160,6 +164,7 @@ with
     bucket_programs as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             academic_year,
             enter_date,
@@ -185,6 +190,7 @@ with
     mtss as (
         select
             sp._dbt_source_relation,
+            sp._dbt_source_project,
             sp.studentid,
             sp.academic_year,
             sp.enter_date,
@@ -198,7 +204,7 @@ with
             on sp.enter_date = t.firstday
             and sp.exit_date = t.lastday
             and sp.academic_year = t.academic_year
-            and {{ union_dataset_join_clause(left_alias="sp", right_alias="t") }}
+            and sp._dbt_source_project = t._dbt_source_project
             and t.schoolid = 0
         where sp.specprog_name like 'MTSS%'
     ),
@@ -278,13 +284,13 @@ cross join subjects as sj
 left join
     {{ ref("int_powerschool__s_nj_stu_x_unpivot") }} as a
     on co.students_dcid = a.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="a") }}
+    and co._dbt_source_project = a._dbt_source_project
     and sj.discipline = a.discipline
     and a.value_type = 'Graduation Pathway'
 left join
     {{ ref("int_powerschool__s_nj_stu_x_unpivot") }} as se
     on co.students_dcid = se.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="se") }}
+    and co._dbt_source_project = se._dbt_source_project
     and sj.discipline = se.discipline
     and se.value_type = 'State Assessment Name'
 left join
@@ -297,7 +303,7 @@ left join
     /* TODO: find records that only match on SID */
     on co.state_studentnumber = py.statestudentidentifier
     and co.academic_year = py.academic_year_plus
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="py") }}
+    and co._dbt_source_project = py._dbt_source_project
     and sj.illuminate_subject_area = py.subject
 left join
     prev_yr_iready as pr
@@ -320,23 +326,23 @@ left join
     magoosh_exempt as ie
     on co.student_number = ie.student_number
     and co.academic_year = ie.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="ie") }}
+    and co._dbt_source_project = ie._dbt_source_project
     and sj.iready_subject = ie.iready_subject
 left join
     intervention_nj as nj
     on co.studentid = nj.studentid
     and co.academic_year = nj.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="nj") }}
+    and co._dbt_source_project = nj._dbt_source_project
     and sj.iready_subject = nj.iready_subject
 left join
     bucket_dedupe as b
     on co.studentid = b.studentid
     and co.academic_year = b.academic_year
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="b") }}
+    and co._dbt_source_project = b._dbt_source_project
     and sj.discipline = b.discipline
 left join
     mtss_dedupe as mtss
     on co.studentid = mtss.studentid
     and co.academic_year = mtss.academic_year
     and sj.discipline = mtss.discipline
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="mtss") }}
+    and co._dbt_source_project = mtss._dbt_source_project

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -124,7 +124,7 @@ with
     -- Finalsite-sourced and drop out of ps_base above, so their person-contact
     -- enrichment rows would never match. Add a region back here if it reverts
     -- to the PowerSchool branch.
-    ps_person_contacts as (
+    ps_person_contacts_union as (
         {{
             dbt_utils.union_relations(
                 relations=[
@@ -136,9 +136,15 @@ with
         }}
     ),
 
+    ps_person_contacts as (
+        select *, {{ extract_source_project() }} as _dbt_source_project,
+        from ps_person_contacts_union
+    ),
+
     ps_methods_ranked as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             personid,
             contact_category,
             contact_type,
@@ -155,6 +161,7 @@ with
     ps_typed as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             personid,
 
             max(
@@ -193,12 +200,13 @@ with
             ) as address_home,
         from ps_methods_ranked
         where method_rank = 1
-        group by _dbt_source_relation, personid
+        group by _dbt_source_relation, _dbt_source_project, personid
     ),
 
     ps_primary_phone_ranked as (
         select
             _dbt_source_relation,
+            _dbt_source_project,
             personid,
             contact as phone_primary,
 
@@ -211,13 +219,13 @@ with
     ),
 
     ps_primary_phone as (
-        select _dbt_source_relation, personid, phone_primary,
+        select _dbt_source_relation, _dbt_source_project, personid, phone_primary,
         from ps_primary_phone_ranked
         where phone_rank = 1
     ),
 
     students as (
-        select _dbt_source_relation, dcid, student_number,
+        select _dbt_source_relation, _dbt_source_project, dcid, student_number,
         from {{ ref("stg_powerschool__students") }}
         where dcid >= 1
     ),
@@ -250,15 +258,15 @@ with
         inner join
             students as s
             on sl.studentdcid = s.dcid
-            and {{ union_dataset_join_clause(left_alias="sl", right_alias="s") }}
+            and sl._dbt_source_project = s._dbt_source_project
         left join
             ps_typed as pt
             on sl.personid = pt.personid
-            and {{ union_dataset_join_clause(left_alias="sl", right_alias="pt") }}
+            and sl._dbt_source_project = pt._dbt_source_project
         left join
             ps_primary_phone as pp
             on sl.personid = pp.personid
-            and {{ union_dataset_join_clause(left_alias="sl", right_alias="pp") }}
+            and sl._dbt_source_project = pp._dbt_source_project
     )
 
 select


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Consumer wave of the #3142 `_dbt_source_project` migration — PR A of a revised
cut. Replaces `union_dataset_join_clause(...)` join predicates with direct
`a._dbt_source_project = b._dbt_source_project` equality across the six
big-fan-out intermediates (23 macro calls), threading the column through the
CTEs that feed each join.

Behavior-preserving: `_dbt_source_project` equals
`regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` by construction, so each
swap is algebraically identical to the macro it replaces.

### Models

Plain swap plus CTE threading:

- `int_students__contacts` — 3 sites. `ps_person_contacts` is an in-model
  `union_relations` CTE with no `_dbt_source_project`, so it is split into a
  `_union` CTE plus a derive wrapper (pass-through principle: derive at the
  union view, never downstream). Column then threads through
  `ps_methods_ranked` / `ps_typed` / `ps_primary_phone_ranked` /
  `ps_primary_phone` / `students`.
- `int_extracts__student_enrollments_subjects` — 8 sites; threaded through
  `intervention_nj`, both `prev_yr_state_test` UNION ALL branches,
  `magoosh_exempt`, `bucket_programs`, `mtss`.
- `int_reporting__promotional_status` — 6 sites; threaded through `attendance`,
  `credits`, `ps_log`, `exempt_override`, `force_retention`.
- `int_kippadb__roster` — 4 sites, no threading needed.

Union-derive restructures — the join alias reads the raw `union_relations` CTE,
which has `_dbt_source_relation` but not `_dbt_source_project`, so the derive
moves into a CTE between the union and the join:

- `base_powerschool__sections` — derive moved out of the final `SELECT` into a
  `sections` CTE.
- `int_powerschool__ps_adaadm_daily_ctod` — derive moved out of the `calcs`
  select list into a `memberships` CTE; the column is now a plain pass-through
  in `calcs` (and moves to the front of that select per ST06 ordering, since it
  is now a column enumeration rather than a function).

### Incidental cleanup

`int_reporting__promotional_status` had three inline
`regexp_extract(mem._dbt_source_relation, ...)` **value** derivations inside
`hs_at_risk_absences` / `hs_off_track_absences`. Now that `mem` carries the
materialized column these become plain `mem._dbt_source_project` refs — same
values, one less regexp per row.

## Batching change

This PR is the first under a revised cut of the remaining work, documented in
`docs/superpowers/plans/2026-07-22-dbt-source-project-completion.md`. The
directory-based cut (`2a-1` … `2f`) was sized before the Batch 1 producers
merged; that ordering constraint is gone, so the binding constraints are now
build-verifiability and descendant fan-out.

Grouping these six together costs **174** `state:modified+` models versus
**410** if split per-model — `int_powerschool__ps_adaadm_daily_ctod` (157) and
`int_students__contacts` (155) alone share 151 descendants, so the other four
add only 17.

The plan update also **corrects** the snapshot gating note. A `check`-strategy
snapshot only writes columns onto rows it touches, so adding
`_dbt_source_project` upstream never backfills history:
`snapshot_powerschool__gpa_term` lacks the column entirely, and
`snapshot_powerschool__gpa_cumulative` carries it with 98.8% of rows NULL. A
plain swap on the topline GPA models would build green and silently drop most of
the join, so they must derive locally — deferred to their own PR.

## AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### dbt

- [x] Column-resolution gate passes for all 6 models: built
      `--empty --defer --favor-state` against the prod manifest, 0 errors.
- [x] Join-predicate swaps and pass-through threading only — no filter, grain,
      or aggregation semantics changed.
- [x] `group by` additions are functionally determined by an existing grouping
      column, so grouping is unchanged.
- [x] `trunk check --force` clean.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
