### PR TITLE
feat(dbt): add network-wide leader rules to lattice user extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -16,6 +16,9 @@ Keep this doc in sync with the model whenever the criteria change.
 - **Miami includes additional leader roles** — gated on a title keyword match
   plus one hardcoded location ("Room 11"), rather than an explicit title or
   department list.
+- **Three network-wide rules apply everywhere** — Heads of School, Managing
+  Directors in School Support, and the whole Teaching and Learning department
+  are included no matter which entity they sit in.
 - **Part-time permanent and temporary workers are excluded; full-time temporary
   staff are included.**
 
@@ -52,6 +55,12 @@ Any one of these qualifies:
   - Managing Director of Operations
 - **Newark or Camden** — anyone in the **Technology** or **Marketing, Comms, and
   Enrollment** department.
+- **Any entity** — job title contains "Head of School." The ADP title is "Head
+  of Schools"; the substring also picks up variants such as "Head of Schools in
+  Residence."
+- **Any entity** — anyone in the **Teaching and Learning** department.
+- **Any entity** — job title contains "Managing Director" **and** their
+  department is **School Support**.
 
 #### 3. Currently employed, or very recently departed
 

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -5,10 +5,13 @@ models:
       Family Schools Inc. employees, all KIPP Paterson employees,
       Director/Head/Leader/Dean-tier (or Room 11) staff in Miami, and Newark and
       Camden staff in select Operations director roles or in the Technology or
-      Marketing, Comms, and Enrollment departments. Interns are excluded. Covers
-      staff who are Active or on Leave, plus any staff who met those same
-      criteria and were terminated within the past 30 days. Includes staff
-      gender identity and race/ethnicity reporting category for Lattice.
+      Marketing, Comms, and Enrollment departments. Regardless of business unit,
+      also includes Heads of School, Managing Directors in the School Support
+      department, and everyone in the Teaching and Learning department. Interns
+      are excluded. Covers staff who are Active or on Leave, plus any staff who
+      met those same criteria and were terminated within the past 30 days.
+      Includes staff gender identity and race/ethnicity reporting category for
+      Lattice.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -44,6 +44,13 @@ with
                     and home_department_name
                     in ('Technology', 'Marketing, Comms, and Enrollment')
                 )
+                -- network-wide leader roles, included regardless of entity
+                or contains_substr(job_title, 'Head of School')
+                or home_department_name = 'Teaching and Learning'
+                or (
+                    home_department_name = 'School Support'
+                    and contains_substr(job_title, 'Managing Director')
+                )
             )
             and (
                 assignment_status in ('Active', 'Leave')


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add three network-wide inclusion rules to
the Lattice user extract (`rpt_lattice__users`), so the following staff get
Lattice accounts **regardless of which entity they sit in**:

- Job title contains `Head of School` (the ADP title is `Head of Schools`)
- Job title contains `Managing Director` **and** home department is
  `School Support`
- Anyone in the `Teaching and Learning` department

Previously the extract gated almost everything on business unit: KTAF central
and Paterson were all-in, Miami used a title-keyword match, and Newark/Camden
were limited to a fixed list of Operations director titles plus the Technology
and Marketing/Comms/Enrollment departments. These three roles fell through that
gate in Newark and Camden.

### Effect on the feed

Verified by running the compiled model against prod and diffing against the
currently deployed view:

| Metric               | Value                    |
| -------------------- | ------------------------ |
| Rows before          | 331                      |
| Rows after           | 338                      |
| Added                | 7                        |
| Dropped              | 0                        |
| `external_user_id`   | still unique, no nulls   |
| Missing `work_email` | none among the added rows|

Breakdown of the 7 added (roles only, no PII):

| Entity | Role                                     | Count | Lattice status |
| ------ | ---------------------------------------- | ----- | -------------- |
| Newark | Head of Schools                          | 2     | Active         |
| Newark | Director, Teaching and Learning          | 1     | Active         |
| Newark | Managing Director, School Support        | 1     | Inactive       |
| Camden | Head of Schools                          | 1     | Active         |
| Camden | Managing Director, School Support        | 2     | Active         |

KTAF central, Paterson, and Miami already covered their matching staff under the
existing rules, so the net effect is Newark and Camden only.

Two judgement calls worth a reviewer's eye:

- The one **Inactive** row is a Newark Managing Director terminated inside the
  existing 30-day window. They were never in Lattice, so this creates a new user
  purely to mark them Inactive; they age out of the extract within a month. This
  is how the 30-day rule already behaves for anyone newly matching. Scoping the
  new rules to Active/Leave only would suppress it if that is preferred.
- `contains_substr` was chosen over exact title matching so the rules survive
  ADP title variants. Side effect: `Head of Schools in Residence` also matches
  (one person historically, not currently active).

`README.md` and the model `description` were updated to match, since the README
asks to be kept in sync with the criteria.

## AI Assistance

AI-assisted: the SQL change, README and properties updates, and the prod
verification queries were authored by Claude Code. Human-directed: the inclusion
criteria themselves, the choice of substring over exact title matching, and the
decision to skip a tracking issue.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties file updated (`rpt_lattice__users.yml` model description now
      documents the new criteria)
- [x] No exposure change needed — the Lattice SFTP extract asset is unchanged
- [x] Not a breaking change — no columns renamed or removed; the contract is
      untouched and only the row set widens
- [x] No external source added or modified

## CI checks

- [x] **Trunk** — `trunk check --force` clean locally on all three changed files
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
