### PR TITLE
[DO NOT MERGE] FRESH scaffold revamp -- superseded snapshot for reference

### DIFF
--- a/docs/reference/fresh-dashboard-data-model.md
+++ b/docs/reference/fresh-dashboard-data-model.md
@@ -13,11 +13,14 @@ same underlying scaffold and goals data.
 
 ```text
 stg_powerschool__schools ─┐
-stg_powerschool__students ┼─▶ int_finalsite__enrollment_scaffold ─┬─▶ rpt_tableau__fresh_dashboard_progress_to_goals
-stg_google_sheets__finalsite__school_scaffold ─┘                  │
-                                                                    └─▶ int_finalsite__goals_scaffold ─▶ rpt_tableau__fresh_dashboard_aggregated
-                                                                          ▲
-stg_google_sheets__finalsite__goals ─────────────────────────────────────┘
+stg_powerschool__students ┼─┐
+int_focus__student_enrollments ─┤
+int_finalsite__status_report_unpivot ─┤
+                                        ├─▶ int_finalsite__enrollment_scaffold ─┬─▶ rpt_tableau__fresh_dashboard_progress_to_goals
+                                                                                 │
+                                                                                 └─▶ int_finalsite__goals_scaffold ─▶ rpt_tableau__fresh_dashboard_aggregated
+                                                                                       ▲
+stg_google_sheets__finalsite__goals ───────────────────────────────────────────────────┘
 
 stg_finalsite__status_report ─▶ int_finalsite__status_report_unpivot ─┐
                                                                         ├─▶ int_tableau__finalsite_student_scaffold ─▶ both rpt_ models above
@@ -25,7 +28,7 @@ stg_google_sheets__finalsite__status_crosswalk ─▶ int_google_sheets__finalsi
                                                                                                                                   │
 int_extracts__student_enrollments (PowerSchool-only, zero Miami rows) ──────────────────────────────────────────────────────────┘
 
-"the current cycle" ─▶ hardcoded literal at each model above needing it (not derived -- see "The current academic year" section below)
+var("finalsite_recruitment_year") ─▶ the current Finalsite recruitment cycle (dbt_project.yml, manually bumped -- see "The current academic year" below)
 ```
 
 The **scaffold** (school × grade spine) and the **goals** (numeric targets) are
@@ -36,97 +39,144 @@ Finalsite pipeline, joined in downstream.
 ## The scaffold: `int_finalsite__enrollment_scaffold`
 
 This model produces one row per `(academic_year, region, schoolid, grade_level)`
-— the spine everything else joins against. It replaced a fully hand-maintained
-Google Sheet with a model that prefers PowerSchool-native data and falls back to
-the sheet only where PowerSchool doesn't have it.
+— the spine everything else joins against. It was originally a fully
+hand-maintained Google Sheet; that sheet
+(`stg_google_sheets__finalsite__school_scaffold`) is now retired (disabled, not
+deleted -- see "Retirement of the Google Sheet" below), replaced by three
+computed sources plus two derived rollup row types, blended together.
 
-**Two builders, blended, controlled by one dbt var (`finalsite_scaffold_source`,
+**Controlled by one dbt var (`finalsite_scaffold_source`,
 `kipptaf/dbt_project.yml`, default `blend`):**
 
-| Value             | Behavior                                                                                                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `gsheet`          | Sheet builder only.                                                                                                                  |
-| `powerschool`     | PowerSchool builder only. Never produces `-1` rows on its own.                                                                       |
-| `blend` (default) | PowerSchool builder, plus sheet rows whose `(schoolid, grade_level)` key is absent from it. PowerSchool wins on any overlapping key. |
+| Value             | Behavior                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `powerschool`     | PowerSchool builder only -- debug/comparison mode. Never produces Focus, Finalsite-new, or either rollup row type. |
+| `blend` (default) | All three real sources plus both rollup row types -- the only complete, production mode.                           |
 
-- **PowerSchool builder** — grade membership comes from actual current
-  enrollment (`stg_powerschool__students`, `enroll_status = 0`), joined to
-  `stg_powerschool__schools` for school metadata (name, region). **Not**
-  `stg_powerschool__schools.low_grade`/`high_grade` — that field encodes a
-  school's eventual, fully-built-out grade span, not what it currently serves.
-  Verified during design: growing schools (Hatch, Rise, Purpose as of AY2026)
-  carry a `low_grade` years below any student they've ever enrolled, so
-  expanding that range produced phantom all-null scaffold rows for grades that
-  don't exist yet at that school. Tradeoff: a school's very first student in a
-  newly-opening grade may not be entered in PowerSchool yet even though
-  Finalsite is already recruiting for that grade — this scaffold won't carry
-  that grade until PowerSchool has at least one enrolled student in it (no clean
-  signal exists for "we're opening this grade but haven't enrolled anyone yet"
-  short of a manual sheet entry for that specific transition year).
-  `stg_powerschool__schools` is filtered to `state_excludefromreporting = 0`
-  first — it includes non-reporting/ administrative rows (e.g. the `999999`
-  "Graduated Students" sentinel) that would otherwise produce garbage scaffold
-  rows. `current_grade_levels` also filters `grade_level >= 0` — PowerSchool's
-  own grade-level domain uses negative values for a different, real meaning
-  (pre-registration/pre-K), and must never produce a `grade_level = -1` row
-  indistinguishable from the scaffold's own `-1` sentinel (see below).
-- **Sheet builder** — `stg_google_sheets__finalsite__school_scaffold`, filtered
-  to the current academic year (a hardcoded literal -- see "The current academic
-  year" section below -- so a stale row from a prior, closed cycle can never
-  look like "PowerSchool doesn't have this yet"). Supplies what PowerSchool
-  structurally can't: every school's `grade_level = -1` whole-school-total row,
-  and genuinely new schools/grades not yet live in PowerSchool.
+**The three real sources, in priority order (each wins on any overlapping
+`(schoolid, grade_level)` key over the ones after it):**
 
-**Important: `grade_level = -1` means "whole-school total row" in this
-scaffold's convention** — a reporting convenience, not a PowerSchool concept.
-The PowerSchool builder never synthesizes a `-1` row — it's always
-sheet-sourced, by design.
+1. **PowerSchool** — grade membership comes from actual current enrollment
+   (`stg_powerschool__students`, `enroll_status = 0`), joined to
+   `stg_powerschool__schools` for school metadata (name, region). **Not**
+   `generate_array(low_grade, high_grade)` — `low_grade` is stale-low on
+   rebanded schools. Verified across all 19 reporting non-Miami schools:
+   `high_grade` equals each school's max enrolled grade **everywhere** (so it
+   tracks current reality, not an aspirational build-out), but three schools
+   declare a `low_grade` below what they actually serve — Hatch 3 vs 5, Purpose
+   4 vs 5, Rise 4 vs 5 — so expanding the declared span injects four phantom
+   scaffold rows for grades those schools don't serve. Current enrollment also
+   yields the correct ceiling on its own, so `high_grade` adds nothing, and it
+   is self-maintaining: nobody updates `low_grade` when a school's band shifts.
+   Tradeoff: a school's very first student in a newly-opening grade may not be
+   entered in PowerSchool yet even though Finalsite is already recruiting for
+   that grade -- covered by the Finalsite source below, not PowerSchool.
+   Filtered to `state_excludefromreporting = 0` (excludes non-reporting/
+   administrative rows, e.g. the `999999` "Graduated Students" sentinel) and
+   `_dbt_source_project != 'kippmiami'` -- Miami's SIS moved to Focus (#4441),
+   and a couple of its schools (Courage, Royalty) still show live-looking
+   PowerSchool rows that would otherwise collide with Focus's real data for the
+   same schools. `enroll_status = 0` alone is sufficient to get a clean 0-12
+   grade range -- verified against real data: `stg_powerschool__students` has
+   zero negative `grade_level` values for any `enroll_status`, and the only
+   out-of-range value (`99`, a graduated-student placeholder) only ever occurs
+   at `enroll_status = 3`, already excluded.
+2. **Focus** — the Miami mirror of the PowerSchool source above, using
+   `int_focus__student_enrollments` (`enroll_status = 0`, current
+   `academic_year`, latest stint per year) for current grade membership, already
+   resolved to a PowerSchool-aligned `ps_schoolid`/region via the location
+   crosswalk that model uses internally. `ps_schoolid is not null` filters out
+   Focus's non-KTAF/administrative/closed entries (Applicants, ZZ Course
+   History, Virtual Franchise, closed legacy schools) -- none of them resolve
+   through that crosswalk, so this is equivalent to PowerSchool's
+   `state_excludefromreporting` filter without relying on Focus's own
+   `exclude_from_state_reporting` flag, which is mostly unpopulated in practice.
+   Deliberately does **not** filter out `grade_level = -1` (PK) -- unlike
+   PowerSchool, Focus's grade_level genuinely can be `-1` for PK
+   (`int_focus__student_enrollments`'s own grade derivation), and there's no
+   sentinel collision risk since this scaffold's own whole-school-total row uses
+   `-9`. No PK-enrolled Miami student exists in Focus as of this writing, but
+   the scaffold will pick one up automatically the day one does.
+3. **Finalsite** (`finalsite_new`) — schools/grades Finalsite is recruiting for
+   that don't exist in PowerSchool or Focus yet (a brand-new grade or school
+   with no enrolled students). Sourced from
+   `int_finalsite__status_report_unpivot`
+   (`enrollment_academic_year = var("finalsite_recruitment_year")`), anti-joined
+   against the PowerSchool + Focus keys. **Only compiled in while
+   `var("finalsite_recruitment_year") != var("current_academic_year")`** -- see
+   "The rollover gate" below. A Finalsite `assigned_school` that doesn't resolve
+   through the location crosswalk (a truly new campus never entered anywhere) is
+   silently dropped -- a known, flagged gap, not solved here.
 
-**Miami carve-out (deliberate and temporary):** Miami is excluded from the
-PowerSchool builder entirely, unconditionally, regardless of the
-`finalsite_scaffold_source` var. Miami's SIS moved to Focus
-(`src/dbt/powerschool/CLAUDE.md`, #4441) and no longer consumes the PowerSchool
-package — `stg_powerschool__schools`' Miami rows are a frozen pre-migration
-snapshot, not a live source of truth. Some actively-recruited Miami schools
-(Legacy ES, Legacy MS, MTH as of AY2026) were never onboarded to PowerSchool
-post-migration at all — a permanent gap, not a transitional one PowerSchool
-coverage will ever close on its own. Miami stays 100% sheet-sourced (a full
-spine — every school, every grade, not just `-1` rows and net-new entries) until
-Focus is ready as a scaffold source and this is revisited.
+**Two derived rollup row types, computed across all three sources above:**
 
-Because the PowerSchool builder never emits a `-1` row and never covers Miami,
-`blend`'s single rule ("PowerSchool wins on any overlapping key; sheet fills the
-rest") naturally and correctly handles `-1` rows, genuinely-new grades/schools,
-and all of Miami — no special-casing needed for any of them.
+- **Whole-school total** -- `grade_level = -9` (not `-1`: `-1` now means Pre-K
+  in `stg_finalsite__status_report.grade_level`, added in this same revamp, and
+  the two conventions must not collide), one per real school, `school_level` /
+  `school_level_alt` both `null`. `scaffold_source` is a priority tag
+  (`'powerschool'` if the school has any PowerSchool-sourced grade, else
+  `'focus'`, else `'finalsite'`).
+- **Region rollup** -- `schoolid = 0`, `school = <region name>`, one row per
+  distinct `(region, grade_level)` across all three sources. `scaffold_source`
+  is `null` (no single source applies to a region-wide rollup).
 
-**`school_level` on PowerSchool-sourced rows is derived per expanded
-grade_level** (`>=9` HS, `>=5` MS, else ES) — **not** read from
-`stg_powerschool__schools.school_level`, which is a single per-school value and
-would incorrectly apply one classification to a school spanning two bands (e.g.
-Sumner, Camden — base-classified `ES` network-wide in
-`stg_powerschool__schools`, with grades 5/6 overridden to `MS` in three _other_
-downstream models that need that override). Because this scaffold computes
-`school_level` fresh, per grade, it already gets Sumner right (`ES` for grades
-0–4, `MS` for grades 5/6) with zero special-casing.
+**`school_level`** is derived per `grade_level` (`>=9` HS, `>=5` MS, else ES) in
+every source -- not read from any source's own per-school classification, which
+would incorrectly apply one label to a school spanning two bands.
 
-## The current academic year: hardcoded, not derived
+**`school_level_alt`** — an override column, formerly computed in the now-
+retired sheet. Set to `'MS'` for KIPP Sumner Elementary (schoolid `179905`)
+grade 5+ rows in each of the three real sources; otherwise equal to
+`school_level`. On the whole-school-total rollup it's `null` (mirrors
+`school_level`); on the region rollup it equals `school_level` with no override
+applied, since Sumner's exception is single-school, not region-wide.
 
-"The current Finalsite recruitment cycle" is a **hardcoded literal** (`2026` as
-of this writing) at each site that needs it, not a column, var, or joined value.
-Two attempts to derive it automatically were built and reverted (see `git log`
-on `int_tableau__finalsite_student_scaffold.sql`): Finalsite can carry **two
-concurrent academic years of live student data at once** during a transition
-period — individual students and regions roll over on their own uncoordinated
-timeline, with no standardized cadence — so there's no reliable signal in the
-ingested data for "which year is current now." SRE's own recruitment-cycle
-timeline is similarly fluid, with no fixed date (unlike PowerSchool's
-`var('current_academic_year')`, which bumps on a predictable July 1 cadence) to
-key an automatic bump off of.
+### The rollover gate
 
-Every hardcode site is marked `-- finalsite year toggle: see skill` (or the
-block-comment form). See the fresh-dashboard skill's "Procedure: Update the
-Finalsite recruitment year" section for the full file list and update steps —
-always confirm the new year with SRE before changing any of them.
+No separate var. The Finalsite source above is gated purely by comparing the two
+existing vars:
+
+- `var("finalsite_recruitment_year") != var("current_academic_year")` — the
+  normal state for most of the year (SRE recruiting for the year ahead while the
+  current year is still in session; typically
+  `finalsite_recruitment_year == current_academic_year + 1`). The Finalsite
+  source contributes: PowerSchool/Focus can't have next year's students yet, so
+  Finalsite is the only signal for schools/grades that will exist.
+- `var("finalsite_recruitment_year") == var("current_academic_year")` — true
+  once `current_academic_year` is bumped at the actual July rollover (an
+  existing, separate annual process). The Finalsite source is compiled out
+  entirely: PowerSchool and Focus now have real enrollment for what Finalsite
+  had projected, so there's no gap left to fill from Finalsite.
+
+"Requesting a rollover" is simply an analyst asking to bump
+`finalsite_recruitment_year` ahead of `current_academic_year` -- see the
+fresh-dashboard skill's year-toggle procedure.
+
+### Retirement of the Google Sheet
+
+`stg_google_sheets__finalsite__school_scaffold` is disabled
+(`config: enabled: false`), not deleted, per team convention -- confirmed no
+downstream consumers remain before disabling. The underlying Google Sheet
+document itself is outside dbt's control and is no longer read by any pipeline.
+
+## The current academic year: a manual var, not derived
+
+"The current Finalsite recruitment cycle" is `var("finalsite_recruitment_year")`
+(`kipptaf/dbt_project.yml`) -- manually bumped, not a column, derived value, or
+joined value. Finalsite can carry **two concurrent academic years of live
+student data at once** during a transition period — individual students and
+regions roll over on their own uncoordinated timeline, with no standardized
+cadence — so there's no reliable signal in the ingested data for "which year is
+current now." SRE's own recruitment-cycle timeline is similarly fluid, with no
+fixed date (unlike PowerSchool's `var("current_academic_year")`, which bumps on
+a predictable July 1 cadence) to key an automatic bump off of. The two vars are
+deliberately distinct, and for most of the year `finalsite_recruitment_year`
+runs one year ahead of `current_academic_year` -- SRE starts recruiting for the
+next cycle mid-year, well before the actual July rollover (see "The rollover
+gate" above).
+
+See the fresh-dashboard skill's "Update the Finalsite recruitment year"
+procedure for how to bump it -- always confirm the new year with SRE first.
 
 `status_crosswalk` still holds config for **exactly one academic year at a
 time** by convention, guarded by
@@ -280,8 +330,8 @@ numbers and the dashboard:
   whose day ends mid-US-night) may not show on the dashboard until the next
   day's pull. Unconfirmed whether this specifically applies to Miami.
 - **Miami's point-in-time enrollment flags (`enroll_status`, `is_enrolled_fdos`,
-  `is_enrolled_oct01`, `is_enrolled_oct15`, `is_enrolled_mar15`) are always
-  NULL, on top of and separate from the scaffold's Miami carve-out above.**
+  `is_enrolled_oct01`, `is_enrolled_oct15`, `is_enrolled_mar15`) are always NULL
+  -- a separate gap from the scaffold, unaffected by this revamp.**
   `int_tableau__finalsite_student_scaffold.sql` backfills these 5 fields via a
   `left join` to `int_extracts__student_enrollments`, keyed on
   `(academic_year, infosnap_id)` -- `int_extracts__student_enrollments` is
@@ -316,14 +366,19 @@ numbers and the dashboard:
 
 ## Annual rollover checklist
 
-1. Review/update `stg_google_sheets__finalsite__exclude_ids` for the new cycle's
+1. Bump `var("finalsite_recruitment_year")` in `kipptaf/dbt_project.yml` -- see
+   the fresh-dashboard skill's year-toggle procedure. The scaffold's
+   PowerSchool/Focus/Finalsite sourcing and rollover gate are fully automatic
+   from there; no scaffold sheet to hand-maintain anymore.
+2. Review/update `stg_google_sheets__finalsite__exclude_ids` for the new cycle's
    Finalsite test/fake records.
-2. Add the new cycle's `status_crosswalk` config row(s) — manual, no generator
+3. Add the new cycle's `status_crosswalk` config row(s) — manual, no generator
    (the status→category mapping is institutional judgment, not computable).
-3. Add the scaffold sheet's `-1` rows and any genuinely new grade/school rows —
-   see the `fresh-dashboard` skill's `-1` candidate-row generator.
 4. Add the goals sheet's gap rows for the new cycle — see the skill's
-   goals-sheet gap-row generator.
+   goals-sheet gap-row generator. Note the goals sheet's own whole-school-total
+   rows still use `grade_level = -1` (a separate, independent convention from
+   the scaffold's `-9`, with no collision risk) until it's manually updated to
+   `-9` to match.
 
 ## Open questions
 

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -30,7 +30,7 @@ vars:
   bigquery_external_connection_name: projects/teamster-332318/locations/us/connections/biglake-teamster-gcs
   current_academic_year: 2026
   current_fiscal_year: 2027
-  finalsite_scaffold_source: blend # 'gsheet' | 'powerschool' (debug only, see model description) | 'blend'
+  finalsite_scaffold_source: blend # 'powerschool' (debug only, see model description) | 'blend'
   # Distinct from current_academic_year -- SRE's recruitment cycle rolls over
   # on its own fluid timeline, not the July 1 academic-year cadence. See the
   # fresh-dashboard skill's "Update the Finalsite recruitment year" procedure

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_aggregated.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_aggregated.sql
@@ -16,7 +16,7 @@ with
 
 -- latest status: deferred and waitlisted
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -53,7 +53,7 @@ select
 from {{ ref("int_finalsite__goals_scaffold") }} as s
 left join
     {{ ref("int_tableau__finalsite_student_scaffold") }} as f
-    on s.academic_year = f.enrollment_academic_year
+    on s.enrollment_academic_year = f.enrollment_academic_year
     and s.region = f.region
     and s.schoolid = f.schoolid
     and s.grade_level = f.grade_level
@@ -67,7 +67,7 @@ union all
 
 -- latest status: enrollment in progress
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -104,7 +104,7 @@ select
 from {{ ref("int_finalsite__goals_scaffold") }} as s
 left join
     {{ ref("int_tableau__finalsite_student_scaffold") }} as f
-    on s.academic_year = f.enrollment_academic_year
+    on s.enrollment_academic_year = f.enrollment_academic_year
     and s.region = f.region
     and s.schoolid = f.schoolid
     and s.grade_level = f.grade_level
@@ -120,7 +120,7 @@ union all
 
 -- pending offers and offers (join includes schoolid)
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -157,7 +157,7 @@ select
 from {{ ref("int_finalsite__goals_scaffold") }} as s
 left join
     {{ ref("int_tableau__finalsite_student_scaffold") }} as f
-    on s.academic_year = f.enrollment_academic_year
+    on s.enrollment_academic_year = f.enrollment_academic_year
     and s.region = f.region
     and s.schoolid = f.schoolid
     and s.grade_level = f.grade_level
@@ -170,7 +170,7 @@ union all
 
 -- inquiries and applications (no schoolid join -- students lack a schoolid)
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -207,7 +207,7 @@ select
 from {{ ref("int_finalsite__goals_scaffold") }} as s
 left join
     {{ ref("int_tableau__finalsite_student_scaffold") }} as f
-    on s.academic_year = f.enrollment_academic_year
+    on s.enrollment_academic_year = f.enrollment_academic_year
     and s.region = f.region
     and s.grade_level = f.grade_level
     and s.goal_type = f.goal_type
@@ -221,7 +221,7 @@ union all
 
 -- benchmark conversions
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -258,7 +258,7 @@ select
 from {{ ref("int_finalsite__goals_scaffold") }} as s
 left join
     {{ ref("int_tableau__finalsite_student_scaffold") }} as f
-    on s.academic_year = f.enrollment_academic_year
+    on s.enrollment_academic_year = f.enrollment_academic_year
     and s.region = f.region
     and s.schoolid = f.schoolid
     and s.grade_level = f.grade_level

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_progress_to_goals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_progress_to_goals.sql
@@ -3,7 +3,7 @@ with
         /* dont have a better location where only one schoolid matches a single school
            name */
         select distinct
-            s.academic_year,
+            s.enrollment_academic_year,
             s.org,
             s.region,
             s.schoolid,
@@ -21,14 +21,14 @@ with
             {{ ref("int_people__location_crosswalk") }} as x
             on s.schoolid = x.location_powerschool_school_id
         cross join unnest(['All', 'New', 'Returning']) as enrollment_type
-        where s.grade_level = -1
+        where s.grade_level = -9
 
         union all
 
         /* dont have a better location where only one schoolid matches a single school
            name */
         select distinct
-            s.academic_year,
+            s.enrollment_academic_year,
             s.org,
             s.region,
             s.schoolid,
@@ -43,7 +43,7 @@ with
 
         from {{ ref("int_finalsite__enrollment_scaffold") }} as s
         cross join unnest(['All', 'New', 'Returning']) as enrollment_type
-        where s.grade_level != -1 and s.schoolid != 0
+        where s.grade_level != -9 and s.schoolid != 0
     ),
 
     data_stack_school as (
@@ -281,7 +281,7 @@ with
     )
 
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -312,17 +312,17 @@ select
 from scaffold as s
 left join
     data_stack_school as d
-    on s.academic_year = d.enrollment_academic_year
+    on s.enrollment_academic_year = d.enrollment_academic_year
     and s.region = d.region
     and s.schoolid = d.schoolid
     and s.grade_level = d.grade_level
     and s.enrollment_type = d.enrollment_type
-where s.grade_level = -1
+where s.grade_level = -9
 
 union all
 
 select
-    s.academic_year,
+    s.enrollment_academic_year as academic_year,
     s.org,
     s.region,
     s.school_level,
@@ -353,9 +353,9 @@ select
 from scaffold as s
 left join
     data_stack_school_grade as d
-    on s.academic_year = d.enrollment_academic_year
+    on s.enrollment_academic_year = d.enrollment_academic_year
     and s.region = d.region
     and s.schoolid = d.schoolid
     and s.grade_level = d.grade_level
     and s.enrollment_type = d.enrollment_type
-where s.grade_level != -1 and s.schoolid != 0
+where s.grade_level != -9 and s.schoolid != 0

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_scaffold.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_scaffold.sql
@@ -1,9 +1,9 @@
 {% set scaffold_source_mode = var("finalsite_scaffold_source", "blend") %}
-{% if scaffold_source_mode not in ("gsheet", "powerschool", "blend") %}
+{% if scaffold_source_mode not in ("powerschool", "blend") %}
     {{
         exceptions.raise_compiler_error(
-            "finalsite_scaffold_source must be 'gsheet', 'powerschool', or"
-            ~ " 'blend' -- got '"
+            "finalsite_scaffold_source must be 'powerschool' or 'blend' -- got"
+            ~ " '"
             ~ scaffold_source_mode
             ~ "'"
         )
@@ -11,111 +11,256 @@
 {% endif %}
 
 with
-    powerschool_region as (
+    powerschool as (
         select
-            sps.school_number,
-            sps.abbreviation,
-            sps._dbt_source_project,
-            {{ extract_region("sps") }} as region,
+            school_level,
+            school_number,
+            abbreviation,
+            _dbt_source_project,
 
-        from {{ ref("stg_powerschool__schools") }} as sps
-        where sps.state_excludefromreporting = 0
+            {{ extract_region("stg_powerschool__schools") }} as region,
+
+        from {{ ref("stg_powerschool__schools") }}
+        where state_excludefromreporting = 0 and _dbt_source_project != 'kippmiami'
     ),
 
-    -- Miami's SIS moved to Focus (#4441); stg_powerschool__schools' Miami
-    -- rows are a frozen pre-migration snapshot, not a live source of truth.
-    -- Deliberate, temporary carve-out -- confirmed with the team to keep
-    -- Miami 100% sheet-sourced regardless of finalsite_scaffold_source
-    -- until Focus is ready as a scaffold source. Remove this filter (and
-    -- update the sheet-side builder's Miami note below) once that happens.
-    powerschool_schools as (
-        select school_number, abbreviation, _dbt_source_project, region,
-        from powerschool_region
-        where region != 'Miami'
-    ),
-
-    -- Grade membership comes from actual current enrollment, not
-    -- stg_powerschool__schools.low_grade/high_grade -- that field encodes a
-    -- school's eventual, fully-built-out grade span, not what it currently
-    -- serves (verified: growing schools like Hatch/Rise/Purpose carry a
-    -- low_grade years below any student they've ever enrolled). enroll_status
-    -- = 0 is "Currently Enrolled" -- this table has no academic_year column,
-    -- so status (not a date range) is what scopes it to now. Also filters
-    -- out negative grade_level (PowerSchool's own domain for
-    -- pre-registration / pre-K, a different, real meaning) so it can never
-    -- collide with the scaffold's grade_level = -1 "whole school total"
-    -- sentinel, which always comes from gsheet_scaffold below.
-    -- Known caveat: a school's very first student in a newly-opening grade
-    -- may not be entered in PowerSchool yet even though Finalsite is already
-    -- recruiting for that grade -- this scaffold won't carry that grade
-    -- until PowerSchool has at least one enrolled student in it.
-    -- Carries _dbt_source_project so grade_membership's join can't collide
-    -- across districts on a repeated numeric schoolid -- each PowerSchool
-    -- instance assigns schoolid independently, so an excluded/out-of-scope
-    -- school in one district can share a schoolid with a reporting school in
-    -- another.
+    /* Grade membership is derived from current enrollment, not
+       low_grade/high_grade -- see fresh-dashboard-data-model.md. */
     current_grade_levels as (
-        select distinct schoolid, grade_level, _dbt_source_project,
+        select distinct
+            schoolid,
+            grade_level,
+            _dbt_source_project,
+
+            case
+                when grade_level >= 9
+                then 'HS'
+                when grade_level >= 5
+                then 'MS'
+                else 'ES'
+            end as school_level_alt,
+
         from {{ ref("stg_powerschool__students") }}
-        where enroll_status = 0 and grade_level >= 0
+        where enroll_status = 0
     ),
 
-    grade_membership as (
-        select ps.school_number, ps.abbreviation, ps.region, cgl.grade_level,
+    powerschool_scaffold as (
+        select
+            ps.school_level,
+            ps.region,
+            ps.school_number as schoolid,
+            ps.abbreviation as school,
 
-        from powerschool_schools as ps
+            cgl.grade_level,
+            cgl.school_level_alt,
+
+            'KTAF' as org,
+            'powerschool' as scaffold_source,
+
+            {{ var("finalsite_recruitment_year") }} as enrollment_academic_year,
+
+        from powerschool as ps
         inner join
             current_grade_levels as cgl
             on ps.school_number = cgl.schoolid
             and ps._dbt_source_project = cgl._dbt_source_project
     ),
 
-    powerschool_scaffold as (
+    focus as (
         select
-            gm.school_number as schoolid,
-            gm.abbreviation as school,
-            gm.region,
-            gm.grade_level,
+            school_level,
+            school_number,
+            abbreviation,
+            _dbt_source_project,
 
-            {{ var("finalsite_recruitment_year") }} as academic_year,
+            {{ extract_region("stg_powerschool__schools") }} as region,
 
-            'KTAF' as org,
-            'powerschool' as scaffold_source,
+        from {{ ref("stg_powerschool__schools") }}
+        where state_excludefromreporting = 0 and _dbt_source_project != 'kippmiami'
+    ),
+
+    /* Focus mirror of powerschool_scaffold above -- see
+       fresh-dashboard-data-model.md. */
+    focus_levels as (
+        select distinct
+            ps_schoolid as schoolid,
+            school_abbreviation as school,
+            region,
+            grade_level,
 
             case
-                when gm.grade_level >= 9
+                when grade_level >= 9
                 then 'HS'
-                when gm.grade_level >= 5
+                when grade_level >= 5
                 then 'MS'
                 else 'ES'
             end as school_level,
 
-        from grade_membership as gm
+        from {{ ref("int_focus__student_enrollments") }}
+        where
+            enroll_status = 0
+            and academic_year = {{ var("current_academic_year") }}
+            and rn_year = 1
+            and ps_schoolid is not null
+    ),
+
+    focus_scaffold as (
+        select
+            schoolid,
+            school,
+            region,
+            grade_level,
+
+            {{ var("finalsite_recruitment_year") }} as enrollment_academic_year,
+
+            'KTAF' as org,
+            'focus' as scaffold_source,
+
+            school_level,
+
+            if(
+                schoolid = 179905 and grade_level >= 5, 'MS', school_level
+            ) as school_level_alt,
+
+        from focus_levels
     )
 
-    {% if scaffold_source_mode in ("gsheet", "blend") %}
+    {% if scaffold_source_mode == "blend" and var(
+        "finalsite_recruitment_year"
+    ) != var("current_academic_year") %}
         ,
 
-        -- Scoped to the current cycle so a stale row from a prior year (a
-        -- closed school, a dropped grade) doesn't look identical to "PS
-        -- doesn't have this yet" and get silently resurrected forever. Miami
-        -- must carry its FULL spine here (every school, every grade), not just
-        -- -1 rows and net-new entries, since the PowerSchool builder excludes
-        -- it entirely above.
-        gsheet_scaffold as (
+        existing_keys as (
+            select schoolid, grade_level,
+            from powerschool_scaffold
+
+            union all
+
+            select schoolid, grade_level,
+            from focus_scaffold
+        ),
+
+        /* Schools/grades Finalsite is recruiting for that don't exist in
+           PowerSchool/Focus yet -- see fresh-dashboard-data-model.md and the
+           fresh-dashboard skill's rollover procedure. */
+        finalsite_new as (
+            select distinct
+                u.schoolid,
+                u.school,
+                u.region,
+                u.grade_level,
+
+                case
+                    when u.grade_level >= 9
+                    then 'HS'
+                    when u.grade_level >= 5
+                    then 'MS'
+                    else 'ES'
+                end as school_level,
+
+            from {{ ref("int_finalsite__status_report_unpivot") }} as u
+            left join
+                existing_keys as k
+                on u.schoolid = k.schoolid
+                and u.grade_level = k.grade_level
+            where
+                u.enrollment_academic_year = {{ var("finalsite_recruitment_year") }}
+                and u.schoolid != 0
+                and k.schoolid is null
+        ),
+
+        finalsite_new_scaffold as (
             select
-                s.schoolid,
-                s.school,
-                s.region,
-                s.grade_level,
-                s.academic_year,
-                s.org,
-                s.school_level,
+                schoolid,
+                school,
+                region,
+                grade_level,
 
-                'gsheet' as scaffold_source,
+                {{ var("finalsite_recruitment_year") }} as enrollment_academic_year,
 
-            from {{ ref("stg_google_sheets__finalsite__school_scaffold") }} as s
-            where s.academic_year = {{ var("finalsite_recruitment_year") }}
+                'KTAF' as org,
+                'finalsite' as scaffold_source,
+
+                school_level,
+
+                if(
+                    schoolid = 179905 and grade_level >= 5, 'MS', school_level
+                ) as school_level_alt,
+
+            from finalsite_new
+        )
+    {% endif %}
+
+    {% if scaffold_source_mode == "blend" %}
+        ,
+
+        selected_scaffold as (
+            select
+                schoolid,
+                school,
+                region,
+                grade_level,
+                enrollment_academic_year,
+                org,
+                scaffold_source,
+                school_level,
+                school_level_alt,
+            from powerschool_scaffold
+
+            union all
+
+            select
+                schoolid,
+                school,
+                region,
+                grade_level,
+                enrollment_academic_year,
+                org,
+                scaffold_source,
+                school_level,
+                school_level_alt,
+            from focus_scaffold
+
+            {% if var("finalsite_recruitment_year") != var(
+                    "current_academic_year"
+                ) %}
+                union all
+
+                select
+                    schoolid,
+                    school,
+                    region,
+                    grade_level,
+                    enrollment_academic_year,
+                    org,
+                    scaffold_source,
+                    school_level,
+                    school_level_alt,
+                from finalsite_new_scaffold
+            {% endif %}
+        ),
+
+        school_priority as (
+            select
+                schoolid,
+                school,
+                region,
+                enrollment_academic_year,
+                org,
+
+                min(
+                    case
+                        scaffold_source
+                        when 'powerschool'
+                        then 1
+                        when 'focus'
+                        then 2
+                        else 3
+                    end
+                ) as source_priority,
+
+            from selected_scaffold
+            group by schoolid, school, region, enrollment_academic_year, org
         )
     {% endif %}
 
@@ -126,24 +271,12 @@ with
         school,
         region,
         grade_level,
-        academic_year,
+        enrollment_academic_year,
         org,
         scaffold_source,
         school_level,
+        school_level_alt,
     from powerschool_scaffold
-
-{% elif scaffold_source_mode == "gsheet" %}
-
-    select
-        schoolid,
-        school,
-        region,
-        grade_level,
-        academic_year,
-        org,
-        scaffold_source,
-        school_level,
-    from gsheet_scaffold
 
 {% else %}
 
@@ -152,28 +285,58 @@ with
         school,
         region,
         grade_level,
-        academic_year,
+        enrollment_academic_year,
         org,
         scaffold_source,
         school_level,
-    from powerschool_scaffold
+        school_level_alt,
+    from selected_scaffold
 
     union all
 
     select
-        g.schoolid,
-        g.school,
-        g.region,
-        g.grade_level,
-        g.academic_year,
-        g.org,
-        g.scaffold_source,
-        g.school_level,
-    from gsheet_scaffold as g
-    left join
-        powerschool_scaffold as p
-        on g.schoolid = p.schoolid
-        and g.grade_level = p.grade_level
-    where p.schoolid is null
+        schoolid,
+        school,
+        region,
+
+        -9 as grade_level,
+
+        enrollment_academic_year,
+        org,
+
+        case
+            source_priority
+            when 1
+            then 'powerschool'
+            when 2
+            then 'focus'
+            else 'finalsite'
+        end as scaffold_source,
+
+        cast(null as string) as school_level,
+        cast(null as string) as school_level_alt,
+
+    from school_priority
+
+    union all
+
+    /* grain projection: school_level is functionally determined by
+       grade_level alone (same CASE everywhere), so distinct on the region
+       grain is safe, not a dup mask. */
+    select distinct
+        0 as schoolid,
+
+        region as school,
+        region,
+        grade_level,
+        enrollment_academic_year,
+        org,
+
+        cast(null as string) as scaffold_source,
+
+        school_level,
+        school_level as school_level_alt,
+
+    from selected_scaffold
 
 {% endif %}

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__goals_scaffold.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__goals_scaffold.sql
@@ -1,5 +1,5 @@
 select
-    b.academic_year,
+    b.enrollment_academic_year,
     b.org,
     b.region,
     b.schoolid,
@@ -29,7 +29,7 @@ select
 from {{ ref("int_finalsite__enrollment_scaffold") }} as b
 inner join
     {{ ref("stg_google_sheets__finalsite__goals") }} as g
-    on b.academic_year = g.enrollment_academic_year
+    on b.enrollment_academic_year = g.enrollment_academic_year
     and b.region = g.region
     and b.schoolid = g.schoolid
     and b.grade_level = g.grade_level

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__enrollment_scaffold.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__enrollment_scaffold.yml
@@ -1,80 +1,84 @@
 models:
   - name: int_finalsite__enrollment_scaffold
     description: >
-      School x grade spine for the FRESH dashboard, replacing the fully
-      hand-maintained stg_google_sheets__finalsite__school_scaffold. Source is
-      controlled by var finalsite_scaffold_source ('gsheet' | 'powerschool' |
-      'blend', default 'blend'): the PowerSchool builder derives grade
-      membership from actual current enrollment in stg_powerschool__students
-      (enroll_status = 0), not stg_powerschool__schools.low_grade/high_grade --
-      that field encodes a school's eventual, fully-built-out grade span, not
-      what it currently serves. Tradeoff: a school's very first student in a
-      newly-opening grade may not be in PowerSchool yet even though Finalsite is
-      already recruiting for it, so that grade won't appear until PowerSchool
-      has at least one enrolled student in it. The sheet builder covers what
-      PowerSchool can't -- every school's grade_level = -1 whole-school row
-      (PowerSchool never supplies this row), genuinely new schools/grades not
-      yet live in PowerSchool, and all of Miami (deliberate, temporary carve-out
-      -- Miami's SIS moved to Focus and Focus isn't ready as a scaffold source
-      yet). In blend mode, PowerSchool wins on any overlapping (schoolid,
-      grade_level) key; the sheet fills everything else -- the same single rule
-      naturally covers -1 rows, genuinely-new grades/schools, and the entire
-      Miami region, with no special-casing. 'powerschool' mode is NOT a complete
-      standalone source and isn't meant to be used in production as currently
-      deployed (the default, only currently-deployed mode is 'blend') -- the -1
-      whole-school row and all of Miami are structurally never derivable from
-      PowerSchool, so selecting 'powerschool' alone drops both entirely, with
-      nothing else backfilling them. Treat it as a debug/comparison mode (e.g.
-      to inspect PowerSchool's own coverage in isolation), not a production
-      toggle, unless a future change gives PowerSchool a way to supply -1 rows
-      and Miami data.
+      School x grade spine for the FRESH dashboard, computed from three sources
+      per var finalsite_scaffold_source ('powerschool' | 'blend', default
+      'blend'): PowerSchool current enrollment for NJ regions, Focus current
+      enrollment for Miami (int_focus__student_enrollments, mirroring the
+      PowerSchool branch), and Finalsite's status_report for schools/grades
+      neither system has enrollment for yet (only compiled in while var
+      finalsite_recruitment_year is ahead of var current_academic_year -- see
+      the fresh-dashboard skill's rollover procedure). PowerSchool wins on any
+      overlapping (schoolid, grade_level) key, then Focus, then Finalsite. Also
+      derives one grade_level = -9 whole-school-total row per school and one
+      schoolid = 0 region-rollup row per (region, grade_level) across all three
+      sources. 'powerschool' mode is debug/comparison only (it alone can never
+      produce Miami rows, Finalsite-only rows, or the two rollup row types) --
+      'blend' is the only complete, production mode.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - academic_year
+              - enrollment_academic_year
               - region
               - schoolid
               - grade_level
           config:
             severity: error
     columns:
-      - name: academic_year
+      - name: enrollment_academic_year
         data_type: int64
         description: >
-          The current Finalsite recruitment cycle. Hardcoded (2026 as of this
-          writing) rather than derived -- SRE's own cycle timeline is too fluid
-          to reliably compute from ingestion data; see the fresh-dashboard
-          skill's year-toggle procedure for how this gets updated.
+          The current Finalsite recruitment cycle -- var
+          finalsite_recruitment_year. Kept manual (not derived) since SRE's own
+          cycle timeline is too fluid to reliably compute from ingestion data;
+          see the fresh-dashboard skill's year-toggle procedure for how this
+          gets updated.
       - name: region
         data_type: string
         description: One of "Newark", "Camden", "Miami", "Paterson".
       - name: schoolid
         data_type: int64
-        description: PowerSchool school_number.
+        description: >
+          PowerSchool-aligned school_number, or 0 for a region-rollup row (see
+          grade_level).
       - name: school
         data_type: string
-        description: Short school abbreviation (e.g. "KURA", "Legacy ES").
+        description: >
+          Short school abbreviation (e.g. "KURA", "Legacy ES"), or the region
+          name on a schoolid = 0 rollup row.
       - name: grade_level
         data_type: int64
         description: >
-          -1 = whole-school total row (never PowerSchool-sourced -- see
-          scaffold_source), else 0-12.
+          -9 = whole-school total row (one per real school, across all sources);
+          else 0-12. -9, not -1, since -1 now means Pre-K in
+          stg_finalsite__status_report.grade_level and the two conventions must
+          not collide.
       - name: org
         data_type: string
         description: Always "KTAF" (verified constant, network-wide).
       - name: school_level
         data_type: string
         description: >
-          ES / MS / HS. On PowerSchool-sourced rows, derived per enrolled
-          grade_level (>=9 HS, >=5 MS, >=0 ES) -- NOT read from
-          stg_powerschool__schools.school_level, which is a single per-school
-          value and would incorrectly apply one classification to a school
-          spanning two bands. On gsheet-sourced rows, whatever the analyst
-          entered.
+          ES / MS / HS, derived per grade_level (>=9 HS, >=5 MS, else ES) -- not
+          read from any source's own per-school classification, which would
+          incorrectly apply one label to a school spanning two bands. Null on
+          grade_level = -9 rows (a whole-school total can't take a single-level
+          label).
+      - name: school_level_alt
+        data_type: string
+        description: >
+          Alternate school level override. Set to 'MS' for KIPP Sumner
+          Elementary (schoolid 179905) grade 5+ rows; otherwise equal to
+          school_level. Null on grade_level = -9 rows (mirrors school_level); on
+          schoolid = 0 region-rollup rows it equals school_level with no
+          override applied, since Sumner's exception is single-school, not
+          region-wide.
       - name: scaffold_source
         data_type: string
         description: >
-          'powerschool' or 'gsheet' -- per-row lineage tag, not a mode-level
-          constant. In blend mode a given row is tagged with whichever builder
-          actually produced it.
+          'powerschool', 'focus', or 'finalsite' -- per-row lineage tag, not a
+          mode-level constant. On a grade_level = -9 total row, the tag is a
+          priority pick (powerschool, else focus, else finalsite) across that
+          school's real rows. Null on schoolid = 0 region-rollup rows, since no
+          single source applies to a region-wide rollup.

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__goals_scaffold.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__goals_scaffold.yml
@@ -7,8 +7,8 @@ models:
       seat/FDOS/budget/new-student/re-enroll -- live on
       int_google_sheets__finalsite__goals_pivot instead, consumed directly by
       the rpt_ models). Feeds rpt_tableau__fresh_dashboard_aggregated. Join is
-      on (academic_year, region, schoolid, grade_level) -- a goals-sheet row
-      whose region doesn't match the scaffold's region for that
+      on (enrollment_academic_year, region, schoolid, grade_level) -- a
+      goals-sheet row whose region doesn't match the scaffold's region for that
       schoolid/grade_level is silently dropped by this inner join (see
       test_int_finalsite__goals_scaffold_region_matches_scaffold).
     config:
@@ -18,7 +18,7 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
-              - academic_year
+              - enrollment_academic_year
               - region
               - schoolid
               - grade_level
@@ -30,11 +30,11 @@ models:
           config:
             severity: error
     columns:
-      - name: academic_year
+      - name: enrollment_academic_year
         data_type: int64
         description: >
           The current Finalsite recruitment cycle -- always
-          int_finalsite__enrollment_scaffold's academic_year value.
+          int_finalsite__enrollment_scaffold's enrollment_academic_year value.
       - name: org
         data_type: string
         description: Always "KTAF" (verified constant, network-wide).
@@ -50,15 +50,15 @@ models:
       - name: grade_level
         data_type: int64
         description: >
-          -1 = whole-school total row, else 0-12. See
-          int_finalsite__enrollment_scaffold for the -1 sentinel's provenance.
+          -9 = whole-school total row, else 0-12. See
+          int_finalsite__enrollment_scaffold for the -9 sentinel's provenance.
       - name: school_level
         data_type: string
         description: ES / MS / HS, as entered on the goals sheet.
       - name: goal_granularity
         data_type: string
         description: >
-          "School" (whole-school total, grade_level = -1), "School/Grade Level",
+          "School" (whole-school total, grade_level = -9), "School/Grade Level",
           or "Region/Grade Level" (Inquiries/Applications/Deferred/ Waitlisted
           -- not tied to a specific school).
       - name: goal_type

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__finalsite__goals.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__finalsite__goals.yml
@@ -16,9 +16,11 @@ models:
       - name: goal_granularity
         data_type: string
         description: >
-          "School" (whole-school total, grade_level = -1), "School/Grade Level",
-          or "Region/Grade Level" (Inquiries/Applications/Deferred/ Waitlisted
-          -- not tied to a specific school).
+          "School" (whole-school total, grade_level = -9 -- -1 until the goals
+          sheet is updated post-merge, see int_finalsite__enrollment_scaffold),
+          "School/Grade Level", or "Region/Grade Level"
+          (Inquiries/Applications/Deferred/ Waitlisted -- not tied to a specific
+          school).
       - name: goal_type
         data_type: string
         description: >

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__finalsite__school_scaffold.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__finalsite__school_scaffold.yml
@@ -1,5 +1,12 @@
 models:
   - name: stg_google_sheets__finalsite__school_scaffold
+    description: >
+      Retired: int_finalsite__enrollment_scaffold now computes this data from
+      PowerSchool, Focus, and Finalsite directly (see
+      docs/reference/fresh-dashboard-data-model.md). Disabled rather than
+      deleted per team convention -- no downstream consumers remain.
+    config:
+      enabled: false
     columns:
       - name: academic_year
         data_type: int64
@@ -15,3 +22,8 @@ models:
         data_type: string
       - name: school_level
         data_type: string
+      - name: school_level_alt
+        data_type: string
+        description: >
+          Alternate school level override. Set to 'MS' for KIPP Sumner
+          Elementary grade 5+ rows; otherwise equal to `school_level`.

--- a/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__finalsite__school_scaffold.sql
+++ b/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__finalsite__school_scaffold.sql
@@ -1,13 +1,29 @@
+with
+    source as (
+        select
+            *,
+
+            case
+                when grade_level >= 9
+                then 'HS'
+                when grade_level >= 5
+                then 'MS'
+                when grade_level >= 0
+                then 'ES'
+            end as school_level,
+
+        from
+            {{
+                source(
+                    "google_sheets", "src_google_sheets__finalsite__school_scaffold"
+                )
+            }}
+    )
+
 select
     *,
 
-    case
-        when grade_level >= 9
-        then 'HS'
-        when grade_level >= 5
-        then 'MS'
-        when grade_level >= 0
-        then 'ES'
-    end as school_level,
+    -- 179905 = KIPP Sumner Elementary
+    if(schoolid = 179905 and grade_level >= 5, 'MS', school_level) as school_level_alt,
 
-from {{ source("google_sheets", "src_google_sheets__finalsite__school_scaffold") }}
+from source

--- a/src/dbt/kipptaf/tests/test_int_finalsite__goals_scaffold_region_matches_scaffold.sql
+++ b/src/dbt/kipptaf/tests/test_int_finalsite__goals_scaffold_region_matches_scaffold.sql
@@ -5,5 +5,5 @@ inner join
     {{ ref("int_finalsite__enrollment_scaffold") }} as s
     on g.schoolid = s.schoolid
     and g.grade_level = s.grade_level
-    and g.enrollment_academic_year = s.academic_year
+    and g.enrollment_academic_year = s.enrollment_academic_year
 where g.region != s.region and g.schoolid != 0


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

**Do not merge. Reference snapshot only.**

This preserves the in-progress FRESH scaffold revamp so it isn't lost. While it
was in flight, `main` landed an equivalent-but-narrower version of most of it
through a separate commit series, and **relocated the models**:

```text
int_finalsite__enrollment_scaffold
  -> extracts/tableau/intermediate/int_tableau__fresh_enrollment_scaffold
int_finalsite__goals_scaffold
  -> extracts/tableau/intermediate/int_tableau__fresh_goals_scaffold
```

So this branch edits paths that no longer exist on `main`. Merging it would
resurrect the deleted files and leave two copies of every model under two names.
Kept as a draft purely to diff against while porting the additive parts forward.

## Already on main (this branch is redundant here)

Landed via `4b2ee25ed`, `03c04690f`, `9663c3d10`, `68416d6f4`, `88bb26a0f`,
`0765bd5ae`, `cf6a8c678`, `367613265`:

- blend-only mode, scaffold-source var dropped
- `grade_level = -9` whole-school sentinel, freeing `-1` for PK
- Miami grade membership derived from Focus
- region-drift guard scoped to real schools
- `academic_year` documented as var-sourced
- status_report transforms promoted into the finalsite package

## Additive versus main (the reason this branch exists)

| item | status on main |
| ---- | -------------- |
| `school_level_alt` (Sumner grade 5+ override) | absent entirely |
| `grade_level = -9` rows **derived** rather than read from the sheet | main reads the sheet |
| `schoolid = 0` region rollups **derived** rather than read from the sheet | main reads the sheet |
| net-new schools/grades derived from `status_report`, Jinja-gated on the recruitment-year rollover | main reads the sheet |
| `academic_year` renamed to `enrollment_academic_year` | main still emits `academic_year` |

The fork in a sentence: `main` kept the Google Sheet as the supplier of the three
row types no SIS can produce; this branch replaced all three with derivations and
disabled the sheet.

## Known defects in this snapshot

Carried over deliberately so the diff reflects reality:

1. A dead `focus` CTE that is a verbatim copy of the PowerSchool one — a paste
   artifact. Unreferenced; nothing selects from it.
1. The region rollup breaks the uniqueness test (7 Camden dupes). Once
   `school_level` comes from the school's official value rather than a per-grade
   CASE, it is no longer functionally determined by `grade_level`, so
   `select distinct ... region, grade_level, school_level` emits more than one
   row per `(region, grade_level)` wherever a region's grade spans schools of
   different levels.
1. The Focus branch applies **NJ** grade bands (`grade_level >= 5` to `MS`) to
   Miami, whose ES/MS boundary is 5/6 rather than 4/5 — so Royalty and Legacy ES
   fifth-graders get labeled `MS` while their school is officially `ES`.
   **`main` shares this defect**, verified: Royalty `ES` serves 0-5, Legacy ES
   `ES` serves 0-5, Courage `MS` starts at 6, Legacy MS `MS` starts at 6.

## Not included

- `.claude/settings.json` — protected path, excluded deliberately.
- The design spec written during brainstorming — left untracked, since a spec
  wasn't wanted for this work.

## Self-review

### General

- [x] Not for merge; no Asana or review coordination needed.

### dbt

- [x] Breaking change? Not applicable — this branch is never merging. Ported
      changes will carry their own review.

## CI checks

Expected to be irrelevant here. dbt Cloud CI selects `state:modified+` against
paths that no longer exist on `main`, so any result on this branch says nothing
about the ported work.
