### PR TITLE
fix(libraries/ssh): banner timeout inversion and lost transient retry break SFTP sensors

### DIFF
--- a/src/teamster/CLAUDE.md
+++ b/src/teamster/CLAUDE.md
@@ -250,6 +250,14 @@ the affected submodule alone (e.g.
 `import teamster.code_locations.kipptaf.finalsite` or
 `teamster.code_locations.kippmiami.extracts`), not the `definitions` module.
 
+`tests/test_dagster_definitions.py` fails all 6 in a FRESH worktree — run
+`prepare-and-package` for all 5 locations first or each dies on a missing
+`target/manifest.json`. The pytest failure is a bare
+`subprocess.CalledProcessError` that hides the cause; re-run
+`dagster definitions validate -m <module>` directly to see it. With manifests,
+conftest's 1Password bootstrap resolves kipptaf's dlt credentials too, so only
+`kippmiami` (`FOCUS_DB`) and `test_definitions_all` still fail.
+
 Importing a kipptaf **asset submodule** (e.g.
 `teamster.code_locations.kipptaf.google.directory.assets`) transitively imports
 `kipptaf.dbt` and needs the dbt manifest — absent in a fresh worktree, so a unit

--- a/src/teamster/code_locations/kipptaf/resources.py
+++ b/src/teamster/code_locations/kipptaf/resources.py
@@ -89,7 +89,9 @@ SSH_RESOURCE_CLEVER = SSHResource(
     remote_port=22,
     username=EnvVar("CLEVER_SFTP_USERNAME"),
     password=EnvVar("CLEVER_SFTP_PASSWORD"),
-    timeout=30,
+    # No `timeout` override: 30s sits exactly ON paramiko's banner + handshake
+    # ceiling, which reintroduces the inversion in #4636. The `SSHResource`
+    # default (45s) already exceeds the 30s this was raised to.
 )
 
 SSH_RESOURCE_COUPA = SSHResource(
@@ -118,7 +120,9 @@ SSH_RESOURCE_ILLUMINATE = SSHResource(
     remote_port=22,
     username=EnvVar("ILLUMINATE_SFTP_USERNAME"),
     password=EnvVar("ILLUMINATE_SFTP_PASSWORD"),
-    timeout=30,
+    # No `timeout` override: 30s sits exactly ON paramiko's banner + handshake
+    # ceiling, which reintroduces the inversion in #4636. The `SSHResource`
+    # default (45s) already exceeds the 30s this was raised to.
 )
 
 SSH_RESOURCE_IDAUTO = SSHResource(

--- a/src/teamster/core/resources.py
+++ b/src/teamster/core/resources.py
@@ -119,10 +119,11 @@ SSH_EDPLAN = SSHResource(
     remote_port=22,
     username=EnvVar("EDPLAN_SFTP_USERNAME"),
     password=EnvVar("EDPLAN_SFTP_PASSWORD"),
-    # Upstream default is 10s. secureftp.easyiep.com TCP handshakes from GKE
-    # occasionally exceed that during peak periods, causing transient TimeoutError
-    # on connect. 30s tolerates those without masking a truly unreachable host.
-    timeout=30,
+    # No `timeout` override: secureftp.easyiep.com TCP handshakes from GKE
+    # occasionally exceed the old 10s upstream default during peak periods, which
+    # is why this used to set 30s. `SSHResource` now defaults to 45s, which
+    # covers those AND clears paramiko's 30s negotiation ceiling — 30s would sit
+    # exactly ON that ceiling and reintroduce the inversion in #4636.
     # secureftp.easyiep.com (GlobalSCAPE EFT 8.1) advertises only `ssh-rsa`
     # (SHA-1 RSA) host keys. paramiko 5.0 dropped ssh-rsa from defaults; opt
     # back in for this host only.

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -18,9 +18,11 @@ from dagster import (
     sensor,
 )
 from dagster_shared import check
-from paramiko.ssh_exception import SSHException
 
-from teamster.libraries.ssh.resources import SSHResource
+from teamster.libraries.ssh.resources import (
+    TRANSIENT_CONNECT_EXCEPTIONS,
+    SSHResource,
+)
 
 
 def build_amplify_mclass_sftp_sensor(
@@ -68,7 +70,7 @@ def build_amplify_mclass_sftp_sensor(
                     sftp_client=sftp_client,
                     remote_dir=remote_dir_regex,
                 )
-        except SSHException as e:
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
             # `get_connection` already retried the transient cases; an
             # unreachable host is not a code error, so skip the tick instead of
             # failing it and let the next one pick the files up (#4636).

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -13,10 +13,12 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
+    SkipReason,
     define_asset_job,
     sensor,
 )
 from dagster_shared import check
+from paramiko.ssh_exception import SSHException
 
 from teamster.libraries.ssh.resources import SSHResource
 
@@ -57,14 +59,20 @@ def build_amplify_mclass_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        with (
-            ssh_amplify.get_connection() as connection,
-            connection.open_sftp() as sftp_client,
-        ):
-            files = ssh_amplify.listdir_attr_r(
-                sftp_client=sftp_client,
-                remote_dir=remote_dir_regex,
-            )
+        try:
+            with (
+                ssh_amplify.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                files = ssh_amplify.listdir_attr_r(
+                    sftp_client=sftp_client,
+                    remote_dir=remote_dir_regex,
+                )
+        except SSHException as e:
+            # `get_connection` already retried the transient cases; an
+            # unreachable host is not a code error, so skip the tick instead of
+            # failing it and let the next one pick the files up (#4636).
+            return SkipReason(str(e))
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/amplify/mclass/sftp/sensors.py
+++ b/src/teamster/libraries/amplify/mclass/sftp/sensors.py
@@ -19,10 +19,7 @@ from dagster import (
 )
 from dagster_shared import check
 
-from teamster.libraries.ssh.resources import (
-    TRANSIENT_CONNECT_EXCEPTIONS,
-    SSHResource,
-)
+from teamster.libraries.ssh.resources import SSHResource
 
 
 def build_amplify_mclass_sftp_sensor(
@@ -61,20 +58,10 @@ def build_amplify_mclass_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        try:
-            with (
-                ssh_amplify.get_connection() as connection,
-                connection.open_sftp() as sftp_client,
-            ):
-                files = ssh_amplify.listdir_attr_r(
-                    sftp_client=sftp_client,
-                    remote_dir=remote_dir_regex,
-                )
-        except TRANSIENT_CONNECT_EXCEPTIONS as e:
-            # `get_connection` already retried the transient cases; an
-            # unreachable host is not a code error, so skip the tick instead of
-            # failing it and let the next one pick the files up (#4636).
-            return SkipReason(str(e))
+        files = ssh_amplify.listdir_attr_r_or_skip(remote_dir=remote_dir_regex)
+
+        if isinstance(files, SkipReason):
+            return files
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/edplan/sensors.py
+++ b/src/teamster/libraries/edplan/sensors.py
@@ -14,10 +14,7 @@ from dagster import (
 )
 from dagster_shared import check
 
-from teamster.libraries.ssh.resources import (
-    TRANSIENT_CONNECT_EXCEPTIONS,
-    SSHResource,
-)
+from teamster.libraries.ssh.resources import SSHResource
 
 
 def build_edplan_sftp_sensor(
@@ -41,19 +38,10 @@ def build_edplan_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        try:
-            with (
-                ssh_edplan.get_connection() as connection,
-                connection.open_sftp() as sftp_client,
-            ):
-                files = ssh_edplan.listdir_attr_r(
-                    sftp_client=sftp_client, remote_dir="Reports"
-                )
-        except TRANSIENT_CONNECT_EXCEPTIONS as e:
-            # `get_connection` already retried the transient cases; an
-            # unreachable host is not a code error, so skip the tick instead of
-            # failing it and let the next one pick the files up (#4636).
-            return SkipReason(str(e))
+        files = ssh_edplan.listdir_attr_r_or_skip(remote_dir="Reports")
+
+        if isinstance(files, SkipReason):
+            return files
 
         asset_identifier = asset.key.to_python_identifier()
         context.log.info(asset_identifier)

--- a/src/teamster/libraries/edplan/sensors.py
+++ b/src/teamster/libraries/edplan/sensors.py
@@ -8,10 +8,12 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
+    SkipReason,
     define_asset_job,
     sensor,
 )
 from dagster_shared import check
+from paramiko.ssh_exception import SSHException
 
 from teamster.libraries.ssh.resources import SSHResource
 
@@ -37,13 +39,19 @@ def build_edplan_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        with (
-            ssh_edplan.get_connection() as connection,
-            connection.open_sftp() as sftp_client,
-        ):
-            files = ssh_edplan.listdir_attr_r(
-                sftp_client=sftp_client, remote_dir="Reports"
-            )
+        try:
+            with (
+                ssh_edplan.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                files = ssh_edplan.listdir_attr_r(
+                    sftp_client=sftp_client, remote_dir="Reports"
+                )
+        except SSHException as e:
+            # `get_connection` already retried the transient cases; an
+            # unreachable host is not a code error, so skip the tick instead of
+            # failing it and let the next one pick the files up (#4636).
+            return SkipReason(str(e))
 
         asset_identifier = asset.key.to_python_identifier()
         context.log.info(asset_identifier)

--- a/src/teamster/libraries/edplan/sensors.py
+++ b/src/teamster/libraries/edplan/sensors.py
@@ -13,9 +13,11 @@ from dagster import (
     sensor,
 )
 from dagster_shared import check
-from paramiko.ssh_exception import SSHException
 
-from teamster.libraries.ssh.resources import SSHResource
+from teamster.libraries.ssh.resources import (
+    TRANSIENT_CONNECT_EXCEPTIONS,
+    SSHResource,
+)
 
 
 def build_edplan_sftp_sensor(
@@ -47,7 +49,7 @@ def build_edplan_sftp_sensor(
                 files = ssh_edplan.listdir_attr_r(
                     sftp_client=sftp_client, remote_dir="Reports"
                 )
-        except SSHException as e:
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
             # `get_connection` already retried the transient cases; an
             # unreachable host is not a code error, so skip the tick instead of
             # failing it and let the next one pick the files up (#4636).

--- a/src/teamster/libraries/iready/sensors.py
+++ b/src/teamster/libraries/iready/sensors.py
@@ -19,10 +19,7 @@ from dagster import (
 )
 from dagster_shared import check
 
-from teamster.libraries.ssh.resources import (
-    TRANSIENT_CONNECT_EXCEPTIONS,
-    SSHResource,
-)
+from teamster.libraries.ssh.resources import SSHResource
 
 
 def build_iready_sftp_sensor(
@@ -62,19 +59,10 @@ def build_iready_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        try:
-            with (
-                ssh_iready.get_connection() as connection,
-                connection.open_sftp() as sftp_client,
-            ):
-                files = ssh_iready.listdir_attr_r(
-                    sftp_client=sftp_client, remote_dir=remote_dir_regex
-                )
-        except TRANSIENT_CONNECT_EXCEPTIONS as e:
-            # `get_connection` already retried the transient cases; an
-            # unreachable host is not a code error, so skip the tick instead of
-            # failing it and let the next one pick the files up (#4636).
-            return SkipReason(str(e))
+        files = ssh_iready.listdir_attr_r_or_skip(remote_dir=remote_dir_regex)
+
+        if isinstance(files, SkipReason):
+            return files
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/iready/sensors.py
+++ b/src/teamster/libraries/iready/sensors.py
@@ -18,9 +18,11 @@ from dagster import (
     sensor,
 )
 from dagster_shared import check
-from paramiko.ssh_exception import SSHException
 
-from teamster.libraries.ssh.resources import SSHResource
+from teamster.libraries.ssh.resources import (
+    TRANSIENT_CONNECT_EXCEPTIONS,
+    SSHResource,
+)
 
 
 def build_iready_sftp_sensor(
@@ -68,7 +70,7 @@ def build_iready_sftp_sensor(
                 files = ssh_iready.listdir_attr_r(
                     sftp_client=sftp_client, remote_dir=remote_dir_regex
                 )
-        except SSHException as e:
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
             # `get_connection` already retried the transient cases; an
             # unreachable host is not a code error, so skip the tick instead of
             # failing it and let the next one pick the files up (#4636).

--- a/src/teamster/libraries/iready/sensors.py
+++ b/src/teamster/libraries/iready/sensors.py
@@ -13,10 +13,12 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
+    SkipReason,
     define_asset_job,
     sensor,
 )
 from dagster_shared import check
+from paramiko.ssh_exception import SSHException
 
 from teamster.libraries.ssh.resources import SSHResource
 
@@ -58,13 +60,19 @@ def build_iready_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        with (
-            ssh_iready.get_connection() as connection,
-            connection.open_sftp() as sftp_client,
-        ):
-            files = ssh_iready.listdir_attr_r(
-                sftp_client=sftp_client, remote_dir=remote_dir_regex
-            )
+        try:
+            with (
+                ssh_iready.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                files = ssh_iready.listdir_attr_r(
+                    sftp_client=sftp_client, remote_dir=remote_dir_regex
+                )
+        except SSHException as e:
+            # `get_connection` already retried the transient cases; an
+            # unreachable host is not a code error, so skip the tick instead of
+            # failing it and let the next one pick the files up (#4636).
+            return SkipReason(str(e))
 
         for asset in asset_selection:
             asset_identifier = asset.key.to_python_identifier()

--- a/src/teamster/libraries/renlearn/sensors.py
+++ b/src/teamster/libraries/renlearn/sensors.py
@@ -20,10 +20,7 @@ from dagster import (
 )
 from dagster_shared import check
 
-from teamster.libraries.ssh.resources import (
-    TRANSIENT_CONNECT_EXCEPTIONS,
-    SSHResource,
-)
+from teamster.libraries.ssh.resources import SSHResource
 
 
 def build_renlearn_sftp_sensor(
@@ -63,17 +60,10 @@ def build_renlearn_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        try:
-            with (
-                ssh_renlearn.get_connection() as connection,
-                connection.open_sftp() as sftp_client,
-            ):
-                files = ssh_renlearn.listdir_attr_r(sftp_client=sftp_client)
-        except TRANSIENT_CONNECT_EXCEPTIONS as e:
-            # `get_connection` already retried the transient cases; an
-            # unreachable host is not a code error, so skip the tick instead of
-            # failing it and let the next one pick the files up (#4636).
-            return SkipReason(str(e))
+        files = ssh_renlearn.listdir_attr_r_or_skip()
+
+        if isinstance(files, SkipReason):
+            return files
 
         for asset in asset_selection:
             asset_metadata = asset.metadata_by_key[asset.key]

--- a/src/teamster/libraries/renlearn/sensors.py
+++ b/src/teamster/libraries/renlearn/sensors.py
@@ -14,10 +14,12 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
+    SkipReason,
     define_asset_job,
     sensor,
 )
 from dagster_shared import check
+from paramiko.ssh_exception import SSHException
 
 from teamster.libraries.ssh.resources import SSHResource
 
@@ -59,11 +61,17 @@ def build_renlearn_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        with (
-            ssh_renlearn.get_connection() as connection,
-            connection.open_sftp() as sftp_client,
-        ):
-            files = ssh_renlearn.listdir_attr_r(sftp_client=sftp_client)
+        try:
+            with (
+                ssh_renlearn.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                files = ssh_renlearn.listdir_attr_r(sftp_client=sftp_client)
+        except SSHException as e:
+            # `get_connection` already retried the transient cases; an
+            # unreachable host is not a code error, so skip the tick instead of
+            # failing it and let the next one pick the files up (#4636).
+            return SkipReason(str(e))
 
         for asset in asset_selection:
             asset_metadata = asset.metadata_by_key[asset.key]

--- a/src/teamster/libraries/renlearn/sensors.py
+++ b/src/teamster/libraries/renlearn/sensors.py
@@ -19,9 +19,11 @@ from dagster import (
     sensor,
 )
 from dagster_shared import check
-from paramiko.ssh_exception import SSHException
 
-from teamster.libraries.ssh.resources import SSHResource
+from teamster.libraries.ssh.resources import (
+    TRANSIENT_CONNECT_EXCEPTIONS,
+    SSHResource,
+)
 
 
 def build_renlearn_sftp_sensor(
@@ -67,7 +69,7 @@ def build_renlearn_sftp_sensor(
                 connection.open_sftp() as sftp_client,
             ):
                 files = ssh_renlearn.listdir_attr_r(sftp_client=sftp_client)
-        except SSHException as e:
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
             # `get_connection` already retried the transient cases; an
             # unreachable host is not a code error, so skip the tick instead of
             # failing it and let the next one pick the files up (#4636).

--- a/src/teamster/libraries/ssh/CLAUDE.md
+++ b/src/teamster/libraries/ssh/CLAUDE.md
@@ -1,13 +1,38 @@
 # CLAUDE.md — `teamster/libraries/ssh/`
 
 Extended SSH/SFTP resource used by every SFTP-based integration. Wraps
-`dagster-ssh`'s `SSHResource` with two extra capabilities:
+`dagster-ssh`'s `SSHResource` with three extra capabilities:
 
 - `listdir_attr_r()` — recursive SFTP directory listing returning
   `(SFTPAttributes, path)` tuples
+- `listdir_attr_r_or_skip()` — connect + `listdir_attr_r` with failure triage;
+  **the entry point every SFTP sensor should use**
 - `open_ssh_tunnel()` — in-process paramiko local port forward, used by the dlt
   PowerSchool path (renamed from `open_ssh_tunnel_paramiko` in #4442; the
   earlier `sshpass` + subprocess tunnel is retired)
+
+## SFTP sensors: use `listdir_attr_r_or_skip`
+
+Do NOT hand-roll `try: ... except SSHException: return SkipReason(...)` in a new
+sensor. It has been got wrong twice (#4636): `except SSHException` misses
+`NoValidConnectionsError` / `TimeoutError` / `socket.gaierror` /
+`ConnectionResetError` (none are `SSHException` subclasses, and `reraise=True`
+re-raises the original type), so a downed host fails the tick; and catching the
+whole `TRANSIENT_CONNECT_EXCEPTIONS` net instead swallows
+`AuthenticationException` / `BadHostKeyException` / `IncompatiblePeer` /
+`ProxyCommandFailure`, so a rotated credential stops ingestion **silently and
+indefinitely** — indistinguishable from "no new files" in the UI.
+
+`listdir_attr_r_or_skip(**listdir_kwargs)` encodes both halves: transient →
+`SkipReason`, deterministic → re-raised so the tick fails and alerts. Callers
+just need:
+
+```python
+files = ssh_x.listdir_attr_r_or_skip(remote_dir=...)
+
+if isinstance(files, SkipReason):
+    return files
+```
 
 ## Key Fields Added
 

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from stat import S_ISDIR, S_ISREG
 
 from cryptography.hazmat.primitives import hashes
+from dagster import SkipReason
 from dagster_shared import check
 from dagster_ssh import SSHResource as DagsterSSHResource
 from paramiko import RSAKey, SFTPAttributes, SFTPClient, SSHClient, Transport
@@ -83,12 +84,13 @@ _NON_RETRYABLE_SSH_EXCEPTIONS = (
 # `SSHException` subclasses (`NoValidConnectionsError` is an `OSError`), so they
 # have to be named separately.
 #
-# Public because SFTP sensors catch this same tuple to decide whether to skip a
-# tick. `reraise=True` on `get_connection` re-raises the ORIGINAL exception once
-# the retry budget is spent, so a sensor catching only `SSHException` would let
-# a downed host (`NoValidConnectionsError`) or a reset peer
-# (`ConnectionResetError`) fail the tick instead of skipping it. Keeping one
-# tuple keeps the retry boundary and the skip boundary from drifting apart.
+# This is the OUTER net — everything a connect can plausibly fail with that is
+# not a programming error. `_is_transient_connect_failure` then subtracts the
+# deterministic subclasses from it. `listdir_attr_r_or_skip` uses both: catch
+# widely, then re-raise the deterministic ones. Catching only `SSHException`
+# here would miss a downed host (`NoValidConnectionsError`) or a reset peer
+# (`ConnectionResetError`), since `reraise=True` on `get_connection` re-raises
+# the ORIGINAL exception once the retry budget is spent.
 TRANSIENT_CONNECT_EXCEPTIONS = (
     SSHException,
     NoValidConnectionsError,
@@ -315,6 +317,40 @@ class SSHResource(DagsterSSHResource):
                     files.append((file, path))
 
         return files
+
+    def listdir_attr_r_or_skip(
+        self, **kwargs
+    ) -> list[tuple[SFTPAttributes, str]] | SkipReason:
+        """Connect, list recursively, and turn a TRANSIENT failure into a skip.
+
+        The SFTP sensors all share the same shape — open a connection, open an
+        SFTP channel, recurse — and the same need to tell two kinds of failure
+        apart:
+
+        - **Transient** (host slow, down, DNS blip, reset peer): already retried
+          by `get_connection`. Nothing is wrong with the code, so skip the tick
+          and let the next one pick the files up.
+        - **Deterministic** (`AuthenticationException`, `BadHostKeyException`,
+          `IncompatiblePeer`, `ProxyCommandFailure`): a rotated credential or a
+          server that changed its host key. These are re-raised so the tick
+          FAILS and alerts. Skipping them looks identical to "no new files" in
+          the UI, which would let ingestion stop silently and indefinitely.
+
+        Centralized rather than repeated per sensor because that distinction is
+        subtle, and 4 of 5 sensors previously got the simpler version of this
+        wrong (#4636). `**kwargs` are forwarded to `listdir_attr_r`.
+        """
+        try:
+            with (
+                self.get_connection() as connection,
+                connection.open_sftp() as sftp_client,
+            ):
+                return self.listdir_attr_r(sftp_client=sftp_client, **kwargs)
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
+            if not _is_transient_connect_failure(e):
+                raise
+
+            return SkipReason(str(e))
 
     @contextmanager
     def open_ssh_tunnel(

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -58,9 +58,12 @@ _REKEY_DISABLED_BYTES = 1 << 48
 # defaults live and fails if an upgrade ever pushes them past this.
 _NEGOTIATION_TIMEOUT_SECONDS = 45
 
-# Ceiling on the whole retry sequence. Five attempts at a 45s negotiation
-# timeout plus backoff could otherwise park a sensor tick for ~4 minutes against
-# a black-holed host; the shortest SFTP sensor interval is 600s.
+# Soft ceiling on the retry sequence: `stop_after_delay` is evaluated BETWEEN
+# attempts, so an attempt starting just under the threshold still runs its full
+# `_NEGOTIATION_TIMEOUT_SECONDS`, putting the true worst case nearer 165s. That
+# is still well inside the 600s shortest SFTP sensor interval, whereas the
+# unbounded five attempts plus backoff it replaces could reach ~4 minutes
+# against a black-holed host.
 _RETRY_DEADLINE_SECONDS = 120
 
 # Deterministic `SSHException` subclasses: a config/compatibility mismatch that
@@ -76,9 +79,17 @@ _NON_RETRYABLE_SSH_EXCEPTIONS = (
 
 # paramiko reports its transient negotiation failures as a BARE `SSHException`
 # ("Error reading SSH protocol banner", "No existing session", "Negotiation
-# failed.") — there is no dedicated subclass to match on. `NoValidConnectionsError`
-# is an `OSError`, not an `SSHException`, so it has to be named separately.
-_RETRYABLE_EXCEPTIONS = (
+# failed.") — there is no dedicated subclass to match on. The rest are NOT
+# `SSHException` subclasses (`NoValidConnectionsError` is an `OSError`), so they
+# have to be named separately.
+#
+# Public because SFTP sensors catch this same tuple to decide whether to skip a
+# tick. `reraise=True` on `get_connection` re-raises the ORIGINAL exception once
+# the retry budget is spent, so a sensor catching only `SSHException` would let
+# a downed host (`NoValidConnectionsError`) or a reset peer
+# (`ConnectionResetError`) fail the tick instead of skipping it. Keeping one
+# tuple keeps the retry boundary and the skip boundary from drifting apart.
+TRANSIENT_CONNECT_EXCEPTIONS = (
     SSHException,
     NoValidConnectionsError,
     TimeoutError,
@@ -100,7 +111,7 @@ def _is_transient_connect_failure(exception: BaseException) -> bool:
     if isinstance(exception, _NON_RETRYABLE_SSH_EXCEPTIONS):
         return False
 
-    return isinstance(exception, _RETRYABLE_EXCEPTIONS)
+    return isinstance(exception, TRANSIENT_CONNECT_EXCEPTIONS)
 
 
 class _DemoteTransportThreadErrors(logging.Filter):
@@ -133,14 +144,16 @@ def _demote_paramiko_transport_errors() -> None:
     A logger-level filter only runs for records logged directly to that logger,
     which is exactly the target: `Transport._log` writes to `paramiko.transport`
     itself. Child loggers (`paramiko.transport.sftp`) are untouched.
+
+    Called from `get_connection` rather than at import so that importing this
+    module does not mutate global logging state in processes that never open an
+    SSH connection. Installing here is still early enough: the transport thread
+    that logs the traceback is not started until `connect()` runs below.
     """
     logger = logging.getLogger("paramiko.transport")
 
     if not any(isinstance(f, _DemoteTransportThreadErrors) for f in logger.filters):
         logger.addFilter(_DemoteTransportThreadErrors())
-
-
-_demote_paramiko_transport_errors()
 
 
 # `RSAKey` subclass that accepts `ssh-rsa` (SHA-1) signatures. paramiko 5.0
@@ -208,6 +221,8 @@ class SSHResource(DagsterSSHResource):
         reraise=True,
     )
     def get_connection(self) -> SSHClient:
+        _demote_paramiko_transport_errors()
+
         if not self.enable_legacy_rsa:
             return super().get_connection()
 

--- a/src/teamster/libraries/ssh/resources.py
+++ b/src/teamster/libraries/ssh/resources.py
@@ -12,11 +12,20 @@ from cryptography.hazmat.primitives import hashes
 from dagster_shared import check
 from dagster_ssh import SSHResource as DagsterSSHResource
 from paramiko import RSAKey, SFTPAttributes, SFTPClient, SSHClient, Transport
-from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.ssh_exception import (
+    AuthenticationException,
+    BadHostKeyException,
+    IncompatiblePeer,
+    NoValidConnectionsError,
+    ProxyCommandFailure,
+    SSHException,
+)
+from pydantic import Field
 from tenacity import (
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
+    stop_after_delay,
     wait_exponential_jitter,
 )
 
@@ -31,6 +40,107 @@ _PREFERRED_KEYS_LOCK = threading.Lock()
 # volume, so paramiko's `need_rekey()` never trips on the tunnel (OpenSSH
 # `RekeyLimit none`). Explicit `Transport.renegotiate_keys()` still works.
 _REKEY_DISABLED_BYTES = 1 << 48
+
+# `SSHClient.connect` hands `timeout` to `Transport.start_client()`, whose wait
+# spans the banner read (`banner_timeout`, 15s) AND the key exchange that
+# follows (`handshake_timeout`, 15s). dagster-ssh defaults `timeout` to 10s, so
+# it expired first — and `start_client()` breaks out of its wait loop WITHOUT
+# raising when its own deadline passes. `connect()` then fell through to
+# `get_remote_server_key()`, which raises the misleading
+# `SSHException("No existing session")` while the real negotiation kept running
+# on an abandoned transport thread that logged an ERROR traceback seconds after
+# the caller had given up (#4636).
+#
+# 45s clears paramiko's 30s negotiation ceiling with headroom. It does NOT need
+# to cover `auth_timeout` (30s) — authentication runs after `start_client()`
+# returns and enforces its own deadline.
+# `tests/resources/test_resource_ssh_banner_timeout.py` reads the paramiko
+# defaults live and fails if an upgrade ever pushes them past this.
+_NEGOTIATION_TIMEOUT_SECONDS = 45
+
+# Ceiling on the whole retry sequence. Five attempts at a 45s negotiation
+# timeout plus backoff could otherwise park a sensor tick for ~4 minutes against
+# a black-holed host; the shortest SFTP sensor interval is 600s.
+_RETRY_DEADLINE_SECONDS = 120
+
+# Deterministic `SSHException` subclasses: a config/compatibility mismatch that
+# fails identically on every attempt, so retrying only burns backoff.
+# `AuthenticationException` covers `BadAuthenticationType` and
+# `PartialAuthentication`.
+_NON_RETRYABLE_SSH_EXCEPTIONS = (
+    AuthenticationException,
+    BadHostKeyException,
+    IncompatiblePeer,
+    ProxyCommandFailure,
+)
+
+# paramiko reports its transient negotiation failures as a BARE `SSHException`
+# ("Error reading SSH protocol banner", "No existing session", "Negotiation
+# failed.") — there is no dedicated subclass to match on. `NoValidConnectionsError`
+# is an `OSError`, not an `SSHException`, so it has to be named separately.
+_RETRYABLE_EXCEPTIONS = (
+    SSHException,
+    NoValidConnectionsError,
+    TimeoutError,
+    socket.gaierror,
+    ConnectionResetError,
+)
+
+
+def _is_transient_connect_failure(exception: BaseException) -> bool:
+    """Retry predicate for `get_connection`.
+
+    Subtracting the deterministic subclasses from `SSHException` rather than
+    dropping the base class outright: `c4541aa1b` did the latter, which
+    correctly stopped retrying `IncompatiblePeer` / `BadHostKeyException` /
+    `BadAuthenticationType` but also silently disabled the retry for every
+    transient bare `SSHException` — including the banner read failure this retry
+    exists for (#4636).
+    """
+    if isinstance(exception, _NON_RETRYABLE_SSH_EXCEPTIONS):
+        return False
+
+    return isinstance(exception, _RETRYABLE_EXCEPTIONS)
+
+
+class _DemoteTransportThreadErrors(logging.Filter):
+    """Lower `paramiko.transport`'s ERROR records to WARNING.
+
+    `Transport.run()` logs its exception message and full traceback at ERROR
+    from a BACKGROUND thread, so GCP Error Reporting files a group even when the
+    retry above recovers the connection on the next attempt. Two such groups
+    (`CPuG15Xz8J-doAE`, `CO7X67XY7MG3YA`) were the two halves of one chained
+    traceback, refiled every time an SFTP host was slow (#4636).
+
+    No signal is lost: `run()` also stores the exception in `saved_exception`,
+    which `start_client()` re-raises on the calling thread, so a failure the
+    retry does NOT recover still propagates and gets logged at the run/tick
+    level by Dagster. This is the vendored-library form of the rule in
+    `core/CLAUDE.md` about not logging tracebacks inside retry-wrapped helpers.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.ERROR:
+            record.levelno = logging.WARNING
+            record.levelname = logging.getLevelName(logging.WARNING)
+
+        return True
+
+
+def _demote_paramiko_transport_errors() -> None:
+    """Install the demoting filter once per process.
+
+    A logger-level filter only runs for records logged directly to that logger,
+    which is exactly the target: `Transport._log` writes to `paramiko.transport`
+    itself. Child loggers (`paramiko.transport.sftp`) are untouched.
+    """
+    logger = logging.getLogger("paramiko.transport")
+
+    if not any(isinstance(f, _DemoteTransportThreadErrors) for f in logger.filters):
+        logger.addFilter(_DemoteTransportThreadErrors())
+
+
+_demote_paramiko_transport_errors()
 
 
 # `RSAKey` subclass that accepts `ssh-rsa` (SHA-1) signatures. paramiko 5.0
@@ -76,22 +186,25 @@ class SSHResource(DagsterSSHResource):
     # _preferred_keys. Set True to re-enable ssh-rsa for servers that only
     # advertise it (otherwise KEX negotiation fails with IncompatiblePeer).
     enable_legacy_rsa: bool = False
+    # Overrides dagster-ssh's 10s default, which expired before paramiko
+    # finished negotiating. See `_NEGOTIATION_TIMEOUT_SECONDS`.
+    timeout: int = Field(
+        default=_NEGOTIATION_TIMEOUT_SECONDS,
+        description=(
+            "Timeout for the attempt to connect to remote host. Must exceed"
+            " paramiko's banner_timeout + handshake_timeout or connect() reports"
+            " a misleading 'No existing session' and abandons the transport"
+            " thread."
+        ),
+    )
 
     @retry(
-        stop=stop_after_attempt(5),
+        stop=stop_after_attempt(5) | stop_after_delay(_RETRY_DEADLINE_SECONDS),
         wait=wait_exponential_jitter(initial=2, max=30),
-        # Only retry true transients. SSHException is too broad — it covers
-        # IncompatiblePeer / BadHostKeyException / BadAuthenticationType, which
-        # are deterministic config failures that will fail identically on every
-        # attempt and burn ~30s per call.
-        retry=retry_if_exception_type(
-            (
-                NoValidConnectionsError,
-                TimeoutError,
-                socket.gaierror,
-                ConnectionResetError,
-            )
-        ),
+        # Retry true transients only — but by SUBTRACTING the deterministic
+        # subclasses from SSHException rather than dropping the base class,
+        # which would take the transient bare SSHExceptions with it.
+        retry=retry_if_exception(_is_transient_connect_failure),
         reraise=True,
     )
     def get_connection(self) -> SSHClient:

--- a/src/teamster/libraries/titan/sensors.py
+++ b/src/teamster/libraries/titan/sensors.py
@@ -12,9 +12,11 @@ from dagster import (
     sensor,
 )
 from dagster_shared import check
-from paramiko.ssh_exception import SSHException
 
-from teamster.libraries.ssh.resources import SSHResource
+from teamster.libraries.ssh.resources import (
+    TRANSIENT_CONNECT_EXCEPTIONS,
+    SSHResource,
+)
 
 
 def build_titan_sftp_sensor(
@@ -46,7 +48,7 @@ def build_titan_sftp_sensor(
                 files = ssh_titan.listdir_attr_r(
                     sftp_client=sftp_client, exclude_dirs=exclude_dirs
                 )
-        except SSHException as e:
+        except TRANSIENT_CONNECT_EXCEPTIONS as e:
             return SkipReason(str(e))
 
         for a in asset_selection:

--- a/src/teamster/libraries/titan/sensors.py
+++ b/src/teamster/libraries/titan/sensors.py
@@ -13,10 +13,7 @@ from dagster import (
 )
 from dagster_shared import check
 
-from teamster.libraries.ssh.resources import (
-    TRANSIENT_CONNECT_EXCEPTIONS,
-    SSHResource,
-)
+from teamster.libraries.ssh.resources import SSHResource
 
 
 def build_titan_sftp_sensor(
@@ -40,16 +37,10 @@ def build_titan_sftp_sensor(
         run_requests = []
         cursor: dict = json.loads(context.cursor or "{}")
 
-        try:
-            with (
-                ssh_titan.get_connection() as connection,
-                connection.open_sftp() as sftp_client,
-            ):
-                files = ssh_titan.listdir_attr_r(
-                    sftp_client=sftp_client, exclude_dirs=exclude_dirs
-                )
-        except TRANSIENT_CONNECT_EXCEPTIONS as e:
-            return SkipReason(str(e))
+        files = ssh_titan.listdir_attr_r_or_skip(exclude_dirs=exclude_dirs)
+
+        if isinstance(files, SkipReason):
+            return files
 
         for a in asset_selection:
             asset_identifier = a.key.to_python_identifier()

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -63,7 +63,11 @@ uv run pytest tests/assets/test_assets_dbt.py                         # requires
   `<Resource>._request.retry.wait = wait_none()` (tenacity) to kill backoff,
   inject `object.__setattr__(r, "_session", SimpleNamespace(request=fake_fn))`
   with a `_FakeResponse` stub, and assert call counts for retry/no-retry paths.
-  Reference harness: `tests/resources/test_resource_adp_workforce_now.py`.
+  Reference harness: `tests/resources/test_resource_adp_workforce_now.py`. For a
+  retry-decorated METHOD (e.g. `SSHResource.get_connection`), use
+  `Cls.method.retry_with(wait=wait_none())(instance)` — it returns a copy, so no
+  class mutation to undo, and `stop=stop_after_attempt(1)` collapses it per
+  test.
 - **SSH `test`**: vestigial config. It formerly switched the sshpass tunnel's
   password source (secret file vs. the `password` field); that tunnel was
   removed in #4442, so no method on `SSHResource` reads it now.
@@ -76,6 +80,10 @@ uv run pytest tests/assets/test_assets_dbt.py                         # requires
   leave the changes stashed and the `stash pop` unrun. To confirm a failure is
   pre-existing, check the test is in an untouched dir and doesn't reference your
   changed symbols, rather than stash-comparing.
+- **`test_resource_ssh_dir_mtime_propagation.py` fails ~10 of 15 on `main`** —
+  it asserts LIVE SFTP servers propagate directory mtime, so failures track
+  vendor behavior, not your change, and `littlesis` flaps between runs. Baseline
+  against `main` before attributing a failure here to an SSH edit.
 - **Cross-file conftest imports fail** (`tests/` has no `__init__.py`). For
   fixture-injected param types, skip the annotation or use `TYPE_CHECKING` with
   a string forward-ref.

--- a/tests/resources/test_resource_ssh_banner_timeout.py
+++ b/tests/resources/test_resource_ssh_banner_timeout.py
@@ -413,13 +413,52 @@ def test_sftp_sensor_skips_rather_than_fails_on_any_transient_failure(
     Driving the real sensor is what makes this meaningful: asserting the tuple's
     contents would just restate the constant.
     """
+    result = _evaluate_edplan_sensor(monkeypatch, build_exception())
+
+    assert isinstance(result, SkipReason), (
+        "a transient failure escaped the sensor and failed the tick; it should"
+        " have produced a SkipReason"
+    )
+
+
+@pytest.mark.parametrize(
+    "build_exception",
+    [
+        lambda: AuthenticationException("auth failed"),
+        lambda: BadAuthenticationType("bad type", ["publickey"]),
+        _bad_host_key,
+        lambda: IncompatiblePeer("no acceptable host key"),
+    ],
+    ids=["auth-failed", "bad-auth-type", "bad-host-key", "incompatible-peer"],
+)
+def test_sftp_sensor_fails_the_tick_on_deterministic_failures(
+    monkeypatch, build_exception: Callable[[], BaseException]
+):
+    """A deterministic failure must FAIL the tick, not skip it.
+
+    A rotated credential or a changed host key fails identically forever.
+    Skipping renders that indistinguishable from "no new files" in the Dagster
+    UI, so ingestion would stop silently and indefinitely — a worse outcome than
+    a noisy tick failure, because nothing surfaces at all.
+
+    These are all `SSHException` subclasses, so a blanket
+    `except SSHException` / `except TRANSIENT_CONNECT_EXCEPTIONS` swallows every
+    one of them.
+    """
     exception = build_exception()
+
+    with pytest.raises(type(exception)):
+        _evaluate_edplan_sensor(monkeypatch, exception)
+
+
+def _evaluate_edplan_sensor(monkeypatch, exception: BaseException):
+    """Run a real edplan sensor whose every connect attempt raises `exception`."""
 
     def _always_fail(_self) -> SSHClient:
         raise exception
 
     # Patch the decorated method itself, so the retry budget is bypassed and the
-    # test exercises the sensor's except clause rather than tenacity.
+    # test exercises the sensor's skip boundary rather than tenacity.
     monkeypatch.setattr(SSHResource, "get_connection", _always_fail)
 
     @asset(name="edplan_probe", metadata={"remote_file_regex": r"(?P<date>.+)\.csv"})
@@ -435,12 +474,7 @@ def test_sftp_sensor_skips_rather_than_fails_on_any_transient_failure(
         resources={"ssh_edplan": SSHResource(remote_host="127.0.0.1", username="svc")}
     )
 
-    result = sensor_def(context)
-
-    assert isinstance(result, SkipReason), (
-        f"{type(exception).__name__} escaped the sensor and failed the tick;"
-        " it should have produced a SkipReason"
-    )
+    return sensor_def(context)
 
 
 def test_transport_thread_errors_do_not_reach_error_severity(caplog):

--- a/tests/resources/test_resource_ssh_banner_timeout.py
+++ b/tests/resources/test_resource_ssh_banner_timeout.py
@@ -4,12 +4,13 @@ transient retry (#4636).
 Two independent defects turned a slow SSH banner into a failed sensor tick plus
 a pair of false-positive GCP Error Reporting groups:
 
-1. **Timeout inversion.** `SSHResource.timeout` defaulted to 10s (dagster-ssh)
-   while paramiko's `Transport.banner_timeout` is 15s and `auth_timeout` is 30s.
-   `Transport.start_client()` breaks out of its wait loop WITHOUT raising when
-   its own deadline passes (`transport.py`, "if event.is_set() or ... >=
-   max_time: break"), so `SSHClient.connect` fell through to
-   `get_remote_server_key()`, which raises the misleading
+1. **Timeout inversion.** `SSHResource.timeout` defaulted to 10s (dagster-ssh),
+   but it is passed to `Transport.start_client()`, whose wait spans BOTH the
+   banner read (`banner_timeout`, 15s) and the key exchange that follows
+   (`handshake_timeout`, 15s) — a 30s budget. `start_client()` breaks out of its
+   wait loop WITHOUT raising when its own deadline passes (`transport.py`, "if
+   event.is_set() or ... >= max_time: break"), so `SSHClient.connect` fell
+   through to `get_remote_server_key()`, which raises the misleading
    `SSHException("No existing session")` — while the real banner read continued
    on an orphaned transport thread that logged an ERROR traceback seconds after
    the caller had already given up.

--- a/tests/resources/test_resource_ssh_banner_timeout.py
+++ b/tests/resources/test_resource_ssh_banner_timeout.py
@@ -1,0 +1,408 @@
+"""Regression tests for the SFTP banner-timeout inversion and the lost
+transient retry (#4636).
+
+Two independent defects turned a slow SSH banner into a failed sensor tick plus
+a pair of false-positive GCP Error Reporting groups:
+
+1. **Timeout inversion.** `SSHResource.timeout` defaulted to 10s (dagster-ssh)
+   while paramiko's `Transport.banner_timeout` is 15s and `auth_timeout` is 30s.
+   `Transport.start_client()` breaks out of its wait loop WITHOUT raising when
+   its own deadline passes (`transport.py`, "if event.is_set() or ... >=
+   max_time: break"), so `SSHClient.connect` fell through to
+   `get_remote_server_key()`, which raises the misleading
+   `SSHException("No existing session")` — while the real banner read continued
+   on an orphaned transport thread that logged an ERROR traceback seconds after
+   the caller had already given up.
+
+2. **Lost transient retry.** `c4541aa1b` narrowed `get_connection`'s tenacity
+   predicate to drop `SSHException`, correctly excluding the deterministic
+   subclasses (`IncompatiblePeer` / `BadHostKeyException` /
+   `BadAuthenticationType`) but also excluding every transient bare
+   `SSHException` — including the banner read failure the retry existed for.
+
+These tests need no external credentials: the loopback server accepts the TCP
+connection and then stays silent, which is exactly what a slow SFTP host looks
+like to paramiko.
+"""
+
+import importlib
+import logging
+import socket
+import threading
+from collections.abc import Callable
+
+import pytest
+from paramiko import RSAKey, SSHClient, Transport
+from paramiko.ssh_exception import (
+    AuthenticationException,
+    BadAuthenticationType,
+    BadHostKeyException,
+    IncompatiblePeer,
+    SSHException,
+)
+from tenacity import stop_after_attempt, wait_none
+
+from teamster.libraries.ssh.resources import SSHResource
+
+
+class _SilentBannerServer:
+    """Accepts the TCP connection, then never sends an SSH banner.
+
+    Mirrors a slow/overloaded SFTP host (`sftp.titank12.com` during the
+    2026-07-30 incident): the socket connects fine, so this is NOT a
+    `NoValidConnectionsError` / `ConnectionRefusedError` path — paramiko gets as
+    far as waiting on the protocol banner and then stalls.
+    """
+
+    def __init__(self) -> None:
+        self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind(("127.0.0.1", 0))
+        self._listener.listen(8)
+
+        self._socks: list[socket.socket] = []
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    @property
+    def port(self) -> int:
+        return self._listener.getsockname()[1]
+
+    def _serve(self) -> None:
+        while True:
+            try:
+                sock, _ = self._listener.accept()
+            except OSError:
+                return  # listener closed → stop accepting
+            # Hold the connection open and send nothing.
+            self._socks.append(sock)
+
+    def close(self) -> None:
+        self._listener.close()
+        for sock in self._socks:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+@pytest.fixture
+def silent_banner_server():
+    server = _SilentBannerServer()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+def _resource(port: int, **kwargs) -> SSHResource:
+    resource = SSHResource(
+        remote_host="127.0.0.1",
+        remote_port=port,
+        username="svc",
+        password="pw",
+        no_host_key_check=True,
+        **kwargs,
+    )
+    # Wires the logger without running `setup_for_execution` (no secret file /
+    # ~/.ssh/config read), matching tests/resources/test_resource_ssh_rekey.py.
+    resource.set_logger(logging.getLogger("test_ssh_banner_timeout"))
+    return resource
+
+
+def _connect_once(resource: SSHResource) -> SSHClient:
+    """Call `get_connection` with retry collapsed to a single attempt.
+
+    The connect-path tests below run against paramiko's REAL banner timeout —
+    scaling it down would also erase the inversion they exist to catch — so a
+    full retry budget would multiply an already-slow test by five.
+    """
+    retry_with = SSHResource.get_connection.retry_with  # type: ignore[attr-defined]
+    return retry_with(stop=stop_after_attempt(1))(resource)
+
+
+def _connect_without_backoff(resource: SSHResource) -> SSHClient:
+    """Call `get_connection` with the retry budget intact but no backoff.
+
+    The predicate tests assert HOW MANY attempts happen, not how long tenacity
+    sleeps between them; keeping the real `wait_exponential_jitter` would add
+    ~30s per parametrized case.
+    """
+    retry_with = SSHResource.get_connection.retry_with  # type: ignore[attr-defined]
+    return retry_with(wait=wait_none())(resource)
+
+
+def test_default_timeout_outlasts_paramiko_negotiation():
+    """`SSHResource.timeout` must outlast everything `start_client()` covers.
+
+    `SSHClient.connect` passes `timeout` to `start_client()`, whose wait spans
+    BOTH the banner read (`banner_timeout`) and the key exchange that follows
+    (`handshake_timeout`) — so the budget has to clear their sum. `auth_timeout`
+    is deliberately excluded: authentication happens after `start_client()`
+    returns and raises on its own deadline.
+
+    Under-budgeting here is not a slow failure, it is a WRONG one:
+    `start_client()` breaks out of its wait loop without raising, and
+    `connect()` falls through to `get_remote_server_key()` → "No existing
+    session", leaving the real negotiation running on an abandoned thread.
+
+    The paramiko defaults are read live rather than hardcoded so an upgrade that
+    raises them fails this test instead of silently reintroducing the inversion.
+    """
+    sock_a, sock_b = socket.socketpair()
+    try:
+        transport = Transport(sock=sock_a)
+        try:
+            negotiation_budget = transport.banner_timeout + transport.handshake_timeout
+        finally:
+            transport.close()
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+    timeout = SSHResource(remote_host="127.0.0.1", username="svc").timeout
+
+    assert timeout > negotiation_budget, (
+        f"SSHResource.timeout ({timeout}s) must exceed paramiko's banner_timeout"
+        f" + handshake_timeout ({negotiation_budget}s), or start_client()"
+        " abandons the transport thread and connect() reports 'No existing"
+        " session'"
+    )
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "teamster.core.resources",
+        "teamster.code_locations.kipptaf.resources",
+        "teamster.code_locations.kippmiami.resources",
+    ],
+)
+def test_no_configured_ssh_resource_undercuts_the_negotiation_budget(module_name: str):
+    """Every configured `SSHResource` must clear the same invariant.
+
+    Raising the default is only half the guarantee — a per-resource `timeout=`
+    override puts that one host back under the ceiling on its own. Three did:
+    `SSH_EDPLAN`, `SSH_RESOURCE_CLEVER`, and `SSH_RESOURCE_ILLUMINATE` all set
+    `timeout=30`, which sits exactly ON paramiko's 30s budget rather than above
+    it — so they would have kept failing with "No existing session" even after
+    the default moved.
+    """
+    module = importlib.import_module(module_name)
+
+    sock_a, sock_b = socket.socketpair()
+    try:
+        transport = Transport(sock=sock_a)
+        try:
+            negotiation_budget = transport.banner_timeout + transport.handshake_timeout
+        finally:
+            transport.close()
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+    ssh_resources = {
+        name: value
+        for name, value in vars(module).items()
+        if isinstance(value, SSHResource)
+    }
+
+    assert ssh_resources, f"expected SSHResource singletons in {module_name}"
+
+    undercutting = {
+        name: resource.timeout
+        for name, resource in ssh_resources.items()
+        if resource.timeout <= negotiation_budget
+    }
+
+    assert not undercutting, (
+        "these SSH resources set a timeout at or below paramiko's"
+        f" {negotiation_budget}s negotiation budget: {undercutting}"
+    )
+
+
+def test_silent_banner_raises_banner_error_not_no_existing_session(
+    silent_banner_server,
+):
+    """A stalled banner must surface as the real banner-read failure.
+
+    Before the fix this raised `SSHException("No existing session")` — a
+    misleading message that made the incident look like an auth/session problem
+    rather than a slow host.
+    """
+    resource = _resource(silent_banner_server.port)
+
+    with pytest.raises(SSHException) as exc_info:
+        _connect_once(resource)
+
+    message = str(exc_info.value)
+
+    assert "No existing session" not in message, (
+        "connect() fell through start_client() without raising — the timeout"
+        f" inversion is back (got: {message!r})"
+    )
+    assert "banner" in message.lower(), (
+        f"expected the protocol-banner read failure, got: {message!r}"
+    )
+
+
+def test_silent_banner_leaves_no_orphaned_transport_thread(
+    silent_banner_server,
+):
+    """The failed connect must not leave a paramiko transport thread running.
+
+    An orphaned thread keeps reading the dead socket and then logs its own ERROR
+    traceback after the caller has moved on — the source of both Error Reporting
+    groups in #4636, and a socket/thread leak multiplied by every retry attempt.
+    """
+    resource = _resource(silent_banner_server.port)
+
+    # `Transport` subclasses `threading.Thread` but never sets a name, so match
+    # on type rather than `thread.name` (which is a default "Thread-N").
+    before = {id(t) for t in threading.enumerate() if isinstance(t, Transport)}
+
+    with pytest.raises(SSHException):
+        _connect_once(resource)
+
+    started = [
+        t
+        for t in threading.enumerate()
+        if isinstance(t, Transport) and id(t) not in before
+    ]
+
+    # Allow a short unwind after the exception propagates — but stay well under
+    # the banner timeout, so a thread abandoned mid-read is still running here.
+    for thread in started:
+        thread.join(timeout=2)
+
+    orphaned = [t for t in started if t.is_alive()]
+
+    assert not orphaned, (
+        f"{len(orphaned)} paramiko transport thread(s) still running after a"
+        " failed connect — connect() returned while the transport was still"
+        " negotiating"
+    )
+
+
+def _count_attempts(monkeypatch, exception: BaseException) -> int:
+    """Drive `get_connection` against an always-failing connect, return the
+    number of attempts tenacity made."""
+    attempts = 0
+
+    def _always_fail(_self) -> SSHClient:
+        nonlocal attempts
+        attempts += 1
+        raise exception
+
+    monkeypatch.setattr(
+        "teamster.libraries.ssh.resources.DagsterSSHResource.get_connection",
+        _always_fail,
+    )
+
+    resource = _resource(port=22)
+
+    with pytest.raises(type(exception)):
+        _connect_without_backoff(resource)
+
+    return attempts
+
+
+def _bad_host_key() -> BadHostKeyException:
+    # `BadHostKeyException.__init__` calls `get_base64()` on both keys, so they
+    # have to be real. 1024 bits keeps generation cheap — this key only ever
+    # gets formatted into an error message.
+    key = RSAKey.generate(1024)
+    return BadHostKeyException("host", key, key)
+
+
+@pytest.mark.parametrize(
+    "build_exception",
+    [
+        lambda: SSHException("Error reading SSH protocol banner"),
+        lambda: SSHException("No existing session"),
+        lambda: SSHException("Negotiation failed."),
+        lambda: TimeoutError(),
+        lambda: ConnectionResetError(),
+        lambda: socket.gaierror(),
+    ],
+    ids=[
+        "banner-read",
+        "no-existing-session",
+        "negotiation-failed",
+        "timeout",
+        "connection-reset",
+        "dns",
+    ],
+)
+def test_transient_failures_are_retried(
+    monkeypatch, build_exception: Callable[[], BaseException]
+):
+    """Transient failures must exhaust the retry budget before giving up.
+
+    `SSHException` is the base class of paramiko's transient negotiation errors.
+    Dropping it from the predicate (`c4541aa1b`) silently disabled the retry for
+    the single most common SFTP failure mode — the banner read.
+    """
+    exception = build_exception()
+    attempts = _count_attempts(monkeypatch, exception)
+
+    assert attempts == 5, (
+        f"expected 5 attempts for transient {type(exception).__name__}"
+        f" ({str(exception)!r}), got {attempts}"
+    )
+
+
+@pytest.mark.parametrize(
+    "build_exception",
+    [
+        lambda: IncompatiblePeer("no acceptable host key"),
+        lambda: BadAuthenticationType("bad type", ["publickey"]),
+        _bad_host_key,
+        lambda: AuthenticationException("auth failed"),
+    ],
+    ids=["incompatible-peer", "bad-auth-type", "bad-host-key", "auth-failed"],
+)
+def test_deterministic_failures_are_not_retried(
+    monkeypatch, build_exception: Callable[[], BaseException]
+):
+    """Deterministic config failures must fail fast on the first attempt.
+
+    These are all `SSHException` SUBCLASSES, so widening the predicate back to
+    the bare base class would burn ~30s of backoff per call re-failing
+    identically. That regression is what `c4541aa1b` set out to fix, and this
+    test keeps the fix for #4636 from undoing it.
+    """
+    exception = build_exception()
+    attempts = _count_attempts(monkeypatch, exception)
+
+    assert attempts == 1, (
+        f"deterministic {type(exception).__name__} must not be retried, got"
+        f" {attempts} attempts"
+    )
+
+
+def test_transport_thread_errors_do_not_reach_error_severity(caplog):
+    """paramiko's transport thread must not log at ERROR.
+
+    `Transport.run()` logs its exception traceback at ERROR from a BACKGROUND
+    thread, so GCP Error Reporting files a group even when the retry above
+    recovers the connection. Unrecovered failures still surface as a raised
+    exception that Dagster logs at the run/tick level, so demoting this
+    particular logger loses no signal.
+
+    Same trap `core/CLAUDE.md` already documents for `log.exception` inside
+    retry-wrapped helpers — here it comes from a vendored logger.
+    """
+    logger = logging.getLogger("paramiko.transport")
+
+    with caplog.at_level(logging.DEBUG, logger="paramiko.transport"):
+        logger.error("Exception (client): Error reading SSH protocol banner")
+        logger.error("Traceback (most recent call last):\n  ...")
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+    assert not error_records, (
+        "paramiko.transport still emits ERROR-severity records; GCP Error"
+        " Reporting will keep filing false-positive groups for transient"
+        f" failures the retry recovers ({[r.getMessage() for r in error_records]})"
+    )

--- a/tests/resources/test_resource_ssh_banner_timeout.py
+++ b/tests/resources/test_resource_ssh_banner_timeout.py
@@ -30,18 +30,22 @@ import logging
 import socket
 import threading
 from collections.abc import Callable
+from zoneinfo import ZoneInfo
 
 import pytest
+from dagster import SkipReason, asset, build_sensor_context
 from paramiko import RSAKey, SSHClient, Transport
 from paramiko.ssh_exception import (
     AuthenticationException,
     BadAuthenticationType,
     BadHostKeyException,
     IncompatiblePeer,
+    NoValidConnectionsError,
     SSHException,
 )
 from tenacity import stop_after_attempt, wait_none
 
+from teamster.libraries.edplan.sensors import build_edplan_sftp_sensor
 from teamster.libraries.ssh.resources import SSHResource
 
 
@@ -149,16 +153,7 @@ def test_default_timeout_outlasts_paramiko_negotiation():
     The paramiko defaults are read live rather than hardcoded so an upgrade that
     raises them fails this test instead of silently reintroducing the inversion.
     """
-    sock_a, sock_b = socket.socketpair()
-    try:
-        transport = Transport(sock=sock_a)
-        try:
-            negotiation_budget = transport.banner_timeout + transport.handshake_timeout
-        finally:
-            transport.close()
-    finally:
-        sock_a.close()
-        sock_b.close()
+    negotiation_budget = _paramiko_negotiation_budget()
 
     timeout = SSHResource(remote_host="127.0.0.1", username="svc").timeout
 
@@ -190,16 +185,7 @@ def test_no_configured_ssh_resource_undercuts_the_negotiation_budget(module_name
     """
     module = importlib.import_module(module_name)
 
-    sock_a, sock_b = socket.socketpair()
-    try:
-        transport = Transport(sock=sock_a)
-        try:
-            negotiation_budget = transport.banner_timeout + transport.handshake_timeout
-        finally:
-            transport.close()
-    finally:
-        sock_a.close()
-        sock_b.close()
+    negotiation_budget = _paramiko_negotiation_budget()
 
     ssh_resources = {
         name: value
@@ -307,6 +293,25 @@ def _count_attempts(monkeypatch, exception: BaseException) -> int:
     return attempts
 
 
+def _paramiko_negotiation_budget() -> float:
+    """Everything `Transport.start_client()`'s wait has to outlast.
+
+    Read from a live `Transport` rather than hardcoded, so a paramiko upgrade
+    that raises either default fails the callers instead of silently
+    reintroducing the inversion.
+    """
+    sock_a, sock_b = socket.socketpair()
+    try:
+        transport = Transport(sock=sock_a)
+        try:
+            return transport.banner_timeout + transport.handshake_timeout
+        finally:
+            transport.close()
+    finally:
+        sock_a.close()
+        sock_b.close()
+
+
 def _bad_host_key() -> BadHostKeyException:
     # `BadHostKeyException.__init__` calls `get_base64()` on both keys, so they
     # have to be real. 1024 bits keeps generation cheap — this key only ever
@@ -378,6 +383,62 @@ def test_deterministic_failures_are_not_retried(
     assert attempts == 1, (
         f"deterministic {type(exception).__name__} must not be retried, got"
         f" {attempts} attempts"
+    )
+
+
+@pytest.mark.parametrize(
+    "build_exception",
+    [
+        lambda: SSHException("Error reading SSH protocol banner"),
+        lambda: NoValidConnectionsError({("10.0.0.1", 22): ConnectionRefusedError()}),
+        lambda: TimeoutError("timed out"),
+        lambda: ConnectionResetError("reset by peer"),
+        lambda: socket.gaierror("name resolution failed"),
+    ],
+    ids=["banner-read", "host-down", "timeout", "connection-reset", "dns"],
+)
+def test_sftp_sensor_skips_rather_than_fails_on_any_transient_failure(
+    monkeypatch, build_exception: Callable[[], BaseException]
+):
+    """A sensor must skip the tick for everything `get_connection` retries.
+
+    `reraise=True` means an exhausted retry budget re-raises the ORIGINAL
+    exception, and four of the five transient types are NOT `SSHException`
+    subclasses. A sensor catching only `SSHException` therefore still failed the
+    tick when a host was simply down (`NoValidConnectionsError`) or reset the
+    connection (`ConnectionResetError`) — the exact case `c4541aa1b` added to
+    the retry set because it had been seen in production.
+
+    Driving the real sensor is what makes this meaningful: asserting the tuple's
+    contents would just restate the constant.
+    """
+    exception = build_exception()
+
+    def _always_fail(_self) -> SSHClient:
+        raise exception
+
+    # Patch the decorated method itself, so the retry budget is bypassed and the
+    # test exercises the sensor's except clause rather than tenacity.
+    monkeypatch.setattr(SSHResource, "get_connection", _always_fail)
+
+    @asset(name="edplan_probe", metadata={"remote_file_regex": r"(?P<date>.+)\.csv"})
+    def _edplan_probe() -> None: ...
+
+    sensor_def = build_edplan_sftp_sensor(
+        asset=_edplan_probe,
+        code_location="test",
+        execution_timezone=ZoneInfo("America/New_York"),
+    )
+
+    context = build_sensor_context(
+        resources={"ssh_edplan": SSHResource(remote_host="127.0.0.1", username="svc")}
+    )
+
+    result = sensor_def(context)
+
+    assert isinstance(result, SkipReason), (
+        f"{type(exception).__name__} escaped the sensor and failed the tick;"
+        " it should have produced a SkipReason"
     )
 
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

When merged, this pull request will fix two independent defects that turned a slow SFTP banner into a failed sensor tick plus a pair of false-positive GCP Error Reporting groups.

The two open groups (`CPuG15Xz8J-doAE`, `CO7X67XY7MG3YA`) are not two bugs — they are the two halves of one chained traceback that paramiko's `Transport.run()` logs at ERROR severity, which Error Reporting filed separately. Confirmed on two pods on 2026-07-30: Camden `ssh_titan` init 15:13:11 to banner timeout 15:13:26, Newark 15:13:37 to 15:13:52. Both exactly 15.0s.

### Root cause 1: timeout inversion

`SSHClient.connect` passes `timeout` to `Transport.start_client()`, whose wait spans the banner read (`banner_timeout`, 15s) **and** the key exchange that follows (`handshake_timeout`, 15s). dagster-ssh defaults `timeout` to 10s, so it expired first — and `start_client()` breaks out of its wait loop **without raising** when its own deadline passes. `connect()` then fell through to `get_remote_server_key()`, which raises the misleading `SSHException('No existing session')` while the real negotiation kept running on an abandoned transport thread that logged its ERROR traceback seconds after the caller had given up.

That ordering is visible in the incident: the Camden tick at 15:13:10 skipped with reason `No existing session` and ended at 15:13:21 — before the 15:13:26 traceback was even emitted.

The default is now 45s, clearing paramiko's 30s negotiation ceiling. Three resources also pinned `timeout=30`, which sits exactly **on** that ceiling and would have stayed broken: `SSH_EDPLAN`, `SSH_RESOURCE_CLEVER`, `SSH_RESOURCE_ILLUMINATE`. All three now inherit the default.

### Root cause 2: lost transient retry

`c4541aa1b` narrowed `get_connection`'s tenacity predicate:

```python
- retry=retry_if_exception_type((SSHException, TimeoutError, socket.gaierror))
+ retry=retry_if_exception_type(
+     (NoValidConnectionsError, TimeoutError, socket.gaierror, ConnectionResetError)
+ )
```

The intent was correct — `IncompatiblePeer` / `BadHostKeyException` / `BadAuthenticationType` are deterministic config failures that should not burn 5 attempts. But those are all **subclasses** of `SSHException`, so dropping the base class also dropped every transient bare `SSHException`, including the banner read failure the retry existed for.

The predicate now **subtracts** the deterministic subclasses from `SSHException` instead of dropping the base class. The non-retryable set is `AuthenticationException` (which covers `BadAuthenticationType` and `PartialAuthentication`), `BadHostKeyException`, `IncompatiblePeer`, and `ProxyCommandFailure` — the latter two beyond what the original narrowing named, both also deterministic. A `stop_after_delay` ceiling bounds the sequence, since each attempt can now run longer; note it is evaluated between attempts, so the bound is soft (worst case nearer 165s), still well inside the 600s shortest sensor interval.

### Root cause 3: the ERROR-severity noise itself

Even with the retry working, a **recovered** attempt still refiles both Error Reporting groups, because `Transport.run()` logs from a background thread regardless of what the caller does. A logging filter demotes `paramiko.transport` ERROR records to WARNING. No signal is lost: `run()` also stores the exception in `saved_exception` for `start_client()` to re-raise on the calling thread, so an unrecovered failure still propagates and is logged by Dagster at the run/tick level. This is the vendored-library form of the rule already in `core/CLAUDE.md` about not logging tracebacks inside retry-wrapped helpers.

Fixing only this part would have hidden a real bug, so it ships with 1 and 2.

### Blast radius

Only 1 of 5 SFTP sensors degraded gracefully. `iready`, `renlearn`, `edplan`, and `amplify/mclass` let `SSHException` escape and **failed the tick**; `titan` alone caught it.

All five now route through `SSHResource.listdir_attr_r_or_skip()`, which triages the failure instead of blanket-catching it:

| Failure | Example | Outcome |
| --- | --- | --- |
| Transient | host slow or down, DNS blip, reset peer | already retried, then `SkipReason` — next tick picks the files up |
| Deterministic | rotated credential, changed host key, algorithm mismatch | **re-raised, tick FAILS and alerts** |

Two separate bugs sat here, both found during review of this PR:

- `except SSHException` missed `NoValidConnectionsError` / `TimeoutError` / `socket.gaierror` / `ConnectionResetError`. None are `SSHException` subclasses, and `reraise=True` re-raises the *original* type once the retry budget is spent, so a host simply being **down** failed the tick.
- Widening to the full transient net then swallowed `AuthenticationException`, `BadHostKeyException`, `IncompatiblePeer`, and `ProxyCommandFailure`. That is the worse direction: `SkipReason` is indistinguishable from "no new files" in the UI, so a rotated credential would stop ingestion **silently and indefinitely** with nothing alerting. `titan` had this behavior before this PR.

The triage is centralized rather than repeated per sensor — a per-sensor `try/except` is exactly the shape that got this wrong twice, and the logic is no longer trivial enough to copy. Each sensor is now a call plus an `isinstance` check (net -95/+55 across the five). This also closes the review's duplication finding.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Human-directed: the two Error Reporting URLs and the decision to fix all three root causes plus the four sensors.

AI-assisted: the investigation (log correlation, reading paramiko's `transport.py` / `client.py` control flow to find the silent `start_client` fall-through, bisecting the retry regression to `c4541aa1b`), the tests, and the implementation.

Findings were verified against the source rather than assumed — the exception hierarchy, the paramiko timeout defaults, and the demotion were each checked at runtime, and the "unaffected" test failures were baselined against `main` rather than dismissed.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location — 4 passed (`kippcamden`, `kippnewark`, `kipppaterson`, `kipptaf`). `kippmiami` fails at `dlt/focus/assets.py:12`, where `resolve_configuration` eagerly needs a `FOCUS_DB` credential that is unset in a codespace; `test_definitions_all` fails only because it includes `kippmiami`. Both are the pre-existing local limitation documented in `src/teamster/CLAUDE.md`, unrelated to SSH. (The fresh worktree also needed `dagster-dbt project prepare-and-package` first — without it every location fails on a missing `target/manifest.json`.)
- [x] New integrations follow the Library plus Config pattern — n/a, no new integrations

Note for review: the one wiring risk worth a look is the `timeout` field override on `SSHResource`, since it redeclares a field inherited from `dagster_ssh.SSHResource`. Every configured resource across `core` / `kipptaf` / `kippmiami` constructs fine under test, and the Dagster Cloud branch deploy exercises the rest.

## Testing

New regression suite: `tests/resources/test_resource_ssh_banner_timeout.py` (26 tests). It uses a loopback server that accepts the TCP connection and then stays silent, so it needs no external credentials.

Written failing first, for exactly the defects being fixed. On the 14 tests that existed at that point, 7 failed. The suite has since grown: the 3 resource-guard cases added after finding the `timeout=30` pins also fail pre-fix (`kippmiami` inherits the old 10s default), and the 5 sensor cases below fail 4-of-5 pre-fix — so against the final suite the pre-fix count is 10, not 7. (An earlier revision of this description said 7 against 17 tests, conflating the two runs.)

- `test_default_timeout_outlasts_paramiko_negotiation` reads paramiko's `banner_timeout` / `handshake_timeout` **live** rather than hardcoding 15/30, so a paramiko upgrade that raises them fails the test instead of silently reintroducing the inversion.
- `test_no_configured_ssh_resource_undercuts_the_negotiation_budget` scans every configured `SSHResource` across `core`, `kipptaf`, and `kippmiami` — raising the default is only half the guarantee when a per-resource override can undercut it, which is how the three `timeout=30` pins were caught.
- Deterministic failures are asserted to fail fast at 1 attempt, so this fix cannot undo what `c4541aa1b` set out to do.
- `test_sftp_sensor_skips_rather_than_fails_on_any_transient_failure` and `test_sftp_sensor_fails_the_tick_on_deterministic_failures` drive a **real** sensor through each exception type, asserting opposite outcomes. Both verified to catch their bug rather than pass vacuously: reverting the sensor to `except SSHException` fails 4 of the 5 transient cases, and removing the deterministic re-raise fails all 4 deterministic cases.

Also verified the **real** runtime path, not just synthetic log calls: an actual failed handshake against a silent-banner server now raises `SSHException: Error reading SSH protocol banner` (not `No existing session`) and produces **zero** paramiko records at ERROR or above.

Full SSH suites pass: `test_resource_ssh_banner_timeout.py`, `test_resource_ssh_rekey.py`, `test_ssh_paramiko_tunnel.py` (22 passed).

`test_resource_ssh_dir_mtime_propagation.py` fails on live-SFTP mtime assertions — baselined on `main` at 10 failures vs 11 here; the one delta (`littlesis`) passes on re-run on both branches, so it is live-server drift, not this change.

## CI checks

- [ ] **Trunk** — `trunk check --force` on the changed files reports no new issues locally.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — shared library change, so expect all five locations to redeploy.

Refs #4636
