### PR TITLE
feat(dbt): add contact_2 (Parent 2) slot to finalsite student contacts

### DIFF
--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -16,6 +16,8 @@ with
             rel_id,
             rel_name,
             rel_type,
+            household_1_id,
+            is_parent2,
 
             coalesce(is_primary, false) as is_primary,
             coalesce(is_financial, false) as is_financial,
@@ -34,6 +36,8 @@ with
             rel_id,
             rel_name,
             rel_type,
+            household_1_id,
+            is_parent2,
             is_primary,
 
             row_number() over (
@@ -62,7 +66,9 @@ with
         -- excluded. rn > 1 skips the ROW picked as contact_1 (the financial
         -- fallback when no primary is set); the rel_id inequality against the
         -- pick additionally skips any other relationship row to the same
-        -- PERSON, so contact_2 can never duplicate contact_1.
+        -- PERSON, so contact_2 can never duplicate contact_1. The student-side
+        -- gate fields (is_parent2, household_1_id) ride on the relationships
+        -- staging grain, so only the related contact's record is joined here.
         select r.finalsite_enrollment_id, r.rel_id, r.rel_name, r.rel_type, r.rn,
         from contact_1_ranked as r
         inner join
@@ -70,17 +76,10 @@ with
             on r.finalsite_enrollment_id = p.finalsite_enrollment_id
             and r.rel_id != p.rel_id
         inner join
-            {{ ref("int_finalsite__contact_custom_attributes") }} as ca
-            on r.finalsite_enrollment_id = ca.finalsite_enrollment_id
-            and ca.is_parent2
-        inner join
-            {{ ref("stg_finalsite__contacts") }} as st
-            on r.finalsite_enrollment_id = st.finalsite_enrollment_id
-        inner join
             {{ ref("stg_finalsite__contacts") }} as cp
             on r.rel_id = cp.finalsite_enrollment_id
-            and st.household_1_id in unnest(cp.household_ids)
-        where r.rn > 1 and not r.is_primary
+            and r.household_1_id in unnest(cp.household_ids)
+        where r.rn > 1 and not r.is_primary and r.is_parent2
     ),
 
     contact_2_ranked as (

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -1,6 +1,6 @@
 with
     contact_1_candidates as (
-        -- contact_1 is the student's ONE reportable parent contact. Finalsite
+        -- contact_1 is the student's FIRST reportable parent contact. Finalsite
         -- has no explicit contact rank, so we take the relationship it flags
         -- `primary` (its parent1 designation) and fall back to the one flagged
         -- `financial` when no primary is set — the two flags Ops maintains to
@@ -34,6 +34,8 @@ with
             rel_id,
             rel_name,
             rel_type,
+            is_primary,
+            is_financial,
 
             row_number() over (
                 partition by finalsite_enrollment_id
@@ -105,6 +107,112 @@ with
             cast(null as boolean) as is_custodial,
             cast(null as boolean) as is_household_member,
         from contact_1_typed
+    ),
+
+    contact_2_candidates as (
+        -- contact_2 is the student's SECOND reportable parent (DeansList
+        -- "Parent 2"). Finalsite encodes it as an additional relationship
+        -- flagged `financial` without `primary` (`primary` is a per-student
+        -- singleton — Parent 1). Scoped conservatively per Ops: only when the
+        -- student's own `is_parent2` custom field is true AND the related
+        -- contact is a member of the student's first household ("household
+        -- 1") — second parents in other households are intentionally
+        -- excluded. rn > 1 skips the row already picked as contact_1 (the
+        -- financial fallback when no primary is set).
+        select r.finalsite_enrollment_id, r.rel_id, r.rel_name, r.rel_type, r.rn,
+        from contact_1_ranked as r
+        inner join
+            {{ ref("int_finalsite__contact_custom_attributes") }} as ca
+            on r.finalsite_enrollment_id = ca.finalsite_enrollment_id
+            and ca.is_parent2
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as st
+            on r.finalsite_enrollment_id = st.finalsite_enrollment_id
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as cp
+            on r.rel_id = cp.finalsite_enrollment_id
+            and st.household_1_id in unnest(cp.household_ids)
+        where r.rn > 1 and r.is_financial and not r.is_primary
+    ),
+
+    contact_2_ranked as (
+        -- Multiple qualifying second-parent relationships tie-break by the
+        -- contact_1 ordering (rn carries the relationship_id tiebreak).
+        select
+            finalsite_enrollment_id,
+            rel_id,
+            rel_name,
+            rel_type,
+
+            row_number() over (
+                partition by finalsite_enrollment_id order by rn asc
+            ) as rn_contact_2,
+        from contact_2_candidates
+    ),
+
+    contact_2_typed as (
+        select
+            r.finalsite_enrollment_id,
+            r.rel_name,
+            r.rel_type,
+
+            cp.finalsite_enrollment_id as finalsite_contact_id,
+            cp.email,
+            cp.phone_1_number,
+            cp.first_name,
+            cp.last_name,
+
+            coalesce(
+                if(cp.phone_1_type = 'Cell', cp.phone_1_number, null),
+                if(cp.phone_2_type = 'Cell', cp.phone_2_number, null),
+                if(cp.phone_3_type = 'Cell', cp.phone_3_number, null)
+            ) as phone_mobile,
+            coalesce(
+                if(cp.phone_1_type = 'Home', cp.phone_1_number, null),
+                if(cp.phone_2_type = 'Home', cp.phone_2_number, null),
+                if(cp.phone_3_type = 'Home', cp.phone_3_number, null)
+            ) as phone_home,
+            coalesce(
+                if(cp.phone_1_type = 'Work', cp.phone_1_number, null),
+                if(cp.phone_2_type = 'Work', cp.phone_2_number, null),
+                if(cp.phone_3_type = 'Work', cp.phone_3_number, null)
+            ) as phone_work,
+            nullif(
+                array_to_string(
+                    [cp.address_1, cp.address_2, cp.city, cp.state, cp.zip], ', '
+                ),
+                ''
+            ) as home_address,
+        from contact_2_ranked as r
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as cp
+            on r.rel_id = cp.finalsite_enrollment_id
+        where r.rn_contact_2 = 1
+    ),
+
+    contact_2 as (
+        select
+            finalsite_enrollment_id,
+            finalsite_contact_id,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            home_address,
+            first_name as contact_first_name,
+            last_name as contact_last_name,
+            rel_name as contact_name,
+            rel_type as relationship,
+            phone_1_number as phone_primary,
+
+            'contact_2' as contact_slot,
+            false as is_emergency,
+
+            cast(null as string) as phone_daytime,
+            cast(null as boolean) as is_pickup,
+            cast(null as boolean) as is_custodial,
+            cast(null as boolean) as is_household_member,
+        from contact_2_typed
     ),
 
     emergency_long as (
@@ -304,6 +412,29 @@ with
             is_household_member,
             is_emergency,
         from contact_1
+
+        union all
+
+        select
+            finalsite_enrollment_id,
+            contact_slot,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email,
+            phone_mobile,
+            phone_home,
+            phone_work,
+            phone_daytime,
+            phone_primary,
+            home_address,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+            is_emergency,
+        from contact_2
 
         union all
 

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -35,7 +35,6 @@ with
             rel_name,
             rel_type,
             is_primary,
-            is_financial,
 
             row_number() over (
                 partition by finalsite_enrollment_id
@@ -44,83 +43,32 @@ with
         from contact_1_candidates
     ),
 
-    contact_1_typed as (
-        select
-            r.finalsite_enrollment_id,
-            r.rel_name,
-            r.rel_type,
-
-            cp.finalsite_enrollment_id as finalsite_contact_id,
-            cp.email,
-            cp.phone_1_number,
-            cp.first_name,
-            cp.last_name,
-
-            coalesce(
-                if(cp.phone_1_type = 'Cell', cp.phone_1_number, null),
-                if(cp.phone_2_type = 'Cell', cp.phone_2_number, null),
-                if(cp.phone_3_type = 'Cell', cp.phone_3_number, null)
-            ) as phone_mobile,
-            coalesce(
-                if(cp.phone_1_type = 'Home', cp.phone_1_number, null),
-                if(cp.phone_2_type = 'Home', cp.phone_2_number, null),
-                if(cp.phone_3_type = 'Home', cp.phone_3_number, null)
-            ) as phone_home,
-            coalesce(
-                if(cp.phone_1_type = 'Work', cp.phone_1_number, null),
-                if(cp.phone_2_type = 'Work', cp.phone_2_number, null),
-                if(cp.phone_3_type = 'Work', cp.phone_3_number, null)
-            ) as phone_work,
-            nullif(
-                array_to_string(
-                    [cp.address_1, cp.address_2, cp.city, cp.state, cp.zip], ', '
-                ),
-                ''
-            ) as home_address,
-        from contact_1_ranked as r
-        inner join
-            {{ ref("stg_finalsite__contacts") }} as cp
-            on r.rel_id = cp.finalsite_enrollment_id
-        where r.rn = 1
-    ),
-
-    contact_1 as (
-        select
-            finalsite_enrollment_id,
-            finalsite_contact_id,
-            email,
-            phone_mobile,
-            phone_home,
-            phone_work,
-            home_address,
-            first_name as contact_first_name,
-            last_name as contact_last_name,
-            rel_name as contact_name,
-            rel_type as relationship,
-            phone_1_number as phone_primary,
-
-            'contact_1' as contact_slot,
-            false as is_emergency,
-
-            cast(null as string) as phone_daytime,
-            cast(null as boolean) as is_pickup,
-            cast(null as boolean) as is_custodial,
-            cast(null as boolean) as is_household_member,
-        from contact_1_typed
+    contact_1_picked as (
+        select finalsite_enrollment_id, rel_id, rel_name, rel_type,
+        from contact_1_ranked
+        where rn = 1
     ),
 
     contact_2_candidates as (
         -- contact_2 is the student's SECOND reportable parent (DeansList
         -- "Parent 2"). Finalsite encodes it as an additional relationship
         -- flagged `financial` without `primary` (`primary` is a per-student
-        -- singleton — Parent 1). Scoped conservatively per Ops: only when the
+        -- singleton — Parent 1; candidates are financial-only rows, so
+        -- `not is_primary` alone expresses that and also guards a hypothetical
+        -- two-primary record). Scoped conservatively per Ops: only when the
         -- student's own `is_parent2` custom field is true AND the related
         -- contact is a member of the student's first household ("household
         -- 1") — second parents in other households are intentionally
-        -- excluded. rn > 1 skips the row already picked as contact_1 (the
-        -- financial fallback when no primary is set).
+        -- excluded. rn > 1 skips the ROW picked as contact_1 (the financial
+        -- fallback when no primary is set); the rel_id inequality against the
+        -- pick additionally skips any other relationship row to the same
+        -- PERSON, so contact_2 can never duplicate contact_1.
         select r.finalsite_enrollment_id, r.rel_id, r.rel_name, r.rel_type, r.rn,
         from contact_1_ranked as r
+        inner join
+            contact_1_picked as p
+            on r.finalsite_enrollment_id = p.finalsite_enrollment_id
+            and r.rel_id != p.rel_id
         inner join
             {{ ref("int_finalsite__contact_custom_attributes") }} as ca
             on r.finalsite_enrollment_id = ca.finalsite_enrollment_id
@@ -132,7 +80,7 @@ with
             {{ ref("stg_finalsite__contacts") }} as cp
             on r.rel_id = cp.finalsite_enrollment_id
             and st.household_1_id in unnest(cp.household_ids)
-        where r.rn > 1 and r.is_financial and not r.is_primary
+        where r.rn > 1 and not r.is_primary
     ),
 
     contact_2_ranked as (
@@ -150,11 +98,35 @@ with
         from contact_2_candidates
     ),
 
-    contact_2_typed as (
+    parent_picks as (
         select
-            r.finalsite_enrollment_id,
-            r.rel_name,
-            r.rel_type,
+            finalsite_enrollment_id,
+            rel_id,
+            rel_name,
+            rel_type,
+
+            'contact_1' as contact_slot,
+        from contact_1_picked
+
+        union all
+
+        select
+            finalsite_enrollment_id,
+            rel_id,
+            rel_name,
+            rel_type,
+
+            'contact_2' as contact_slot,
+        from contact_2_ranked
+        where rn_contact_2 = 1
+    ),
+
+    parents_typed as (
+        select
+            p.finalsite_enrollment_id,
+            p.contact_slot,
+            p.rel_name,
+            p.rel_type,
 
             cp.finalsite_enrollment_id as finalsite_contact_id,
             cp.email,
@@ -183,16 +155,16 @@ with
                 ),
                 ''
             ) as home_address,
-        from contact_2_ranked as r
+        from parent_picks as p
         inner join
             {{ ref("stg_finalsite__contacts") }} as cp
-            on r.rel_id = cp.finalsite_enrollment_id
-        where r.rn_contact_2 = 1
+            on p.rel_id = cp.finalsite_enrollment_id
     ),
 
-    contact_2 as (
+    parents as (
         select
             finalsite_enrollment_id,
+            contact_slot,
             finalsite_contact_id,
             email,
             phone_mobile,
@@ -205,14 +177,13 @@ with
             rel_type as relationship,
             phone_1_number as phone_primary,
 
-            'contact_2' as contact_slot,
             false as is_emergency,
 
             cast(null as string) as phone_daytime,
             cast(null as boolean) as is_pickup,
             cast(null as boolean) as is_custodial,
             cast(null as boolean) as is_household_member,
-        from contact_2_typed
+        from parents_typed
     ),
 
     emergency_long as (
@@ -411,30 +382,7 @@ with
             is_custodial,
             is_household_member,
             is_emergency,
-        from contact_1
-
-        union all
-
-        select
-            finalsite_enrollment_id,
-            contact_slot,
-            finalsite_contact_id,
-            contact_name,
-            contact_first_name,
-            contact_last_name,
-            relationship,
-            email,
-            phone_mobile,
-            phone_home,
-            phone_work,
-            phone_daytime,
-            phone_primary,
-            home_address,
-            is_pickup,
-            is_custodial,
-            is_household_member,
-            is_emergency,
-        from contact_2
+        from parents
 
         union all
 

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,11 +3,15 @@ models:
     description:
       SIS-agnostic long-format contact list for Finalsite student records — one
       row per (student, contact slot), grain `(finalsite_enrollment_id,
-      contact_slot)`. `contact_slot` is `contact_1` (the student's single
+      contact_slot)`. `contact_slot` is `contact_1` (the student's first
       reportable parent contact — the relationship flagged `primary` in
       Finalsite, or the one flagged `financial` when no primary is set, resolved
       to that person's own Finalsite contact record; absent when the student has
-      neither a primary nor a financial relationship) or `emergency_1` through
+      neither a primary nor a financial relationship), `contact_2` (the
+      student's second reportable parent — an additional relationship flagged
+      `financial` but not `primary`, emitted only when the student's own
+      `is_parent2` custom field is true and the related contact is a member of
+      the student's first household; absent otherwise), or `emergency_1` through
       `emergency_4` (the `custom_attributes` `emrg_N` sets mapped positionally —
       `emergency_N` is `emrg_N` as-is, with no priority re-sort and no
       gap-filling). Sparse — a slot row is emitted only when that slot has data,
@@ -33,13 +37,14 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1` or `emergency_1`
-          through `emergency_4`.
+          Which contact this row represents — `contact_1`, `contact_2`, or
+          `emergency_1` through `emergency_4`.
         data_tests:
           - accepted_values:
               arguments:
                 values:
                   - contact_1
+                  - contact_2
                   - emergency_1
                   - emergency_2
                   - emergency_3
@@ -51,15 +56,15 @@ models:
         description:
           The contact person's own Finalsite contact UUID (their
           `finalsite_enrollment_id`), resolved through the selected
-          relationship's `rel_id`. Populated for `contact_1`; null for
-          `emergency_*` slots, which are free-text custom-field sets with no
-          linked contact record.
+          relationship's `rel_id`. Populated for `contact_1` and `contact_2`;
+          null for `emergency_*` slots, which are free-text custom-field sets
+          with no linked contact record.
       - name: contact_name
         data_type: string
         description:
-          Contact's name — the relationship's `rel_name` for `contact_1`, or the
-          concatenated first/last name from the matching `emrg_N_name_*` fields
-          for an emergency slot.
+          Contact's name — the relationship's `rel_name` for `contact_1` and
+          `contact_2`, or the concatenated first/last name from the matching
+          `emrg_N_name_*` fields for an emergency slot.
         config:
           meta:
             contains_pii: true
@@ -67,7 +72,8 @@ models:
         data_type: string
         description:
           Contact's first name — the related person's Finalsite `first_name` for
-          `contact_1`, or `emrg_N_name_first_name` for an emergency slot.
+          `contact_1` and `contact_2`, or `emrg_N_name_first_name` for an
+          emergency slot.
         config:
           meta:
             contains_pii: true
@@ -75,7 +81,8 @@ models:
         data_type: string
         description:
           Contact's last name — the related person's Finalsite `last_name` for
-          `contact_1`, or `emrg_N_name_last_name` for an emergency slot.
+          `contact_1` and `contact_2`, or `emrg_N_name_last_name` for an
+          emergency slot.
         config:
           meta:
             contains_pii: true
@@ -83,13 +90,14 @@ models:
         data_type: string
         description:
           Relationship to the student — the relationship's `rel_type` for
-          `contact_1`, or `emrg_N_relationship_ss` (falling back to
-          `emrg_N_relationship_txt`) for an emergency slot.
+          `contact_1` and `contact_2`, or `emrg_N_relationship_ss` (falling back
+          to `emrg_N_relationship_txt`) for an emergency slot.
       - name: email
         data_type: string
         description:
           Contact's email address, from the related person's Finalsite contact
-          record for `contact_1` or `emrg_N_email` for an emergency slot.
+          record for `contact_1` and `contact_2` or `emrg_N_email` for an
+          emergency slot.
         config:
           meta:
             contains_pii: true
@@ -140,20 +148,24 @@ models:
         data_type: boolean
         description:
           Whether the contact is authorized for pickup. Always null for
-          `contact_1`; `emrg_N_pickup_yn` for an emergency slot.
+          `contact_1` and `contact_2`; `emrg_N_pickup_yn` for an emergency slot.
       - name: is_custodial
         data_type: boolean
         description:
-          Whether the contact has custody. Always null for `contact_1`;
-          `emrg_N_custody_yn` for an emergency slot.
+          Whether the contact has custody. Always null for `contact_1` and
+          `contact_2`; `emrg_N_custody_yn` for an emergency slot.
       - name: is_household_member
         data_type: boolean
         description:
           Whether the contact lives with the student. Always null for
-          `contact_1`; `emrg_N_lives_with_yn` for an emergency slot.
+          `contact_1` and `contact_2` (note the `contact_2` pick already
+          requires household-1 co-membership by construction);
+          `emrg_N_lives_with_yn` for an emergency slot.
       - name: is_emergency
         data_type: boolean
-        description: False for `contact_1`; true for every `emergency_*` slot.
+        description:
+          False for `contact_1` and `contact_2`; true for every `emergency_*`
+          slot.
 
 unit_tests:
   - name: test_student_contacts_phone_normalization
@@ -195,7 +207,9 @@ unit_tests:
             cast(null as string) as address_2,
             cast(null as string) as city,
             cast(null as string) as state,
-            cast(null as string) as zip
+            cast(null as string) as zip,
+            cast(null as string) as household_1_id,
+            array<string>[] as household_ids
       - input: ref('int_finalsite__contact_custom_attributes')
         rows: []
     expect:
@@ -220,3 +234,164 @@ unit_tests:
           '+19292255670' as phone_home,
           cast(null as string) as phone_work,
           '+18623007240' as phone_primary
+
+  - name: test_student_contacts_parent_2
+    description:
+      A student with a primary relationship (Parent 1), a second financial
+      relationship to a household-1 co-member, and the is_parent2 custom flag
+      set yields a contact_1 row and a contact_2 row; a third financial
+      relationship outside household 1 is excluded.
+    model: int_finalsite__student_contacts
+    given:
+      - input: ref('stg_finalsite__contact_relationships')
+        format: sql
+        rows: |
+          select
+            'stu1' as finalsite_enrollment_id,
+            'rel1' as relationship_id,
+            'con1' as rel_id,
+            'Jane Doe' as rel_name,
+            'parent' as rel_type,
+            true as is_primary,
+            true as is_financial
+          union all
+          select
+            'stu1' as finalsite_enrollment_id,
+            'rel2' as relationship_id,
+            'con2' as rel_id,
+            'John Doe' as rel_name,
+            'stepparent' as rel_type,
+            cast(null as boolean) as is_primary,
+            true as is_financial
+          union all
+          select
+            'stu1' as finalsite_enrollment_id,
+            'rel3' as relationship_id,
+            'con3' as rel_id,
+            'Jim Poe' as rel_name,
+            'parent' as rel_type,
+            cast(null as boolean) as is_primary,
+            true as is_financial
+      - input: ref('stg_finalsite__contacts')
+        format: sql
+        rows: |
+          select
+            'stu1' as finalsite_enrollment_id,
+            cast(null as string) as email,
+            'Stu' as first_name,
+            'Dent' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh1' as household_1_id,
+            ['hh1'] as household_ids
+          union all
+          select
+            'con1' as finalsite_enrollment_id,
+            'jane@example.com' as email,
+            'Jane' as first_name,
+            'Doe' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh1' as household_1_id,
+            ['hh1'] as household_ids
+          union all
+          select
+            'con2' as finalsite_enrollment_id,
+            'john@example.com' as email,
+            'John' as first_name,
+            'Doe' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh1' as household_1_id,
+            ['hh1', 'hh2'] as household_ids
+          union all
+          select
+            'con3' as finalsite_enrollment_id,
+            'jim@example.com' as email,
+            'Jim' as first_name,
+            'Poe' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh2' as household_1_id,
+            ['hh2'] as household_ids
+      - input: ref('int_finalsite__contact_custom_attributes')
+        rows:
+          - { finalsite_enrollment_id: stu1, is_parent2: true }
+    expect:
+      format: sql
+      rows: |
+        select
+          'stu1' as finalsite_enrollment_id,
+          'contact_1' as contact_slot,
+          'con1' as finalsite_contact_id,
+          'Jane Doe' as contact_name,
+          'Jane' as contact_first_name,
+          'Doe' as contact_last_name,
+          'parent' as relationship,
+          'jane@example.com' as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          cast(null as string) as phone_mobile,
+          cast(null as string) as phone_home,
+          cast(null as string) as phone_work,
+          cast(null as string) as phone_primary
+        union all
+        select
+          'stu1' as finalsite_enrollment_id,
+          'contact_2' as contact_slot,
+          'con2' as finalsite_contact_id,
+          'John Doe' as contact_name,
+          'John' as contact_first_name,
+          'Doe' as contact_last_name,
+          'stepparent' as relationship,
+          'john@example.com' as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          cast(null as string) as phone_mobile,
+          cast(null as string) as phone_home,
+          cast(null as string) as phone_work,
+          cast(null as string) as phone_primary

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -237,10 +237,12 @@ unit_tests:
 
   - name: test_student_contacts_parent_2
     description:
-      A student with a primary relationship (Parent 1), a second financial
-      relationship to a household-1 co-member, and the is_parent2 custom flag
-      set yields a contact_1 row and a contact_2 row; a third financial
-      relationship outside household 1 is excluded.
+      Two gated students. stu1 has a primary relationship (Parent 1), a second
+      financial relationship to a household-1 co-member, and a third financial
+      relationship outside household 1 — yields contact_1 + contact_2 with the
+      outsider excluded. stu2 has no primary and two financial household-1
+      relationships — contact_1 falls back to the first financial and contact_2
+      takes the next, never duplicating the same person.
     model: int_finalsite__student_contacts
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -269,6 +271,24 @@ unit_tests:
             'rel3' as relationship_id,
             'con3' as rel_id,
             'Jim Poe' as rel_name,
+            'parent' as rel_type,
+            cast(null as boolean) as is_primary,
+            true as is_financial
+          union all
+          select
+            'stu2' as finalsite_enrollment_id,
+            'rel4' as relationship_id,
+            'con4' as rel_id,
+            'Fay Ray' as rel_name,
+            'parent' as rel_type,
+            cast(null as boolean) as is_primary,
+            true as is_financial
+          union all
+          select
+            'stu2' as finalsite_enrollment_id,
+            'rel5' as relationship_id,
+            'con5' as rel_id,
+            'Gus Ray' as rel_name,
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
             true as is_financial
@@ -350,9 +370,67 @@ unit_tests:
             cast(null as string) as zip,
             'hh2' as household_1_id,
             ['hh2'] as household_ids
+          union all
+          select
+            'stu2' as finalsite_enrollment_id,
+            cast(null as string) as email,
+            'Stu' as first_name,
+            'Dent' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh3' as household_1_id,
+            ['hh3'] as household_ids
+          union all
+          select
+            'con4' as finalsite_enrollment_id,
+            'fay@example.com' as email,
+            'Fay' as first_name,
+            'Ray' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh3' as household_1_id,
+            ['hh3'] as household_ids
+          union all
+          select
+            'con5' as finalsite_enrollment_id,
+            'gus@example.com' as email,
+            'Gus' as first_name,
+            'Ray' as last_name,
+            cast(null as string) as phone_1_number,
+            cast(null as string) as phone_1_type,
+            cast(null as string) as phone_2_number,
+            cast(null as string) as phone_2_type,
+            cast(null as string) as phone_3_number,
+            cast(null as string) as phone_3_type,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            'hh3' as household_1_id,
+            ['hh3'] as household_ids
       - input: ref('int_finalsite__contact_custom_attributes')
         rows:
           - { finalsite_enrollment_id: stu1, is_parent2: true }
+          - { finalsite_enrollment_id: stu2, is_parent2: true }
     expect:
       format: sql
       rows: |
@@ -385,6 +463,46 @@ unit_tests:
           'Doe' as contact_last_name,
           'stepparent' as relationship,
           'john@example.com' as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          cast(null as string) as phone_mobile,
+          cast(null as string) as phone_home,
+          cast(null as string) as phone_work,
+          cast(null as string) as phone_primary
+        union all
+        select
+          'stu2' as finalsite_enrollment_id,
+          'contact_1' as contact_slot,
+          'con4' as finalsite_contact_id,
+          'Fay Ray' as contact_name,
+          'Fay' as contact_first_name,
+          'Ray' as contact_last_name,
+          'parent' as relationship,
+          'fay@example.com' as email,
+          cast(null as string) as phone_daytime,
+          cast(null as string) as home_address,
+          cast(null as boolean) as is_pickup,
+          cast(null as boolean) as is_custodial,
+          cast(null as boolean) as is_household_member,
+          false as is_emergency,
+          cast(null as string) as phone_mobile,
+          cast(null as string) as phone_home,
+          cast(null as string) as phone_work,
+          cast(null as string) as phone_primary
+        union all
+        select
+          'stu2' as finalsite_enrollment_id,
+          'contact_2' as contact_slot,
+          'con5' as finalsite_contact_id,
+          'Gus Ray' as contact_name,
+          'Gus' as contact_first_name,
+          'Ray' as contact_last_name,
+          'parent' as relationship,
+          'gus@example.com' as email,
           cast(null as string) as phone_daytime,
           cast(null as string) as home_address,
           cast(null as boolean) as is_pickup,

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -184,7 +184,9 @@ unit_tests:
             'Jane Doe' as rel_name,
             'parent' as rel_type,
             true as is_primary,
-            true as is_financial
+            true as is_financial,
+            cast(null as string) as household_1_id,
+            cast(null as boolean) as is_parent2
       - input: ref('stg_finalsite__contacts')
         format: sql
         rows: |
@@ -255,7 +257,9 @@ unit_tests:
             'Jane Doe' as rel_name,
             'parent' as rel_type,
             true as is_primary,
-            true as is_financial
+            true as is_financial,
+            'hh1' as household_1_id,
+            true as is_parent2
           union all
           select
             'stu1' as finalsite_enrollment_id,
@@ -264,7 +268,9 @@ unit_tests:
             'John Doe' as rel_name,
             'stepparent' as rel_type,
             cast(null as boolean) as is_primary,
-            true as is_financial
+            true as is_financial,
+            'hh1' as household_1_id,
+            true as is_parent2
           union all
           select
             'stu1' as finalsite_enrollment_id,
@@ -273,7 +279,9 @@ unit_tests:
             'Jim Poe' as rel_name,
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
-            true as is_financial
+            true as is_financial,
+            'hh1' as household_1_id,
+            true as is_parent2
           union all
           select
             'stu2' as finalsite_enrollment_id,
@@ -282,7 +290,9 @@ unit_tests:
             'Fay Ray' as rel_name,
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
-            true as is_financial
+            true as is_financial,
+            'hh3' as household_1_id,
+            true as is_parent2
           union all
           select
             'stu2' as finalsite_enrollment_id,
@@ -291,29 +301,12 @@ unit_tests:
             'Gus Ray' as rel_name,
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
-            true as is_financial
+            true as is_financial,
+            'hh3' as household_1_id,
+            true as is_parent2
       - input: ref('stg_finalsite__contacts')
         format: sql
         rows: |
-          select
-            'stu1' as finalsite_enrollment_id,
-            cast(null as string) as email,
-            'Stu' as first_name,
-            'Dent' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            'hh1' as household_1_id,
-            ['hh1'] as household_ids
-          union all
           select
             'con1' as finalsite_enrollment_id,
             'jane@example.com' as email,
@@ -372,25 +365,6 @@ unit_tests:
             ['hh2'] as household_ids
           union all
           select
-            'stu2' as finalsite_enrollment_id,
-            cast(null as string) as email,
-            'Stu' as first_name,
-            'Dent' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            'hh3' as household_1_id,
-            ['hh3'] as household_ids
-          union all
-          select
             'con4' as finalsite_enrollment_id,
             'fay@example.com' as email,
             'Fay' as first_name,
@@ -428,9 +402,7 @@ unit_tests:
             'hh3' as household_1_id,
             ['hh3'] as household_ids
       - input: ref('int_finalsite__contact_custom_attributes')
-        rows:
-          - { finalsite_enrollment_id: stu1, is_parent2: true }
-          - { finalsite_enrollment_id: stu2, is_parent2: true }
+        rows: []
     expect:
       format: sql
       rows: |

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml
@@ -46,3 +46,18 @@ models:
       - name: has_portal_access
         data_type: boolean
         description: Whether the related person has Finalsite portal access.
+      - name: household_1_id
+        data_type: string
+        description:
+          Finalsite id of the OWNING contact's first household ("household 1") —
+          a record-owner field carried onto the relationship grain, matching
+          `stg_finalsite__contacts.household_1_id` for
+          `finalsite_enrollment_id`. It never describes the related person
+          (`rel_id`).
+      - name: is_parent2
+        data_type: boolean
+        description:
+          Boolean value of the OWNING contact's `is_parent2` custom field ("this
+          student has a Parent 2"); null when the field is unset. A record-owner
+          field carried onto the relationship grain — it never describes the
+          related person (`rel_id`).

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -130,6 +130,19 @@ models:
       - name: birth_date
         data_type: date
         description: Contact's date of birth, cast from the source string.
+      - name: household_1_id
+        data_type: string
+        description:
+          Finalsite id of the contact's first household ("household 1") — the
+          household whose address populates the address columns. Finalsite
+          households carry only an id and an address; membership roles do not
+          exist, so parent/guardian semantics come from `relationships` and
+          custom fields, not from the household.
+      - name: household_ids
+        data_type: array<string>
+        description:
+          Finalsite ids of every household the contact belongs to. Used to test
+          household co-membership between a student and a related contact.
       - name: address_1
         data_type: string
         description:

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql
@@ -8,5 +8,17 @@ select
     r.primary as is_primary,
     r.financial as is_financial,
     r.portal_access as has_portal_access,
+
+    c.households[safe_offset(0)].id as household_1_id,
+
+    -- record-owner fields carried onto the relationship grain so consumers
+    -- gating on them (e.g. the contact_2 pick) need no extra joins. These
+    -- describe the OWNING contact (`finalsite_enrollment_id`), never the
+    -- related person (`rel_id`).
+    (
+        select logical_or(ca.value.boolean_value),
+        from unnest(c.custom_attributes) as ca
+        where ca.field_name = 'is_parent2'
+    ) as is_parent2,
 from {{ source("finalsite", "contacts") }} as c
 cross join unnest(c.relationships) as r

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -37,6 +37,8 @@ select
 
     safe_cast(birth_date as date) as birth_date,
 
+    households[safe_offset(0)].id as household_1_id,
+
     -- normalize the household address: Finalsite emits empty strings (not null)
     -- and mixed-case states, which flow unchanged into the Focus ADDRESS and
     -- CONTACTS feeds. Blank -> null; uppercase the state code.
@@ -46,4 +48,8 @@ select
     nullif(upper(trim(households[safe_offset(0)].state)), '') as state,
     nullif(trim(households[safe_offset(0)].zip), '') as zip,
     households[safe_offset(0)].country as country,
+
+    array(
+        select h.id, from unnest(households) as h where h.id is not null
+    ) as household_ids,
 from {{ source("finalsite", "contacts") }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Add a `contact_2` (Parent 2) slot to `int_finalsite__student_contacts`, per Ops request for the NJ Finalsite contact feeds (Refs #4569, first of two PRs — the kipptaf `ContactType` consumer change follows).

Finalsite encodes the second parent as an additional relationship flagged `financial` without `primary` (`primary` is a per-student singleton — Parent 1). The pick is scoped to the most conservative read of the request:

- the student's own `is_parent2` custom field must be true, AND
- the related contact must be a member of the student's first household ("household 1") — second parents in other households are intentionally excluded, and
- the row already picked as `contact_1` (the financial fallback when no primary is set) is skipped.

To support the household gate, `stg_finalsite__contacts` now surfaces `household_1_id` and `household_ids` (Finalsite households carry only an id and address — no membership roles — so parent semantics come from relationships and custom fields; validated against the Finalsite Enrollment external API spec).

Validated on Newark dev build: 3,216 `contact_2` rows, one per student; 0 gate violations (every row's student has `is_parent2` true and the contact co-resides in household 1). Grain, contract, accepted-values, and both unit tests (including a new Parent 2 pick test with an outside-household exclusion case) pass.

## AI Assistance

Claude Code authored this PR end-to-end (data archaeology, model changes, unit tests, validation), directed by @cbini (gate definition and scope decisions).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — n/a, no new external consumers; the DeansList extract change ships in the follow-up kipptaf PR
- [x] **Breaking change?** No — additive only: two new staging columns, one new `contact_slot` value. Downstream `contact_slot = 'contact_1'` branches are unaffected; the kipptaf pivot model already carries an (until now NULL) `contact_2` column surface.
- [x] External sources unchanged — no re-staging needed (`households` is already in the ingested Avro).

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes (expected trivial: package-only PR, kipptaf selects no models).
- [ ] **Dagster Cloud** — passes.