### PR TITLE
fix(google): stop batch_update_users logging the full user payload

### DIFF
--- a/src/teamster/libraries/google/CLAUDE.md
+++ b/src/teamster/libraries/google/CLAUDE.md
@@ -31,11 +31,12 @@ a per-sub-request 5xx. All four batch methods route through
 (429/5xx) sub-requests in follow-up batches (bounded by `_MAX_BATCH_ATTEMPTS`);
 already-succeeded sub-requests are not re-sent (re-sending would 409).
 
-**`batch_insert_users` returns `list[dict]`** (`{"primaryEmail", "error"}`), NOT
-`list[str]` like the other three batch methods — the create asset needs the
-failed emails to skip group membership for uncreated users (via
-`members_for_created_users`), and the dict form keeps the create payload (which
-includes the password hash) out of logs and asset-check metadata.
+**`batch_insert_users` and `batch_update_users` return `list[dict]`**
+(`{"primaryEmail", "error"}`), NOT `list[str]` like the other two batch methods
+— the dict form keeps the user payload (which includes the password hash on
+create and update rows alike) out of logs and asset-check metadata. The create
+asset additionally needs the failed emails to skip group membership for
+uncreated users (via `members_for_created_users`).
 
 **409 conflict handling**: 409 is deliberately excluded from
 `_TRANSIENT_HTTP_CODES` because its meaning is method-specific: for

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -515,7 +515,8 @@ class GoogleDirectoryResource(ConfigurableResource):
         each individual sub-request within it — is retried on transient errors
         (5xx, 429) with backoff.
 
-        Unlike the sibling batch helpers (which return error strings), this
+        Like :meth:`batch_update_users`, and unlike ``batch_insert_members`` /
+        ``batch_insert_role_assignments`` (which return error strings), this
         returns structured per-user errors. Callers use the returned emails to
         skip follow-on group membership for users that were not created (see
         ``members_for_created_users``), and the structured form keeps the create

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -571,15 +571,22 @@ class GoogleDirectoryResource(ConfigurableResource):
             retry_on=(_TransientHttpError,),
         )
 
-    def batch_update_users(self, users: list[dict]) -> list[str]:
+    def batch_update_users(self, users: list[dict]) -> list[dict]:
         """Update multiple users in batches of 40.
+
+        Like :meth:`batch_insert_users` (and unlike the remaining batch helpers,
+        which return error strings), this returns structured per-user errors:
+        the update payload carries the password hash on rows that rotate a
+        password, and the structured form keeps it out of logs and asset-check
+        metadata.
 
         Args:
             users: User resource dicts to update; each must include
                 ``primaryEmail``.
 
         Returns:
-            Error strings for any failed requests.
+            One ``{"primaryEmail": ..., "error": ...}`` dict per user whose
+            update ultimately failed (empty if all succeeded).
         """
         exceptions = []
 
@@ -604,9 +611,16 @@ class GoogleDirectoryResource(ConfigurableResource):
                     try:
                         self._retry_update_user(user)
                     except errors.HttpError as retry_e:
-                        exceptions.append(f"{user} {retry_e}")
+                        exceptions.append(
+                            {
+                                "primaryEmail": user["primaryEmail"],
+                                "error": str(retry_e),
+                            }
+                        )
                 else:
-                    exceptions.append(f"{user} {e}")
+                    exceptions.append(
+                        {"primaryEmail": user["primaryEmail"], "error": str(e)}
+                    )
 
             if i < len(batches) - 1:
                 time.sleep(1)

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -357,7 +357,51 @@ def test_batch_update_users_collects_exception_when_409_retry_also_fails():
     with patch("teamster.libraries.google.directory.resources.time.sleep"):
         exceptions = resource.batch_update_users([{"primaryEmail": "a@b.com"}])
     assert len(exceptions) == 1
-    assert "a@b.com" in exceptions[0]
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
+
+
+def test_batch_update_users_error_dict_omits_user_payload():
+    # The returned error must not carry the update payload (e.g. the password
+    # hash) into logs / asset-check metadata — only the email and the message.
+    resource, mock_api = _make_resource()
+    err = _http_error(400, b"Bad Request")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [[(None, err)]]
+    )
+    user = {
+        "primaryEmail": "a@b.com",
+        "password": "deadbeefsecrethash",
+        "hashFunction": "SHA-1",
+    }
+    exceptions = resource.batch_update_users([user])
+    assert len(exceptions) == 1
+    assert set(exceptions[0].keys()) == {"primaryEmail", "error"}
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
+    assert "deadbeefsecrethash" not in str(exceptions[0])
+
+
+def test_batch_update_users_409_retry_error_dict_omits_user_payload():
+    # Same guarantee on the single-user 409 retry path, which formats its own
+    # error entry.
+    resource, mock_api = _make_resource()
+    err = _http_error(409, b"Conflicting requests. Please try again")
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [[(None, err)]]
+    )
+    mock_api.users.return_value.update.return_value.execute.side_effect = _http_error(
+        409, b"Conflicting requests. Please try again"
+    )
+    user = {
+        "primaryEmail": "a@b.com",
+        "password": "deadbeefsecrethash",
+        "hashFunction": "SHA-1",
+    }
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_update_users([user])
+    assert len(exceptions) == 1
+    assert set(exceptions[0].keys()) == {"primaryEmail", "error"}
+    assert exceptions[0]["primaryEmail"] == "a@b.com"
+    assert "deadbeefsecrethash" not in str(exceptions[0])
 
 
 def test_batch_update_users_retries_transient_subrequest_and_succeeds():

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -378,6 +378,10 @@ def test_batch_update_users_error_dict_omits_user_payload():
     assert set(exceptions[0].keys()) == {"primaryEmail", "error"}
     assert exceptions[0]["primaryEmail"] == "a@b.com"
     assert "deadbeefsecrethash" not in str(exceptions[0])
+    # the diagnostic the redaction is meant to preserve must actually survive:
+    # an empty "error" would satisfy every assertion above
+    assert "400" in exceptions[0]["error"]
+    assert "Bad Request" in exceptions[0]["error"]
 
 
 def test_batch_update_users_409_retry_error_dict_omits_user_payload():


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop student Google Workspace password
hashes being written into Dagster run logs and asset-check metadata.

`batch_update_users` built its error entries with `f"{user} {e}"`, embedding the
whole warehouse row. Those rows come from
`rpt_google_directory__users_import`, which selects `hashFunction` and
`to_hex(sha1(student_web_password)) as password` under
`where is_create or is_update` — so update rows carry the hash, not just create
rows. The resulting strings reach `context.log.error` and are persisted as
`AssetCheckResult` metadata, which Dagster stores in the event log indefinitely.
The hash is unsalted and the plaintext follows a predictable pattern, so anyone
with Dagster viewer access could recover it and sign in as the student.

Both sites — the direct path and the 409-retry path — now return
`{"primaryEmail": ..., "error": str(e)}` dicts, mirroring `batch_insert_users`
on the create path, which was already hardened this way and has a regression
test. The failing account and the API's own message both survive; only the
request payload is dropped.

The return type changes from `list[str]` to `list[dict]`. Both consumers — the
kipptaf `user_update` asset and the legacy op — compute their result from
`len(errors)`, which is unchanged, and both already handle the dict shape
because the create path returns dicts today. `HttpError` carries the response
body and URI, never the request body, so `str(e)` cannot reintroduce the hash.

`batch_insert_members` and `batch_insert_role_assignments` use the same f-string
shape, but their payloads carry no credential — verified against the cube and
the source model — so they are deliberately left alone.

### AI Assistance

Found by a Claude Security scan and fixed by Claude Code. The fix was reviewed
by an independent agent that ran the test suite, and re-attacked by a second
agent asked what the change itself makes possible. Human-directed: the decision
to fix it, the scope, and this PR. Not yet reviewed by a human — please read the
diff rather than trusting the label.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location

Tests run in the patch workspace: the 35 mocked tests in
`tests/resources/test_resource_google_directory.py` — 39 passed after
parametrize expansion, including two new regression tests (one per flagged
site). A baseline run of the 33 pre-existing node IDs against unpatched source
passed 37. The live-API tests in that file were excluded by node ID and not
called.

One existing assertion changed shape: a substring test over the old f-string
became an exact key match on the dict, which preserves its intent rather than
weakening it.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #4572
