### PR TITLE
fix(deanslist): keep the API key out of run logs on error responses

### DIFF
--- a/src/teamster/libraries/deanslist/resources.py
+++ b/src/teamster/libraries/deanslist/resources.py
@@ -1,21 +1,21 @@
 import pathlib
 import re
-from collections.abc import Iterable
+from collections.abc import Collection
 
 import fastavro
 import fastavro.types
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster_shared import check
 from pydantic import PrivateAttr
-from requests import Session
-from requests.exceptions import HTTPError
+from requests import Response, Session
+from requests.exceptions import HTTPError, RequestException
 
 _REDACTED = "***"
 
 _APIKEY_QUERY_PATTERN = re.compile(pattern=r"apikey=[^&\s]*", flags=re.IGNORECASE)
 
 
-def redact_api_keys(text: str, api_keys: Iterable[str] = ()) -> str:
+def redact_api_keys(text: str, api_keys: Collection[str] = ()) -> str:
     """Mask DeansList API keys in text bound for a log or an exception message.
 
     The credential travels as an ``apikey`` query parameter, so it appears in
@@ -27,7 +27,9 @@ def redact_api_keys(text: str, api_keys: Iterable[str] = ()) -> str:
         text: Text that may contain a key.
         api_keys: Known key values, masked literally so that renderings which do
             not use the ``apikey=`` query form (a params dict, for instance) are
-            covered too.
+            covered too. A ``Collection`` rather than an ``Iterable`` because
+            callers pass the same object to more than one call -- a one-shot
+            generator would silently redact nothing on the second.
 
     Returns:
         The text with every key occurrence replaced by ``***``.
@@ -85,7 +87,9 @@ class DeansListResource(ConfigurableResource):
         else:
             return f"{self._base_url}/{api_version}/{endpoint}"
 
-    def _request(self, method: str, url: str, school_id: int, params: dict, **kwargs):
+    def _request(
+        self, method: str, url: str, school_id: int, params: dict, **kwargs
+    ) -> Response:
         api_keys = self._api_key_map.values()
 
         self._log.info(
@@ -109,13 +113,40 @@ class DeansListResource(ConfigurableResource):
         # in the log line above on the next call
         request_params = {**params, "apikey": api_key}
 
-        response = self._session.request(
-            method=method,
-            url=url,
-            params=request_params,
-            timeout=self.request_timeout,
-            **kwargs,
-        )
+        # a transport failure never reaches `raise_for_status` below, and its
+        # message renders the URL too -- urllib3's MaxRetryError embeds
+        # "url: <path>?apikey=<key>" -- so it needs the same redaction
+        transport_error: RequestException | None = None
+        maybe_response: Response | None = None
+
+        try:
+            maybe_response = self._session.request(
+                method=method,
+                url=url,
+                params=request_params,
+                timeout=self.request_timeout,
+                **kwargs,
+            )
+        except RequestException as e:
+            # rebuild as the same subclass: the retry predicate documented in
+            # src/teamster/CLAUDE.md matches on (RequestsConnectionError,
+            # Timeout, HTTPError), so flattening to the base class would break a
+            # future tenacity wrapper here
+            transport_error = type(e)(
+                redact_api_keys(text=str(e), api_keys=api_keys), request=e.request
+            )
+
+        # raised outside the `except` block on purpose. `raise ... from None`
+        # only sets __suppress_context__; __context__ still references the
+        # original, whose message carries the unredacted URL, and any consumer
+        # that walks the chain re-leaks the key. Raising once the block has
+        # exited leaves __context__ None, so the original is unreachable.
+        if transport_error is not None:
+            raise transport_error
+
+        response = check.not_none(value=maybe_response)
+
+        http_error: HTTPError | None = None
 
         try:
             response.raise_for_status()
@@ -126,10 +157,10 @@ class DeansListResource(ConfigurableResource):
 
             self._log.error(msg=f"{message}\nSCHOOL_ID:\t{school_id}")
 
-            # `from None` drops the original from the traceback: its message
-            # carries the unredacted URL, and Dagster serializes an unsuppressed
-            # __context__ into the run event log
-            raise HTTPError(message, response=response) from None
+            http_error = HTTPError(message, response=response)
+
+        if http_error is not None:
+            raise http_error
 
         return response
 
@@ -204,10 +235,17 @@ class DeansListResource(ConfigurableResource):
         fo = data_filepath.open("a+b")
 
         while page <= total_pages:
-            params.update({"page_size": page_size, "page": page})
+            # a copy, for the same reason `_request` copies before adding the
+            # key: `params` belongs to the caller and is shared across an
+            # asset's partitions
+            request_params = {**params, "page_size": page_size, "page": page}
 
             response_json = self._request(
-                method="GET", url=url, school_id=school_id, params=params, **kwargs
+                method="GET",
+                url=url,
+                school_id=school_id,
+                params=request_params,
+                **kwargs,
             ).json()
 
             total_count = response_json["total_count"]

--- a/src/teamster/libraries/deanslist/resources.py
+++ b/src/teamster/libraries/deanslist/resources.py
@@ -1,4 +1,6 @@
 import pathlib
+import re
+from collections.abc import Iterable
 
 import fastavro
 import fastavro.types
@@ -7,6 +9,36 @@ from dagster_shared import check
 from pydantic import PrivateAttr
 from requests import Session
 from requests.exceptions import HTTPError
+
+_REDACTED = "***"
+
+_APIKEY_QUERY_PATTERN = re.compile(pattern=r"apikey=[^&\s]*", flags=re.IGNORECASE)
+
+
+def redact_api_keys(text: str, api_keys: Iterable[str] = ()) -> str:
+    """Mask DeansList API keys in text bound for a log or an exception message.
+
+    The credential travels as an ``apikey`` query parameter, so it appears in
+    every rendered URL -- ``response.url``, ``response.request.url``, and the
+    message ``requests`` builds for ``HTTPError`` -- as well as in any rendering
+    of a params mapping that still carries it.
+
+    Args:
+        text: Text that may contain a key.
+        api_keys: Known key values, masked literally so that renderings which do
+            not use the ``apikey=`` query form (a params dict, for instance) are
+            covered too.
+
+    Returns:
+        The text with every key occurrence replaced by ``***``.
+    """
+    redacted = _APIKEY_QUERY_PATTERN.sub(repl=f"apikey={_REDACTED}", string=text)
+
+    for api_key in api_keys:
+        if api_key:
+            redacted = redacted.replace(api_key, _REDACTED)
+
+    return redacted
 
 
 def load_deanslist_config(
@@ -54,7 +86,14 @@ class DeansListResource(ConfigurableResource):
             return f"{self._base_url}/{api_version}/{endpoint}"
 
     def _request(self, method: str, url: str, school_id: int, params: dict, **kwargs):
-        self._log.info(f"GET:\t{url}\nSCHOOL_ID:\t{school_id}\nPARAMS:\t{params}")
+        api_keys = self._api_key_map.values()
+
+        self._log.info(
+            redact_api_keys(
+                text=f"GET:\t{url}\nSCHOOL_ID:\t{school_id}\nPARAMS:\t{params}",
+                api_keys=api_keys,
+            )
+        )
 
         api_key = self._api_key_map.get(school_id)
 
@@ -65,12 +104,15 @@ class DeansListResource(ConfigurableResource):
                 "district's DeansList 1Password item, then re-sync the secret."
             )
 
-        params["apikey"] = api_key
+        # send the credential from a copy: `params` belongs to the caller and is
+        # shared across an asset's partitions, so a key left behind in it lands
+        # in the log line above on the next call
+        request_params = {**params, "apikey": api_key}
 
         response = self._session.request(
             method=method,
             url=url,
-            params=params,
+            params=request_params,
             timeout=self.request_timeout,
             **kwargs,
         )
@@ -78,10 +120,17 @@ class DeansListResource(ConfigurableResource):
         try:
             response.raise_for_status()
         except HTTPError as e:
-            self._log.exception(e)
-            raise e
+            # `str(e)` is "<status> <Client|Server> Error: <reason> for url:
+            # <url>" -- the rendered URL, api key and all
+            message = redact_api_keys(text=str(e), api_keys=api_keys)
 
-        params.pop("apikey")
+            self._log.error(msg=f"{message}\nSCHOOL_ID:\t{school_id}")
+
+            # `from None` drops the original from the traceback: its message
+            # carries the unredacted URL, and Dagster serializes an unsuppressed
+            # __context__ into the run event log
+            raise HTTPError(message, response=response) from None
+
         return response
 
     def get(

--- a/tests/resources/test_resource_deanslist.py
+++ b/tests/resources/test_resource_deanslist.py
@@ -1,12 +1,58 @@
 import logging
 import pathlib
+import traceback
 
 import pytest
+from requests import PreparedRequest, Response
+from requests.exceptions import HTTPError
 
 from teamster.libraries.deanslist.resources import (
     DeansListResource,
     load_deanslist_config,
+    redact_api_keys,
 )
+
+# synthetic stand-in for a per-school key; low entropy so no secret scanner bites
+PLACEHOLDER_KEY = "placeholder-key-for-school-121"
+
+
+class _FakeSession:
+    """Renders the query string exactly as ``requests`` would, offline.
+
+    The rendered URL is what carries the ``apikey`` parameter into
+    ``response.url`` and into the message ``raise_for_status()`` builds, so the
+    test has to reproduce it faithfully to prove the leak is closed.
+    """
+
+    def __init__(self, status_codes: list[int]) -> None:
+        self._status_codes = list(status_codes)
+        self.sent_params: list[dict] = []
+
+    def request(self, method: str, url: str, params: dict, timeout: float, **kwargs):
+        self.sent_params.append(dict(params))
+
+        prepared = PreparedRequest()
+        prepared.prepare(method=method, url=url, params=params)
+
+        response = Response()
+
+        response.status_code = self._status_codes.pop(0)
+        response.reason = "Internal Server Error"
+        response.url = prepared.url  # pyright: ignore[reportAttributeAccessIssue]
+        response.request = prepared
+
+        return response
+
+
+def _build_offline_resource(session: _FakeSession, logger_name: str):
+    """Instantiate the resource without the secret-volume setup path."""
+    resource = DeansListResource(api_key_dir="/etc/deanslist")
+
+    object.__setattr__(resource, "_api_key_map", {121: PLACEHOLDER_KEY})
+    object.__setattr__(resource, "_session", session)
+    object.__setattr__(resource, "_log", logging.getLogger(logger_name))
+
+    return resource
 
 
 def test_load_deanslist_config(tmp_path: pathlib.Path):
@@ -32,3 +78,116 @@ def test_request_missing_school_key_raises_named_error():
     # network call, naming the school id and the mount
     with pytest.raises(KeyError, match="No DeansList API key for school_id 999"):
         resource._request(method="GET", url="https://x/api", school_id=999, params={})
+
+
+def test_redact_api_keys():
+    """Every rendering the key can reach a log through must come back masked."""
+    # the query form `raise_for_status()` embeds, with the value percent-encoded
+    # by requests so a literal match on the raw key would miss it
+    assert (
+        redact_api_keys("500 Server Error: for url: https://x/api?a=1&apikey=a%2Bb%2F")
+        == "500 Server Error: for url: https://x/api?a=1&apikey=***"
+    )
+
+    # the query form is masked even when the key value is unknown to the caller
+    assert redact_api_keys("?APIKEY=abc123&page=2") == "?apikey=***&page=2"
+
+    # a params dict repr uses no `apikey=` form, so the literal value is masked
+    assert (
+        redact_api_keys("PARAMS:\t{'apikey': 'abc123'}", api_keys=["abc123"])
+        == "PARAMS:\t{'apikey': '***'}"
+    )
+
+    # every school's key is masked, not just the one for the failing request
+    assert redact_api_keys("a-b", api_keys=["a", "b"]) == "***-***"
+
+    # text with no key is untouched
+    assert redact_api_keys("GET:\thttps://x/api/v1/students") == (
+        "GET:\thttps://x/api/v1/students"
+    )
+
+
+def test_request_error_never_logs_or_raises_the_api_key(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A 4xx/5xx must not put the school's API key into the Dagster event log.
+
+    The key is sent as an `apikey` query parameter, so `raise_for_status()`
+    builds its message around the fully rendered URL. Logging that exception (or
+    letting it propagate for Dagster to serialize) persisted a live credential
+    into the run log on every DeansList error.
+    """
+    session = _FakeSession(status_codes=[500])
+    resource = _build_offline_resource(session, "test_deanslist_error")
+    params = {"IncludeInactive": "Y"}
+
+    with caplog.at_level(logging.INFO, logger="test_deanslist_error"):
+        with pytest.raises(HTTPError) as exc_info:
+            resource._request(
+                method="GET",
+                url="https://kippnj.deanslistsoftware.com/api/v1/students",
+                school_id=121,
+                params=params,
+            )
+
+    # the key really was sent on the wire — the redaction is a logging change,
+    # not a protocol change
+    assert session.sent_params == [{"IncludeInactive": "Y", "apikey": PLACEHOLDER_KEY}]
+
+    # ...and it reaches neither the log, the raised message, nor the traceback
+    # Dagster serializes (`raise ... from None` suppresses the original)
+    rendered_traceback = "".join(traceback.format_exception(exc_info.value))
+
+    assert PLACEHOLDER_KEY not in caplog.text
+    assert PLACEHOLDER_KEY not in str(exc_info.value)
+    assert PLACEHOLDER_KEY not in rendered_traceback
+
+    # what survives is still enough to debug: status, endpoint, school, and a
+    # masked URL keeping the non-secret query params
+    assert "500 Server Error" in caplog.text
+    assert "/api/v1/students" in caplog.text
+    assert "IncludeInactive=Y" in caplog.text
+    assert "apikey=***" in caplog.text
+    assert "SCHOOL_ID:\t121" in caplog.text
+
+    # the same exception type still propagates, with the response attached
+    assert exc_info.value.response is not None
+    assert exc_info.value.response.status_code == 500
+
+
+def test_request_does_not_retain_the_api_key_in_the_caller_params(
+    caplog: pytest.LogCaptureFixture,
+):
+    """A failed request must not leave the key in the caller's params dict.
+
+    The asset factories build one params dict per asset and reuse it for every
+    partition, so a key retained after a failure was logged verbatim by the next
+    partition's request line.
+    """
+    session = _FakeSession(status_codes=[500, 200])
+    resource = _build_offline_resource(session, "test_deanslist_retention")
+    params = {"IncludeInactive": "Y"}
+
+    with caplog.at_level(logging.INFO, logger="test_deanslist_retention"):
+        with pytest.raises(HTTPError):
+            resource._request(
+                method="GET",
+                url="https://kippnj.deanslistsoftware.com/api/v1/students",
+                school_id=121,
+                params=params,
+            )
+
+        assert params == {"IncludeInactive": "Y"}
+        caplog.clear()
+
+        # the next partition reuses the same dict
+        response = resource._request(
+            method="GET",
+            url="https://kippnj.deanslistsoftware.com/api/v1/students",
+            school_id=121,
+            params=params,
+        )
+
+    assert response.status_code == 200
+    assert PLACEHOLDER_KEY not in caplog.text
+    assert params == {"IncludeInactive": "Y"}

--- a/tests/resources/test_resource_deanslist.py
+++ b/tests/resources/test_resource_deanslist.py
@@ -4,6 +4,7 @@ import traceback
 
 import pytest
 from requests import PreparedRequest, Response
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 
 from teamster.libraries.deanslist.resources import (
@@ -44,7 +45,33 @@ class _FakeSession:
         return response
 
 
-def _build_offline_resource(session: _FakeSession, logger_name: str):
+class _FakeConnectionErrorSession:
+    """Fails in transport, with the rendered URL in the message.
+
+    Mirrors urllib3, whose `MaxRetryError` embeds `url: <path>?apikey=<key>` —
+    the reason a transport failure leaks the same credential a 4xx does.
+    """
+
+    def __init__(self) -> None:
+        self.sent_params: list[dict] = []
+
+    def request(self, method: str, url: str, params: dict, timeout: float, **kwargs):
+        self.sent_params.append(dict(params))
+
+        prepared = PreparedRequest()
+        prepared.prepare(method=method, url=url, params=params)
+
+        error = RequestsConnectionError(
+            f"HTTPSConnectionPool(host='kippnj.deanslistsoftware.com', port=443): "
+            f"Max retries exceeded with url: {prepared.url} "
+            "(Caused by NewConnectionError('Connection refused'))"
+        )
+        error.request = prepared
+
+        raise error
+
+
+def _build_offline_resource(session, logger_name: str):
     """Instantiate the resource without the secret-volume setup path."""
     resource = DeansListResource(api_key_dir="/etc/deanslist")
 
@@ -153,6 +180,48 @@ def test_request_error_never_logs_or_raises_the_api_key(
     # the same exception type still propagates, with the response attached
     assert exc_info.value.response is not None
     assert exc_info.value.response.status_code == 500
+
+    # `__context__` must be None, not merely suppressed. `raise ... from None`
+    # sets `__suppress_context__`, which `traceback` honors — but the original
+    # exception object, whose message holds the unredacted URL, stays reachable
+    # on `__context__` for any consumer that walks the chain unconditionally.
+    # Raising outside the `except` block is what actually drops it.
+    assert exc_info.value.__context__ is None
+
+
+def test_transport_error_never_raises_the_api_key(caplog: pytest.LogCaptureFixture):
+    """A connection failure must not leak the key either.
+
+    `raise_for_status()` is never reached when the request dies in transport, and
+    urllib3 renders the full URL — query string included — into the
+    `ConnectionError` message, which then propagates uncaught for Dagster to
+    serialize. Same credential, same surface, different trigger.
+    """
+    session = _FakeConnectionErrorSession()
+    resource = _build_offline_resource(session, "test_deanslist_transport")
+
+    with caplog.at_level(logging.INFO, logger="test_deanslist_transport"):
+        with pytest.raises(RequestsConnectionError) as exc_info:
+            resource._request(
+                method="GET",
+                url="https://kippnj.deanslistsoftware.com/api/v1/students",
+                school_id=121,
+                params={"IncludeInactive": "Y"},
+            )
+
+    rendered_traceback = "".join(traceback.format_exception(exc_info.value))
+
+    assert PLACEHOLDER_KEY not in caplog.text
+    assert PLACEHOLDER_KEY not in str(exc_info.value)
+    assert PLACEHOLDER_KEY not in rendered_traceback
+    assert exc_info.value.__context__ is None
+
+    # the subclass is preserved so the documented retry predicate still matches
+    assert isinstance(exc_info.value, RequestsConnectionError)
+
+    # and the diagnostic survives
+    assert "apikey=***" in str(exc_info.value)
+    assert "/api/v1/students" in str(exc_info.value)
 
 
 def test_request_does_not_retain_the_api_key_in_the_caller_params(


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the DeansList API key reaching the
Dagster run log.

The per-school key travels as a URL query parameter, and `raise_for_status()`
builds its `HTTPError` message from the fully rendered URL. Logging that
exception with a traceback put a live credential into the event log and the step
compute logs — readable by anyone with Dagster UI access, and retained well past
the secret's rotation window. Any 4xx or 5xx triggered it; no attacker action
was required.

There was a second path: the key was written into a shared params dict and
popped only on success, so after a failure the dict still held it and the next
request logged it verbatim.

Three changes:

- `redact_api_keys` masks the `apikey` query form and every known key literally,
  so a params-dict rendering is covered as well as a URL.
- The credential now goes into a request-local copy, so the caller's dict never
  retains it. That is a root-cause fix for the second path, not a redaction of
  it.
- The error path logs a redacted diagnostic — status, reason, endpoint, masked
  URL, school id — instead of the exception object, and re-raises with
  `from None`. That last part is load-bearing: `dagster_shared` serialises an
  unsuppressed `__context__` into the run event log, so chaining would have
  re-leaked the key through the failure event even with the log line fixed.

The wire protocol is unchanged — the same query parameter is still sent, and the
same `HTTPError` still propagates with its response and request attached.

### AI Assistance

Found by a Claude Security scan and fixed by Claude Code. The fix was reviewed
by an independent agent that ran the test suite, and re-attacked by a second
agent asked what the change itself makes possible. Human-directed: the decision
to fix it, the scope, and this PR. Not yet reviewed by a human — please read the
diff rather than trusting the label.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

Tests run in the patch workspace: `tests/resources/test_resource_deanslist.py` —
5 passed, including three new regression tests asserting the key reaches neither
the log, the raised message, nor the formatted traceback. The verifier
reproduced all four leak variants against the pre-fix code first, then confirmed
each is closed.

One residual worth knowing, pre-existing and out of scope: a transport failure
(`ConnectionError` / `Timeout`) is not caught, and its message embeds the
rendered URL. Different trigger from this finding; worth its own issue.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #4571
