### PR TITLE
docs: fold four pilot-session findings into the direction files

### DIFF
--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -22,9 +22,21 @@ it yourself — flag it per Flag, don't invent, and keep going.
 
 Run these six steps, in order, at the start of every session. Step 1 is a hard
 gate: do not answer a substantive participant query before it passes. Steps 3-6
-apply to every query in the session, not only the first. Before step 1, capture
-the participant's name (or initials) — ask if you do not have it, because the
-session log's filename depends on it (see Session log below).
+apply to every query in the session, not only the first.
+
+Before step 1, do two things:
+
+- **Ask the participant their name.** Ask directly, in one line. Do not infer it
+  from earlier conversation, chat history, or repository metadata — three of the
+  first four logged sessions guessed instead of asking, and one guessed from a
+  GitHub commit author. The session log's filename depends on it (see Session
+  log below).
+- **Do not carry forward "known issues" from memory.** Anything you list as
+  carried in from a prior session must either be re-verified against live data
+  this session or cited to `assessment-cube-reference.md`. Recalled issues go
+  stale and compound: one session re-asserted a field was unpopulated — and
+  built a manual workaround around it — when the field had been fine all along.
+  If you cannot verify it, write "unverified" next to it.
 
 1. **Calibration first (hard gate).** Before answering any participant query —
    regardless of how urgent or complex the opening request is — check network
@@ -84,6 +96,15 @@ leadership:
   a convenience, not a ratified threshold
 - how to attribute a mid-year transfer student in growth reporting: to the
   school they started the year at, or the one they ended it at
+- which Illuminate subjects count as "ELA" — `Text Study`, `Writing`,
+  `English 100`–`400`, `CCR 1`–`4` and the AP courses are all candidates, the
+  same shape of question as "which count as math"
+- whether grade-band reporting keys on `grade_level` (the student's enrolled
+  grade) or `grade_level_tested` (the grade the assessment targets)
+- how to rank a "highest-leverage next step" across standards — lowest score
+  alone, or weighted by how many students are non-proficient and by
+  prerequisite/transfer value. A session applied its own framework twice; it
+  reads as authoritative and is not.
 
 Some individual fields also carry their own narrower open question (for example,
 which count measure is the default for a count/share question) — those are

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -54,10 +54,19 @@ Apply to every assessment source unless a source section overrides them.
   text** — the label strings are wildly inconsistent (dozens of variants per
   band number). Other sources use their own `proficiency_level` scales (see each
   section).
-- **Two different subject fields.** `academic_subject` is the subject _tested_
-  (e.g., `Mathematics`, `English Language Arts`); `discipline` is the _course_
-  subject from the course crosswalk (e.g., `Math`, `ELA`). They answer different
-  questions — do not use one in place of the other.
+- **Two different subject fields, and `academic_subject` values are
+  source-dependent.** `academic_subject` is the subject _tested_; `discipline`
+  is the _course_ subject from the course crosswalk (e.g. `Math`, `ELA`). They
+  answer different questions — do not use one in place of the other.
+  - **Illuminate has no `English Language Arts` value** — filtering for it
+    returns zero rows. Illuminate's ELA-equivalent is **`Text Study`** (4.7M
+    scores), alongside `Writing`, `English 100`–`400`, `CCR 1`–`4`,
+    `Composition 200`, and AP Language / AP Literature. Math-side it uses
+    `Mathematics` plus `Algebra I`, `Algebra I MS`, `Algebra II`, `Geometry`,
+    `Pre-Calculus`, `Math 4`.
+  - State and vendor sources use the plainer labels (`English Language Arts`,
+    `Mathematics`). Check the values for the source you are querying before
+    filtering — a wrong label returns zero rows silently, not an error.
 - **Three different grade fields.** `grade_band` is a school-level attribute
   (the band a location serves — `ES` / `MS` / `HS`), not a per-student grade;
   filtering `grade_band = 'MS'` is a school proxy, not a student-grade filter.
@@ -93,10 +102,19 @@ Apply to every assessment source unless a source section overrides them.
   — reliable for CCSS-aligned content, unreliable for FL state-aligned
   standards. Illuminate only (null elsewhere, since `response_type` is null
   elsewhere).
+- **The view is enrollment-scoped — its totals are not the vendor's or the
+  state's totals.** A score appears only if it resolves to a section enrollment;
+  scores that don't resolve are out of scope by design. For 2025-26 i-Ready that
+  is about 6% of tests, unevenly: Newark 8.0%, Camden 4.2%, Miami 2.5% — and
+  `Outside Round` sittings lose roughly a third. So a Cube count will not
+  reconcile to a vendor or state report, and the gap is expected, not a bug. Say
+  which one you are quoting.
 - **Open decisions — flag, never assume a value** (per the orchestrator):
   minimum-sample suppression threshold; intervention tier cut-scores;
   pool-vs-per-instrument for multi-module "overall mastery"; which subjects
-  count as "math"; and the default grain (record vs distinct-student) for
+  count as "math" _and_ which count as "ELA" (see the Illuminate subject list
+  above); whether grade-band reporting keys on `grade_level` or
+  `grade_level_tested`; and the default grain (record vs distinct-student) for
   count/share questions. None has a documented network default — surface the
   assumption and log it.
 
@@ -137,6 +155,22 @@ Apply to every assessment source unless a source section overrides them.
   `Outside Round` for sittings taken outside the three benchmark windows.
   Filtering to only `BOY` / `MOY` / `EOY` silently drops the `Outside Round`
   rows — scope deliberately and state which windows you used.
+- **`Outside Round` is also the least complete round.** Roughly a third of
+  `Outside Round` sittings never resolve to a section enrollment, so they never
+  reach this view (Newark loses ~40%); the named rounds lose under 10%. Treat
+  `Outside Round` counts as a floor, not a census.
+- **Resolving "the most recent diagnostic":** take the latest _named_ round
+  (`BOY` / `MOY` / `EOY`) within the latest `academic_year_label` — do **not**
+  take the maximum `date_taken`. The literal latest rows are usually one-off
+  `Outside Round` makeup sittings, and a July test date lands in the _next_
+  July-start academic year, so a max-date pick returns a single student rather
+  than the administration.
+- **Proficiency cutoff:** `is_mastery` is TRUE for `Early On Grade Level` and
+  `Mid or Above Grade Level`, FALSE for the three below-grade-level bands. Note
+  that `Early On Grade Level` counts as proficient — a looser bar than "at or
+  above grade level", and it is roughly half of all proficient scores. If a
+  participant means the stricter definition, filter `proficiency_level` directly
+  instead of using `pct_proficient`.
 - **Region coverage: Newark, Camden, and Miami only — there is no i-Ready data
   for Paterson.** A "compare i-Ready across all regions" question therefore
   returns three of the four regions; say so rather than implying network-wide
@@ -154,9 +188,14 @@ Apply to every assessment source unless a source section overrides them.
   vendor/state sources), not a gap. Genuine multiple sittings occur even within
   a single benchmark window, so dedup to the most recent `date_taken` per
   student per window before computing anything student-level.
-- Documented from the live schema and two working-group sessions (a Camden ES
-  ELA DIBELS-vs-i-Ready concordance, and a BOY-to-EOY growth-quadrant analysis)
-  — confirm interpretations before external use.
+- **Query this view, not the upstream i-Ready model.** i-Ready arrives with
+  fiscal-year re-pull duplicates — the same physical test landing under two
+  partitions. The mart collapses them, so counts here are right; a query
+  straight against the warehouse source double-counts nearly every row.
+- Documented from the live schema and four working-group sessions (a Camden ES
+  ELA DIBELS-vs-i-Ready concordance, a BOY-to-EOY growth-quadrant analysis, and
+  two Camden proficiency-by-grade pulls) — confirm interpretations before
+  external use.
 
 ## Vendor normed diagnostics — DIBELS
 
@@ -170,6 +209,10 @@ Apply to every assessment source unless a source section overrides them.
   school year with them.
 - **Administrations:** `administration_period` = `BOY` / `MOY` / `EOY`, the same
   benchmark-window vocabulary as i-Ready.
+- **Coverage starts in 2023-24**, and that first year is partial (about a third
+  of a normal year's volume, consistent with mid-year adoption). Earlier years
+  are simply absent — do not read a pre-2023-24 gap as a load failure, and don't
+  trend across the 2023-24 boundary.
 - Documented from the live schema and one working-group session (used as the
   comparison instrument in a Camden ES ELA concordance) — confirm before
   external use.
@@ -187,6 +230,8 @@ Apply to every assessment source unless a source section overrides them.
 - **Administrations:** `administration_period` = `Fall` / `Winter` / `Spring` —
   season names, **not** the `BOY` / `MOY` / `EOY` vocabulary i-Ready and DIBELS
   use. Do not carry a benchmark-window filter across from those sources.
+- **Coverage starts in 2023-24** at a steady but small volume (~2.3-2.5k scores
+  per year, far below the other sources). Earlier years are absent, not lost.
 - Not exercised in the working-group sessions; documented from the live schema —
   confirm before external use.
 


### PR DESCRIPTION
## Summary and Motivation

Second pass of the update loop, from four working-group session logs filed to the shared Drive folder. Every claim re-verified against live Cube or BigQuery before being written.

### A doc bug of mine, caught by a participant

The reference used `English Language Arts` as its `academic_subject` example. **Illuminate has no such value** — filtering for it returns zero rows, silently. Illuminate's ELA-equivalent is `Text Study` (4.7M scores), alongside `Writing`, `English 100`–`400`, `CCR 1`–`4`, `Composition 200`, and the AP courses. The reference now says values are source-dependent and lists Illuminate's actual subjects on both the ELA and math sides.

### New settled mechanics

- **`is_mastery` cutoff for i-Ready** (answers an open question from another session): TRUE for `Early On Grade Level` and `Mid or Above Grade Level`, FALSE for the three below-grade bands. Flagged that `Early On` counting as proficient is a looser bar than people assume, and is about half of all proficient scores.
- **The view is enrollment-scoped, so its totals are not the vendor's or the state's.** A score appears only if it resolves to a section enrollment. For 2025-26 i-Ready that is ~6% of tests, unevenly: Newark 8.0%, Camden 4.2%, Miami 2.5%. Cube counts will not reconcile to a vendor report and that is expected.
- **`Outside Round` is also the least-complete round** — roughly a third never resolve to a section (Newark ~40%), versus under 10% for the named rounds. Treat those counts as a floor.
- **A "most recent diagnostic" convention:** take the latest *named* round within the latest `academic_year_label`; never the max `date_taken`. The literal latest rows are one-off makeup sittings, and a July test date lands in the next July-start year — a max-date pick returns one student, not an administration. Two sessions derived this by hand.
- **Query the view, not the upstream i-Ready model** — fiscal-year re-pull duplicates are collapsed in the mart but still present at source, so a direct warehouse query double-counts nearly every row.
- **DIBELS and STAR coverage starts in 2023-24** (DIBELS' first year partial, ~a third of normal volume). Earlier years are absent, not lost — answers a recurring open question.

### Orchestrator

Three new open decisions: Illuminate ELA bucketing, `grade_level` vs `grade_level_tested` for grade-band reporting, and how to rank a "highest-leverage next step" (one session applied its own framework twice and it reads as authoritative).

Two protocol fixes, both from observed failures:

- **Ask the participant's name; do not infer it.** Three of the first four sessions guessed — one from a GitHub commit author.
- **Do not carry "known issues" forward from memory.** Carried-in items must be re-verified against live data or cited to the reference file. One session re-asserted that a field was unpopulated and built a manual workaround around it, when the field had been correct all along.

## Not included

Two logged items were verified as non-defects and need no doc change: the 2025-26 NJSLA absence (scores not yet released — the rows are genuinely absent upstream, not dropped by a join) and the stray 2026-27 i-Ready rows (July test dates landing correctly in the next July-start year).

## Self-review

### Docs

Not applicable — no schedule, sensor, or integration changes. These are claude.ai Project-knowledge files.

## CI checks

- [ ] Trunk — passes (`trunk check --force` clean after the commit-hook format).
