### PR TITLE
docs: file the session log to the shared Drive folder

### DIFF
--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -139,7 +139,7 @@ WG_LOG_<YYYY-MM-DD>_<HHMM>_<participant>.md
   reconcile.** Several logs per day, including several from the same person, are
   expected; this keeps them from colliding and sorts them chronologically.
 
-### When to write it
+### When to write the downloadable file
 
 1. Write the file as soon as the first substantive query is logged, so the
    artifact exists even if the session ends abruptly.
@@ -150,6 +150,33 @@ Reuse the same filename all session so each write replaces the previous one
 instead of accumulating near-duplicates. If file creation is unavailable to you,
 fall back to emitting the whole log as one fenced Markdown block for the
 participant to save by hand — and say that is what you did.
+
+### Filing the log to Drive
+
+When the participant signals the session is wrapping — or asks you to file the
+log — write the final log to the shared Drive folder (`parentId`
+`1bLmma3PlSUbzSVZtNEjCNCfSi4l5GVAo`) with `contentMimeType: text/markdown` and
+`disableConversionToGoogleType: true`, so it stays a real `.md` file instead of
+being converted to a Google Doc.
+
+Search that folder for the filename FIRST. If it already exists, this is a
+re-file: create it as `..._rev2.md` (then `_rev3`) and say which one is
+authoritative. Never create a second file under the identical name.
+
+Write once per session, at the end — not per query. The connector can only
+create, never update or delete, so every extra write is permanent clutter that
+nobody can clean up programmatically. The conversation itself is the backstop if
+a session ends abruptly: the log can be filed later from the same chat.
+
+Report the resulting Drive link so the participant can confirm it landed.
+
+Only the session log goes to the shared folder. An authorized identified
+deliverable (a student roster or CSV) stays with the participant who was
+authorized for it — never auto-file it somewhere the whole group can read it.
+
+The folder ID above is committed to a public repository, so it must stay
+restricted to the working group. Never widen that folder to "anyone with the
+link."
 
 ### What goes in it
 


### PR DESCRIPTION
## Summary and Motivation

When merged, assessment working-group participants stop hand-uploading their session logs. `assessment-cube-orchestrator.md` gains a Drive-filing step: at the end of a session Claude writes the final log straight into the shared Drive folder via the claude.ai Google Drive connector.

**Verified end to end against the live connector before writing this**, not assumed. A test log was created in the target folder and came back `mimeType: text/markdown` with `fileExtension: md` — it stays real Markdown rather than converting to a Google Doc, which is what `disableConversionToGoogleType: true` buys. Filename convention survived verbatim, the file landed in the right folder, and it was discoverable by a follow-up folder search. Cube and Drive connectors also coexisted in one session.

## How the cadence is managed

The connector is **create-only** — it exposes no update, delete, or move tool — and a chat has **no end-of-session event**. So the step is built around both constraints:

- **Once per session, at the end**, not per query. Every extra write would be permanent clutter nobody can clean up programmatically. The neighboring heading is renamed to `When to write the downloadable file` so the per-query refresh cadence is not misread as applying to Drive.
- **Search the folder for the filename first.** If it exists, this is a re-file: create `..._rev2.md` (then `_rev3`) and state which is authoritative. Never duplicate a name silently.
- **Trigger is a wrap signal or an explicit ask**, and Claude reports the Drive link back — so a write that did not happen is visible rather than silent. The conversation is the backstop: a missed filing can be done later from the same chat, since the log content was never lost.

## Guardrails

- **Session logs only.** An authorized identified deliverable (a student roster or CSV) stays with the participant who was authorized for it — never auto-filed where the whole group can read it. Logs are PII-free by design; rosters are not.
- **The folder ID is committed to a public repo**, so the file states plainly that the folder must stay restricted to the working group and must never be widened to anyone-with-the-link.

Follow-up for team-owned rather than individually-owned logs is tracked in #4565. Refs #4565.

## Self-review

### Docs

Not applicable — no schedule, sensor, or integration changes. This is a claude.ai Project-knowledge file, not an MkDocs page.

## CI checks

- [ ] Trunk — passes (`trunk check --force` clean, no issues).
