### PR TITLE
test(dbt): assert gpa goal coverage so an omitted row is not silent

### DIFF
--- a/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_aggregations.yml
+++ b/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_aggregations.yml
@@ -7,7 +7,11 @@ models:
       the resulting rate meets the goal. Goal-driven — a grain surfaces here
       only when it has a matching goal row; students in a grain with no goal
       simply don't aggregate into a row. One row per academic year, metric, and
-      goal aggregation key.
+      goal aggregation key. A consequence worth stating plainly — a grade
+      missing from the goals sheet is indistinguishable in this model's output
+      from a grade that has no students, since both yield no row rather than a
+      null. Two singular tests on stg_google_sheets__gpa_goals assert coverage
+      from each direction so an accidental omission is not silent.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__every_goal_aggregates.sql
+++ b/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__every_goal_aggregates.sql
@@ -1,6 +1,14 @@
 with
     /* scoped to years the student spine actually covers, so a goal entered ahead
-       of its academic year does not fail before enrollment exists */
+       of its academic year does not fail before enrollment exists.
+
+       Deliberately NOT scoped by region. TODO(#4581): int_gpa__goal_student_metrics
+       excludes kipppaterson pending the gpa_term / gpa_cumulative unions, and
+       Paterson runs ES and MS only, so a Paterson-scoped goal targets a
+       population of zero and genuinely reaches no dashboard — flagging it is
+       correct, not a false positive. Revisit only if Paterson opens a high
+       school BEFORE that union lands, which would make this fire on a goal that
+       is merely early rather than wrong. */
     measured_years as (
         select distinct academic_year, from {{ ref("int_gpa__goal_student_metrics") }}
     )

--- a/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__every_goal_aggregates.sql
+++ b/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__every_goal_aggregates.sql
@@ -1,0 +1,23 @@
+with
+    /* scoped to years the student spine actually covers, so a goal entered ahead
+       of its academic year does not fail before enrollment exists */
+    measured_years as (
+        select distinct academic_year, from {{ ref("int_gpa__goal_student_metrics") }}
+    )
+
+select
+    g.academic_year,
+    g.metric,
+    g.org_level,
+    g.region,
+    g.schoolid,
+    g.grade_band,
+    g.aggregation_hash,
+from {{ ref("int_google_sheets__gpa_goals") }} as g
+inner join measured_years as my on g.academic_year = my.academic_year
+left join
+    {{ ref("int_gpa__goal_aggregations") }} as a
+    on g.academic_year = a.academic_year
+    and g.metric = a.metric
+    and g.aggregation_hash = a.aggregation_hash
+where a.aggregation_hash is null

--- a/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
+++ b/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
@@ -1,0 +1,45 @@
+with
+    goal_grades as (
+        select academic_year, metric, org_level, region, schoolid, grade_level,
+        from {{ ref("int_google_sheets__gpa_goals") }}
+        cross join unnest(generate_array(grade_low, grade_high)) as grade_level
+    ),
+
+    grains as (
+        select distinct academic_year, metric, org_level, region, schoolid,
+        from goal_grades
+    ),
+
+    metric_grades as (
+        select distinct academic_year, metric, grade_level, from goal_grades
+    ),
+
+    /* every grade any grain covers for a metric is expected at every grain that
+       has goals for that same metric */
+    expected as (
+        select
+            gr.academic_year,
+            gr.metric,
+            gr.org_level,
+            gr.region,
+            gr.schoolid,
+
+            mg.grade_level,
+        from grains as gr
+        inner join
+            metric_grades as mg
+            on gr.academic_year = mg.academic_year
+            and gr.metric = mg.metric
+    )
+
+select e.academic_year, e.metric, e.org_level, e.region, e.schoolid, e.grade_level,
+from expected as e
+left join
+    goal_grades as gg
+    on e.academic_year = gg.academic_year
+    and e.metric = gg.metric
+    and e.org_level = gg.org_level
+    and e.grade_level = gg.grade_level
+    and e.region is not distinct from gg.region
+    and e.schoolid is not distinct from gg.schoolid
+where gg.grade_level is null

--- a/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
+++ b/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
@@ -21,9 +21,10 @@ with
     ),
 
     /* pooled WITHIN org_level, never across it — a school is compared against
-       what other schools cover, not against network-level coverage. Otherwise a
-       school legitimately serving a narrower grade band than the network (a new
-       high school still adding a grade a year) reads as an omission. */
+       what other schools cover, not against network-level coverage, so a school
+       band narrower than the network's is not itself an omission. This does NOT
+       cover a school newer than its peers and still adding a grade a year; that
+       still flags, because intent is recorded nowhere the test can read. */
     org_level_grades as (
         select distinct academic_year, metric, org_level, grade_level, from goal_grades
     ),

--- a/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
+++ b/src/dbt/kipptaf/tests/int_google_sheets__gpa_goals__grade_coverage_consistent.sql
@@ -1,8 +1,18 @@
 with
+    /* scoped to years the student spine covers, matching the sibling
+       every_goal_aggregates test. Goals for a year not yet underway are entered
+       school by school, so an in-progress rollout would otherwise read as an
+       omission. */
+    measured_years as (
+        select distinct academic_year, from {{ ref("int_gpa__goal_student_metrics") }}
+    ),
+
     goal_grades as (
-        select academic_year, metric, org_level, region, schoolid, grade_level,
-        from {{ ref("int_google_sheets__gpa_goals") }}
-        cross join unnest(generate_array(grade_low, grade_high)) as grade_level
+        select
+            g.academic_year, g.metric, g.org_level, g.region, g.schoolid, grade_level,
+        from {{ ref("int_google_sheets__gpa_goals") }} as g
+        inner join measured_years as my on g.academic_year = my.academic_year
+        cross join unnest(generate_array(g.grade_low, g.grade_high)) as grade_level
     ),
 
     grains as (
@@ -10,12 +20,14 @@ with
         from goal_grades
     ),
 
-    metric_grades as (
-        select distinct academic_year, metric, grade_level, from goal_grades
+    /* pooled WITHIN org_level, never across it — a school is compared against
+       what other schools cover, not against network-level coverage. Otherwise a
+       school legitimately serving a narrower grade band than the network (a new
+       high school still adding a grade a year) reads as an omission. */
+    org_level_grades as (
+        select distinct academic_year, metric, org_level, grade_level, from goal_grades
     ),
 
-    /* every grade any grain covers for a metric is expected at every grain that
-       has goals for that same metric */
     expected as (
         select
             gr.academic_year,
@@ -24,12 +36,13 @@ with
             gr.region,
             gr.schoolid,
 
-            mg.grade_level,
+            olg.grade_level,
         from grains as gr
         inner join
-            metric_grades as mg
-            on gr.academic_year = mg.academic_year
-            and gr.metric = mg.metric
+            org_level_grades as olg
+            on gr.academic_year = olg.academic_year
+            and gr.metric = olg.metric
+            and gr.org_level = olg.org_level
     )
 
 select e.academic_year, e.metric, e.org_level, e.region, e.schoolid, e.grade_level,

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -290,14 +290,20 @@ data_tests:
       is invisible downstream. This test catches the likely shape of that
       omission — Ops enters goals per school, so a fat-fingered or skipped row
       leaves one grain short while its siblings are complete, and only that
-      grain's grade silently disappears. Fails on any grade covered by some
-      grain for a metric but missing from another grain that has goals for the
-      same metric and year. Grains with no goals at all for a metric are not
-      checked, so a metric intentionally scoped to fewer org levels does not
-      fire. A grade omitted uniformly at every grain is indistinguishable from a
-      deliberate choice and is NOT caught here — grade 12 has no Y1 GPA goal by
-      design, and detecting that case would need the intent recorded in the
-      sheet.
+      grain's grade silently disappears. Fails on any grade covered by one grain
+      but missing from another grain of the SAME org level with goals for the
+      same metric and year. Comparison is pooled within org level, never across
+      it, so a school serving a narrower grade band than the network does not
+      read as an omission. A school newer than its peers and still adding a
+      grade a year does still flag against them — the same limit as grade 12
+      below, in that intent is not recorded anywhere the test can read. Grains
+      with no goals at all for a metric are not checked, so a metric
+      intentionally scoped to fewer org levels does not fire, and coverage is
+      scoped to years the student spine covers so an in-progress rollout of a
+      future year's goals does not fire either. A grade omitted uniformly across
+      an entire org level is indistinguishable from a deliberate choice and is
+      NOT caught here — grade 12 has no Y1 GPA goal by design, and detecting
+      that case would need the intent recorded in the sheet.
     config:
       severity: error
       meta:
@@ -315,9 +321,12 @@ data_tests:
       appears nowhere in rpt_tableau__gpa_goals. Fails on any goal row with no
       matching aggregation. Scoped to academic years the student spine covers so
       a goal entered ahead of its year does not fail before enrollment data
-      exists. Not expressible as a relationships test — aggregation_hash alone
-      is not unique across years and metrics, so the check needs the full
-      three-column key.
+      exists, but deliberately not scoped by region — Paterson is absent from
+      the spine and runs ES and MS only, so a Paterson-scoped GPA goal targets
+      no students and genuinely reaches no dashboard, which is worth flagging
+      rather than suppressing. Not expressible as a relationships test —
+      aggregation_hash alone is not unique across years and metrics, so the
+      check needs the full three-column key.
     config:
       severity: error
       meta:

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -279,3 +279,48 @@ data_tests:
         dagster:
           ref:
             name: rpt_tableau__gpa_cumulative_year
+
+  - name: int_google_sheets__gpa_goals__grade_coverage_consistent
+    description: >-
+      int_gpa__goal_aggregations inner-joins the student spine to the goals
+      sheet, so a grade with no goal row produces no output row at all — no
+      null, no zero, no error. That is correct (the goal row supplies the
+      metric, threshold, direction, and the aggregation_hash grain key, so a
+      goalless row could not be computed) but it means an omission in the sheet
+      is invisible downstream. This test catches the likely shape of that
+      omission — Ops enters goals per school, so a fat-fingered or skipped row
+      leaves one grain short while its siblings are complete, and only that
+      grain's grade silently disappears. Fails on any grade covered by some
+      grain for a metric but missing from another grain that has goals for the
+      same metric and year. Grains with no goals at all for a metric are not
+      checked, so a metric intentionally scoped to fewer org levels does not
+      fire. A grade omitted uniformly at every grain is indistinguishable from a
+      deliberate choice and is NOT caught here — grade 12 has no Y1 GPA goal by
+      design, and detecting that case would need the intent recorded in the
+      sheet.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: stg_google_sheets__gpa_goals
+
+  - name: int_google_sheets__gpa_goals__every_goal_aggregates
+    description: >-
+      The mirror of the silent-drop problem above — a goal row that matches no
+      student also vanishes without a signal, because int_gpa__goal_aggregations
+      is built through an inner join from the student spine. A typo in schoolid,
+      a misspelled region, or a grade_low/grade_high range covering nobody all
+      produce a goal that exists in the sheet, aggregates to nothing, and
+      appears nowhere in rpt_tableau__gpa_goals. Fails on any goal row with no
+      matching aggregation. Scoped to academic years the student spine covers so
+      a goal entered ahead of its year does not fail before enrollment data
+      exists. Not expressible as a relationships test — aggregation_hash alone
+      is not unique across years and metrics, so the check needs the full
+      three-column key.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: stg_google_sheets__gpa_goals


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make an omitted GPA goal row visible instead of silently deleting a grade from `rpt_tableau__gpa_goals`.

`int_gpa__goal_aggregations` inner-joins the student spine to the goals sheet, so a grade with no goal row produces no output row at all — no null, no zero, no error. Live example: grade 12 has no `y1_gpa_weighted` goal at any org level, so grade 12 is absent from every `y1_gpa_weighted` row of `rpt_tableau__gpa_goals` in both 2025 and 2026. A dashboard built on that table shows three grades and gives the reader no way to know a fourth was expected.

**The join is correct and stays.** The goal row is what supplies `metric`, `threshold`, and `direction`, and it supplies `aggregation_hash`, the model's grain key. A left join would not yield "grade 12 with a null goal" — it would yield a row with no metric to select, nothing to compare against, and no key. The output grain is one row per goal, not one row per student grain. What was missing is any signal that a row is absent, and that is what this PR adds.

Blast radius of the original gap was narrow, which is why this is a test and not a model change: the lineage is a single unbranched chain (`int_gpa__goal_student_metrics` to `int_gpa__goal_aggregations` to `rpt_tableau__gpa_goals` to the `gpa_goals_dashboard` exposure), and grade 12's 398 AY2025 students are fully present in the upstream spine and in `rpt_tableau__gpa_cumulative_year`. One reporting table was quietly incomplete; no students were missing from the warehouse.

## The two tests

### `int_google_sheets__gpa_goals__grade_coverage_consistent`

A grade covered by one grain must be covered by every grain that has goals for the same metric and year.

This catches the likely shape of a data-entry error. Goals are entered per school, so a skipped or fat-fingered row leaves one grain short while its siblings are complete, and only that grain's grade disappears. Grains with no goals at all for a metric are not checked, so the current absence of region-level `y1_gpa_weighted` rows does not fire.

### `int_google_sheets__gpa_goals__every_goal_aggregates`

Every goal row must produce an aggregation row.

The mirror case: a typo in `schoolid`, a misspelled region, or a `grade_low`/`grade_high` range covering nobody produces a goal that exists in the sheet, aggregates to nothing, and appears nowhere downstream — silent in exactly the same way. Scoped to academic years the student spine covers, so a goal entered ahead of its year does not fail before enrollment data exists.

Not expressible as a `relationships` test: `aggregation_hash` alone is not unique across years and metrics, so the check needs the full three-column key.

## What is deliberately not caught

A grade omitted uniformly at **every** grain. Grade 12 having no Y1 GPA goal is intentional — seniors are held to cumulative GPA, and grade 12 does carry a `cumulative_gpa_unweighted` goal. Separating that from an accident would require the intent recorded in the sheet, which does not exist today. A test demanding uniform grade coverage would be a permanent warning, so it is not included.

This is stated in the `int_gpa__goal_aggregations` description as well, so the next reader does not have to rediscover it.

## Test

Both tests pass against production, and both were verified to fire on a simulated omission rather than merely passing:

| Test | Clean run | Simulated defect |
| --- | --- | --- |
| `grade_coverage_consistent` | PASS | removing one school's grade 11 goal flags it |
| `every_goal_aggregates` | PASS | injecting a goal with a non-existent `schoolid` flags it |

```text
Concurrency: 40 threads (target='dev')
PASS int_google_sheets__gpa_goals__grade_coverage_consistent
PASS int_google_sheets__gpa_goals__every_goal_aggregates
Done. PASS=2 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=2
```

Run with `--defer --favor-state` against a freshly parsed prod manifest, so both executed against production relations rather than stale dev copies.

`severity: error` on both. They pass on current data, so neither introduces CI noise.

## Asset-check anchoring

Both set `meta.dagster.ref` to **`stg_google_sheets__gpa_goals`**, not to the model each logically describes. `int_google_sheets__gpa_goals` and `int_gpa__goal_aggregations` are both views, and a check anchored to a view does not re-run on data change — only table-materialized models re-materialize. The staging model is the only table in the chain, and it is also the thing that rematerializes when Ops edits the sheet, which is precisely when these checks need to run.

## AI Assistance

Claude Code wrote these tests. The gap was found by a human asking why the aggregation uses an inner join and pointing out that it would exclude grade 12 from reporting — the premise about blast radius turned out to be narrower than feared, but the underlying concern about silent exclusion was correct and is what this PR addresses. The human also confirmed the grade 12 omission is deliberate, which is why the originally-planned grade-completeness test was dropped in favor of the two consistency checks here.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Descriptions added to `tests/properties.yml` for both singular tests, per the singular-test description convention.
- [x] `int_gpa__goal_aggregations` description updated to name the silence tradeoff.
- [x] `severity: error` set explicitly on both — the project default is `warn`.
- [x] `dbt parse --no-partial-parse` run after editing the singular-test properties yml.
- [x] `trunk check --force` clean on all four files.
- [ ] **Breaking change?** No. Tests only, plus two description edits. No model SQL, no columns, no contracts.
- [ ] Exposure — `gpa_goals_dashboard` unchanged; no new consumer.
- [ ] External source — not applicable.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

Closes #4632
Refs #4581
