### PR TITLE
refactor(dbt): swap union_dataset_join_clause in leaf reports and marts

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__promo_status.sql
@@ -126,7 +126,7 @@ left join
     on co.studentid = gpa.studentid
     and co.yearid = gpa.yearid
     and term = gpa.term_name
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
 left join
     {{ ref("int_reporting__promotional_status") }} as p
     on co.student_number = p.student_number
@@ -142,6 +142,6 @@ left join
     on co.studentid = ss.studentid
     and co.academic_year = ss.academic_year
     and ss.log_type = 'ARFR (Summer School)'
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="ss") }}
+    and co._dbt_source_project = ss._dbt_source_project
 
 where co.academic_year = {{ var("current_academic_year") }} and co.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_students.sql
+++ b/src/dbt/kipptaf/models/extracts/powerschool/rpt_powerschool__autocomm_students.sql
@@ -1,12 +1,12 @@
 with
     grad_path as (
-        select _dbt_source_relation, student_number, discipline, final_grad_path_code,
+        select _dbt_source_project, student_number, discipline, final_grad_path_code,
         from {{ ref("int_students__graduation_path_codes") }}
     ),
 
     grad_path_pivot as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             student_number,
             s_nj_stu_x__graduation_pathway_math,
             s_nj_stu_x__graduation_pathway_ela,
@@ -77,20 +77,20 @@ from {{ ref("int_extracts__student_enrollments") }} as se
 left join
     {{ ref("stg_powerschool__students") }} as s
     on se.student_number = s.student_number
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="s") }}
+    and se._dbt_source_project = s._dbt_source_project
 left join
     {{ ref("int_powerschool__district_entry_date") }} as de
     on se.studentid = de.studentid
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="de") }}
+    and se._dbt_source_project = de._dbt_source_project
     and de.rn_entry = 1
 left join
     grad_path_pivot as g
     on se.student_number = g.student_number
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="g") }}
+    and se._dbt_source_project = g._dbt_source_project
 left join
     {{ ref("stg_powerschool__s_stu_x") }} as pfs
     on se.students_dcid = pfs.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="pfs") }}
+    and se._dbt_source_project = pfs._dbt_source_project
 where
     se.academic_year = {{ var("current_academic_year") }}
     and se.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ops_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ops_dashboard.sql
@@ -1,7 +1,7 @@
 with
     att_mem as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             studentid,
             yearid,
 
@@ -9,7 +9,7 @@ with
             sum(membershipvalue) as n_membership,
         from {{ ref("int_powerschool__ps_adaadm_daily_ctod") }}
         where membershipvalue = 1
-        group by studentid, yearid, _dbt_source_relation
+        group by studentid, yearid, _dbt_source_project
     ),
 
     target_union as (
@@ -25,7 +25,7 @@ with
             at_risk_and_lep_ratio,
             lep_only_ratio,
             sped_ratio,
-            _dbt_source_relation,
+            _dbt_source_project,
         from {{ ref("int_finance__enrollment_targets") }}
 
         union all
@@ -45,18 +45,17 @@ with
             null as lep_only_ratio,
             null as sped_ratio,
 
-            _dbt_source_relation,
+            _dbt_source_project,
         from {{ ref("int_extracts__student_enrollments") }}
         where
             (is_self_contained or is_out_of_district)
             and rn_year = 1
-            and regexp_extract(_dbt_source_relation, r'(kipp\w+)_')
-            in ('kippnewark', 'kippmiami')
+            and _dbt_source_project in ('kippnewark', 'kippmiami')
     ),
 
     targets as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             schoolid,
             is_self_contained,
@@ -71,11 +70,7 @@ with
             max(sped_ratio) as sped_ratio,
         from target_union
         group by
-            academic_year,
-            schoolid,
-            grade_level,
-            is_self_contained,
-            _dbt_source_relation
+            academic_year, schoolid, grade_level, is_self_contained, _dbt_source_project
     )
 
 select
@@ -180,17 +175,17 @@ left join
     on se.schoolid = cal.schoolid
     and se.yearid = cal.yearid
     and se.track = cal.track
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="cal") }}
+    and se._dbt_source_project = cal._dbt_source_project
 left join
     att_mem
     on se.studentid = att_mem.studentid
     and se.yearid = att_mem.yearid
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="att_mem") }}
+    and se._dbt_source_project = att_mem._dbt_source_project
 left join
     targets as t
     on se.academic_year = t.academic_year
     and se.reporting_schoolid = t.schoolid
     and se.grade_level = t.grade_level
     and se.is_self_contained = t.is_self_contained
-    and {{ union_dataset_join_clause(left_alias="se", right_alias="t") }}
+    and se._dbt_source_project = t._dbt_source_project
 where se.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
@@ -70,7 +70,7 @@ with
 
     schedules as (
         select
-            e._dbt_source_relation,
+            e._dbt_source_project,
             e.cc_academic_year,
             e.students_student_number,
             e.teachernumber,
@@ -140,7 +140,7 @@ with
 
     assessment_scores as (
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             localstudentidentifier,
             statestudentidentifier as state_id,
@@ -173,7 +173,7 @@ with
         union all
 
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
 
             null as localstudentidentifier,
@@ -208,7 +208,7 @@ with
         union all
 
         select
-            _dbt_source_relation,
+            _dbt_source_project,
             academic_year,
             local_student_identifier as localstudentidentifier,
             cast(state_student_identifier as string) as state_id,
@@ -336,7 +336,7 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as e
     on a.academic_year = e.academic_year
     and a.localstudentidentifier = e.pearson_local_student_identifier
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="e") }}
+    and a._dbt_source_project = e._dbt_source_project
     and e.rn_year = 1
     and a.results_type = 'Actual'
     and a.academic_year >= {{ var("current_academic_year") - 7 }}
@@ -358,21 +358,21 @@ left join
     schedules as m
     on a.academic_year = m.cc_academic_year
     and a.discipline = m.discipline
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="m") }}
+    and a._dbt_source_project = m._dbt_source_project
     and e.student_number = m.students_student_number
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf
     on a.academic_year = sf.academic_year
     and a.discipline = sf.discipline
     and a.localstudentidentifier = sf.pearson_local_student_identifier
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf") }}
+    and a._dbt_source_project = sf._dbt_source_project
     and sf.rn_year = 1
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf2
     on a.academic_year = (sf2.academic_year - 1)
     and a.discipline = sf2.discipline
     and a.localstudentidentifier = sf2.pearson_local_student_identifier
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf2") }}
+    and a._dbt_source_project = sf2._dbt_source_project
     and sf2.rn_year = 1
 
 union all
@@ -468,7 +468,7 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as e
     on a.academic_year = e.academic_year
     and a.state_id = e.state_studentnumber
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="e") }}
+    and a._dbt_source_project = e._dbt_source_project
     and a.results_type = 'Actual'
     and e.region = 'Miami'
     and e.rn_year = 1
@@ -491,21 +491,21 @@ left join
     schedules as m
     on a.academic_year = m.cc_academic_year
     and a.discipline = m.discipline
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="m") }}
+    and a._dbt_source_project = m._dbt_source_project
     and e.student_number = m.students_student_number
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf
     on a.academic_year = sf.academic_year
     and a.discipline = sf.discipline
     and a.state_id = sf.state_studentnumber
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf") }}
+    and a._dbt_source_project = sf._dbt_source_project
     and sf.rn_year = 1
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf2
     on a.academic_year = sf2.academic_year - 1
     and a.discipline = sf2.discipline
     and a.state_id = sf2.state_studentnumber
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf2") }}
+    and a._dbt_source_project = sf2._dbt_source_project
     and sf2.rn_year = 1
 
 union all
@@ -601,7 +601,7 @@ inner join
     {{ ref("int_extracts__student_enrollments") }} as e
     on a.academic_year = e.academic_year
     and a.state_id = e.state_studentnumber
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="e") }}
+    and a._dbt_source_project = e._dbt_source_project
     -- 2024: first year we track preliminary scores for comparison
     and a.academic_year >= 2024
     and a.results_type = 'Preliminary'
@@ -629,18 +629,18 @@ left join
     on a.academic_year = m.cc_academic_year
     and a.localstudentidentifier = m.students_student_number
     and a.discipline = m.discipline
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="m") }}
+    and a._dbt_source_project = m._dbt_source_project
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf
     on a.academic_year = sf.academic_year
     and a.discipline = sf.discipline
     and a.localstudentidentifier = sf.student_number
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf") }}
+    and a._dbt_source_project = sf._dbt_source_project
     and sf.rn_year = 1
 left join
     {{ ref("int_extracts__student_enrollments_subjects") }} as sf2
     on a.academic_year = sf2.academic_year - 1
     and a.discipline = sf2.discipline
     and a.localstudentidentifier = sf2.student_number
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="sf2") }}
+    and a._dbt_source_project = sf2._dbt_source_project
     and sf2.rn_year = 1

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__state_assessments_dashboard.sql
@@ -40,7 +40,6 @@ with
 
     schedules_current as (
         select
-            c._dbt_source_relation,
             c.cc_academic_year,
             c.students_student_number,
             c.courses_credittype,

--- a/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
+++ b/src/dbt/kipptaf/models/finance/intermediate/int_finance__enrollment_targets.sql
@@ -16,11 +16,6 @@ select
     et.sped_ratio,
 
     sch._dbt_source_project,
-
-    '`{{ target.database }}`.`'
-    || sch._dbt_source_project
-    || '_powerschool'
-    || '`.`base_powerschool__student_enrollments`' as _dbt_source_relation,
 from {{ ref("stg_google_sheets__finance__enrollment_targets") }} as et
 inner join
     {{ ref("stg_powerschool__schools") }} as sch on et.schoolid = sch.school_number

--- a/src/dbt/kipptaf/models/finance/intermediate/properties/int_finance__enrollment_targets.yml
+++ b/src/dbt/kipptaf/models/finance/intermediate/properties/int_finance__enrollment_targets.yml
@@ -12,14 +12,12 @@ models:
               - schoolid
               - grade_level
     columns:
-      - name: _dbt_source_relation
-        data_type: string
-        description: >-
-          Synthesized relation path referencing the source district's
-          base_powerschool__student_enrollments, used for cross-district joins.
       - name: _dbt_source_project
         data_type: string
-        description: District code location derived from `_dbt_source_relation`.
+        description: >-
+          District code location, passed through from
+          `stg_powerschool__schools`. Used to join enrollment targets to
+          district-scoped models.
       - name: fiscal_year
         data_type: int64
       - name: academic_year

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
@@ -16,16 +16,16 @@ from {{ ref("base_powerschool__sections") }} as sec
 inner join
     {{ ref("stg_powerschool__sectionteacher") }} as st
     on sec.sections_id = st.sectionid
-    and {{ union_dataset_join_clause(left_alias="sec", right_alias="st") }}
+    and sec._dbt_source_project = st._dbt_source_project
 inner join
     {{ ref("int_powerschool__teachers") }} as t
     on st.teacherid = t.id
     and sec.sections_schoolid = t.schoolid
-    and {{ union_dataset_join_clause(left_alias="st", right_alias="t") }}
+    and st._dbt_source_project = t._dbt_source_project
 inner join
     {{ ref("stg_powerschool__roledef") }} as r
     on st.roleid = r.id
-    and {{ union_dataset_join_clause(left_alias="st", right_alias="r") }}
+    and st._dbt_source_project = r._dbt_source_project
 inner join
     {{ ref("int_people__staff_roster") }} as sr
     on t.teachernumber = sr.powerschool_teacher_number

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_students.sql
@@ -73,8 +73,8 @@ left join
 left join
     {{ ref("stg_powerschool__u_studentsuserfields") }} as suf
     on s.dcid = suf.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="suf") }}
+    and s._dbt_source_project = suf._dbt_source_project
 left join
     {{ ref("stg_powerschool__s_nj_stu_x") }} as njs
     on s.dcid = njs.studentsdcid
-    and {{ union_dataset_join_clause(left_alias="s", right_alias="njs") }}
+    and s._dbt_source_project = njs._dbt_source_project

--- a/src/dbt/kipptaf/models/marts/facts/fct_family_communications.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_family_communications.sql
@@ -54,7 +54,7 @@ inner join
     enrollments as enr
     on c.student_school_id = enr.student_number
     and c.academic_year = enr.academic_year
-    and {{ union_dataset_join_clause(left_alias="c", right_alias="enr") }}
+    and c._dbt_source_project = enr._dbt_source_project
     and enr.rn = 1
 left join {{ ref("stg_deanslist__users") }} as u on c.user_id_str = u.dl_user_id
 left join {{ ref("int_people__staff_roster") }} as sr on u.email = sr.work_email

--- a/src/dbt/kipptaf/tests/test_incorrect_student_number_pearson.sql
+++ b/src/dbt/kipptaf/tests/test_incorrect_student_number_pearson.sql
@@ -13,7 +13,7 @@ left join
     {{ ref("base_powerschool__student_enrollments") }} as e
     on a.localstudentidentifier = e.student_number
     and a.academic_year = e.academic_year
-    and {{ union_dataset_join_clause(left_alias="a", right_alias="e") }}
+    and a._dbt_source_project = e._dbt_source_project
     and e.rn_year = 1
 where
     /* we only report on SY 2017+ scores */


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

Consumer wave of the #3142 `_dbt_source_project` migration — PR B of the revised
cut (PR A was #4547). Replaces the remaining `union_dataset_join_clause(...)`
join predicates in the **leaf** models: reports, marts, and one singular test.
28 macro calls, plus one structural cleanup described below.

Behavior-preserving: `_dbt_source_project` equals
`regexp_extract(_dbt_source_relation, r'(kipp\w+)_')` by construction, so each
swap is algebraically identical to the macro it replaces.

**One qualification, surfaced in review.** That claim holds unconditionally for
the 28 join-predicate swaps, but **not** for the `targets` `group by` rewrite in
`rpt_tableau__ops_dashboard` — there it is prod-equivalent and a *fix* for
non-prod targets. The old code grouped on `_dbt_source_relation`, comparing
`int_finance__enrollment_targets`' synthetic literal against the real value from
`int_extracts__student_enrollments`. Measured in prod, those are byte-identical
(e.g. `` `teamster-332318`.`kippnewark_powerschool`.`base_powerschool__student_enrollments` ``
on both sides), so one group forms per key and the rewrite changes nothing.
Under `target=staging`/`dev` the real side resolves to
`zz_stg_<proj>_powerschool` while the synthetic hardcodes `_powerschool`, so
they did *not* match — two groups formed, both matched `se` through the regexp,
and the result fanned out. The rewrite collapses that.

Practical consequence: a dev- or CI-built before/after comparison of this model
will legitimately differ, and only a prod comparison shows parity. Noting it so
the delta isn't later mistaken for a regression.

### Plain swaps

- `rpt_tableau__state_assessments_dashboard` (12) — plus threading
  `_dbt_source_project` through the `assessment_scores` CTE (all three UNION ALL
  branches) and the `schedules` CTE.
- `rpt_powerschool__autocomm_students` (4) — plus threading through
  `grad_path` / `grad_path_pivot`.
- `bridge_course_section_teachers` (3, contracted mart)
- `dim_students` (2, contracted mart)
- `rpt_deanslist__promo_status` (2)
- `fct_family_communications` (1, contracted mart)
- `test_incorrect_student_number_pearson` (1, singular test)

The pearson test is a CRLF file; only the changed line had its carriage return
stripped, so the diff stays at one line.

### `rpt_tableau__ops_dashboard` plus `int_finance__enrollment_targets`

These two are grouped because they are one change.
`int_finance__enrollment_targets` carried a **synthetic**
`_dbt_source_relation` — a string literal assembled as
`'...' || sch._dbt_source_project || '_powerschool' || '...'` — that existed
solely so the macro's `regexp_extract` would find a region to match on. It was
never a real relation path, and `rpt_tableau__ops_dashboard` was its only
consumer.

With the join swapped to `_dbt_source_project` that scaffolding is dead, so this
PR removes it and rewrites the ops_dashboard chain to carry the real column end
to end:

- `att_mem` selects and groups by `_dbt_source_project` (available since #4547
  threaded it through `int_powerschool__ps_adaadm_daily_ctod`).
- Both `target_union` branches project `_dbt_source_project`.
- The Newark/Miami region filter becomes
  `_dbt_source_project in ('kippnewark', 'kippmiami')` rather than a
  `regexp_extract` over the relation string.
- `targets` selects and groups by `_dbt_source_project`.
- `int_finance__enrollment_targets` drops the synthetic column; its
  `properties.yml` entry is removed and the `_dbt_source_project` description
  corrected — it referenced a column this model no longer has.

`rpt_tableau__ops_dashboard` never projected `_dbt_source_relation` in its final
`SELECT`, so its contract is unaffected.

## Verification

- Column-resolution gate: `--empty --defer --favor-state` against the prod
  manifest for all 9 nodes — **PASS=33, ERROR=0**.
- The gate reports only the first unresolved name per model, so rather than
  fix-and-retry blind I traced every join alias in
  `rpt_tableau__state_assessments_dashboard` (`e`, `m`, `sf`, `sf2`, `a`) to its
  producer and confirmed each exposes the column.
- Equivalence rests on the algebraic identity, measured directly against prod
  during #4547 — `_dbt_source_project IS DISTINCT FROM regexp_extract(...)`
  returned 0 mismatches across 239,077 rows on every table-materialized join
  partner.
- Confirmed before editing: `int_powerschool__calendar_rollup` (the `cal` alias)
  exposes `_dbt_source_project`, and `int_finance__enrollment_targets` has
  exactly one consumer.

## Two things left deliberately out of scope

Both are pre-existing and worth a separate look rather than a drive-by fix:

1. `rpt_powerschool__autocomm_students` derives an output column as
   `regexp_extract(se._dbt_source_relation, ...) as code_location`. It could
   collapse to `se._dbt_source_project`, same value — but it is a
   contract-visible output column and the change would force an ST06 reordering
   inside a contracted model. Queued for the macro-removal batch alongside the
   duplicate `_dbt_source_project` / `code_location` expressions on
   `base_powerschool__student_enrollments` flagged in #4547 review.
1. In `rpt_tableau__state_assessments_dashboard`, the `schedules_current` join
   carries **no** region predicate at all — it matches only on
   `students_student_number` and `courses_credittype`. Whether it should have
   one is a real question, but adding it is a behavior change that needs its own
   analysis, not a rider on a behavior-preserving PR.

   (The dead `c._dbt_source_relation` that CTE also selected **was** removed, in
   `890f9b1c1` — dropping a column no consumer reads is not a behavior change,
   unlike adding the predicate.)

## AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### dbt

- [x] Column-resolution gate passes for all 9 nodes (0 errors).
- [x] Contracted marts unchanged in output column set — join predicates only.
- [x] `group by` changes swap one functionally-equivalent region key for
      another, so grain is unchanged.
- [x] `trunk check --force` clean.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142

