### PR TITLE
perf(dbt): nightly cron for int_topline__student_retention_weekly_aggregations

### DIFF
--- a/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_retention_weekly_aggregations.yml
+++ b/src/dbt/kipptaf/models/topline/intermediate/properties/int_topline__student_retention_weekly_aggregations.yml
@@ -2,3 +2,12 @@ models:
   - name: int_topline__student_retention_weekly_aggregations
     config:
       materialized: table
+      meta:
+        dagster:
+          # nightly instead of eager: int_students__retention_over_time updates
+          # all day, driving 35-150 rebuilds/day that each cascade to
+          # rpt_tableau__topline_cascade_dashboard — whose Tableau refresh runs
+          # once at 05:00 ET. Same treatment as int_topline__student_metrics
+          # (the chain's other table input). Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put `int_topline__student_retention_weekly_aggregations` on the nightly cron automation condition (`0 0 * * *` ET), completing the topline cascade chain started in #4560.

Missed in #4560: `int_topline__dashboard_aggregations` (the view feeding `rpt_tableau__topline_cascade_dashboard`) has **two** eager table inputs. `int_topline__student_metrics` was converted; this one kept its eager condition and — driven by all-day `int_students__retention_over_time` updates — rebuilt 35-151x/day (BigQuery jobs, Jul 24-27), cascading each time into a rebuild of the cascade dashboard rpt table whose Tableau refresh runs once at 05:00 ET. Scan cost is minor (~1-2.6 GiB/day); the waste is Dagster/Kubernetes run churn and the downstream rpt rebuilds.

YAML-only change using the `meta.dagster.automation_condition.cron_schedule` contract from #4560; verified via `dbt parse` + manifest-driven translator check (resolves to the cron condition in America/New_York).

## AI Assistance

Claude Code diagnosed the residual refresh churn and authored the change; human-directed (hotfix, no issue).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] No Dagster code changes — dbt YAML meta only; translator behavior covered by #4560's tests

### dbt

- [x] Properties file — edit to an existing properties file
- [x] Exposures — unchanged
- [x] **Breaking change?** No — automation cadence only

### Docs

- [x] No schedule or sensor definitions changed

## CI checks

- [ ] **Trunk**
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud**

Refs #4559
