### PR TITLE
fix(sftp): reject traversing remote filenames in download paths

### DIFF
--- a/src/teamster/libraries/sftp/assets.py
+++ b/src/teamster/libraries/sftp/assets.py
@@ -40,6 +40,31 @@ def compose_regex(
         return regexp
 
 
+def build_local_filepath(asset_key_string: str, remote_filepath: str) -> str:
+    """Map a remote SFTP path to its download location under `/tmp/dagster`.
+
+    The remote directory structure is kept intact — two files sharing a basename
+    in different remote folders must not collide — and the resolved path is
+    asserted to stay inside the asset's own transient directory, so a remote
+    path that traverses upward can never redirect the download elsewhere on
+    disk.
+
+    Raises:
+        ValueError: if the remote path resolves outside the asset's directory.
+    """
+    # trunk-ignore(bandit/B108): intentional /tmp/dagster transient dir
+    local_dir = os.path.normpath(f"/tmp/dagster/{asset_key_string}")
+
+    local_filepath = os.path.normpath(f"{local_dir}/{remote_filepath}")
+
+    if not local_filepath.startswith(f"{local_dir}{os.sep}"):
+        raise ValueError(
+            f"Remote filepath '{remote_filepath}' resolves outside '{local_dir}'"
+        )
+
+    return local_filepath
+
+
 def extract_pdf_to_dict(stream: str, pdf_row_pattern: str):
     records = []
 
@@ -183,7 +208,10 @@ def build_sftp_file_asset(
 
         local_filepath = ssh.sftp_get(
             remote_filepath=file_match,
-            local_filepath=f"/tmp/dagster/{context.asset_key.to_user_string()}/{file_match}",  # trunk-ignore(bandit/B108): intentional /tmp/dagster transient dir
+            local_filepath=build_local_filepath(
+                asset_key_string=context.asset_key.to_user_string(),
+                remote_filepath=file_match,
+            ),
         )
 
         if os.path.getsize(local_filepath) == 0:
@@ -321,7 +349,10 @@ def build_sftp_archive_asset(
 
         local_filepath = ssh.sftp_get(
             remote_filepath=file_match,
-            local_filepath=f"/tmp/dagster/{context.asset_key.to_user_string()}/{file_match}",  # trunk-ignore(bandit/B108): intentional /tmp/dagster transient dir
+            local_filepath=build_local_filepath(
+                asset_key_string=context.asset_key.to_user_string(),
+                remote_filepath=file_match,
+            ),
         )
 
         # exit if file is empty
@@ -467,7 +498,10 @@ def build_sftp_folder_asset(
         for file in file_matches:
             local_filepath = ssh.sftp_get(
                 remote_filepath=file,
-                local_filepath=f"/tmp/dagster/{context.asset_key.to_user_string()}/{file}",  # trunk-ignore(bandit/B108): intentional /tmp/dagster transient dir
+                local_filepath=build_local_filepath(
+                    asset_key_string=context.asset_key.to_user_string(),
+                    remote_filepath=file,
+                ),
             )
 
             # skip if file is empty

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import select
 import socket
 import socketserver
@@ -45,6 +46,30 @@ _LegacyRSAKey = type(
     (RSAKey,),
     {"HASHES": {**RSAKey.HASHES, "ssh-rsa": hashes.SHA1}},
 )
+
+
+def _check_listing_filename(filename: str, remote_dir: str) -> None:
+    """Reject a directory entry that is not a single, non-traversing name.
+
+    Entry names come from the remote server and are joined onto ``remote_dir``
+    to build the paths callers list, match, and download. A real SFTP entry is
+    always one path component (paramiko already drops the exact ``.`` and
+    ``..`` entries, nothing else), so a name carrying a separator or a ``..``
+    could steer that join — and the local download path derived from it —
+    outside the directory being walked.
+
+    Raises:
+        ValueError: if the entry name is empty, a relative-directory reference,
+            or contains a path separator.
+    """
+    separators = {"/", os.sep, os.altsep}
+
+    if filename in ("", ".", "..") or any(
+        sep is not None and sep in filename for sep in separators
+    ):
+        raise ValueError(
+            f"Illegal filename in SFTP listing of '{remote_dir}': '{filename}'"
+        )
 
 
 def _persist_legacy_rsa(transport: Transport) -> None:
@@ -161,6 +186,8 @@ class SSHResource(DagsterSSHResource):
 
         files: list[tuple[SFTPAttributes, str]] = []
         for file in sftp_client.listdir_attr(remote_dir):
+            _check_listing_filename(filename=file.filename, remote_dir=remote_dir)
+
             path = str(Path(remote_dir) / file.filename)
             mtime = check.not_none(value=file.st_mtime)
 

--- a/tests/libraries/test_sftp_local_filepath.py
+++ b/tests/libraries/test_sftp_local_filepath.py
@@ -1,0 +1,58 @@
+"""Unit tests for the SFTP asset local download path builder (no external deps)."""
+
+import pytest
+
+from teamster.libraries.sftp.assets import build_local_filepath
+
+ASSET_KEY_STRING = "kipptaf/nsc/student_tracker"
+LOCAL_DIR = f"/tmp/dagster/{ASSET_KEY_STRING}"
+
+
+def test_relative_remote_path_keeps_directory_structure():
+    assert (
+        build_local_filepath(
+            asset_key_string=ASSET_KEY_STRING,
+            remote_filepath="reconcile_report_files/2026/report.csv",
+        )
+        == f"{LOCAL_DIR}/reconcile_report_files/2026/report.csv"
+    )
+
+
+def test_absolute_remote_path_nests_under_the_asset_directory():
+    assert (
+        build_local_filepath(
+            asset_key_string=ASSET_KEY_STRING,
+            remote_filepath="/data-team/kipptaf/nsc/student_tracker/report.csv",
+        )
+        == f"{LOCAL_DIR}/data-team/kipptaf/nsc/student_tracker/report.csv"
+    )
+
+
+def test_same_basename_in_different_remote_dirs_does_not_collide():
+    first = build_local_filepath(
+        asset_key_string=ASSET_KEY_STRING, remote_filepath="/BM/report.csv"
+    )
+    second = build_local_filepath(
+        asset_key_string=ASSET_KEY_STRING, remote_filepath="/PM/report.csv"
+    )
+
+    assert first != second
+
+
+def test_traversing_remote_path_is_rejected():
+    with pytest.raises(ValueError, match="resolves outside"):
+        build_local_filepath(
+            asset_key_string=ASSET_KEY_STRING,
+            remote_filepath=(
+                "report.csv/../../../../../../app/.venv/lib/python3.13/"
+                "site-packages/evil.pth"
+            ),
+        )
+
+
+def test_sibling_directory_of_the_asset_directory_is_rejected():
+    with pytest.raises(ValueError, match="resolves outside"):
+        build_local_filepath(
+            asset_key_string=ASSET_KEY_STRING,
+            remote_filepath="../student_tracker_evil/report.csv",
+        )

--- a/tests/resources/test_resource_ssh_listdir.py
+++ b/tests/resources/test_resource_ssh_listdir.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from dagster import build_resources
 from paramiko import SFTPAttributes
 
@@ -172,6 +173,58 @@ def test_dir_mtimes_traverses_unseen_directory():
     filenames = [attr.filename for attr, _ in files]
     assert filenames == ["data.csv"]
     assert dir_mtimes["newdir"] == 300
+
+
+def test_traversing_filename_is_rejected():
+    """A server-supplied name with a separator must not reach the join."""
+    sftp = _build_mock_sftp(
+        {
+            ".": [
+                _make_sftp_attr("good.csv", FILE_MODE, st_mtime=100, st_size=50),
+                _make_sftp_attr(
+                    "report.txt/../../../../app/evil.pth",
+                    FILE_MODE,
+                    st_mtime=300,
+                    st_size=50,
+                ),
+            ],
+        }
+    )
+
+    with (
+        build_resources(
+            {"ssh": SSHResource(remote_host="fake-host", username="u", password="p")}
+        ) as resources,
+        pytest.raises(ValueError, match="Illegal filename in SFTP listing"),
+    ):
+        resources.ssh.listdir_attr_r(
+            sftp_client=sftp,
+            remote_dir=".",
+            exclude_dirs=[],
+        )
+
+
+def test_parent_directory_entry_is_rejected():
+    """A `..` directory entry must not be walked upward."""
+    sftp = _build_mock_sftp(
+        {
+            ".": [
+                _make_sftp_attr("..", DIR_MODE, st_mtime=100, st_size=0),
+            ],
+        }
+    )
+
+    with (
+        build_resources(
+            {"ssh": SSHResource(remote_host="fake-host", username="u", password="p")}
+        ) as resources,
+        pytest.raises(ValueError, match="Illegal filename in SFTP listing"),
+    ):
+        resources.ssh.listdir_attr_r(
+            sftp_client=sftp,
+            remote_dir=".",
+            exclude_dirs=[],
+        )
 
 
 def test_dir_mtimes_none_returns_list_only():


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop a hostile or compromised SFTP peer from
writing files outside `/tmp/dagster` on the ingestion pod.

`listdir_attr_r` joined the server-supplied `filename` onto `remote_dir` —
paramiko drops only the exact `.` and `..` entries — and the result was
interpolated straight into the local path handed to `sftp_get`, which creates
parent directories before writing. The regex gate is an unanchored `re.search`,
so a name whose prefix matches the configured pattern could still carry
traversal segments. The folder factory was the most exposed, since its deployed
patterns (`.+\.csv` for nsc and tableau) match `/` and `..`.

Two layers of defence:

- `_check_listing_filename` rejects listing entries that are empty, `.` or `..`,
  or contain a path separator, before the join in `listdir_attr_r`. This covers
  the sensors that call `listdir_attr_r` directly, not just the download path.
- `build_local_filepath` normalises the download target and refuses anything
  outside `/tmp/dagster/{asset key}/`. All three factories — file, archive and
  folder — route through it.

Remote directory structure is preserved, so two files sharing a basename in
different remote folders still land in distinct paths. The only string
difference for legitimate input is a collapsed double slash when `remote_dir` is
absolute, which resolves to the same file on disk.

One behaviour note for reviewers: a listing entry that is not a single path
component now raises rather than being walked. No conformant SFTP server
produces one, and such a name is indistinguishable from the exploit input.

### AI Assistance

Found by a Claude Security scan and fixed by Claude Code. The fix was reviewed
by an independent agent that ran the test suite, and re-attacked by a second
agent asked what the change itself makes possible. Human-directed: the decision
to fix it, the scope, and this PR. Not yet reviewed by a human — please read the
diff rather than trusting the label.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

Tests run in the patch workspace: `tests/libraries/test_sftp_local_filepath.py`
(new, 5 tests) and `tests/resources/test_resource_ssh_listdir.py` (2 added, 9
pre-existing) — 16 passed. `tests/sensors/sftp` and the utils tests — 80 passed,
with the remaining failures reproducing identically on an unpatched baseline
(live-host timeouts and a missing dbt manifest).

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #4570
