### PR TITLE
feat(dbt): DeansList ContactType column and contact_2 mart keying

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -3,18 +3,21 @@ models:
     description:
       DeansList nightly Family Contacts import (`contacts.txt`) for the NJ
       regions — one row per Finalsite contact for each currently enrolled
-      student, covering the primary parent (`contact_1`, the relationship
-      flagged primary, falling back to financial) plus emergency contacts
-      (`emergency_1` through `emergency_4`). Emergency contacts carry a numbered
-      `Emergency N` relationship so Ops can exclude them from DeansList guardian
-      messaging; the primary parent keeps its real Finalsite relationship.
-      Column names match the DeansList import template headers exactly.
-      Delivered by the Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
+      student, covering the parents (`contact_1`, the relationship flagged
+      primary, falling back to financial; `contact_2`, the second parent from
+      the student's household 1) plus emergency contacts (`emergency_1` through
+      `emergency_4`). `ContactType` distinguishes `Parent1` / `Parent2` /
+      `Emergency` so DeansList can scope automated guardian messaging; emergency
+      contacts additionally carry a numbered `Emergency N` relationship, while
+      parents keep their real Finalsite relationship. Column names match the
+      DeansList import template headers exactly. Delivered by the Dagster asset
+      `kipptaf/extracts/deanslist/contacts_txt`.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - StudentID
+              - ContactType
               - Relationship
           config:
             severity: error
@@ -47,13 +50,28 @@ models:
       - name: Relationship
         data_type: string
         description:
-          Relationship of the contact to the student. For the primary parent
-          (`contact_1`) this is the Finalsite `rel_type` (`parent`,
+          Relationship of the contact to the student. For parents (`contact_1`
+          and `contact_2`) this is the Finalsite `rel_type` (`parent`,
           `stepparent`, `guardian`, `grandparent`, etc.). For emergency contacts
           this is `Emergency N`, numbered by the Finalsite emergency slot
           (`emergency_1` through `emergency_4`).
         data_tests:
           - not_null
+      - name: ContactType
+        data_type: string
+        description:
+          DeansList contact classification — `Parent1` for the `contact_1` slot,
+          `Parent2` for the `contact_2` slot, `Emergency` for every emergency
+          slot. DeansList sends automated reports, texts, and emails only to
+          `Parent1`/`Parent2` contacts.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Parent1
+                  - Parent2
+                  - Emergency
       - name: HomePhone
         data_type: string
         description: Parent contact's phone number typed `Home`, if any.
@@ -88,10 +106,11 @@ models:
 unit_tests:
   - name: test_family_contacts_emergency_numbering
     description:
-      One enrolled student with a primary parent plus all four emergency slots.
-      Asserts the primary parent keeps its Finalsite relationship and each
-      emergency slot is relabeled Emergency N by slot number (exercising every
-      case branch).
+      One enrolled student with two parents plus all four emergency slots.
+      Asserts the parents keep their Finalsite relationship and get
+      Parent1/Parent2 contact types, and each emergency slot is relabeled
+      Emergency N by slot number with an Emergency contact type (exercising
+      every case branch).
     model: rpt_deanslist__family_contacts
     given:
       - input: ref('int_finalsite__student_contacts')
@@ -108,6 +127,11 @@ unit_tests:
             '+19292255670' as phone_home,
             cast(null as string) as phone_work,
             '+18623007240x216' as phone_mobile
+          union all
+          select
+            'enr-001', 'kippnewark', 'contact_2', 'stepparent',
+            'Adam', 'Johnson', 'adam@example.com', cast(null as string),
+            cast(null as string), cast(null as string)
           union all
           select
             'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
@@ -153,6 +177,19 @@ unit_tests:
             CellPhone: 18623007240x216,
             Email: alice@example.com,
             Relationship: parent,
+            ContactType: Parent1,
+            Language: null,
+          }
+        - {
+            StudentID: 123456,
+            ParentFirstName: Adam,
+            ParentLastName: Johnson,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: adam@example.com,
+            Relationship: stepparent,
+            ContactType: Parent2,
             Language: null,
           }
         - {
@@ -164,6 +201,7 @@ unit_tests:
             CellPhone: "13055550200",
             Email: null,
             Relationship: Emergency 1,
+            ContactType: Emergency,
             Language: null,
           }
         - {
@@ -175,6 +213,7 @@ unit_tests:
             CellPhone: null,
             Email: null,
             Relationship: Emergency 2,
+            ContactType: Emergency,
             Language: null,
           }
         - {
@@ -186,6 +225,7 @@ unit_tests:
             CellPhone: null,
             Email: null,
             Relationship: Emergency 3,
+            ContactType: Emergency,
             Language: null,
           }
         - {
@@ -197,6 +237,7 @@ unit_tests:
             CellPhone: null,
             Email: null,
             Relationship: Emergency 4,
+            ContactType: Emergency,
             Language: null,
           }
 
@@ -272,5 +313,6 @@ unit_tests:
             CellPhone: null,
             Email: null,
             Relationship: parent,
+            ContactType: Parent1,
             Language: null,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -129,7 +129,7 @@ unit_tests:
             '+18623007240x216' as phone_mobile
           union all
           select
-            'enr-001', 'kippnewark', 'contact_2', 'stepparent',
+            'enr-001', 'kippnewark', 'contact_2', 'parent',
             'Adam', 'Johnson', 'adam@example.com', cast(null as string),
             cast(null as string), cast(null as string)
           union all
@@ -188,7 +188,7 @@ unit_tests:
             WorkPhone: null,
             CellPhone: null,
             Email: adam@example.com,
-            Relationship: stepparent,
+            Relationship: parent,
             ContactType: Parent2,
             Language: null,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -26,6 +26,17 @@ with
                 then 'Emergency 4'
                 else sc.relationship
             end as relationship,
+
+            -- DeansList routes guardian-only automated messaging (reports,
+            -- texts, emails) by ContactType; Relationship stays informational.
+            case
+                sc.contact_slot
+                when 'contact_1'
+                then 'Parent1'
+                when 'contact_2'
+                then 'Parent2'
+                else 'Emergency'
+            end as contact_type,
         from {{ ref("int_finalsite__student_contacts") }} as sc
         inner join
             {{ ref("int_finalsite__contact_id_attributes") }} as xw
@@ -45,6 +56,7 @@ select
     c.phone_mobile as `CellPhone`,
     c.email as `Email`,
     c.relationship as `Relationship`,
+    c.contact_type as `ContactType`,
 
     cast(null as string) as `Language`,
 from contacts as c

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,10 +3,12 @@ models:
     description:
       Network-wide union of the per-region Finalsite
       `int_finalsite__student_contacts` models — the SIS-agnostic long-format
-      contact list (one row per student per contact slot, `contact_1` plus
-      `emergency_1` through `emergency_4`). Enabled only where the Finalsite API
-      layer is wired (today KIPP Miami and KIPP Newark); carries
-      `_dbt_source_relation` and the derived `_dbt_source_project`.
+      contact list (one row per student per contact slot, `contact_1` and
+      `contact_2` plus `emergency_1` through `emergency_4`). Unions the NJ
+      cutover regions (Newark, Camden, Paterson) only — Miami has the API wired
+      but is excluded to avoid double-counting against the PowerSchool branch of
+      `int_students__contacts`. Carries `_dbt_source_relation` and the derived
+      `_dbt_source_project`.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -23,5 +25,17 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1` or `emergency_1`
-          through `emergency_4`.
+          Which contact this row represents — `contact_1`, `contact_2`, or
+          `emergency_1` through `emergency_4`.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - contact_1
+                  - contact_2
+                  - emergency_1
+                  - emergency_2
+                  - emergency_3
+                  - emergency_4
+              config:
+                severity: error

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
@@ -26,10 +26,11 @@ with
 
             {{ dbt_utils.generate_surrogate_key(["student_number"]) }} as student_key,
 
-            -- keyed identically to dim_student_contact_persons: contact_1 by the
-            -- person's real identity, emergency by student + contact slot
+            -- keyed identically to dim_student_contact_persons: parent slots
+            -- (contact_1/contact_2) by the person's real identity, emergency by
+            -- student + contact slot
             if(
-                contact_slot = 'contact_1',
+                contact_slot in ('contact_1', 'contact_2'),
                 {{
                     dbt_utils.generate_surrogate_key(
                         ["_dbt_source_project", "person_identity"]

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -72,7 +72,9 @@ models:
       - name: is_emergency
         data_type: boolean
         description:
-          True for every emergency slot; false for contact_1 and contact_2.
+          True for every emergency slot. For contact_1/contact_2, false on the
+          Finalsite branch by construction; a Miami PowerSchool priority-1
+          contact keeps its own PowerSchool emergency flag and can be true.
 
       - name: is_pickup
         data_type: boolean

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -2,7 +2,7 @@ models:
   - name: bridge_student_contacts
     description: >-
       Bridge resolving the many-to-many between students and their contact
-      persons under the Finalsite 1+4 contact shape. One row per (student,
+      persons under the Finalsite 2+4 contact shape. One row per (student,
       contact person, contact slot). The relationship and the emergency flags
       that vary per student-contact pair live here; stable person attributes
       (name, email, phones, address) live on dim_student_contact_persons.
@@ -66,27 +66,28 @@ models:
       - name: contact_slot
         data_type: string
         description: >-
-          Which contact this pairing represents — contact_1 or emergency_1
-          through emergency_4.
+          Which contact this pairing represents — contact_1, contact_2, or
+          emergency_1 through emergency_4.
 
       - name: is_emergency
         data_type: boolean
-        description: True for every emergency slot; false for contact_1.
+        description:
+          True for every emergency slot; false for contact_1 and contact_2.
 
       - name: is_pickup
         data_type: boolean
         description: >-
           Whether the contact is authorized to pick the student up. Null for
-          Finalsite contact_1 rows.
+          Finalsite contact_1 and contact_2 rows.
 
       - name: is_custodial
         data_type: boolean
         description: >-
           Whether the contact has custody of the student. Null for Finalsite
-          contact_1 rows.
+          contact_1 and contact_2 rows.
 
       - name: is_household_member
         data_type: boolean
         description: >-
           Whether the student lives with the contact. Null for Finalsite
-          contact_1 rows.
+          contact_1 and contact_2 rows.

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
@@ -17,11 +17,12 @@ with
         from {{ ref("int_students__contacts") }}
     ),
 
-    /* contact_1 is a real contact record that siblings share, so it keys on the
-       person's identity and collapses to one row per person. Every selected
-       attribute is functionally determined by (_dbt_source_project,
-       person_identity) — grain projection, not a mask for upstream duplicates. */
-    contact_1_persons as (
+    /* contact_1 and contact_2 are real contact records that siblings share, so
+       they key on the person's identity and collapse to one row per person.
+       Every selected attribute is functionally determined by
+       (_dbt_source_project, person_identity) — grain projection, not a mask for
+       upstream duplicates. */
+    parent_persons as (
         select distinct
             contact_name,
             email_current,
@@ -34,10 +35,10 @@ with
             _dbt_source_project,
             person_identity,
         from contacts
-        where contact_slot = 'contact_1'
+        where contact_slot in ('contact_1', 'contact_2')
     ),
 
-    /* emergency contacts have no stable person record under the Finalsite 1+4
+    /* emergency contacts have no stable person record under the Finalsite 2+4
        shape, so each (student, slot) is its own person keyed by student + slot. */
     emergency_persons as (
         select
@@ -53,7 +54,7 @@ with
             address_home,
             _dbt_source_project,
         from contacts
-        where contact_slot != 'contact_1'
+        where contact_slot not in ('contact_1', 'contact_2')
     )
 
 select
@@ -68,7 +69,7 @@ select
     phone_work,
     phone_primary,
     address_home as home_address,
-from contact_1_persons
+from parent_persons
 
 union all
 

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -2,10 +2,10 @@ models:
   - name: dim_student_contact_persons
     description: >-
       Contact person dimension. One row per unique student contact person. A
-      contact_1 person shared across siblings appears once here (keyed by their
-      real contact identity) and has one bridge_student_contacts row per
-      student. Emergency contacts have no stable person record under the
-      Finalsite 1+4 contact shape, so each is its own person keyed by student
+      parent (contact_1 or contact_2) shared across siblings appears once here
+      (keyed by their real contact identity) and has one bridge_student_contacts
+      row per student. Emergency contacts have no stable person record under the
+      Finalsite 2+4 contact shape, so each is its own person keyed by student
       and contact slot. Person attributes (name, email, typed phones, home
       address) live on this dimension; the relationship and the emergency flags
       that vary per student-contact pair live on bridge_student_contacts.
@@ -15,9 +15,9 @@ models:
         data_type: string
         description: >-
           Surrogate key for the contact person. Primary key for this dimension.
-          For contact_1 it is hashed from the district and the contact's real
-          identity; for emergency contacts it is hashed from the district,
-          student, and contact slot.
+          For parents (contact_1 and contact_2) it is hashed from the district
+          and the contact's real identity; for emergency contacts it is hashed
+          from the district, student, and contact slot.
         constraints:
           - type: primary_key
             warn_unsupported: false

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts_pivot.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts_pivot.sql
@@ -18,9 +18,8 @@ with
 
 -- Wide one-row-per-student contact surface, pivoted from the long
 -- int_students__contacts model. Preserves the legacy column surface so
--- downstream extracts do not churn: contact_1, contact_2 (NJ Finalsite
--- regions), and emergency_1..4 carry data, while pickup_1..3 have no source
--- rows and materialize as NULL.
+-- downstream extracts do not churn: contact_1 and emergency_1..4 carry data,
+-- while contact_2 and pickup_1..3 have no source rows and materialize as NULL.
 select
     student_number,
     _dbt_source_project,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts_pivot.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts_pivot.sql
@@ -18,8 +18,9 @@ with
 
 -- Wide one-row-per-student contact surface, pivoted from the long
 -- int_students__contacts model. Preserves the legacy column surface so
--- downstream extracts do not churn: contact_1 and emergency_1..4 carry data,
--- while contact_2 and pickup_1..3 have no source rows and materialize as NULL.
+-- downstream extracts do not churn: contact_1, contact_2 (NJ Finalsite
+-- regions), and emergency_1..4 carry data, while pickup_1..3 have no source
+-- rows and materialize as NULL.
 select
     student_number,
     _dbt_source_project,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -33,8 +33,8 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1` or `emergency_1`
-          through `emergency_4`.
+          Which contact this row represents — `contact_1`, `contact_2`, or
+          `emergency_1` through `emergency_4`.
         data_tests:
           - not_null:
               config:
@@ -43,6 +43,7 @@ models:
               arguments:
                 values:
                   - contact_1
+                  - contact_2
                   - emergency_1
                   - emergency_2
                   - emergency_3
@@ -68,9 +69,9 @@ models:
         data_type: string
         description:
           Finalsite contact UUID of the contact person, for Finalsite-sourced
-          `contact_1` rows; null for PowerSchool regions and for emergency slots
-          (which have no linked contact record). Used to key the contact person
-          in the dimension.
+          `contact_1`/`contact_2` rows; null for PowerSchool regions and for
+          emergency slots (which have no linked contact record). Used to key the
+          contact person in the dimension.
       - name: contact_name
         data_type: string
         description: The contact's full name.
@@ -130,18 +131,21 @@ models:
             contains_pii: true
       - name: is_emergency
         data_type: boolean
-        description: False for `contact_1`; true for every `emergency_*` slot.
+        description:
+          False for `contact_1` and `contact_2`; true for every `emergency_*`
+          slot.
       - name: is_pickup
         data_type: boolean
         description:
           Whether the contact is authorized for pickup. Null for Finalsite
-          `contact_1` rows.
+          `contact_1` and `contact_2` rows.
       - name: is_custodial
         data_type: boolean
         description:
-          Whether the contact has custody. Null for Finalsite `contact_1` rows.
+          Whether the contact has custody. Null for Finalsite `contact_1` and
+          `contact_2` rows.
       - name: is_household_member
         data_type: boolean
         description:
           Whether the contact lives with the student. Null for Finalsite
-          `contact_1` rows.
+          `contact_1` and `contact_2` rows.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -132,8 +132,10 @@ models:
       - name: is_emergency
         data_type: boolean
         description:
-          False for `contact_1` and `contact_2`; true for every `emergency_*`
-          slot.
+          True for every `emergency_*` slot. For `contact_1`/`contact_2`, false
+          on the Finalsite branch by construction; a Miami PowerSchool
+          priority-1 contact keeps its own PowerSchool emergency flag and can be
+          true.
       - name: is_pickup
         data_type: boolean
         description:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts_pivot.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts_pivot.yml
@@ -5,11 +5,11 @@ models:
       `int_students__contacts`. Preserves the legacy contact column surface
       (`contact_1`/`contact_2`, `emergency_1` through `emergency_3`, and
       `pickup_1` through `pickup_3`, each with the nine attribute suffixes) plus
-      the new additive `emergency_4` set. Under the 1+4 contact shape only
-      `contact_1` and `emergency_1` through `emergency_4` carry data;
-      `contact_2` and the `pickup` slots are retained as NULL so downstream
-      extracts keep their column lists. Grain is one row per (student, source
-      project).
+      the new additive `emergency_4` set. Under the 2+4 contact shape,
+      `contact_1`, `contact_2` (NJ Finalsite regions), and `emergency_1` through
+      `emergency_4` carry data; the `pickup` slots are retained as NULL so
+      downstream extracts keep their column lists. Grain is one row per
+      (student, source project).
     config:
       materialized: table
     data_tests:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Add the `ContactType` column to the DeansList `contacts.txt` extract and prepare the kipptaf consumers for `contact_2` (Parent 2) rows — the kipptaf half of #4569 (companion to #4578, the finalsite package half).

- `rpt_deanslist__family_contacts`: new `ContactType` column (`Parent1` / `Parent2` / `Emergency`), positioned between `Relationship` and `Language` per the DeansList template, so DeansList can send automated reports/texts/emails to guardians only. The PK widens to `(StudentID, ContactType, Relationship)` — two parents can legitimately share a `rel_type` (e.g. both `parent`), which would have broken the old `(StudentID, Relationship)` uniqueness test the moment Parent 2 rows arrive.
- `bridge_student_contacts` / `dim_student_contact_persons`: person-key `contact_2` the same way as `contact_1` (a second parent is a real, sibling-shared contact record, unlike the free-text emergency slots). Both models change together so bridge and dim keys stay consistent.
- `int_students__contacts`: admit `contact_2` in the `contact_slot` accepted values; description updates. The pivot model already carried a NULL `contact_2_*` column surface — comment updated.

Everything here is a no-op until #4578 merges and district prod rebuilds produce `contact_2` rows; the two PRs are order-independent but both are required for the Asana asks (Emergency-contact import is blocked in DeansList until `ContactType` lands).

Validated locally: full dev build of the five touched models plus tests — 27 pass, 2 pre-existing warns (8 null `ParentLastName` rows, identical count in prod; 20 bridge `student_key` orphans, known dev-defer drift). Both rpt unit tests updated for `ContactType` and extended with a Parent2 row exercising the new case branch.

Open question flagged to Ops (not changed here): emergency rows currently send `Relationship = 'Emergency 1'` (with a space); DeansList's sample shows `Emergency1`. With `ContactType` now distinguishing emergencies, the real relationship could go in `Relationship` instead — awaiting confirmation with DeansList before changing behavior.

## AI Assistance

Claude Code authored this PR end-to-end, directed by @cbini (gate definition and scope decisions).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties files updated for all touched models
- [x] Exposure — the DeansList extract exposure already covers `rpt_deanslist__family_contacts`; no new consumers
- [x] **Breaking change?** Additive column on the rpt contract (`ContactType`); DeansList requested the new column and will map it on import. The bridge/dim `student_contact_person_key` values are unchanged for all existing rows (`contact_1` and emergency keying is identical; `contact_2` rows do not exist yet).
- [x] No external source changes

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.