### PR TITLE
feat(dbt): assign PM1 to all teachers and scope by ADP job function

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__schoolmint_grow_observation_details.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__schoolmint_grow_observation_details.yml
@@ -103,7 +103,8 @@ models:
         description: >-
           Date after which the tracking term's data is locked for reporting. It
           also anchors PM2 and PM3 eligibility and the recent-leave lookback
-          window. Null on prior-year rows.
+          window. Null on prior-year rows. For unscored/unlocked BOY rounds,
+          this is the start date for coaching conversations.
       - name: final_score
         data_type: float64
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__schoolmint_grow_observation_details.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__schoolmint_grow_observation_details.yml
@@ -1,115 +1,280 @@
 models:
   - name: rpt_tableau__schoolmint_grow_observation_details
+    description: >-
+      Teacher observation detail feed for the SchoolMint Grow performance
+      management Tableau workbook. UNION of two branches. The first is a
+      current-academic-year tracking scaffold that crosses every active teacher
+      against the PM tracking terms and left-joins whatever observation data
+      exists, so teammates who have not been observed still appear with
+      `is_observed = 0` and a populated `pm_round_eligible`. The second carries
+      actual observation responses from prior years, where every `tracking_*`
+      column and `pm_round_eligible` are null. Grain is one row per teammate per
+      tracking term per observation measurement item, so rows fan out below the
+      observation level — deduplicate on `observation_id` before counting
+      observations.
     columns:
       - name: employee_number
         data_type: int64
+        description: ADP employee number of the observed teammate.
       - name: teammate
         data_type: string
+        description:
+          Formatted name of the observed teammate, from the current staff
+          roster.
       - name: entity
         data_type: string
+        description: >-
+          Home business unit of the teammate — the KTAF central entity or a
+          regional entity.
       - name: location
         data_type: string
+        description:
+          Name of the teammate's home work location (school or office).
       - name: grade_band
         data_type: string
+        description: Grade band of the teammate's home work location.
       - name: department
         data_type: string
+        description: Name of the teammate's home department.
       - name: job_title
         data_type: string
+        description: >-
+          Job title the teammate held on the roster-history row covering the
+          tracking term.
       - name: manager
         data_type: string
+        description: Formatted name of the teammate's manager.
       - name: worker_original_hire_date
         data_type: date
+        description: Date the teammate was originally hired.
       - name: assignment_status
         data_type: string
+        description: >-
+          Work assignment status on the roster-history row covering the tracking
+          term. The model keeps only Active rows, so teammates on leave are
+          excluded outright rather than marked ineligible.
       - name: sam_account_name
         data_type: string
+        description: Active Directory account name of the teammate.
       - name: report_to_sam_account_name
         data_type: string
+        description: Active Directory account name of the teammate's manager.
       - name: tracking_type
         data_type: string
+        description: >-
+          Type of the PM tracking term from the reporting-terms sheet — `PMC`
+          for comment forms, `PMS` for score forms, `TR` for teacher
+          reflections. Null on prior-year rows.
       - name: tracking_code
         data_type: string
+        description: >-
+          PM round of the tracking term — `PM1`, `PM2`, or `PM3`. Note that PM1
+          exists only for the `PMC` and `TR` types, not `PMS`. Null on
+          prior-year rows.
       - name: tracking_rubric
         data_type: string
+        description: >-
+          Name of the Grow form expected for the tracking round, such as Manager
+          Reflection, Teacher Reflection, Coach Comments, or Coach Scores.
+          Sourced from the reporting-term name, not from the rubric actually
+          recorded on an observation — compare against `rubric_name` for that.
+          Null on prior-year rows.
       - name: tracking_academic_year
         data_type: int64
+        description:
+          Academic year of the tracking term. Null on prior-year rows.
       - name: is_current
         data_type: boolean
+        description: >-
+          TRUE when the tracking term is the current one per the reporting-terms
+          sheet. Hardcoded FALSE on prior-year rows.
       - name: start_date
         data_type: date
+        description:
+          First date of the tracking term window (inclusive). Null on prior-year
+          rows.
       - name: end_date
         data_type: date
+        description:
+          Last date of the tracking term window (inclusive). Null on prior-year
+          rows.
       - name: lockbox_date
         data_type: date
+        description: >-
+          Date after which the tracking term's data is locked for reporting. It
+          also anchors PM2 and PM3 eligibility and the recent-leave lookback
+          window. Null on prior-year rows.
       - name: final_score
         data_type: float64
+        description: >-
+          Teammate's year-level PM score — the average observation score across
+          their `PMS` PM2 and PM3 observations for the academic year.
       - name: final_tier
         data_type: int64
+        description: >-
+          Performance tier banded from `final_score`. At or above 3.495 is tier
+          4, at or above 2.745 is tier 3, at or above 1.745 is tier 2, below
+          1.75 is tier 1.
       - name: observer_employee_number
         data_type: int64
+        description: ADP employee number of the observer.
       - name: observation_id
         data_type: string
+        description: >-
+          SchoolMint Grow observation identifier. Null on tracking rows where no
+          observation matched the term window.
       - name: rubric_name
         data_type: string
+        description:
+          Display name of the rubric actually recorded on the observation.
       - name: observation_score
         data_type: float64
+        description: >-
+          Overall numeric score for the observation as computed by Grow,
+          averaged across its measurement items.
       - name: glows
         data_type: string
+        description:
+          Pipe-delimited positive feedback items recorded during the
+          observation.
       - name: grows
         data_type: string
+        description: >-
+          Pipe-delimited growth-area items (improvements needed) recorded during
+          the observation.
       - name: locked
         data_type: boolean
+        description:
+          TRUE if the observation is locked and can no longer be edited.
       - name: observed_at
         data_type: date
+        description: Local-timezone date the observation was conducted.
       - name: academic_year
         data_type: int64
+        description: Academic year the observation occurred in.
       - name: observation_type
         data_type: string
+        description:
+          Display name of the observation type, such as Walkthrough or PM
+          Semester.
       - name: observation_type_abbreviation
         data_type: string
+        description: >-
+          Short code for the observation type, such as `WT` or `PMS`. Matched
+          against `tracking_type` to attach an observation to its tracking term.
       - name: term_code
         data_type: string
+        description: >-
+          Reporting term code the observation itself was matched to. Equals
+          `tracking_code` on current-year tracking rows that found an
+          observation.
       - name: term_name
         data_type: string
+        description: Reporting term display name matched alongside `term_code`.
       - name: row_score
         data_type: float64
+        description: >-
+          Score recorded for a single measurement item within the observation.
+          This is what drives the measurement-level grain of the model.
       - name: strand_name
         data_type: string
+        description:
+          Measurement group (strand) the measurement item belongs to within the
+          rubric.
       - name: measurement_name
         data_type: string
+        description: Display name of the measurement item scored.
       - name: overall_tier
         data_type: float64
+        description: >-
+          Performance tier for the individual observation, banded from
+          `observation_score` on the same thresholds as `final_tier`.
       - name: observation_notes
         data_type: string
+        description: >-
+          Free-text observer notes, from Grow's magic notes field. Null on
+          archived prior-year rows.
       - name: current_assignment_status
         data_type: string
+        description: >-
+          Teammate's assignment status as of today, from the current staff
+          roster. Distinct from `assignment_status`, which reflects the
+          roster-history row covering the tracking term.
       - name: observer_name
         data_type: string
+        description: Formatted name of the observer.
       - name: grade_taught
         data_type: int64
+        description: >-
+          Primary grade level the teammate teaches, taking the first-ranked
+          grade from their PowerSchool section assignments. 0 is Kindergarten.
       - name: etr_score
         data_type: float64
+        description: >-
+          Archived ETR score component from the pre-Grow performance-management
+          data. Populated only on prior-year rows and always null for the
+          current academic year.
       - name: so_score
         data_type: float64
+        description: >-
+          Archived SO score component from the pre-Grow performance-management
+          data. Populated only on prior-year rows and always null for the
+          current academic year.
       - name: is_observed
         data_type: int64
+        description: >-
+          1 when an observation matched the row, 0 when a tracking row has no
+          observation. Sum it against a count of rows to get observation
+          completion.
       - name: measurement_comments
         data_type: string
+        description: >-
+          Free-text comment recorded on the measurement item, with HTML tags
+          stripped.
       - name: pm_round_eligible
         data_type: boolean
+        description: >-
+          Whether the teammate is expected to receive an observation for this
+          tracking round. Every teammate is eligible for PM1 regardless of start
+          date. PM2 and PM3 require the work assignment to have started at least
+          six weeks before the term's lockbox date. A teammate whose assignment
+          status changed to or from Leave within the six weeks before the
+          lockbox date is ineligible for any round. Null on prior-year rows.
       - name: race_ethnicity_reporting
         data_type: string
+        description: Teammate's race and ethnicity as reported.
       - name: work_assignment_actual_start_date
         data_type: date
+        description: >-
+          Date the teammate's current work assignment began. Drives PM2 and PM3
+          eligibility.
       - name: is_leader_development_program
         data_type: boolean
+        description: >-
+          TRUE if the teammate held a leader development program membership for
+          the academic year.
       - name: is_leader_development_program_observer
         data_type: boolean
+        description: >-
+          TRUE if the observer held a leader development program membership for
+          the academic year.
       - name: is_teacher_development_program
         data_type: boolean
+        description: >-
+          TRUE if the teammate held a teacher development program membership for
+          the academic year.
       - name: is_teacher_development_program_observer
         data_type: boolean
+        description: >-
+          TRUE if the observer held a teacher development program membership for
+          the academic year.
       - name: memberships
         data_type: string
+        description: >-
+          Program membership recorded for the teammate for the academic year,
+          such as AP Cohort or TiR Year 2.
       - name: memberships_observer
         data_type: string
+        description: >-
+          Program membership recorded for the observer for the academic year,
+          such as AP Cohort or TiR Year 2.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -153,7 +153,17 @@ left join
 where
     srh.primary_indicator
     and srh.assignment_status = 'Active'
-    and (srh.job_title like '%Teacher%' or srh.job_title like '%Learning%')
+    /*
+        job_function (ADP codes TEACH / TIR) is not set on newly created work
+        assignments, so fall back to the job title until it fills in
+    */
+    and (
+        srh.job_function in ('Teacher', 'Teacher in Residence')
+        or (
+            srh.job_function is null
+            and (srh.job_title like '%Teacher%' or srh.job_title like '%Learning%')
+        )
+    )
 
 union all
 

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -1,6 +1,12 @@
 with
     recent_leave as (
-        {# TODO: document distinct #}
+        -- Joins PMS terms only, and AY2026 has no PMS PM1 term row (AY2024 and
+        -- AY2025 did), so this yields PM2/PM3 rows only. The pm_round_eligible
+        -- leave guard is therefore inert for PM1 until Ops re-adds that row.
+        -- grain projection: every selected column is functionally determined by
+        -- (employee_number, academic_year, code) -- recent_leave is a constant,
+        -- so multiple matching roster-history rows collapse to one
+        -- byte-identical tuple. Not a mask for upstream duplicates.
         select distinct
             srh.employee_number, t.academic_year, t.code, true as recent_leave,
         from {{ ref("int_people__staff_roster_history") }} as srh

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -1,15 +1,4 @@
 with
-    tir_previous as (
-        {# TODO: document distinct #}
-        select distinct srh.employee_number, true as prior_year_tir,
-        from {{ ref("int_people__staff_roster_history") }} as srh
-        where
-            srh.assignment_status = 'Active'
-            and srh.job_title in ('Teacher in Residence', 'Paraprofessional')
-            and srh.effective_date_start
-            >= '{{ var("current_academic_year") - 1 }}-07-01'
-    ),
-
     recent_leave as (
         {# TODO: document distinct #}
         select distinct
@@ -17,7 +6,7 @@ with
         from {{ ref("int_people__staff_roster_history") }} as srh
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as t
-            on assignment_status_effective_date
+            on srh.assignment_status_effective_date
             between date_sub(t.lockbox_date, interval 6 week) and t.lockbox_date
             and t.type = 'PMS'
         where srh.assignment_status = 'Leave' or srh.assignment_status_lag = 'Leave'
@@ -94,23 +83,13 @@ select
 
     /*
         round eligibility for PM
-            1: TiRs, Miami, Prior TiR (New Lead), New to KIPP
+            1: all teachers, regardless of start date
             2 & 3: Active six weeks prior to lockbox date
     */
     case
         when r.recent_leave
         then false
-        when
-            t.code = 'PM1'
-            and (
-                srh.job_title = 'Teacher in Residence'
-                or tir.prior_year_tir
-                or srh.home_business_unit_name = 'KIPP Miami'
-                or srh.worker_hire_date_recent
-                between '{{ var("current_academic_year") }}-04-01' and date_sub(
-                    t.lockbox_date, interval 3 week
-                )
-            )
+        when t.code = 'PM1'
         then true
         when
             t.code in ('PM2', 'PM3')
@@ -150,7 +129,6 @@ left join
 left join
     {{ ref("int_people__staff_roster") }} as sro
     on od.observer_employee_number = sro.employee_number
-left join tir_previous as tir on srh.employee_number = tir.employee_number
 left join
     {{ ref("int_powerschool__teacher_grade_levels") }} as tgl
     on srh.powerschool_teacher_number = tgl.teachernumber


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will change two things about who appears in the
SchoolMint Grow PM observation feed
(`rpt_tableau__schoolmint_grow_observation_details`), and document the model.

### 1. Every teacher is eligible for PM1, regardless of start date

The PM1 branch of `pm_round_eligible` previously required one of four
carve-outs -- currently a Teacher in Residence, a prior-year TiR or Para (New
Lead), KIPP Miami, or hired between April 1 and three weeks before the lockbox
date. All of that is gone; PM1 is now simply `true`.

- PM2 and PM3 are unchanged -- the work assignment must have started at least six
  weeks before the term's lockbox date.
- The `tir_previous` CTE and its `left join` are removed. They existed only to
  feed the PM1 branch, and `prior_year_tir` had no other consumer in the repo. The
  CTE resolved to 271 rows across 271 distinct `employee_number`, so removing the
  join is row-count-neutral.

### 2. Teachers are scoped by ADP job function, not job title

The current-year branch previously selected teachers with
`job_title like '%Teacher%' or job_title like '%Learning%'`. It now uses the
roster's `job_function` (the ADP job group, codes `TEACH` and `TIR`), falling back
to the title match only where `job_function` is null.

The fallback is load-bearing: `job_function` is not populated on newly created
work assignments, so without it 23 current teachers would silently drop out of PM
tracking -- all with a July 2026 `effective_date_start`, across all four entities.

On current roster rows this nets 774 to 786:

- **Drops 14 false positives** the title match dragged in -- Teacher Aide,
  Substitute Teacher, Learning Disabilities Teacher Consultant, and Managing
  Director of Teaching and Learning.
- **Adds 26 genuine teachers** the title match missed. 21 are Paterson TiRs
  titled *Instructor in Residence*, which the pattern never caught. The other 5
  are classified into the Teacher job group in ADP despite a non-teaching title
  (3 Assistant School Leader, 1 Dean, 1 Director of Orchestra and Music).

### 3. Documentation

The properties file had no descriptions at all. It now has a model description and
a description for all 56 contract columns. Column names, data types, and order are
unchanged, so contract enforcement is unaffected.

Most descriptions came from `int_performance_management__observations` (the real
origin of the observation columns) and `stg_google_sheets__reporting__terms`;
derived columns came from the upstream model SQL. Three points were resolved
against prod data rather than assumed:

- `tracking_rubric` holds Grow form names (Manager Reflection, Teacher Reflection,
  Coach Comments, Coach Scores), not observation rubric names.
- `grade_taught` ranges 0 to 12 with no negative preschool codes, contrary to the
  upstream description inherited from a student model.
- `etr_score` and `so_score` are populated only on prior-year rows.

Also replaces a leftover `TODO: document distinct` stub on `recent_leave` with the
`grain projection:` annotation the SQL guide requires.

## Impact, measured against prod

Combined effect of changes 1 and 2 on PM1:

| Metric | Value |
| --- | --- |
| Teachers with PM1 tracking rows, after this PR | 790 |
| Eligible in prod today | 170 |
| Newly eligible | 620 |

Measured on the model's own spine (roster joined to the AY2026 `PMS`/`PMC`/`TR`
terms). The same population under the old title filter is 776, so the job-function
change accounts for 14 of the 620.

### A structural finding worth recording

`recent_leave` **cannot** exclude anyone from PM1 this year. The CTE inner joins
`PMS` terms only, and AY2026 has no `PMS` PM1 term row -- AY2024 and AY2025 both
did. So it yields PM2 and PM3 rows only, and
`when r.recent_leave then false` never fires for PM1.

The leave guard is deliberately kept in the `case` so the behavior is correct if
Ops re-adds that term row. This is now commented at the CTE, since it is invisible
from the SQL alone.

## Rollback

Revert the commits. No schema change, so no coordination is needed with downstream
consumers -- only which teachers appear, and the values in `pm_round_eligible`.

## Follow-ups

None block this PR.

- #4631 -- expose `job_function_code` on the roster, so the filter can compare
  stable codes (`TEACH`, `TIR`) instead of display names.
- #4633 -- the model has no uniqueness test, and cannot get one until the
  prior-year archive branch's fan-out is understood (about 685k excess rows on a
  7-column key; the current-year branch is nearly clean at 30).
- The two ADP data-quality gaps behind the null fallback are tracked with Ops for
  an HR follow-up.

## AI Assistance

Human-directed: dropping PM1 round eligibility, keeping the leave exclusion,
switching to the job group, keeping Paterson's Instructor in Residence staff in
scope, and the `lockbox_date` note about BOY coaching conversations.
AI-assisted: the SQL edits, the prod impact and row-count-neutrality queries, the
first draft of the column descriptions, and the PMS/PM1 finding.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      Both findings verified. The TODO stub is fixed. The missing uniqueness test
      is real and pre-existing, but its suggested remedy would fail immediately --
      no near-unique key exists -- so it is tracked in #4633 with the
      measurements. The updated review's request to document the job-function
      change and re-check the impact numbers is what this description now does.

### Dagster

Skipped -- no Dagster changes.

### dbt

- [x] Properties file -- no new models; the existing properties file gains a model
      description and descriptions for all 56 columns.
- [x] Exposure -- two exposures already depend on this model
      (`schoolmint_grow_dashboard` and `coaching_conversation_tool`). No change
      needed, since no columns were added or removed.
- [x] **Breaking change?** Not breaking. No column is renamed, removed, or
      retyped. This is a value-level and row-population change, which the two
      Tableau exposures will see as more teachers marked eligible for PM1.
- [x] External sources -- none added or modified, so no `stage_external_sources`
      run is needed.

### Docs

Skipped -- no schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** -- passes.
- [x] **dbt Cloud** -- passes.
- [x] **Dagster Cloud** -- not triggered; no Dagster paths changed.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
