### PR TITLE
fix(dbt): align ops dashboard union branch column order

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ops_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ops_dashboard.sql
@@ -39,9 +39,13 @@ with
 
             1 as target_enrollment,
             1 as target_enrollment_finance,
+
+            /* union all is positional — keep these five in the same order as
+               the targets branch above, or the values cross under each other's
+               aliases with no error */
             null as grade_band_ratio,
-            null as at_risk_and_lep_ratio,
             null as at_risk_only_ratio,
+            null as at_risk_and_lep_ratio,
             null as lep_only_ratio,
             null as sped_ratio,
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Align the two `UNION ALL` branches in `target_union` so the five financial-model
factor columns appear in the same order on both sides.

`UNION ALL` matches columns by **position, not name**, so the aliases on the
second branch are decoration. Positions two and three were crossed:

| Position | Targets branch | Self-contained / OOD branch |
| --- | --- | --- |
| 1 | `grade_band_ratio` | `grade_band_ratio` |
| 2 | `at_risk_only_ratio` | **`at_risk_and_lep_ratio`** |
| 3 | `at_risk_and_lep_ratio` | **`at_risk_only_ratio`** |
| 4 | `lep_only_ratio` | `lep_only_ratio` |
| 5 | `sped_ratio` | `sped_ratio` |

Both columns are `FLOAT64`, so BigQuery raises nothing. That is what makes it a
trap rather than a bug — there is no error to notice.

### Why this is inert today, and why it is still worth fixing

The second branch hardcodes `null` for all five factors, and a null swapped with
a null is still a null. Output column names come from the first branch, which is
correct. So today the crossing has no effect.

It bites the moment anyone gives that branch real values — say self-contained
students get their own factors. Two of the five would populate under each
other's labels, flow through `targets` (which aggregates them with `max()`), and
reach Tableau. No error, no failing test, just two wrong columns.

### Provenance

Not a regression from the recent `_dbt_source_project` work. `git log -L` places
this ordering in `a74a0f8f3`, the commit that created the model. My #4549
changes to this file touched the `att_mem` / `target_union` / `targets`
region-join predicates and left the column order as-is.

Surfaced by the code review on #4555 as an out-of-diff observation.

### Verification

The change is inert **by inspection**, not just by test: all five values on the
edited branch are `null` literals, so reordering two of them cannot alter any
output value. Backed by `dbt build --empty --defer --favor-state` over
`rpt_tableau__ops_dashboard+` (PASS=1, ERROR=0) and a clean
`trunk check --force`.

Added a short comment above the block explaining the positional coupling, since
nothing in the SQL makes it visible.

## AI Assistance

Claude Code authored the change; the decision to ship it separately rather than
fold it into #4555 was human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] No new models, no schema change, no column added or removed.
- [x] No exposure change — the model's output columns and their names are
      unchanged.
- [x] **Not a breaking change.** Value-identical today; the fix only removes a
      latent hazard.
- [x] No external source changes.

## CI checks

- [ ] **Trunk**
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud**
