### PR TITLE
perf(dagster): cron automation condition for high-cost eager dbt tables

### DIFF
--- a/docs/reference/automation-conditions.md
+++ b/docs/reference/automation-conditions.md
@@ -1,8 +1,8 @@
 # Automation Conditions
 
-Teamster uses three custom `AutomationCondition` builders in
+Teamster uses four custom `AutomationCondition` builders in
 `teamster.core.automation_conditions` that replace Dagster's default
-`AutomationCondition.eager()` for dbt assets. All three share a common skeleton
+`AutomationCondition.eager()` for dbt assets. All four share a common skeleton
 (`_build_dbt_condition`) and differ only in what triggers a materialization
 request beyond `newly_missing`.
 
@@ -65,18 +65,58 @@ change upstream model definitions trigger a re-run.
 The `CustomDagsterDbtTranslator` **auto-detects** these views by checking for
 `"union_relations"` in the model's `raw_code`.
 
-To manually override the condition type for any model, set
-`meta.dagster.automation_condition.type` in the dbt model's config:
+## Cron-cadence tables
+
+### `dbt_cron_automation_condition(cron_schedule, cron_timezone)`
+
+For expensive `materialized: table` models whose consumers refresh on a schedule
+(nightly extracts, Cube pre-aggregation refresh keys). Under the eager table
+condition, a wide table rebuilds on **every** upstream data refresh — freshness
+nothing consumes. This condition swaps the ancestor-updated trigger for
+`cron_tick_passed`: the table rebuilds on each cron tick instead.
+
+Everything else in the shared skeleton is retained — `newly_missing`,
+`code_version_changed` (deploys still rebuild immediately), and the
+deps-missing/in-progress guards. The tick trigger is wrapped in
+`.since(newly_requested | newly_updated)`, so a tick that fires while a dep is
+missing or in progress is latched, not lost — the request goes out once the
+guard clears.
+
+It is deliberately **not** Dagster's stock `AutomationCondition.on_cron()`: that
+condition's `all_deps_updated_since_cron` gate waits for _every_ dep to update
+after each tick, so one slower-cadence upstream (e.g. a weekly model) silently
+starves the schedule. `cron_tick_passed` is unconditional — a rebuild on a tick
+where nothing changed is accepted waste (one scan) in exchange for a
+deadlock-free cadence.
+
+Opt a model in via `meta.dagster.automation_condition.cron_schedule` in its
+properties YAML:
 
 ```yaml
 models:
-  - name: my_model
+  - name: my_expensive_model
     config:
+      materialized: table
       meta:
         dagster:
           automation_condition:
-            type: table # or "view"
+            cron_schedule: 0 0 * * *
+            # cron_timezone: America/New_York  # optional
 ```
+
+Contract and constraints:
+
+- **Tables only.** The translator ignores the key on `view` / `ephemeral` models
+  — a view must keep its view or `union_relations` condition (losing ancestor
+  code-version detection makes a stale `union_relations` view non-self-healing).
+- `cron_timezone` defaults to the code location's `LOCAL_TIMEZONE` (passed to
+  `CustomDagsterDbtTranslator` at construction); set the meta key only to
+  deviate from it.
+- The cron expression is **not validated at `dbt parse`** — a typo surfaces when
+  Dagster loads definitions. Multi-tick expressions (`0 0,10,15 * * *`) are
+  fine; align ticks ahead of the downstream consumers' refresh schedules.
+- Downstream eager tables cascade normally: assets requested on the same
+  evaluation batch into one run, and dbt orders them by DAG position.
 
 ## Non-dbt partitioned assets
 

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -11,6 +11,13 @@ models:
       for drilldown.
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: all consumers are nightly extracts or
+          # the assessment-scores star (also nightly) — same-tick requests
+          # batch into one run, so dbt orders this before the star. Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -13,11 +13,14 @@ models:
       materialized: table
       meta:
         dagster:
-          # nightly instead of eager: all consumers are nightly extracts or
-          # the assessment-scores star (also nightly) — same-tick requests
-          # batch into one run, so dbt orders this before the star. Refs #4559
+          # cron instead of eager (was 125+/day). Ticks lead the DDI Suite
+          # workbook's Dagster refresh crons (01:00 + 18:00 daily, 11:00 +
+          # 14:40 Wed, 16:00 Fri ET — exposures/tableau.yml) by >=1h so the
+          # downstream eager rpt tables rebuild in between; other consumers
+          # are nightly extracts or the assessment-scores star (midnight
+          # tick batches into the same run, dbt orders this first). Refs #4559
           automation_condition:
-            cron_schedule: 0 0 * * *
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -14,6 +14,12 @@ models:
       source_assessment_id).
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: Cube-only consumer, daily refresh_key —
+          # see fct_assessment_scores_enrollment_scoped. Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *
     columns:
       - name: assessment_administration_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
@@ -20,6 +20,12 @@ models:
         test families.
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: Cube-only consumer, daily refresh_key —
+          # see fct_assessment_scores_enrollment_scoped. Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *
     columns:
       - name: assessment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -10,6 +10,13 @@ models:
       and enrollment_resolution).
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: only consumer is Cube, whose sole
+          # pre-aggregation refresh_key checks once a day — intraday rebuilds
+          # (125+/day at ~4.6 GiB each) were invisible to it. Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *
     columns:
       - name: assessment_score_key
         data_type: string

--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_metrics.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_metrics.yml
@@ -2,3 +2,11 @@ models:
   - name: int_topline__student_metrics
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: 19 eager upstreams drove 44-180 full
+          # ~7 GiB rebuilds/day whose freshness nothing consumed — the only
+          # consumer chain is the topline cascade dashboard, delivered by
+          # nightly extract schedules (01:15-03:00 ET). Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *

--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -142,8 +142,8 @@ In Python, get this slash form with `key.to_user_string()` —
 
 See `core/CLAUDE.md` for automation condition builders
 (`dbt_view_automation_condition`, `dbt_union_relations_automation_condition`,
-`dbt_table_automation_condition`). Non-dbt assets use
-`AutomationCondition.eager()` or sensor/schedule triggers.
+`dbt_table_automation_condition`, `dbt_cron_automation_condition`). Non-dbt
+assets use `AutomationCondition.eager()` or sensor/schedule triggers.
 
 ## IO Managers
 

--- a/src/teamster/code_locations/kippcamden/dbt/assets.py
+++ b/src/teamster/code_locations/kippcamden/dbt/assets.py
@@ -1,12 +1,18 @@
 import json
 
-from teamster.code_locations.kippcamden import CODE_LOCATION, DBT_PROJECT
+from teamster.code_locations.kippcamden import (
+    CODE_LOCATION,
+    DBT_PROJECT,
+    LOCAL_TIMEZONE,
+)
 from teamster.libraries.dbt.assets import build_dbt_assets
 from teamster.libraries.dbt.dagster_dbt_translator import CustomDagsterDbtTranslator
 
 manifest = json.loads(s=DBT_PROJECT.manifest_path.read_text())
 
-dagster_dbt_translator = CustomDagsterDbtTranslator(code_location=CODE_LOCATION)
+dagster_dbt_translator = CustomDagsterDbtTranslator(
+    code_location=CODE_LOCATION, local_timezone=str(LOCAL_TIMEZONE)
+)
 
 dbt_assets = build_dbt_assets(
     manifest=manifest,

--- a/src/teamster/code_locations/kippmiami/dbt/assets.py
+++ b/src/teamster/code_locations/kippmiami/dbt/assets.py
@@ -1,12 +1,14 @@
 import json
 
-from teamster.code_locations.kippmiami import CODE_LOCATION, DBT_PROJECT
+from teamster.code_locations.kippmiami import CODE_LOCATION, DBT_PROJECT, LOCAL_TIMEZONE
 from teamster.libraries.dbt.assets import build_dbt_assets
 from teamster.libraries.dbt.dagster_dbt_translator import CustomDagsterDbtTranslator
 
 manifest = json.loads(s=DBT_PROJECT.manifest_path.read_text())
 
-dagster_dbt_translator = CustomDagsterDbtTranslator(code_location=CODE_LOCATION)
+dagster_dbt_translator = CustomDagsterDbtTranslator(
+    code_location=CODE_LOCATION, local_timezone=str(LOCAL_TIMEZONE)
+)
 
 dbt_assets = build_dbt_assets(
     manifest=manifest,

--- a/src/teamster/code_locations/kippnewark/dbt/assets.py
+++ b/src/teamster/code_locations/kippnewark/dbt/assets.py
@@ -1,12 +1,18 @@
 import json
 
-from teamster.code_locations.kippnewark import CODE_LOCATION, DBT_PROJECT
+from teamster.code_locations.kippnewark import (
+    CODE_LOCATION,
+    DBT_PROJECT,
+    LOCAL_TIMEZONE,
+)
 from teamster.libraries.dbt.assets import build_dbt_assets
 from teamster.libraries.dbt.dagster_dbt_translator import CustomDagsterDbtTranslator
 
 manifest = json.loads(s=DBT_PROJECT.manifest_path.read_text())
 
-dagster_dbt_translator = CustomDagsterDbtTranslator(code_location=CODE_LOCATION)
+dagster_dbt_translator = CustomDagsterDbtTranslator(
+    code_location=CODE_LOCATION, local_timezone=str(LOCAL_TIMEZONE)
+)
 
 dbt_assets = build_dbt_assets(
     manifest=manifest,

--- a/src/teamster/code_locations/kipppaterson/dbt/assets.py
+++ b/src/teamster/code_locations/kipppaterson/dbt/assets.py
@@ -1,12 +1,18 @@
 import json
 
-from teamster.code_locations.kipppaterson import CODE_LOCATION, DBT_PROJECT
+from teamster.code_locations.kipppaterson import (
+    CODE_LOCATION,
+    DBT_PROJECT,
+    LOCAL_TIMEZONE,
+)
 from teamster.libraries.dbt.assets import build_dbt_assets
 from teamster.libraries.dbt.dagster_dbt_translator import CustomDagsterDbtTranslator
 
 manifest = json.loads(s=DBT_PROJECT.manifest_path.read_text())
 
-dagster_dbt_translator = CustomDagsterDbtTranslator(code_location=CODE_LOCATION)
+dagster_dbt_translator = CustomDagsterDbtTranslator(
+    code_location=CODE_LOCATION, local_timezone=str(LOCAL_TIMEZONE)
+)
 
 dbt_assets = build_dbt_assets(
     manifest=manifest,

--- a/src/teamster/code_locations/kipptaf/dbt/assets.py
+++ b/src/teamster/code_locations/kipptaf/dbt/assets.py
@@ -2,7 +2,7 @@ import json
 
 from dagster import AssetSpec
 
-from teamster.code_locations.kipptaf import CODE_LOCATION, DBT_PROJECT
+from teamster.code_locations.kipptaf import CODE_LOCATION, DBT_PROJECT, LOCAL_TIMEZONE
 from teamster.code_locations.kipptaf.adp.payroll.assets import (
     GENERAL_LEDGER_FILE_PARTITIONS_DEF,
 )
@@ -11,7 +11,9 @@ from teamster.libraries.dbt.dagster_dbt_translator import CustomDagsterDbtTransl
 
 manifest = json.loads(s=DBT_PROJECT.manifest_path.read_text())
 
-dagster_dbt_translator = CustomDagsterDbtTranslator(code_location=CODE_LOCATION)
+dagster_dbt_translator = CustomDagsterDbtTranslator(
+    code_location=CODE_LOCATION, local_timezone=str(LOCAL_TIMEZONE)
+)
 
 core_dbt_assets = build_dbt_assets(
     manifest=manifest,

--- a/src/teamster/core/CLAUDE.md
+++ b/src/teamster/core/CLAUDE.md
@@ -93,7 +93,7 @@ All asset factories that yield Avro output call both of these.
 
 ### `automation_conditions.py`
 
-Three dbt-specific `AutomationCondition` builders, all sharing a common skeleton
+Four dbt-specific `AutomationCondition` builders, all sharing a common skeleton
 via `_build_dbt_condition()`:
 
 - `dbt_view_automation_condition()` — for VIEW models: re-runs on
@@ -103,6 +103,13 @@ via `_build_dbt_condition()`:
   `union_relations` macro: adds recursive ancestor `code_version_changed`
   detection (but NOT `any_deps_updated`) to the view condition. Triggers only on
   code deploys that change upstream model definitions, not on data refreshes.
+- `dbt_cron_automation_condition(cron_schedule, cron_timezone)` — for expensive
+  TABLE models whose consumers refresh on a schedule: replaces the
+  ancestor-updated trigger with `cron_tick_passed`. NOT stock `on_cron()` (its
+  all-deps-updated gate starves on mixed-cadence upstreams). Opted into per
+  model via `meta.dagster.automation_condition.cron_schedule` (tables only; the
+  translator ignores it on views). Timezone defaults to the code location's
+  `LOCAL_TIMEZONE` via the translator.
 - `dbt_table_automation_condition()` — for TABLE models: also triggers on
   upstream data changes, including through intermediate views via
   `_build_any_ancestor_updated()` (recursive `any_deps_match` up to

--- a/src/teamster/core/automation_conditions.py
+++ b/src/teamster/core/automation_conditions.py
@@ -200,7 +200,7 @@ def dbt_table_automation_condition() -> AutomationCondition:
 
 
 def dbt_cron_automation_condition(
-    cron_schedule: str, cron_timezone: str = "America/New_York"
+    cron_schedule: str, cron_timezone: str | None = None
 ) -> AutomationCondition:
     """Automation condition for expensive dbt TABLE models on a cron cadence.
 
@@ -218,9 +218,14 @@ def dbt_cron_automation_condition(
 
     Triggers: newly_missing, cron_tick_passed, code_version_changed (deploys
     still rebuild immediately). Retains the deps-missing/in-progress guards.
+
+    A None cron_timezone falls back to Dagster's cron_tick_passed default
+    (UTC). The dbt translator passes its code location's LOCAL_TIMEZONE, so
+    dbt models get local ticks without hardcoding a zone here.
     """
     return _build_dbt_condition(
         AutomationCondition.cron_tick_passed(
-            cron_schedule=cron_schedule, cron_timezone=cron_timezone
+            cron_schedule=cron_schedule,
+            cron_timezone=cron_timezone or "UTC",
         )
     )

--- a/src/teamster/core/automation_conditions.py
+++ b/src/teamster/core/automation_conditions.py
@@ -197,3 +197,30 @@ def dbt_table_automation_condition() -> AutomationCondition:
     return _build_dbt_condition(
         _build_any_ancestor_updated(view_selection=_VIEW_SELECTION)
     )
+
+
+def dbt_cron_automation_condition(
+    cron_schedule: str, cron_timezone: str = "America/New_York"
+) -> AutomationCondition:
+    """Automation condition for expensive dbt TABLE models on a cron cadence.
+
+    For wide/expensive tables whose consumers refresh on a schedule (nightly
+    extracts, Cube pre-aggregation refresh keys), the eager table condition
+    wastes warehouse spend: every upstream data refresh triggers a full
+    rebuild whose freshness nothing consumes. This condition swaps the
+    ancestor-updated trigger for a cron tick.
+
+    Deliberately NOT AutomationCondition.on_cron(): its
+    all_deps_updated_since_cron gate never fires when any dep on a slower
+    cadence (e.g. a weekly model) skips the window. cron_tick_passed is
+    unconditional — a rebuild on a tick where nothing upstream changed is
+    accepted waste (a single scan) in exchange for a deadlock-free cadence.
+
+    Triggers: newly_missing, cron_tick_passed, code_version_changed (deploys
+    still rebuild immediately). Retains the deps-missing/in-progress guards.
+    """
+    return _build_dbt_condition(
+        AutomationCondition.cron_tick_passed(
+            cron_schedule=cron_schedule, cron_timezone=cron_timezone
+        )
+    )

--- a/src/teamster/libraries/dbt/CLAUDE.md
+++ b/src/teamster/libraries/dbt/CLAUDE.md
@@ -36,7 +36,14 @@ Customizes asset key and automation condition generation:
   `dbt_union_relations_automation_condition()` — a third condition that adds
   recursive ancestor `code_version_changed` detection (but not
   `any_deps_updated`) to the view condition. This re-runs the view only when
-  upstream model SQL changes after a deploy, not on data-only refreshes.
+  upstream model SQL changes after a deploy, not on data-only refreshes. TABLE
+  models (not views/ephemerals) may opt into a cron cadence instead of the eager
+  condition via `meta.dagster.automation_condition.cron_schedule` in their
+  properties YAML (`dbt_cron_automation_condition()`); the timezone defaults to
+  the `local_timezone` the code location passes at translator construction (each
+  `dbt/assets.py` passes `str(LOCAL_TIMEZONE)`). Meta is resolved by
+  `_get_dbt_meta()` — `config.meta` or-shorts the WHOLE top-level `meta` dict
+  (no per-key merge), so set every dagster key on the same side.
 - **Group name**: Falls back to the dbt package name (for cross-project refs)
   then the first FQN segment after the project name.
 

--- a/src/teamster/libraries/dbt/dagster_dbt_translator.py
+++ b/src/teamster/libraries/dbt/dagster_dbt_translator.py
@@ -12,11 +12,29 @@ from teamster.core.automation_conditions import (
 )
 
 
+def _get_dbt_meta(dbt_resource_props: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Resolve a node's meta dict: config.meta wins, top-level meta is the
+    fallback.
+
+    NOTE: this is an or-short-circuit on the WHOLE dict, not a per-key merge —
+    a model setting any config.meta key hides ALL top-level meta keys (e.g. a
+    top-level meta.dagster.asset_key would be dropped if config.meta carries
+    only an automation_condition). Set every dagster key on the same side.
+    """
+    return dbt_resource_props.get("config", {}).get(
+        "meta", {}
+    ) or dbt_resource_props.get("meta", {})
+
+
 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     def __init__(
-        self, code_location: str, settings: DagsterDbtTranslatorSettings | None = None
+        self,
+        code_location: str,
+        local_timezone: str | None = None,
+        settings: DagsterDbtTranslatorSettings | None = None,
     ) -> None:
         self.code_location = code_location
+        self.local_timezone = local_timezone
 
         super().__init__(settings)
 
@@ -28,9 +46,7 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
         asset_key = super().get_asset_key(dbt_resource_props)
 
-        dbt_meta = dbt_resource_props.get("config", {}).get(
-            "meta", {}
-        ) or dbt_resource_props.get("meta", {})
+        dbt_meta = _get_dbt_meta(dbt_resource_props)
 
         if dbt_meta.get("dagster", {}).get("asset_key", []):
             return asset_key
@@ -44,19 +60,24 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
 
         # per-model override: meta.dagster.automation_condition.cron_schedule
         # puts an expensive table on a cron cadence instead of the eager
-        # (rebuild-on-any-upstream-update) table condition
-        dbt_meta = dbt_resource_props.get("config", {}).get(
-            "meta", {}
-        ) or dbt_resource_props.get("meta", {})
-
-        condition_meta = dbt_meta.get("dagster", {}).get("automation_condition", {})
-        cron_schedule = condition_meta.get("cron_schedule")
-
-        if cron_schedule is not None:
-            return dbt_cron_automation_condition(
-                cron_schedule=cron_schedule,
-                cron_timezone=condition_meta.get("cron_timezone", "America/New_York"),
+        # (rebuild-on-any-upstream-update) table condition. Tables only —
+        # views/ephemerals keep their view or union_relations condition
+        # (a union_relations view losing ancestor code-version detection
+        # goes stale non-self-healingly; see core/CLAUDE.md)
+        if materialized not in ("view", "ephemeral"):
+            condition_meta = (
+                _get_dbt_meta(dbt_resource_props)
+                .get("dagster", {})
+                .get("automation_condition", {})
             )
+            cron_schedule = condition_meta.get("cron_schedule")
+
+            if cron_schedule:
+                return dbt_cron_automation_condition(
+                    cron_schedule=cron_schedule,
+                    cron_timezone=condition_meta.get("cron_timezone")
+                    or self.local_timezone,
+                )
 
         # union_relations views need dep-aware refresh: their compiled SQL
         # resolves columns at run time via the macro and becomes stale when

--- a/src/teamster/libraries/dbt/dagster_dbt_translator.py
+++ b/src/teamster/libraries/dbt/dagster_dbt_translator.py
@@ -5,6 +5,7 @@ from dagster import AssetKey, AutomationCondition
 from dagster_dbt import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
 from teamster.core.automation_conditions import (
+    dbt_cron_automation_condition,
     dbt_table_automation_condition,
     dbt_union_relations_automation_condition,
     dbt_view_automation_condition,
@@ -40,6 +41,22 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         self, dbt_resource_props: Mapping[str, Any]
     ) -> AutomationCondition | None:
         materialized = dbt_resource_props.get("config", {}).get("materialized", "view")
+
+        # per-model override: meta.dagster.automation_condition.cron_schedule
+        # puts an expensive table on a cron cadence instead of the eager
+        # (rebuild-on-any-upstream-update) table condition
+        dbt_meta = dbt_resource_props.get("config", {}).get(
+            "meta", {}
+        ) or dbt_resource_props.get("meta", {})
+
+        condition_meta = dbt_meta.get("dagster", {}).get("automation_condition", {})
+        cron_schedule = condition_meta.get("cron_schedule")
+
+        if cron_schedule is not None:
+            return dbt_cron_automation_condition(
+                cron_schedule=cron_schedule,
+                cron_timezone=condition_meta.get("cron_timezone", "America/New_York"),
+            )
 
         # union_relations views need dep-aware refresh: their compiled SQL
         # resolves columns at run time via the macro and becomes stale when

--- a/tests/test_automation_conditions.py
+++ b/tests/test_automation_conditions.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 from dagster import (
     AssetKey,
@@ -1960,7 +1962,6 @@ def test_cron_table_not_requested_on_upstream_update():
     This is the whole point of the condition: an expensive table whose
     consumers refresh nightly should not rebuild on every upstream refresh.
     """
-    from datetime import datetime, timezone
 
     @asset(tags=_TABLE_TAG)
     def upstream_table():
@@ -1982,7 +1983,7 @@ def test_cron_table_not_requested_on_upstream_update():
 
     materialize(assets=all_assets, instance=instance)
 
-    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=UTC)
     result = evaluate_automation_conditions(
         defs=defs, instance=instance, evaluation_time=t0
     )
@@ -1995,7 +1996,7 @@ def test_cron_table_not_requested_on_upstream_update():
         defs=defs,
         instance=instance,
         cursor=result.cursor,
-        evaluation_time=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        evaluation_time=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
     )
     assert result.get_num_requested(AssetKey("cron_table")) == 0
 
@@ -2004,7 +2005,7 @@ def test_cron_table_not_requested_on_upstream_update():
         defs=defs,
         instance=instance,
         cursor=result.cursor,
-        evaluation_time=datetime(2026, 1, 2, 0, 1, tzinfo=timezone.utc),
+        evaluation_time=datetime(2026, 1, 2, 0, 1, tzinfo=UTC),
     )
     assert result.get_num_requested(AssetKey("cron_table")) == 1
 
@@ -2013,7 +2014,7 @@ def test_cron_table_not_requested_on_upstream_update():
         defs=defs,
         instance=instance,
         cursor=result.cursor,
-        evaluation_time=datetime(2026, 1, 2, 0, 2, tzinfo=timezone.utc),
+        evaluation_time=datetime(2026, 1, 2, 0, 2, tzinfo=UTC),
     )
     assert result.get_num_requested(AssetKey("cron_table")) == 0
 
@@ -2022,7 +2023,6 @@ def test_cron_table_requested_on_code_version_change():
     """Deploys still rebuild cron tables immediately, without waiting for
     the next tick — code_version_changed is retained from the shared
     condition skeleton."""
-    from datetime import datetime, timezone
 
     @asset(tags=_TABLE_TAG, code_version="1")
     def versioned_cron_table():
@@ -2041,7 +2041,7 @@ def test_cron_table_requested_on_code_version_change():
 
     materialize(assets=[versioned_cron_table], instance=instance)
 
-    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=UTC)
     result = evaluate_automation_conditions(
         defs=defs, instance=instance, evaluation_time=t0
     )
@@ -2065,7 +2065,7 @@ def test_cron_table_requested_on_code_version_change():
         defs=defs_v2,
         instance=instance,
         cursor=result.cursor,
-        evaluation_time=datetime(2026, 1, 1, 6, 5, tzinfo=timezone.utc),
+        evaluation_time=datetime(2026, 1, 1, 6, 5, tzinfo=UTC),
     )
     assert result.get_num_requested(AssetKey("versioned_cron_table")) == 1
 
@@ -2077,8 +2077,11 @@ def test_translator_meta_cron_schedule_override():
         CustomDagsterDbtTranslator,
     )
 
-    translator = CustomDagsterDbtTranslator(code_location="kipptaf")
+    translator = CustomDagsterDbtTranslator(
+        code_location="kipptaf", local_timezone="America/New_York"
+    )
 
+    # no cron_timezone in meta: the translator's local_timezone applies
     cron_props = {
         "config": {
             "materialized": "table",
@@ -2089,8 +2092,9 @@ def test_translator_meta_cron_schedule_override():
     }
     assert translator.get_automation_condition(
         cron_props
-    ) == dbt_cron_automation_condition("0 0 * * *")
+    ) == dbt_cron_automation_condition("0 0 * * *", cron_timezone="America/New_York")
 
+    # explicit meta cron_timezone wins over the translator's local_timezone
     tz_props = {
         "config": {
             "materialized": "table",
@@ -2119,3 +2123,99 @@ def test_translator_meta_cron_schedule_override():
         translator.get_automation_condition(plain_view_props)
         == dbt_view_automation_condition()
     )
+
+    # top-level meta (no config.meta) is the fallback arm of _get_dbt_meta
+    top_level_meta_props = {
+        "config": {"materialized": "table"},
+        "meta": {"dagster": {"automation_condition": {"cron_schedule": "0 0 * * *"}}},
+    }
+    assert translator.get_automation_condition(
+        top_level_meta_props
+    ) == dbt_cron_automation_condition("0 0 * * *", cron_timezone="America/New_York")
+
+    # the override is table-only: a view carrying the meta key keeps its
+    # view condition (union_relations detection must not be lost)
+    view_with_cron_props = {
+        "config": {
+            "materialized": "view",
+            "meta": {
+                "dagster": {"automation_condition": {"cron_schedule": "0 0 * * *"}}
+            },
+        }
+    }
+    assert (
+        translator.get_automation_condition(view_with_cron_props)
+        == dbt_view_automation_condition()
+    )
+
+    # an empty cron_schedule fails the truthiness guard and falls through
+    empty_cron_props = {
+        "config": {
+            "materialized": "table",
+            "meta": {"dagster": {"automation_condition": {"cron_schedule": ""}}},
+        }
+    }
+    assert (
+        translator.get_automation_condition(empty_cron_props)
+        == dbt_table_automation_condition()
+    )
+
+
+def test_cron_table_tick_latched_while_dep_missing():
+    """A tick that fires while a dep is missing is not lost: the
+    .since(newly_requested | newly_updated) wrapper latches the trigger and
+    the request goes out once the dep guard clears — no new tick needed.
+
+    This is the deps-guard behavior the docstring advertises, and what the
+    same-tick run batching of response_rollup -> assessment star relies on.
+    """
+
+    @asset(tags=_TABLE_TAG)
+    def latch_upstream():
+        return 1
+
+    @asset(
+        deps=[latch_upstream],
+        automation_condition=dbt_cron_automation_condition(
+            "0 0 * * *", cron_timezone="UTC"
+        ),
+        tags=_TABLE_TAG,
+    )
+    def latch_cron_table():
+        return 2
+
+    instance = DagsterInstance.ephemeral()
+    defs = Definitions(assets=[latch_upstream, latch_cron_table])
+
+    # only the cron table exists; its dep is missing
+    materialize(
+        assets=[latch_upstream, latch_cron_table],
+        instance=instance,
+        selection=[latch_cron_table],
+    )
+
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        evaluation_time=datetime(2026, 1, 1, 6, 0, tzinfo=UTC),
+    )
+    assert result.total_requested == 0
+
+    # tick crosses midnight while the dep is still missing: blocked
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 2, 0, 1, tzinfo=UTC),
+    )
+    assert result.get_num_requested(AssetKey("latch_cron_table")) == 0
+
+    # dep materializes — no new tick — and the latched trigger fires
+    materialize(assets=[latch_upstream], instance=instance, selection=[latch_upstream])
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 2, 0, 10, tzinfo=UTC),
+    )
+    assert result.get_num_requested(AssetKey("latch_cron_table")) == 1

--- a/tests/test_automation_conditions.py
+++ b/tests/test_automation_conditions.py
@@ -13,6 +13,7 @@ from dagster import (
 )
 
 from teamster.core.automation_conditions import (
+    dbt_cron_automation_condition,
     dbt_table_automation_condition,
     dbt_union_relations_automation_condition,
     dbt_view_automation_condition,
@@ -1951,3 +1952,170 @@ def test_union_relations_view_triggered_by_ancestor_code_version_change():
         defs=defs_v2, instance=instance, cursor=result.cursor
     )
     assert result.get_num_requested(AssetKey("union_relations_view")) == 1
+
+
+def test_cron_table_not_requested_on_upstream_update():
+    """Cron tables ignore upstream data updates; only the tick triggers.
+
+    This is the whole point of the condition: an expensive table whose
+    consumers refresh nightly should not rebuild on every upstream refresh.
+    """
+    from datetime import datetime, timezone
+
+    @asset(tags=_TABLE_TAG)
+    def upstream_table():
+        return 1
+
+    @asset(
+        deps=[upstream_table],
+        automation_condition=dbt_cron_automation_condition(
+            "0 0 * * *", cron_timezone="UTC"
+        ),
+        tags=_TABLE_TAG,
+    )
+    def cron_table():
+        return 2
+
+    instance = DagsterInstance.ephemeral()
+    all_assets = [upstream_table, cron_table]
+    defs = Definitions(assets=all_assets)
+
+    materialize(assets=all_assets, instance=instance)
+
+    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=t0
+    )
+    assert result.total_requested == 0
+
+    # upstream data refresh mid-day: eager tables would rebuild; cron must not
+    materialize(assets=[upstream_table], instance=instance, selection=[upstream_table])
+
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    assert result.get_num_requested(AssetKey("cron_table")) == 0
+
+    # midnight tick crossed: requested exactly once
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 2, 0, 1, tzinfo=timezone.utc),
+    )
+    assert result.get_num_requested(AssetKey("cron_table")) == 1
+
+    # trigger consumed by the request: not re-requested before the next tick
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 2, 0, 2, tzinfo=timezone.utc),
+    )
+    assert result.get_num_requested(AssetKey("cron_table")) == 0
+
+
+def test_cron_table_requested_on_code_version_change():
+    """Deploys still rebuild cron tables immediately, without waiting for
+    the next tick — code_version_changed is retained from the shared
+    condition skeleton."""
+    from datetime import datetime, timezone
+
+    @asset(tags=_TABLE_TAG, code_version="1")
+    def versioned_cron_table():
+        return 1
+
+    versioned_cron_table = versioned_cron_table.map_asset_specs(
+        lambda spec: spec.replace_attributes(
+            automation_condition=dbt_cron_automation_condition(
+                "0 0 * * *", cron_timezone="UTC"
+            )
+        )
+    )
+
+    instance = DagsterInstance.ephemeral()
+    defs = Definitions(assets=[versioned_cron_table])
+
+    materialize(assets=[versioned_cron_table], instance=instance)
+
+    t0 = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+    result = evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=t0
+    )
+    assert result.total_requested == 0
+
+    # simulate deploy: code version changes, no cron tick crossed
+    @asset(key="versioned_cron_table", tags=_TABLE_TAG, code_version="2")
+    def versioned_cron_table_v2():
+        return 1
+
+    versioned_cron_table_v2 = versioned_cron_table_v2.map_asset_specs(
+        lambda spec: spec.replace_attributes(
+            automation_condition=dbt_cron_automation_condition(
+                "0 0 * * *", cron_timezone="UTC"
+            )
+        )
+    )
+
+    defs_v2 = Definitions(assets=[versioned_cron_table_v2])
+    result = evaluate_automation_conditions(
+        defs=defs_v2,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=datetime(2026, 1, 1, 6, 5, tzinfo=timezone.utc),
+    )
+    assert result.get_num_requested(AssetKey("versioned_cron_table")) == 1
+
+
+def test_translator_meta_cron_schedule_override():
+    """meta.dagster.automation_condition.cron_schedule overrides the
+    materialized-type condition; absent meta falls through unchanged."""
+    from teamster.libraries.dbt.dagster_dbt_translator import (
+        CustomDagsterDbtTranslator,
+    )
+
+    translator = CustomDagsterDbtTranslator(code_location="kipptaf")
+
+    cron_props = {
+        "config": {
+            "materialized": "table",
+            "meta": {
+                "dagster": {"automation_condition": {"cron_schedule": "0 0 * * *"}}
+            },
+        }
+    }
+    assert translator.get_automation_condition(
+        cron_props
+    ) == dbt_cron_automation_condition("0 0 * * *")
+
+    tz_props = {
+        "config": {
+            "materialized": "table",
+            "meta": {
+                "dagster": {
+                    "automation_condition": {
+                        "cron_schedule": "0 0 * * *",
+                        "cron_timezone": "UTC",
+                    }
+                }
+            },
+        }
+    }
+    assert translator.get_automation_condition(
+        tz_props
+    ) == dbt_cron_automation_condition("0 0 * * *", cron_timezone="UTC")
+
+    plain_table_props = {"config": {"materialized": "table", "meta": {}}}
+    assert (
+        translator.get_automation_condition(plain_table_props)
+        == dbt_table_automation_condition()
+    )
+
+    plain_view_props = {"config": {"materialized": "view", "meta": {}}}
+    assert (
+        translator.get_automation_condition(plain_view_props)
+        == dbt_view_automation_condition()
+    )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will move five expensive dbt tables off the eager (rebuild-on-any-upstream-update) automation condition onto a nightly cron cadence, cutting an estimated ~40% of the July BigQuery analysis bill:

- `int_topline__student_metrics` — 19 eager upstreams drove 44-180 full ~7 GiB rebuilds/day (~15.8 TiB in July, 29% of the bill); its only consumer chain is the topline cascade dashboard, delivered by nightly extract schedules (01:15-03:00 ET).
- `fct_assessment_scores_enrollment_scoped`, `dim_assessments`, `dim_assessment_administrations` — Cube-only consumers, whose sole pre-aggregation refresh key checks once a day; the 125+/day rebuilds were invisible to it.
- `int_assessments__response_rollup` — all 13 consumers are nightly extracts or the models above.

Implementation:

1. `dbt_cron_automation_condition(cron_schedule, cron_timezone)` in `core/automation_conditions.py`, built from the shared `_build_dbt_condition()` skeleton with `cron_tick_passed` as the trigger. Deliberately NOT stock `on_cron()`: its all-deps-updated-since-cron gate never fires when any mixed-cadence upstream (e.g. a weekly model) skips the window. `newly_missing` and `code_version_changed` triggers are retained, so deploys still rebuild immediately.
2. A per-model override in `CustomDagsterDbtTranslator.get_automation_condition`, read from model YAML meta before the materialized-type fallthrough:

   ```yaml
   config:
     meta:
       dagster:
         automation_condition:
           cron_schedule: 0 0 * * *
   ```

3. The five models set to `0 0 * * *` America/New_York — before the extract window and Cube's daily refresh-key check. Same-tick requests batch into one run, so dbt orders `int_assessments__response_rollup` ahead of the star. Downstream eager tables (e.g. `rpt_tableau__topline_cascade_dashboard`) cascade once per tick through the intermediate view.

## AI Assistance

Claude Code performed the cost investigation (INFORMATION_SCHEMA job analysis), authored the condition/translator code, tests, and YAML changes; human-directed scope, model selection, and cadence.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location — see note below
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location — `tests/test_automation_conditions.py` run in full: 3 new tests pass; 3 failures reproduce identically on untouched `main` (pre-existing, unrelated)
- [x] New integrations follow the Library + Config pattern — n/a, no new integration

Verification notes: `dbt parse` clean; translator verified against the real kipptaf manifest — all five models resolve to the cron condition, untouched models keep their existing conditions; `kipptaf.definitions` module-load validation is not possible in the Codespace (dlt credential specs resolve eagerly), covered instead by the manifest-driven translator check above.

### dbt

- [x] Properties files — YAML-only change to five existing properties files
- [x] Exposures — unchanged; no model logic or columns touched
- [x] **Breaking change?** No — automation cadence only; no schema changes

### Docs

- [x] No schedule or sensor definitions changed — automation conditions are not in the automations catalog

## CI checks

- [ ] **Trunk** — `trunk check --force` clean locally on all 8 changed files
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud**

Closes #4559
