### PR TITLE
fix(dbt): materialize FK-carrying marts models as views

### DIFF
--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -12,14 +12,6 @@ models:
       scheduling column carry a typed NULL for that column (e.g. Illuminate and
       AP carry NULL administration_period; state branches carry NULL
       source_assessment_id).
-    config:
-      materialized: table
-      meta:
-        dagster:
-          # nightly instead of eager: Cube-only consumer, daily refresh_key —
-          # see fct_assessment_scores_enrollment_scoped. Refs #4559
-          automation_condition:
-            cron_schedule: 0 0 * * *
     columns:
       - name: assessment_administration_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -1,7 +1,5 @@
 models:
   - name: dim_course_sections
-    config:
-      materialized: table
     description: >-
       Course section dimension. One row per section instance per source region.
       Sections are discrete scheduled offerings of a course at a school. Teacher

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -1,7 +1,5 @@
 models:
   - name: dim_locations
-    config:
-      materialized: table
     description: >-
       School and office location dimension. One row per school or office.
       Conformed dimension. Region context is reached via the region_key FK to

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -1,7 +1,5 @@
 models:
   - name: dim_student_enrollments
-    config:
-      materialized: table
     description: >-
       Student enrollment dimension. One row per student x school x academic year
       enrollment record. Each re-enrollment within a year is a distinct record

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -1,7 +1,5 @@
 models:
   - name: dim_student_section_enrollments
-    config:
-      materialized: table
     description: >-
       Student section enrollment dimension. One row per CC record — each
       enrollment of a student into a section. Multiple rows per student x

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
@@ -1,7 +1,5 @@
 models:
   - name: dim_terms
-    config:
-      materialized: table
     description: >-
       Generalized term/period dimension. One row per named period per region.
       Covers academic terms, performance management rounds, survey windows,

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -8,15 +8,6 @@ models:
       assessment administration (via assessment_administration_key) and to the
       student's resolved section enrollment (via student_section_enrollment_key
       and enrollment_resolution).
-    config:
-      materialized: table
-      meta:
-        dagster:
-          # nightly instead of eager: only consumer is Cube, whose sole
-          # pre-aggregation refresh_key checks once a day — intraday rebuilds
-          # (125+/day at ~4.6 GiB each) were invisible to it. Refs #4559
-          automation_condition:
-            cron_schedule: 0 0 * * *
     columns:
       - name: assessment_score_key
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop the recurring BigQuery `Referenced primary key in table ... has been updated` failures on the marts star by materializing the 7 FK-carrying marts models as views instead of tables.

**Root cause.** Marts models declare BigQuery PK/FK constraints under an enforced contract. For `materialized: table`, dbt emits the FK into the CTAS DDL:

```sql
course_section_key string references `teamster-332318`.`kipptaf_marts`.`dim_course_sections` (course_section_key) not enforced,
```

BigQuery resolves the referenced table's primary key at query-analysis time and re-validates it at commit. A concurrent `create or replace table` on the parent gives it a new PK identity, so the child's CTAS aborts. `not enforced` means no row is ever validated — this is a catalog-metadata consistency failure, not a data-integrity one.

All four occurrences in the last 30 days overlap a parent rebuild:

| failed model | job window (UTC) | FK parent | parent CTAS window |
| --- | --- | --- | --- |
| `dim_student_section_enrollments` | 07-28 13:39:19 to 13:39:31 | `dim_course_sections` | 13:39:25 to 13:39:26 |
| `dim_student_section_enrollments` | 07-28 04:10:57 to 04:11:10 | `dim_student_enrollments` | 04:11:02 to 04:11:04 |
| `fct_assessment_scores_enrollment_scoped` | 07-23 16:17:33 to 16:17:45 | `dim_assessment_administrations` | 16:17:22 to 16:17:27 |
| `fct_assessment_scores_enrollment_scoped` | 07-21 01:48:47 to 01:48:57 | `dim_student_section_enrollments` | 01:48:37 to 01:48:48 |

The colliding runs come from different automation-condition sensor ticks. `dbt_table_automation_condition()`'s `~any_deps_in_progress()` guard is upward-facing only, so a child correctly waits for its parents but a parent never waits for an in-flight child.

**Why views.** `create view` has no column-constraint syntax, so dbt emits no `references` clause for view models — while the constraint's `to: ref(...)` still registers the dbt dependency at parse time. 66 of the 79 constraint-carrying marts models were already views under an enforced contract and have never produced this error; every failure came from the 13 tables. Because only a table child emits the clause and only a table parent has a PK to pin, the whole failure surface was 18 table-to-table FK edges across 7 models.

**Change.** Dropped `materialized: table` from those 7 models so they fall back to the project default (the `marts:` block sets only `+schema` and `+contract`). The now-inert nightly cron override was removed alongside it on the two Cube-only models — the translator skips `cron_schedule` for view materializations, so leaving it would read as active config that does nothing. Constraints, contracts, primary keys, and all `relationships` tests are unchanged.

**Verified against a fresh `dbt parse`:** all 7 are `view`; `depends_on` is identical to `main` for every one of them (the FK-derived edges survive); FK/PK constraint counts unchanged; zero table-to-table FK edges remain project-wide; no table model emits any FK constraint; exactly 7 models changed materialization out of 756.

**Tradeoff.** These models now recompute per read instead of being stored, partially reversing the table materialization from #4464 (which moved the assessment star to tables to cut Cube query-time slot cost) and #4559. Accepted deliberately in favor of removing the failure class; the per-query cost lands on Cube, whose pre-aggregation latency is not a concern here. Rollback is a one-line revert per file.

Closes #4587

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude Code did the root-cause investigation (Dagster run logs, `INFORMATION_SCHEMA.JOBS` correlation of all four failures against parent CTAS windows, manifest analysis of the constraint and dependency graph), the cycle and blast-radius checks, and the edits. Direction was human throughout — including correcting Claude's initial claim that BigQuery views cannot carry constraints, which is what redirected the fix from removing 163 constraints to changing 7 materializations.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      **The reviewer crashed before producing findings** — `is_error: true` after
      30 turns with 3 permission denials ([job](https://github.com/TEAMSchools/teamster/actions/runs/30389007968)).
      Its two verification items both needed `manifest.json` parsing, which its
      tool allowlist (`Glob,Grep,LS,Read` and `git` only) cannot do on an 18 MB
      file. There are no findings to address or dismiss. `claude-review` is not a
      required check, and it does not re-run on `synchronize` — re-triggering
      needs a draft / ready-for-review toggle. Flagging so a human reviewer knows
      the advisory pass is absent.

### dbt _(skip if no dbt changes)_

- [x] No new models; all 7 already have properties files, which is what this PR edits.
- [x] No column renames or removals, so no exposure impact. Contracts stay enforced and column lists are untouched.
- [x] **Breaking change: yes, per dbt** — though not the column kind the template asks about. The CI run emits 7 warnings, one per model:

      ```text
      [WARNING]: Breaking change to contracted, unversioned model dim_course_sections
        - Materialization changed with enforced constraints:
          - table -> view
      ```

      dbt flags this because an adapter *may* enforce constraints on tables and not on views. On BigQuery neither is enforced — the emitted DDL says `not enforced` — so no consumer loses a guarantee it actually had. The warning is a state comparison against prod and clears once prod's manifest carries `view`.

      The consumer-side risk that would be real: a view requires the querying identity to have access to every underlying table, not just `kipptaf_marts`. Verified non-issue — the 66 marts models that were already views read the same upstream datasets (`kipptaf_powerschool`, `kipptaf_people`, and so on) in prod today, so Cube's service account already has that access.

      **Rollback plan:** restore `config: materialized: table` in the affected properties file(s). Per-model and independent, so a single regressing model can be reverted without the others. If recomputation cost bites on `fct_assessment_scores_enrollment_scoped` specifically, the alternative that keeps the fix is dropping its 4 `foreign_key` constraints and restoring the table.
- [x] No external sources touched.

## CI checks

Both required checks pass (the ruleset requires exactly `dbt Cloud` and `Trunk Check Runner`).

- [x] **Trunk** — passes. `trunk check --force` was also clean on all 7 files locally.
- [x] **dbt Cloud** — passes ([run 70403218738233](https://rn998.us1.dbt.com/deploy/116510/projects/211862/runs/70403218738233/)). This is the load-bearing check: it confirms BigQuery accepts all 7 as views with constraints declared, which local work could not prove (without `--defer` against prod state the refs resolve to a non-existent dev schema). 7 warnings, all the contract/materialization class documented above; no errors. Build coverage confirmed at node level against BigQuery job history for the run window: **42 of 42 selected models built (the 7 changed plus all 35 marts descendants), and 302 of 302 data tests ran, with 0 errors** — counts match the `state:modified+` closure computed independently from the branch manifest, which rules out skipped descendants. All 7 are present as views in `dbt_cloud_pr_70403104388001_4588_marts` (`VIEW: 42`, zero tables), and each test issued a real `SELECT` against them, so the view chain is proven queryable over data rather than merely valid SQL. Test coverage was also checked from the other direction: **88 tests reference one of the 7 affected models, and all 88 fall inside the selection (set difference 0)** — 58 of them are attached to a *different* model, including six on non-marts models (`stg_powerschool__schools`, `int_deanslist__incidents`, `int_adp_workforce_now__workers__work_assignments`, `int_schoolmint_grow__observations`, `int_seat_tracker__snapshot`, `int_zendesk__tickets__custom_fields_pivot`) that point at `dim_locations`. Those ran with their attached model deferred to prod and `dim_locations` resolving to the PR-schema view, which is the intended comparison.
- [x] **CodeQL** — passes (`Analyze` actions / javascript / python).
- [x] **Dagster Cloud** — not triggered; no code-location paths changed.
- [ ] **claude-review** — errored, see General above. Not a required check.
