### PR TITLE
fix(dbt): scope gpa goal metrics by enrollment dates, not enroll_status

### DIFF
--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
@@ -24,7 +24,12 @@ left join
 where
     sr.school_level = 'HS'
     and sr.rn_year = 1
-    and sr.enroll_status = 0
+    /* date-derived, not status-derived: true when the enrollment ran to the end
+       of the school year or is active today. enroll_status is student-level and
+       current-only, so it drops graduated seniors from every completed year —
+       for AY2025 that was 382 of 398 grade-12 students, reporting the cohort at
+       0 percent attainment. */
+    and sr.is_enrolled_recent
     /* TODO(#4581): Paterson is excluded until int_powerschool__gpa_term and
        int_powerschool__gpa_cumulative union kipppaterson (both are
        newark/camden/miami only today). Without this, Paterson HS students carry

--- a/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
+++ b/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
@@ -7,7 +7,11 @@ models:
       unweighted cumulative GPA. A `LEFT JOIN` to the GPA source preserves
       enrolled students who have no GPA on record yet (measures null) so the
       goal aggregation can count them as not-yet-meeting rather than dropping
-      them from the denominator.
+      them from the denominator. Population is scoped by `is_enrolled_recent`,
+      which is derived from enrollment dates — the enrollment ran to the end of
+      its school year, or covers today. Deliberately not `enroll_status`, which
+      is student-level and current-only and therefore excludes graduated seniors
+      from every completed year.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -64,7 +68,10 @@ unit_tests:
       current-term GPA row, and a third enrolled student with no matching GPA
       row surviving the `LEFT JOIN` with null measures. A non-current GPA term
       row for the first student proves the `is_current` selection excludes it in
-      favor of the current-term row.
+      favor of the current-term row. Two further students pin the population
+      predicate in both directions — a graduated senior whose year ran to
+      completion is retained, and a mid-year withdrawal is dropped even though
+      its status is still active.
     model: int_gpa__goal_student_metrics
     given:
       - input: ref('int_extracts__student_enrollments')
@@ -81,6 +88,7 @@ unit_tests:
               'HS' as school_level,
               1 as rn_year,
               0 as enroll_status,
+              true as is_enrolled_recent,
               'kippnewark' as _dbt_source_project,
               cast(3.10 as float64) as cumulative_y1_gpa_projected_unweighted
           union all
@@ -95,6 +103,7 @@ unit_tests:
               'HS',
               1,
               0,
+              true,
               'kippnewark',
               cast(2.75 as float64)
           union all
@@ -109,8 +118,44 @@ unit_tests:
               'HS',
               1,
               0,
+              true,
               'kippnewark',
               cast(3.40 as float64)
+          union all
+          /* graduated senior: enroll_status 3, but the year ran to completion.
+             MUST be included — this is the case the old enroll_status filter
+             silently dropped from every prior year. */
+          select
+              2025,
+              'Newark',
+              101,
+              12,
+              90004,
+              1004,
+              35,
+              'HS',
+              1,
+              3,
+              true,
+              'kippnewark',
+              cast(2.90 as float64)
+          union all
+          /* mid-year withdrawal: still status 0, but the enrollment neither ran
+             to the end of the year nor covers today. MUST be excluded. */
+          select
+              2025,
+              'Newark',
+              101,
+              10,
+              90005,
+              1005,
+              35,
+              'HS',
+              1,
+              0,
+              false,
+              'kippnewark',
+              cast(3.80 as float64)
       - input: ref('int_powerschool__gpa_term')
         format: sql
         rows: |
@@ -176,6 +221,18 @@ unit_tests:
             grade_level: 9,
             student_number: 90003,
             cumulative_gpa_unweighted: 3.40,
+            y1_gpa_weighted: null,
+            y1_gpa_unweighted: null,
+            is_on_pace: null,
+            is_on_pace_denominator: null,
+          }
+        - {
+            academic_year: 2025,
+            region: Newark,
+            schoolid: 101,
+            grade_level: 12,
+            student_number: 90004,
+            cumulative_gpa_unweighted: 2.90,
             y1_gpa_weighted: null,
             y1_gpa_unweighted: null,
             is_on_pace: null,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop `int_gpa__goal_student_metrics` from dropping graduated seniors out of every completed academic year.

The model scoped its population with `sr.enroll_status = 0`. That column is student-level and current-only — it never reflects a student's status on a past date. `src/dbt/kipptaf/CLAUDE.md` warns about exactly this and prescribes filtering by enrollment dates instead.

The damage lands on twelfth grade in a completed year, because seniors graduate out of the active population. For academic year 2025, Newark and Camden HS, grade 12, the model saw **16 of 398 students** — 382 carry `enroll_status = 3` (graduated) and 11 carry 2 (withdrawn). It then reported that cohort at **0 percent attainment against a 56 percent goal**. The true figure is 39.9 percent, 159 of 398. Nothing in the output distinguishes that from genuine catastrophic underperformance.

The fix swaps the predicate for `sr.is_enrolled_recent`, which is derived from enrollment dates — true when the enrollment ran to the end of its school year, or when today falls inside the enrollment window.

## Verified: current-year tracking does not move

This matters because AY2026 goals have been communicated to school leaders. The two filters select an **identical** population for the year in progress:

| grade (AY2026) | before | after | delta |
| ---: | ---: | ---: | ---: |
| 9 | 663 | 663 | 0 |
| 10 | 533 | 533 | 0 |
| 11 | 456 | 456 | 0 |
| 12 | 398 | 398 | 0 |

Rebuilt in a dev schema with upstreams deferred to production, every AY2026 output row is byte-identical to what production publishes today — same `n_students_met` at 242, 179, and 144, same rates. No live goal number changes.

## Verified: history is corrected, and the two models now agree

`rpt_tableau__gpa_goals` and `rpt_tableau__gpa_cumulative_year` both publish a share-at-3.0 and previously disagreed. After this change, for AY2025:

| grade | goals table before | goals table after | student extract |
| ---: | ---: | ---: | ---: |
| 9 | 47.7% (507) | 46.5% (542) | 46.5% (542) |
| 10 | 39.5% (456) | 39.4% (485) | 39.5% (484) |
| 11 | 34.1% (422) | 33.9% (425) | 33.9% (425) |
| 12 | **0% (16)** | **39.9% (398)** | **39.9% (398)** |

The grade-12 row moves from 0 to 39.9 percent and the two models converge. That removes a reconciliation problem the Cumulative GPA Monitor dashboard would otherwise have had to work around in its presentation layer.

## Test

`unit_gpa_goal_student_metrics_grain` gains two students that pin the predicate in both directions:

- a **graduated senior** — `enroll_status = 3`, year ran to completion — asserted present in the output. This is the exact case the old filter silently dropped.
- a **mid-year withdrawal** — `enroll_status = 0`, but the enrollment neither ran to year end nor covers today — asserted absent.

The existing three students and the `is_current` GPA-term selection assertions are unchanged. `dbt build --select int_gpa__goal_student_metrics+` passes 8 of 8. `trunk check --force` clean on both files.

## AI Assistance

Claude Code authored this change. The defect surfaced while a human was asking how the two Tableau data sources relate for a dashboard build, and it was the human who pointed at `is_enrolled_recent` — already used by the sibling extract — as the likely correct filter. Claude verified that instinct against production, confirmed the zero current-year impact, wrote the change and the test, and drafted this description.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file updated — the model description now states the date-derived population and why `enroll_status` is deliberately not used.
- [x] Exposure — `gpa_goals_dashboard` unchanged; no new consumer.
- [ ] **Breaking change?** No. No column renamed, removed, or retyped. Values change only for completed academic years, where the previous values were wrong. Current-year values are provably unchanged.
- [ ] External source — not applicable.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

Closes #4623
Refs #4581
Refs #4619
