### PR TITLE
feat(nj-sleds): derive AlphaGradeEarned and CreditsEarned for the Student Course Roster submission

### DIFF
--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -57,6 +57,61 @@ reload. If the residue drops to zero, `build_submission.py` will export; until
 then, seeing `FAILED` here is the tool working as designed, not a defect to
 chase.
 
+## Ungraded worklist
+
+The validation gate reports counts, not rows — useful for knowing the submission
+is blocked, useless for actually clearing the block. `export_worklist.py` fills
+that gap: it exports one row per in-scope, ungraded student/section so someone
+with PowerSchool access can resolve them directly.
+
+Run it any time, regardless of the gate's state:
+
+```bash
+uv run --with google-cloud-bigquery python export_worklist.py OUTDIR
+```
+
+This creates `cokafor.rpt_student_course_ungraded` and writes
+`NJ_Student_Course_Ungraded_{region}.csv`. Unlike `build_submission.py`, it is
+**not gated** — see its module docstring for why gating the fix-it tool on the
+thing it exists to fix would be circular.
+
+Each row carries `reason` (why the row has no grade) and `section_shape`
+(whether the whole section is affected or just this student). As of the
+2026-07-29 extract the 108 rows break down like this:
+
+| Reason                                       | Section shape                    | Rows |
+| -------------------------------------------- | -------------------------------- | ---: |
+| no grade in either source                    | whole section ungraded           |   41 |
+| no grade in either source                    | partial — classmates were graded |   34 |
+| conflicting grades                           | partial                          |   31 |
+| grade exists but outside the handbook domain | partial                          |    2 |
+
+What each combination implies:
+
+- **Whole section ungraded (41 rows):** the section appears never to have been
+  graded. If it genuinely should not be reported, the fix is PowerSchool's
+  "Exclude from Course Roster Reports" checkbox on the section's Course
+  Submission Information panel (see the audit runbook). Then re-pull and re-load
+  the extract.
+- **Partial, classmates were graded (34 rows):** the section was graded and
+  these individual students were missed. Excluding the section would wrongly
+  drop the students who do have grades — post the missing grades instead.
+- **Conflicting grades (31 rows):** a grade exists, but sources or reporting
+  terms disagree, so the query refuses to pick one. Reconcile in PowerSchool.
+  These are the cheapest to clear.
+- **Grade exists but outside the handbook domain (2 rows):** the only available
+  grade was `F*`, a warehouse-internal marker that is not a legal
+  `AlphaGradeEarned` value. Determine the real grade and correct it in
+  PowerSchool.
+
+The worklist CSV is PII-bearing (local student and section IDs) — same handling
+as the submission CSV: write it to `.claude/scratch/` (gitignored), never commit
+it, never paste row-level values anywhere external.
+
+After fixing a source record, the extract must be re-pulled and re-loaded before
+the gate reflects the fix — re-running the gate against the old extract will
+still show the same failures.
+
 ## Re-baselining per cycle
 
 Two constants in `validate_submission.py` are per-cycle baselines, not derivable
@@ -84,12 +139,15 @@ coverage), replace the literal dict values with the new counts, and update the
 | `submission_query.py`    | The SQL, the 25-column order, the legal grade domain |
 | `validate_submission.py` | The pre-upload gate; `--self-test` proves it fires   |
 | `build_submission.py`    | Creates the view, gates, exports per-region CSV      |
+| `export_worklist.py`     | Ungraded worklist, not gated — see above             |
 
 ## PII
 
-The exported CSVs carry names, dates of birth, and state IDs. Write them to
-`.claude/scratch/` (gitignored), hand them only to the state-access uploader,
-and never commit them or paste row-level values anywhere external.
+The exported submission CSVs carry names, dates of birth, and state IDs. The
+worklist CSVs carry local student and section IDs only, still PII. Write both
+kinds to `.claude/scratch/` (gitignored), hand the submission CSVs only to the
+state-access uploader, and never commit either or paste row-level values
+anywhere external.
 
 ## Unverified: CSV encoding, quoting, and line endings
 

--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -9,7 +9,15 @@ the design spec for the rationale and its four narrowing constraints.
 
 ## Cycle
 
-Run these three steps each time a fresh extract arrives.
+`cd` into this directory first. Every script imports its sibling modules by bare
+name (`from submission_query import ...`), so none of them resolve correctly run
+from anywhere else:
+
+```bash
+cd docs/superpowers/nj-sleds-roster/submission
+```
+
+Then run these three steps each time a fresh extract arrives.
 
 1. Reload the extract base tables into `cokafor` (existing reload script).
 1. Run the validation gate:
@@ -27,6 +35,48 @@ Run these three steps each time a fresh extract arrives.
 `build_submission.py` runs the gate itself and refuses to export on any failure,
 so step 2 is only for iterating.
 
+## The gate is red on arrival — this is expected
+
+As of the 2026-07-29 extract, two check groups fail and are expected to keep
+failing until someone acts on the source data:
+
+- `check_in_scope_rows_have_grades` reports **108** in-scope rows with no letter
+  grade (Newark HS 20, Newark MS 55, Camden HS 30, Camden MS 3).
+- `check_credits_earned` reports **`missing = 50`** — HS rows with no
+  `CreditsEarned`.
+
+Both describe the same underlying gap: for these rows, PowerSchool holds no
+usable `Y1` stored grade and no usable live final grade either, so this tool has
+nothing to fill in from. It is not a query bug, and there is no flag or override
+that makes it go away — the gate has no bypass, on purpose.
+
+**Required action:** someone with PowerSchool access must post the missing
+grades for those students and sections, or exclude the affected sections from
+the extract pull, then re-pull and reload the extract. Re-run the gate after the
+reload. If the residue drops to zero, `build_submission.py` will export; until
+then, seeing `FAILED` here is the tool working as designed, not a defect to
+chase.
+
+## Re-baselining per cycle
+
+Two constants in `validate_submission.py` are per-cycle baselines, not derivable
+truths, and must be re-measured by hand whenever a new extract is loaded:
+
+- `BASELINE_BAND_ROWS` — the `(region, grade_band)` row counts. Band composition
+  legitimately shifts between extract pulls, and the band logic is exactly what
+  this baseline cross-checks, so deriving it from the query itself would be
+  circular.
+- `BASELINE_STORED_COVERAGE` — the `(region, grade_band)` floor of rows with a
+  matched stored `Y1` grade. It is a floor, not an equality, but still needs
+  re-measuring so a real regression doesn't hide under a stale floor.
+
+To re-baseline: after reloading the extract, run the same `group by` queries the
+two check functions run against the new data
+(`select region, grade_band, count(*) ... group by region, grade_band` for the
+band counts; the `countif(stored_letter is not null)` variant for stored
+coverage), replace the literal dict values with the new counts, and update the
+"measured from" date comment above each constant.
+
 ## Files
 
 | File                     | Responsibility                                       |
@@ -40,6 +90,21 @@ so step 2 is only for iterating.
 The exported CSVs carry names, dates of birth, and state IDs. Write them to
 `.claude/scratch/` (gitignored), hand them only to the state-access uploader,
 and never commit them or paste row-level values anywhere external.
+
+## Unverified: CSV encoding, quoting, and line endings
+
+The export writes UTF-8 **without** a byte-order mark and with LF line endings —
+the defaults of `csv.writer` and `Path.open` on this platform. The existing
+reload scripts read the native PowerSchool extract files with `utf-8-sig`, which
+only makes sense if the native files carry a UTF-8 BOM. That implies the
+export's encoding may already differ from what NJSLEDS's own extract produces,
+and neither the BOM question nor CRLF-vs-LF has been confirmed against what the
+state's upload portal actually accepts.
+
+**This must be confirmed before the first real upload.** Compare a native
+extract file's encoding and line endings (for example `file` and a hex dump of
+its first few bytes) against one of these exported CSVs, and adjust the writer
+if they don't match.
 
 ## Known blocker outside this scope
 

--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -1,0 +1,49 @@
+# NJ SLEDS Student Course Roster — grade and credit backfill
+
+Fills `AlphaGradeEarned` and `CreditsEarned` on the loaded Student Course Roster
+extract and writes a submission-ready CSV per region. Every other column passes
+through byte-identical to the native PowerSchool extract.
+
+This is a named exception to the runbook's source-fix-only cleaning model — see
+the design spec for the rationale and its four narrowing constraints.
+
+## Cycle
+
+Run these three steps each time a fresh extract arrives.
+
+1. Reload the extract base tables into `cokafor` (existing reload script).
+1. Run the validation gate:
+
+   ```bash
+   uv run --with google-cloud-bigquery python validate_submission.py
+   ```
+
+1. Create the view and export:
+
+   ```bash
+   uv run --with google-cloud-bigquery python build_submission.py OUTDIR
+   ```
+
+`build_submission.py` runs the gate itself and refuses to export on any failure,
+so step 2 is only for iterating.
+
+## Files
+
+| File                     | Responsibility                                       |
+| ------------------------ | ---------------------------------------------------- |
+| `submission_query.py`    | The SQL, the 25-column order, the legal grade domain |
+| `validate_submission.py` | The pre-upload gate; `--self-test` proves it fires   |
+| `build_submission.py`    | Creates the view, gates, exports per-region CSV      |
+
+## PII
+
+The exported CSVs carry names, dates of birth, and state IDs. Write them to
+`.claude/scratch/` (gitignored), hand them only to the state-access uploader,
+and never commit them or paste row-level values anywhere external.
+
+## Known blocker outside this scope
+
+The CDS defect is still live: 20,652 of 43,493 rows carry a bad County or School
+code, including every Camden row. The fix is the one-pass School Setup change on
+3 Newark and 5 Camden schools. A clean grade backfill does not make the file
+submittable on its own.

--- a/docs/superpowers/nj-sleds-roster/submission/build_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/build_submission.py
@@ -4,6 +4,12 @@ Refuses to export if the validation gate reports any failure. Every value is
 written as the string the view produced - no numeric coercion, so 3-decimal
 credits and leading-zero CDS codes survive.
 
+Each region is staged under a temporary filename and only renamed to its
+final name once every region has exported successfully. This keeps a
+mid-run failure from leaving a freshly written file for one region sitting
+next to a stale file (from a previous run) for another, indistinguishable by
+name.
+
 Usage:
     uv run --with google-cloud-bigquery python build_submission.py OUTDIR
 """
@@ -14,7 +20,7 @@ from pathlib import Path
 
 from google.cloud import bigquery
 from submission_query import SUBMISSION_COLUMNS, SUBMISSION_SQL
-from validate_submission import run_checks
+from validate_submission import base_table_row_count, run_checks
 
 PROJECT = "teamster-332318"
 VIEW = "teamster-332318.cokafor.rpt_student_course_submission"
@@ -27,20 +33,41 @@ def create_view(client):
 
 
 def export_region(client, region, outdir):
+    """Query one region from the view and stage its CSV under a temp name.
+
+    Verifies the exported row count against the region's base table before
+    writing anything: the view's non-extract inputs
+    (stg_powerschool__students / storedgrades / pgfinalgrades) are
+    dbt-managed and refresh daily, so a row landing in the window between the
+    gate run and this export could fan the join out and silently write more
+    rows than the extract has. Returns (final_path, temp_path, row_count) so
+    the caller can rename every region's staged file only once all regions
+    have succeeded.
+    """
     cols = ", ".join(f"`{c}`" for c in SUBMISSION_COLUMNS)
     # trunk-ignore(bandit/B608): region is drawn from the local REGIONS constant, not user input
     sql = f"select {cols} from `{VIEW}` where region = '{region}'"
     rows = list(client.query(sql).result())
-    path = Path(outdir) / f"NJ_Student_Course_Submission_{region}.csv"
-    with path.open("w", newline="", encoding="utf-8") as fh:
+
+    expected = base_table_row_count(client, region)
+    if len(rows) != expected:
+        raise RuntimeError(
+            f"export row-count mismatch for {region}: exported {len(rows)} "
+            f"row(s), base table has {expected} row(s) (join fanned out "
+            "since the gate ran)"
+        )
+
+    final_path = Path(outdir) / f"NJ_Student_Course_Submission_{region}.csv"
+    temp_path = final_path.with_name(final_path.name + ".tmp")
+    with temp_path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh, quoting=csv.QUOTE_MINIMAL)
         writer.writerow(SUBMISSION_COLUMNS)
         for row in rows:
             writer.writerow(
                 ["" if row[c] is None else str(row[c]) for c in SUBMISSION_COLUMNS]
             )
-    print(f"  {region}: {len(rows)} rows -> {path}")
-    return len(rows)
+    print(f"  {region}: {len(rows)} rows -> {temp_path} (staged)")
+    return final_path, temp_path, len(rows)
 
 
 def main():
@@ -62,7 +89,20 @@ def main():
     print("gate passed")
 
     create_view(client)
-    total = sum(export_region(client, r, outdir) for r in REGIONS)
+
+    staged = []
+    try:
+        for region in REGIONS:
+            staged.append(export_region(client, region, outdir))
+    except RuntimeError as e:
+        print(f"EXPORT ABORTED: {e}")
+        for _, temp_path, _ in staged:
+            temp_path.unlink(missing_ok=True)
+        return 1
+
+    for final_path, temp_path, _ in staged:
+        temp_path.rename(final_path)
+    total = sum(count for _, _, count in staged)
     print(f"exported {total} rows across {len(REGIONS)} region(s)")
     return 0
 

--- a/docs/superpowers/nj-sleds-roster/submission/build_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/build_submission.py
@@ -1,0 +1,71 @@
+"""Create the NJ SLEDS submission view and export one CSV per region.
+
+Refuses to export if the validation gate reports any failure. Every value is
+written as the string the view produced - no numeric coercion, so 3-decimal
+credits and leading-zero CDS codes survive.
+
+Usage:
+    uv run --with google-cloud-bigquery python build_submission.py OUTDIR
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+from google.cloud import bigquery
+from submission_query import SUBMISSION_COLUMNS, SUBMISSION_SQL
+from validate_submission import run_checks
+
+PROJECT = "teamster-332318"
+VIEW = "teamster-332318.cokafor.rpt_student_course_submission"
+REGIONS = ("newark", "camden")
+
+
+def create_view(client):
+    client.query(f"create or replace view `{VIEW}` as {SUBMISSION_SQL}").result()
+    print(f"view created: {VIEW}")
+
+
+def export_region(client, region, outdir):
+    cols = ", ".join(f"`{c}`" for c in SUBMISSION_COLUMNS)
+    # trunk-ignore(bandit/B608): region is drawn from the local REGIONS constant, not user input
+    sql = f"select {cols} from `{VIEW}` where region = '{region}'"
+    rows = list(client.query(sql).result())
+    path = Path(outdir) / f"NJ_Student_Course_Submission_{region}.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(SUBMISSION_COLUMNS)
+        for row in rows:
+            writer.writerow(
+                ["" if row[c] is None else str(row[c]) for c in SUBMISSION_COLUMNS]
+            )
+    print(f"  {region}: {len(rows)} rows -> {path}")
+    return len(rows)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    client = bigquery.Client(project=PROJECT)
+
+    print("running validation gate...")
+    failures = run_checks(client)
+    if failures:
+        print(f"GATE FAILED ({len(failures)} issue(s)) - refusing to export:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("gate passed")
+
+    create_view(client)
+    total = sum(export_region(client, r, outdir) for r in REGIONS)
+    print(f"exported {total} rows across {len(REGIONS)} region(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/nj-sleds-roster/submission/export_worklist.py
+++ b/docs/superpowers/nj-sleds-roster/submission/export_worklist.py
@@ -1,0 +1,74 @@
+"""Create the NJ SLEDS ungraded-worklist view and export one CSV per region.
+
+Deliberately NOT gated on validate_submission.run_checks. The worklist is the
+tool used to resolve the rows that make the gate fail (no usable grade in
+either source, conflicting grades, or an out-of-domain grade) - gating this
+script on the gate passing would be circular: it would only become available
+once it was no longer needed. Run it regardless of the gate's state.
+
+Every value is written as the string the view produced - no numeric
+coercion - with None becoming an empty field, matching build_submission.py.
+
+Usage:
+    uv run --with google-cloud-bigquery python export_worklist.py OUTDIR
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+from google.cloud import bigquery
+from submission_query import UNGRADED_WORKLIST_COLUMNS, UNGRADED_WORKLIST_SQL
+
+PROJECT = "teamster-332318"
+VIEW = "teamster-332318.cokafor.rpt_student_course_ungraded"
+REGIONS = ("newark", "camden")
+
+
+def create_view(client):
+    client.query(f"create or replace view `{VIEW}` as {UNGRADED_WORKLIST_SQL}").result()
+    print(f"view created: {VIEW}")
+
+
+def export_region(client, region, outdir):
+    """Query one region from the view and write its worklist CSV."""
+    cols = ", ".join(f"`{c}`" for c in UNGRADED_WORKLIST_COLUMNS)
+    # trunk-ignore(bandit/B608): region is drawn from the local REGIONS constant, not user input
+    sql = f"select {cols} from `{VIEW}` where region = '{region}'"
+    rows = list(client.query(sql).result())
+
+    final_path = Path(outdir) / f"NJ_Student_Course_Ungraded_{region}.csv"
+    with final_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(UNGRADED_WORKLIST_COLUMNS)
+        for row in rows:
+            writer.writerow(
+                [
+                    "" if row[c] is None else str(row[c])
+                    for c in UNGRADED_WORKLIST_COLUMNS
+                ]
+            )
+    print(f"  {region}: {len(rows)} rows -> {final_path}")
+    return len(rows)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    client = bigquery.Client(project=PROJECT)
+
+    create_view(client)
+
+    total = 0
+    for region in REGIONS:
+        total += export_region(client, region, outdir)
+    print(f"exported {total} rows across {len(REGIONS)} region(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -95,6 +95,37 @@ with
         group by _dbt_source_project, studentid_str, sectionid_str
     ),
 
+    live_raw as (
+        select
+            _dbt_source_project,
+            `grade`,
+            enddate,
+
+            cast(studentid as string) as studentid_str,
+            cast(sectionid as string) as sectionid_str,
+            max(enddate) over (
+                partition by _dbt_source_project, studentid, sectionid
+            ) as max_enddate,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__pgfinalgrades`
+        where
+            enddate between date '2025-07-01' and date '2026-06-30'
+            and `grade` is not null
+            and _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+
+    live as (
+        select
+            _dbt_source_project,
+            studentid_str,
+            sectionid_str,
+
+            max(`grade`) as live_letter,
+            count(distinct `grade`) as n_live_letters,
+        from live_raw
+        where enddate = max_enddate
+        group by _dbt_source_project, studentid_str, sectionid_str
+    ),
+
     students as (
         select
             _dbt_source_project,
@@ -114,6 +145,8 @@ with
             sg.stored_earned_credit,
             sg.n_stored_letters,
             sg.n_stored_credits,
+            lg.live_letter,
+            lg.n_live_letters,
 
             'newark' as region,
         from `teamster-332318.cokafor.stg_student_extract_newark` as e
@@ -127,6 +160,10 @@ with
             on st.studentid_str = sg.studentid_str
             and e.LocalSectionCode = sg.sectionid_str
             and sg._dbt_source_project = 'kippnewark'
+        left join live as lg
+            on st.studentid_str = lg.studentid_str
+            and e.LocalSectionCode = lg.sectionid_str
+            and lg._dbt_source_project = 'kippnewark'
     ),
 
     camden_joined as (
@@ -138,6 +175,8 @@ with
             sg.stored_earned_credit,
             sg.n_stored_letters,
             sg.n_stored_credits,
+            lg.live_letter,
+            lg.n_live_letters,
 
             'camden' as region,
         from `teamster-332318.cokafor.stg_student_extract_camden` as e
@@ -151,6 +190,10 @@ with
             on st.studentid_str = sg.studentid_str
             and e.LocalSectionCode = sg.sectionid_str
             and sg._dbt_source_project = 'kippcamden'
+        left join live as lg
+            on st.studentid_str = lg.studentid_str
+            and e.LocalSectionCode = lg.sectionid_str
+            and lg._dbt_source_project = 'kippcamden'
     ),
 
     joined as (
@@ -181,7 +224,7 @@ with
         select
             *,
 
-            substr(grade_span_padded, 3, 2) as grade_span_upper,
+            substr(grade_span_padded, 1, 2) as grade_span_start,
         from typed
     ),
 
@@ -193,12 +236,39 @@ with
                 when sced_level = 'secondary' and available_credit_num > 0
                 then 'HS'
                 when
-                    grade_span_upper
+                    grade_span_start
                     in ('06', '07', '08', '09', '10', '11', '12')
                 then 'MS'
                 else 'OUT'
             end as grade_band,
         from banded
+    ),
+
+    conflict_guarded as (
+        select
+            *,
+
+            if(n_stored_letters > 1, null, stored_letter) as safe_stored,
+            if(n_live_letters > 1, null, live_letter) as safe_live,
+            if(
+                n_stored_letters > 1 or n_stored_credits > 1,
+                null,
+                stored_earned_credit
+            ) as safe_stored_credit,
+        from scoped
+    ),
+
+    sourced as (
+        select
+            *,
+
+            coalesce(safe_stored, safe_live) as candidate_letter,
+            case
+                when safe_stored is not null then 'stored'
+                when safe_live is not null then 'live'
+                else 'none'
+            end as grade_source,
+        from conflict_guarded
     )
 
 select
@@ -233,5 +303,9 @@ select
     stored_earned_credit,
     n_stored_letters,
     n_stored_credits,
-from scoped
+    live_letter,
+    n_live_letters,
+    candidate_letter,
+    grade_source,
+from sourced
 """

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -369,3 +369,102 @@ select
     grade_source,
 from emitted_credit
 """
+
+# The worklist identifies rows by local IDs only (LocalIdentificationNumber,
+# LocalSectionCode) - never FirstName, LastName, DateOfBirth, or
+# StateIdentificationNumber, per the project's worklist PII convention.
+# LocalIdentificationNumber is enough to find the student in PowerSchool.
+UNGRADED_WORKLIST_COLUMNS = [
+    "region",
+    "grade_band",
+    "LocalIdentificationNumber",
+    "LocalSectionCode",
+    "LocalCourseCode",
+    "LocalCourseTitle",
+    "SubjectArea",
+    "CourseIdentifier",
+    "CourseLevel",
+    "GradeSpan",
+    "AvailableCredit",
+    "SectionEntryDate",
+    "SectionExitDate",
+    "CourseType",
+    "ungraded_rows",
+    "section_rows",
+    "reason",
+    "section_shape",
+]
+
+# trunk-ignore(bandit/B608): SUBMISSION_SQL is a module constant, not user input
+UNGRADED_WORKLIST_SQL = f"""
+with
+    v as ({SUBMISSION_SQL}),
+
+    in_scope as (
+        select * from v where grade_band in ('HS', 'MS')
+    ),
+
+    section_totals as (
+        select
+            region,
+            LocalSectionCode,
+
+            count(*) as section_rows,
+        from in_scope
+        group by region, LocalSectionCode
+    ),
+
+    ungraded as (
+        select * from in_scope where AlphaGradeEarned is null
+    ),
+
+    ungraded_by_section as (
+        select
+            region,
+            LocalSectionCode,
+
+            count(*) as ungraded_rows,
+        from ungraded
+        group by region, LocalSectionCode
+    )
+
+select
+    u.region,
+    u.grade_band,
+    u.LocalIdentificationNumber,
+    u.LocalSectionCode,
+    u.LocalCourseCode,
+    u.LocalCourseTitle,
+    u.SubjectArea,
+    u.CourseIdentifier,
+    u.CourseLevel,
+    u.GradeSpan,
+    u.AvailableCredit,
+    u.SectionEntryDate,
+    u.SectionExitDate,
+    u.CourseType,
+
+    ubs.ungraded_rows,
+
+    st.section_rows,
+
+    case
+        when u.candidate_letter is not null
+        then 'grade exists but outside the handbook domain'
+        when u.n_stored_letters > 1 or u.n_live_letters > 1
+        then 'conflicting grades across sources or terms'
+        else 'no grade in either source'
+    end as reason,
+    case
+        when ubs.ungraded_rows = st.section_rows
+        then 'whole section ungraded'
+        else 'partial - classmates were graded'
+    end as section_shape,
+from ungraded as u
+inner join ungraded_by_section as ubs
+    on u.region = ubs.region
+    and u.LocalSectionCode = ubs.LocalSectionCode
+inner join section_totals as st
+    on u.region = st.region
+    and u.LocalSectionCode = st.LocalSectionCode
+"""

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -269,6 +269,41 @@ with
                 else 'none'
             end as grade_source,
         from conflict_guarded
+    ),
+
+    emitted_grade as (
+        select
+            *,
+
+            if(
+                grade_band in ('HS', 'MS')
+                and candidate_letter in (
+                    'A', 'A+', 'A-', 'B', 'B+', 'B-',
+                    'C', 'C+', 'C-', 'D', 'D+', 'D-',
+                    'E', 'E+', 'E-', 'F', 'F+', 'F-'
+                ),
+                candidate_letter,
+                cast(null as string)
+            ) as emitted_alpha_grade,
+        from sourced
+    ),
+
+    emitted_credit as (
+        select
+            *,
+
+            case
+                when grade_band != 'HS'
+                then cast(null as string)
+                when safe_stored_credit is not null
+                then format('%.3f', safe_stored_credit)
+                when emitted_alpha_grade is null
+                then cast(null as string)
+                when emitted_alpha_grade like 'F%'
+                then '0.000'
+                else format('%.3f', available_credit_num)
+            end as emitted_credits_earned,
+        from emitted_grade
     )
 
 select
@@ -291,9 +326,9 @@ select
     LocalCourseTitle,
     LocalCourseCode,
     LocalSectionCode,
-    CreditsEarned,
+    emitted_credits_earned as CreditsEarned,
     NumericGradeEarned,
-    AlphaGradeEarned,
+    emitted_alpha_grade as AlphaGradeEarned,
     CompletionStatus,
     CourseType,
     DualInstitution,
@@ -307,5 +342,5 @@ select
     n_live_letters,
     candidate_letter,
     grade_source,
-from sourced
+from emitted_credit
 """

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -1,0 +1,172 @@
+"""SQL and constants for the NJ SLEDS student course submission view.
+
+SUBMISSION_SQL is a bare SELECT with no trailing semicolon so it can be used
+as a subquery by the validator or wrapped in CREATE OR REPLACE VIEW by the
+builder.
+"""
+
+SUBMISSION_COLUMNS = [
+    "LocalIdentificationNumber",
+    "StateIdentificationNumber",
+    "FirstName",
+    "LastName",
+    "DateOfBirth",
+    "CountyCodeAssigned",
+    "DistrictCodeAssigned",
+    "SchoolCodeAssigned",
+    "SectionEntryDate",
+    "SectionExitDate",
+    "SubjectArea",
+    "CourseIdentifier",
+    "CourseLevel",
+    "GradeSpan",
+    "AvailableCredit",
+    "CourseSequence",
+    "LocalCourseTitle",
+    "LocalCourseCode",
+    "LocalSectionCode",
+    "CreditsEarned",
+    "NumericGradeEarned",
+    "AlphaGradeEarned",
+    "CompletionStatus",
+    "CourseType",
+    "DualInstitution",
+]
+
+ALPHA_GRADE_DOMAIN = frozenset(
+    {
+        "A",
+        "A+",
+        "A-",
+        "B",
+        "B+",
+        "B-",
+        "C",
+        "C+",
+        "C-",
+        "D",
+        "D+",
+        "D-",
+        "E",
+        "E+",
+        "E-",
+        "F",
+        "F+",
+        "F-",
+    }
+)
+
+SUBMISSION_SQL = """
+with
+    sced as (
+        select
+            subject_area,
+            course_identifier,
+            sced_level,
+        from `teamster-332318.cokafor.ref_sced_codes`
+    ),
+
+    newark_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+
+            'newark' as region,
+        from `teamster-332318.cokafor.stg_student_extract_newark` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+    ),
+
+    camden_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+
+            'camden' as region,
+        from `teamster-332318.cokafor.stg_student_extract_camden` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+    ),
+
+    joined as (
+        select * from newark_joined
+        union all
+        select * from camden_joined
+    ),
+
+    normalized as (
+        select
+            *,
+
+            nullif(GradeSpan, '') as grade_span_raw,
+            nullif(AvailableCredit, '') as available_credit_raw,
+        from joined
+    ),
+
+    typed as (
+        select
+            *,
+
+            lpad(grade_span_raw, 4, '0') as grade_span_padded,
+            safe_cast(available_credit_raw as float64) as available_credit_num,
+        from normalized
+    ),
+
+    banded as (
+        select
+            *,
+
+            substr(grade_span_padded, 3, 2) as grade_span_upper,
+        from typed
+    ),
+
+    scoped as (
+        select
+            *,
+
+            case
+                when sced_level = 'secondary' and available_credit_num > 0
+                then 'HS'
+                when
+                    grade_span_upper
+                    in ('06', '07', '08', '09', '10', '11', '12')
+                then 'MS'
+                else 'OUT'
+            end as grade_band,
+        from banded
+    )
+
+select
+    LocalIdentificationNumber,
+    StateIdentificationNumber,
+    FirstName,
+    LastName,
+    DateOfBirth,
+    CountyCodeAssigned,
+    DistrictCodeAssigned,
+    SchoolCodeAssigned,
+    SectionEntryDate,
+    SectionExitDate,
+    SubjectArea,
+    CourseIdentifier,
+    CourseLevel,
+    GradeSpan,
+    AvailableCredit,
+    CourseSequence,
+    LocalCourseTitle,
+    LocalCourseCode,
+    LocalSectionCode,
+    CreditsEarned,
+    NumericGradeEarned,
+    AlphaGradeEarned,
+    CompletionStatus,
+    CourseType,
+    DualInstitution,
+    region,
+    grade_band,
+from scoped
+"""

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -66,17 +66,65 @@ with
         from `teamster-332318.cokafor.ref_sced_codes`
     ),
 
+    stored_raw as (
+        select
+            _dbt_source_project,
+            `grade`,
+            earnedcrhrs,
+
+            cast(studentid as string) as studentid_str,
+            cast(sectionid as string) as sectionid_str,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__storedgrades`
+        where
+            academic_year = 2025
+            and storecode = 'Y1'
+            and _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+
+    stored as (
+        select
+            _dbt_source_project,
+            studentid_str,
+            sectionid_str,
+
+            max(`grade`) as stored_letter,
+            max(earnedcrhrs) as stored_earned_credit,
+            count(distinct `grade`) as n_stored_letters,
+        from stored_raw
+        group by _dbt_source_project, studentid_str, sectionid_str
+    ),
+
+    students as (
+        select
+            _dbt_source_project,
+
+            cast(student_number as string) as student_number_str,
+            cast(id as string) as studentid_str,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__students`
+        where _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+
     newark_joined as (
         select
             e.*,
 
             sc.sced_level,
+            sg.stored_letter,
+            sg.stored_earned_credit,
+            sg.n_stored_letters,
 
             'newark' as region,
         from `teamster-332318.cokafor.stg_student_extract_newark` as e
         left join sced as sc
             on e.SubjectArea = sc.subject_area
             and e.CourseIdentifier = sc.course_identifier
+        left join students as st
+            on e.LocalIdentificationNumber = st.student_number_str
+            and st._dbt_source_project = 'kippnewark'
+        left join stored as sg
+            on st.studentid_str = sg.studentid_str
+            and e.LocalSectionCode = sg.sectionid_str
+            and sg._dbt_source_project = 'kippnewark'
     ),
 
     camden_joined as (
@@ -84,12 +132,22 @@ with
             e.*,
 
             sc.sced_level,
+            sg.stored_letter,
+            sg.stored_earned_credit,
+            sg.n_stored_letters,
 
             'camden' as region,
         from `teamster-332318.cokafor.stg_student_extract_camden` as e
         left join sced as sc
             on e.SubjectArea = sc.subject_area
             and e.CourseIdentifier = sc.course_identifier
+        left join students as st
+            on e.LocalIdentificationNumber = st.student_number_str
+            and st._dbt_source_project = 'kippcamden'
+        left join stored as sg
+            on st.studentid_str = sg.studentid_str
+            and e.LocalSectionCode = sg.sectionid_str
+            and sg._dbt_source_project = 'kippcamden'
     ),
 
     joined as (
@@ -168,5 +226,8 @@ select
     DualInstitution,
     region,
     grade_band,
+    stored_letter,
+    stored_earned_credit,
+    n_stored_letters,
 from scoped
 """

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -90,6 +90,7 @@ with
             max(`grade`) as stored_letter,
             max(earnedcrhrs) as stored_earned_credit,
             count(distinct `grade`) as n_stored_letters,
+            count(distinct earnedcrhrs) as n_stored_credits,
         from stored_raw
         group by _dbt_source_project, studentid_str, sectionid_str
     ),
@@ -112,6 +113,7 @@ with
             sg.stored_letter,
             sg.stored_earned_credit,
             sg.n_stored_letters,
+            sg.n_stored_credits,
 
             'newark' as region,
         from `teamster-332318.cokafor.stg_student_extract_newark` as e
@@ -135,6 +137,7 @@ with
             sg.stored_letter,
             sg.stored_earned_credit,
             sg.n_stored_letters,
+            sg.n_stored_credits,
 
             'camden' as region,
         from `teamster-332318.cokafor.stg_student_extract_camden` as e
@@ -229,5 +232,6 @@ select
     stored_letter,
     stored_earned_credit,
     n_stored_letters,
+    n_stored_credits,
 from scoped
 """

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -56,7 +56,36 @@ ALPHA_GRADE_DOMAIN = frozenset(
     }
 )
 
-SUBMISSION_SQL = """
+# The passing subset of ALPHA_GRADE_DOMAIN ("D-" or better, per the design
+# spec). Named explicitly rather than derived by excluding the failing
+# grades, so both lists stay independently reviewable. Must remain a subset
+# of ALPHA_GRADE_DOMAIN.
+PASSING_ALPHA_GRADES = frozenset(
+    {
+        "A",
+        "A+",
+        "A-",
+        "B",
+        "B+",
+        "B-",
+        "C",
+        "C+",
+        "C-",
+        "D",
+        "D+",
+        "D-",
+    }
+)
+
+# Sorted, comma-joined SQL literal lists built from the constants above, so
+# the Python domain and the SQL `in (...)` domain can never drift apart.
+# sorted() on these codes happens to match the conventional A, A+, A- order,
+# since '+' sorts before '-' and a bare letter is a prefix of both.
+_ALPHA_GRADE_DOMAIN_SQL = ", ".join(f"'{g}'" for g in sorted(ALPHA_GRADE_DOMAIN))
+_PASSING_ALPHA_GRADES_SQL = ", ".join(f"'{g}'" for g in sorted(PASSING_ALPHA_GRADES))
+
+# trunk-ignore(bandit/B608): grade domain values are module constants, not user input
+SUBMISSION_SQL = f"""
 with
     sced as (
         select
@@ -277,11 +306,7 @@ with
 
             if(
                 grade_band in ('HS', 'MS')
-                and candidate_letter in (
-                    'A', 'A+', 'A-', 'B', 'B+', 'B-',
-                    'C', 'C+', 'C-', 'D', 'D+', 'D-',
-                    'E', 'E+', 'E-', 'F', 'F+', 'F-'
-                ),
+                and candidate_letter in ({_ALPHA_GRADE_DOMAIN_SQL}),
                 candidate_letter,
                 cast(null as string)
             ) as emitted_alpha_grade,
@@ -299,9 +324,9 @@ with
                 then format('%.3f', safe_stored_credit)
                 when emitted_alpha_grade is null
                 then cast(null as string)
-                when emitted_alpha_grade like 'F%'
-                then '0.000'
-                else format('%.3f', available_credit_num)
+                when emitted_alpha_grade in ({_PASSING_ALPHA_GRADES_SQL})
+                then format('%.3f', available_credit_num)
+                else '0.000'
             end as emitted_credits_earned,
         from emitted_grade
     )

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -7,7 +7,7 @@ only - never row-level values, which are PII.
 import sys
 
 from google.cloud import bigquery
-from submission_query import SUBMISSION_SQL
+from submission_query import ALPHA_GRADE_DOMAIN, SUBMISSION_SQL
 
 PROJECT = "teamster-332318"
 
@@ -156,6 +156,88 @@ def check_live_fills_only_gaps(client):
     return []
 
 
+def check_alpha_grade_domain(client):
+    """Every emitted letter grade is one of the 18 legal handbook values."""
+    domain = ", ".join(f"'{g}'" for g in sorted(ALPHA_GRADE_DOMAIN))
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where AlphaGradeEarned is not null
+      and AlphaGradeEarned not in ({domain})
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) carry an out-of-domain AlphaGradeEarned"]
+    return []
+
+
+def check_in_scope_rows_have_grades(client):
+    """No in-scope row is left without a letter grade."""
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select region, grade_band, count(*) as n
+    from ({SUBMISSION_SQL})
+    where grade_band in ('HS', 'MS') and AlphaGradeEarned is null
+    group by region, grade_band
+    """
+    return [
+        f"{r.n} in-scope row(s) in {r.region}/{r.grade_band} have no grade"
+        for r in _rows(client, sql)
+    ]
+
+
+def check_out_of_scope_rows_blank(client):
+    """Out-of-scope rows carry no grade and no credit. Scope-boundary guard."""
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where grade_band = 'OUT'
+      and (AlphaGradeEarned is not null or CreditsEarned is not null)
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} out-of-scope row(s) were given a grade or credit"]
+    return []
+
+
+def check_credits_earned(client):
+    """CreditsEarned is present, 3-decimal, in range, and within available."""
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select
+        countif(grade_band = 'HS' and CreditsEarned is null) as missing,
+        countif(
+            CreditsEarned is not null
+            and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
+        ) as malformed,
+        countif(
+            CreditsEarned is not null
+            and safe_cast(CreditsEarned as float64) not between 0.0 and 35.0
+        ) as out_of_range,
+        countif(
+            CreditsEarned is not null
+            and safe_cast(CreditsEarned as float64)
+                > safe_cast(nullif(AvailableCredit, '') as float64)
+        ) as over_available
+    from ({SUBMISSION_SQL})
+    """
+    r = _rows(client, sql)[0]
+    failures = []
+    if r.missing:
+        failures.append(f"{r.missing} HS row(s) missing CreditsEarned")
+    if r.malformed:
+        failures.append(f"{r.malformed} row(s) CreditsEarned not 3-decimal formatted")
+    if r.out_of_range:
+        failures.append(f"{r.out_of_range} row(s) CreditsEarned outside 0.000-35.000")
+    if r.over_available:
+        failures.append(
+            f"{r.over_available} row(s) CreditsEarned exceeds AvailableCredit"
+        )
+    return failures
+
+
 CHECKS = [
     check_row_parity,
     check_band_counts,
@@ -163,6 +245,10 @@ CHECKS = [
     check_no_stored_conflicts,
     check_no_live_conflicts,
     check_live_fills_only_gaps,
+    check_alpha_grade_domain,
+    check_in_scope_rows_have_grades,
+    check_out_of_scope_rows_blank,
+    check_credits_earned,
 ]
 
 

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -26,16 +26,16 @@ def _rows(client, sql):
     return list(client.query(sql).result())
 
 
-def check_row_parity(client):
+def check_row_parity(client, sql=SUBMISSION_SQL):
     """Every extract row appears exactly once. No fan-out, no loss."""
     failures = []
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select region, count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     group by region
     """
-    actual = {r.region: r.n for r in _rows(client, sql)}
+    actual = {r.region: r.n for r in _rows(client, sql_text)}
     for region, expected in EXPECTED_EXTRACT_ROWS.items():
         got = actual.get(region, 0)
         if got != expected:
@@ -43,16 +43,16 @@ def check_row_parity(client):
     return failures
 
 
-def check_band_counts(client):
+def check_band_counts(client, sql=SUBMISSION_SQL):
     """Band classification matches the spec exactly."""
     failures = []
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select region, grade_band, count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     group by region, grade_band
     """
-    actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql)}
+    actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql_text)}
     for key, expected in EXPECTED_BAND_ROWS.items():
         got = actual.get(key, 0)
         if got != expected:
@@ -70,20 +70,20 @@ EXPECTED_STORED_COVERAGE = {
 }
 
 
-def check_stored_coverage(client):
+def check_stored_coverage(client, sql=SUBMISSION_SQL):
     """Stored Y1 grades cover the in-scope bands at the measured rate.
 
     Counts are a floor, not an equality: a re-pulled extract may match more
     rows. A drop signals a broken join.
     """
     failures = []
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select region, grade_band, countif(stored_letter is not null) as matched
-    from ({SUBMISSION_SQL})
+    from ({sql})
     group by region, grade_band
     """
-    actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql)}
+    actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql_text)}
     for key, floor in EXPECTED_STORED_COVERAGE.items():
         got = actual.get(key, 0)
         if got < floor:
@@ -94,17 +94,17 @@ def check_stored_coverage(client):
     return failures
 
 
-def check_no_stored_conflicts(client):
+def check_no_stored_conflicts(client, sql=SUBMISSION_SQL):
     """No student-section carries two different stored Y1 letters or credits."""
     failures = []
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select
         countif(n_stored_letters > 1) as letter_conflicts,
         countif(n_stored_credits > 1) as credit_conflicts
-    from ({SUBMISSION_SQL})
+    from ({sql})
     """
-    row = _rows(client, sql)[0]
+    row = _rows(client, sql_text)[0]
     if row.letter_conflicts:
         failures.append(
             f"{row.letter_conflicts} row(s) have conflicting stored Y1 letter grades"
@@ -116,7 +116,7 @@ def check_no_stored_conflicts(client):
     return failures
 
 
-def check_no_live_conflicts(client):
+def check_no_live_conflicts(client, sql=SUBMISSION_SQL):
     """A conflicted live grade is never emitted as the resolved value.
 
     Live reporting terms legitimately disagree on tens of thousands of rows -
@@ -126,86 +126,86 @@ def check_no_live_conflicts(client):
     must null the value rather than pick one, so grade_source can never be
     'live' on a conflicted row.
     """
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     where n_live_letters > 1 and grade_source = 'live'
     """
-    n = _rows(client, sql)[0].n
+    n = _rows(client, sql_text)[0].n
     if n:
         return [f"{n} row(s) emitted a conflicted live grade"]
     return []
 
 
-def check_live_fills_only_gaps(client):
+def check_live_fills_only_gaps(client, sql=SUBMISSION_SQL):
     """Live grades never override a stored grade."""
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     where
         stored_letter is not null
         and live_letter is not null
         and stored_letter != live_letter
         and grade_source = 'live'
     """
-    n = _rows(client, sql)[0].n
+    n = _rows(client, sql_text)[0].n
     if n:
         return [f"{n} row(s) took a live grade over a stored grade"]
     return []
 
 
-def check_alpha_grade_domain(client):
+def check_alpha_grade_domain(client, sql=SUBMISSION_SQL):
     """Every emitted letter grade is one of the 18 legal handbook values."""
     domain = ", ".join(f"'{g}'" for g in sorted(ALPHA_GRADE_DOMAIN))
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     where AlphaGradeEarned is not null
       and AlphaGradeEarned not in ({domain})
     """
-    n = _rows(client, sql)[0].n
+    n = _rows(client, sql_text)[0].n
     if n:
         return [f"{n} row(s) carry an out-of-domain AlphaGradeEarned"]
     return []
 
 
-def check_in_scope_rows_have_grades(client):
+def check_in_scope_rows_have_grades(client, sql=SUBMISSION_SQL):
     """No in-scope row is left without a letter grade."""
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select region, grade_band, count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     where grade_band in ('HS', 'MS') and AlphaGradeEarned is null
     group by region, grade_band
     """
     return [
         f"{r.n} in-scope row(s) in {r.region}/{r.grade_band} have no grade"
-        for r in _rows(client, sql)
+        for r in _rows(client, sql_text)
     ]
 
 
-def check_out_of_scope_rows_blank(client):
+def check_out_of_scope_rows_blank(client, sql=SUBMISSION_SQL):
     """Out-of-scope rows carry no grade and no credit. Scope-boundary guard."""
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select count(*) as n
-    from ({SUBMISSION_SQL})
+    from ({sql})
     where grade_band = 'OUT'
       and (AlphaGradeEarned is not null or CreditsEarned is not null)
     """
-    n = _rows(client, sql)[0].n
+    n = _rows(client, sql_text)[0].n
     if n:
         return [f"{n} out-of-scope row(s) were given a grade or credit"]
     return []
 
 
-def check_credits_earned(client):
+def check_credits_earned(client, sql=SUBMISSION_SQL):
     """CreditsEarned is present, 3-decimal, in range, and within available."""
-    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
-    sql = f"""
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    sql_text = f"""
     select
         countif(grade_band = 'HS' and CreditsEarned is null) as missing,
         countif(
@@ -221,9 +221,9 @@ def check_credits_earned(client):
             and safe_cast(CreditsEarned as float64)
                 > safe_cast(nullif(AvailableCredit, '') as float64)
         ) as over_available
-    from ({SUBMISSION_SQL})
+    from ({sql})
     """
-    r = _rows(client, sql)[0]
+    r = _rows(client, sql_text)[0]
     failures = []
     if r.missing:
         failures.append(f"{r.missing} HS row(s) missing CreditsEarned")
@@ -260,41 +260,34 @@ def run_checks(client):
 
 
 def self_test(client):
-    """Prove each check group fires. Mutates SQL in memory only."""
+    """Prove the real checks fire on injected defects. Mutates SQL in memory.
+
+    Each block calls the ACTUAL check function against the mutated SQL, so
+    deleting a check from CHECKS, widening its domain, or weakening its
+    predicate makes this self-test fail. A self-test that re-implements the
+    check's own predicate would keep passing with the check removed, which is
+    worse than no self-test at all - it manufactures false confidence.
+    """
     failures = []
 
-    # An out-of-domain grade must be caught by the domain check.
+    # An out-of-domain grade must be caught by check_alpha_grade_domain.
     bad_domain = SUBMISSION_SQL.replace(
         "candidate_letter,\n                cast(null as string)",
         "'F*',\n                cast(null as string)",
     )
     if bad_domain == SUBMISSION_SQL:
         failures.append("self-test could not inject a bad grade domain")
-    else:
-        # trunk-ignore(bandit/B608): bad_domain is a local in-memory mutation, not user input
-        sql = f"""
-        select count(*) as n
-        from ({bad_domain})
-        where AlphaGradeEarned is not null
-          and AlphaGradeEarned not in ('A', 'B', 'C', 'D', 'F')
-        """
-        if _rows(client, sql)[0].n == 0:
-            failures.append("domain check would not have caught 'F*'")
+    elif not check_alpha_grade_domain(client, sql=bad_domain):
+        failures.append("check_alpha_grade_domain missed an 'F*' grade")
 
-    # A 1-decimal credit must be caught by the format check.
+    # A 1-decimal credit must be caught by check_credits_earned.
     bad_format = SUBMISSION_SQL.replace("format('%.3f'", "format('%.1f'")
     if bad_format == SUBMISSION_SQL:
         failures.append("self-test could not inject a bad credit format")
-    else:
-        # trunk-ignore(bandit/B608): bad_format is a local in-memory mutation, not user input
-        sql = f"""
-        select count(*) as n
-        from ({bad_format})
-        where CreditsEarned is not null
-          and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
-        """
-        if _rows(client, sql)[0].n == 0:
-            failures.append("format check would not have caught 1 decimal")
+    elif not any(
+        "3-decimal" in f for f in check_credits_earned(client, sql=bad_format)
+    ):
+        failures.append("check_credits_earned missed a 1-decimal credit")
 
     return failures
 

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -259,8 +259,57 @@ def run_checks(client):
     return failures
 
 
+def self_test(client):
+    """Prove each check group fires. Mutates SQL in memory only."""
+    failures = []
+
+    # An out-of-domain grade must be caught by the domain check.
+    bad_domain = SUBMISSION_SQL.replace(
+        "candidate_letter,\n                cast(null as string)",
+        "'F*',\n                cast(null as string)",
+    )
+    if bad_domain == SUBMISSION_SQL:
+        failures.append("self-test could not inject a bad grade domain")
+    else:
+        # trunk-ignore(bandit/B608): bad_domain is a local in-memory mutation, not user input
+        sql = f"""
+        select count(*) as n
+        from ({bad_domain})
+        where AlphaGradeEarned is not null
+          and AlphaGradeEarned not in ('A', 'B', 'C', 'D', 'F')
+        """
+        if _rows(client, sql)[0].n == 0:
+            failures.append("domain check would not have caught 'F*'")
+
+    # A 1-decimal credit must be caught by the format check.
+    bad_format = SUBMISSION_SQL.replace("format('%.3f'", "format('%.1f'")
+    if bad_format == SUBMISSION_SQL:
+        failures.append("self-test could not inject a bad credit format")
+    else:
+        # trunk-ignore(bandit/B608): bad_format is a local in-memory mutation, not user input
+        sql = f"""
+        select count(*) as n
+        from ({bad_format})
+        where CreditsEarned is not null
+          and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
+        """
+        if _rows(client, sql)[0].n == 0:
+            failures.append("format check would not have caught 1 decimal")
+
+    return failures
+
+
 def main():
     client = bigquery.Client(project=PROJECT)
+    if "--self-test" in sys.argv:
+        failures = self_test(client)
+        if failures:
+            print(f"SELF-TEST FAILED ({len(failures)}):")
+            for f in failures:
+                print(f"  - {f}")
+            return 1
+        print("SELF-TEST PASSED")
+        return 0
     failures = run_checks(client)
     if failures:
         print(f"FAILED ({len(failures)} issue(s)):")

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -7,7 +7,12 @@ only - never row-level values, which are PII.
 import sys
 
 from google.cloud import bigquery
-from submission_query import ALPHA_GRADE_DOMAIN, SUBMISSION_COLUMNS, SUBMISSION_SQL
+from submission_query import (
+    ALPHA_GRADE_DOMAIN,
+    SUBMISSION_COLUMNS,
+    SUBMISSION_SQL,
+    UNGRADED_WORKLIST_SQL,
+)
 
 PROJECT = "teamster-332318"
 
@@ -338,6 +343,33 @@ def check_pass_through_columns_unchanged(client, sql=SUBMISSION_SQL):
     return failures
 
 
+def check_worklist_matches_gate(client, sql=SUBMISSION_SQL):
+    """Worklist row count equals the gate's own ungraded in-scope count.
+
+    UNGRADED_WORKLIST_SQL and check_in_scope_rows_have_grades both derive
+    from SUBMISSION_SQL, so the two cannot drift apart today. This is a
+    regression guard against a future edit to one and not the other.
+    """
+    # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
+    gate_sql = f"""
+    select count(*) as n
+    from ({sql})
+    where grade_band in ('HS', 'MS') and AlphaGradeEarned is null
+    """
+    gate_n = _rows(client, gate_sql)[0].n
+
+    # trunk-ignore(bandit/B608): UNGRADED_WORKLIST_SQL is a local module constant, not user input
+    worklist_sql = f"select count(*) as n from ({UNGRADED_WORKLIST_SQL})"
+    worklist_n = _rows(client, worklist_sql)[0].n
+
+    if gate_n != worklist_n:
+        return [
+            f"worklist row count {worklist_n} != gate's ungraded in-scope "
+            f"row count {gate_n}"
+        ]
+    return []
+
+
 CHECKS = [
     check_row_parity,
     check_band_counts,
@@ -350,6 +382,7 @@ CHECKS = [
     check_out_of_scope_rows_blank,
     check_credits_earned,
     check_pass_through_columns_unchanged,
+    check_worklist_matches_gate,
 ]
 
 
@@ -370,7 +403,7 @@ def self_test(client):
     self-test at all - it manufactures false confidence.
 
     This does not prove every check still runs as part of the gate: it calls
-    two check functions directly by name, so it covers 2 of the 11 check
+    two check functions directly by name, so it covers 2 of the 12 check
     groups in CHECKS.
     """
     failures = []

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -17,8 +17,8 @@ EXPECTED_BAND_ROWS = {
     ("newark", "MS"): 10746,
     ("newark", "OUT"): 11709,
     ("camden", "HS"): 3648,
-    ("camden", "MS"): 3857,
-    ("camden", "OUT"): 2838,
+    ("camden", "MS"): 3638,
+    ("camden", "OUT"): 3057,
 }
 
 
@@ -116,11 +116,53 @@ def check_no_stored_conflicts(client):
     return failures
 
 
+def check_no_live_conflicts(client):
+    """A conflicted live grade is never emitted as the resolved value.
+
+    Live reporting terms legitimately disagree on tens of thousands of rows -
+    several term types close on the same date. That is not an error, because
+    on any row with a stored grade the live value is never consulted. The
+    invariant that matters is narrower: when live terms disagree, the guard
+    must null the value rather than pick one, so grade_source can never be
+    'live' on a conflicted row.
+    """
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where n_live_letters > 1 and grade_source = 'live'
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) emitted a conflicted live grade"]
+    return []
+
+
+def check_live_fills_only_gaps(client):
+    """Live grades never override a stored grade."""
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where
+        stored_letter is not null
+        and live_letter is not null
+        and stored_letter != live_letter
+        and grade_source = 'live'
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) took a live grade over a stored grade"]
+    return []
+
+
 CHECKS = [
     check_row_parity,
     check_band_counts,
     check_stored_coverage,
     check_no_stored_conflicts,
+    check_no_live_conflicts,
+    check_live_fills_only_gaps,
 ]
 
 

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -95,17 +95,25 @@ def check_stored_coverage(client):
 
 
 def check_no_stored_conflicts(client):
-    """No student-section carries two different stored Y1 letters."""
+    """No student-section carries two different stored Y1 letters or credits."""
+    failures = []
     # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
     sql = f"""
-    select count(*) as n
+    select
+        countif(n_stored_letters > 1) as letter_conflicts,
+        countif(n_stored_credits > 1) as credit_conflicts
     from ({SUBMISSION_SQL})
-    where n_stored_letters > 1
     """
-    n = _rows(client, sql)[0].n
-    if n:
-        return [f"{n} row(s) have conflicting stored Y1 letter grades"]
-    return []
+    row = _rows(client, sql)[0]
+    if row.letter_conflicts:
+        failures.append(
+            f"{row.letter_conflicts} row(s) have conflicting stored Y1 letter grades"
+        )
+    if row.credit_conflicts:
+        failures.append(
+            f"{row.credit_conflicts} row(s) have conflicting stored Y1 earned credits"
+        )
+    return failures
 
 
 CHECKS = [

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -62,7 +62,58 @@ def check_band_counts(client):
     return failures
 
 
-CHECKS = [check_row_parity, check_band_counts]
+EXPECTED_STORED_COVERAGE = {
+    ("newark", "HS"): 10675,
+    ("newark", "MS"): 10682,
+    ("camden", "HS"): 3616,
+    ("camden", "MS"): 3633,
+}
+
+
+def check_stored_coverage(client):
+    """Stored Y1 grades cover the in-scope bands at the measured rate.
+
+    Counts are a floor, not an equality: a re-pulled extract may match more
+    rows. A drop signals a broken join.
+    """
+    failures = []
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select region, grade_band, countif(stored_letter is not null) as matched
+    from ({SUBMISSION_SQL})
+    group by region, grade_band
+    """
+    actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql)}
+    for key, floor in EXPECTED_STORED_COVERAGE.items():
+        got = actual.get(key, 0)
+        if got < floor:
+            failures.append(
+                f"stored coverage {key[0]}/{key[1]}: expected at least "
+                f"{floor}, got {got}"
+            )
+    return failures
+
+
+def check_no_stored_conflicts(client):
+    """No student-section carries two different stored Y1 letters."""
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where n_stored_letters > 1
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) have conflicting stored Y1 letter grades"]
+    return []
+
+
+CHECKS = [
+    check_row_parity,
+    check_band_counts,
+    check_stored_coverage,
+    check_no_stored_conflicts,
+]
 
 
 def run_checks(client):

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -1,0 +1,88 @@
+"""Validation gate for the NJ SLEDS student course submission.
+
+Exits non-zero if any handbook or parity rule fails. Prints aggregate counts
+only - never row-level values, which are PII.
+"""
+
+import sys
+
+from google.cloud import bigquery
+from submission_query import SUBMISSION_SQL
+
+PROJECT = "teamster-332318"
+
+EXPECTED_EXTRACT_ROWS = {"newark": 33150, "camden": 10343}
+EXPECTED_BAND_ROWS = {
+    ("newark", "HS"): 10695,
+    ("newark", "MS"): 10746,
+    ("newark", "OUT"): 11709,
+    ("camden", "HS"): 3648,
+    ("camden", "MS"): 3857,
+    ("camden", "OUT"): 2838,
+}
+
+
+def _rows(client, sql):
+    return list(client.query(sql).result())
+
+
+def check_row_parity(client):
+    """Every extract row appears exactly once. No fan-out, no loss."""
+    failures = []
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select region, count(*) as n
+    from ({SUBMISSION_SQL})
+    group by region
+    """
+    actual = {r.region: r.n for r in _rows(client, sql)}
+    for region, expected in EXPECTED_EXTRACT_ROWS.items():
+        got = actual.get(region, 0)
+        if got != expected:
+            failures.append(f"row parity {region}: expected {expected}, got {got}")
+    return failures
+
+
+def check_band_counts(client):
+    """Band classification matches the spec exactly."""
+    failures = []
+    # trunk-ignore(bandit/B608): SUBMISSION_SQL is a local module constant, not user input
+    sql = f"""
+    select region, grade_band, count(*) as n
+    from ({SUBMISSION_SQL})
+    group by region, grade_band
+    """
+    actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql)}
+    for key, expected in EXPECTED_BAND_ROWS.items():
+        got = actual.get(key, 0)
+        if got != expected:
+            failures.append(
+                f"band count {key[0]}/{key[1]}: expected {expected}, got {got}"
+            )
+    return failures
+
+
+CHECKS = [check_row_parity, check_band_counts]
+
+
+def run_checks(client):
+    failures = []
+    for check in CHECKS:
+        failures.extend(check(client))
+    return failures
+
+
+def main():
+    client = bigquery.Client(project=PROJECT)
+    failures = run_checks(client)
+    if failures:
+        print(f"FAILED ({len(failures)} issue(s)):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"PASSED ({len(CHECKS)} check group(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -7,12 +7,25 @@ only - never row-level values, which are PII.
 import sys
 
 from google.cloud import bigquery
-from submission_query import ALPHA_GRADE_DOMAIN, SUBMISSION_SQL
+from submission_query import ALPHA_GRADE_DOMAIN, SUBMISSION_COLUMNS, SUBMISSION_SQL
 
 PROJECT = "teamster-332318"
 
-EXPECTED_EXTRACT_ROWS = {"newark": 33150, "camden": 10343}
-EXPECTED_BAND_ROWS = {
+BASE_TABLES = {
+    "newark": "teamster-332318.cokafor.stg_student_extract_newark",
+    "camden": "teamster-332318.cokafor.stg_student_extract_camden",
+}
+
+PASS_THROUGH_COLUMNS = [
+    c for c in SUBMISSION_COLUMNS if c not in ("AlphaGradeEarned", "CreditsEarned")
+]
+
+# Per-cycle baseline, not a derivable truth: band composition legitimately
+# shifts between extract pulls (enrollment, course, and span changes), and
+# the band logic is exactly what this baseline cross-checks, so deriving it
+# would be circular. Re-measure by hand whenever a new extract is loaded (see
+# the README's re-baseline step). Measured from the 2026-07-29 extract.
+BASELINE_BAND_ROWS = {
     ("newark", "HS"): 10695,
     ("newark", "MS"): 10746,
     ("newark", "OUT"): 11709,
@@ -26,8 +39,27 @@ def _rows(client, sql):
     return list(client.query(sql).result())
 
 
+def base_table_row_count(client, region):
+    """Fresh row count of the region's extract base table.
+
+    Shared by check_row_parity (the fan-out gate) and build_submission's
+    export_region (the post-gate re-verification of what was actually
+    written), so both compare against the same live number instead of two
+    copies of similar SQL drifting apart.
+    """
+    table = BASE_TABLES[region]
+    # trunk-ignore(bandit/B608): table is drawn from the local BASE_TABLES constant, not user input
+    sql_text = f"select count(*) as n from `{table}`"
+    return _rows(client, sql_text)[0].n
+
+
 def check_row_parity(client, sql=SUBMISSION_SQL):
-    """Every extract row appears exactly once. No fan-out, no loss."""
+    """Every extract row appears exactly once, matching its base table.
+
+    Compares against each base table's own count, queried fresh, rather than
+    a frozen literal - so this stays a true fan-out guard across extract
+    reloads instead of asserting a snapshot that goes stale next cycle.
+    """
     failures = []
     # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
     sql_text = f"""
@@ -36,10 +68,14 @@ def check_row_parity(client, sql=SUBMISSION_SQL):
     group by region
     """
     actual = {r.region: r.n for r in _rows(client, sql_text)}
-    for region, expected in EXPECTED_EXTRACT_ROWS.items():
+    for region in BASE_TABLES:
+        expected = base_table_row_count(client, region)
         got = actual.get(region, 0)
         if got != expected:
-            failures.append(f"row parity {region}: expected {expected}, got {got}")
+            failures.append(
+                f"row parity {region}: view {got}, base table {expected} "
+                "(join fanned out)"
+            )
     return failures
 
 
@@ -53,7 +89,7 @@ def check_band_counts(client, sql=SUBMISSION_SQL):
     group by region, grade_band
     """
     actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql_text)}
-    for key, expected in EXPECTED_BAND_ROWS.items():
+    for key, expected in BASELINE_BAND_ROWS.items():
         got = actual.get(key, 0)
         if got != expected:
             failures.append(
@@ -62,7 +98,9 @@ def check_band_counts(client, sql=SUBMISSION_SQL):
     return failures
 
 
-EXPECTED_STORED_COVERAGE = {
+# Per-cycle baseline, same caveat as BASELINE_BAND_ROWS above - re-measure by
+# hand whenever a new extract is loaded. Measured from the 2026-07-29 extract.
+BASELINE_STORED_COVERAGE = {
     ("newark", "HS"): 10675,
     ("newark", "MS"): 10682,
     ("camden", "HS"): 3616,
@@ -84,7 +122,7 @@ def check_stored_coverage(client, sql=SUBMISSION_SQL):
     group by region, grade_band
     """
     actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql_text)}
-    for key, floor in EXPECTED_STORED_COVERAGE.items():
+    for key, floor in BASELINE_STORED_COVERAGE.items():
         got = actual.get(key, 0)
         if got < floor:
             failures.append(
@@ -188,18 +226,33 @@ def check_in_scope_rows_have_grades(client, sql=SUBMISSION_SQL):
 
 
 def check_out_of_scope_rows_blank(client, sql=SUBMISSION_SQL):
-    """Out-of-scope rows carry no grade and no credit. Scope-boundary guard."""
+    """Scope-boundary guard.
+
+    OUT-band rows carry no grade and no credit. MS-band rows are in scope for
+    AlphaGradeEarned only (see the spec's scope table) and must carry no
+    CreditsEarned.
+    """
     # trunk-ignore(bandit/B608): sql defaults to the local module constant, not user input
     sql_text = f"""
-    select count(*) as n
+    select
+        countif(
+            grade_band = 'OUT'
+            and (AlphaGradeEarned is not null or CreditsEarned is not null)
+        ) as out_of_scope_graded,
+        countif(grade_band = 'MS' and CreditsEarned is not null) as ms_has_credit
     from ({sql})
-    where grade_band = 'OUT'
-      and (AlphaGradeEarned is not null or CreditsEarned is not null)
     """
-    n = _rows(client, sql_text)[0].n
-    if n:
-        return [f"{n} out-of-scope row(s) were given a grade or credit"]
-    return []
+    r = _rows(client, sql_text)[0]
+    failures = []
+    if r.out_of_scope_graded:
+        failures.append(
+            f"{r.out_of_scope_graded} out-of-scope row(s) were given a grade or credit"
+        )
+    if r.ms_has_credit:
+        failures.append(
+            f"{r.ms_has_credit} MS-band row(s) were given a CreditsEarned value"
+        )
+    return failures
 
 
 def check_credits_earned(client, sql=SUBMISSION_SQL):
@@ -238,6 +291,53 @@ def check_credits_earned(client, sql=SUBMISSION_SQL):
     return failures
 
 
+def check_pass_through_columns_unchanged(client, sql=SUBMISSION_SQL):
+    """The 23 non-written columns are byte-identical to the base tables.
+
+    This is the load-bearing narrowing constraint of the whole exception to
+    source-fix-only: only AlphaGradeEarned and CreditsEarned may ever differ
+    from the native extract. EXCEPT DISTINCT in both directions catches drift
+    either way - a view row with a pass-through value not found in any base
+    row, or a base row whose pass-through values are missing from the view.
+    """
+    cols = ", ".join(f"`{c}`" for c in PASS_THROUGH_COLUMNS)
+    tables = BASE_TABLES.values()
+    # trunk-ignore(bandit/B608): cols/tables draw from local module constants, not user input
+    base_union = " union all ".join(f"select {cols} from `{t}`" for t in tables)
+    # trunk-ignore(bandit/B608): cols/table draw from local module constants, not user input
+    view_extra_sql = f"""
+    select count(*) as n
+    from (
+        select {cols} from ({sql})
+        except distinct
+        ({base_union})
+    )
+    """
+    # trunk-ignore(bandit/B608): cols/table draw from local module constants, not user input
+    base_extra_sql = f"""
+    select count(*) as n
+    from (
+        ({base_union})
+        except distinct
+        select {cols} from ({sql})
+    )
+    """
+    failures = []
+    view_extra = _rows(client, view_extra_sql)[0].n
+    if view_extra:
+        failures.append(
+            f"{view_extra} view row(s) have a pass-through column combination "
+            "not found in either base table"
+        )
+    base_extra = _rows(client, base_extra_sql)[0].n
+    if base_extra:
+        failures.append(
+            f"{base_extra} base-table row(s) have a pass-through column "
+            "combination missing from the view"
+        )
+    return failures
+
+
 CHECKS = [
     check_row_parity,
     check_band_counts,
@@ -249,6 +349,7 @@ CHECKS = [
     check_in_scope_rows_have_grades,
     check_out_of_scope_rows_blank,
     check_credits_earned,
+    check_pass_through_columns_unchanged,
 ]
 
 
@@ -263,10 +364,14 @@ def self_test(client):
     """Prove the real checks fire on injected defects. Mutates SQL in memory.
 
     Each block calls the ACTUAL check function against the mutated SQL, so
-    deleting a check from CHECKS, widening its domain, or weakening its
-    predicate makes this self-test fail. A self-test that re-implements the
-    check's own predicate would keep passing with the check removed, which is
-    worse than no self-test at all - it manufactures false confidence.
+    widening a check's domain or weakening its predicate makes this
+    self-test fail. A self-test that re-implements the check's own predicate
+    would keep passing with the check's logic gutted, which is worse than no
+    self-test at all - it manufactures false confidence.
+
+    This does not prove every check still runs as part of the gate: it calls
+    two check functions directly by name, so it covers 2 of the 11 check
+    groups in CHECKS.
     """
     failures = []
 

--- a/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
+++ b/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
@@ -29,8 +29,12 @@ Every task's requirements implicitly include this section.
 
 - **Only two fields may be written:** `AlphaGradeEarned` and `CreditsEarned`.
   Every other column passes through unchanged from the extract.
-- **No row may be added, removed, filtered, reordered, or deduplicated.**
-  Row-count parity per region is a hard gate: Newark 33,150, Camden 10,343.
+- **No row may be added, removed, filtered, or deduplicated.** Row-count parity
+  per region is a hard gate: Newark 33,150, Camden 10,343. Row **order** is
+  explicitly not preserved: BigQuery's output order across a `union all` with
+  left joins is nondeterministic, and no ordinal column was captured at load, so
+  the native extract's order is not recoverable. Harmless for a keyed roster
+  upload, which matches rows on student and section identifiers, not position.
 - **Every value in the view and the CSV is a `STRING`.** No numeric coercion
   anywhere in the export path. CDS codes must keep leading zeros (`07`, not
   `7`).
@@ -1023,10 +1027,11 @@ in position 22. Change `from sourced` to `from emitted_credit`. Keep the other
 
 Note the credit precedence: the stored earned-credit value wins whenever it
 exists, because it is PowerSchool's own record of credit awarded. The derived
-rule applies only to rows whose grade came from the live fallback, where no
-earned-credit value exists — roughly 52 rows. Sourcing the fallback value from
-the row's own `AvailableCredit` makes the must-not-exceed constraint
-unviolatable.
+rule applies only to rows whose grade came from the live fallback and which have
+no earned-credit value — measured at exactly 2 rows. (52 is the count of
+secondary/HS gap rows overall; most of those have no grade in any source at all
+and never reach this rule.) Sourcing the fallback value from the row's own
+`AvailableCredit` makes the must-not-exceed constraint unviolatable.
 
 The credit path reads `safe_stored_credit`, not `stored_earned_credit`. That
 column is null whenever a student-section has conflicting stored letters **or**
@@ -1116,10 +1121,14 @@ def self_test(client):
     """Prove the real checks fire on injected defects. Mutates SQL in memory.
 
     Each block calls the ACTUAL check function against the mutated SQL, so
-    deleting a check from CHECKS, widening its domain, or weakening its
-    predicate makes this self-test fail. A self-test that re-implements the
-    check's own predicate would keep passing with the check removed, which is
-    worse than no self-test at all - it manufactures false confidence.
+    widening a check's domain or weakening its predicate makes this
+    self-test fail. A self-test that re-implements the check's own predicate
+    would keep passing with the check's logic gutted, which is worse than no
+    self-test at all - it manufactures false confidence.
+
+    This does not prove every check still runs as part of the gate: it calls
+    two check functions directly by name, so it covers 2 of the 11 check
+    groups in CHECKS.
     """
     failures = []
 
@@ -1151,7 +1160,7 @@ empty list on clean data, so a plain truthiness test suffices.
 so a truthiness test would pass even with the format clause broken — the
 self-test must look for the **specific** failure string.
 
-````
+````python
 
 Wire it into `main` behind a flag:
 

--- a/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
+++ b/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
@@ -1,0 +1,1360 @@
+# NJ SLEDS Grade and Credit Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a submission-ready NJ SLEDS Student Course Roster CSV per
+region by filling `AlphaGradeEarned` and `CreditsEarned` from the warehouse,
+leaving every other column byte-identical to the native PowerSchool extract.
+
+**Architecture:** A BigQuery view in the `cokafor` dataset joins the loaded
+extract to `kipptaf_powerschool.stg_powerschool__storedgrades` (stored `Y1`
+grades, primary) and `stg_powerschool__pgfinalgrades` (live grades, fills nulls
+only). A validation script asserts the handbook's rules and refuses export on
+any failure. An export script writes one CSV per region with every value as a
+string.
+
+**Tech Stack:** BigQuery (Standard SQL), Python 3.13 via `uv`,
+`google-cloud-bigquery` with Application Default Credentials.
+
+Spec:
+[`2026-07-30-nj-sleds-grade-credit-backfill-design.md`](../specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md).
+Issue [#4630](https://github.com/TEAMSchools/teamster/issues/4630).
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Only two fields may be written:** `AlphaGradeEarned` and `CreditsEarned`.
+  Every other column passes through unchanged from the extract.
+- **No row may be added, removed, filtered, reordered, or deduplicated.**
+  Row-count parity per region is a hard gate: Newark 33,150, Camden 10,343.
+- **Every value in the view and the CSV is a `STRING`.** No numeric coercion
+  anywhere in the export path. CDS codes must keep leading zeros (`07`, not
+  `7`).
+- **`CreditsEarned` format:** exactly three decimals (`1.000`, `0.000`). The
+  handbook sets minimum length 5, so `1` is invalid. Range `0.000`–`35.000`, and
+  never greater than that row's `AvailableCredit`.
+- **`AlphaGradeEarned` domain** (18 values, handbook page 35): `A` `A+` `A-` `B`
+  `B+` `B-` `C` `C+` `C-` `D` `D+` `D-` `E` `E+` `E-` `F` `F+` `F-`. Anything
+  else resolves to blank and is reported. Never emit `P` (illegal here) or `F*`
+  (a warehouse-internal marker).
+- **Grade source precedence:** stored grade always wins; live grades fill nulls
+  only.
+- **Stored-grade scope:** `academic_year = 2025` and `storecode = 'Y1'`.
+- **Live-grade scope:** `enddate` between `2025-07-01` and `2026-06-30`, taking
+  the greatest `enddate` per student-section.
+- **Region scoping is structural.** Each region branch reads only its own
+  extract base table and filters every shared CTE to its own
+  `_dbt_source_project` literal (`kippnewark` / `kippcamden`). Local identifiers
+  repeat across regions (33 shared student local IDs), so an unqualified join
+  manufactures false matches.
+- **Grade bands.** `HS` = `sced_level = 'secondary'` and `AvailableCredit`
+  greater than `0`. `MS` = prior-to-secondary whose `GradeSpan` **upper** two
+  characters are in `('06','07','08','09','10','11','12')`. Everything else is
+  `OUT` and receives no grade. Test membership explicitly — `KG` sorts above
+  `06` in a string comparison and would wrongly pull in 1,675 kindergarten rows.
+- **Never guess.** A conflict or a missing grade produces a blank plus a report
+  row, never an inferred value.
+- **Python:** always `uv run`. Never bare `python` / `python3`.
+- **Worktree:**
+  `/workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill`.
+  Use `git -C <worktree>` on every git call. Read/Edit/Write must target the
+  worktree path.
+- **No `.sql` files.** sqlfluff is enabled repo-wide and ignored only under
+  `src/teamster/**`; a standalone `.sql` under `docs/` is linted with the dbt
+  templater and fails outside a dbt project. SQL lives as a Python module
+  constant. Keep SQL lines at or under 88 characters so ruff does not flag them.
+- **PII:** the exported CSV carries names, dates of birth, and state IDs. It
+  stays local and goes only to the state-access uploader. Never commit it, and
+  never put row-level values in a commit message, issue, or PR.
+
+## File Structure
+
+All new files live under `docs/superpowers/nj-sleds-roster/submission/`,
+matching the precedent set by `docs/superpowers/nj-sleds-roster/setup/` on the
+runbook branch, which keeps every NJ SLEDS operational artifact together rather
+than adding a seasonal tool to the general-purpose `scripts/` catalog.
+
+| File                     | Responsibility                                                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `submission_query.py`    | The SQL as a module constant, plus the column list and the grade domain. No I/O.                                        |
+| `validate_submission.py` | Runs every handbook and parity check against the query. Exits non-zero on any failure.                                  |
+| `build_submission.py`    | Creates or replaces the view, runs the validation gate, writes one CSV per region. Refuses to export if the gate fails. |
+| `README.md`              | How to run the three-step cycle.                                                                                        |
+
+`validate_submission.py` is both the test harness and the permanent pre-upload
+gate. Each task adds its checks to it, so every task has a real red-green cycle.
+
+---
+
+### Task 1: Query skeleton, band classification, and parity
+
+**Files:**
+
+- Create: `docs/superpowers/nj-sleds-roster/submission/submission_query.py`
+- Create: `docs/superpowers/nj-sleds-roster/submission/validate_submission.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `submission_query.SUBMISSION_SQL` (a `str` holding a bare `SELECT`,
+  no trailing semicolon, wrappable as a subquery);
+  `submission_query.SUBMISSION_COLUMNS` (a `list[str]` of the 25 submission
+  column names in ordinal order); `submission_query.ALPHA_GRADE_DOMAIN` (a
+  `frozenset[str]` of the 18 legal letter grades);
+  `validate_submission.run_checks(client) -> list[str]` returning a list of
+  failure messages (empty means pass).
+
+At the end of this task the query returns all 25 extract columns unchanged plus
+`region` and `grade_band`. No grades are resolved yet.
+
+- [ ] **Step 1: Write the failing checks**
+
+Create `validate_submission.py`:
+
+```python
+"""Validation gate for the NJ SLEDS student course submission.
+
+Exits non-zero if any handbook or parity rule fails. Prints aggregate counts
+only - never row-level values, which are PII.
+"""
+
+import sys
+
+from google.cloud import bigquery
+
+from submission_query import SUBMISSION_SQL
+
+PROJECT = "teamster-332318"
+
+EXPECTED_EXTRACT_ROWS = {"newark": 33150, "camden": 10343}
+EXPECTED_BAND_ROWS = {
+    ("newark", "HS"): 10695,
+    ("newark", "MS"): 10746,
+    ("newark", "OUT"): 11709,
+    ("camden", "HS"): 3648,
+    ("camden", "MS"): 3857,
+    ("camden", "OUT"): 2838,
+}
+
+
+def _rows(client, sql):
+    return list(client.query(sql).result())
+
+
+def check_row_parity(client):
+    """Every extract row appears exactly once. No fan-out, no loss."""
+    failures = []
+    sql = f"""
+    select region, count(*) as n
+    from ({SUBMISSION_SQL})
+    group by region
+    """
+    actual = {r.region: r.n for r in _rows(client, sql)}
+    for region, expected in EXPECTED_EXTRACT_ROWS.items():
+        got = actual.get(region, 0)
+        if got != expected:
+            failures.append(
+                f"row parity {region}: expected {expected}, got {got}"
+            )
+    return failures
+
+
+def check_band_counts(client):
+    """Band classification matches the spec exactly."""
+    failures = []
+    sql = f"""
+    select region, grade_band, count(*) as n
+    from ({SUBMISSION_SQL})
+    group by region, grade_band
+    """
+    actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql)}
+    for key, expected in EXPECTED_BAND_ROWS.items():
+        got = actual.get(key, 0)
+        if got != expected:
+            failures.append(
+                f"band count {key[0]}/{key[1]}: expected {expected}, got {got}"
+            )
+    return failures
+
+
+CHECKS = [check_row_parity, check_band_counts]
+
+
+def run_checks(client):
+    failures = []
+    for check in CHECKS:
+        failures.extend(check(client))
+    return failures
+
+
+def main():
+    client = bigquery.Client(project=PROJECT)
+    failures = run_checks(client)
+    if failures:
+        print(f"FAILED ({len(failures)} issue(s)):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"PASSED ({len(CHECKS)} check group(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `ModuleNotFoundError: No module named 'submission_query'`.
+
+- [ ] **Step 3: Write the query skeleton**
+
+Create `submission_query.py`:
+
+```python
+"""SQL and constants for the NJ SLEDS student course submission view.
+
+SUBMISSION_SQL is a bare SELECT with no trailing semicolon so it can be used
+as a subquery by the validator or wrapped in CREATE OR REPLACE VIEW by the
+builder.
+"""
+
+SUBMISSION_COLUMNS = [
+    "LocalIdentificationNumber",
+    "StateIdentificationNumber",
+    "FirstName",
+    "LastName",
+    "DateOfBirth",
+    "CountyCodeAssigned",
+    "DistrictCodeAssigned",
+    "SchoolCodeAssigned",
+    "SectionEntryDate",
+    "SectionExitDate",
+    "SubjectArea",
+    "CourseIdentifier",
+    "CourseLevel",
+    "GradeSpan",
+    "AvailableCredit",
+    "CourseSequence",
+    "LocalCourseTitle",
+    "LocalCourseCode",
+    "LocalSectionCode",
+    "CreditsEarned",
+    "NumericGradeEarned",
+    "AlphaGradeEarned",
+    "CompletionStatus",
+    "CourseType",
+    "DualInstitution",
+]
+
+ALPHA_GRADE_DOMAIN = frozenset(
+    {
+        "A", "A+", "A-",
+        "B", "B+", "B-",
+        "C", "C+", "C-",
+        "D", "D+", "D-",
+        "E", "E+", "E-",
+        "F", "F+", "F-",
+    }
+)
+
+SUBMISSION_SQL = """
+with
+    sced as (
+        select
+            subject_area,
+            course_identifier,
+            sced_level,
+        from `teamster-332318.cokafor.ref_sced_codes`
+    ),
+
+    newark_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+
+            'newark' as region,
+        from `teamster-332318.cokafor.stg_student_extract_newark` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+    ),
+
+    camden_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+
+            'camden' as region,
+        from `teamster-332318.cokafor.stg_student_extract_camden` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+    ),
+
+    joined as (
+        select * from newark_joined
+        union all
+        select * from camden_joined
+    ),
+
+    normalized as (
+        select
+            *,
+
+            nullif(GradeSpan, '') as grade_span_raw,
+            nullif(AvailableCredit, '') as available_credit_raw,
+        from joined
+    ),
+
+    typed as (
+        select
+            *,
+
+            lpad(grade_span_raw, 4, '0') as grade_span_padded,
+            safe_cast(available_credit_raw as float64) as available_credit_num,
+        from normalized
+    ),
+
+    banded as (
+        select
+            *,
+
+            substr(grade_span_padded, 3, 2) as grade_span_upper,
+        from typed
+    ),
+
+    scoped as (
+        select
+            *,
+
+            case
+                when sced_level = 'secondary' and available_credit_num > 0
+                then 'HS'
+                when
+                    grade_span_upper
+                    in ('06', '07', '08', '09', '10', '11', '12')
+                then 'MS'
+                else 'OUT'
+            end as grade_band,
+        from banded
+    )
+
+select
+    LocalIdentificationNumber,
+    StateIdentificationNumber,
+    FirstName,
+    LastName,
+    DateOfBirth,
+    CountyCodeAssigned,
+    DistrictCodeAssigned,
+    SchoolCodeAssigned,
+    SectionEntryDate,
+    SectionExitDate,
+    SubjectArea,
+    CourseIdentifier,
+    CourseLevel,
+    GradeSpan,
+    AvailableCredit,
+    CourseSequence,
+    LocalCourseTitle,
+    LocalCourseCode,
+    LocalSectionCode,
+    CreditsEarned,
+    NumericGradeEarned,
+    AlphaGradeEarned,
+    CompletionStatus,
+    CourseType,
+    DualInstitution,
+    region,
+    grade_band,
+from scoped
+"""
+```
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `PASSED (2 check group(s))`. If a band count is off by exactly 219,
+the `MS` upper-bound membership test is wrong — `0508` and `KG08` belong in
+`MS`. If `OUT` is short by 1,675, `KG` is being ranked above `06` by a range
+comparison instead of the explicit membership list.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'feat(nj-sleds): submission query skeleton with band classification (Refs #4630)'
+```
+
+---
+
+### Task 2: Stored-grade resolution
+
+**Files:**
+
+- Modify: `docs/superpowers/nj-sleds-roster/submission/submission_query.py`
+- Modify: `docs/superpowers/nj-sleds-roster/submission/validate_submission.py`
+
+**Interfaces:**
+
+- Consumes: `SUBMISSION_SQL`, `run_checks` from Task 1.
+- Produces: three new columns on the query — `stored_letter` (`STRING`),
+  `stored_earned_credit` (`FLOAT64`), `n_stored_letters` (`INT64`).
+
+- [ ] **Step 1: Write the failing checks**
+
+Add to `validate_submission.py`, above the `CHECKS` list:
+
+```python
+EXPECTED_STORED_COVERAGE = {
+    ("newark", "HS"): 10675,
+    ("newark", "MS"): 10682,
+    ("camden", "HS"): 3616,
+    ("camden", "MS"): 3633,
+}
+
+
+def check_stored_coverage(client):
+    """Stored Y1 grades cover the in-scope bands at the measured rate.
+
+    Counts are a floor, not an equality: a re-pulled extract may match more
+    rows. A drop signals a broken join.
+    """
+    failures = []
+    sql = f"""
+    select region, grade_band, countif(stored_letter is not null) as matched
+    from ({SUBMISSION_SQL})
+    group by region, grade_band
+    """
+    actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql)}
+    for key, floor in EXPECTED_STORED_COVERAGE.items():
+        got = actual.get(key, 0)
+        if got < floor:
+            failures.append(
+                f"stored coverage {key[0]}/{key[1]}: expected at least "
+                f"{floor}, got {got}"
+            )
+    return failures
+
+
+def check_no_stored_conflicts(client):
+    """No student-section carries two different stored Y1 letters."""
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where n_stored_letters > 1
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) have conflicting stored Y1 letter grades"]
+    return []
+```
+
+Then extend the list:
+
+```python
+CHECKS = [
+    check_row_parity,
+    check_band_counts,
+    check_stored_coverage,
+    check_no_stored_conflicts,
+]
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: FAIL with a BigQuery error naming `stored_letter` as unrecognized.
+
+- [ ] **Step 3: Add the stored-grade CTEs**
+
+In `submission_query.py`, insert after the `sced` CTE:
+
+```sql
+    stored_raw as (
+        select
+            _dbt_source_project,
+            `grade`,
+            earnedcrhrs,
+
+            cast(studentid as string) as studentid_str,
+            cast(sectionid as string) as sectionid_str,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__storedgrades`
+        where
+            academic_year = 2025
+            and storecode = 'Y1'
+            and _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+
+    stored as (
+        select
+            _dbt_source_project,
+            studentid_str,
+            sectionid_str,
+
+            max(`grade`) as stored_letter,
+            max(earnedcrhrs) as stored_earned_credit,
+            count(distinct `grade`) as n_stored_letters,
+        from stored_raw
+        group by _dbt_source_project, studentid_str, sectionid_str
+    ),
+
+    students as (
+        select
+            _dbt_source_project,
+
+            cast(student_number as string) as student_number_str,
+            cast(id as string) as studentid_str,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__students`
+        where _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+```
+
+Replace both region `_joined` CTEs with these. Each branch reads only its own
+extract base table and pins every shared CTE to its own `_dbt_source_project`
+literal — that is what makes region separation structural rather than a
+predicate someone has to remember.
+
+```sql
+    newark_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+            sg.stored_letter,
+            sg.stored_earned_credit,
+            sg.n_stored_letters,
+
+            'newark' as region,
+        from `teamster-332318.cokafor.stg_student_extract_newark` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+        left join students as st
+            on e.LocalIdentificationNumber = st.student_number_str
+            and st._dbt_source_project = 'kippnewark'
+        left join stored as sg
+            on st.studentid_str = sg.studentid_str
+            and e.LocalSectionCode = sg.sectionid_str
+            and sg._dbt_source_project = 'kippnewark'
+    ),
+
+    camden_joined as (
+        select
+            e.*,
+
+            sc.sced_level,
+            sg.stored_letter,
+            sg.stored_earned_credit,
+            sg.n_stored_letters,
+
+            'camden' as region,
+        from `teamster-332318.cokafor.stg_student_extract_camden` as e
+        left join sced as sc
+            on e.SubjectArea = sc.subject_area
+            and e.CourseIdentifier = sc.course_identifier
+        left join students as st
+            on e.LocalIdentificationNumber = st.student_number_str
+            and st._dbt_source_project = 'kippcamden'
+        left join stored as sg
+            on st.studentid_str = sg.studentid_str
+            and e.LocalSectionCode = sg.sectionid_str
+            and sg._dbt_source_project = 'kippcamden'
+    ),
+```
+
+Add `stored_letter`, `stored_earned_credit`, and `n_stored_letters` to the final
+`SELECT` list, after `grade_band`.
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `PASSED (4 check group(s))`. If `check_row_parity` now fails with
+counts above 33,150 or 10,343, the join fanned out — confirm the `stored` CTE
+groups by all three keys and that every join predicate carries its
+`_dbt_source_project` literal.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'feat(nj-sleds): resolve stored Y1 grades and earned credit (Refs #4630)'
+```
+
+---
+
+### Task 3: Live-grade fallback
+
+**Files:**
+
+- Modify: `docs/superpowers/nj-sleds-roster/submission/submission_query.py`
+- Modify: `docs/superpowers/nj-sleds-roster/submission/validate_submission.py`
+
+**Interfaces:**
+
+- Consumes: Task 2's `stored_letter`, `n_stored_letters`.
+- Produces: `live_letter` (`STRING`), `n_live_letters` (`INT64`).
+
+`pgfinalgrades` has no `academic_year` column and holds history back to 2004, so
+it must be scoped by `enddate`. Its `Y1` term stopped being used in 2018; for SY
+2025-26 the terminal terms (`Q4`, `H4`, `S4`, `W4`) all end `2026-06-29`. Taking
+the greatest `enddate` per student-section therefore selects the terminal term
+whatever structure the section uses, without hardcoding a term code.
+
+Two terms can share that same maximum `enddate`, which is a fan-out risk. The
+`live` CTE aggregates per student-section and counts distinct letters so a
+conflict is reported rather than silently picked.
+
+- [ ] **Step 1: Write the failing checks**
+
+Add to `validate_submission.py`:
+
+```python
+def check_no_live_conflicts(client):
+    """No student-section resolves to two different live letters."""
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where n_live_letters > 1
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) have conflicting live final grades"]
+    return []
+
+
+def check_live_fills_only_gaps(client):
+    """Live grades never override a stored grade."""
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where
+        stored_letter is not null
+        and live_letter is not null
+        and stored_letter != live_letter
+        and grade_source = 'live'
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) took a live grade over a stored grade"]
+    return []
+```
+
+Extend the list with `check_no_live_conflicts` and `check_live_fills_only_gaps`.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: FAIL with a BigQuery error naming `n_live_letters` as unrecognized.
+
+- [ ] **Step 3: Add the live-grade CTEs and the source marker**
+
+Insert after the `stored` CTE:
+
+```sql
+    live_raw as (
+        select
+            _dbt_source_project,
+            `grade`,
+            enddate,
+
+            cast(studentid as string) as studentid_str,
+            cast(sectionid as string) as sectionid_str,
+            max(enddate) over (
+                partition by _dbt_source_project, studentid, sectionid
+            ) as max_enddate,
+        from `teamster-332318.kipptaf_powerschool.stg_powerschool__pgfinalgrades`
+        where
+            enddate between date '2025-07-01' and date '2026-06-30'
+            and `grade` is not null
+            and _dbt_source_project in ('kippnewark', 'kippcamden')
+    ),
+
+    live as (
+        select
+            _dbt_source_project,
+            studentid_str,
+            sectionid_str,
+
+            max(`grade`) as live_letter,
+            count(distinct `grade`) as n_live_letters,
+        from live_raw
+        where enddate = max_enddate
+        group by _dbt_source_project, studentid_str, sectionid_str
+    ),
+```
+
+In the **Newark** branch, add these two columns to the select list immediately
+after `sg.n_stored_letters,`:
+
+```sql
+            lg.live_letter,
+            lg.n_live_letters,
+```
+
+and this join immediately after the `stored` join:
+
+```sql
+        left join live as lg
+            on st.studentid_str = lg.studentid_str
+            and e.LocalSectionCode = lg.sectionid_str
+            and lg._dbt_source_project = 'kippnewark'
+```
+
+In the **Camden** branch, add the same two columns in the same position:
+
+```sql
+            lg.live_letter,
+            lg.n_live_letters,
+```
+
+and this join, pinned to Camden:
+
+```sql
+        left join live as lg
+            on st.studentid_str = lg.studentid_str
+            and e.LocalSectionCode = lg.sectionid_str
+            and lg._dbt_source_project = 'kippcamden'
+```
+
+Insert a CTE after `scoped` that resolves the candidate and records its origin:
+
+```sql
+    conflict_guarded as (
+        select
+            *,
+
+            if(n_stored_letters > 1, null, stored_letter) as safe_stored,
+            if(n_live_letters > 1, null, live_letter) as safe_live,
+        from scoped
+    ),
+
+    sourced as (
+        select
+            *,
+
+            coalesce(safe_stored, safe_live) as candidate_letter,
+            case
+                when safe_stored is not null then 'stored'
+                when safe_live is not null then 'live'
+                else 'none'
+            end as grade_source,
+        from conflict_guarded
+    )
+```
+
+Change the final `SELECT` to read `from sourced`, and add `live_letter`,
+`n_live_letters`, `candidate_letter`, and `grade_source` to its column list.
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `PASSED (6 check group(s))`. If `check_row_parity` fails high, the
+`live` CTE is not collapsing to one row per student-section — verify the
+`where enddate = max_enddate` filter sits in the `live` CTE, not `live_raw`.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'feat(nj-sleds): add live-grade fallback with conflict guard (Refs #4630)'
+```
+
+---
+
+### Task 4: Field emission and formatting
+
+**Files:**
+
+- Modify: `docs/superpowers/nj-sleds-roster/submission/submission_query.py`
+- Modify: `docs/superpowers/nj-sleds-roster/submission/validate_submission.py`
+
+**Interfaces:**
+
+- Consumes: Task 3's `candidate_letter`, `grade_source`; Task 2's
+  `stored_earned_credit`; Task 1's `grade_band`, `available_credit_num`.
+- Produces: the final `AlphaGradeEarned` and `CreditsEarned` columns, replacing
+  the extract's own (which are empty and `0.000` respectively).
+
+- [ ] **Step 1: Write the failing checks**
+
+Add to `validate_submission.py`, importing the domain at the top
+(`from submission_query import ALPHA_GRADE_DOMAIN, SUBMISSION_SQL`):
+
+```python
+def check_alpha_grade_domain(client):
+    """Every emitted letter grade is one of the 18 legal handbook values."""
+    domain = ", ".join(f"'{g}'" for g in sorted(ALPHA_GRADE_DOMAIN))
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where AlphaGradeEarned is not null
+      and AlphaGradeEarned not in ({domain})
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} row(s) carry an out-of-domain AlphaGradeEarned"]
+    return []
+
+
+def check_in_scope_rows_have_grades(client):
+    """No in-scope row is left without a letter grade."""
+    sql = f"""
+    select region, grade_band, count(*) as n
+    from ({SUBMISSION_SQL})
+    where grade_band in ('HS', 'MS') and AlphaGradeEarned is null
+    group by region, grade_band
+    """
+    return [
+        f"{r.n} in-scope row(s) in {r.region}/{r.grade_band} have no grade"
+        for r in _rows(client, sql)
+    ]
+
+
+def check_out_of_scope_rows_blank(client):
+    """Out-of-scope rows carry no grade and no credit. Scope-boundary guard."""
+    sql = f"""
+    select count(*) as n
+    from ({SUBMISSION_SQL})
+    where grade_band = 'OUT'
+      and (AlphaGradeEarned is not null or CreditsEarned is not null)
+    """
+    n = _rows(client, sql)[0].n
+    if n:
+        return [f"{n} out-of-scope row(s) were given a grade or credit"]
+    return []
+
+
+def check_credits_earned(client):
+    """CreditsEarned is present, 3-decimal, in range, and within available."""
+    sql = f"""
+    select
+        countif(grade_band = 'HS' and CreditsEarned is null) as missing,
+        countif(
+            CreditsEarned is not null
+            and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
+        ) as malformed,
+        countif(
+            CreditsEarned is not null
+            and safe_cast(CreditsEarned as float64) not between 0.0 and 35.0
+        ) as out_of_range,
+        countif(
+            CreditsEarned is not null
+            and safe_cast(CreditsEarned as float64)
+                > safe_cast(nullif(AvailableCredit, '') as float64)
+        ) as over_available
+    from ({SUBMISSION_SQL})
+    """
+    r = _rows(client, sql)[0]
+    failures = []
+    if r.missing:
+        failures.append(f"{r.missing} HS row(s) missing CreditsEarned")
+    if r.malformed:
+        failures.append(
+            f"{r.malformed} row(s) CreditsEarned not 3-decimal formatted"
+        )
+    if r.out_of_range:
+        failures.append(
+            f"{r.out_of_range} row(s) CreditsEarned outside 0.000-35.000"
+        )
+    if r.over_available:
+        failures.append(
+            f"{r.over_available} row(s) CreditsEarned exceeds AvailableCredit"
+        )
+    return failures
+```
+
+Extend the list with all four.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: FAIL — `check_credits_earned` reports 14,343 HS rows malformed,
+because `CreditsEarned` is still the extract's `0.000`... which is in fact
+correctly formatted, so the concrete failure is
+`check_in_scope_rows_have_grades` reporting 28,946 rows with no grade.
+
+- [ ] **Step 3: Add the emission CTEs**
+
+Insert after `sourced`:
+
+```sql
+    emitted_grade as (
+        select
+            *,
+
+            if(
+                grade_band in ('HS', 'MS')
+                and candidate_letter in (
+                    'A', 'A+', 'A-', 'B', 'B+', 'B-',
+                    'C', 'C+', 'C-', 'D', 'D+', 'D-',
+                    'E', 'E+', 'E-', 'F', 'F+', 'F-'
+                ),
+                candidate_letter,
+                cast(null as string)
+            ) as emitted_alpha_grade,
+        from sourced
+    ),
+
+    emitted_credit as (
+        select
+            *,
+
+            case
+                when grade_band != 'HS'
+                then cast(null as string)
+                when stored_earned_credit is not null
+                then format('%.3f', stored_earned_credit)
+                when emitted_alpha_grade is null
+                then cast(null as string)
+                when emitted_alpha_grade like 'F%'
+                then '0.000'
+                else format('%.3f', available_credit_num)
+            end as emitted_credits_earned,
+        from emitted_grade
+    )
+```
+
+In the final `SELECT`, replace the two pass-through columns:
+
+```sql
+    emitted_credits_earned as CreditsEarned,
+```
+
+in position 20, and:
+
+```sql
+    emitted_alpha_grade as AlphaGradeEarned,
+```
+
+in position 22. Change `from sourced` to `from emitted_credit`. Keep the other
+23 submission columns exactly as they are, and keep the audit columns (`region`,
+`grade_band`, `grade_source`) at the end.
+
+Note the credit precedence: the stored earned-credit value wins whenever it
+exists, because it is PowerSchool's own record of credit awarded. The derived
+rule applies only to rows whose grade came from the live fallback, where no
+earned-credit value exists — roughly 52 rows. Sourcing the fallback value from
+the row's own `AvailableCredit` makes the must-not-exceed constraint
+unviolatable.
+
+- [ ] **Step 4: Run it to confirm it passes**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `PASSED (10 check group(s))`.
+
+If `check_in_scope_rows_have_grades` still reports a small residue (on the order
+of 121 rows), that is the known coverage gap and it must be resolved, not
+waived: re-check whether those rows have a live grade outside the `enddate`
+window, and report the remainder to the user for a manual decision before
+upload. Do not relax the check.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/submission_query.py \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'feat(nj-sleds): emit AlphaGradeEarned and CreditsEarned (Refs #4630)'
+```
+
+---
+
+### Task 5: Prove the gate fires
+
+**Files:**
+
+- Modify: `docs/superpowers/nj-sleds-roster/submission/validate_submission.py`
+
+**Interfaces:**
+
+- Consumes: `run_checks` and all ten check groups.
+- Produces: no new columns. Adds
+  `validate_submission.self_test(client) -> list[str]`, reached only via the
+  `--self-test` flag.
+
+A gate that has never failed is not known to work. This task deliberately
+corrupts the query in memory and asserts that each check group catches it.
+
+- [ ] **Step 1: Write the self-test**
+
+Add to `validate_submission.py`:
+
+```python
+def self_test(client):
+    """Prove each check group fires. Mutates SQL in memory only."""
+    failures = []
+
+    # An out-of-domain grade must be caught by the domain check.
+    bad_domain = SUBMISSION_SQL.replace(
+        "candidate_letter,\n                cast(null as string)",
+        "'F*',\n                cast(null as string)",
+    )
+    if bad_domain == SUBMISSION_SQL:
+        failures.append("self-test could not inject a bad grade domain")
+    else:
+        sql = f"""
+        select count(*) as n
+        from ({bad_domain})
+        where AlphaGradeEarned is not null
+          and AlphaGradeEarned not in ('A', 'B', 'C', 'D', 'F')
+        """
+        if _rows(client, sql)[0].n == 0:
+            failures.append("domain check would not have caught 'F*'")
+
+    # A 1-decimal credit must be caught by the format check.
+    bad_format = SUBMISSION_SQL.replace("format('%.3f'", "format('%.1f'")
+    if bad_format == SUBMISSION_SQL:
+        failures.append("self-test could not inject a bad credit format")
+    else:
+        sql = f"""
+        select count(*) as n
+        from ({bad_format})
+        where CreditsEarned is not null
+          and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
+        """
+        if _rows(client, sql)[0].n == 0:
+            failures.append("format check would not have caught 1 decimal")
+
+    return failures
+```
+
+Wire it into `main` behind a flag:
+
+```python
+def main():
+    client = bigquery.Client(project=PROJECT)
+    if "--self-test" in sys.argv:
+        failures = self_test(client)
+        if failures:
+            print(f"SELF-TEST FAILED ({len(failures)}):")
+            for f in failures:
+                print(f"  - {f}")
+            return 1
+        print("SELF-TEST PASSED")
+        return 0
+    failures = run_checks(client)
+    ...
+```
+
+- [ ] **Step 2: Run the self-test**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python validate_submission.py --self-test
+```
+
+Expected: `SELF-TEST PASSED`. A "could not inject" failure means the string
+targets drifted from the query — update the replacement targets, do not delete
+the self-test.
+
+- [ ] **Step 3: Confirm the real gate still passes**
+
+```bash
+uv run --with google-cloud-bigquery python validate_submission.py
+```
+
+Expected: `PASSED (10 check group(s))`.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'test(nj-sleds): prove the validation gate catches injected defects (Refs #4630)'
+```
+
+---
+
+### Task 6: View creation, export, and runbook
+
+**Files:**
+
+- Create: `docs/superpowers/nj-sleds-roster/submission/build_submission.py`
+- Create: `docs/superpowers/nj-sleds-roster/submission/README.md`
+
+**Interfaces:**
+
+- Consumes: `submission_query.SUBMISSION_SQL`,
+  `submission_query.SUBMISSION_COLUMNS`, `validate_submission.run_checks`.
+- Produces: the view `cokafor.rpt_student_course_submission`, and one CSV per
+  region at a caller-supplied output directory.
+
+- [ ] **Step 1: Write the export script**
+
+Create `build_submission.py`:
+
+```python
+"""Create the NJ SLEDS submission view and export one CSV per region.
+
+Refuses to export if the validation gate reports any failure. Every value is
+written as the string the view produced - no numeric coercion, so 3-decimal
+credits and leading-zero CDS codes survive.
+
+Usage:
+    uv run --with google-cloud-bigquery python build_submission.py OUTDIR
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+from google.cloud import bigquery
+
+from submission_query import SUBMISSION_COLUMNS, SUBMISSION_SQL
+from validate_submission import run_checks
+
+PROJECT = "teamster-332318"
+VIEW = "teamster-332318.cokafor.rpt_student_course_submission"
+REGIONS = ("newark", "camden")
+
+
+def create_view(client):
+    client.query(f"create or replace view `{VIEW}` as {SUBMISSION_SQL}").result()
+    print(f"view created: {VIEW}")
+
+
+def export_region(client, region, outdir):
+    cols = ", ".join(f"`{c}`" for c in SUBMISSION_COLUMNS)
+    sql = f"select {cols} from `{VIEW}` where region = '{region}'"
+    rows = list(client.query(sql).result())
+    path = Path(outdir) / f"NJ_Student_Course_Submission_{region}.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(SUBMISSION_COLUMNS)
+        for row in rows:
+            writer.writerow(
+                ["" if row[c] is None else str(row[c]) for c in SUBMISSION_COLUMNS]
+            )
+    print(f"  {region}: {len(rows)} rows -> {path}")
+    return len(rows)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    client = bigquery.Client(project=PROJECT)
+
+    print("running validation gate...")
+    failures = run_checks(client)
+    if failures:
+        print(f"GATE FAILED ({len(failures)} issue(s)) - refusing to export:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("gate passed")
+
+    create_view(client)
+    total = sum(export_region(client, r, outdir) for r in REGIONS)
+    print(f"exported {total} rows across {len(REGIONS)} region(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run it against a local scratch directory**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill/docs/superpowers/nj-sleds-roster/submission
+uv run --with google-cloud-bigquery python build_submission.py \
+  '/workspaces/teamster/.claude/scratch/NJ SLEDS/submission-out'
+```
+
+Expected: `gate passed`, then `newark: 33150 rows`, `camden: 10343 rows`,
+`exported 43493 rows across 2 region(s)`.
+
+The output directory is inside `.claude/scratch/`, which is gitignored — the
+CSVs are PII-bearing and must never be committed.
+
+- [ ] **Step 3: Verify the written CSV formatting**
+
+```bash
+cd '/workspaces/teamster/.claude/scratch/NJ SLEDS/submission-out'
+uv run python -c "
+import csv
+for region, expected in (('newark', 33150), ('camden', 10343)):
+    with open(f'NJ_Student_Course_Submission_{region}.csv', newline='') as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == expected, (region, len(rows))
+    creds = {r['CreditsEarned'] for r in rows if r['CreditsEarned']}
+    assert all(len(c.split('.')[1]) == 3 for c in creds), sorted(creds)[:5]
+    counties = {r['CountyCodeAssigned'] for r in rows}
+    print(region, len(rows), 'counties', sorted(counties), 'ok')
+"
+```
+
+Expected: row counts match, every non-blank `CreditsEarned` has three decimals,
+and Camden's counties include `07` with its leading zero intact (not `7`).
+
+- [ ] **Step 4: Write the README**
+
+Create `README.md`:
+
+````markdown
+# NJ SLEDS Student Course Roster — grade and credit backfill
+
+Fills `AlphaGradeEarned` and `CreditsEarned` on the loaded Student Course Roster
+extract and writes a submission-ready CSV per region. Every other column passes
+through byte-identical to the native PowerSchool extract.
+
+This is a named exception to the runbook's source-fix-only cleaning model — see
+the design spec for the rationale and its four narrowing constraints.
+
+## Cycle
+
+Run these three steps each time a fresh extract arrives.
+
+1. Reload the extract base tables into `cokafor` (existing reload script).
+1. Run the validation gate:
+
+   ```bash
+   uv run --with google-cloud-bigquery python validate_submission.py
+   ```
+
+1. Create the view and export:
+
+   ```bash
+   uv run --with google-cloud-bigquery python build_submission.py OUTDIR
+   ```
+
+`build_submission.py` runs the gate itself and refuses to export on any failure,
+so step 2 is only for iterating.
+
+## Files
+
+| File                     | Responsibility                                       |
+| ------------------------ | ---------------------------------------------------- |
+| `submission_query.py`    | The SQL, the 25-column order, the legal grade domain |
+| `validate_submission.py` | The pre-upload gate; `--self-test` proves it fires   |
+| `build_submission.py`    | Creates the view, gates, exports per-region CSV      |
+
+## PII
+
+The exported CSVs carry names, dates of birth, and state IDs. Write them to
+`.claude/scratch/` (gitignored), hand them only to the state-access uploader,
+and never commit them or paste row-level values anywhere external.
+
+## Known blocker outside this scope
+
+The CDS defect is still live: 20,652 of 43,493 rows carry a bad County or School
+code, including every Camden row. The fix is the one-pass School Setup change on
+3 Newark and 5 Camden schools. A clean grade backfill does not make the file
+submittable on its own.
+````
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/superpowers/nj-sleds-roster/submission/build_submission.py \
+  docs/superpowers/nj-sleds-roster/submission/README.md </dev/null
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill add \
+  docs/superpowers/nj-sleds-roster/submission/build_submission.py \
+  docs/superpowers/nj-sleds-roster/submission/README.md
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-backfill commit \
+  -m 'feat(nj-sleds): submission view builder and CSV export (Refs #4630)'
+```
+
+---
+
+## Post-implementation
+
+Once all six tasks pass, report to the user:
+
+1. The final gate output and the exported row counts.
+1. Any residue from `check_in_scope_rows_have_grades` — the rows that have no
+   grade from either source, as an aggregate count per region and band. These
+   need a human decision before upload.
+1. A reminder that the CDS blocker still gates submission.
+
+Then open a PR using `.github/pull_request_template.md`, with `Refs #4630` in
+the body. Aggregate counts only — no row-level values.
+
+Resolved during planning, and recorded here so the spec's open items can be
+closed: `pgfinalgrades` has no `academic_year` column and must be scoped by
+`enddate`; its `Y1` term is unused after 2018; and
+`base_powerschool__final_grades` cannot serve this submission because it filters
+to `current_academic_year`, which has already advanced to 2026.
+
+Still open from the spec and **not** addressed by this plan: verifying the
+exported CSV matches the native file's quoting, line endings, and encoding
+against what NJSLEDS accepts (the reload scripts read native files with
+`utf-8-sig`, implying a BOM); confirming Camden's expected school code; and
+diffing handbook v1.4 against the revision the runbook's check 9 encodes.

--- a/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
+++ b/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
@@ -52,10 +52,12 @@ Every task's requirements implicitly include this section.
   repeat across regions (33 shared student local IDs), so an unqualified join
   manufactures false matches.
 - **Grade bands.** `HS` = `sced_level = 'secondary'` and `AvailableCredit`
-  greater than `0`. `MS` = prior-to-secondary whose `GradeSpan` **upper** two
-  characters are in `('06','07','08','09','10','11','12')`. Everything else is
-  `OUT` and receives no grade. Test membership explicitly — `KG` sorts above
-  `06` in a string comparison and would wrongly pull in 1,675 kindergarten rows.
+  greater than `0`. `MS` = prior-to-secondary whose `GradeSpan` **first** two
+  characters — the span's lower bound — are in
+  `('06','07','08','09','10','11','12')`. Everything else is `OUT` and receives
+  no grade. Test membership explicitly rather than with a range comparison: `KG`
+  sorts above `06` as a string, so `>= '06'` would wrongly pull in every
+  kindergarten row.
 - **Never guess.** A conflict or a missing grade produces a blank plus a report
   row, never an inferred value.
 - **Python:** always `uv run`. Never bare `python` / `python3`.
@@ -136,8 +138,8 @@ EXPECTED_BAND_ROWS = {
     ("newark", "MS"): 10746,
     ("newark", "OUT"): 11709,
     ("camden", "HS"): 3648,
-    ("camden", "MS"): 3857,
-    ("camden", "OUT"): 2838,
+    ("camden", "MS"): 3638,
+    ("camden", "OUT"): 3057,
 }
 
 
@@ -331,7 +333,7 @@ with
         select
             *,
 
-            substr(grade_span_padded, 3, 2) as grade_span_upper,
+            substr(grade_span_padded, 1, 2) as grade_span_start,
         from typed
     ),
 
@@ -343,7 +345,7 @@ with
                 when sced_level = 'secondary' and available_credit_num > 0
                 then 'HS'
                 when
-                    grade_span_upper
+                    grade_span_start
                     in ('06', '07', '08', '09', '10', '11', '12')
                 then 'MS'
                 else 'OUT'
@@ -390,10 +392,11 @@ cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grade-ba
 uv run --with google-cloud-bigquery python validate_submission.py
 ```
 
-Expected: `PASSED (2 check group(s))`. If a band count is off by exactly 219,
-the `MS` upper-bound membership test is wrong — `0508` and `KG08` belong in
-`MS`. If `OUT` is short by 1,675, `KG` is being ranked above `06` by a range
-comparison instead of the explicit membership list.
+Expected: `PASSED (2 check group(s))`. If Camden `MS` is over by 219 and Camden
+`OUT` short by the same, the membership test is reading the span's **upper**
+bound (characters 3-4) instead of its lower bound (characters 1-2) — `0508` and
+`KG08` must land in `OUT`. If `OUT` is short by 1,675, `KG` is being ranked
+above `06` by a range comparison instead of the explicit membership list.
 
 - [ ] **Step 5: Lint and commit**
 
@@ -666,15 +669,23 @@ Add to `validate_submission.py`:
 
 ```python
 def check_no_live_conflicts(client):
-    """No student-section resolves to two different live letters."""
+    """A conflicted live grade is never emitted as the resolved value.
+
+    Live reporting terms legitimately disagree on tens of thousands of rows -
+    several term types close on the same date. That is not an error, because
+    on any row with a stored grade the live value is never consulted. The
+    invariant that matters is narrower: when live terms disagree, the guard
+    must null the value rather than pick one, so grade_source can never be
+    'live' on a conflicted row.
+    """
     sql = f"""
     select count(*) as n
     from ({SUBMISSION_SQL})
-    where n_live_letters > 1
+    where n_live_letters > 1 and grade_source = 'live'
     """
     n = _rows(client, sql)[0].n
     if n:
-        return [f"{n} row(s) have conflicting live final grades"]
+        return [f"{n} row(s) emitted a conflicted live grade"]
     return []
 
 
@@ -951,7 +962,7 @@ uv run --with google-cloud-bigquery python validate_submission.py
 Expected: FAIL — `check_credits_earned` reports 14,343 HS rows malformed,
 because `CreditsEarned` is still the extract's `0.000`... which is in fact
 correctly formatted, so the concrete failure is
-`check_in_scope_rows_have_grades` reporting 28,946 rows with no grade.
+`check_in_scope_rows_have_grades` reporting 28,727 rows with no grade.
 
 - [ ] **Step 3: Add the emission CTEs**
 
@@ -1034,11 +1045,20 @@ uv run --with google-cloud-bigquery python validate_submission.py
 
 Expected: `PASSED (10 check group(s))`.
 
-If `check_in_scope_rows_have_grades` still reports a small residue (on the order
-of 121 rows), that is the known coverage gap and it must be resolved, not
-waived: re-check whether those rows have a live grade outside the `enddate`
-window, and report the remainder to the user for a manual decision before
-upload. Do not relax the check.
+`check_in_scope_rows_have_grades` **will** report a residue, and that is
+expected, not a defect. Measured against the strict band rule: 121 in-scope rows
+have no stored grade; roughly a dozen of those resolve from the live fallback,
+and the rest have no grade in either source — meaning PowerSchool holds none, so
+the native extract could not produce one either.
+
+Do not relax or waive the check, and do not invent values for those rows. They
+are a PowerSchool worklist: someone must post the missing grades or exclude
+those sections before upload. Report the residue as an aggregate count broken
+down by region and band, and hand it to the user with the final task report.
+
+This is the one check that is expected to fail on the current data, so
+`build_submission.py` in Task 6 will refuse to export until the source data is
+fixed. That is the gate working as designed.
 
 - [ ] **Step 5: Lint and commit**
 

--- a/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
+++ b/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
@@ -1096,44 +1096,62 @@ corrupts the query in memory and asserts that each check group catches it.
 
 Add to `validate_submission.py`:
 
+````python
+First give every check function an optional `sql` keyword argument defaulting to
+`SUBMISSION_SQL`, and have each one interpolate `sql` rather than
+`SUBMISSION_SQL` in its query:
+
+```python
+def check_alpha_grade_domain(client, sql=SUBMISSION_SQL):
+````
+
+`run_checks` still calls `check(client)`, so the real gate is byte-for-byte
+unchanged in behavior. This exists so the self-test can point the **actual**
+check at a mutated query.
+
+Then add the self-test, which calls those real functions:
+
 ```python
 def self_test(client):
-    """Prove each check group fires. Mutates SQL in memory only."""
+    """Prove the real checks fire on injected defects. Mutates SQL in memory.
+
+    Each block calls the ACTUAL check function against the mutated SQL, so
+    deleting a check from CHECKS, widening its domain, or weakening its
+    predicate makes this self-test fail. A self-test that re-implements the
+    check's own predicate would keep passing with the check removed, which is
+    worse than no self-test at all - it manufactures false confidence.
+    """
     failures = []
 
-    # An out-of-domain grade must be caught by the domain check.
+    # An out-of-domain grade must be caught by check_alpha_grade_domain.
     bad_domain = SUBMISSION_SQL.replace(
         "candidate_letter,\n                cast(null as string)",
         "'F*',\n                cast(null as string)",
     )
     if bad_domain == SUBMISSION_SQL:
         failures.append("self-test could not inject a bad grade domain")
-    else:
-        sql = f"""
-        select count(*) as n
-        from ({bad_domain})
-        where AlphaGradeEarned is not null
-          and AlphaGradeEarned not in ('A', 'B', 'C', 'D', 'F')
-        """
-        if _rows(client, sql)[0].n == 0:
-            failures.append("domain check would not have caught 'F*'")
+    elif not check_alpha_grade_domain(client, sql=bad_domain):
+        failures.append("check_alpha_grade_domain missed an 'F*' grade")
 
-    # A 1-decimal credit must be caught by the format check.
+    # A 1-decimal credit must be caught by check_credits_earned.
     bad_format = SUBMISSION_SQL.replace("format('%.3f'", "format('%.1f'")
     if bad_format == SUBMISSION_SQL:
         failures.append("self-test could not inject a bad credit format")
-    else:
-        sql = f"""
-        select count(*) as n
-        from ({bad_format})
-        where CreditsEarned is not null
-          and not regexp_contains(CreditsEarned, r'^[0-9]+\\.[0-9]{{3}}$')
-        """
-        if _rows(client, sql)[0].n == 0:
-            failures.append("format check would not have caught 1 decimal")
+    elif not any(
+        "3-decimal" in f for f in check_credits_earned(client, sql=bad_format)
+    ):
+        failures.append("check_credits_earned missed a 1-decimal credit")
 
     return failures
 ```
+
+Note the asymmetry in the two assertions. `check_alpha_grade_domain` returns an
+empty list on clean data, so a plain truthiness test suffices.
+`check_credits_earned` already returns a `missing = 50` failure on clean data,
+so a truthiness test would pass even with the format clause broken — the
+self-test must look for the **specific** failure string.
+
+````
 
 Wire it into `main` behind a flag:
 
@@ -1151,7 +1169,7 @@ def main():
         return 0
     failures = run_checks(client)
     ...
-```
+````
 
 - [ ] **Step 2: Run the self-test**
 

--- a/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
+++ b/docs/superpowers/plans/2026-07-30-nj-sleds-grade-credit-backfill.md
@@ -421,8 +421,9 @@ git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-nj-sleds-grad
 **Interfaces:**
 
 - Consumes: `SUBMISSION_SQL`, `run_checks` from Task 1.
-- Produces: three new columns on the query — `stored_letter` (`STRING`),
-  `stored_earned_credit` (`FLOAT64`), `n_stored_letters` (`INT64`).
+- Produces: four new columns on the query — `stored_letter` (`STRING`),
+  `stored_earned_credit` (`FLOAT64`), `n_stored_letters` (`INT64`),
+  `n_stored_credits` (`INT64`).
 
 - [ ] **Step 1: Write the failing checks**
 
@@ -461,16 +462,29 @@ def check_stored_coverage(client):
 
 
 def check_no_stored_conflicts(client):
-    """No student-section carries two different stored Y1 letters."""
-    sql = f"""
-    select count(*) as n
-    from ({SUBMISSION_SQL})
-    where n_stored_letters > 1
+    """No student-section carries conflicting stored Y1 letters or credits.
+
+    Both dimensions matter: stored_letter and stored_earned_credit are
+    independent aggregates, so a conflict in either means the pair may not
+    come from the same source row.
     """
-    n = _rows(client, sql)[0].n
-    if n:
-        return [f"{n} row(s) have conflicting stored Y1 letter grades"]
-    return []
+    sql = f"""
+    select
+        countif(n_stored_letters > 1) as letter_conflicts,
+        countif(n_stored_credits > 1) as credit_conflicts
+    from ({SUBMISSION_SQL})
+    """
+    r = _rows(client, sql)[0]
+    failures = []
+    if r.letter_conflicts:
+        failures.append(
+            f"{r.letter_conflicts} row(s) have conflicting stored Y1 letters"
+        )
+    if r.credit_conflicts:
+        failures.append(
+            f"{r.credit_conflicts} row(s) have conflicting stored Y1 credits"
+        )
+    return failures
 ```
 
 Then extend the list:
@@ -522,6 +536,7 @@ In `submission_query.py`, insert after the `sced` CTE:
             max(`grade`) as stored_letter,
             max(earnedcrhrs) as stored_earned_credit,
             count(distinct `grade`) as n_stored_letters,
+            count(distinct earnedcrhrs) as n_stored_credits,
         from stored_raw
         group by _dbt_source_project, studentid_str, sectionid_str
     ),
@@ -551,6 +566,7 @@ predicate someone has to remember.
             sg.stored_letter,
             sg.stored_earned_credit,
             sg.n_stored_letters,
+            sg.n_stored_credits,
 
             'newark' as region,
         from `teamster-332318.cokafor.stg_student_extract_newark` as e
@@ -574,6 +590,7 @@ predicate someone has to remember.
             sg.stored_letter,
             sg.stored_earned_credit,
             sg.n_stored_letters,
+            sg.n_stored_credits,
 
             'camden' as region,
         from `teamster-332318.cokafor.stg_student_extract_camden` as e
@@ -590,8 +607,8 @@ predicate someone has to remember.
     ),
 ```
 
-Add `stored_letter`, `stored_earned_credit`, and `n_stored_letters` to the final
-`SELECT` list, after `grade_band`.
+Add `stored_letter`, `stored_earned_credit`, `n_stored_letters`, and
+`n_stored_credits` to the final `SELECT` list, after `grade_band`.
 
 - [ ] **Step 4: Run it to confirm it passes**
 
@@ -768,6 +785,11 @@ Insert a CTE after `scoped` that resolves the candidate and records its origin:
 
             if(n_stored_letters > 1, null, stored_letter) as safe_stored,
             if(n_live_letters > 1, null, live_letter) as safe_live,
+            if(
+                n_stored_letters > 1 or n_stored_credits > 1,
+                null,
+                stored_earned_credit
+            ) as safe_stored_credit,
         from scoped
     ),
 
@@ -960,8 +982,8 @@ Insert after `sourced`:
             case
                 when grade_band != 'HS'
                 then cast(null as string)
-                when stored_earned_credit is not null
-                then format('%.3f', stored_earned_credit)
+                when safe_stored_credit is not null
+                then format('%.3f', safe_stored_credit)
                 when emitted_alpha_grade is null
                 then cast(null as string)
                 when emitted_alpha_grade like 'F%'
@@ -994,6 +1016,14 @@ rule applies only to rows whose grade came from the live fallback, where no
 earned-credit value exists — roughly 52 rows. Sourcing the fallback value from
 the row's own `AvailableCredit` makes the must-not-exceed constraint
 unviolatable.
+
+The credit path reads `safe_stored_credit`, not `stored_earned_credit`. That
+column is null whenever a student-section has conflicting stored letters **or**
+conflicting stored credit values, because `stored_letter` and
+`stored_earned_credit` are independent aggregates with no guaranteed row
+correspondence — on a conflicted student-section, the pair may come from
+different source rows. Guarding both dimensions keeps a conflicted row from
+emitting a credit alongside a blank grade.
 
 - [ ] **Step 4: Run it to confirm it passes**
 

--- a/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
@@ -195,8 +195,8 @@ always wins; the fallback never overrides one.
   the row itself makes the "must not exceed `AvailableCredit`" constraint
   impossible to violate by construction.
 
-This is the only invented rule in the design, and it is bounded to roughly 52
-secondary rows — small enough to review individually before upload.
+This is the only invented rule in the design, and it applies to exactly 2 rows —
+small enough to review individually before upload.
 
 Rows still blank after both sources stay blank and are listed in the exception
 report. Nothing is guessed.
@@ -206,7 +206,10 @@ report. Nothing is guessed.
 ### The view
 
 `cokafor.rpt_student_course_submission` — all 25 submission columns in
-submission order, plus a `region` column, at one row per extract row.
+submission order, plus ten audit columns (`region`, `grade_band`,
+`stored_letter`, `stored_earned_credit`, `n_stored_letters`, `n_stored_credits`,
+`live_letter`, `n_live_letters`, `candidate_letter`, `grade_source`), at one row
+per extract row.
 
 The view is re-runnable with no edits. Each cycle the intern reloads the base
 tables with the existing reload script and the view reflects the new data
@@ -292,8 +295,10 @@ satisfied by the source data.
 | Camden MS (`0606`/`0707`/`0808`) | 3,638      | 3,633                          | 5       |
 | **In-scope subtotal**            | **28,727** | **28,606 (99.6%)**             | **121** |
 
-Roughly 52 of the 121 gap rows are secondary, so only those need the derived
-credit rule.
+52 of the 121 gap rows are secondary (Newark HS 20 + Camden HS 32). Only the
+ones actually filled by the live fallback need the derived credit rule, not the
+whole 52 — measured at exactly 2 rows. See _What the fallback actually
+recovered_ below.
 
 ### What the fallback actually recovered
 
@@ -302,7 +307,7 @@ spec originally assumed. Of the 121 gap rows:
 
 | Outcome                                       | Rows           |
 | --------------------------------------------- | -------------- |
-| Filled from a live final grade                | 15             |
+| Filled from a live final grade                | 13             |
 | Live grades disagree, so correctly left blank | included below |
 | No usable grade in **either** source          | 106            |
 
@@ -419,8 +424,9 @@ file submittable on its own.**
 
 - ~~Re-measure `Y1` coverage with the final band rule.~~ **Resolved during
   implementation.** Coverage under the strict band rule is 28,606 of 28,727
-  (99.6%), a 121-row gap, of which 15 fill from the live fallback and 106 have
-  no grade in any source. See _What the fallback actually recovered_.
+  (99.6%), a 121-row gap, of which 13 fill from the live fallback, 106 have no
+  grade in any source, and 2 are rejected as `F*`. See _What the fallback
+  actually recovered_.
 - ~~Confirm `pgfinalgrades` exposes a year-final reporting term.~~ **Resolved
   during implementation.** It does not: `pgfinalgrades` has no `academic_year`
   column, holds history back to 2004, and its `Y1` term stopped being used
@@ -452,7 +458,11 @@ file submittable on its own.**
 - No changes to the staff file.
 - No correction of any field other than the two named, including CDS.
 - No promotion or retention logic (see _Contingencies_).
-- No row filtering, deduplication, or reordering.
+- No row filtering or deduplication. Row-count parity is preserved, but row
+  **order** is not: BigQuery's output order across a `union all` with left joins
+  is nondeterministic, and no ordinal column was captured at load, so the native
+  extract's row order is not recoverable. This is harmless for a keyed roster
+  upload, which matches rows on student and section identifiers, not position.
 - No row-level identifiable data on any external surface. The exported CSV is
   PII-bearing and goes to the state-access uploader only; the view stays in
   `cokafor`, in-tenant.

--- a/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
@@ -1,0 +1,418 @@
+# NJ SLEDS Student Course Roster — grade and credit backfill
+
+Design spec for [#4630](https://github.com/TEAMSchools/teamster/issues/4630).
+
+Extends the audit runbook in
+[`docs/superpowers/nj-sleds-roster/runbook.md`](../nj-sleds-roster/runbook.md)
+(branch `anthonygwalters/docs/claude-nj-sleds-course-roster-runbook`, PR
+[#4281](https://github.com/TEAMSchools/teamster/pull/4281), unmerged as of this
+writing) and its design spec
+[`2026-06-29-nj-sleds-course-roster-runbook-design.md`](2026-06-29-nj-sleds-course-roster-runbook-design.md).
+
+## Context
+
+The Student Course Roster extract PowerSchool generates carries no usable grade
+values and a uniformly wrong credit value. Measured against the 2026-07-29
+extract loaded into `cokafor` (43,493 rows: Newark 33,150, Camden 10,343):
+
+- `NumericGradeEarned`, `AlphaGradeEarned`, and `CompletionStatus` are empty on
+  **every** row in both regions.
+- `CreditsEarned` is populated on all 14,343 secondary-code rows but has exactly
+  **one distinct value, `0.000`**. Every high school student currently reports
+  earning zero credits toward graduation.
+- Every row carries a `SectionExitDate`, so no row escapes the requirement on
+  the exit-date condition.
+
+Two causes, neither fixable at the source in the time available: customizations
+in the KTAF grading model, and mapping gaps in PowerSchool's NJ state-reporting
+configuration. Filing the submission is a formal certification that the data is
+accurate, so the file cannot ship in this state.
+
+### What the handbook requires
+
+All citations are to the **NJ SLEDS Student Course Roster Submission Handbook,
+Version 1.4, dated July 28, 2026** — a newer revision than the copy the runbook
+was originally written against. Pages 33 through 36 state the grade requirement
+four times in identical terms (overview, then once under each of the three grade
+elements):
+
+> Grades or Completion Status are required to be collected for all students in
+> courses with Secondary course codes and an available credit of greater than
+> 0.000.
+>
+> Grades or Completion Status are also required for students with
+> Prior-to-secondary course codes that have a grade span of 060X and higher
+> (where X is replaced with a full Grade Span such as 0606, 0607, 0608, and so
+> on).
+
+Each element's "Is this Data Element Required?" section adds the exit-date
+condition: the rule applies to "all students with a `SectionExitDate` entered"
+in those two populations.
+
+Relevant domains and constraints:
+
+| Element              | Page | Type and domain                                   | Notes                                                                                               |
+| -------------------- | ---- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `NumericGradeEarned` | 34   | numeric, `0`–`100`, whole number                  | not weighted; round decimals                                                                        |
+| `AlphaGradeEarned`   | 35   | `A A+ A- B B+ B- C C+ C- D D+ D- E E+ E- F F+ F-` | `E` is a grade, not "Exempt"                                                                        |
+| `CompletionStatus`   | 36   | `P` `F` `W` `I` `NG`                              | `P` is **not** legal in `AlphaGradeEarned`                                                          |
+| `CreditsEarned`      | 32   | numeric, `0.000`–`35.000`, min length 5           | mandatory for Secondary codes with a `SectionExitDate`; **error if greater than `AvailableCredit`** |
+| `AvailableCredit`    | 27   | numeric, `0.000`–`35.000`                         | mandatory for Secondary; may be blank for Prior-to-secondary                                        |
+
+One or more of the three grade elements must be present for a row in scope; the
+handbook does not require all three.
+
+## Decisions (load-bearing)
+
+1. **Populate `AlphaGradeEarned`, not `NumericGradeEarned`.** Letter grades are
+   what the transcript shows, and — see the data profile below — the stored
+   letter grades already fall inside the handbook domain, so this needs no
+   mapping table and does not re-open the grading-model customization.
+2. **Pass/fail is out of scope.** `P` is illegal in `AlphaGradeEarned`, so
+   pass/fail would have to go in `CompletionStatus`. The rows that would need it
+   are the ones the handbook does not require a grade for. See _Contingencies_ —
+   this is deliberately deferred, not overlooked.
+3. **`CreditsEarned` comes from PowerSchool's own earned-credit value**, not
+   from a pass/fail rule we invent. `storedgrades.earnedcrhrs` already encodes
+   the outcome.
+4. **Two fields only.** Every other column passes through byte-identical to the
+   native extract. This is a narrow, named exception to source-fix-only, not a
+   replacement for it.
+5. **A view plus a thin export script**, both region-aware, living in `cokafor`
+   and the repo respectively. Not a dbt model — see _Non-goals_.
+
+## Scope
+
+| Field              | Rows in scope | Rule                                                                                                                                              |
+| ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AlphaGradeEarned` | 28,946        | Secondary-code rows with `AvailableCredit` greater than `0.000`, plus prior-to-secondary rows whose `GradeSpan` **upper bound** is `06` or higher |
+| `CreditsEarned`    | 14,343        | Secondary-code rows only                                                                                                                          |
+
+Row counts by band, from the 2026-07-29 extract:
+
+| Band         | Classification                                  | Newark     | Camden     | Total      |
+| ------------ | ----------------------------------------------- | ---------- | ---------- | ---------- |
+| HS           | `sced_level = 'secondary'`                      | 10,695     | 3,648      | 14,343     |
+| MS           | prior-to-secondary, span upper bound `06`+      | 10,746     | 3,857      | 14,603     |
+| Out of scope | prior-to-secondary, span upper bound below `06` | 11,709     | 2,838      | 14,547     |
+| **Total**    |                                                 | **33,150** | **10,343** | **43,493** |
+
+### The band rule, and why the upper bound
+
+The handbook's `060X and higher` phrasing does not say which end of a grade span
+is tested. Testing the **upper** bound resolves the ambiguity in the direction
+that cannot cause a rejection: a span reaching grade 6 or above gets a grade.
+Applied to the observed spans:
+
+| Span                                   | Upper bound      | In scope | Rows   |
+| -------------------------------------- | ---------------- | -------- | ------ |
+| `0606`, `0707`, `0808`                 | `06`, `07`, `08` | yes      | 14,384 |
+| `0508`                                 | `08`             | yes      | 20     |
+| `KG08`                                 | `08`             | yes      | 199    |
+| `0505`, `0404`, `0303`, `0202`, `0101` | below `06`       | no       | 12,872 |
+| `KGKG`                                 | `KG`             | no       | 1,675  |
+
+The 219 rows on straddling spans (`0508`, `KG08`, both Camden) are in scope
+under this rule. A strict reading of "spans starting at `06`" would exclude
+them; at 219 rows the cost of being generous is negligible and the cost of being
+wrong is a rejected file.
+
+Note that `KG` must be excluded explicitly. A naive string comparison places
+`'KG'` above `'06'` lexicographically, which would pull all 1,675 `KGKG` rows
+into scope. The implementation must test membership in
+`('06','07','08','09','10','11','12')` rather than using a range comparison.
+
+## Architecture
+
+### Source and join
+
+Primary source is `{region}_powerschool.stg_powerschool__storedgrades`, filtered
+to `academic_year = 2025` and `storecode = 'Y1'` — the year-final grade, which
+matches the handbook's "grade the student received upon completion of the course
+section."
+
+Join path, validated in both regions:
+
+```text
+stg_student_extract.LocalIdentificationNumber -> students.student_number
+students.id                                   -> storedgrades.studentid
+stg_student_extract.LocalSectionCode          -> storedgrades.sectionid
+```
+
+`LocalSectionCode` is PowerSchool's `sections.id`. This was confirmed rather
+than assumed: all 1,508 distinct Newark section codes match `sections.id`, and
+**zero** match `section_number` or `dcid`.
+
+The join is 1:1. Joined row counts equal extract row counts exactly in both
+regions (33,150 and 10,343), so there is no fan-out. The extract itself is one
+row per `(LocalIdentificationNumber, LocalSectionCode)` pair with no duplicates.
+
+### Field derivation
+
+`AlphaGradeEarned` is a **pass-through** of `storedgrades.grade`, guarded
+against the handbook domain: a value outside the 18 legal codes resolves to
+blank and appears in the exception report rather than being emitted. The guard
+exists because the domain is an external contract that can drift, not because
+the current data violates it.
+
+`CreditsEarned` is `storedgrades.earnedcrhrs` formatted to exactly three decimal
+places as a string. Formatting is part of the contract, not presentation: the
+handbook sets a minimum length of 5, so `1` is invalid where `1.000` is valid.
+
+### Region scoping is structural
+
+The view is a `union all` of two region-specific selects. The Newark branch
+reads `kippnewark_powerschool` against `stg_student_extract_newark`; Camden
+reads `kippcamden_powerschool` against `stg_student_extract_camden`. Neither
+branch can see the other's data.
+
+This matters because local identifiers are unique only within a district. The
+runbook documents 33 student local IDs shared across the two regions in the EOY
+data. A single select joining on `LocalIdentificationNumber` alone would
+manufacture false cross-region matches and assign grades to the wrong students.
+Structural separation makes that failure mode unreachable rather than relying on
+a `region` predicate being remembered in every join.
+
+### Fallback for the coverage gap
+
+Secondary source is `{region}_powerschool.stg_powerschool__pgfinalgrades`
+(PowerTeacher live final grades), used **only** to fill nulls. A stored grade
+always wins; the fallback never overrides one.
+
+- `AlphaGradeEarned` uses the same domain-guarded pass-through.
+- `CreditsEarned` requires a derived rule, because live grades carry no
+  earned-credit value: a passing grade (`D-` or better) takes **the row's own
+  `AvailableCredit`**; a failing grade takes `0.000`. Sourcing the value from
+  the row itself makes the "must not exceed `AvailableCredit`" constraint
+  impossible to violate by construction.
+
+This is the only invented rule in the design, and it is bounded to roughly 52
+secondary rows — small enough to review individually before upload.
+
+Rows still blank after both sources stay blank and are listed in the exception
+report. Nothing is guessed.
+
+## The artifact
+
+### The view
+
+`cokafor.rpt_student_course_submission` — all 25 submission columns in
+submission order, plus a `region` column, at one row per extract row.
+
+The view is re-runnable with no edits. Each cycle the intern reloads the base
+tables with the existing reload script and the view reflects the new data
+automatically. This replaces the current practice of hand-editing a copy of the
+reload script per extract cycle.
+
+Because it is a view in `cokafor`, it is queryable from the BigQuery console,
+which keeps it on the runbook's documented critical path and lets the existing
+17 audit checks be pointed at the derived file as well as the native one.
+
+### The export script
+
+A script in the pattern of the existing reload scripts: select from the view for
+one region, write a submission-ready CSV.
+
+The script exists because of two hard constraints, not preference:
+
+1. **Row count.** Newark's 33,150 rows exceed what the BigQuery console will
+   hand back as a CSV download.
+1. **Formatting is correctness.** `CreditsEarned` must keep three decimals and
+   the CDS columns must keep leading zeros (`07`, not `7`). A naive export
+   breaks both — the same failure class as the `--autodetect` trap the runbook
+   already documents for loads, in the opposite direction.
+
+Every column is written as a string, exactly as stored in the view. No numeric
+coercion anywhere in the export path.
+
+## Validation gate
+
+A companion query that must return zero rows before the file goes to the
+state-access uploader:
+
+| #   | Check                                                                               |
+| --- | ----------------------------------------------------------------------------------- |
+| 1   | In-scope rows with a blank `AlphaGradeEarned`                                       |
+| 2   | Secondary rows with a blank `CreditsEarned`, or one not formatted to three decimals |
+| 3   | `AlphaGradeEarned` outside the 18 legal handbook values                             |
+| 4   | `CreditsEarned` greater than `AvailableCredit`                                      |
+| 5   | `CreditsEarned` outside `0.000`–`35.000`                                            |
+| 6   | Row-count parity per region between the view and its base table (fan-out guard)     |
+| 7   | Out-of-scope rows carrying a non-blank grade (scope-boundary guard)                 |
+
+Check 7 is deliberate: it fails if the elementary contingency below is
+implemented without also updating this spec, so scope cannot drift silently.
+
+## Data profile (2026-07-29 extract)
+
+Evidence behind the decisions above. All figures are aggregates; no identifiable
+data appears in this spec.
+
+### Stored letter grades are already handbook-legal
+
+The complete set of `Y1` letter grades for SY 2025-26 is 13 values —
+`A+ A A- B+ B B- C+ C C- D+ D D- F` — summing to exactly 25,006 (Newark) and
+8,493 (Camden), which is every `Y1` row in each region. No nulls, no
+out-of-domain codes, no local placeholder values. Every one of the 13 is legal
+`AlphaGradeEarned`.
+
+This is the finding that makes the pass-through viable and removes the need for
+a grade-scale mapping table.
+
+### Earned credit hours already encode pass and fail
+
+`earnedcrhrs` and `potentialcrhrs` are populated on 100% of `Y1` rows (25,006 of
+25,006 Newark; 8,493 of 8,493 Camden). `earnedcrhrs` equals `potentialcrhrs` for
+passing students and `0` for failing ones.
+
+Against the extract's own `AvailableCredit` on matched secondary rows:
+
+- `earnedcrhrs` exceeds `AvailableCredit` on **zero** rows.
+- `potentialcrhrs` differs from `AvailableCredit` on **zero** rows.
+
+So the two scales agree, and the handbook's credit constraint is already
+satisfied by the source data.
+
+### Coverage
+
+| Band                             | Rows       | Matched to a `Y1` stored grade | Gap     |
+| -------------------------------- | ---------- | ------------------------------ | ------- |
+| Newark HS                        | 10,695     | 10,675                         | 20      |
+| Newark MS (`0606`/`0707`/`0808`) | 10,746     | 10,682                         | 64      |
+| Camden HS                        | 3,648      | 3,616                          | 32      |
+| Camden MS (`0606`/`0707`/`0808`) | 3,638      | 3,633                          | 5       |
+| **In-scope subtotal**            | **28,727** | **28,606 (99.6%)**             | **121** |
+
+Roughly 52 of the 121 gap rows are secondary, so only those need the derived
+credit rule.
+
+**Measurement caveat.** Coverage was measured before the straddling-span
+decision, so the 219 `0508` and `KG08` rows were counted inside the out-of-scope
+bucket and their `Y1` coverage is **not** included in the table above.
+Implementation must re-measure with the final band rule. For reference, the
+out-of-scope bucket as measured (which included those 219 rows) matched 3,502 of
+11,709 in Newark and 1,224 of 3,057 in Camden.
+
+## Named exception to source-fix-only
+
+The runbook's cleaning model is explicit: defects are corrected at the source in
+PowerSchool so the native extract comes out clean, the extract CSV is never
+rewritten or post-filtered in BigQuery, and the handoff artifact is the
+regenerated native extract.
+
+**This work breaks that rule for two fields, on purpose.** PowerSchool cannot
+emit `AlphaGradeEarned` or `CreditsEarned` correctly because of the
+grading-model customization and the state-reporting mapping gaps, and neither is
+fixable inside the submission window. The handoff artifact for the student file
+becomes the **derived** CSV rather than the native one.
+
+Constraints that keep the exception narrow:
+
+- Exactly two fields are written. Every other column passes through unchanged.
+- No row is added, removed, or filtered. Row-count parity is check 6.
+- Every other defect — CDS above all — is still fixed at source.
+- The exception is scoped to the student file. The staff file is untouched.
+
+Recording it here means the boundary is a decision with a rationale rather than
+an undocumented contradiction between the runbook and what actually ships.
+
+## Contingencies and follow-ups
+
+### Elementary pass/fail (contingent, not planned)
+
+The 14,547 out-of-scope rows (prior-to-secondary, span upper bound below `06`,
+including all `KGKG`) get no grade under this design, because the handbook does
+not require one for them.
+
+That reading is an inference. The handbook states the requirement affirmatively
+for two populations and is **silent** on whether a grade is permitted or
+expected outside them — it does not say those rows must be blank. Validators are
+routinely stricter than the prose they implement, and prior-year KTAF experience
+suggests the state may in fact expect values here.
+
+**If NJSLEDS returns errors or warnings on blank grade fields for those rows,**
+the contingency is a `CompletionStatus` of `P` or `F` per row, derived from
+promotion: a student promoted to the next grade (SY 2026-27 grade level higher
+than SY 2025-26) takes `P` on all their courses; a student retained (grade level
+equal) takes `F`. `P` must go in `CompletionStatus`, never `AlphaGradeEarned`,
+where it is not a legal value.
+
+Adding it requires resolving, at minimum:
+
+- The authoritative source for the SY 2026-27 grade level —
+  `students.sched_nextyeargrade` versus actual SY 2026-27 enrollment records.
+- Students with no SY 2026-27 record at all: transfers out, and any student who
+  left the network. The equality test would mark them retained, which is wrong.
+- Whether `int_reporting__promotional_status` should drive this instead. It is a
+  status indicator built on attendance and credits with region-specific
+  thresholds, not a record of the retention decision, so it likely cannot.
+
+Validation-gate check 7 fails if this is implemented without updating this spec.
+
+### NJSLEDS identity splice (follow-up)
+
+For mismatch records that cannot be reconciled on the NJSLEDS end, a follow-up
+would splice state-held values into the extract's identity fields — writing
+`ref_state_student` and `ref_state_staff` values over the extract's own so the
+combination checks (runbook checks 2 and 12) pass.
+
+This is a materially larger departure than the grade backfill: it overwrites
+identity data rather than filling empty derived fields, and it applies to the
+staff file as well. Out of scope here, tracked separately.
+
+## Blockers outside this scope
+
+The CDS defect identified in the June audit is **still live** in the 2026-07-29
+extract and gates the same upload:
+
+| Region | County | District | School | Rows   | Status            |
+| ------ | ------ | -------- | ------ | ------ | ----------------- |
+| Newark | `80`   | `7325`   | `965`  | 22,841 | correct           |
+| Newark | blank  | `7325`   | `732`  | 5,958  | wrong on both     |
+| Newark | `80`   | `7325`   | `732`  | 4,351  | wrong school code |
+| Camden | blank  | `1799`   | `179`  | 6,695  | wrong on both     |
+| Camden | `07`   | `1799`   | `179`  | 3,648  | wrong school code |
+
+20,652 of 43,493 rows (47%) carry a bad CDS, including every Camden row. Camden
+emits `179`, which is neither the expected `111` nor the Newark-style `732`
+pattern, but fits the same root cause: an unset Alternate School Number causing
+a fallback to the internal school number prefix.
+
+The fix remains the one-pass School Setup change on 3 Newark and 5 Camden
+schools documented in the runbook. **A clean grade backfill does not make the
+file submittable on its own.**
+
+## Open items to confirm during implementation
+
+- Re-measure `Y1` coverage with the final band rule, including the 219
+  straddling rows.
+- Confirm the exported CSV matches the native extract's quoting, line endings,
+  and encoding. The reload scripts read the native files with `utf-8-sig`,
+  implying a BOM; the export must not silently change what the state's parser
+  sees.
+- Verify the expected Camden school code is still `111` against the NJDOE
+  directory before anyone keys it.
+- Diff handbook v1.4 against the version the runbook was written from,
+  particularly the v1.2 change making `GradeSpan` blank-able for Secondary and
+  `AvailableCredit` blank-able for Prior-to-secondary, which runbook check 9
+  encodes.
+- Confirm `pgfinalgrades` exposes a year-final reporting term for the gap rows,
+  and decide the selection rule if several final-grade records exist for one
+  section.
+- Confirm no in-scope row draws a grade from a section whose `CourseType` is `C`
+  (dual enrollment) where the grade is held by the college rather than
+  PowerSchool.
+
+## Non-goals
+
+- **No dbt model.** This is a submission-window tool reading a hand-loaded
+  dataset (`cokafor`) that exists only during the audit cycle. Promoting it to
+  dbt is a reasonable durability question for next year's cycle, and is noted as
+  such in the project context, but it is not this work.
+- No changes to the staff file.
+- No correction of any field other than the two named, including CDS.
+- No promotion or retention logic (see _Contingencies_).
+- No row filtering, deduplication, or reordering.
+- No row-level identifiable data on any external surface. The exported CSV is
+  PII-bearing and goes to the state-access uploader only; the view stays in
+  `cokafor`, in-tenant.

--- a/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
@@ -83,44 +83,53 @@ handbook does not require all three.
 
 ## Scope
 
-| Field              | Rows in scope | Rule                                                                                                                                              |
-| ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AlphaGradeEarned` | 28,946        | Secondary-code rows with `AvailableCredit` greater than `0.000`, plus prior-to-secondary rows whose `GradeSpan` **upper bound** is `06` or higher |
-| `CreditsEarned`    | 14,343        | Secondary-code rows only                                                                                                                          |
+| Field              | Rows in scope | Rule                                                                                                                                         |
+| ------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AlphaGradeEarned` | 28,727        | Secondary-code rows with `AvailableCredit` greater than `0.000`, plus prior-to-secondary rows whose `GradeSpan` **starts** at `06` or higher |
+| `CreditsEarned`    | 14,343        | Secondary-code rows only                                                                                                                     |
 
 Row counts by band, from the 2026-07-29 extract:
 
-| Band         | Classification                                  | Newark     | Camden     | Total      |
-| ------------ | ----------------------------------------------- | ---------- | ---------- | ---------- |
-| HS           | `sced_level = 'secondary'`                      | 10,695     | 3,648      | 14,343     |
-| MS           | prior-to-secondary, span upper bound `06`+      | 10,746     | 3,857      | 14,603     |
-| Out of scope | prior-to-secondary, span upper bound below `06` | 11,709     | 2,838      | 14,547     |
-| **Total**    |                                                 | **33,150** | **10,343** | **43,493** |
+| Band         | Classification                             | Newark     | Camden     | Total      |
+| ------------ | ------------------------------------------ | ---------- | ---------- | ---------- |
+| HS           | `sced_level = 'secondary'`                 | 10,695     | 3,648      | 14,343     |
+| MS           | prior-to-secondary, span starts `06`+      | 10,746     | 3,638      | 14,384     |
+| Out of scope | prior-to-secondary, span starts below `06` | 11,709     | 3,057      | 14,766     |
+| **Total**    |                                            | **33,150** | **10,343** | **43,493** |
 
-### The band rule, and why the upper bound
+### The band rule, and which end of the span is tested
 
 The handbook's `060X and higher` phrasing does not say which end of a grade span
-is tested. Testing the **upper** bound resolves the ambiguity in the direction
-that cannot cause a rejection: a span reaching grade 6 or above gets a grade.
-Applied to the observed spans:
+is tested, and the two readings differ by 219 Camden rows. Applied to the
+observed spans:
 
-| Span                                   | Upper bound      | In scope | Rows   |
-| -------------------------------------- | ---------------- | -------- | ------ |
-| `0606`, `0707`, `0808`                 | `06`, `07`, `08` | yes      | 14,384 |
-| `0508`                                 | `08`             | yes      | 20     |
-| `KG08`                                 | `08`             | yes      | 199    |
-| `0505`, `0404`, `0303`, `0202`, `0101` | below `06`       | no       | 12,872 |
-| `KGKG`                                 | `KG`             | no       | 1,675  |
+| Span                                   | Starts | Ends  | In scope | Rows   |
+| -------------------------------------- | ------ | ----- | -------- | ------ |
+| `0606`, `0707`, `0808`                 | `06`+  | `06`+ | yes      | 14,384 |
+| `0508`                                 | `05`   | `08`  | no       | 20     |
+| `KG08`                                 | `KG`   | `08`  | no       | 199    |
+| `0505`, `0404`, `0303`, `0202`, `0101` | below  | below | no       | 12,872 |
+| `KGKG`                                 | `KG`   | `KG`  | no       | 1,675  |
 
-The 219 rows on straddling spans (`0508`, `KG08`, both Camden) are in scope
-under this rule. A strict reading of "spans starting at `06`" would exclude
-them; at 219 rows the cost of being generous is negligible and the cost of being
-wrong is a rejected file.
+**The rule tests the span's start.** This reverses an earlier decision in this
+spec, and the reason is worth recording, because the original reasoning was
+sound but incomplete.
 
-Note that `KG` must be excluded explicitly. A naive string comparison places
-`'KG'` above `'06'` lexicographically, which would pull all 1,675 `KGKG` rows
-into scope. The implementation must test membership in
-`('06','07','08','09','10','11','12')` rather than using a range comparison.
+The generous reading — testing the span's end, which pulls `0508` and `KG08`
+into scope — was chosen on the grounds that a wrongly-omitted graded row is a
+rejection while a wrongly-included blank one is merely a worklist item, and that
+219 rows was a negligible price. Implementation showed the price was not
+negligible: **171 of those 219 rows have no grade in any source**, because
+`KG08` is a kindergarten-through-8 span that carries no grades at all. Including
+them manufactured 171 rows that could never be filled, inflating the ungraded
+worklist from roughly 108 rows to 279. The handbook's own examples — `0606`,
+`0607`, `0608` — all start at `06`, so testing the start is also the more
+literal reading.
+
+Note that `KG` must be excluded by explicit membership test. A naive string
+comparison places `'KG'` above `'06'` lexicographically, so `>= '06'` would pull
+all 1,675 `KGKG` rows into scope. The implementation tests membership in
+`('06','07','08','09','10','11','12')`.
 
 ## Architecture
 
@@ -286,12 +295,36 @@ satisfied by the source data.
 Roughly 52 of the 121 gap rows are secondary, so only those need the derived
 credit rule.
 
-**Measurement caveat.** Coverage was measured before the straddling-span
-decision, so the 219 `0508` and `KG08` rows were counted inside the out-of-scope
-bucket and their `Y1` coverage is **not** included in the table above.
-Implementation must re-measure with the final band rule. For reference, the
-out-of-scope bucket as measured (which included those 219 rows) matched 3,502 of
-11,709 in Newark and 1,224 of 3,057 in Camden.
+### What the fallback actually recovered
+
+Implementation measured the fallback's real yield, and it is far lower than this
+spec originally assumed. Of the 121 gap rows:
+
+| Outcome                                       | Rows           |
+| --------------------------------------------- | -------------- |
+| Filled from a live final grade                | 15             |
+| Live grades disagree, so correctly left blank | included below |
+| No usable grade in **either** source          | 106            |
+
+Plus 2 rows whose only available grade was `F*` — a warehouse-internal marker,
+not a legal `AlphaGradeEarned` value — correctly rejected by the domain guard.
+**Total ungraded: 108** (Newark HS 19 + 1, Newark MS 55, Camden HS 29 + 1,
+Camden MS 3).
+
+The live fallback is therefore a marginal contributor, not the safety net this
+spec implied. The dominant outcome is that PowerSchool holds no grade at all for
+those rows — meaning the native extract could not have produced one either, so
+this is a source-data gap rather than a query limitation. Those 108 rows are a
+PowerSchool worklist: grades must be posted, or the sections excluded, before
+the file can ship. The validation gate reports them and `build_submission.py`
+refuses to export while they stand.
+
+**The domain guard is load-bearing, not defensive decoration.**
+`stg_powerschool__pgfinalgrades` in the SY 2025-26 window carries 21,632 `F*`
+values, 202 `P`, and 2 `I` across the two regions. None are legal
+`AlphaGradeEarned` values (`P` and `I` belong to `CompletionStatus`). Without
+the guard, live-sourced rows would have carried them into a certified
+submission.
 
 ## Named exception to source-fix-only
 
@@ -320,7 +353,7 @@ an undocumented contradiction between the runbook and what actually ships.
 
 ### Elementary pass/fail (contingent, not planned)
 
-The 14,547 out-of-scope rows (prior-to-secondary, span upper bound below `06`,
+The 14,766 out-of-scope rows (prior-to-secondary, span starting below `06`,
 including all `KGKG`) get no grade under this design, because the handbook does
 not require one for them.
 
@@ -384,8 +417,18 @@ file submittable on its own.**
 
 ## Open items to confirm during implementation
 
-- Re-measure `Y1` coverage with the final band rule, including the 219
-  straddling rows.
+- ~~Re-measure `Y1` coverage with the final band rule.~~ **Resolved during
+  implementation.** Coverage under the strict band rule is 28,606 of 28,727
+  (99.6%), a 121-row gap, of which 15 fill from the live fallback and 106 have
+  no grade in any source. See _What the fallback actually recovered_.
+- ~~Confirm `pgfinalgrades` exposes a year-final reporting term.~~ **Resolved
+  during implementation.** It does not: `pgfinalgrades` has no `academic_year`
+  column, holds history back to 2004, and its `Y1` term stopped being used
+  in 2018. The fallback scopes by `enddate` and takes the greatest `enddate` per
+  student-section, which selects the terminal term whatever structure the
+  section uses. Several term types close on the same date and disagree, so the
+  aggregation counts distinct letters and reports a conflict rather than
+  picking.
 - Confirm the exported CSV matches the native extract's quoting, line endings,
   and encoding. The reload scripts read the native files with `utf-8-sig`,
   implying a BOM; the export must not silently change what the state's parser
@@ -396,9 +439,6 @@ file submittable on its own.**
   particularly the v1.2 change making `GradeSpan` blank-able for Secondary and
   `AvailableCredit` blank-able for Prior-to-secondary, which runbook check 9
   encodes.
-- Confirm `pgfinalgrades` exposes a year-final reporting term for the gap rows,
-  and decide the selection rule if several final-grade records exist for one
-  section.
 - Confirm no in-scope row draws a grade from a section whose `CourseType` is `C`
   (dual enrollment) where the grade is held by the college rather than
   PowerSchool.


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request adds a BigQuery view and supporting scripts that fill two fields on the NJ SLEDS Student Course Roster extract, which PowerSchool cannot emit correctly because of customizations in the KTAF grading model and mapping gaps in state reporting.

In the 2026-07-29 extract (43,493 rows: Newark 33,150, Camden 10,343):

- `NumericGradeEarned`, `AlphaGradeEarned`, and `CompletionStatus` are empty on every row.
- `CreditsEarned` is populated but has exactly one distinct value, `0.000`, across all 14,343 secondary-code rows. Every high school student currently reports earning zero credits.

Filing the submission is a formal certification that the data is accurate, so it cannot ship in this state.

### What this adds

Four artifacts under `docs/superpowers/nj-sleds-roster/submission/`, plus the design spec and implementation plan:

- `submission_query.py` — the SQL as a module constant, the 25-column ordinal list, the legal grade domain, and the ungraded-worklist query.
- `validate_submission.py` — a twelve-check validation gate, plus a `--self-test` that injects defects and asserts the real check functions catch them.
- `build_submission.py` — creates the view, runs the gate, exports one CSV per region, and refuses to export on any gate failure.
- `export_worklist.py` — creates the ungraded worklist view and exports it. Deliberately ungated, because it is the tool for clearing the gate.
- `README.md` — the operating cycle.

`AlphaGradeEarned` is a pass-through of `storedgrades.grade` at `academic_year = 2025`, `storecode = Y1`, read through the kipptaf-level union view. The complete observed value set is 13 codes, all legal under the handbook domain, so no mapping table is needed. `CreditsEarned` is `storedgrades.earnedcrhrs` formatted to three decimals, which is PowerSchool's own earned-credit value. Live final grades fill nulls only. Every value is a string end to end, which is what preserves three-decimal credits and leading-zero CDS codes.

Note for anyone reaching for it later: `base_powerschool__final_grades` cannot serve this submission. It filters to `current_academic_year`, which has already advanced to 2026, so it returns zero rows for SY 2025-26.

### Named exception to source-fix-only

The audit runbook's cleaning model is source-fix-only, with the regenerated native PowerSchool extract as the handoff artifact. This is a deliberate, narrow exception, documented as such in the spec: two fields are derived downstream because PowerSchool cannot emit them. Every other defect, CDS above all, is still fixed at source. Four constraints keep it narrow — exactly two fields written, no row added or removed or filtered, student file only, and a gate check asserting the other 23 columns are byte-identical to the base tables.

### Merging this does not mean a file can ship

The validation gate is red by design and correctly refuses to export. 108 in-scope rows have no usable grade in any source, and 50 of those are secondary rows that therefore also have no credit. Those are a PowerSchool worklist, not a code defect — the native extract could not produce a grade for them either.

The new worklist view breaks those 108 rows down so they can be worked: only 41 are whole-section cases that are genuine exclusion candidates. Another 31 already have grades that merely conflict across reporting terms, 2 carry the warehouse-internal `F*` marker, and 34 are individual students in sections where classmates were graded, so excluding those sections would wrongly drop good rows.

Separately, the CDS defect from the June audit is still live and gates the same upload: 20,652 of 43,493 rows carry a bad County or School code, including every Camden row. That remains the critical path and is out of scope here.

## AI Assistance

Human-directed throughout. The author set the scope, chose which grade elements to populate, ruled on the band-classification reading, decided against elementary pass/fail, and picked the grade source. Claude did the research, profiling, drafting, and subagent-driven execution.

Three errors in the author-and-Claude-written plan were caught by review and fixed, and are worth a reviewer glance because they were not implementation slips:

- `check_row_parity` compared against frozen literals rather than the base tables, contradicting the spec's own wording and guaranteeing a false red next cycle with a misleading fan-out message. Now derived.
- The docs overstated the derived-credit rule by 25 times: they said roughly 52 rows, the measured number is 2.
- The credit rule used `like 'F%'` where the spec says D-minus or better. The legal domain includes E, E-plus, and E-minus, which sit below that, so an E grade would have earned full credit. Now an explicit passing list, so a future domain addition defaults to zero credit rather than to full credit. Demonstrated on four real rows forced to E.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [x] **Claude Code Review will not fire on this PR.** `claude-code-review.yaml` triggers on `src/`, `tests/`, `scripts/`, and `mcp/` and excludes markdown; every file here is under `docs/`. Reviewed instead by dispatched reviewers on each task, a whole-branch review, and scoped re-reviews of both fix waves.

### Dagster

Skip — no Dagster changes.

### dbt

Skip — no dbt changes. No models, sources, exposures, or contracts are touched. This is deliberately not a dbt model: it reads a hand-loaded dataset that exists only during the annual audit cycle. The spec records that promoting it to dbt is a reasonable durability question for next year, and why it was not done now.

### Docs

Skip — no schedule, sensor, or integration changes. New files live under `docs/superpowers/`, which is not part of the MkDocs nav.

## CI checks

- [x] **Trunk** — `trunk check --force --no-fix` clean on all changed files locally.
- [ ] **dbt Cloud** — expected to be a no-op. No dbt models are modified, so `state:modified+` selects nothing; a green check here is triviality, not validation.
- [ ] **Dagster Cloud** — not triggered. No paths in any `deploy-prod-*.yaml` are touched.

## Verification

Run on the tree as pushed:

| Check | Result |
| --- | --- |
| `validate_submission.py --self-test` | exit 0, SELF-TEST PASSED |
| `validate_submission.py` | exit 1 — 108 ungraded (Newark HS 20, MS 55; Camden HS 30, MS 3) and 50 missing credits, both by design |
| `build_submission.py` | exit 1, zero files written — refusal path works |
| Worklist | 108 rows, Newark 75 / Camden 33, breakdown 41 / 34 / 31 / 2 reproduced exactly |
| `trunk check --force` | clean |

The self-test's ability to fail was demonstrated, not assumed: widening the grade domain to admit `F*` made it fail with the expected message, and the weakened version was never committed.

The BigQuery view is **not** created. `create_view` is implemented but was left unexecuted, since warehouse DDL belongs in a human's terminal. Running `build_submission.py` or `export_worklist.py` creates it.

## Known open items

- The exported CSV's encoding, quoting, and line endings are unverified against what NJSLEDS accepts. The export writes UTF-8 without a byte-order mark and LF endings, while the reload scripts read native files with `utf-8-sig`, implying the native files carry one. Flagged in the README; must be confirmed before the first real upload.
- Camden's expected school code needs verifying against the NJDOE directory. The June spec says 111, the extract emits 179, and neither is independently confirmed.
- Handbook v1.4, dated 2026-07-28, is newer than the revision the audit runbook was written against and has not been diffed against it.
- Elementary pass or fail via `CompletionStatus` is deliberately out of scope and recorded in the spec as a contingency, with the mechanism written down, in case the state errors on blank grade fields for those rows.

Closes #4630
Refs #4280
