### PR TITLE
fix(cube): gate staff status_reason behind the staff_pii scope

### DIFF
--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -150,12 +150,12 @@ combination to reason about.
 - **Staff views are split.** `staff_directory` (roster/employment/work-contact
   fields — no personal or sensitive data) has one open block:
   `member_level: { includes: "*" }` under `staff-directory`, no `row_level` —
-  every resolved staff viewer gets this group. `staff_pii` (the six sensitive
+  every resolved staff viewer gets this group. `staff_pii` (the seven sensitive
   fields — `personal_email`, `personal_cell_phone`, `birth_date`,
-  `gender_identity`, `race`, `is_hispanic` — plus the identity/remit keys needed
-  to filter on) has one policy per `staff_pii_scope`: `staff-pii-all_in_scope`
-  (`locations_abbreviation` ∩ `department_group` remit),
-  `staff-pii-teaching_staff` (that remit +
+  `gender_identity`, `race`, `is_hispanic`, `status_reason` — plus the
+  identity/remit keys needed to filter on) has one policy per `staff_pii_scope`:
+  `staff-pii-all_in_scope` (`locations_abbreviation` ∩ `department_group`
+  remit), `staff-pii-teaching_staff` (that remit +
   `job_function_code IN ('TEACH', 'TIR')`), `staff-pii-reporting_chain`
   (`staff_key IN reportee_staff_keys`),
   `staff-pii-reporting_chain_or_below_rank` (OR of the remit-plus-rank check and

--- a/src/cube/access.js
+++ b/src/cube/access.js
@@ -24,14 +24,17 @@ const STAFF_SENSITIVE_SCOPE_BY_MEMBER = {
   gender_identity: "staff_pii_scope",
   race: "staff_pii_scope",
   is_hispanic: "staff_pii_scope",
+  // Leave type (Medical / Family / Disability) or termination reason behind a
+  // period's status_name. status_name itself stays on the open directory.
+  status_reason: "staff_pii_scope",
   salary: "staff_compensation_scope",
 };
 
 // The sensitive staff columns kept out of the open staff_directory view. Each
-// maps to its gating scope column in STAFF_SENSITIVE_SCOPE_BY_MEMBER — the six
-// PII fields to staff_pii_scope (surfaced in staff_pii), salary to
-// staff_compensation_scope (forward-compat; no view yet). Not PII-only, so not
-// named *_PII_*.
+// maps to its gating scope column in STAFF_SENSITIVE_SCOPE_BY_MEMBER — the
+// personal/demographic fields plus status_reason to staff_pii_scope (surfaced
+// in staff_pii), salary to staff_compensation_scope (forward-compat; no view
+// yet). Not PII-only, so not named *_PII_*.
 const STAFF_SENSITIVE_MEMBERS = Object.keys(STAFF_SENSITIVE_SCOPE_BY_MEMBER);
 
 // One column-visibility tier per forward-compat sensitive staff scope.

--- a/src/cube/access.test.js
+++ b/src/cube/access.test.js
@@ -1,7 +1,30 @@
 "use strict";
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const a = require("./access");
+
+// Member names a staff view file lists. The views are YAML and no parser is
+// installed (src/cube depends only on the Cube server + driver, and the suite
+// must run without node_modules), so match the bare `- <member>` sequence
+// entries — that covers both the `includes:` blocks and the meta.folders
+// lists, and skips `- group:` / `- name:` / `- join_path:` mapping entries.
+// Enough to assert a member is absent from a view file entirely, which is the
+// property the open staff-directory tier depends on.
+function viewMembers(file) {
+  const text = fs.readFileSync(
+    path.join(__dirname, "model", "views", "staff", file),
+    "utf8",
+  );
+  return new Set(
+    text
+      .split("\n")
+      .map((line) => /^\s+- ([a-z0-9_]+)\s*$/.exec(line))
+      .filter((m) => m !== null)
+      .map((m) => m[1]),
+  );
+}
 
 // Refold-c access row: open staff directory + summary, sensitive staff fields
 // gated by the shared remit (staff_location_scope ∩ staff_department_scope) plus
@@ -283,5 +306,39 @@ test("STAFF_SENSITIVE_MEMBERS lists all gated sensitive columns", () => {
     "personal_email",
     "race",
     "salary",
+    "status_reason",
   ]);
+});
+
+// status_reason is the leave type (Medical / Family / Disability) or the
+// termination reason behind a period's status. It used to sit on the open
+// staff_directory view, so every resolved viewer — including one whose every
+// scope is "none" — could read it for all staff network-wide. It is now a
+// staff_pii_scope-gated member of staff_pii.
+test("status_reason is gated by staff_pii_scope", () => {
+  assert.equal(
+    a.STAFF_SENSITIVE_SCOPE_BY_MEMBER.status_reason,
+    "staff_pii_scope",
+  );
+});
+
+test("a full-deny viewer holds no group exposing status_reason", () => {
+  const directory = viewMembers("staff_directory.yml");
+  const pii = viewMembers("staff_pii.yml");
+  // Guard against a path/regex regression making the assertions vacuous.
+  assert.ok(directory.has("status_name") && pii.has("status_name"));
+
+  const denied = {
+    ...SL,
+    student_location_scope: "none",
+    staff_location_scope: "none",
+    staff_department_scope: "none",
+    staff_pii_scope: "none",
+  };
+  // The only tier this viewer holds is the open directory...
+  assert.deepEqual(a.buildGroups(denied), ["staff-directory"]);
+  // ...which no longer exposes status_reason at all — the member moved to
+  // staff_pii, whose every policy requires a staff-pii-<scope> group.
+  assert.ok(!directory.has("status_reason"));
+  assert.ok(pii.has("status_reason"));
 });

--- a/src/cube/model/views/staff/staff_directory.yml
+++ b/src/cube/model/views/staff/staff_directory.yml
@@ -6,8 +6,8 @@ views:
       which status, job, worker type, org unit, and location all held
       simultaneously — with point-in-time manager context. Use for the staff
       roster, drill-down, and individual investigations. Contains no personal or
-      sensitive data (personal contact, DOB, demographics) — see staff_pii for
-      those fields.
+      sensitive data (personal contact, DOB, demographics, leave/termination
+      reason) — see staff_pii for those fields.
 
       Always apply a date filter. Without one, each employment period fans out
       to one row per calendar day in its effective range. For a current roster,
@@ -21,7 +21,6 @@ views:
         includes:
           - count_employees
           - status_name
-          - status_reason
           - position_title
           - job_code
           - worker_type
@@ -94,7 +93,6 @@ views:
         - name: Employment
           members:
             - status_name
-            - status_reason
             - position_title
             - job_code
             - job_function_code
@@ -145,10 +143,13 @@ views:
 
     access_policy:
       # Open staff-directory tier: roster/employment structure without personal
-      # or sensitive data. Personal contact, DOB, and demographics live in
-      # staff_pii instead — they are simply absent here, so no excludes are
-      # needed. Work-directory info (names, work/google email, AD username,
-      # manager contacts) stays visible — already internally public.
+      # or sensitive data. Personal contact, DOB, demographics, and the
+      # leave/termination reason (status_reason) live in staff_pii instead —
+      # they are simply absent here, so no excludes are needed. status_name
+      # (Active / Leave / Terminated) stays: it is the employment state every
+      # roster query filters on, and it carries no reason. Work-directory info
+      # (names, work/google email, AD username, manager contacts) stays visible
+      # — already internally public.
       - group: staff-directory
         member_level:
           includes: "*"

--- a/src/cube/model/views/staff/staff_pii.yml
+++ b/src/cube/model/views/staff/staff_pii.yml
@@ -1,8 +1,8 @@
 views:
   - name: staff_pii
     description: >-
-      Sensitive staff PII — personal contact info, date of birth, and
-      demographics — split out of the open staff directory (see
+      Sensitive staff PII — personal contact info, date of birth, demographics,
+      and leave/termination reason — split out of the open staff directory (see
       staff_directory). One row per employee x employment period; always apply a
       date filter or each period fans out to one row per calendar day in its
       effective range. Filter is_primary_position = true and status_name =
@@ -23,6 +23,11 @@ views:
           - count_employees
           - is_primary_position
           - status_name
+          # Leave type (Medical / Family / Disability) or termination reason —
+          # sensitive, so it lives here behind the staff_pii_scope remit rather
+          # than on the open staff_directory view. status_name (the state
+          # itself) stays open there.
+          - status_reason
 
       - join_path: staff_work_history.dates
         prefix: true
@@ -65,6 +70,7 @@ views:
           members:
             - is_primary_position
             - status_name
+            - status_reason
         - name: Date
           members:
             - dates_date_day


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop every staff viewer being able to read
every colleague's leave and termination reason.

`status_reason` holds the leave type — Medical, Family, Disability — or the
termination reason — Resignation, Non-Renewal. It sat in `staff_directory`,
whose only policy is `group: staff-directory` with `member_level` including
everything and no `row_level`, and `access.js` pushes that group unconditionally
for every resolved viewer. So any employee with a row in
`dim_staff_cube_access` — including one whose every scope is `none`, a case
`access.test.js` covers explicitly — could enumerate that field for all staff
across Newark, Camden, Miami and Paterson, joined to name, work email, location
and manager. The view's own description says it contains no sensitive data,
which is why this reads as unintended rather than an accepted policy.

The member moves into `staff_pii`, whose four policies all carry remit or
reporting-chain `row_level` filters, and is registered in
`STAFF_SENSITIVE_SCOPE_BY_MEMBER` as `src/cube/CLAUDE.md` prescribes.

This grants no one a new read: every viewer holding a `staff-pii-<scope>` group
already read the field network-wide through the open directory group, so they
now get a strict subset, filtered to their remit. `staff_pii_scope` was chosen
over the `staff_benefits_scope` tier because `staff-benefits` is a flat group
with no `row_level` — routing the field there would reproduce the same unscoped
read. `status_name` stays on `staff_directory`; it is the state every roster
query filters on and carries no reason.

**Two things for reviewers.** First, because the member is removed from the view
rather than excluded by policy, a stale query naming
`staff_directory.status_reason` now fails as a schema error rather than an
access denial. No in-repo consumer selects it, but a Tableau workbook or
Superset dataset built on the Cube SQL API cannot be checked from here — worth a
look before merge. Second, this is employee health and HR data: worth
confirming with People Operations which employment-status fields may be
network-visible, rather than treating the scoping decision here as settled.

### AI Assistance

Found by a Claude Security scan and fixed by Claude Code. The fix was reviewed
by an independent agent that ran both test suites, and re-attacked by a second
agent asked what the change itself makes possible. Human-directed: the decision
to fix it, the scope, and this PR. Not yet reviewed by a human — please read the
diff rather than trusting the label.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

Tests run in the patch workspace: `node --test src/cube/access.test.js` — 28
passed, 26 pre-existing plus 2 new (one asserting the field is gated by
`staff_pii_scope`, one asserting a full-deny viewer holds no group exposing it).
`uv run pytest tests/cube/ -q` — 30 passed, including the view and access-policy
invariants. A baseline run of the pre-change files passed 26.

`cube.test.js` could not run — `src/cube/node_modules` is absent in the patch
workspace and `npm install` was deliberately not run. That file is untouched by
this change; CI will cover it.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #4573
