### PR TITLE
feat(kipptaf): add Overgrad award-letter out-of-pocket and unmet-need to roster and KFWD SPI

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_spi.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_spi.yml
@@ -81,6 +81,10 @@ models:
         data_type: numeric
       - name: best_guess_pathway
         data_type: string
+      - name: out_of_pocket
+        data_type: float64
+      - name: unmet_need
+        data_type: float64
       - name: is_graduated
         data_type: boolean
       - name: is_ecc_enrollment

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_spi.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_spi.sql
@@ -1,3 +1,25 @@
+with
+    overgrad_admissions as (
+        select
+            student__external_student_id,
+            award_letter__out_of_pocket,
+            award_letter__unmet_need,
+            updated_at,
+
+            safe_cast(university__ipeds_id as string) as university_ipeds_id_str,
+        from {{ ref("int_overgrad__admissions") }}
+    ),
+
+    overgrad_award_letter as (
+        {{
+            dbt_utils.deduplicate(
+                relation="overgrad_admissions",
+                partition_by="student__external_student_id, university_ipeds_id_str",
+                order_by="updated_at desc",
+            )
+        }}
+    )
+
 select
     r.contact_id,
     r.lastfirst as student_name,
@@ -45,6 +67,9 @@ select
     null as is_ed_ea,
     null as student_aid_index,
     null as best_guess_pathway,
+
+    cast(null as float64) as out_of_pocket,
+    cast(null as float64) as unmet_need,
 
     if(e.status = 'Graduated', true, false) as is_graduated,
     if(e.id = ei.ecc_enrollment_id, true, false) as is_ecc_enrollment,
@@ -196,6 +221,9 @@ select
     r.contact_efc_from_fafsa as student_aid_index,
     r.best_guess_pathway,
 
+    adm.award_letter__out_of_pocket as out_of_pocket,
+    adm.award_letter__unmet_need as unmet_need,
+
     false as is_graduated,
     null as is_ecc_enrollment,
     null as is_ugrad_enrollment,
@@ -222,4 +250,9 @@ left join
     {{ ref("base_kippadb__application") }} as a
     on r.contact_id = a.applicant
     and a.rn_application_school = 1
+left join {{ ref("stg_kippadb__account") }} as acc on a.school = acc.id
+left join
+    overgrad_award_letter as adm
+    on r.contact_id = adm.student__external_student_id
+    and acc.nces_id = adm.university_ipeds_id_str
 left join {{ ref("int_kippadb__enrollment_pivot") }} as ei on r.contact_id = ei.student

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
@@ -96,6 +96,44 @@ with
         where test_type in ('ASVAB', 'Military Physical Training')
     ),
 
+    overgrad_admissions as (
+        select
+            student__external_student_id,
+            award_letter__out_of_pocket,
+            award_letter__unmet_need,
+            updated_at,
+
+            safe_cast(university__ipeds_id as string) as university_ipeds_id_str,
+        from {{ ref("int_overgrad__admissions") }}
+    ),
+
+    # trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    matriculated_award_letter_all as (
+        select
+            app.applicant as contact_id,
+
+            adm.award_letter__out_of_pocket,
+            adm.award_letter__unmet_need,
+            adm.updated_at,
+        from {{ ref("base_kippadb__application") }} as app
+        inner join {{ ref("stg_kippadb__account") }} as acc on app.school = acc.id
+        inner join
+            overgrad_admissions as adm
+            on app.applicant = adm.student__external_student_id
+            and acc.nces_id = adm.university_ipeds_id_str
+        where app.is_matriculated
+    ),
+
+    matriculated_award_letter as (
+        {{
+            dbt_utils.deduplicate(
+                relation="matriculated_award_letter_all",
+                partition_by="contact_id",
+                order_by="updated_at desc",
+            )
+        }}
+    ),
+
     roster as (
         select
             se._dbt_source_relation as exit_db_name,
@@ -277,6 +315,9 @@ with
 
             mpt.physical_training_requirement_passed,
 
+            mal.award_letter__out_of_pocket as out_of_pocket_matriculated,
+            mal.award_letter__unmet_need as unmet_need_matriculated,
+
             concat(
                 os.assigned_counselor__last_name,
                 ', ',
@@ -366,6 +407,7 @@ with
             on c.contact_id = mpt.contact
             and mpt.test_type = 'Military Physical Training'
             and mpt.rn_military_testing = 1
+        left join matriculated_award_letter as mal on c.contact_id = mal.contact_id
         where se.rn_undergrad = 1 and se.grade_level between 8 and 12
     )
 

--- a/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__roster.yml
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/properties/int_kippadb__roster.yml
@@ -15,3 +15,31 @@ models:
             source_column: student_number
             contains_pii: true
             column_role: primary_key
+
+      - name: out_of_pocket_matriculated
+        data_type: float64
+        description:
+          Overgrad award-letter out-of-pocket cost for the college the student
+          matriculated to. The matriculated school is the student's
+          base_kippadb__application row flagged is_matriculated, bridged to the
+          Overgrad admission by NCES/IPEDS id; null when the student has no
+          matriculated application or no matching Overgrad award letter.
+        config:
+          meta:
+            source_system: Overgrad
+            source_model: int_overgrad__admissions
+            source_column: award_letter__out_of_pocket
+
+      - name: unmet_need_matriculated
+        data_type: float64
+        description:
+          Overgrad award-letter unmet need for the college the student
+          matriculated to. The matriculated school is the student's
+          base_kippadb__application row flagged is_matriculated, bridged to the
+          Overgrad admission by NCES/IPEDS id; null when the student has no
+          matriculated application or no matching Overgrad award letter.
+        config:
+          meta:
+            source_system: Overgrad
+            source_model: int_overgrad__admissions
+            source_column: award_letter__unmet_need


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will surface the Overgrad award-letter cost figures (`award_letter__out_of_pocket`, `award_letter__unmet_need`) from `int_overgrad__admissions` in two KIPP Forward Tableau surfaces:

- **`int_kippadb__roster`** gains `out_of_pocket_matriculated` and `unmet_need_matriculated` — one value per student, for the college the student matriculated to. A new `matriculated_award_letter` CTE picks the student's `is_matriculated` application (`base_kippadb__application`), bridges the school to the Overgrad admission via `stg_kippadb__account.nces_id` = Overgrad `university__ipeds_id`, and dedupes to one row per student with `dbt_utils.deduplicate`.
- **`rpt_tableau__kfwd_spi`** gains `out_of_pocket` and `unmet_need` (`float64`) populated **per applied school** on the Applications branch (no enrolled/matriculated filter), and null on the Enrollments branch. A leading deduped-admissions CTE (one row per student + IPEDS) keeps the join 1:1 to prevent fan-out.

Both award columns already existed upstream in `int_overgrad__admissions`, so this is a single kipptaf-only change (no district / two-PR work). Overgrad data covers Newark and Camden only; other regions read null by design.

Accepted scope limitation: a school with Overgrad award data but no kippadb (Salesforce) application row, or whose account is missing an `nces_id`, will not surface on the SPI.

### AI Assistance

Claude Code (Opus 4.8) authored the SQL/YAML edits and ran the verification below under human direction; design decisions (matriculated-pick source, per-school SPI grain, accepted limitation) were human-directed.

Verification (local `dbt build --defer`, dev target):

- PASS=3, WARN=0, ERROR=0 — roster `unique(student_number)` passes; SPI contract enforced.
- Roster coverage: Newark 1,122 / Camden 231 populated; Miami and Paterson null.
- SPI Applications: 25,473 of 72,503 rows carry figures; 1,832 students have 5+ distinct schools (max 52). Enrollments branch all null.
- No fan-out: dev vs prod row counts identical (72,503 Applications / 19,362 Enrollments).
- Roster value matches the SPI matriculated-school figure for 1,353 of 1,366 students; the 13 are legitimate multi-matriculation cases (82 such students exist).
- Trunk check clean on all four files.

## Self-review

### dbt

- [x] Properties files updated for the modified models (`int_kippadb__roster.yml` documents the two new columns; `rpt_tableau__kfwd_spi.yml` contract adds both `float64` columns).
- [x] Existing `rpt_tableau__kfwd_spi` exposure already covers the Tableau consumer; no new exposure needed.
- [x] Not a breaking change — additive columns only; no renames or removals on the contracted `rpt_` model.
- [x] No external sources added or modified.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
