### PR TITLE
docs: fold i-Ready growth and administration-window findings into the reference

### DIFF
--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -79,6 +79,11 @@ leadership:
   per instrument
 - which subjects count as `math` for network reporting
 - how `grade_level_tested` should be handled when it reflects a prior grade
+- what counts as high vs low growth, or high vs low proficiency, for
+  quadrant-style school reporting — a median split of the charted population is
+  a convenience, not a ratified threshold
+- how to attribute a mid-year transfer student in growth reporting: to the
+  school they started the year at, or the one they ended it at
 
 Some individual fields also carry their own narrower open question (for example,
 which count measure is the default for a count/share question) — those are
@@ -131,7 +136,8 @@ WG_LOG_<YYYY-MM-DD>_<HHMM>_<participant>.md
 
 - `<YYYY-MM-DD>_<HHMM>` — session start, 24-hour clock. State in the header
   which timezone you used; if you only have a UTC clock, say UTC.
-- `<participant>` — the participant's last name, lowercased (`walters`). Two
+- `<participant>` — the participant's name, lowercased, as a single word:
+  whichever of last or first name you have (`walters`, `anthony`). Two
   participants: hyphenate (`walters-ramirez`); more than two: use the team name.
   No name given: use initials, then `unknown` as a last resort.
 - Example: `WG_LOG_2026-07-24_1430_walters.md`

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -77,6 +77,18 @@ Apply to every assessment source unless a source section overrides them.
   "scores in May") mixes those two date concepts. `date_taken` is a standalone
   field (nullable for a small share of internal rows); prefer the
   `academic_year` / `academic_year_label` members for year rollups.
+- **`administration_period` is populated for every source except Illuminate**,
+  but the vocabulary differs by source — so never filter it without also scoping
+  `assessment_type`. i-Ready and DIBELS use `BOY` / `MOY` / `EOY`; STAR and NJ
+  state use `Fall` / `Winter` / `Spring`; FL state uses the FLDOE window (`PM1`
+  / `PM2` / `PM3`). It is null only for `illuminate`. (The field's own
+  description covers the state and college windows only — it does not mention
+  the vendor values.)
+- **There is no growth measure.** The view carries point-in-time scores only —
+  no native growth, gain, or progress-to-target measure exists for any source.
+  Any growth figure is therefore constructed by the analyst: say so explicitly,
+  and see the i-Ready section for why cross-grade-band growth comparisons are a
+  trap.
 - **Domain rollup: `response_type_root_description`** is the CCSS domain rollup
   — reliable for CCSS-aligned content, unreliable for FL state-aligned
   standards. Illuminate only (null elsewhere, since `response_type` is null
@@ -121,11 +133,30 @@ Apply to every assessment source unless a source section overrides them.
   shorthand does not apply).
 - **Time:** `academic_year` / `academic_year_label` now resolve (derived from
   the completion/test date) — filter the school year with them.
+- **Administrations:** `administration_period` = `BOY` / `MOY` / `EOY`, plus
+  `Outside Round` for sittings taken outside the three benchmark windows.
+  Filtering to only `BOY` / `MOY` / `EOY` silently drops the `Outside Round`
+  rows — scope deliberately and state which windows you used.
+- **Region coverage: Newark, Camden, and Miami only — there is no i-Ready data
+  for Paterson.** A "compare i-Ready across all regions" question therefore
+  returns three of the four regions; say so rather than implying network-wide
+  coverage.
+- **Growth is not in the model, and scale scores do not normalize across grade
+  bands.** i-Ready's vendor growth norms (typical growth, percent progress to
+  typical growth) are not ingested, so that metric cannot be computed — do not
+  approximate it and label it with the vendor's name. A BOY-to-EOY scale-score
+  delta _is_ computable, but it compresses at higher grades, and dividing by the
+  BOY baseline makes the distortion worse because the baseline itself rises with
+  grade. Report growth **within** a grade band, never pooled across ES and MS:
+  pooling makes every MS school look low-growth from scale mechanics alone, not
+  from instruction.
 - **`is_replacement` is Illuminate-only by design** — null for i-Ready (and all
-  vendor/state sources), not a gap. For a genuine multiple sitting, pick the
-  authoritative score by most recent `date_taken`.
-- Documented from the live schema and one working-group session (Camden ES ELA
-  DIBELS-vs-i-Ready concordance) — confirm interpretations before external use.
+  vendor/state sources), not a gap. Genuine multiple sittings occur even within
+  a single benchmark window, so dedup to the most recent `date_taken` per
+  student per window before computing anything student-level.
+- Documented from the live schema and two working-group sessions (a Camden ES
+  ELA DIBELS-vs-i-Ready concordance, and a BOY-to-EOY growth-quadrant analysis)
+  — confirm interpretations before external use.
 
 ## Vendor normed diagnostics — DIBELS
 
@@ -137,6 +168,8 @@ Apply to every assessment source unless a source section overrides them.
   `is_mastery` is populated. `performance_band_label_number` is null.
 - **Time:** `academic_year` / `academic_year_label` now resolve — filter the
   school year with them.
+- **Administrations:** `administration_period` = `BOY` / `MOY` / `EOY`, the same
+  benchmark-window vocabulary as i-Ready.
 - Documented from the live schema and one working-group session (used as the
   comparison instrument in a Camden ES ELA concordance) — confirm before
   external use.
@@ -151,6 +184,9 @@ Apply to every assessment source unless a source section overrides them.
   is null.
 - **Time:** `academic_year` / `academic_year_label` now resolve — filter the
   school year with them.
+- **Administrations:** `administration_period` = `Fall` / `Winter` / `Spring` —
+  season names, **not** the `BOY` / `MOY` / `EOY` vocabulary i-Ready and DIBELS
+  use. Do not carry a benchmark-window filter across from those sources.
 - Not exercised in the working-group sessions; documented from the live schema —
   confirm before external use.
 


### PR DESCRIPTION
## Summary and Motivation

First full run of the update loop through the new Drive pipeline: a working-group session filed its log to the shared Drive folder, the log was read back from Drive, and its findings are folded into the direction files here. **Every claim was re-verified against live Cube before being written** — the log itself flagged one item as "needs confirmation," and the checks turned up two things the log did not catch.

### New in Shared conventions

- **`administration_period` is populated for every source except `illuminate`, but the vocabulary differs by source** — so it must never be filtered without also scoping `assessment_type`. i-Ready and DIBELS use `BOY` / `MOY` / `EOY`; STAR and NJ state use `Fall` / `Winter` / `Spring`; FL state uses the FLDOE windows. This also settles a stale prior-session backlog note claiming vendor administration periods were null: verified, `illuminate` is the only source with nulls.
- **There is no growth measure** anywhere on the view — point-in-time scores only. Any growth figure is analyst-constructed and must be labeled as such.

### New in the i-Ready section

- **`Outside Round` is a fourth `administration_period` value** (~10k scores) that the log did not mention. Filtering to just BOY/MOY/EOY silently drops it.
- **No i-Ready data exists for Paterson at all** — Newark, Camden, and Miami only. This answers the log's open coverage question: it is not a BOY-plus-EOY matching artifact. A "compare all regions" question silently returns three of four.
- **Vendor growth norms are not ingested**, so percent-progress-to-typical-growth cannot be computed — and must not be approximated under the vendor's name. A scale-score delta is computable but compresses at higher grades, and dividing by the BOY baseline worsens the distortion. Report growth within a grade band, never pooled across ES and MS, or scale mechanics alone make every MS school look low-growth.
- Duplicate sittings occur **within** a single benchmark window, not only across windows.

### New in DIBELS and STAR

Administration windows documented per source, with an explicit warning that STAR's season names are not interchangeable with the BOY/MOY/EOY vocabulary.

### Orchestrator

Two open decisions added to the flag-do-not-invent list, both surfaced by the session as self-constructed conventions: quadrant high/low thresholds (a median split is a convenience, not policy), and mid-year transfer-student attribution in growth reporting. The filename rule is also relaxed to whichever of last or first name is available, matching what the live session actually produced.

## Note for a future Cube issue

The `administration_period` field description documents only the state and college windows — it does not mention the vendor values at all. Same class of description gap as the ones fixed in #4551. Not filed yet.

## Self-review

### Docs

Not applicable — no schedule, sensor, or integration changes. These are claude.ai Project-knowledge files, not MkDocs pages.

## CI checks

- [ ] Trunk — passes (`trunk check --force` clean after the commit-hook format).
