### PR TITLE
fix(dbt): anchor Finalsite Parent 2 to the Parent 1 household

### DIFF
--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -1,90 +1,83 @@
 with
-    contact_1_candidates as (
-        -- contact_1 is the student's FIRST reportable parent contact. Finalsite
-        -- has no explicit contact rank, so we take the relationship it flags
-        -- `primary` (its parent1 designation) and fall back to the one flagged
-        -- `financial` when no primary is set — the two flags Ops maintains to
-        -- mark the responsible caregiver. A record with neither flag gets no
-        -- contact_1 (a Finalsite data-entry gap for Ops to resolve).
-        -- `primary`/`financial` are NULL (not false) when unset, so normalize
-        -- to false here to keep the downstream rank ordering deterministic. No
-        -- SIS scoping — downstream receivers filter to enrolled students by
-        -- joining on the student id.
-        select
-            finalsite_enrollment_id,
-            relationship_id,
-            rel_id,
-            rel_name,
-            rel_type,
-            household_1_id,
-            is_parent2,
-
-            coalesce(is_primary, false) as is_primary,
-            coalesce(is_financial, false) as is_financial,
-        from {{ ref("stg_finalsite__contact_relationships") }}
-        where is_primary or is_financial
-    ),
-
-    contact_1_ranked as (
-        -- Rank primary above financial; within a tier break on relationship_id.
-        -- Ties occur only among multiple `financial` relationships (a student
-        -- never has two `primary`); relationship_id is an arbitrary but stable
-        -- tiebreak — every candidate in a tier is a valid contact, and
-        -- Finalsite exposes no field that reproduces a caregiver ordering.
-        select
-            finalsite_enrollment_id,
-            rel_id,
-            rel_name,
-            rel_type,
-            household_1_id,
-            is_parent2,
-            is_primary,
-
-            row_number() over (
-                partition by finalsite_enrollment_id
-                order by is_primary desc, is_financial desc, relationship_id asc
-            ) as rn,
-        from contact_1_candidates
-    ),
-
     contact_1_picked as (
+        -- contact_1 is the student's Parent 1: the relationship Finalsite flags
+        -- `primary`. That flag is a per-student singleton and is never `false`
+        -- — it is true or NULL — so a bare `where is_primary` selects exactly
+        -- the Parent 1 row. A student with no primary relationship gets no
+        -- contact_1, and therefore no contact_2: per Ops, a missing primary
+        -- flag is a Finalsite data-entry gap to fix at the source rather than
+        -- something to infer from `financial`. A second primary on one student
+        -- would surface as a duplicate contact_1 and fail this model's
+        -- uniqueness test, which is the intended loud failure. No SIS scoping —
+        -- downstream receivers filter to enrolled students by joining on the
+        -- student id.
         select finalsite_enrollment_id, rel_id, rel_name, rel_type,
-        from contact_1_ranked
-        where rn = 1
+        from {{ ref("stg_finalsite__contact_relationships") }}
+        where is_primary
+    ),
+
+    primary_household_ids as (
+        -- The student's primary household is the household their Parent 1
+        -- belongs to. Finalsite's own household-1 designation is per-student and
+        -- set in the UI, but it is absent from every field the API exposes (the
+        -- Household object is id plus address only), and array position does not
+        -- reproduce it — `households[safe_offset(0)]` is the UI's Household 2
+        -- for confirmed students. Parent 1's membership is therefore what
+        -- defines the household both parent slots must share. Exploded to one
+        -- row per household so the contact_2 match below is a plain join.
+        select p.finalsite_enrollment_id, p.rel_id as contact_1_rel_id, household_id,
+        from contact_1_picked as p
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as cp
+            on p.rel_id = cp.finalsite_enrollment_id
+        cross join unnest(cp.household_ids) as household_id
+    ),
+
+    contact_household_ids as (
+        -- One row per (contact, household) so household co-membership is a join
+        -- rather than an array containment check.
+        select finalsite_enrollment_id, household_id,
+        from {{ ref("stg_finalsite__contacts") }}
+        cross join unnest(household_ids) as household_id
     ),
 
     contact_2_candidates as (
-        -- contact_2 is the student's SECOND reportable parent (DeansList
-        -- "Parent 2"). Finalsite encodes it as an additional relationship
-        -- flagged `financial` without `primary` (`primary` is a per-student
-        -- singleton — Parent 1; candidates are financial-only rows, so
-        -- `not is_primary` alone expresses that and also guards a hypothetical
-        -- two-primary record). Scoped conservatively per Ops: only when the
-        -- student's own `is_parent2` custom field is true AND the related
-        -- contact is a member of the student's first household ("household
-        -- 1") — second parents in other households are intentionally
-        -- excluded. rn > 1 skips the ROW picked as contact_1 (the financial
-        -- fallback when no primary is set); the rel_id inequality against the
-        -- pick additionally skips any other relationship row to the same
-        -- PERSON, so contact_2 can never duplicate contact_1. The student-side
-        -- gate fields (is_parent2, household_1_id) ride on the relationships
-        -- staging grain, so only the related contact's record is joined here.
-        select r.finalsite_enrollment_id, r.rel_id, r.rel_name, r.rel_type, r.rn,
-        from contact_1_ranked as r
+        -- contact_2 is any OTHER contact flagged `primary` or `financial` that
+        -- belongs to the primary household. `primary` is a singleton already
+        -- taken by contact_1, so in practice these are financial-only rows; the
+        -- disjunction states the rule as Ops expressed it and guards a
+        -- hypothetical second primary. The rel_id inequality skips every
+        -- relationship row pointing at the PERSON already chosen as contact_1,
+        -- so contact_2 can never duplicate contact_1. The student's own
+        -- `is_parent2` custom field is deliberately NOT part of this gate — it
+        -- is false for students who do have a co-resident second parent and true
+        -- for students who have none, so it removed real rows without excluding
+        -- any wrong ones.
+        -- grain projection: every selected column is functionally determined
+        -- by the partition key; not a mask for upstream duplicates. A candidate
+        -- sharing several households with Parent 1 would otherwise repeat.
+        select distinct
+            r.finalsite_enrollment_id,
+            r.relationship_id,
+            r.rel_id,
+            r.rel_name,
+            r.rel_type,
+        from {{ ref("stg_finalsite__contact_relationships") }} as r
         inner join
-            contact_1_picked as p
-            on r.finalsite_enrollment_id = p.finalsite_enrollment_id
-            and r.rel_id != p.rel_id
+            primary_household_ids as h
+            on r.finalsite_enrollment_id = h.finalsite_enrollment_id
+            and r.rel_id != h.contact_1_rel_id
         inner join
-            {{ ref("stg_finalsite__contacts") }} as cp
-            on r.rel_id = cp.finalsite_enrollment_id
-            and r.household_1_id in unnest(cp.household_ids)
-        where r.rn > 1 and not r.is_primary and r.is_parent2
+            contact_household_ids as ch
+            on r.rel_id = ch.finalsite_enrollment_id
+            and h.household_id = ch.household_id
+        where r.is_primary or r.is_financial
     ),
 
     contact_2_ranked as (
-        -- Multiple qualifying second-parent relationships tie-break by the
-        -- contact_1 ordering (rn carries the relationship_id tiebreak).
+        -- Multiple qualifying second parents tie-break on relationship_id — an
+        -- arbitrary but stable pick, as Finalsite exposes no caregiver ordering
+        -- among them. Only the first fills the single contact_2 slot.
         select
             finalsite_enrollment_id,
             rel_id,
@@ -92,7 +85,7 @@ with
             rel_type,
 
             row_number() over (
-                partition by finalsite_enrollment_id order by rn asc
+                partition by finalsite_enrollment_id order by relationship_id asc
             ) as rn_contact_2,
         from contact_2_candidates
     ),

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -184,7 +184,6 @@ unit_tests:
             'parent' as rel_type,
             true as is_primary,
             true as is_financial,
-            cast(null as string) as household_1_id,
             cast(null as boolean) as is_parent2
       - input: ref('stg_finalsite__contacts')
         format: sql
@@ -209,7 +208,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            cast(null as string) as household_1_id,
             array<string>[] as household_ids
       - input: ref('int_finalsite__contact_custom_attributes')
         rows: []
@@ -259,7 +257,6 @@ unit_tests:
             'parent' as rel_type,
             true as is_primary,
             true as is_financial,
-            'hh1' as household_1_id,
             false as is_parent2
           union all
           select
@@ -270,7 +267,6 @@ unit_tests:
             'stepparent' as rel_type,
             cast(null as boolean) as is_primary,
             true as is_financial,
-            'hh1' as household_1_id,
             false as is_parent2
           union all
           select
@@ -281,7 +277,6 @@ unit_tests:
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
             true as is_financial,
-            'hh1' as household_1_id,
             false as is_parent2
           union all
           select
@@ -292,7 +287,6 @@ unit_tests:
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
             true as is_financial,
-            'hh3' as household_1_id,
             false as is_parent2
           union all
           select
@@ -303,7 +297,6 @@ unit_tests:
             'parent' as rel_type,
             cast(null as boolean) as is_primary,
             true as is_financial,
-            'hh3' as household_1_id,
             false as is_parent2
       - input: ref('stg_finalsite__contacts')
         format: sql
@@ -324,7 +317,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            'hh1' as household_1_id,
             ['hh1'] as household_ids
           union all
           select
@@ -343,7 +335,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            'hh1' as household_1_id,
             ['hh1', 'hh2'] as household_ids
           union all
           select
@@ -362,7 +353,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            'hh2' as household_1_id,
             ['hh2'] as household_ids
           union all
           select
@@ -381,7 +371,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            'hh3' as household_1_id,
             ['hh3'] as household_ids
           union all
           select
@@ -400,7 +389,6 @@ unit_tests:
             cast(null as string) as city,
             cast(null as string) as state,
             cast(null as string) as zip,
-            'hh3' as household_1_id,
             ['hh3'] as household_ids
       - input: ref('int_finalsite__contact_custom_attributes')
         rows: []

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,20 +3,19 @@ models:
     description:
       SIS-agnostic long-format contact list for Finalsite student records — one
       row per (student, contact slot), grain `(finalsite_enrollment_id,
-      contact_slot)`. `contact_slot` is `contact_1` (the student's first
-      reportable parent contact — the relationship flagged `primary` in
-      Finalsite, or the one flagged `financial` when no primary is set, resolved
-      to that person's own Finalsite contact record; absent when the student has
-      neither a primary nor a financial relationship), `contact_2` (the
-      student's second reportable parent — an additional relationship flagged
-      `financial` but not `primary`, emitted only when the student's own
-      `is_parent2` custom field is true and the related contact is a member of
-      the student's first household; absent otherwise), or `emergency_1` through
-      `emergency_4` (the `custom_attributes` `emrg_N` sets mapped positionally —
-      `emergency_N` is `emrg_N` as-is, with no priority re-sort and no
-      gap-filling). Sparse — a slot row is emitted only when that slot has data,
-      so emergency slots may have gaps. Feeds the downstream PowerSchool/Focus
-      contact receivers built on top of this model.
+      contact_slot)`. `contact_slot` is `contact_1` (the student's Parent 1 —
+      the relationship flagged `primary` in Finalsite, resolved to that person's
+      own Finalsite contact record; absent when the student has no primary
+      relationship, which Ops treats as a Finalsite data-entry gap to fix at the
+      source), `contact_2` (the student's Parent 2 — any other relationship
+      flagged `primary` or `financial` whose contact shares a household with
+      Parent 1, that shared household being the student's primary household;
+      absent otherwise), or `emergency_1` through `emergency_4` (the
+      `custom_attributes` `emrg_N` sets mapped positionally — `emergency_N` is
+      `emrg_N` as-is, with no priority re-sort and no gap-filling). Sparse — a
+      slot row is emitted only when that slot has data, so emergency slots may
+      have gaps. Feeds the downstream PowerSchool/Focus contact receivers built
+      on top of this model.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -159,7 +158,7 @@ models:
         description:
           Whether the contact lives with the student. Always null for
           `contact_1` and `contact_2` (note the `contact_2` pick already
-          requires household-1 co-membership by construction);
+          requires co-membership of Parent 1's household by construction);
           `emrg_N_lives_with_yn` for an emergency slot.
       - name: is_emergency
         data_type: boolean
@@ -239,12 +238,14 @@ unit_tests:
 
   - name: test_student_contacts_parent_2
     description:
-      Two gated students. stu1 has a primary relationship (Parent 1), a second
-      financial relationship to a household-1 co-member, and a third financial
-      relationship outside household 1 — yields contact_1 + contact_2 with the
-      outsider excluded. stu2 has no primary and two financial household-1
-      relationships — contact_1 falls back to the first financial and contact_2
-      takes the next, never duplicating the same person.
+      Two students. stu1 has a primary relationship (Parent 1), a second
+      financial relationship to a contact sharing Parent 1's household, and a
+      third financial relationship in a different household — yields contact_1
+      plus contact_2 with the outsider excluded. Every fixture row carries
+      `is_parent2` false, so a contact_2 on stu1 also proves that flag no longer
+      gates the pick. stu2 has no primary relationship and two financial ones —
+      yields no rows at all, since Parent 1 is the primary contact and there is
+      no financial fallback.
     model: int_finalsite__student_contacts
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -259,7 +260,7 @@ unit_tests:
             true as is_primary,
             true as is_financial,
             'hh1' as household_1_id,
-            true as is_parent2
+            false as is_parent2
           union all
           select
             'stu1' as finalsite_enrollment_id,
@@ -270,7 +271,7 @@ unit_tests:
             cast(null as boolean) as is_primary,
             true as is_financial,
             'hh1' as household_1_id,
-            true as is_parent2
+            false as is_parent2
           union all
           select
             'stu1' as finalsite_enrollment_id,
@@ -281,7 +282,7 @@ unit_tests:
             cast(null as boolean) as is_primary,
             true as is_financial,
             'hh1' as household_1_id,
-            true as is_parent2
+            false as is_parent2
           union all
           select
             'stu2' as finalsite_enrollment_id,
@@ -292,7 +293,7 @@ unit_tests:
             cast(null as boolean) as is_primary,
             true as is_financial,
             'hh3' as household_1_id,
-            true as is_parent2
+            false as is_parent2
           union all
           select
             'stu2' as finalsite_enrollment_id,
@@ -303,7 +304,7 @@ unit_tests:
             cast(null as boolean) as is_primary,
             true as is_financial,
             'hh3' as household_1_id,
-            true as is_parent2
+            false as is_parent2
       - input: ref('stg_finalsite__contacts')
         format: sql
         rows: |
@@ -435,46 +436,6 @@ unit_tests:
           'Doe' as contact_last_name,
           'stepparent' as relationship,
           'john@example.com' as email,
-          cast(null as string) as phone_daytime,
-          cast(null as string) as home_address,
-          cast(null as boolean) as is_pickup,
-          cast(null as boolean) as is_custodial,
-          cast(null as boolean) as is_household_member,
-          false as is_emergency,
-          cast(null as string) as phone_mobile,
-          cast(null as string) as phone_home,
-          cast(null as string) as phone_work,
-          cast(null as string) as phone_primary
-        union all
-        select
-          'stu2' as finalsite_enrollment_id,
-          'contact_1' as contact_slot,
-          'con4' as finalsite_contact_id,
-          'Fay Ray' as contact_name,
-          'Fay' as contact_first_name,
-          'Ray' as contact_last_name,
-          'parent' as relationship,
-          'fay@example.com' as email,
-          cast(null as string) as phone_daytime,
-          cast(null as string) as home_address,
-          cast(null as boolean) as is_pickup,
-          cast(null as boolean) as is_custodial,
-          cast(null as boolean) as is_household_member,
-          false as is_emergency,
-          cast(null as string) as phone_mobile,
-          cast(null as string) as phone_home,
-          cast(null as string) as phone_work,
-          cast(null as string) as phone_primary
-        union all
-        select
-          'stu2' as finalsite_enrollment_id,
-          'contact_2' as contact_slot,
-          'con5' as finalsite_contact_id,
-          'Gus Ray' as contact_name,
-          'Gus' as contact_first_name,
-          'Ray' as contact_last_name,
-          'parent' as relationship,
-          'gus@example.com' as email,
           cast(null as string) as phone_daytime,
           cast(null as string) as home_address,
           cast(null as boolean) as is_pickup,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop Finalsite Parent 2 from being pulled out of a household that Parent 1 does not live in, and redefine the parent slots per the rule Ops confirmed.

Closes #4610. Follow-up to #4569 (PRs #4578, #4579, both merged and live).

**Root cause.** `contact_2` was gated on `households[safe_offset(0)]` of the student. Array position does not identify Finalsite's primary household — for the reported student the UI's `Household1 (Primary)` is offset **1**, so a stepparent belonging only to the offset-0 household passed the gate. The `Household` API object carries id plus address fields and nothing else (verified against the vendor spec, our Pydantic model, and the ingested Avro), so the designation cannot be read, and no ordering of the array or of the household ids reproduces it. The gate was also one-sided: `contact_1` was chosen on the `primary` / `financial` flags with no household condition, so nothing required the two slots to share a household.

**New rule**, as Ops stated it:

1. A student's Parent 1 is their primary contact.
2. A student's primary household is the household to which their primary contact is associated.
3. Any other primary or financial contact within that household is Parent 2.

The `is_parent2` student custom field is dropped from the gate. It is unreliable in both directions — false for students who do have a co-resident second parent, true for students who have none — so it removed real rows without excluding any wrong ones.

### Impact, and the part that needs sign-off

Across Newark, Camden and Paterson:

| Slot | Now | After |
| --- | --- | --- |
| `contact_1` rows | 15,957 | 14,983 |
| `contact_2` rows | 4,360 | 4,741 |

**The `contact_1` reduction is deliberate and should not be merged without Ops sign-off.** Rule 1 removes the existing financial fallback, so a student with no relationship flagged `primary` no longer gets a Parent 1 at all — 974 rows, 483 of them enrolled students, who will reach the DeansList feed with no parent contact. This was raised as a cost before the rule was chosen and accepted knowingly; flagging it here so the decision is visible at merge rather than discovered downstream.

Underlying data gap for context: 673 enrolled students have no contact flagged `primary`; 192 have neither `primary` nor `financial` and already get no Parent 1 today.

### Known limitations

Both are cases where a student who arguably should get a Parent 2 does not. Neither is a regression against the reported bug; both are consequences of anchoring on Parent 1's household.

1. **Duplicate household records.** One street address is often entered several times as separate households. Because matching is on household id, a Parent 2 living at Parent 1's address but attached to a different household record is excluded. Roughly 34 students network-wide. Normalized-address matching would resolve them; deferred rather than folded into an interim patch.

2. **Parent 1 with no household.** If Parent 1's own `household_ids` is empty, the primary household resolves to nothing and no Parent 2 can match. 300 student-to-Parent-1 links network-wide have this shape (Newark 189, Camden 95, Paterson 16), but only **21** of them have another caregiver sharing the student's household who would otherwise qualify. Raised by the automated review; quantified against prod rather than left as a hypothesis.

### Validation

- `dbt build` of `int_finalsite__student_contacts` through `kippnewark` with prod deferral — model plus 2 unit tests plus 3 data tests all pass.
- The `unique_combination_of_columns` test passing on real Newark data confirms the `primary` singleton assumption the new `contact_1` relies on.
- Newark dev output: `contact_1` 11,169 to 10,543, `contact_2` 3,222 to 3,465. The 10,543 equals exactly the count of Newark students holding a `primary` relationship, which is the rule restated.
- Spot-checked six named students, including the reported case (Parent 2 correctly dropped), a known-good case (unchanged), and a student whose Parent 1 lives outside the UI's primary household (Parent 1 correctly retained — an earlier candidate rule would have removed her).
- Unit tests rewritten: one now asserts a Parent 2 is still selected with `is_parent2` false on every fixture row, the other that a student with no primary yields no rows at all.
- Second commit drops the now-inert `household_1_id` values from those fixtures (they no longer drive any behavior); build re-run clean afterward.

**CI note:** the two dbt Cloud runs on this PR behaved differently and the second one is the meaningful record. The first (commit 1) selected essentially nothing — a 30s no-op, which is the usual outcome for a source-package-only change. The second (commit 2) drew a different `deferring_run_id`, so the state baseline shifted and it rebuilt a wide slice of the `kipptaf` graph over 2m45s. That run reported 9 warn-level test results; all 9 are on descendants of this model, and all 9 match prod's current counts exactly, so they are pre-existing rather than introduced here. Detail in the review reply below.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude did the investigation, the SQL, and the validation. The rule in the three numbered points was specified by a human after reviewing the Finalsite UI directly; several earlier candidate rules Claude proposed were falsified against that UI evidence and discarded. The decision to remove the Parent 1 financial fallback was human, made with the row-loss figure in hand.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — model
      description, the `is_household_member` note, and both unit tests updated
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — n/a, no
      new consumers
- [x] **Breaking change?** No columns renamed or removed; the contract is
      unchanged. Row membership changes in both parent slots — see the impact
      table above. Rollback is a revert of this commit; the model is a table
      rebuilt on each run, so no backfill is required.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — n/a

## CI checks

- [x] **Trunk** — passing. `trunk check --force` also run locally on both changed
      files, clean.
- [x] **dbt Cloud** — passing. The run on the current head rebuilt a wide graph
      (2m45s) and reported 9 warn-level tests; each one was checked against prod
      and matches its current count exactly, so none are introduced by this PR.
      See the CI note above.
- [x] **Dagster Cloud** — not triggered; no Dagster paths changed.
