### PR TITLE
refactor(dbt): resolve topline region joins without the macro

### DIFF
--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_cumulative_weekly.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_cumulative_weekly.sql
@@ -10,6 +10,11 @@ with
 
             cast(dbt_valid_from as date) as dbt_valid_from_date,
             cast(dbt_valid_to as date) as dbt_valid_to_date,
+
+            /* Snapshot-fed, so derive locally rather than passing the stored
+               column through: the check strategy only writes columns onto rows
+               it touches, leaving snapshot history ~99% null. */
+            {{ extract_source_project() }} as _dbt_source_project,
         from {{ ref("snapshot_powerschool__gpa_cumulative") }}
     ),
 
@@ -36,7 +41,7 @@ left join
     on co.studentid = gpa.studentid
     and co.schoolid = gpa.schoolid
     and co.week_start_monday between gpa.dbt_valid_from_date and gpa.dbt_valid_to_date
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
 where
     co.is_enrolled_week
     and co.school_level in ('MS', 'HS')

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_cumulative_weekly.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_cumulative_weekly.sql
@@ -11,9 +11,8 @@ with
             cast(dbt_valid_from as date) as dbt_valid_from_date,
             cast(dbt_valid_to as date) as dbt_valid_to_date,
 
-            /* Snapshot-fed, so derive locally rather than passing the stored
-               column through: the check strategy only writes columns onto rows
-               it touches, leaving snapshot history ~99% null. */
+            /* snapshot-fed: derive locally — the check strategy never backfills
+               the stored column across history (see kipptaf CLAUDE.md) */
             {{ extract_source_project() }} as _dbt_source_project,
         from {{ ref("snapshot_powerschool__gpa_cumulative") }}
     ),

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_term_weekly.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_term_weekly.sql
@@ -11,6 +11,12 @@ with
 
             cast(dbt_valid_from as date) as dbt_valid_from_date,
             cast(dbt_valid_to as date) as dbt_valid_to_date,
+
+            /* Snapshot-fed, so derive locally. This snapshot does not carry
+               _dbt_source_project at all, and adding it upstream would not help
+               — the check strategy only writes columns onto rows it touches, so
+               snapshot history would stay null. */
+            {{ extract_source_project() }} as _dbt_source_project,
         from {{ ref("snapshot_powerschool__gpa_term") }}
     ),
 
@@ -38,7 +44,7 @@ left join
     and co.schoolid = gpa.schoolid
     and co.yearid = gpa.yearid
     and co.week_start_monday between gpa.dbt_valid_from_date and gpa.dbt_valid_to_date
-    and {{ union_dataset_join_clause(left_alias="co", right_alias="gpa") }}
+    and co._dbt_source_project = gpa._dbt_source_project
 where
     co.is_enrolled_week
     and co.school_level in ('MS', 'HS')

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_term_weekly.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__gpa_term_weekly.sql
@@ -12,10 +12,10 @@ with
             cast(dbt_valid_from as date) as dbt_valid_from_date,
             cast(dbt_valid_to as date) as dbt_valid_to_date,
 
-            /* Snapshot-fed, so derive locally. This snapshot does not carry
-               _dbt_source_project at all, and adding it upstream would not help
-               — the check strategy only writes columns onto rows it touches, so
-               snapshot history would stay null. */
+            /* snapshot-fed: derive locally — this snapshot has no stored
+               _dbt_source_project, and adding it upstream would not help since
+               the check strategy never backfills history (see kipptaf
+               CLAUDE.md) */
             {{ extract_source_project() }} as _dbt_source_project,
         from {{ ref("snapshot_powerschool__gpa_term") }}
     ),

--- a/src/dbt/kipptaf/models/topline/intermediate/int_topline__iready_diagnostic_weekly.sql
+++ b/src/dbt/kipptaf/models/topline/intermediate/int_topline__iready_diagnostic_weekly.sql
@@ -53,7 +53,7 @@ left join
     on cw.student_number = ir.student_id
     and cw.academic_year = ir.academic_year_int
     and cw.iready_subject = ir.subject
-    and {{ union_dataset_join_clause(left_alias="cw", right_alias="ir") }}
+    and cw._dbt_source_project = ir._dbt_source_project
     and rt.region = ir.region
     and rt.name = ir.test_round
     and ir.rn_subj_round = 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

PR C of the revised #3142 cut (PR A was #4547; PR B is the leaf reports and
marts). Removes the last `union_dataset_join_clause` calls from the topline
weekly models.

Two of the three are **not** a plain column swap, which is why they were split
into their own PR.

### Snapshot-fed — derive locally

`int_topline__gpa_cumulative_weekly` and `int_topline__gpa_term_weekly` read
snapshots, so they derive `_dbt_source_project` inside the snapshot-reading CTE
rather than passing a stored column through. A `check`-strategy snapshot only
writes columns onto rows it touches, so it never backfills a new column onto
history. Measured against prod:

- `snapshot_powerschool__gpa_term` does not carry `_dbt_source_project` at all —
  a pass-through swap fails the build.
- `snapshot_powerschool__gpa_cumulative` does carry it, with **2,151,864 of
  2,178,255 rows null (98.8%)**; only rows written since 2026-06-24 are
  populated. A pass-through swap there compiles, builds green, passes the
  empty-resolution gate, and **silently drops most of the join**.

Deriving locally computes exactly what the macro computed, so both models stay
behavior-preserving by construction rather than depending on stored-column
freshness. This is the snapshot-fed exception already documented in
`src/dbt/kipptaf/CLAUDE.md`; the plan doc's older "wait for the snapshot to
re-run" framing was corrected in #4547.

### iReady — plain swap, but verified first

`int_topline__iready_diagnostic_weekly` is a straight swap. iReady is flagged as
a region **carve-out** because the shared `kippnj_iready` schema can make the
region regex disagree with the resolved project — which would have made this
swap a behavior change rather than a no-op. Verified against prod that it does
not apply here:

| `_dbt_source_project` | regexp-derived | rows |
| --- | --- | --- |
| kippnewark | kippnewark | 189,295 |
| kippcamden | kippcamden | 66,809 |
| kippmiami | kippmiami | 54,168 |

Zero divergence — the union is over district-level models, not the shared NJ
schema.

## Verification

- Column-resolution gate: `--empty --defer --favor-state` against the prod
  manifest — **PASS=3, ERROR=0**.
- `_dbt_source_project` stays CTE-internal in all three models, so no output
  column set changes and no `properties.yml` entries are required.
- `trunk check --force` clean.

## AI Assistance

AI-assisted (Claude Code), human-directed.

## Self-review

### dbt

- [x] Column-resolution gate passes (0 errors).
- [x] Snapshot-fed models derive rather than pass through, per the documented
      exception.
- [x] Carve-out risk on the iReady join checked against prod before swapping.
- [x] No output column set changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #3142
