### PR TITLE
feat(nj-sleds): attribute NJSLEDS upload errors locally while detailed reporting is delayed

### DIFF
--- a/.claude/skills/nj-sleds-error-attribution/SKILL.md
+++ b/.claude/skills/nj-sleds-error-attribution/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: nj-sleds-error-attribution
+description: >-
+  Use when an NJSLEDS Course Roster upload comes back with an error count but no
+  error detail. Triggers: "NJSLEDS says 23 errors but won't tell me what they
+  are", "which errors are in this upload", attributing or guessing upload
+  errors, or any question about what a bare NJSLEDS error count represents. Also
+  use when asked what the Staff or Student Course Roster handbook validates for
+  a given field.
+---
+
+# NJSLEDS upload error attribution
+
+## The situation this exists for
+
+NJSLEDS has reduced its service level because of capacity constraints. It still
+accepts and processes Course Roster uploads, but it only generates detailed
+error information overnight, roughly midnight to 1am the following day. So an
+upload returns a bare count — "23 errors" — with no indication of which records
+failed or which rules they broke.
+
+Waiting a day per iteration is not workable inside the submission window. This
+skill closes that gap: it evaluates the handbook's documented validation rules
+against the exact file that was uploaded and works out which rule, or
+combination of rules, accounts for the reported count.
+
+## Before you start
+
+Ask for two things if they were not given:
+
+1. **The exact file that was uploaded.** Not a regenerated one — a re-pull may
+   differ from what the state saw, and then you are explaining the wrong
+   artifact.
+2. **The error count NJSLEDS reported**, and whether it was the staff or student
+   submission.
+
+You can run without a count to get a plain violation report, but the attribution
+is the point.
+
+## How to run it
+
+Everything lives in `docs/superpowers/nj-sleds-roster/error-attribution/`. Run
+from inside that directory so the sibling imports resolve.
+
+```bash
+cd docs/superpowers/nj-sleds-roster/error-attribution
+uv run python attribute_errors.py /path/to/NJ_Student_Course_Submission.csv --errors 23
+```
+
+The submission type is inferred from the header. To drill into one rule and get
+the local identifiers of its violating rows:
+
+```bash
+uv run python attribute_errors.py /path/to/file.csv --rule STU-CREDITSEARNED-RANGE
+```
+
+## How to read the output
+
+The report has four parts, and the order matters:
+
+1. **Handbook rule violations** — a count per rule, with the handbook page and
+   the verbatim error text. This is the evidence base; everything else is
+   inference on top of it.
+2. **Attribution** — rule combinations summing exactly to the reported count.
+   **Prefer single-rule explanations.** Several rules coincidentally summing to
+   the same total is common and is not a diagnosis.
+3. **Additional local findings** — KTAF expectations the handbook does not
+   impose. The state never validates these, so they can never explain its count.
+   Do not fold them into a hypothesis.
+4. **Rules that cannot be checked locally** — an unexplained residual most
+   likely lives here.
+
+Two numbers are reported because a bare count is ambiguous: **error instances**
+(one per violated field, so a row failing two rules contributes two) and **error
+rows** (one per bad row). Which one the state means is not documented. Check
+both against the target before concluding.
+
+## The confirmation loop — this is what makes it converge
+
+Do not treat the top hypothesis as settled. Confirm it in one cycle instead of
+waiting for overnight detail:
+
+1. Fix the top candidate at source in PowerSchool.
+1. Re-pull and re-upload.
+1. Check the count dropped by **exactly** that rule's violation count.
+
+A match confirms the hypothesis. A partial drop means the rule was real but not
+the whole story. No drop means it was the wrong guess — rule it out and move to
+the next candidate. Over a few uploads this triangulates the whole error set.
+
+Record what each cycle proved on
+[issue #4659](https://github.com/TEAMSchools/teamster/issues/4659). Which rules
+actually fired is the data that makes the next cycle faster, and it is lost if
+nobody writes it down.
+
+## Reading the rules directly
+
+When asked what the handbook requires for a field rather than to attribute a
+count, read the extracted rule text rather than the PDF:
+
+- `handbook-rules-staff.md` — Staff Course Roster handbook v1.1, May 2026
+- `handbook-rules-student.md` — Student Course Roster handbook v1.4, July 2026
+
+Both are mechanically extracted from the handbooks and committed, so a fresh
+clone needs no PDFs. The PDFs themselves live in gitignored scratch and will not
+be present.
+
+Quote the `error_text` verbatim when justifying a hypothesis. Paraphrasing loses
+the citation, and the wording is what someone will check against the handbook.
+
+## What this cannot do
+
+Be straight about the limits rather than filling them with a guess:
+
+- Rules needing an external input are marked not-checkable with the reason. The
+  staff five-field combination error needs the state Staff Management export;
+  SCED code validity needs the NCES code list; the dual-enrollment check needs
+  the NJSLEDS OPE ID list.
+- The tool cannot know which reading of the count the state used, or whether it
+  stops at the first error per row.
+- A combination summing to the target is a hypothesis, not a finding. Say so.
+
+If the residual is unexplained, the honest answer is which uncheckable rules
+could account for it — not a fabricated cause.
+
+## PII
+
+The upload files carry names, dates of birth, and state IDs. The report prints
+only counts and rule ids. `--rule` prints local identifiers only, deliberately
+omitting names, dates of birth, and state IDs, following the audit runbook's
+worklist convention.
+
+Keep all row-level output local. Only counts and rule ids may go to an issue, a
+pull request, Slack, or any other external surface.
+
+## Related
+
+- `docs/superpowers/nj-sleds-roster/error-attribution/HANDOFF.md` — the task
+  brief and setup steps.
+- Issue [#4659](https://github.com/TEAMSchools/teamster/issues/4659) — this
+  work, and where to record what each upload cycle proved.
+- Issue [#4280](https://github.com/TEAMSchools/teamster/issues/4280) — the audit
+  runbook and helper-query pack for the wider submission.

--- a/.claude/skills/nj-sleds-error-attribution/SKILL.md
+++ b/.claude/skills/nj-sleds-error-attribution/SKILL.md
@@ -123,6 +123,25 @@ Be straight about the limits rather than filling them with a guess:
 If the residual is unexplained, the honest answer is which uncheckable rules
 could account for it — not a fabricated cause.
 
+## The residual parameter sweep
+
+When the reported count exceeds what the checkable rules explain, the report
+adds a sweep of the tool's **own assumed parameters** — the school-year window,
+the `060X or higher` band threshold, and the name-pattern character classes.
+Each is an assumption rather than a handbook fact, so a wrong one could be the
+residual's cause.
+
+Read it the same way as the rest: a matching candidate is a hypothesis, not a
+finding. And read a negative result as informative — ruling out every sweepable
+parameter narrows the residual to the not-locally-checkable rules, which is real
+progress.
+
+Do not extend the sweep to a parameter on the exclusion list in
+`residual_sweep.py`. The CDS combinations and every handbook-enumerated domain
+are deliberately off limits: tuning a reference value until the file passes is
+the opposite of testing whether an assumption explains the state's count, and
+`rules.py` records what happened the one time that line was crossed.
+
 ## PII
 
 The upload files carry names, dates of birth, and state IDs. The report prints

--- a/docs/superpowers/nj-sleds-roster/error-attribution/HANDOFF.md
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/HANDOFF.md
@@ -1,0 +1,156 @@
+# Handoff — attributing NJSLEDS upload errors
+
+## What you are picking up
+
+NJSLEDS has cut back its service level because of capacity problems. It still
+accepts and processes Course Roster uploads, but it now only produces the
+detailed error report overnight, somewhere around midnight to 1am the next day.
+
+So when you upload a file, you get back a number — "23 errors" — and nothing
+else. No record list, no field names, no rule references. Waiting a day per
+attempt does not fit inside the submission window, and checking by hand does not
+scale and never tells you when you are finished.
+
+Your job is to work out what those errors are on the same day, using the
+handbooks' own validation rules.
+
+## The idea
+
+Both Course Roster handbooks document every validation rule explicitly, as "An
+error will occur if..." statements. There are 122 of them — 54 for staff, 68 for
+student. They have all been extracted and turned into code you can run against
+the file you uploaded.
+
+So instead of guessing, you get a count per rule. If the state says 23 errors
+and one rule is violated on exactly 23 rows, that is almost certainly your
+answer.
+
+The state's count is the only feedback it gives you, so use it as the test:
+
+1. Run the tool against the file you uploaded, with the count the state gave
+   you.
+1. Take the most likely explanation.
+1. Fix it at source in PowerSchool.
+1. Re-pull, re-upload.
+1. Check the count dropped by exactly the amount that rule predicted.
+
+A clean match confirms it. A partial drop means the rule was real but there is
+more. No drop means it was the wrong guess — cross it off and take the next
+candidate. A few cycles of this maps the whole error set without ever waiting
+for the overnight report.
+
+## Setup
+
+You need a clone of the `TEAMSchools/teamster` repo and `uv`. Nothing else — no
+BigQuery access, no dbt, no warehouse credentials.
+
+```bash
+git clone https://github.com/TEAMSchools/teamster.git
+cd teamster/docs/superpowers/nj-sleds-roster/error-attribution
+```
+
+**You do not need the handbook PDFs.** The rules are already extracted into
+`handbook-rules-staff.md` and `handbook-rules-student.md`, which are committed.
+The PDFs themselves live in a gitignored scratch folder and will not be in your
+clone.
+
+**You do need the upload files** — the CSVs PowerSchool generates. Use the exact
+file you uploaded to the state, not a fresh re-pull. A re-pull can differ from
+what the state actually saw, and then you are explaining the wrong file.
+
+## Using it
+
+Run from inside the `error-attribution` directory.
+
+```bash
+uv run python attribute_errors.py "/path/to/NJ_Student_Course_Submission.csv" --errors 23
+```
+
+It works out whether the file is a staff or student submission from its header.
+
+To see which rows a specific rule is flagging:
+
+```bash
+uv run python attribute_errors.py "/path/to/file.csv" --rule STU-CREDITSEARNED-RANGE
+```
+
+That prints local IDs and section codes so you can find the records in
+PowerSchool. It deliberately leaves out names, dates of birth, and state IDs.
+
+If you would rather just describe the situation to Claude, there is a skill that
+picks all this up: tell it something like "NJSLEDS says 23 errors on the student
+upload but won't give me detail until tomorrow" and it will run the right thing.
+
+## Reading the output
+
+Four sections, in the order you should trust them:
+
+| Section                              | What it is                                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Handbook rule violations             | Count per rule, with the handbook page and exact wording. This is evidence.                                   |
+| Attribution                          | Rule combinations that sum to the state's count. This is inference.                                           |
+| Additional local findings            | KTAF expectations the handbook does not require. The state never checks these, so they cannot be your answer. |
+| Rules that cannot be checked locally | Where an unexplained leftover probably lives.                                                                 |
+
+Two things to keep in mind:
+
+**Prefer single-rule explanations.** If four rules happen to add up to 23, that
+is usually coincidence. One rule violated on exactly 23 rows is a real lead.
+
+**The count is ambiguous.** The state may mean 23 bad rows, or 23 bad fields
+across fewer rows. The report gives you both numbers. Check the target against
+both before you commit to a theory.
+
+## What it cannot tell you
+
+Some rules need something the file alone does not contain, and those are marked
+with the reason rather than guessed at:
+
+- The staff five-field identity match needs the state's Staff Management export.
+- SCED subject-area and course-identifier validity needs the NCES SCED code
+  list.
+- The dual-enrollment institution check needs the NJSLEDS OPE ID list.
+
+If the numbers do not add up, the answer is probably in that list. Say that
+rather than inventing a cause — a confident wrong guess costs more than an
+honest "I don't know yet," because someone will go and act on it.
+
+## Please record what you learn
+
+On [issue #4659](https://github.com/TEAMSchools/teamster/issues/4659), after
+each upload cycle, note:
+
+- the count the state reported
+- which rule you thought it was
+- whether the count dropped by the predicted amount
+
+That record is what makes the next cycle faster, and it is the only way we find
+out which rules the state actually enforces versus merely documents. It is lost
+if nobody writes it down.
+
+**Counts and rule ids only.** These files carry student and staff names, dates
+of birth, and state IDs. Never put a row, a name, a date of birth, or an ID in
+an issue, a pull request, Slack, or anywhere else outside your machine.
+
+## If a rule looks wrong
+
+It might be. The catalog was built by reading 122 handbook statements and
+turning each into code, and a misread is possible. The verbatim handbook wording
+sits right next to each rule in the report — if the code and the wording
+disagree, the wording wins. Flag it on the issue and it gets fixed.
+
+## Where things are
+
+| File                                         | What it does                                          |
+| -------------------------------------------- | ----------------------------------------------------- |
+| `attribute_errors.py`                        | The tool you run                                      |
+| `rules.py`                                   | Rule structure and shared value helpers               |
+| `rules_staff.py`                             | The 54 staff rules                                    |
+| `rules_student.py`                           | The 68 student rules                                  |
+| `handbook-rules-staff.md`                    | Extracted Staff handbook text, v1.1 May 2026          |
+| `handbook-rules-student.md`                  | Extracted Student handbook text, v1.4 July 2026       |
+| `.claude/skills/nj-sleds-error-attribution/` | The skill, so Claude picks this up from a description |
+
+Wider context for the submission itself, including the audit runbook and the
+helper-query pack, is in
+[issue #4280](https://github.com/TEAMSchools/teamster/issues/4280).

--- a/docs/superpowers/nj-sleds-roster/error-attribution/HANDOFF.md
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/HANDOFF.md
@@ -115,6 +115,30 @@ If the numbers do not add up, the answer is probably in that list. Say that
 rather than inventing a cause — a confident wrong guess costs more than an
 honest "I don't know yet," because someone will go and act on it.
 
+## When the numbers still don't add up
+
+If the state's count is higher than anything the rules explain, the leftover is
+the **residual**, and the tool does one more thing automatically: it tests its
+own assumptions against it.
+
+A few values in this tool are assumptions rather than handbook facts — mainly
+the school-year date window, which has no cited source. If one of those is
+wrong, it could be the residual's cause. So the report sweeps each assumed value
+against a few candidates and tells you whether any of them would produce exactly
+the missing count.
+
+Most of the time on current data it comes back negative, and that is genuinely
+useful: it rules the assumptions out and points you at the not-locally-checkable
+rules instead, which is where the leftover probably lives. When it does find a
+match, treat it as a lead to confirm by fixing and re-uploading — not as an
+answer.
+
+One thing it deliberately will not do: change a value to make the file look
+cleaner. Testing whether an assumption explains a count the state already gave
+you is legitimate. Retuning a rule until the file passes hides real errors —
+that mistake has already been made once on this project and is documented in
+`rules.py` so it isn't repeated.
+
 ## Please record what you learn
 
 On [issue #4659](https://github.com/TEAMSchools/teamster/issues/4659), after

--- a/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
@@ -105,11 +105,17 @@ def find_coextensive_rules(
     comparison, stated once under each date element, so a single bad row fires
     both and contributes 2 to the error-instance total.
 
-    Whether NJSLEDS emits one error or two for such a row is not documented, so
-    this makes no attempt to decide - it detects the overlap from the data
-    (identical violating-row sets) and discloses it, so the instance total is
-    read as a range rather than a fact. Detecting it rather than hand-tagging
-    known pairs means a pair nobody anticipated is caught too.
+    But an identical row set has a second, quite different cause: several
+    genuinely distinct conditions co-occurring on the same records, as a
+    placeholder row with a bad name and a missing date of birth does. There the
+    instance total is already correct.
+
+    So this only detects the overlap and hands both readings to the caller; it
+    does not adjust anything. `report` distinguishes the two by predicate
+    identity - rules sharing one predicate object are certainly one condition -
+    and offers an adjusted range only for that case. Detecting overlap from the
+    data rather than hand-tagging known pairs means a pair nobody anticipated
+    still surfaces, just without a claim attached.
     """
     signatures: dict[frozenset[int], list[str]] = {}
     for rule in rules:

--- a/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
@@ -141,8 +141,12 @@ def rows_with_any_violation(rules: Sequence[Rule], rows: Sequence[Row]) -> int:
     This is the other reading of a bare count: the state may report one error
     per bad row rather than one per bad field.
     """
-    row_rules = [r for r in rules if r.checkable and r.predicate is not None]
-    return sum(1 for row in rows if any(r.predicate(row) for r in row_rules))
+    predicates = [
+        rule.predicate
+        for rule in rules
+        if rule.checkable and rule.predicate is not None
+    ]
+    return sum(1 for row in rows if any(check(row) for check in predicates))
 
 
 def find_explanations(counts: dict[str, int], target: int) -> list[tuple[str, ...]]:

--- a/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
@@ -95,6 +95,33 @@ def violating_rows(rule: Rule, rows: Sequence[Row]) -> list[Row]:
     return [row for row in rows if rule.predicate(row)]
 
 
+def find_coextensive_rules(
+    rules: Sequence[Rule], rows: Sequence[Row]
+) -> list[tuple[tuple[str, ...], int]]:
+    """Groups of rules that flag exactly the same rows.
+
+    Some handbook statements describe one underlying condition from two sides.
+    Entry-date-after-exit-date and exit-date-before-entry-date are the same
+    comparison, stated once under each date element, so a single bad row fires
+    both and contributes 2 to the error-instance total.
+
+    Whether NJSLEDS emits one error or two for such a row is not documented, so
+    this makes no attempt to decide - it detects the overlap from the data
+    (identical violating-row sets) and discloses it, so the instance total is
+    read as a range rather than a fact. Detecting it rather than hand-tagging
+    known pairs means a pair nobody anticipated is caught too.
+    """
+    signatures: dict[frozenset[int], list[str]] = {}
+    for rule in rules:
+        if not rule.checkable or rule.predicate is None:
+            continue
+        hits = frozenset(i for i, row in enumerate(rows) if rule.predicate(row))
+        if not hits:
+            continue
+        signatures.setdefault(hits, []).append(rule.id)
+    return [(tuple(ids), len(hits)) for hits, ids in signatures.items() if len(ids) > 1]
+
+
 def rows_with_any_violation(rules: Sequence[Rule], rows: Sequence[Row]) -> int:
     """How many rows break at least one rule.
 
@@ -162,6 +189,47 @@ def report(
     print(f"  total error instances (one per violated field) : {instances}")
     print(f"  total rows with at least one violation         : {bad_rows}")
     print()
+
+    handbook_rules = [r for r in rules if r.source == "handbook"]
+    overlaps = find_coextensive_rules(handbook_rules, rows)
+    if overlaps:
+        by_id = {rule.id: rule for rule in rules}
+        print("=== rules flagging identical row sets ===")
+        print()
+        print("  Each group below flags exactly the same rows. That has two very")
+        print("  different possible causes, so check which before adjusting any")
+        print("  total:")
+        print()
+        print("    - One condition stated twice. The handbook sometimes states")
+        print("      the same test under two elements - entry-date-after-exit and")
+        print("      exit-date-before-entry are one comparison. Then the instance")
+        print("      total counts one defect more than once.")
+        print("    - Distinct conditions that co-occur. A placeholder record with")
+        print("      a bad name AND a missing date of birth breaks several real,")
+        print("      separate rules. Then the total is correct as it stands.")
+        print()
+        for ids, hits in overlaps:
+            shared = len({id(by_id[rid].predicate) for rid in ids}) == 1
+            marker = (
+                "same predicate - one condition"
+                if shared
+                else "distinct predicates - check whether these co-occur"
+            )
+            print(f"  {hits:6}  {', '.join(ids)}")
+            print(f"          {marker}")
+        print()
+        definite = sum(
+            (len(ids) - 1) * hits
+            for ids, hits in overlaps
+            if len({id(by_id[rid].predicate) for rid in ids}) == 1
+        )
+        if definite:
+            print(
+                f"  Groups sharing a predicate account for {definite} redundant "
+                f"instance(s),"
+            )
+            print(f"  so the total reads as {instances - definite} to {instances}.")
+            print()
 
     if ktaf:
         print("=== additional local findings, NOT state errors ===")

--- a/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
@@ -16,6 +16,12 @@ The submission type is inferred from the header. Pass --submission to override.
 Only handbook rules can explain a state error count, because only those are what
 the state validates. Local KTAF expectations are reported separately and never
 counted toward the target.
+
+When a residual remains - the target exceeds what checkable rules explain -
+`residual_sweep` tests a small, fixed set of this tool's own assumed
+parameters (the school-year window, the grade-span band reading, and the
+name-pattern character classes) against that residual. See
+`residual_sweep.py`'s module docstring for what that does and does not mean.
 """
 
 from __future__ import annotations
@@ -28,6 +34,7 @@ from collections.abc import Sequence
 from itertools import combinations
 from pathlib import Path
 
+import residual_sweep
 from rules import Row, Rule
 
 # Columns safe to print when drilling into a rule's violating rows. Names, dates
@@ -247,7 +254,9 @@ def report(
         print()
 
     if target is not None:
-        attribute(target, instances, bad_rows, handbook, by_id, uncheckable)
+        attribute(
+            target, instances, bad_rows, handbook, by_id, uncheckable, rows, submission
+        )
 
     if uncheckable:
         print("=== rules this tool cannot check ===")
@@ -266,6 +275,8 @@ def attribute(
     handbook: dict[str, int],
     by_id: dict[str, Rule],
     uncheckable: Sequence[Rule],
+    rows: Sequence[Row],
+    submission: str,
 ) -> None:
     print(f"=== attributing the state's reported {target} errors ===")
     print()
@@ -316,6 +327,7 @@ def attribute(
         )
         print("  most likely lives there, or in a rule the handbook omits.")
         print()
+        residual_sweep.report(rows, submission, target - instances)
     elif target < instances:
         print(
             f"  This tool finds {instances} violations but the state reported {target}."

--- a/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/attribute_errors.py
@@ -1,0 +1,321 @@
+"""Attribute a bare NJSLEDS error count to specific handbook validation rules.
+
+NJSLEDS has reduced its service level: it processes Course Roster uploads but
+only generates detailed error information overnight. An upload therefore returns
+a count with no detail. This tool evaluates the handbook's documented rules
+against the file that was uploaded and works out which rule, or combination of
+rules, accounts for that count.
+
+Usage:
+    uv run python attribute_errors.py FILE.csv --errors 23
+    uv run python attribute_errors.py FILE.csv                  # counts only
+    uv run python attribute_errors.py FILE.csv --rule STU-CREDITSEARNED-RANGE
+
+The submission type is inferred from the header. Pass --submission to override.
+
+Only handbook rules can explain a state error count, because only those are what
+the state validates. Local KTAF expectations are reported separately and never
+counted toward the target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib
+import sys
+from collections.abc import Sequence
+from itertools import combinations
+from pathlib import Path
+
+from rules import Row, Rule
+
+# Columns safe to print when drilling into a rule's violating rows. Names, dates
+# of birth, and state IDs are deliberately excluded - the audit runbook's
+# worklist convention identifies records by local IDs only.
+SAFE_COLUMNS = {
+    "staff": [
+        "LocalStaffIdentifier",
+        "StaffMemberIdentifier",
+        "LocalSectionCode",
+        "LocalCourseCode",
+    ],
+    "student": [
+        "LocalIdentificationNumber",
+        "LocalSectionCode",
+        "LocalCourseCode",
+    ],
+}
+
+# A header column unique to each submission, used to infer the type.
+SIGNATURE = {"staff": "LocalStaffIdentifier", "student": "CreditsEarned"}
+
+MAX_COMBINATION_SIZE = 3
+
+
+def load_rows(path: Path) -> tuple[list[Row], list[str]]:
+    """Read the upload file. utf-8-sig because the native exports carry a BOM."""
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        header = list(reader.fieldnames or [])
+        return [dict(row) for row in reader], header
+
+
+def infer_submission(header: Sequence[str]) -> str:
+    for submission, column in SIGNATURE.items():
+        if column in header:
+            return submission
+    raise SystemExit(
+        "cannot infer submission type from the header; pass --submission "
+        "staff or --submission student"
+    )
+
+
+def load_rules(submission: str) -> list[Rule]:
+    module = importlib.import_module(f"rules_{submission}")
+    return list(module.RULES)
+
+
+def evaluate(rules: Sequence[Rule], rows: Sequence[Row]) -> dict[str, int]:
+    """Count violations per rule id. Row predicates and file counts both."""
+    counts: dict[str, int] = {}
+    for rule in rules:
+        if not rule.checkable:
+            continue
+        if rule.file_count is not None:
+            counts[rule.id] = rule.file_count(rows)
+        elif rule.predicate is not None:
+            counts[rule.id] = sum(1 for row in rows if rule.predicate(row))
+    return counts
+
+
+def violating_rows(rule: Rule, rows: Sequence[Row]) -> list[Row]:
+    if rule.predicate is None:
+        return []
+    return [row for row in rows if rule.predicate(row)]
+
+
+def rows_with_any_violation(rules: Sequence[Rule], rows: Sequence[Row]) -> int:
+    """How many rows break at least one rule.
+
+    This is the other reading of a bare count: the state may report one error
+    per bad row rather than one per bad field.
+    """
+    row_rules = [r for r in rules if r.checkable and r.predicate is not None]
+    return sum(1 for row in rows if any(r.predicate(row) for r in row_rules))
+
+
+def find_explanations(counts: dict[str, int], target: int) -> list[tuple[str, ...]]:
+    """Rule-id sets whose violation counts sum exactly to target.
+
+    Ranked by fewest rules first, then by largest single contribution — one rule
+    accounting for the whole count is a likelier explanation than several
+    coincidentally summing to it.
+    """
+    candidates = {rid: n for rid, n in counts.items() if n > 0}
+    found: list[tuple[str, ...]] = []
+    for size in range(1, MAX_COMBINATION_SIZE + 1):
+        for combo in combinations(sorted(candidates), size):
+            if sum(candidates[rid] for rid in combo) == target:
+                found.append(combo)
+    found.sort(key=lambda combo: (len(combo), -max(candidates[r] for r in combo)))
+    return found
+
+
+def report(
+    submission: str,
+    path: Path,
+    rows: Sequence[Row],
+    rules: Sequence[Rule],
+    counts: dict[str, int],
+    target: int | None,
+) -> None:
+    by_id = {rule.id: rule for rule in rules}
+    handbook = {rid: n for rid, n in counts.items() if by_id[rid].source == "handbook"}
+    ktaf = {rid: n for rid, n in counts.items() if by_id[rid].source == "ktaf"}
+    uncheckable = [r for r in rules if not r.checkable]
+
+    print(f"file        : {path.name}")
+    print(f"submission  : {submission}")
+    print(f"rows        : {len(rows)}")
+    print(
+        f"rules       : {len(handbook)} handbook checkable, "
+        f"{len(ktaf)} KTAF, {len(uncheckable)} not locally checkable"
+    )
+    print()
+
+    instances = sum(handbook.values())
+    bad_rows = rows_with_any_violation(
+        [r for r in rules if r.source == "handbook"], rows
+    )
+    print("=== handbook rule violations ===")
+    print()
+    firing = {rid: n for rid, n in handbook.items() if n > 0}
+    if not firing:
+        print("  none - no handbook rule this tool can check is violated")
+    for rid, count in sorted(firing.items(), key=lambda kv: -kv[1]):
+        rule = by_id[rid]
+        print(f"  {count:6}  {rid}")
+        print(f"          {rule.element} (handbook p{rule.page})")
+        print(f"          {rule.error_text}")
+    print()
+    print(f"  total error instances (one per violated field) : {instances}")
+    print(f"  total rows with at least one violation         : {bad_rows}")
+    print()
+
+    if ktaf:
+        print("=== additional local findings, NOT state errors ===")
+        print()
+        print("  The state does not validate these; they cannot explain its count.")
+        for rid, count in sorted(ktaf.items(), key=lambda kv: -kv[1]):
+            if count:
+                print(f"  {count:6}  {rid}  {by_id[rid].element}")
+        print()
+
+    if target is not None:
+        attribute(target, instances, bad_rows, handbook, by_id, uncheckable)
+
+    if uncheckable:
+        print("=== rules this tool cannot check ===")
+        print()
+        print("  An unexplained residual most likely lives here.")
+        for rule in uncheckable:
+            print(f"  {rule.id}  ({rule.element}, p{rule.page})")
+            print(f"      {rule.uncheckable_reason}")
+        print()
+
+
+def attribute(
+    target: int,
+    instances: int,
+    bad_rows: int,
+    handbook: dict[str, int],
+    by_id: dict[str, Rule],
+    uncheckable: Sequence[Rule],
+) -> None:
+    print(f"=== attributing the state's reported {target} errors ===")
+    print()
+
+    for label, total in (
+        ("error instances", instances),
+        ("error rows", bad_rows),
+    ):
+        if total == target:
+            print(
+                f"  EXACT MATCH on total {label}: everything this tool can "
+                f"check accounts for all {target}."
+            )
+            print()
+
+    explanations = find_explanations(handbook, target)
+    if explanations:
+        print(f"  Rule combinations summing exactly to {target}:")
+        print()
+        for combo in explanations[:10]:
+            total = sum(handbook[rid] for rid in combo)
+            parts = " + ".join(f"{rid} ({handbook[rid]})" for rid in combo)
+            print(f"    {parts} = {total}")
+            if len(combo) == 1:
+                rule = by_id[combo[0]]
+                print(f"      {rule.error_text}")
+        if len(explanations) > 10:
+            print(f"    ... and {len(explanations) - 10} more combinations")
+        print()
+        print("  Prefer the single-rule explanations. Several rules summing to the")
+        print("  same total is often coincidence, not diagnosis.")
+        print()
+    else:
+        print(
+            f"  No combination of up to {MAX_COMBINATION_SIZE} checkable rules "
+            f"sums to {target}."
+        )
+        print()
+
+    if target > instances:
+        print(
+            f"  RESIDUAL: {target - instances} errors beyond what this tool "
+            f"can account for."
+        )
+        print(
+            f"  {len(uncheckable)} rules cannot be checked locally - see below. "
+            "The residual"
+        )
+        print("  most likely lives there, or in a rule the handbook omits.")
+        print()
+    elif target < instances:
+        print(
+            f"  This tool finds {instances} violations but the state reported {target}."
+        )
+        print("  Likely causes: the state stops at the first error per row, or")
+        print("  it does not enforce every documented rule. Compare against the")
+        print(f"  {bad_rows} rows-with-a-violation figure.")
+        print()
+
+    print("  To confirm a hypothesis without waiting for overnight detail: fix")
+    print("  the top candidate, re-upload, and check the count drops by exactly")
+    print("  that rule's violation count. One cycle confirms or refutes it.")
+    print()
+
+
+def drill(rule: Rule, rows: Sequence[Row], submission: str) -> None:
+    """Print local identifiers for a rule's violating rows. No names or DOBs."""
+    if not rule.checkable:
+        raise SystemExit(f"{rule.id} is not locally checkable")
+    if rule.predicate is None:
+        raise SystemExit(f"{rule.id} is file-scoped; there are no per-row hits")
+    hits = violating_rows(rule, rows)
+    columns = SAFE_COLUMNS[submission]
+    print(f"{rule.id}: {len(hits)} violating row(s)")
+    print(f"  {rule.error_text}")
+    print()
+    print("  " + ",".join(columns))
+    for row in hits:
+        print("  " + ",".join(str(row.get(c, "") or "") for c in columns))
+    print()
+    print("  Local identifiers only - names, dates of birth, and state IDs are")
+    print("  deliberately omitted. Keep this output local.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("file", type=Path, help="the CSV that was uploaded")
+    parser.add_argument(
+        "--errors",
+        type=int,
+        default=None,
+        help="the error count NJSLEDS reported for this upload",
+    )
+    parser.add_argument(
+        "--submission",
+        choices=sorted(SIGNATURE),
+        default=None,
+        help="override the submission type inferred from the header",
+    )
+    parser.add_argument(
+        "--rule",
+        default=None,
+        help="print local identifiers for one rule's violating rows",
+    )
+    args = parser.parse_args()
+
+    if not args.file.exists():
+        raise SystemExit(f"no such file: {args.file}")
+
+    rows, header = load_rows(args.file)
+    submission = args.submission or infer_submission(header)
+    rules = load_rules(submission)
+
+    if args.rule:
+        matching = [r for r in rules if r.id == args.rule]
+        if not matching:
+            raise SystemExit(f"unknown rule id: {args.rule}")
+        drill(matching[0], rows, submission)
+        return 0
+
+    counts = evaluate(rules, rows)
+    report(submission, args.file, rows, rules, counts, args.errors)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/nj-sleds-roster/error-attribution/handbook-rules-staff.md
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/handbook-rules-staff.md
@@ -1,0 +1,659 @@
+# NJSLEDS Staff Course Roster — extracted validation rules
+
+Source: Staff Course Roster Submission Handbook, **Version 1.1**, May 2026.
+
+Mechanically extracted from the handbook PDF so the rule catalog is built from
+verbatim text rather than transcription. Do not hand-edit — regenerate if the
+handbook is revised.
+
+Data elements found: **19**.
+
+---
+
+## LocalStaffIdentifier (LSID)
+
+_Handbook page 9._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if this field does not exactly match the value in Staff
+  Management.
+
+### Additional Notes
+
+• Only the staff member responsible for 100% of the roster should be reported.
+
+### Common Errors
+
+Error Message: Duplicate staff record with the same information already exists
+in the LEA. Resolution: Review the staff member’s course records to identify
+which courses are duplicated. To resolve, upload a file with each course record
+listed once for each staff member.
+
+---
+
+## StaffMemberIdentifier (SMID)
+
+_Handbook page 10._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 8 Maximum Length: 8
+
+### Validation Checks
+
+- • An error will occur when the value submitted is not exactly 8 digits.
+- • An error will occur if this field is left blank.
+- • An error will occur when the Staff Member Identifier is not a valid number
+  issued by NJSLEDS.
+- • An error will occur if this field does not exactly match the value in Staff
+  Management.
+
+### Additional Notes
+
+• Only the staff member responsible for 100% of the roster should be reported.
+
+### Common Errors
+
+Error Message: Combination of LSID, SMID, First Name, Last Name, and Date of
+Birth does not match data submitted during the Staff Management submission.
+Resolution: To resolve this error, click on the Snapshot page in Staff
+Management. Compare the values of all five fields (LSID, SMID, First Name, Last
+Name, and Date of Birth) in the record against the fields in the Staff Course
+Roster submission. All five fields in the Staff Course Roster submission must
+match exactly to the Staff Management Snapshot page, and the record on the
+Snapshot must be free of Error, Sync, and Unresolved. Make the necessary changes
+within your local data system and then re-upload to the Staff Course Roster
+submission to resolve the combination error.
+
+---
+
+## FirstName
+
+_Handbook page 11._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 30
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if this field contains any special characters except for
+  apostrophes (‘) and hyphens (-).
+- • An error will occur if this field does not exactly match the value in Staff
+  Management.
+
+### Additional Notes
+
+• First names and last names must be reported as separate fields. • No nicknames
+or abbreviated names should be reported. • Only the staff member responsible for
+100% of the roster should be reported.
+
+### Common Errors
+
+N/A
+
+---
+
+## LastName
+
+_Handbook page 12._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 50
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if this field contains any special characters except for
+  apostrophes (‘) and hyphens (-).
+- • An error will occur if this field does not exactly match the value in Staff
+  Management.
+
+### Additional Notes
+
+• First name and last name must be reported as separate fields. • Staff members
+with more than one last name should include all last names in this field.
+Hyphens may be used if they are part of the legal name (e.g., Smith-Jones).
+Names without hyphens should be entered with a space (e.g., Davis Smyth). • Only
+the staff member responsible for 100% of the roster should be reported.
+
+### Common Errors
+
+N/A
+
+---
+
+## DateOfBirth
+
+_Handbook page 13._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20150128).
+- • An error will occur if this field does not exactly match the value in Staff
+  Management.
+
+### Additional Notes
+
+• Only the staff member responsible for 100% of the course roster should be
+reported.
+
+### Common Errors
+
+N/A
+
+---
+
+## CountyCodeAssigned
+
+_Handbook page 14._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 2 Maximum Length: 2 For County Codes, please
+refer to the NJSLEDS County District School Code List.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the County Code submitted does not conform to the
+  codes listed for your district in the CDS list.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if this field does not exactly match one of the six
+  CountyCodeAssigned values in Staff Management.
+
+### Additional Notes
+
+• The CountyCodeAssigned should reflect the accurate County Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## DistrictCodeAssigned
+
+_Handbook page 15._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 4 Maximum Length: 4 For District Codes, please
+refer to the NJSLEDS County District School Code List.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the District Code submitted does not match the
+  Submitting District.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if this field does not exactly match one of the six
+  DistrictCodeAssigned values in Staff Management.
+
+### Additional Notes
+
+• The DistrictCodeAssigned should reflect the accurate District Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## SchoolCodeAssigned
+
+_Handbook page 16._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 3 Maximum Length: 3 For School Codes, please
+refer to the NJSLEDS County District School Code List.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the School Code submitted does not conform to the
+  codes listed for your district in the CDS list.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if this field does not exactly match one of the six
+  SchoolCodeAssigned values in Staff Management.
+
+### Additional Notes
+
+• The SchoolCodeAssigned should reflect the accurate School Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## SectionEntryDate
+
+_Handbook page 17._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all staff members.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value does not meet the acceptable range of
+  values.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20250128).
+- • An error will occur if the staff course entry date occurs after the staff
+  course exit date.
+- • An error will occur if the SectionEntryDate does not occur in the current
+  School Year.
+
+### Additional Notes
+
+• Only the staff member responsible for 100% of the roster should be reported. •
+If a staff member enters, exits, and later re-enters the same course section
+within the School Year, submit multiple records to reflect each teaching period.
+Do not overwrite earlier exit/entry dates with the most recent entry date. •
+Section Entry and Section Exit Dates are used in the mSGP calculation to
+determine the time in course for the teacher of record. For more information on
+how an mSGP is calculated, please review the Median Student Growth Percentiles
+page.
+
+### Common Errors
+
+N/A
+
+---
+
+## SectionExitDate
+
+_Handbook page 18._
+
+### Is this Data Element Required?
+
+This field is mandatory for all staff who are no longer active in the course.
+Otherwise, this field is not mandatory.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value does not meet the acceptable range of
+  values.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20250128).
+- • An error will occur if the staff course exit date occurs before the staff
+  course entry date.
+- • An error will occur if the SectionExitDate does not occur in the current
+  School Year.
+- • An error will occur if the SectionExitDate is later than the file submission
+  date (for example, a future date).
+
+### Additional Notes
+
+• Only the staff member responsible for 100% of the roster should be reported. •
+If a staff member enters, exits, and later re-enters the same course section
+within the School Year, submit multiple records to reflect each teaching period.
+Do not overwrite earlier exit/entry dates with the most recent entry date. •
+Section Entry and Section Exit Dates are used in the mSGP calculation to
+determine the time in course for the teacher of record. For more information on
+how an mSGP is calculated, please review the Median Student Growth Percentiles
+page.
+
+### Common Errors
+
+N/A
+
+---
+
+## SubjectArea
+
+_Handbook page 19._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 2 Maximum Length: 2 For Subject Area Codes, please
+refer to the NJSLEDS SCED Course Codes document.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Subject Area code.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate subject area code. Some courses will require your professional
+judgement. • Prior-to-secondary course codes should be used for all courses that
+do not have Available Credit. Secondary course codes should be used for all
+courses that have an Available Credit of greater than 0.000. • Staff members
+reported with a Subject Area of 51, 52, or 73 will be pulled to the Teacher
+median SGP District Summary Report. For more information on how an mSGP is
+calculated, please review the Median Student Growth Percentiles page.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseIdentifier
+
+_Handbook page 20._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 3 Maximum Length: 3 For Course Identifier Codes,
+please refer to the NJSLEDS SCED Course Codes document.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Course Identifier code.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate Course Identifier code. Some courses will require your
+professional judgement. • Prior-to-secondary course codes should be used for all
+courses that do not have Available Credit. Secondary course codes should be used
+for all courses that have an Available Credit or greater than 0.000.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseLevel
+
+_Handbook page 21._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 1 • B = Basic or remedial. A
+course focusing primarily on skills development, including literacy in language,
+mathematics, and the physical and social sciences. These courses are typically
+less rigorous than standard courses and may be intended to prepare a student for
+a general course. • G = General or regular. A course providing instruction in a
+given subject area that focuses primarily on general concepts appropriate for
+the grade level. General courses typically meet the state’s or district’s
+expectations of scope and difficulty for mastery of the content. • E = Enriched
+or advanced. A course that augments the content and/or rigor of a general
+course, but does not carry an honors designation. • H = Honors. An advanced
+level course designed for students who have earned honors status according to
+educational requirements. • X = No specified level of rigor.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Course Level code.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate Course Level. Some courses will require your professional
+judgment.
+
+### Common Errors
+
+N/A
+
+---
+
+## GradeSpan
+
+_Handbook page 22._
+
+### Is this Data Element Required?
+
+This field is mandatory for all prior-to-secondary courses. This field is not
+required for secondary courses and can be blank.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 4 Maximum Length: 4 • 4-character
+alphanumeric code with no decimals. • Each grade level from PK through 12 is
+represented by a two-digit code, ranging from PK to 12; kindergarten is
+represented by the letters KG, and prekindergarten by the letters PK.
+
+### Validation Checks
+
+- • An error will occur if the field is left blank for a course with a
+  Prior-To-Secondary course code.
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• For example, a course appropriate for kindergarten and first grade would be
+assigned a Grade Span of KG01.
+
+### Common Errors
+
+N/A
+
+---
+
+## AvailableCredit
+
+_Handbook page 23._
+
+### Is this Data Element Required?
+
+This field is mandatory for all secondary courses. This field is not required
+for prior-to-secondary courses and can be blank.
+
+### Acceptable Values
+
+Type: Numeric with a decimal point Minimum Length: 5 Maximum Length: 6 Values:
+0.000-35.000
+
+### Validation Checks
+
+- • An error will occur if this field is left blank for a course with a
+  Secondary course code.
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• Decimal points rounded up to the nearest thousandths are accepted in this
+field. • 0.000 means the course does not carry any credits.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseSequence
+
+_Handbook page 24._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 2 Maximum Length: 2 Values: 11-99
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value of the first digit is greater than the
+  value of the second digit.
+
+### Additional Notes
+
+• For single section courses, Course Sequence will equal 11 which means 1 of 1
+in a course sequence. Example of a Course with multiple sections: a science
+course that includes a lecture and lab section. Lecture would be coded with a
+Course Sequence of 12 (1 of 2), the lab would be coded with a Course Sequence of
+22 (2 of 2).
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalCourseTitle
+
+_Handbook page 25._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 50
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local course titles. Enter the
+local course title currently used in your district. You do not need to change
+your local course title.
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalCourseCode
+
+_Handbook page 26._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local course codes. Enter the
+local course code currently used in your district. You do not need to change
+your local course codes.
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalSectionCode
+
+_Handbook page 27._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if the field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local section codes. Enter the
+local section code currently used in your district. You do not need to change
+your local section codes.
+
+### Common Errors
+
+N/A
+
+---
+
+Total error conditions extracted: **54**.

--- a/docs/superpowers/nj-sleds-roster/error-attribution/handbook-rules-student.md
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/handbook-rules-student.md
@@ -1,0 +1,922 @@
+# NJSLEDS Student Course Roster — extracted validation rules
+
+Source: Student Course Roster Submission Handbook, **Version 1.4**, July 2026.
+
+Mechanically extracted from the handbook PDF so the rule catalog is built from
+verbatim text rather than transcription. Do not hand-edit — regenerate if the
+handbook is revised.
+
+Data elements found: **25**.
+
+---
+
+## LocalIdentificationNumber (LID)
+
+_Handbook page 11._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+
+### Additional Notes
+
+• Type and length can vary based on a series of numbers and letters used by a
+school district. A student’s LID must be unique throughout the student’s
+enrollment in the district. For districts without LIDs, an LID scheme must be
+created and assigned for all students so that the NJDOE can uniquely identify
+all students in a particular district. • For LIDs that contain leading zeros, be
+sure when extracting and storing the data for transmission that the zeros are
+maintained. • It is important for confidentiality purposes that LIDs do not
+contain any embedded meaning linked to student- specific information.
+
+### Common Errors
+
+Error Message: Duplicate student record with the same information exists in the
+LEA. Resolution: Review the student’s course records to identify which courses
+are duplicated. To resolve, upload a new file with each course record listed
+once for each student.
+
+---
+
+## StateIdentificationNumber (SID)
+
+_Handbook page 12._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for students.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 10 Maximum Length: 10
+
+### Validation Checks
+
+- • An error will occur when the value submitted is not exactly 10 digits.
+- • An error will occur if this field is left blank.
+- • An error will occur when the State Identification Number is not a valid
+  number issued by NJSLEDS.
+- • An error will occur if this field does not exactly match the value in
+  Student Management.
+
+### Additional Notes
+
+• All submission files must include SIDs for students who have had SIDs issued.
+
+### Common Errors
+
+Error Message: Combination of State ID, First Name, Last Name, and Date of Birth
+does not match data submitted during Student Management. Resolution: To resolve
+this error, click on the Snapshot page in Student Management. Compare the values
+of all four fields (SID, First Name, Last Name, and Date of Birth) in the record
+against the fields in the Student Course Roster submission. All four fields in
+the Student Course Roster submission must match exactly to the Student Snapshot
+page, and the record on the Snapshot must be free of Error, Sync, Transfer
+Requests, and Unresolved. Make the necessary changes within your Student
+Information System (SIS) and then re-export and re-upload to the Student Course
+Roster submission to resolve the combination error.
+
+---
+
+## FirstName
+
+_Handbook page 13._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 30
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if this data element contains any special characters
+  except for apostrophes (‘) and hyphens (-).
+- • An error will occur if this field does not exactly match the value in
+  Student Management.
+
+### Additional Notes
+
+• First names and last names must be reported as separate fields. • No nicknames
+or abbreviated names should be reported.
+
+### Common Errors
+
+N/A
+
+---
+
+## LastName
+
+_Handbook page 14._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 50
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if this data element contains any special characters
+  except for apostrophes (‘) and hyphens (-).
+- • An error will occur if this field does not exactly match the value in
+  Student Management.
+
+### Additional Notes
+
+• First name and last name must be reported as separate fields. • Students with
+more than one last name should include all last names in this field. Hyphens may
+be used if they are part of the legal name (e.g., Smith-Jones). Names without
+hyphens should be entered with a space (e.g., Davis Smyth).
+
+### Common Errors
+
+N/A
+
+---
+
+## DateOfBirth
+
+_Handbook page 15._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20150128).
+- • An error will occur if the date falls outside of reasonable parameters (i.
+- • An error will occur if this field does not exactly match the value in
+  Student Management.
+
+### Additional Notes
+
+N/A
+
+### Common Errors
+
+N/A
+
+---
+
+## CountyCodeAssigned
+
+_Handbook page 16._
+
+### Is this Data Element Required?
+
+Yes. This field is The New Jersey County in which the student is currently
+assigned to the course. for all students.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 2 Maximum Length: 2 For County Codes, please
+refer to the NJSLEDS County District School Code List, found on the Key
+Documents page on the NJSLEDS User Resources website.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the County Code submitted does not conform to the
+  codes listed for your district in the CDS list.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if the County Code, District Code, and School Code
+  reported in Student Course Roster do not align with the corresponding Student
+  Management record for the same student (SID).
+
+### Additional Notes
+
+• The CountyCodeAssigned should reflect the accurate County Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## DistrictCodeAssigned
+
+_Handbook page 17._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 4 Maximum Length: 4 For District Codes, please
+refer to the NJSLEDS County District School Code List, found on the Key
+Documents page on the NJSLEDS User Resources website.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the District Code submitted does not match the
+  Submitting District.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if the County Code, District Code, and School Code
+  reported in Student Course Roster do not align with the corresponding Student
+  Management record for the same student (SID).
+
+### Additional Notes
+
+• The DistrictCodeAssigned should reflect the accurate District Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## SchoolCodeAssigned
+
+_Handbook page 18._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 3 Maximum Length: 3 For School Codes, please
+refer to the NJSLEDS County District School Code List, found on the Key
+Documents page on the NJSLEDS User Resources website.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the School Code submitted does not conform to the
+  codes listed for your district in the CDS list.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+- • An error will occur if a School Code designated for a non-operational school
+  is used.
+- • An error will occur if the County Code, District Code, and School Code
+  reported in Student Course Roster do not align with the corresponding Student
+  Management record for the same student (SID).
+
+### Additional Notes
+
+• The SchoolCodeAssigned should reflect the accurate School Code for the
+specific course section.
+
+### Common Errors
+
+N/A
+
+---
+
+## SectionEntryDate
+
+_Handbook page 20._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value does not meet the acceptable range of
+  values.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20250128).
+- • An error will occur if the student course entry date occurs after the
+  student course exit date.
+- • An error will occur if the SectionEntryDate does not occur in the current
+  School Year.
+
+### Additional Notes
+
+• Report each continuous period of enrollment in a section as a separate record.
+If a student enters a course sections, exits, and later re-enters the same
+course section within the School Year, submit multiple records to reflect each
+enrollment period. If records were submitted in error, please submit a delete
+request. Section Entry and Section Exit dates are used in the mSGP calculation
+to determine the time in course for the student. For more information on how an
+mSGP is calculated, please review the Median Student Growth Percentiles page.
+
+### Common Errors
+
+Error Message: Date must be in the current school year. Resolution: Review the
+SectionEntryDate reported for the student’s course section and confirm that it
+reflects the date the student began attending that specific course section
+during the current school year. If the date is outside the current school year,
+correct the value in the Student Information System, re-export, and re-upload
+the file. If the student’s course section record already exists in NJSLEDS, do
+not change the SectionEntryDate unless the original date was incorrect. Because
+NJSLEDS is a target system, changing key course roster information may result in
+an additional record being created rather than updating the existing record. If
+the student exited and later
+
+---
+
+## SectionExitDate
+
+_Handbook page 22._
+
+### Is this Data Element Required?
+
+Sometimes. This field is mandatory for all students who are no longer active in
+the course. Otherwise, this field is not mandatory and should be left blank.
+
+### Acceptable Values
+
+Type: Date Minimum Length: 8 Maximum Length: 8 Format: YYYYMMDD
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value does not meet the acceptable range of
+  values.
+- • An error will occur if the date is not entered in YYYYMMDD format (for
+  example, 20250128).
+- • An error will occur if the student course exit date occurs before the
+  student course entry date.
+- • An error will occur if the SectionExitDate does not occur in the current
+  School Year.
+- • An error will occur if the SectionExitDate is later than the file submission
+  date (for example, a future date).
+
+### Additional Notes
+
+• Report each continuous period of enrollment in a section as a separate record.
+If a student enters a course sections, exits, and later re-enters the same
+course section within the School Year, submit multiple records to reflect each
+enrollment period. Do not overwrite earlier exit/entry dates with the most
+recent entry date. • Section Entry and Section Exit dates are used in the mSGP
+calculation to determine the time in course for the student. For more
+information on how an mSGP is calculated, please review the Median Student
+Growth Percentiles page.
+
+### Common Errors
+
+N/A
+
+---
+
+## SubjectArea
+
+_Handbook page 23._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 2 Maximum Length: 2 For Subject Area Codes, please
+refer to the NJSLEDS SCED Course Codes document, found on the Key Documents page
+of the NJSLEDS User Resources website.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Subject Area code.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate subject area code. Some courses will require your professional
+judgement. • Prior-to-secondary course codes should be used for all courses that
+do not have Available Credit. Secondary course codes should be used for all
+courses that have an Available Credit of greater than 0.000. • Students reported
+with a Subject Area of 51, 52, or 73 may affect a staff member’s mSGP . For more
+information on how an mSGP is calculated, please review the Median Student
+Growth Percentiles page.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseIdentifier
+
+_Handbook page 24._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 3 Maximum Length: 3 For Course Identifier Codes,
+please refer to the NJSLEDS SCED Course Codes document, found on the Key
+Documents page of the NJSLEDS User Resources website.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Course Identifier code.
+- • An error will occur if required leading zeros are missing, resulting in an
+  incorrect value format.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate Course Identifier code. Some courses will require your
+professional judgement. • Prior-to-secondary course codes should be used for all
+courses that do not have Available Credit. Secondary course codes should be used
+for all courses that have an Available Credit or greater than 0.000.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseLevel
+
+_Handbook page 25._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 1 • B = Basic or remedial. A
+course focusing primarily on skills development, including literacy in language,
+mathematics, and the physical and social sciences. These courses are typically
+less rigorous than standard courses and may be intended to prepare a student for
+a general course. • G = General or regular. A course providing instruction in a
+given subject area that focuses primarily on general concepts appropriate for
+the grade level. General courses typically meet the state’s or district’s
+expectations of scope and difficulty for mastery of the content. • E = Enriched
+or advanced. A course that augments the content and/or rigor of a general
+course, but does not carry an honors designation. • H = Honors. An advanced
+level course designed for students who have earned honors status according to
+educational requirements. • X = No specified level of rigor.
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value is not a valid SCED Course Level code.
+
+### Additional Notes
+
+• You will need to work cooperatively with your curriculum coordinator to assign
+the appropriate Course Level. Some courses will require your professional
+judgment.
+
+### Common Errors
+
+N/A
+
+---
+
+## GradeSpan
+
+_Handbook page 26._
+
+### Is this Data Element Required?
+
+This field is mandatory for all prior-to-secondary courses. This field is not
+mandatory for secondary courses and can be blank.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 4 Maximum Length: 4 • 4-character
+alphanumeric code with no decimals. • Each grade level from PK through 12 is
+represented by a two-digit code, ranging from PK to 12; kindergarten is
+represented by the letters KG, and prekindergarten by the letters PK.
+
+### Validation Checks
+
+- • An error will occur if the field is left blank for a course with a
+  Prior-To-Secondary course code.
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• For example, a course appropriate for kindergarten and first grade would be
+assigned a Grade Span of KG01.
+
+### Common Errors
+
+N/A
+
+---
+
+## AvailableCredit
+
+_Handbook page 27._
+
+### Is this Data Element Required?
+
+This field is mandatory for all secondary courses. This field is not mandatory
+for prior-to-secondary courses and can be blank.
+
+### Acceptable Values
+
+Type: Numeric with a decimal point Minimum Length: 5 Maximum Length: 6 Values:
+0.000-35.000
+
+### Validation Checks
+
+- • An error will occur if this field is left blank for a course with a
+  Secondary course code.
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• Decimal points rounded up to the nearest thousandths are accepted in this
+field. • 0.000 means the course does not carry any credits.
+
+### Common Errors
+
+Error Message: Field must be a value in the range 0.000 to 35.000. Resolution:
+Verify that the value reported to this field falls in the appropriate range and
+includes three decimal places in your source system. Re-export and re-upload the
+file to NJSLEDS to the Student Course Roster Submission to resolve the error.
+
+---
+
+## CourseSequence
+
+_Handbook page 28._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 2 Maximum Length: 2 Values: 11-99
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+- • An error will occur if the value of the first digit is greater than the
+  value of the second digit.
+
+### Additional Notes
+
+• For single section courses, Course Sequence will equal 11 which means 1 of 1
+in a course sequence. Example of a Course with multiple sections: a science
+course that includes a lecture and lab section. Lecture would be coded with a
+Course Sequence of 12 (1 of 2), the lab would be coded with a Course Sequence of
+22 (2 of 2).
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalCourseTitle
+
+_Handbook page 29._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 50
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local course titles. Enter the
+local course title currently used in your district. You do not need to change
+your local course title.
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalCourseCode
+
+_Handbook page 30._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if this field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local course codes. Enter the
+local course code currently used in your district. You do not need to change
+your local course codes.
+
+### Common Errors
+
+N/A
+
+---
+
+## LocalSectionCode
+
+_Handbook page 31._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all courses.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 20
+
+### Validation Checks
+
+- • An error will occur if the field is left blank.
+
+### Additional Notes
+
+• There is no state-wide standardized list of local section codes. Enter the
+local section code currently used in your district. You do not need to change
+your local section codes.
+
+### Common Errors
+
+N/A
+
+---
+
+## CreditsEarned
+
+_Handbook page 32._
+
+### Is this Data Element Required?
+
+This field is mandatory for all students in courses with Secondary course codes
+who are no longer active in the course and have been assigned a SectionExitDate.
+Otherwise, this field is not mandatory.
+
+### Acceptable Values
+
+Type: Numeric with decimal point Minimum Length: 5 Maximum Length: 6 Values:
+0.000-35.000
+
+### Validation Checks
+
+- • An error will occur if the field is left blank.
+- • An error will occur if the value does not match the acceptable range of
+  values.
+- • An error will occur if the value is not entered for students who have a
+  SectionExitDate and a Secondary course code.
+- • An error will occur if CreditsEarned is greater than AvailableCredit.
+
+### Additional Notes
+
+• Decimal points are accepted in this field.
+
+### Common Errors
+
+Error Message: Field must be a value in the range 0.000 to 35.000. Resolution:
+Verify that the value reported to this data element falls in the appropriate
+range and includes three decimal places in your source system. Re-export and
+re-upload the file to the Student Course Roster submission to resolve the error.
+
+---
+
+## NumericGradeEarned
+
+_Handbook page 34._
+
+### Is this Data Element Required?
+
+• All students with a SectionExitDate entered for Secondary course codes with an
+available credit of greater than 0.000 must have either the NumericGradeEarned,
+AlphaGradeEarned, or CompletionStatus field filled in. • All students with a
+SectionExitDate entered for Prior-to-secondary course codes with an grade span
+of 060X or higher (where X is replaced with a full GradeSpan such as 0606, 0607,
+0608, and so on) must have either the NumericGradeEarned, AlphaGradeEarned, or
+CompletionStatus field filled in. • NumericGradeEarned field is mandatory for
+the aforementioned students if AlphaGradeEarned and CompletionStatus are left
+blank.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 1 Maximum Length: 3 Values: 0-100
+
+### Validation Checks
+
+- • An error will occur if the value does not match the acceptable range of
+  values.
+- • An error will occur if NumericGradeEarned is not entered as a whole number.
+
+### Additional Notes
+
+• NumericGradeEarned is not a weighted value. If the highest allowed numeric
+grade is greater than 100, convert it to a percentage grade that falls within
+the acceptable values. • Range of Values provided for CompletionStatus,
+NumericGradeEarned, and AlphaGradeEarned will not be expanded for the current
+collection. Continue to maintain your local records to account for any necessary
+data that is not collected in the Course Roster submission.
+
+### Common Errors
+
+N/A
+
+---
+
+## AlphaGradeEarned
+
+_Handbook page 35._
+
+### Is this Data Element Required?
+
+• All students with a SectionExitDate entered for Secondary course codes with an
+available credit of greater than 0.000 must have either the NumericGradeEarned,
+AlphaGradeEarned, or CompletionStatus field filled in. • All students with a
+SectionExitDate entered for Prior-to-secondary course codes with an grade span
+of 060X or higher (where X is replaced with a full GradeSpan such as 0606, 0607,
+0608, and so on) must have either the NumericGradeEarned, AlphaGradeEarned, or
+CompletionStatus field filled in. • AlphaGradeEarned field is mandatory for the
+aforementioned students if NumericGradeEarned and CompletionStatus are left
+blank.
+
+### Acceptable Values
+
+Type: Character Minimum Length: 1 Maximum Length: 2 Values: A, A+, A-, B, B+,
+B-, C, C+, C-, D, D+, D-, E, E+, E-, F , F+, F-
+
+### Validation Checks
+
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• E, E+ and E- refer to a grade and not “Exempt”. • Range of Values provided for
+CompletionStatus, NumericGradeEarned, and AlphaGradeEarned will not be expanded
+for the current collection. Continue to maintain your local records to account
+for any necessary data that is not collected in the Course Roster submission.
+
+### Common Errors
+
+N/A
+
+---
+
+## CompletionStatus
+
+_Handbook page 36._
+
+### Is this Data Element Required?
+
+• All students with a SectionExitDate entered for Secondary course codes with an
+available credit of greater than 0.000 must have either the NumericGradeEarned,
+AlphaGradeEarned, or CompletionStatus field filled in. • All students with a
+SectionExitDate entered for Prior-to-secondary course codes with an grade span
+of 060X or higher (where X is replaced with a full GradeSpan such as 0606, 0607,
+0608, and so on) must have either the NumericGradeEarned, AlphaGradeEarned, or
+CompletionStatus field filled in. • CompletionStatus field is mandatory for the
+aforementioned students if NumericGradeEarned and AlphaGradeEarned are left
+blank.
+
+### Acceptable Values
+
+Type: Alpha Minimum Length: 1 Maximum Length: 2 Values: • P = Pass • F = Fail •
+W = Withdrawal • I = Incomplete • NG = No grade earned
+
+### Validation Checks
+
+- • An error will occur if the value does not match the acceptable range of
+  values.
+
+### Additional Notes
+
+• Range of Values provided for CompletionStatus, NumericGradeEarned, and
+AlphaGradeEarned will not be expanded for the current collection. Continue to
+maintain your local records to account for any necessary data that is not
+collected in the Course Roster submission.
+
+### Common Errors
+
+N/A
+
+---
+
+## CourseType
+
+_Handbook page 37._
+
+### Is this Data Element Required?
+
+Yes. This field is mandatory for all students.
+
+### Acceptable Values
+
+Type: Alphanumeric Minimum Length: 1 Maximum Length: 2 Values: • S1 = Standard
+course taught by a single teacher assigned to your district • S2 = Standard
+course taught by co-teachers assigned to your district • R = Remote course
+physically attended by the student off-site and taught by staff assigned or not
+assigned to your district • C = College level dual enrollment/dual credit course
+taught by staff assigned or not assigned to your district • O = Online course
+taught by staff assigned or not assigned to your district
+
+### Validation Checks
+
+- • An error will occur if a student’s course type is S1 or S2 and that student
+  does not have a staff member assigned to the course in the Staff Course Roster
+  submission.
+- • An error will occur if a value of S2 is entered for a student course that
+  does not have more than one staff member assigned to the course.
+
+### Additional Notes
+
+• The majority of the course sections reported will be reported with a
+CourseType of S1 or S2. • Course Type C should only be used if there is an
+existing articulation agreement between the high school and a college or
+university. • Staff course data is required only for student courses that have a
+CourseType of S1 or S2. If a course section has a CourseType of R, C, or O and
+the course is taught by a staff member not assigned to your district, do not
+report a staff record to the Staff Course Roster submission. This student record
+will not be placed into Out-of- Sync when uploaded. • Course Types R, C, and O
+are exceptions to the Course Roster Submission reporting responsibilities. In
+most cases, these courses are taught by staff not assigned to your district.
+These CourseType values have been developed to allow an opportunity to report
+these courses regardless of the lack of staff data. If the staff member taught
+the course and is assigned to your district, you should report the staff member
+to the Staff
+
+---
+
+## DualInstitution
+
+_Handbook page 39._
+
+### Is this Data Element Required?
+
+This field is mandatory for student course records with a CourseType = C
+(College level dual enrollment/dual credit course taught by staff assigned or
+not assigned to your district). Otherwise, this field is not mandatory.
+
+### Acceptable Values
+
+Type: Numeric Minimum Length: 8 Maximum Length: 8 For OPE ID Codes, please refer
+to the NJSLEDS OPE ID List, found on the Key Documents page of the NJSLEDS User
+Resources website.
+
+### Validation Checks
+
+- • An error will occur if a student’s CourseType = C and DualInstitution is
+  left blank.
+- • An error will occur if a student’s CourseType ≠ C and DualInstitution is
+  populated.
+- • An error will occur if the OPE ID Code does not match a valid code on the
+  OPE ID List.
+
+### Additional Notes
+
+• The DualInstitution field (and CourseType of C) should only be used if there
+is an existing articulation agreement between the high school and a college or
+university.
+
+### Common Errors
+
+N/A
+
+---
+
+Total error conditions extracted: **68**.

--- a/docs/superpowers/nj-sleds-roster/error-attribution/residual_sweep.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/residual_sweep.py
@@ -1,0 +1,477 @@
+"""Bounded residual-parameter sweep for NJSLEDS error attribution.
+
+Sometimes the checkable handbook rules explain fewer errors than the state
+reported for an upload - the gap between "the rule counts add up to N" and
+"the state said M" is the **residual**. A handful of this tool's own
+parameters are not handbook facts; they are judgment calls the catalog had to
+make where the handbook is silent or ambiguous (see `rules.py`'s module
+docstring: the SY_START/SY_END window and the NAME_PATTERN character classes
+are both flagged there as assumptions, not transcriptions). A wrong judgment
+call could be why the residual exists. This module tests that, one parameter
+at a time, against the residual the state already reported.
+
+## Why this is not the Camden 111/179 mistake
+
+`rules.py` documents an incident where a first draft retuned a KTAF reference
+value - Camden's expected CDS school code - until the FILE passed, because the
+rule fired on every row and firing on every row looked like a bad reference
+value. It was not: the file was the defect, and the retune would have
+reported a wholly non-compliant file as clean. That is fitting a parameter to
+the artifact under test.
+
+This module does the opposite. It fits a parameter to an INDEPENDENT number
+that already exists before this tool runs: the error count NJSLEDS reported
+for this specific upload. A candidate here only "matches" when it closes a
+gap the state itself told us exists - not when it makes the file look
+cleaner. Nothing here ever changes what counts as a violation in the real
+rule catalog; every sweep is evaluated in this module's own throwaway
+predicates, against `rows`, and thrown away when the process exits. A match
+is a hypothesis to go confirm by fixing the record at source and
+re-uploading - never a verdict.
+
+## The four bounding constraints
+
+1. One parameter at a time, never a cross-product. Searching combinations of
+   parameters ("widen the window AND flip the band AND drop spaces sums to
+   the residual") is numerology, not diagnosis, and the combinatorics
+   explode. Every sweep function below varies exactly one parameter and
+   holds everything else - including every other sweepable parameter - fixed
+   at its current, shipped value.
+2. Small, fixed candidate sets. Only the candidates enumerated per parameter
+   below are ever evaluated - no continuous range (no day-by-day calendar
+   sweep, no numeric threshold search).
+3. Silent when there is nothing to explain. `report()` returns immediately if
+   the residual it is given is not positive. Callers should only invoke it
+   once they already know a residual exists (no `--errors`, or a target that
+   the checkable rules already account for, both mean this module never
+   runs).
+4. Capped, honest output. At most `MAX_CANDIDATES_REPORTED` candidates print
+   per parameter, and the closing summary states the total number of matches
+   across every parameter swept - including zero. Zero matches is not a null
+   result: it rules the swept parameters out and points the analyst at the
+   rules this tool cannot check locally instead. Several matches is weak
+   evidence, not a menu to pick from, and the summary says so plainly.
+
+## Anti-patterns this module deliberately avoids
+
+- Never modifies `SY_START`, `SY_END`, `NAME_PATTERN`, or any `Rule` in
+  `rules.py` / `rules_staff.py` / `rules_student.py`. Every alternative is
+  evaluated hypothetically, in this module's own local predicates.
+- Never searches parameter combinations (constraint 1).
+- Never generates a continuous candidate range (constraint 2).
+- Never reports a matching candidate as a finding - only as something to
+  confirm by fixing at source and re-uploading.
+- Never sweeps anything on `NEVER_SWEEPABLE` below.
+- No BigQuery, no `eval`/`exec`, no new third-party dependencies - file-only,
+  same as the rest of this tool.
+
+## What is never sweepable, and why
+
+See `NEVER_SWEEPABLE`. If a future maintainer is tempted to add a parameter
+to this module, that constant is where to check first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from rules import NAME_PATTERN, SY_END, SY_START, Row, blank, is_date8, malformed
+
+MAX_CANDIDATES_REPORTED = 5
+
+
+@dataclass(frozen=True)
+class ExcludedParameter:
+    """One parameter this module will never sweep, and why."""
+
+    name: str
+    reason: str
+
+
+# Hard exclusion list. These are handbook facts or authoritative external
+# references, not judgment calls - sweeping them would be indistinguishable
+# from tuning a value until the file passes, which is the mistake this whole
+# module exists to avoid. See the module docstring's "Camden 111/179" section.
+NEVER_SWEEPABLE: tuple[ExcludedParameter, ...] = (
+    ExcludedParameter(
+        name="KTAF CDS combinations (County/District/School triples)",
+        reason=(
+            "Sourced from the data team and the NJDOE directory, not from "
+            "handbook ambiguity - see rules.py's module docstring for the "
+            "Camden 111-vs-179 incident this guards against."
+        ),
+    ),
+    ExcludedParameter(
+        name="CourseLevel codes (B, G, E, H, X)",
+        reason="Enumerated directly in the handbook's Acceptable Values; not ambiguous.",
+    ),
+    ExcludedParameter(
+        name="AlphaGradeEarned values (18: A-F, each optionally with + or -)",
+        reason="Enumerated directly in the handbook's Acceptable Values; not ambiguous.",
+    ),
+    ExcludedParameter(
+        name="CompletionStatus values (P, F, W, I, NG)",
+        reason="Enumerated directly in the handbook's Acceptable Values; not ambiguous.",
+    ),
+    ExcludedParameter(
+        name="Credits / AvailableCredit numeric range (0.000-35.000)",
+        reason="Stated explicitly in the handbook; not ambiguous.",
+    ),
+    ExcludedParameter(
+        name="NumericGradeEarned numeric range (0-100)",
+        reason="Stated explicitly in the handbook; not ambiguous.",
+    ),
+    ExcludedParameter(
+        name=(
+            "Field formats and lengths (8-digit SMID, 10-digit SID, "
+            "2/4/3-digit CDS segments, YYYYMMDD dates, etc.)"
+        ),
+        reason="Stated explicitly in the handbook; not ambiguous.",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class SweepCandidate:
+    """One candidate value for one swept parameter.
+
+    count: the violation count this candidate would produce.
+    delta: count minus the count the CURRENT (shipped) value produces - this
+        is what gets compared against the residual, not the raw count.
+    is_match: whether delta exactly equals the residual being tested against.
+    """
+
+    label: str
+    count: int
+    delta: int
+    is_match: bool
+
+
+@dataclass(frozen=True)
+class SweepSection:
+    """All candidates swept for one parameter."""
+
+    parameter: str
+    candidates: list[SweepCandidate]
+
+
+# --------------------------------------------------------------------------- #
+# 1 & 2. School-year window start/end (SY_START / SY_END).
+# --------------------------------------------------------------------------- #
+
+
+def _valid_dates(rows: Sequence[Row], column: str) -> list[str]:
+    values = (str(row.get(column) or "").strip() for row in rows)
+    return [value for value in values if is_date8(value)]
+
+
+def _earliest_present(rows: Sequence[Row], column: str) -> str | None:
+    dates = _valid_dates(rows, column)
+    return min(dates) if dates else None
+
+
+def _latest_present(rows: Sequence[Row], columns: Sequence[str]) -> str | None:
+    dates: list[str] = []
+    for column in columns:
+        dates.extend(_valid_dates(rows, column))
+    return max(dates) if dates else None
+
+
+def _count_before(rows: Sequence[Row], candidate: str) -> int:
+    """Rows whose SectionEntryDate or SectionExitDate is a valid date earlier
+    than `candidate`. One count per row (not per field) even if both dates
+    qualify.
+    """
+    count = 0
+    for row in rows:
+        entry = row.get("SectionEntryDate")
+        exit_ = row.get("SectionExitDate")
+        entry_before = is_date8(entry) and str(entry).strip() < candidate
+        exit_before = is_date8(exit_) and str(exit_).strip() < candidate
+        if entry_before or exit_before:
+            count += 1
+    return count
+
+
+def _count_after(rows: Sequence[Row], candidate: str) -> int:
+    """Rows whose SectionEntryDate or SectionExitDate is a valid date later
+    than `candidate`. One count per row, same reasoning as `_count_before`.
+    """
+    count = 0
+    for row in rows:
+        entry = row.get("SectionEntryDate")
+        exit_ = row.get("SectionExitDate")
+        entry_after = is_date8(entry) and str(entry).strip() > candidate
+        exit_after = is_date8(exit_) and str(exit_).strip() > candidate
+        if entry_after or exit_after:
+            count += 1
+    return count
+
+
+def _sweep_date_window(
+    rows: Sequence[Row],
+    current: str,
+    fixed_alternates: Sequence[str],
+    dynamic_label: str,
+    dynamic_value: str | None,
+    count_fn: Callable[[Sequence[Row], str], int],
+    residual: int,
+) -> list[SweepCandidate]:
+    entries: list[tuple[str, str]] = [(current, "current")]
+    entries.extend((value, "candidate") for value in fixed_alternates)
+    if dynamic_value is not None:
+        entries.append((dynamic_value, dynamic_label))
+
+    baseline_count = count_fn(rows, current)
+    candidates: list[SweepCandidate] = []
+    for value, label in entries:
+        count = count_fn(rows, value)
+        delta = count - baseline_count
+        candidates.append(
+            SweepCandidate(
+                label=f"{value} ({label})",
+                count=count,
+                delta=delta,
+                is_match=delta == residual,
+            )
+        )
+    return candidates
+
+
+def sweep_sy_start(rows: Sequence[Row], residual: int) -> list[SweepCandidate]:
+    """Candidates: SY_START (current), 20250801, 20250901, and the earliest
+    SectionEntryDate present in the file. Violations = rows whose
+    SectionEntryDate or SectionExitDate falls before the candidate.
+    """
+    earliest = _earliest_present(rows, "SectionEntryDate")
+    return _sweep_date_window(
+        rows,
+        current=SY_START,
+        fixed_alternates=("20250801", "20250901"),
+        dynamic_label="earliest SectionEntryDate present",
+        dynamic_value=earliest,
+        count_fn=_count_before,
+        residual=residual,
+    )
+
+
+def sweep_sy_end(rows: Sequence[Row], residual: int) -> list[SweepCandidate]:
+    """Candidates: SY_END (current), 20260601, 20260701, and the latest valid
+    date present in the file across SectionEntryDate and SectionExitDate.
+    Violations = rows whose SectionEntryDate or SectionExitDate falls after
+    the candidate.
+    """
+    latest = _latest_present(rows, ("SectionEntryDate", "SectionExitDate"))
+    return _sweep_date_window(
+        rows,
+        current=SY_END,
+        fixed_alternates=("20260601", "20260701"),
+        dynamic_label="latest date present",
+        dynamic_value=latest,
+        count_fn=_count_after,
+        residual=residual,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Grade-span band threshold (student files only).
+# --------------------------------------------------------------------------- #
+
+# The handbook's "grade span of 060X or higher" (pp34-36, quoted verbatim in
+# STU-GRADE-COMPLETION-REQUIRED) does not say which two-character half of a
+# concatenated GradeSpan (e.g. "0810" = grade 08 through grade 10) is tested
+# against the 06-12 band. KTAF-GRADE-COMPLETION-MISSING-HEURISTIC in
+# rules_student.py reads it as the span START; this sweep tests the only other
+# plausible reading, the span END, against the same 06-12 band. Two
+# candidates only - this is not a range to search, it is one either/or
+# question.
+_GRADE_SPAN_BAND = frozenset({"06", "07", "08", "09", "10", "11", "12"})
+
+
+def _grade_span_in_band(value: str | None, *, use_end_token: bool) -> bool:
+    if blank(value):
+        return False
+    text = str(value).strip()
+    token = text[2:4] if use_end_token else text[:2]
+    return token in _GRADE_SPAN_BAND
+
+
+def sweep_band_threshold(rows: Sequence[Row], residual: int) -> list[SweepCandidate]:
+    """Candidates: span start in 06-12 (current reading), span end in 06-12
+    (the alternative). Violations = rows that newly fall in scope for the
+    grade-or-completion mandate under the alternative reading - i.e. rows
+    where the end token is in-band but the start token is not.
+    """
+    newly_in_scope = sum(
+        1
+        for row in rows
+        if _grade_span_in_band(row.get("GradeSpan"), use_end_token=True)
+        and not _grade_span_in_band(row.get("GradeSpan"), use_end_token=False)
+    )
+    return [
+        SweepCandidate(
+            label="span start in 06-12 (current reading)",
+            count=0,
+            delta=0,
+            is_match=0 == residual,
+        ),
+        SweepCandidate(
+            label="span end in 06-12 (alternative reading)",
+            count=newly_in_scope,
+            delta=newly_in_scope,
+            is_match=newly_in_scope == residual,
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# 4. Name pattern character classes.
+# --------------------------------------------------------------------------- #
+
+# Each is NAME_PATTERN (rules.py) with exactly one allowed character class
+# removed, to test that class's toggle in isolation. These never replace
+# NAME_PATTERN and are never written back to rules.py - see the module
+# docstring.
+_NAME_NO_SPACE = r"(?:[^\W\d_]|['‘’\-])+"
+_NAME_NO_ACCENTED = r"(?:[A-Za-z]|[ '‘’\-])+"
+_NAME_NO_TYPOGRAPHIC_APOSTROPHE = r"(?:[^\W\d_]|[ '’\-])+"
+
+_NAME_TOGGLES: tuple[tuple[str, str], ...] = (
+    ("disallow space", _NAME_NO_SPACE),
+    ("disallow accented Latin letters", _NAME_NO_ACCENTED),
+    ("disallow the typographic apostrophe (U+2018)", _NAME_NO_TYPOGRAPHIC_APOSTROPHE),
+)
+
+
+def _newly_flagged_name_rows(rows: Sequence[Row], alternate_pattern: str) -> int:
+    """Rows where FirstName or LastName passes NAME_PATTERN today but would
+    fail under `alternate_pattern` - i.e. would newly be flagged.
+    """
+    count = 0
+    for row in rows:
+        first = row.get("FirstName")
+        last = row.get("LastName")
+        newly_first = malformed(first, alternate_pattern) and not malformed(
+            first, NAME_PATTERN
+        )
+        newly_last = malformed(last, alternate_pattern) and not malformed(
+            last, NAME_PATTERN
+        )
+        if newly_first or newly_last:
+            count += 1
+    return count
+
+
+def sweep_name_pattern(rows: Sequence[Row], residual: int) -> list[SweepCandidate]:
+    """Three independent toggles, each evaluated alone against the current
+    NAME_PATTERN baseline: disallow space, disallow accented Latin letters,
+    disallow the typographic apostrophe. Violations = additional FirstName or
+    LastName rows that would be flagged with that one character class
+    removed.
+    """
+    candidates: list[SweepCandidate] = []
+    for label, alternate_pattern in _NAME_TOGGLES:
+        count = _newly_flagged_name_rows(rows, alternate_pattern)
+        candidates.append(
+            SweepCandidate(
+                label=label, count=count, delta=count, is_match=count == residual
+            )
+        )
+    return candidates
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration and report.
+# --------------------------------------------------------------------------- #
+
+
+def _sections(
+    rows: Sequence[Row], submission: str, residual: int
+) -> list[SweepSection]:
+    sections = [
+        SweepSection(
+            "school-year window start (SY_START)", sweep_sy_start(rows, residual)
+        ),
+        SweepSection("school-year window end (SY_END)", sweep_sy_end(rows, residual)),
+    ]
+    if submission == "student":
+        sections.append(
+            SweepSection(
+                "grade-span band threshold (student files only)",
+                sweep_band_threshold(rows, residual),
+            )
+        )
+    sections.append(
+        SweepSection(
+            "name pattern character classes", sweep_name_pattern(rows, residual)
+        )
+    )
+    return sections
+
+
+def report(rows: Sequence[Row], submission: str, residual: int) -> None:
+    """Print the residual sweep, or nothing at all if there is no residual to
+    explain. Only call this from a branch that already knows `residual` is
+    positive (see constraint 3 in the module docstring); the check below is
+    defense in depth, not the primary gate.
+    """
+    if residual <= 0:
+        return
+
+    print("=== residual parameter sweep ===")
+    print()
+    print(
+        "  Testing whether one of this tool's own assumed parameters (not a "
+        "handbook fact) explains"
+    )
+    print(f"  the {residual} error(s) left unexplained by checkable handbook rules.")
+    print(
+        "  One parameter at a time, against the state's own reported count - "
+        "never combined, never"
+    )
+    print("  tuned until the file passes. A match is a hypothesis to confirm by")
+    print("  fixing at source and re-uploading, not a finding.")
+    print()
+
+    total_matches = 0
+    for section in _sections(rows, submission, residual):
+        print(f"  --- {section.parameter} ---")
+        shown = section.candidates[:MAX_CANDIDATES_REPORTED]
+        for candidate in shown:
+            marker = "  <-- MATCHES RESIDUAL" if candidate.is_match else ""
+            print(
+                f"    {candidate.count:6}  delta {candidate.delta:+6}  "
+                f"{candidate.label}{marker}"
+            )
+            if candidate.is_match:
+                total_matches += 1
+        hidden = len(section.candidates) - len(shown)
+        if hidden:
+            print(f"    ... and {hidden} more candidate(s) not shown")
+        print()
+
+    if total_matches == 0:
+        print(f"  No swept candidate explains the residual of {residual}.")
+        print(
+            "  That rules out every parameter this tool can sweep - look at "
+            "the rules this"
+        )
+        print(
+            "  tool cannot check locally instead; the residual most likely lives there."
+        )
+    elif total_matches == 1:
+        print(f"  1 candidate matches the residual of {residual}.")
+        print(
+            "  Confirm it by fixing the record at source and re-uploading - a "
+            "match here is"
+        )
+        print("  a hypothesis, not a finding.")
+    else:
+        print(f"  {total_matches} candidates match the residual of {residual}.")
+        print(
+            "  Several matches is weak evidence, not a menu to choose from - "
+            "confirm one at"
+        )
+        print("  a time by fixing at source and re-uploading.")
+    print()

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
@@ -52,6 +52,32 @@ Row = Mapping[str, str]
 SY_START = "20250701"
 SY_END = "20260630"
 
+# Allowed characters in FirstName and LastName. Both handbooks word the rule
+# identically - "any special characters except for apostrophes and hyphens" - so
+# both catalogs must share one pattern. They did not at first, and the staff
+# FirstName variant disallowed spaces while the student one allowed them; on the
+# 2026-07-31 staff files that produced 17 false positives out of 29 flags, all
+# of them ordinary compound first names.
+#
+# Three judgement calls, all erring toward a false negative over a false
+# positive, because a false positive sends someone hunting a problem that is not
+# there:
+#
+# - **Space is allowed.** The handbook's own compound-surname example is
+#   "Davis Smyth", and real data has compound first names too.
+# - **Both apostrophe forms are allowed.** The handbook prints the permitted
+#   apostrophe as the typographic U+2018, so accepting only the ASCII U+0027
+#   would reject the very character it names.
+# - **Accented Latin letters are letters, not special characters.** A state
+#   system could not plausibly reject "é" in a name. This reading is not
+#   certain from the handbook text, so a hit on an accented letter should be
+#   treated as a question rather than a finding.
+#
+# `[^\W\d_]` is any Unicode letter: a word character that is neither a digit nor
+# an underscore. Underscore stays excluded deliberately - it is not a name
+# character, and it does appear in real placeholder records.
+NAME_PATTERN = r"(?:[^\W\d_]|[ '‘’\-])+"
+
 
 @dataclass(frozen=True)
 class Rule:

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
@@ -37,6 +37,25 @@ substitution would have reported a wholly non-compliant file as clean.
 
 When a rule fires on everything, that is a hypothesis to check against an
 authoritative source - not a licence to retune the rule until the file passes.
+
+## Methodology limit: Required-ness vs Validation Checks
+
+Both catalogs were built by transcribing "An error will occur if..." bullets
+from each element's **Validation Checks** section. Some handbook requirements
+are stated only in an element's **Is this Data Element Required?** section,
+with no matching Validation Checks bullet to transcribe - a transcription
+pass produces no rule for those, silently, because there is nothing in the
+section it reads that says so.
+
+Two such gaps have been found and closed by deliberate manual addition rather
+than by the transcription pass itself: the NumericGradeEarned /
+AlphaGradeEarned / CompletionStatus grade-or-completion mandate
+(`STU-GRADE-COMPLETION-REQUIRED` in `rules_student.py`, pages 34-36) and
+CourseType's mandatory-for-all-students requirement (`KTAF-COURSETYPE-BLANK`,
+a KTAF proxy since no handbook Validation Check bullet exists to transcribe
+for it). A future maintainer adding elements or rules to either catalog must
+read both sections of each element, not just Validation Checks, or a central
+requirement like this one can go silently unencoded again.
 """
 
 from __future__ import annotations
@@ -47,8 +66,18 @@ from dataclasses import dataclass, field
 
 Row = Mapping[str, str]
 
-# SY 2025-26 instructional window, inclusive, as YYYYMMDD strings. Update each
-# year to the actual first and last instructional days.
+# SY 2025-26 reporting-year window, inclusive, as YYYYMMDD strings: a
+# calendar July-to-June span (2025-07-01 through 2026-06-30). These are NOT
+# the actual first and last instructional days - the instructional calendar
+# runs a narrower span inside this window (roughly September-June). The
+# values were not derived from the sample files either: real
+# SectionEntryDate/SectionExitDate values in the 2026-07-31 extracts sit well
+# inside this window, so passing those files is not evidence the boundary
+# itself is right - a materially narrower or wider window would pass the
+# same data. OPEN ITEM: this window has not been confirmed against NJDOE's
+# own definition of the school year for Course Roster reporting purposes: it
+# is an assumption, not a verified value. Update each year, and confirm
+# against NJDOE guidance if you get the chance.
 SY_START = "20250701"
 SY_END = "20260630"
 

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules.py
@@ -1,0 +1,174 @@
+"""Rule model and predicate helpers for NJSLEDS upload-error attribution.
+
+NJSLEDS returns a bare error count on upload and only generates detailed error
+information overnight. This package evaluates the handbook's documented
+validation rules against the file that was uploaded so the count can be
+attributed to specific rules the same day.
+
+Two kinds of rule live here, and the distinction is load-bearing:
+
+- **Handbook rules** (`source="handbook"`) transcribe an "An error will occur..."
+  statement verbatim from a Course Roster handbook. Only these can explain a
+  state error count, because only these are what the state actually validates.
+- **KTAF rules** (`source="ktaf"`) encode a local expectation that the handbook
+  does not impose - for example that a CDS code matches the specific combination
+  KTAF reports under. These are useful for finding real problems but must never
+  be counted toward a state error total, because the state does not check them.
+
+`predicate` returns **True when the row VIOLATES the rule**. That polarity is
+easy to invert by accident, so every predicate is named for the violation it
+detects, not for the condition it requires.
+
+## Reference values never come from the file under test
+
+A KTAF rule needs a reference value - the CDS combination the region reports
+under, the instructional-year window, the credit ceiling. Those come from the
+data team, the handbook, or an authoritative directory. **Never from the file
+being validated.**
+
+This is not hypothetical. A first draft of the staff catalog found that Camden's
+expected school code of 111 made its CDS rule fire on 100 percent of Camden
+rows, applied the usual heuristic that a rule firing on every row has a bad
+reference value, and substituted the 179 the file actually contained. But 179 is
+the defect: the Alternate School Number is unset in PowerSchool School Setup, so
+the extract falls back to a prefix of the internal school number. Every Camden
+row genuinely is wrong, so 100 percent was the correct answer, and the
+substitution would have reported a wholly non-compliant file as clean.
+
+When a rule fires on everything, that is a hypothesis to check against an
+authoritative source - not a licence to retune the rule until the file passes.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+Row = Mapping[str, str]
+
+# SY 2025-26 instructional window, inclusive, as YYYYMMDD strings. Update each
+# year to the actual first and last instructional days.
+SY_START = "20250701"
+SY_END = "20260630"
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One documented validation condition.
+
+    id: stable identifier, prefix STU- or STF- for handbook rules and KTAF- for
+        local expectations.
+    element: the handbook data element the rule belongs to.
+    page: handbook page the rule is stated on, for citation.
+    error_text: the handbook's wording, verbatim. Never paraphrase - this is what
+        the report quotes back to justify a hypothesis.
+    checkable: whether the rule can be evaluated from the upload file alone.
+    predicate: row-scoped test, True when the row violates the rule.
+    file_count: file-scoped count, for rules about duplication across rows.
+    uncheckable_reason: required when checkable is False. Says what external
+        input the rule would need, so an unexplained residual points somewhere
+        real instead of looking like a tool failure.
+    """
+
+    id: str
+    element: str
+    page: int
+    error_text: str
+    checkable: bool
+    source: str = "handbook"
+    predicate: Callable[[Row], bool] | None = None
+    file_count: Callable[[Sequence[Row]], int] | None = None
+    uncheckable_reason: str | None = None
+    notes: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.source not in {"handbook", "ktaf"}:
+            raise ValueError(f"{self.id}: source must be handbook or ktaf")
+        if self.checkable and not (self.predicate or self.file_count):
+            raise ValueError(f"{self.id}: checkable but has no predicate")
+        if not self.checkable:
+            if self.predicate or self.file_count:
+                raise ValueError(f"{self.id}: not checkable but has a predicate")
+            if not self.uncheckable_reason:
+                raise ValueError(f"{self.id}: not checkable but gives no reason")
+        if self.predicate and self.file_count:
+            raise ValueError(f"{self.id}: give a row predicate or a file count")
+
+
+# --------------------------------------------------------------------------- #
+# Value helpers.
+#
+# Every helper treats None, "" and whitespace as blank, because a CSV read gives
+# "" where BigQuery gives None and the rules must behave identically either way.
+# --------------------------------------------------------------------------- #
+
+
+def blank(value: str | None) -> bool:
+    """True when the field carries no value."""
+    return value is None or not str(value).strip()
+
+
+def present(value: str | None) -> bool:
+    """True when the field carries a value."""
+    return not blank(value)
+
+
+def matches(value: str | None, pattern: str) -> bool:
+    """True when a populated value fully matches pattern. Blank never matches."""
+    if blank(value):
+        return False
+    return re.fullmatch(pattern, str(value).strip()) is not None
+
+
+def malformed(value: str | None, pattern: str) -> bool:
+    """True when a populated value fails pattern.
+
+    Use this rather than `not matches(...)` so a blank field does not also count
+    as a format violation - blankness is its own rule, and double-counting one
+    bad field as two errors corrupts the attribution arithmetic.
+    """
+    return present(value) and not matches(value, pattern)
+
+
+def as_float(value: str | None) -> float | None:
+    """Parse a numeric field, or None when blank or non-numeric."""
+    if blank(value):
+        return None
+    try:
+        return float(str(value).strip())
+    except ValueError:
+        return None
+
+
+def is_date8(value: str | None) -> bool:
+    """True when a populated value is a real calendar date in YYYYMMDD."""
+    if not matches(value, r"\d{8}"):
+        return False
+    text = str(value).strip()
+    year, month, day = int(text[:4]), int(text[4:6]), int(text[6:])
+    if not 1 <= month <= 12:
+        return False
+    lengths = [31, 29 if _is_leap(year) else 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    return 1 <= day <= lengths[month - 1]
+
+
+def _is_leap(year: int) -> bool:
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def in_window(value: str | None, start: str = SY_START, end: str = SY_END) -> bool:
+    """True when a populated YYYYMMDD value falls inside the window, inclusive."""
+    return is_date8(value) and start <= str(value).strip() <= end
+
+
+def duplicates_on(rows: Sequence[Row], keys: Sequence[str]) -> int:
+    """Count rows whose key tuple appears more than once. Blank keys are skipped."""
+    seen: dict[tuple[str, ...], int] = {}
+    for row in rows:
+        values = tuple(str(row.get(k, "") or "").strip() for k in keys)
+        if any(not v for v in values):
+            continue
+        seen[values] = seen.get(values, 0) + 1
+    return sum(count for count in seen.values() if count > 1)

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
@@ -1,0 +1,908 @@
+"""NJSLEDS Staff Course Roster validation rule catalog.
+
+Transcribes every "An error will occur..." statement from the Staff Course
+Roster Submission Handbook v1.1 (May 2026), as extracted verbatim into
+`handbook-rules-staff.md`, into one `Rule` (see `rules.py`) per statement.
+There are 54 handbook statements across 19 data elements; this module
+constructs exactly 54 `source="handbook"` rules plus a small number of
+`source="ktaf"` rules for local expectations the handbook itself does not
+impose (never counted toward a state error total).
+
+Judgment calls worth flagging for a future maintainer:
+
+- **LastName special-character format** (`STF-LN-SPECIAL-CHARS`): the
+  Validation Check text only exempts apostrophes and hyphens, but the
+  Additional Notes explicitly instruct submitters to use a space to join
+  multiple last names lacking a hyphen ("Davis Smyth"). The format check
+  below allows a space for LastName (not FirstName) to avoid flagging the
+  handbook's own recommended usage as an error.
+- **Date "format" checks** (`STF-DOB-FORMAT`, `STF-SED-FORMAT`,
+  `STF-SXD-FORMAT`) use `is_date8`, which validates real calendar dates, not
+  just an 8-digit shape - a value like 20250230 fails both a plain digit
+  regex and this check, and the handbook's "not entered in YYYYMMDD format"
+  wording is read broadly enough to cover both.
+- **"Value does not [meet|match] the acceptable range of values"** repeats
+  across four elements. For GradeSpan and AvailableCredit, the Acceptable
+  Values section gives a concrete range/shape, so the rule is checkable. For
+  SectionEntryDate and SectionExitDate, no additional range is documented
+  beyond the format, School-Year-window, and entry/exit-order checks already
+  stated as their own separate bullets - what else "range" would test is
+  genuinely ambiguous, so those two are marked `checkable=False`.
+- **SectionExitDate "later than the file submission date"**
+  (`STF-SXD-FUTURE`) needs the actual NJSLEDS submission timestamp. The
+  wall-clock date this script runs on is not a reliable stand-in when a file
+  is audited after the fact (the two sample files here are already several
+  days old), so the handbook rule itself is marked uncheckable. A KTAF
+  heuristic version (`KTAF-SXD-FUTURE-HEURISTIC`) is provided separately,
+  clearly caveated, for same-day triage only.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from rules import Row, Rule, blank, in_window, is_date8, malformed, matches, present
+
+# --------------------------------------------------------------------------- #
+# KTAF-local reference data (not from the handbook - see module docstring).
+# --------------------------------------------------------------------------- #
+
+_KTAF_KNOWN_CDS_COMBOS: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        ("80", "7325", "965"),  # Newark
+        ("07", "1799", "179"),  # Camden - see notes on KTAF-CDS-COMBO below
+    }
+)
+
+
+# --------------------------------------------------------------------------- #
+# Predicates. Each returns True when the row VIOLATES the named rule.
+# --------------------------------------------------------------------------- #
+
+
+def _lsid_blank(row: Row) -> bool:
+    return blank(row.get("LocalStaffIdentifier"))
+
+
+def _smid_blank(row: Row) -> bool:
+    return blank(row.get("StaffMemberIdentifier"))
+
+
+def _smid_not_8_digits(row: Row) -> bool:
+    return malformed(row.get("StaffMemberIdentifier"), r"\d{8}")
+
+
+def _fn_blank(row: Row) -> bool:
+    return blank(row.get("FirstName"))
+
+
+def _fn_special_chars(row: Row) -> bool:
+    return malformed(row.get("FirstName"), r"[A-Za-z'\-]+")
+
+
+def _ln_blank(row: Row) -> bool:
+    return blank(row.get("LastName"))
+
+
+def _ln_special_chars(row: Row) -> bool:
+    # Space allowed - see module docstring (Additional Notes vs Validation Check).
+    return malformed(row.get("LastName"), r"[A-Za-z'\- ]+")
+
+
+def _dob_blank(row: Row) -> bool:
+    return blank(row.get("DateOfBirth"))
+
+
+def _dob_bad_format(row: Row) -> bool:
+    value = row.get("DateOfBirth")
+    return present(value) and not is_date8(value)
+
+
+def _cnty_blank(row: Row) -> bool:
+    return blank(row.get("CountyCodeAssigned"))
+
+
+def _cnty_leading_zeros(row: Row) -> bool:
+    return malformed(row.get("CountyCodeAssigned"), r"\d{2}")
+
+
+def _dist_blank(row: Row) -> bool:
+    return blank(row.get("DistrictCodeAssigned"))
+
+
+def _dist_leading_zeros(row: Row) -> bool:
+    return malformed(row.get("DistrictCodeAssigned"), r"\d{4}")
+
+
+def _schl_blank(row: Row) -> bool:
+    return blank(row.get("SchoolCodeAssigned"))
+
+
+def _schl_leading_zeros(row: Row) -> bool:
+    return malformed(row.get("SchoolCodeAssigned"), r"\d{3}")
+
+
+def _sed_blank(row: Row) -> bool:
+    return blank(row.get("SectionEntryDate"))
+
+
+def _sed_bad_format(row: Row) -> bool:
+    value = row.get("SectionEntryDate")
+    return present(value) and not is_date8(value)
+
+
+def _sed_not_in_school_year(row: Row) -> bool:
+    value = row.get("SectionEntryDate")
+    return is_date8(value) and not in_window(value)
+
+
+def _sxd_blank(row: Row) -> bool:
+    return blank(row.get("SectionExitDate"))
+
+
+def _sxd_bad_format(row: Row) -> bool:
+    value = row.get("SectionExitDate")
+    return present(value) and not is_date8(value)
+
+
+def _sxd_not_in_school_year(row: Row) -> bool:
+    value = row.get("SectionExitDate")
+    return is_date8(value) and not in_window(value)
+
+
+def _entry_exit_out_of_order(row: Row) -> bool:
+    """Shared by STF-SED-AFTER-EXIT and STF-SXD-BEFORE-ENTRY - same condition,
+    two separately-worded handbook statements under two different elements.
+    """
+    entry = row.get("SectionEntryDate")
+    exit_ = row.get("SectionExitDate")
+    if not (is_date8(entry) and is_date8(exit_)):
+        return False
+    return str(entry).strip() > str(exit_).strip()
+
+
+def _subj_blank(row: Row) -> bool:
+    return blank(row.get("SubjectArea"))
+
+
+def _crsid_blank(row: Row) -> bool:
+    return blank(row.get("CourseIdentifier"))
+
+
+def _crsid_leading_zeros(row: Row) -> bool:
+    return malformed(row.get("CourseIdentifier"), r"\d{3}")
+
+
+def _crslvl_blank(row: Row) -> bool:
+    return blank(row.get("CourseLevel"))
+
+
+def _crslvl_invalid_code(row: Row) -> bool:
+    return malformed(row.get("CourseLevel"), r"[BGEHX]")
+
+
+def _grdspn_bad_range(row: Row) -> bool:
+    return malformed(row.get("GradeSpan"), r"(?:PK|KG|0[1-9]|1[0-2]){2}")
+
+
+def _avlcr_out_of_range(row: Row) -> bool:
+    value = row.get("AvailableCredit")
+    if blank(value):
+        return False
+    if not matches(value, r"\d{1,2}\.\d{3}"):
+        return True
+    return not (0.0 <= float(str(value).strip()) <= 35.0)
+
+
+def _crsseq_blank(row: Row) -> bool:
+    return blank(row.get("CourseSequence"))
+
+
+def _crsseq_digit_order(row: Row) -> bool:
+    value = row.get("CourseSequence")
+    if not matches(value, r"\d{2}"):
+        return False
+    text = str(value).strip()
+    return int(text[0]) > int(text[1])
+
+
+def _lct_blank(row: Row) -> bool:
+    return blank(row.get("LocalCourseTitle"))
+
+
+def _lcc_blank(row: Row) -> bool:
+    return blank(row.get("LocalCourseCode"))
+
+
+def _lsc_blank(row: Row) -> bool:
+    return blank(row.get("LocalSectionCode"))
+
+
+def _ktaf_cds_combo_invalid(row: Row) -> bool:
+    county = str(row.get("CountyCodeAssigned") or "").strip()
+    district = str(row.get("DistrictCodeAssigned") or "").strip()
+    school = str(row.get("SchoolCodeAssigned") or "").strip()
+    if not (county and district and school):
+        return False  # already covered by the handbook blank rules
+    return (county, district, school) not in _KTAF_KNOWN_CDS_COMBOS
+
+
+def _ktaf_sxd_future_heuristic(row: Row) -> bool:
+    value = row.get("SectionExitDate")
+    if not is_date8(value):
+        return False
+    return str(value).strip() > datetime.date.today().strftime("%Y%m%d")
+
+
+# --------------------------------------------------------------------------- #
+# Rule catalog.
+# --------------------------------------------------------------------------- #
+
+RULES: list[Rule] = [
+    # --- LocalStaffIdentifier (LSID) -- handbook page 9 ------------------- #
+    Rule(
+        id="STF-LSID-BLANK",
+        element="LocalStaffIdentifier",
+        page=9,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_lsid_blank,
+    ),
+    Rule(
+        id="STF-LSID-STAFFMGMT-MISMATCH",
+        element="LocalStaffIdentifier",
+        page=9,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Management snapshot for this staff member "
+            "(LSID/SMID/First Name/Last Name/Date of Birth combination) - "
+            "not derivable from the Course Roster file alone."
+        ),
+        tags=("staff_management",),
+    ),
+    # --- StaffMemberIdentifier (SMID) -- handbook page 10 ------------------ #
+    Rule(
+        id="STF-SMID-LENGTH",
+        element="StaffMemberIdentifier",
+        page=10,
+        error_text="An error will occur when the value submitted is not exactly 8 digits.",
+        checkable=True,
+        predicate=_smid_not_8_digits,
+    ),
+    Rule(
+        id="STF-SMID-BLANK",
+        element="StaffMemberIdentifier",
+        page=10,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_smid_blank,
+    ),
+    Rule(
+        id="STF-SMID-INVALID-NJSLEDS-ID",
+        element="StaffMemberIdentifier",
+        page=10,
+        error_text=(
+            "An error will occur when the Staff Member Identifier is not a "
+            "valid number issued by NJSLEDS."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the NJSLEDS-issued Staff Member Identifier registry.",
+    ),
+    Rule(
+        id="STF-SMID-STAFFMGMT-MISMATCH",
+        element="StaffMemberIdentifier",
+        page=10,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Management snapshot for this staff member "
+            "(LSID/SMID/First Name/Last Name/Date of Birth combination) - "
+            "not derivable from the Course Roster file alone."
+        ),
+        tags=("staff_management",),
+    ),
+    # --- FirstName -- handbook page 11 ------------------------------------ #
+    Rule(
+        id="STF-FN-BLANK",
+        element="FirstName",
+        page=11,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_fn_blank,
+    ),
+    Rule(
+        id="STF-FN-SPECIAL-CHARS",
+        element="FirstName",
+        page=11,
+        error_text=(
+            "An error will occur if this field contains any special characters "
+            "except for apostrophes (‘) and hyphens (-)."
+        ),
+        checkable=True,
+        predicate=_fn_special_chars,
+    ),
+    Rule(
+        id="STF-FN-STAFFMGMT-MISMATCH",
+        element="FirstName",
+        page=11,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Management snapshot for this staff member "
+            "(LSID/SMID/First Name/Last Name/Date of Birth combination) - "
+            "not derivable from the Course Roster file alone."
+        ),
+        tags=("staff_management",),
+    ),
+    # --- LastName -- handbook page 12 ------------------------------------- #
+    Rule(
+        id="STF-LN-BLANK",
+        element="LastName",
+        page=12,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_ln_blank,
+    ),
+    Rule(
+        id="STF-LN-SPECIAL-CHARS",
+        element="LastName",
+        page=12,
+        error_text=(
+            "An error will occur if this field contains any special characters "
+            "except for apostrophes (‘) and hyphens (-)."
+        ),
+        checkable=True,
+        predicate=_ln_special_chars,
+        notes=(
+            "Allows a literal space in addition to letters/apostrophe/hyphen: "
+            "Additional Notes for this element instruct submitters to join "
+            "multiple last names with a space when no hyphen is used "
+            "('Davis Smyth'), which the bare Validation Check text does not "
+            "itself exempt."
+        ),
+    ),
+    Rule(
+        id="STF-LN-STAFFMGMT-MISMATCH",
+        element="LastName",
+        page=12,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Management snapshot for this staff member "
+            "(LSID/SMID/First Name/Last Name/Date of Birth combination) - "
+            "not derivable from the Course Roster file alone."
+        ),
+        tags=("staff_management",),
+    ),
+    # --- DateOfBirth -- handbook page 13 ----------------------------------- #
+    Rule(
+        id="STF-DOB-BLANK",
+        element="DateOfBirth",
+        page=13,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_dob_blank,
+    ),
+    Rule(
+        id="STF-DOB-FORMAT",
+        element="DateOfBirth",
+        page=13,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20150128)."
+        ),
+        checkable=True,
+        predicate=_dob_bad_format,
+        notes="Uses is_date8, which also rejects a syntactically 8-digit but calendar-invalid date.",
+    ),
+    Rule(
+        id="STF-DOB-STAFFMGMT-MISMATCH",
+        element="DateOfBirth",
+        page=13,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Management snapshot for this staff member "
+            "(LSID/SMID/First Name/Last Name/Date of Birth combination) - "
+            "not derivable from the Course Roster file alone."
+        ),
+        tags=("staff_management",),
+    ),
+    # --- CountyCodeAssigned -- handbook page 14 ---------------------------- #
+    Rule(
+        id="STF-CNTY-BLANK",
+        element="CountyCodeAssigned",
+        page=14,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_cnty_blank,
+    ),
+    Rule(
+        id="STF-CNTY-CDS-LIST",
+        element="CountyCodeAssigned",
+        page=14,
+        error_text=(
+            "An error will occur if the County Code submitted does not "
+            "conform to the codes listed for your district in the CDS list."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the NJSLEDS County District School (CDS) code list for the LEA.",
+        tags=("cds_list",),
+    ),
+    Rule(
+        id="STF-CNTY-LEADING-ZEROS",
+        element="CountyCodeAssigned",
+        page=14,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_cnty_leading_zeros,
+    ),
+    Rule(
+        id="STF-CNTY-STAFFMGMT-MISMATCH",
+        element="CountyCodeAssigned",
+        page=14,
+        error_text=(
+            "An error will occur if this field does not exactly match one of "
+            "the six CountyCodeAssigned values in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the Staff Management snapshot's six CountyCodeAssigned values.",
+        tags=("staff_management",),
+    ),
+    # --- DistrictCodeAssigned -- handbook page 15 -------------------------- #
+    Rule(
+        id="STF-DIST-BLANK",
+        element="DistrictCodeAssigned",
+        page=15,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_dist_blank,
+    ),
+    Rule(
+        id="STF-DIST-SUBMITTING-MISMATCH",
+        element="DistrictCodeAssigned",
+        page=15,
+        error_text=(
+            "An error will occur if the District Code submitted does not "
+            "match the Submitting District."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the identity of the actual submitting LEA for this upload, "
+            "which is not a column in the Course Roster file."
+        ),
+        tags=("cds_list",),
+    ),
+    Rule(
+        id="STF-DIST-LEADING-ZEROS",
+        element="DistrictCodeAssigned",
+        page=15,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_dist_leading_zeros,
+    ),
+    Rule(
+        id="STF-DIST-STAFFMGMT-MISMATCH",
+        element="DistrictCodeAssigned",
+        page=15,
+        error_text=(
+            "An error will occur if this field does not exactly match one of "
+            "the six DistrictCodeAssigned values in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the Staff Management snapshot's six DistrictCodeAssigned values.",
+        tags=("staff_management",),
+    ),
+    # --- SchoolCodeAssigned -- handbook page 16 ---------------------------- #
+    Rule(
+        id="STF-SCHL-BLANK",
+        element="SchoolCodeAssigned",
+        page=16,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_schl_blank,
+    ),
+    Rule(
+        id="STF-SCHL-CDS-LIST",
+        element="SchoolCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if the School Code submitted does not "
+            "conform to the codes listed for your district in the CDS list."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the NJSLEDS County District School (CDS) code list for the LEA.",
+        tags=("cds_list",),
+    ),
+    Rule(
+        id="STF-SCHL-LEADING-ZEROS",
+        element="SchoolCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_schl_leading_zeros,
+    ),
+    Rule(
+        id="STF-SCHL-STAFFMGMT-MISMATCH",
+        element="SchoolCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if this field does not exactly match one of "
+            "the six SchoolCodeAssigned values in Staff Management."
+        ),
+        checkable=False,
+        uncheckable_reason="Needs the Staff Management snapshot's six SchoolCodeAssigned values.",
+        tags=("staff_management",),
+    ),
+    # --- SectionEntryDate -- handbook page 17 ------------------------------ #
+    Rule(
+        id="STF-SED-BLANK",
+        element="SectionEntryDate",
+        page=17,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_sed_blank,
+    ),
+    Rule(
+        id="STF-SED-RANGE",
+        element="SectionEntryDate",
+        page=17,
+        error_text="An error will occur if the value does not meet the acceptable range of values.",
+        checkable=False,
+        uncheckable_reason=(
+            "Ambiguous for a date field: no range beyond the format, "
+            "School-Year-window, and entry/exit-order checks is documented "
+            "elsewhere on this page, and those are already their own bullets."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STF-SED-FORMAT",
+        element="SectionEntryDate",
+        page=17,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20250128)."
+        ),
+        checkable=True,
+        predicate=_sed_bad_format,
+        notes="Uses is_date8, which also rejects a syntactically 8-digit but calendar-invalid date.",
+    ),
+    Rule(
+        id="STF-SED-AFTER-EXIT",
+        element="SectionEntryDate",
+        page=17,
+        error_text=(
+            "An error will occur if the staff course entry date occurs after "
+            "the staff course exit date."
+        ),
+        checkable=True,
+        predicate=_entry_exit_out_of_order,
+    ),
+    Rule(
+        id="STF-SED-NOT-IN-SY",
+        element="SectionEntryDate",
+        page=17,
+        error_text=(
+            "An error will occur if the SectionEntryDate does not occur in "
+            "the current School Year."
+        ),
+        checkable=True,
+        predicate=_sed_not_in_school_year,
+    ),
+    # --- SectionExitDate -- handbook page 18 ------------------------------- #
+    Rule(
+        id="STF-SXD-BLANK",
+        element="SectionExitDate",
+        page=18,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_sxd_blank,
+    ),
+    Rule(
+        id="STF-SXD-RANGE",
+        element="SectionExitDate",
+        page=18,
+        error_text="An error will occur if the value does not meet the acceptable range of values.",
+        checkable=False,
+        uncheckable_reason=(
+            "Ambiguous for a date field: no range beyond the format, "
+            "School-Year-window, and entry/exit-order checks is documented "
+            "elsewhere on this page, and those are already their own bullets."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STF-SXD-FORMAT",
+        element="SectionExitDate",
+        page=18,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20250128)."
+        ),
+        checkable=True,
+        predicate=_sxd_bad_format,
+        notes="Uses is_date8, which also rejects a syntactically 8-digit but calendar-invalid date.",
+    ),
+    Rule(
+        id="STF-SXD-BEFORE-ENTRY",
+        element="SectionExitDate",
+        page=18,
+        error_text=(
+            "An error will occur if the staff course exit date occurs before "
+            "the staff course entry date."
+        ),
+        checkable=True,
+        predicate=_entry_exit_out_of_order,
+    ),
+    Rule(
+        id="STF-SXD-NOT-IN-SY",
+        element="SectionExitDate",
+        page=18,
+        error_text=(
+            "An error will occur if the SectionExitDate does not occur in "
+            "the current School Year."
+        ),
+        checkable=True,
+        predicate=_sxd_not_in_school_year,
+    ),
+    Rule(
+        id="STF-SXD-FUTURE",
+        element="SectionExitDate",
+        page=18,
+        error_text=(
+            "An error will occur if the SectionExitDate is later than the "
+            "file submission date (for example, a future date)."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the actual NJSLEDS file submission date/timestamp, which "
+            "is not a column in the upload. The wall-clock date this script "
+            "runs on is not a reliable stand-in for a file audited after the "
+            "fact (see KTAF-SXD-FUTURE-HEURISTIC for a caveated same-day proxy)."
+        ),
+        tags=("ambiguous",),
+    ),
+    # --- SubjectArea -- handbook page 19 ----------------------------------- #
+    Rule(
+        id="STF-SUBJ-BLANK",
+        element="SubjectArea",
+        page=19,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_subj_blank,
+    ),
+    Rule(
+        id="STF-SUBJ-INVALID-SCED",
+        element="SubjectArea",
+        page=19,
+        error_text="An error will occur if the value is not a valid SCED Subject Area code.",
+        checkable=False,
+        uncheckable_reason="Needs the NJSLEDS/NCES SCED Course Codes document's Subject Area list.",
+        tags=("sced",),
+    ),
+    # --- CourseIdentifier -- handbook page 20 ------------------------------ #
+    Rule(
+        id="STF-CRSID-BLANK",
+        element="CourseIdentifier",
+        page=20,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_crsid_blank,
+    ),
+    Rule(
+        id="STF-CRSID-INVALID-SCED",
+        element="CourseIdentifier",
+        page=20,
+        error_text="An error will occur if the value is not a valid SCED Course Identifier code.",
+        checkable=False,
+        uncheckable_reason="Needs the NJSLEDS/NCES SCED Course Codes document's Course Identifier list.",
+        tags=("sced",),
+    ),
+    Rule(
+        id="STF-CRSID-LEADING-ZEROS",
+        element="CourseIdentifier",
+        page=20,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_crsid_leading_zeros,
+    ),
+    # --- CourseLevel -- handbook page 21 ----------------------------------- #
+    Rule(
+        id="STF-CRSLVL-BLANK",
+        element="CourseLevel",
+        page=21,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_crslvl_blank,
+    ),
+    Rule(
+        id="STF-CRSLVL-INVALID-CODE",
+        element="CourseLevel",
+        page=21,
+        error_text="An error will occur if the value is not a valid SCED Course Level code.",
+        checkable=True,
+        predicate=_crslvl_invalid_code,
+        notes=(
+            "Unlike SubjectArea/CourseIdentifier, the valid Course Level "
+            "codes (B, G, E, H, X) are enumerated directly in the handbook's "
+            "Acceptable Values text rather than deferred to an external SCED "
+            "document, so this is checkable without outside data."
+        ),
+    ),
+    # --- GradeSpan -- handbook page 22 ------------------------------------- #
+    Rule(
+        id="STF-GRDSPN-BLANK-PRIOR-TO-SECONDARY",
+        element="GradeSpan",
+        page=22,
+        error_text=(
+            "An error will occur if the field is left blank for a course "
+            "with a Prior-To-Secondary course code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Whether a course is Prior-To-Secondary is a property of its "
+            "SubjectArea/CourseIdentifier SCED classification, which needs "
+            "the NJSLEDS/NCES SCED Course Codes document - not derivable "
+            "from whether other fields happen to be populated."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STF-GRDSPN-RANGE",
+        element="GradeSpan",
+        page=22,
+        error_text="An error will occur if the value does not match the acceptable range of values.",
+        checkable=True,
+        predicate=_grdspn_bad_range,
+    ),
+    # --- AvailableCredit -- handbook page 23 ------------------------------- #
+    Rule(
+        id="STF-AVLCR-BLANK-SECONDARY",
+        element="AvailableCredit",
+        page=23,
+        error_text=(
+            "An error will occur if this field is left blank for a course "
+            "with a Secondary course code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Whether a course is Secondary is a property of its "
+            "SubjectArea/CourseIdentifier SCED classification, which needs "
+            "the NJSLEDS/NCES SCED Course Codes document - not derivable "
+            "from whether other fields happen to be populated."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STF-AVLCR-RANGE",
+        element="AvailableCredit",
+        page=23,
+        error_text="An error will occur if the value does not match the acceptable range of values.",
+        checkable=True,
+        predicate=_avlcr_out_of_range,
+    ),
+    # --- CourseSequence -- handbook page 24 -------------------------------- #
+    Rule(
+        id="STF-CRSSEQ-BLANK",
+        element="CourseSequence",
+        page=24,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_crsseq_blank,
+    ),
+    Rule(
+        id="STF-CRSSEQ-DIGIT-ORDER",
+        element="CourseSequence",
+        page=24,
+        error_text=(
+            "An error will occur if the value of the first digit is greater "
+            "than the value of the second digit."
+        ),
+        checkable=True,
+        predicate=_crsseq_digit_order,
+    ),
+    # --- LocalCourseTitle -- handbook page 25 ------------------------------ #
+    Rule(
+        id="STF-LCT-BLANK",
+        element="LocalCourseTitle",
+        page=25,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_lct_blank,
+    ),
+    # --- LocalCourseCode -- handbook page 26 ------------------------------- #
+    Rule(
+        id="STF-LCC-BLANK",
+        element="LocalCourseCode",
+        page=26,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_lcc_blank,
+    ),
+    # --- LocalSectionCode -- handbook page 27 ------------------------------ #
+    Rule(
+        id="STF-LSC-BLANK",
+        element="LocalSectionCode",
+        page=27,
+        error_text="An error will occur if the field is left blank.",
+        checkable=True,
+        predicate=_lsc_blank,
+    ),
+    # --- KTAF local expectations (not counted toward a state error total) - #
+    Rule(
+        id="KTAF-CDS-COMBO",
+        element="CountyCodeAssigned+DistrictCodeAssigned+SchoolCodeAssigned",
+        page=0,
+        error_text=(
+            "Local KTAF expectation: CountyCodeAssigned, DistrictCodeAssigned, "
+            "and SchoolCodeAssigned must together match one of KTAF's known "
+            "CDS combinations for the submitting region."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_ktaf_cds_combo_invalid,
+        notes=(
+            "Known combinations: Newark (80, 7325, 965) and Camden "
+            "(07, 1799, 179). The brief that seeded this catalog gave the "
+            "Camden school code as 111 and flagged it unconfirmed against "
+            "the NJDOE directory; the real Camden upload used for "
+            "verification instead shows a single consistent non-blank "
+            "school code of 179 across all 380 populated-CDS rows (county "
+            "07 and district 1799 do match the brief exactly). 179 is used "
+            "here as the better-evidenced value, but it is still only "
+            "corroborated by internal consistency in one file, not by the "
+            "authoritative NJDOE CDS directory - confirm before relying on "
+            "this rule for Camden decisions, and treat any hit here as a "
+            "hypothesis to verify, not a confirmed error."
+        ),
+        tags=("cds_list",),
+    ),
+    Rule(
+        id="KTAF-SXD-FUTURE-HEURISTIC",
+        element="SectionExitDate",
+        page=0,
+        error_text=(
+            "Local heuristic: SectionExitDate is later than the date this "
+            "script was run, as a same-day proxy for the handbook's "
+            "file-submission-date check (STF-SXD-FUTURE, marked uncheckable)."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_ktaf_sxd_future_heuristic,
+        notes=(
+            "Only a reliable proxy when run the same day the file is "
+            "actually submitted to NJSLEDS. Do not treat a hit as a "
+            "confirmed state error for a file audited after the fact."
+        ),
+        tags=("ambiguous",),
+    ),
+]

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
@@ -50,7 +50,7 @@ from rules import Row, Rule, blank, in_window, is_date8, malformed, matches, pre
 _KTAF_KNOWN_CDS_COMBOS: frozenset[tuple[str, str, str]] = frozenset(
     {
         ("80", "7325", "965"),  # Newark
-        ("07", "1799", "179"),  # Camden - see notes on KTAF-CDS-COMBO below
+        ("07", "1799", "111"),  # Camden - see notes on KTAF-CDS-COMBO below
     }
 )
 
@@ -872,17 +872,26 @@ RULES: list[Rule] = [
         predicate=_ktaf_cds_combo_invalid,
         notes=(
             "Known combinations: Newark (80, 7325, 965) and Camden "
-            "(07, 1799, 179). The brief that seeded this catalog gave the "
-            "Camden school code as 111 and flagged it unconfirmed against "
-            "the NJDOE directory; the real Camden upload used for "
-            "verification instead shows a single consistent non-blank "
-            "school code of 179 across all 380 populated-CDS rows (county "
-            "07 and district 1799 do match the brief exactly). 179 is used "
-            "here as the better-evidenced value, but it is still only "
-            "corroborated by internal consistency in one file, not by the "
-            "authoritative NJDOE CDS directory - confirm before relying on "
-            "this rule for Camden decisions, and treat any hit here as a "
-            "hypothesis to verify, not a confirmed error."
+            "(07, 1799, 111), set by the data team.\n\n"
+            "This rule is EXPECTED to fire heavily, and that is the point. "
+            "Camden's uploads carry school code 179 on every populated-CDS "
+            "row, and Newark's carry 732 on a large block of rows. Those are "
+            "not alternative valid codes - they are the documented CDS "
+            "defect: the Alternate School Number is unset in PowerSchool "
+            "School Setup for those schools, so the extract falls back to a "
+            "prefix of the internal school number. As of the 2026-07-29 "
+            "extract this affected 20,652 of 43,493 student rows, including "
+            "every Camden row.\n\n"
+            "Do not 'fix' this rule by changing the expected codes to match "
+            "what the file contains. An earlier draft of this catalog did "
+            "exactly that - it substituted 179 for 111 on the reasoning that "
+            "a rule firing on 100% of rows must have a bad reference value. "
+            "Here, 100% is the correct answer, and the substitution would "
+            "have reported a wholly non-compliant file as clean. Reference "
+            "values come from the data team or the NJDOE directory, never "
+            "from the file under test.\n\n"
+            "Camden's 111 is still worth confirming against the NJDOE "
+            "directory before anyone keys it into School Setup."
         ),
         tags=("cds_list",),
     ),

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_staff.py
@@ -10,12 +10,14 @@ impose (never counted toward a state error total).
 
 Judgment calls worth flagging for a future maintainer:
 
-- **LastName special-character format** (`STF-LN-SPECIAL-CHARS`): the
-  Validation Check text only exempts apostrophes and hyphens, but the
-  Additional Notes explicitly instruct submitters to use a space to join
-  multiple last names lacking a hyphen ("Davis Smyth"). The format check
-  below allows a space for LastName (not FirstName) to avoid flagging the
-  handbook's own recommended usage as an error.
+- **Name special-character format** (`STF-FN-SPECIAL-CHARS`,
+  `STF-LN-SPECIAL-CHARS`): both use the shared `NAME_PATTERN` from `rules.py`,
+  which allows spaces, both apostrophe forms, and accented letters. An earlier
+  draft allowed a space for LastName but not FirstName; on the 2026-07-31 files
+  that produced 17 false positives out of 29 flags, all ordinary compound first
+  names. The student catalog words the same rule identically, so the pattern is
+  shared rather than duplicated. See `rules.py` for the three judgement calls
+  behind it.
 - **Date "format" checks** (`STF-DOB-FORMAT`, `STF-SED-FORMAT`,
   `STF-SXD-FORMAT`) use `is_date8`, which validates real calendar dates, not
   just an 8-digit shape - a value like 20250230 fails both a plain digit
@@ -41,7 +43,17 @@ from __future__ import annotations
 
 import datetime
 
-from rules import Row, Rule, blank, in_window, is_date8, malformed, matches, present
+from rules import (
+    NAME_PATTERN,
+    Row,
+    Rule,
+    blank,
+    in_window,
+    is_date8,
+    malformed,
+    matches,
+    present,
+)
 
 # --------------------------------------------------------------------------- #
 # KTAF-local reference data (not from the handbook - see module docstring).
@@ -77,7 +89,7 @@ def _fn_blank(row: Row) -> bool:
 
 
 def _fn_special_chars(row: Row) -> bool:
-    return malformed(row.get("FirstName"), r"[A-Za-z'\-]+")
+    return malformed(row.get("FirstName"), NAME_PATTERN)
 
 
 def _ln_blank(row: Row) -> bool:
@@ -85,8 +97,7 @@ def _ln_blank(row: Row) -> bool:
 
 
 def _ln_special_chars(row: Row) -> bool:
-    # Space allowed - see module docstring (Additional Notes vs Validation Check).
-    return malformed(row.get("LastName"), r"[A-Za-z'\- ]+")
+    return malformed(row.get("LastName"), NAME_PATTERN)
 
 
 def _dob_blank(row: Row) -> bool:
@@ -872,26 +883,24 @@ RULES: list[Rule] = [
         predicate=_ktaf_cds_combo_invalid,
         notes=(
             "Known combinations: Newark (80, 7325, 965) and Camden "
-            "(07, 1799, 111), set by the data team.\n\n"
-            "This rule is EXPECTED to fire heavily, and that is the point. "
-            "Camden's uploads carry school code 179 on every populated-CDS "
-            "row, and Newark's carry 732 on a large block of rows. Those are "
-            "not alternative valid codes - they are the documented CDS "
-            "defect: the Alternate School Number is unset in PowerSchool "
-            "School Setup for those schools, so the extract falls back to a "
-            "prefix of the internal school number. As of the 2026-07-29 "
-            "extract this affected 20,652 of 43,493 student rows, including "
-            "every Camden row.\n\n"
-            "Do not 'fix' this rule by changing the expected codes to match "
-            "what the file contains. An earlier draft of this catalog did "
-            "exactly that - it substituted 179 for 111 on the reasoning that "
-            "a rule firing on 100% of rows must have a bad reference value. "
-            "Here, 100% is the correct answer, and the substitution would "
-            "have reported a wholly non-compliant file as clean. Reference "
-            "values come from the data team or the NJDOE directory, never "
-            "from the file under test.\n\n"
-            "Camden's 111 is still worth confirming against the NJDOE "
-            "directory before anyone keys it into School Setup."
+            "(07, 1799, 111), set by the data team and since confirmed by the "
+            "corrected source data.\n\n"
+            "Passes clean as of the 2026-07-31 extract: all four files carry "
+            "the correct triple on every row. It did not before. The "
+            "2026-07-29 extract carried school code 179 on every "
+            "populated-CDS Camden row and 732 on a large block of Newark "
+            "rows - 20,652 of 43,493 student rows - because the Alternate "
+            "School Number was unset in PowerSchool School Setup, so the "
+            "extract fell back to a prefix of the internal school number. "
+            "The School Setup fix landed between those two extracts.\n\n"
+            "That history is the reason this rule exists in this form. An "
+            "earlier draft substituted 179 for 111, reasoning that a rule "
+            "firing on 100% of rows must have a bad reference value. The "
+            "file was wrong and the reference value was right; the "
+            "substitution would have reported a wholly non-compliant file as "
+            "clean, and would now be silently wrong in the opposite "
+            "direction. Reference values come from the data team or the NJDOE "
+            "directory, never from the file under test."
         ),
         tags=("cds_list",),
     ),

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
@@ -223,26 +223,36 @@ def _dual_institution_populated_for_non_c(row: Row) -> bool:
 # KTAF-local rules (source="ktaf"). Never counted toward a state error total -
 # see rules.py's module docstring and HANDOFF.md.
 #
-# The org-provided expectation was Newark county 80 / district 7325 / school
-# 965, and Camden county 07 / district 1799 / school 111 (school unconfirmed).
-# Profiling the real Newark and Camden student files against that expectation
-# found:
-#   - County and District match the given values exactly wherever populated
-#     (Newark: county always "80" or blank, district always "7325"; Camden:
-#     county always "07" or blank, district always "1799"). Both are encoded
-#     below.
-#   - School does NOT match: Newark legitimately uses two School Codes ("965"
-#     and "732"), not only "965", and Camden's only School Code in the file is
-#     "179", not "111". Encoding either single value as a KTAF check would
-#     misfire on real rows, so no KTAF school-code rule is included. This
-#     confirms the Camden "111" guess was wrong and that the org's
-#     Newark-school assumption was incomplete; flagged in the report for the
-#     org to confirm the intended KTAF CDS combinations before anyone builds
-#     on "965"/"111" elsewhere.
+# The CDS combinations KTAF reports under, set by the data team: Newark county
+# 80 / district 7325 / school 965, and Camden county 07 / district 1799 /
+# school 111.
+#
+# These rules are EXPECTED to fire heavily, and that is the point. The real
+# files carry school code 732 on a large block of Newark rows and 179 on every
+# populated-CDS Camden row. Those are not alternative valid codes - they are the
+# documented CDS defect: the Alternate School Number is unset in PowerSchool
+# School Setup for those schools, so the extract falls back to a prefix of the
+# internal school number. As of the 2026-07-29 extract this affected 20,652 of
+# 43,493 student rows, including every Camden row.
+#
+# An earlier draft of this catalog omitted the school-code rule entirely,
+# reasoning that 965/111 "does not match real data" and would misfire. It would
+# not misfire - it would correctly flag a wholly non-compliant file. Reference
+# values come from the data team or the NJDOE directory, never from the file
+# under test. See rules.py's module docstring.
+#
+# Camden's 111 is still worth confirming against the NJDOE directory before
+# anyone keys it into School Setup.
 # --------------------------------------------------------------------------- #
 
 _KTAF_KNOWN_COUNTY_CODES = frozenset({"80", "07"})
 _KTAF_KNOWN_DISTRICT_CODES = frozenset({"7325", "1799"})
+_KTAF_KNOWN_CDS_COMBOS: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        ("80", "7325", "965"),  # Newark
+        ("07", "1799", "111"),  # Camden
+    }
+)
 
 
 def _county_code_not_ktaf_known(row: Row) -> bool:
@@ -255,6 +265,22 @@ def _district_code_not_ktaf_known(row: Row) -> bool:
     """KTAF-DISTRICTCODE-KNOWN: populated District Code outside KTAF's known set."""
     value = row.get("DistrictCodeAssigned")
     return present(value) and str(value).strip() not in _KTAF_KNOWN_DISTRICT_CODES
+
+
+def _ktaf_cds_combo_invalid(row: Row) -> bool:
+    """KTAF-CDS-COMBO: the CDS triple is not one KTAF reports under.
+
+    A blank component cannot form a valid combination, so a blank county counts
+    as a violation here. That is deliberate - the state attributes the row by the
+    whole triple, and an incomplete triple mis-attributes it just as a wrong one
+    does.
+    """
+    combo = (
+        str(row.get("CountyCodeAssigned", "") or "").strip(),
+        str(row.get("DistrictCodeAssigned", "") or "").strip(),
+        str(row.get("SchoolCodeAssigned", "") or "").strip(),
+    )
+    return combo not in _KTAF_KNOWN_CDS_COMBOS
 
 
 # --------------------------------------------------------------------------- #
@@ -1198,5 +1224,33 @@ RULES: list[Rule] = [
             "validate this catalog is exactly '7325' or '1799' "
             "respectively, with no blanks."
         ),
+    ),
+    Rule(
+        id="KTAF-CDS-COMBO",
+        element="CountyCodeAssigned+DistrictCodeAssigned+SchoolCodeAssigned",
+        page=0,
+        error_text=(
+            "KTAF expectation, not a handbook rule: County, District, and "
+            "School Code together must match one of the CDS combinations KTAF "
+            "reports under - Newark (80, 7325, 965) or Camden (07, 1799, 111)."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_ktaf_cds_combo_invalid,
+        notes=(
+            "Expected to fire heavily on the 2026-07-29 extract, and that is "
+            "the signal, not a bug. Newark carries school code 732 on a large "
+            "block of rows and Camden carries 179 on every populated-CDS row; "
+            "both are the documented CDS defect (Alternate School Number unset "
+            "in PowerSchool School Setup, so the extract falls back to a "
+            "prefix of the internal school number), affecting 20,652 of 43,493 "
+            "rows network-wide.\n\n"
+            "Do not retune the expected codes to match what the file "
+            "contains - see rules.py's module docstring for why an earlier "
+            "draft did exactly that and what it cost. Camden's 111 is still "
+            "worth confirming against the NJDOE directory before anyone keys "
+            "it into School Setup."
+        ),
+        tags=("cds_list",),
     ),
 ]

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
@@ -2,10 +2,15 @@
 
 Transcribes every "An error will occur..." statement in
 `handbook-rules-student.md` (Student Course Roster Submission Handbook,
-Version 1.4, July 2026) into a `Rule`. There are 68 handbook statements; this
-module exports exactly one `Rule` per statement, plus a small set of
-`source="ktaf"` rules for local expectations the handbook itself does not
-impose (see `rules.py`'s module docstring for why that distinction matters).
+Version 1.4, July 2026) into a `Rule`. There are 68 such statements, each
+transcribed from an element's Validation Checks section, plus one further
+handbook rule (`STU-GRADE-COMPLETION-REQUIRED`) added deliberately rather than
+transcribed, for a requirement stated only under an element's "Is this Data
+Element Required?" section with no matching Validation Checks bullet - see
+`rules.py`'s module docstring for that methodology limit. That is 69
+`source="handbook"` rules in total, plus a small set of `source="ktaf"` rules
+for local expectations the handbook itself does not impose (see `rules.py`'s
+module docstring for why that distinction matters).
 
 Several handbook elements require the SCED (School Courses for the Exchange of
 Data) Subject Area / Course Identifier code to know whether a course is
@@ -280,6 +285,54 @@ def _ktaf_cds_combo_invalid(row: Row) -> bool:
     return combo not in _KTAF_KNOWN_CDS_COMBOS
 
 
+# GradeSpan tokens in scope for the Prior-to-secondary "060X or higher" proxy
+# below. KG and PK must be excluded by this explicit membership test rather
+# than a range comparison: as strings, "KG" and "PK" both sort ABOVE "06"
+# (letters sort above digits), so a naive `token >= "06"` bound - read from
+# the handbook's "or higher" wording - would wrongly include them. Bounding
+# above at "12" does not save a range check either, since "KG"/"PK" also sort
+# above "12" and so would still need a separate exclusion; membership in the
+# concrete set is the only reading that cannot mis-admit KG/PK.
+_KTAF_GRADE_SPAN_SECONDARY_SCOPE = frozenset({"06", "07", "08", "09", "10", "11", "12"})
+
+
+def _grade_completion_missing_heuristic(row: Row) -> bool:
+    """KTAF-GRADE-COMPLETION-MISSING-HEURISTIC: proxy for
+    STU-GRADE-COMPLETION-REQUIRED (checkable=False - see that rule).
+
+    Fires when SectionExitDate is populated, NumericGradeEarned,
+    AlphaGradeEarned, and CompletionStatus are all blank, and the row is in
+    scope by proxy for one of the handbook's two triggering conditions:
+
+    - AvailableCredit parses as a number greater than 0 (proxy for a
+      Secondary course code with available credit), or
+    - GradeSpan is populated and its first two characters are a grade token
+      06-12 (proxy for a Prior-to-secondary course code with a grade span of
+      060X or higher).
+
+    Both proxies substitute for the real test, which needs the NCES SCED
+    code list this tool does not have - see STU-GRADE-COMPLETION-REQUIRED's
+    `uncheckable_reason`.
+    """
+    if blank(row.get("SectionExitDate")):
+        return False
+    if not (
+        blank(row.get("NumericGradeEarned"))
+        and blank(row.get("AlphaGradeEarned"))
+        and blank(row.get("CompletionStatus"))
+    ):
+        return False
+    available_credit = as_float(row.get("AvailableCredit"))
+    if available_credit is not None and available_credit > 0:
+        return True
+    grade_span = row.get("GradeSpan")
+    if present(grade_span):
+        token = str(grade_span).strip()[:2]
+        if token in _KTAF_GRADE_SPAN_SECONDARY_SCOPE:
+            return True
+    return False
+
+
 # --------------------------------------------------------------------------- #
 # The catalog.
 # --------------------------------------------------------------------------- #
@@ -512,11 +565,12 @@ RULES: list[Rule] = [
         checkable=True,
         predicate=_format_check("CountyCodeAssigned", r"\d{2}"),
         notes=(
-            "Acceptable Values gives Min/Max Length 2; read here as a "
-            "fixed-width 2-digit numeric check, which is exactly what a "
-            "missing leading zero would violate. Populated values in the "
-            "real Newark/Camden files are exclusively 2-digit numeric "
-            "('80'/'07'), consistent with this reading."
+            "Acceptable Values gives Min/Max Length 2. The handbook's own "
+            "'leading zeros' bullet only makes sense if the field's content "
+            "is numeric digit positions - a true alphabetic value has no "
+            "notion of a missing leading zero. That implication, not what "
+            "any particular file contains, is what justifies reading this "
+            "as a fixed-width 2-digit numeric check."
         ),
     ),
     Rule(
@@ -574,8 +628,12 @@ RULES: list[Rule] = [
         checkable=True,
         predicate=_format_check("DistrictCodeAssigned", r"\d{4}"),
         notes=(
-            "Acceptable Values gives Min/Max Length 4; the real Newark/"
-            "Camden files are exclusively 4-digit numeric ('7325'/'1799')."
+            "Acceptable Values gives Min/Max Length 4; the same reasoning "
+            "as STU-COUNTYCODE-LEADINGZEROS applies at this width - the "
+            "handbook's own 'leading zeros' bullet only makes sense for "
+            "numeric digit content, which is what justifies a fixed-width "
+            "4-digit numeric check here, independent of what any file "
+            "contains."
         ),
     ),
     Rule(
@@ -619,15 +677,20 @@ RULES: list[Rule] = [
             "the submitting LEA; not present in the upload file."
         ),
         notes=(
-            "No KTAF-known-school-code rule is included below. The "
-            "org-provided expectation (Newark school 965, Camden school "
-            "111) does not hold against the real data used to build this "
-            "catalog: the Newark file legitimately uses two School Codes "
-            "(965 and 732), and the Camden file's only School Code is 179, "
-            "not 111. Encoding either single value would misfire on real "
-            "rows, so it was left out rather than approximated - flagged in "
-            "the report for the org to confirm the correct KTAF CDS school "
-            "combinations."
+            "A KTAF school-code expectation IS encoded below, as part of "
+            "KTAF-CDS-COMBO (County+District+School together: Newark "
+            "80/7325/965, Camden 07/1799/111). An earlier version of this "
+            "note argued the opposite - that expecting 965/111 'does not "
+            "hold against real data' because the file then in hand showed "
+            "732 and 179 - and left the rule out entirely. That reasoning "
+            "was wrong: 732 and 179 were the PowerSchool School Setup "
+            "defect (Alternate School Number unset, so the extract fell "
+            "back to a prefix of the internal school number), not valid "
+            "alternative codes. The 2026-07-31 extract carries the correct "
+            "965/111 codes on every row, confirming the original "
+            "expectation rather than the substitution. See KTAF-CDS-COMBO's "
+            "own notes, and rules.py's module docstring, for the fuller "
+            "account."
         ),
         tags=("cds-list",),
     ),
@@ -642,9 +705,12 @@ RULES: list[Rule] = [
         checkable=True,
         predicate=_format_check("SchoolCodeAssigned", r"\d{3}"),
         notes=(
-            "Acceptable Values gives Min/Max Length 3; the real Newark/"
-            "Camden files are exclusively 3-digit numeric ('965'/'732'/"
-            "'179')."
+            "Acceptable Values gives Min/Max Length 3; the same reasoning "
+            "applies at this width. The check rests on the handbook's own "
+            "'leading zeros' bullet implying numeric digit content, not on "
+            "what any file contains - in particular, not on 732 or 179, "
+            "which KTAF-CDS-COMBO's notes document as the PowerSchool "
+            "School Setup defect rather than valid codes."
         ),
     ),
     Rule(
@@ -1063,6 +1129,49 @@ RULES: list[Rule] = [
         checkable=True,
         predicate=_credits_earned_exceeds_available,
     ),
+    # --- Grade-or-completion mandate, handbook pp34-36 (Is this Data Element
+    # Required?, not Validation Checks - see rules.py's module docstring for
+    # why this rule has no Validation-Checks-transcribed counterpart) -------
+    Rule(
+        id="STU-GRADE-COMPLETION-REQUIRED",
+        element="NumericGradeEarned+AlphaGradeEarned+CompletionStatus",
+        page=34,
+        error_text=(
+            "All students with a SectionExitDate entered for Secondary "
+            "course codes with an available credit of greater than 0.000 "
+            "must have either the NumericGradeEarned, AlphaGradeEarned, or "
+            "CompletionStatus field filled in. All students with a "
+            "SectionExitDate entered for Prior-to-secondary course codes "
+            "with an grade span of 060X or higher (where X is replaced with "
+            "a full GradeSpan such as 0606, 0607, 0608, and so on) must "
+            "have either the NumericGradeEarned, AlphaGradeEarned, or "
+            "CompletionStatus field filled in."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Deciding whether a course is Secondary or Prior-to-secondary "
+            "requires the NCES SCED (School Courses for the Exchange of "
+            "Data) code list to classify the course's SubjectArea/"
+            "CourseIdentifier combination; the upload file does not contain "
+            "that list."
+        ),
+        notes=(
+            "This is stated identically under 'Is this Data Element "
+            "Required?' on pages 34 (NumericGradeEarned), 35 "
+            "(AlphaGradeEarned), and 36 (CompletionStatus) - error_text is "
+            "quoted from the NumericGradeEarned section verbatim, including "
+            "its 'an grade span' wording. None of the three elements' "
+            "Validation Checks sections has a matching blank-check bullet, "
+            "which is why the original transcription pass never produced a "
+            "rule for this requirement; see rules.py's module docstring. A "
+            "checkable proxy is provided separately as "
+            "KTAF-GRADE-COMPLETION-MISSING-HEURISTIC, below, using "
+            "AvailableCredit and GradeSpan in place of the SCED list - it is "
+            "a KTAF rule, not this handbook rule, and is never counted "
+            "toward a state error total."
+        ),
+        tags=("sced",),
+    ),
     # --- NumericGradeEarned, handbook p34 --------------------------------------------
     Rule(
         id="STU-NUMERICGRADEEARNED-RANGE",
@@ -1249,5 +1358,61 @@ RULES: list[Rule] = [
             "draft dropped this rule entirely and what that would have cost."
         ),
         tags=("cds_list",),
+    ),
+    Rule(
+        id="KTAF-GRADE-COMPLETION-MISSING-HEURISTIC",
+        element="NumericGradeEarned+AlphaGradeEarned+CompletionStatus",
+        page=0,
+        error_text=(
+            "KTAF heuristic, not a handbook rule: SectionExitDate is "
+            "populated, NumericGradeEarned/AlphaGradeEarned/CompletionStatus "
+            "are all blank, and the row proxies into scope for the "
+            "handbook's grade-or-completion mandate (STU-GRADE-COMPLETION-"
+            "REQUIRED, checkable=False) via AvailableCredit > 0 or a "
+            "GradeSpan of 06-12."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_grade_completion_missing_heuristic,
+        notes=(
+            "This is a proxy for STU-GRADE-COMPLETION-REQUIRED, not the "
+            "handbook rule itself - it substitutes AvailableCredit and "
+            "GradeSpan for the NCES SCED code list that rule actually needs "
+            "to decide Secondary vs. Prior-to-secondary, so it can both "
+            "over- and under-fire relative to what the state actually "
+            "checks. As a KTAF rule it is never counted toward a state "
+            "error total; it exists to give an analyst a number to act on "
+            "the same day, not a verified violation count.\n\n"
+            "On the 2026-07-31 extract this is expected to fire on roughly "
+            "28,727 rows across the two student files, because the "
+            "submitted file is the raw PowerSchool extract without the "
+            "grade backfill applied - most rows with a SectionExitDate "
+            "genuinely have no grade or completion status recorded yet."
+        ),
+        tags=("sced", "ambiguous"),
+    ),
+    Rule(
+        id="KTAF-COURSETYPE-BLANK",
+        element="CourseType",
+        page=37,
+        error_text=(
+            "KTAF expectation, not a handbook rule: CourseType, when "
+            "blank, is flagged directly. The handbook states under 'Is "
+            "this Data Element Required?' that CourseType is mandatory for "
+            "all students, but its Validation Checks section has no "
+            "matching blank-check bullet to transcribe (only the S1/S2 "
+            "staff-assignment checks), so no handbook rule encodes this."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_blank_check("CourseType"),
+        notes=(
+            "Substitutes for the missing Validation Check, not a state "
+            "rule - the state may or may not actually reject a blank "
+            "CourseType, and this cannot be counted toward its error total. "
+            "Reports 0 on the 2026-07-31 files: CourseType is populated on "
+            "every row in both student files."
+        ),
+        tags=("ambiguous",),
     ),
 ]

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from rules import (
+    NAME_PATTERN,
     Row,
     Rule,
     as_float,
@@ -37,15 +38,11 @@ from rules import (
 # Shared format patterns.
 # --------------------------------------------------------------------------- #
 
-# FirstName/LastName: "any special characters except for apostrophes (') and
-# hyphens (-)". Space is included for both fields, not just LastName: the
-# LastName Additional Notes give a compound-name example with a plain space
-# ("Davis Smyth"), and the real Newark/Camden files carry legitimately
-# space-containing FirstName values too (78 rows across both files) - treating
-# space as a disallowed "special character" for FirstName produced false
-# positives against real data during validation, so it is allowed here for
-# both name fields.
-_NAME_PATTERN = r"[A-Za-z‘’' \-]+"
+# FirstName/LastName. Shared with the staff catalog, which words the same rule
+# identically - see rules.py for the pattern and the judgement calls behind it
+# (space allowed, both apostrophe forms allowed, accented letters treated as
+# letters).
+_NAME_PATTERN = NAME_PATTERN
 
 # GradeSpan: "each grade level from PK through 12... two-digit code... KG for
 # kindergarten... PK for prekindergarten". A GradeSpan is two such codes
@@ -1238,18 +1235,18 @@ RULES: list[Rule] = [
         source="ktaf",
         predicate=_ktaf_cds_combo_invalid,
         notes=(
-            "Expected to fire heavily on the 2026-07-29 extract, and that is "
-            "the signal, not a bug. Newark carries school code 732 on a large "
-            "block of rows and Camden carries 179 on every populated-CDS row; "
-            "both are the documented CDS defect (Alternate School Number unset "
-            "in PowerSchool School Setup, so the extract falls back to a "
-            "prefix of the internal school number), affecting 20,652 of 43,493 "
-            "rows network-wide.\n\n"
-            "Do not retune the expected codes to match what the file "
+            "Passes clean as of the 2026-07-31 extract: both student files "
+            "carry the correct triple on every row. It did not before. The "
+            "2026-07-29 extract carried 732 on a large block of Newark rows "
+            "and 179 on every populated-CDS Camden row - 20,652 of 43,493 "
+            "rows - because the Alternate School Number was unset in "
+            "PowerSchool School Setup, so the extract fell back to a prefix "
+            "of the internal school number. The School Setup fix landed "
+            "between those two extracts, which also confirms 111 as Camden's "
+            "real code.\n\n"
+            "Do not retune the expected codes to match what a file "
             "contains - see rules.py's module docstring for why an earlier "
-            "draft did exactly that and what it cost. Camden's 111 is still "
-            "worth confirming against the NJDOE directory before anyone keys "
-            "it into School Setup."
+            "draft dropped this rule entirely and what that would have cost."
         ),
         tags=("cds_list",),
     ),

--- a/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
+++ b/docs/superpowers/nj-sleds-roster/error-attribution/rules_student.py
@@ -1,0 +1,1202 @@
+"""NJSLEDS Student Course Roster handbook rule catalog.
+
+Transcribes every "An error will occur..." statement in
+`handbook-rules-student.md` (Student Course Roster Submission Handbook,
+Version 1.4, July 2026) into a `Rule`. There are 68 handbook statements; this
+module exports exactly one `Rule` per statement, plus a small set of
+`source="ktaf"` rules for local expectations the handbook itself does not
+impose (see `rules.py`'s module docstring for why that distinction matters).
+
+Several handbook elements require the SCED (School Courses for the Exchange of
+Data) Subject Area / Course Identifier code to know whether a course is
+"Secondary" or "Prior-to-Secondary" before a conditional requirement even
+applies (e.g. GradeSpan is mandatory only for Prior-to-Secondary courses;
+AvailableCredit and CreditsEarned only for Secondary courses). This file does
+not have the SCED code list, so those conditional rules are marked
+`checkable=False` rather than approximated - see each rule's
+`uncheckable_reason`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from rules import (
+    Row,
+    Rule,
+    as_float,
+    blank,
+    in_window,
+    is_date8,
+    malformed,
+    matches,
+    present,
+)
+
+# --------------------------------------------------------------------------- #
+# Shared format patterns.
+# --------------------------------------------------------------------------- #
+
+# FirstName/LastName: "any special characters except for apostrophes (') and
+# hyphens (-)". Space is included for both fields, not just LastName: the
+# LastName Additional Notes give a compound-name example with a plain space
+# ("Davis Smyth"), and the real Newark/Camden files carry legitimately
+# space-containing FirstName values too (78 rows across both files) - treating
+# space as a disallowed "special character" for FirstName produced false
+# positives against real data during validation, so it is allowed here for
+# both name fields.
+_NAME_PATTERN = r"[A-Za-z‘’' \-]+"
+
+# GradeSpan: "each grade level from PK through 12... two-digit code... KG for
+# kindergarten... PK for prekindergarten". A GradeSpan is two such codes
+# concatenated (e.g. "KG01", "0810"); the handbook's own example does not
+# require the two halves to be ordered low-to-high, so ordering is not
+# enforced here.
+_GRADE_SPAN_CODE = r"(?:PK|KG|0[1-9]|1[0-2])"
+_GRADE_SPAN_PATTERN = _GRADE_SPAN_CODE + "{2}"
+
+# CourseLevel: the valid set (B, G, E, H, X) is enumerated directly in the
+# handbook's Acceptable Values, unlike SubjectArea/CourseIdentifier which defer
+# to an external SCED document - so this one is checkable without that list.
+_COURSE_LEVEL_PATTERN = r"[BGEHX]"
+
+# AlphaGradeEarned: A/B/C/D/E/F, each optionally with + or -.
+_ALPHA_GRADE_PATTERN = r"[A-F][+\-]?"
+
+# CompletionStatus: P, F, W, I, NG.
+_COMPLETION_STATUS_PATTERN = r"P|F|W|I|NG"
+
+
+# --------------------------------------------------------------------------- #
+# Predicate factories, for the repeated shapes (blank / format / date format /
+# school-year window / numeric range).
+# --------------------------------------------------------------------------- #
+
+
+def _blank_check(column: str) -> Callable[[Row], bool]:
+    """Factory: True when `column` is blank."""
+
+    def check(row: Row) -> bool:
+        return blank(row.get(column))
+
+    return check
+
+
+def _format_check(column: str, pattern: str) -> Callable[[Row], bool]:
+    """Factory: True when a populated `column` fails to fullmatch `pattern`.
+
+    Uses `malformed()`, not `not matches(...)`, so a blank `column` is silent
+    here - blankness is its own rule where the handbook states one.
+    """
+
+    def check(row: Row) -> bool:
+        return malformed(row.get(column), pattern)
+
+    return check
+
+
+def _date_format_check(column: str) -> Callable[[Row], bool]:
+    """Factory: True when a populated `column` is not a real YYYYMMDD date."""
+
+    def check(row: Row) -> bool:
+        value = row.get(column)
+        return present(value) and not is_date8(value)
+
+    return check
+
+
+def _school_year_check(column: str) -> Callable[[Row], bool]:
+    """Factory: True when a validly-formatted `column` date is outside SY.
+
+    Guarded on `is_date8` so a malformed date is attributed only to the
+    element's own format rule, not double-counted here as a school-year miss
+    too.
+    """
+
+    def check(row: Row) -> bool:
+        value = row.get(column)
+        return is_date8(value) and not in_window(value)
+
+    return check
+
+
+def _out_of_range(value: str | None, low: float, high: float) -> bool:
+    """True when a populated value fails to parse as a number in [low, high].
+
+    None of AvailableCredit/CreditsEarned/NumericGradeEarned has a separate
+    format-only bullet, so a non-numeric populated value is treated as out of
+    range too - the range bullet is the only Validation Check that would
+    catch it.
+    """
+    if blank(value):
+        return False
+    parsed = as_float(value)
+    return parsed is None or not (low <= parsed <= high)
+
+
+def _range_check(column: str, low: float, high: float) -> Callable[[Row], bool]:
+    """Factory: True when a populated `column` is outside [low, high]."""
+
+    def check(row: Row) -> bool:
+        return _out_of_range(row.get(column), low, high)
+
+    return check
+
+
+# --------------------------------------------------------------------------- #
+# One-off cross-field predicates.
+# --------------------------------------------------------------------------- #
+
+
+def _entry_date_after_exit_date(row: Row) -> bool:
+    """STU-SECTIONENTRYDATE-AFTER-EXIT: entry date later than exit date.
+
+    Only evaluated when both dates are validly formatted, so a malformed date
+    is attributed to its own format rule instead of this ordering rule too.
+    """
+    entry = row.get("SectionEntryDate")
+    exit_date = row.get("SectionExitDate")
+    if not (is_date8(entry) and is_date8(exit_date)):
+        return False
+    return str(entry).strip() > str(exit_date).strip()
+
+
+def _exit_date_before_entry_date(row: Row) -> bool:
+    """STU-SECTIONEXITDATE-BEFORE-ENTRY: exit date earlier than entry date.
+
+    Same underlying comparison as `_entry_date_after_exit_date`, kept as a
+    separate, separately-named function because it is a distinct handbook
+    statement scoped to SectionExitDate rather than SectionEntryDate.
+    """
+    entry = row.get("SectionEntryDate")
+    exit_date = row.get("SectionExitDate")
+    if not (is_date8(entry) and is_date8(exit_date)):
+        return False
+    return str(exit_date).strip() < str(entry).strip()
+
+
+def _course_sequence_first_digit_exceeds_second(row: Row) -> bool:
+    """STU-COURSESEQUENCE-FIRSTDIGIT-GT-SECOND: first digit exceeds the second.
+
+    Only evaluated when the value is a well-formed 2-digit sequence - there is
+    no separate format bullet for CourseSequence, and the handbook's wording
+    ("the value of the first digit... the second digit") presumes exactly two
+    digits to compare.
+    """
+    value = row.get("CourseSequence")
+    if not matches(value, r"\d{2}"):
+        return False
+    text = str(value).strip()
+    return int(text[0]) > int(text[1])
+
+
+def _credits_earned_exceeds_available(row: Row) -> bool:
+    """STU-CREDITSEARNED-EXCEEDS-AVAILABLE: CreditsEarned > AvailableCredit."""
+    earned = as_float(row.get("CreditsEarned"))
+    available = as_float(row.get("AvailableCredit"))
+    if earned is None or available is None:
+        return False
+    return earned > available
+
+
+def _numeric_grade_not_whole(row: Row) -> bool:
+    """STU-NUMERICGRADEEARNED-NOTWHOLE: a parseable value that is not whole."""
+    parsed = as_float(row.get("NumericGradeEarned"))
+    if parsed is None:
+        return False
+    return parsed != int(parsed)
+
+
+def _dual_institution_blank_for_coursetype_c(row: Row) -> bool:
+    """STU-DUALINSTITUTION-BLANK-COURSETYPE-C: CourseType C, DualInstitution blank."""
+    course_type = str(row.get("CourseType") or "").strip()
+    return course_type == "C" and blank(row.get("DualInstitution"))
+
+
+def _dual_institution_populated_for_non_c(row: Row) -> bool:
+    """STU-DUALINSTITUTION-POPULATED-NOT-C: DualInstitution set without CourseType C."""
+    course_type = str(row.get("CourseType") or "").strip()
+    return course_type != "C" and present(row.get("DualInstitution"))
+
+
+# --------------------------------------------------------------------------- #
+# KTAF-local rules (source="ktaf"). Never counted toward a state error total -
+# see rules.py's module docstring and HANDOFF.md.
+#
+# The org-provided expectation was Newark county 80 / district 7325 / school
+# 965, and Camden county 07 / district 1799 / school 111 (school unconfirmed).
+# Profiling the real Newark and Camden student files against that expectation
+# found:
+#   - County and District match the given values exactly wherever populated
+#     (Newark: county always "80" or blank, district always "7325"; Camden:
+#     county always "07" or blank, district always "1799"). Both are encoded
+#     below.
+#   - School does NOT match: Newark legitimately uses two School Codes ("965"
+#     and "732"), not only "965", and Camden's only School Code in the file is
+#     "179", not "111". Encoding either single value as a KTAF check would
+#     misfire on real rows, so no KTAF school-code rule is included. This
+#     confirms the Camden "111" guess was wrong and that the org's
+#     Newark-school assumption was incomplete; flagged in the report for the
+#     org to confirm the intended KTAF CDS combinations before anyone builds
+#     on "965"/"111" elsewhere.
+# --------------------------------------------------------------------------- #
+
+_KTAF_KNOWN_COUNTY_CODES = frozenset({"80", "07"})
+_KTAF_KNOWN_DISTRICT_CODES = frozenset({"7325", "1799"})
+
+
+def _county_code_not_ktaf_known(row: Row) -> bool:
+    """KTAF-COUNTYCODE-KNOWN: populated County Code outside KTAF's known set."""
+    value = row.get("CountyCodeAssigned")
+    return present(value) and str(value).strip() not in _KTAF_KNOWN_COUNTY_CODES
+
+
+def _district_code_not_ktaf_known(row: Row) -> bool:
+    """KTAF-DISTRICTCODE-KNOWN: populated District Code outside KTAF's known set."""
+    value = row.get("DistrictCodeAssigned")
+    return present(value) and str(value).strip() not in _KTAF_KNOWN_DISTRICT_CODES
+
+
+# --------------------------------------------------------------------------- #
+# The catalog.
+# --------------------------------------------------------------------------- #
+
+RULES: list[Rule] = [
+    # --- LocalIdentificationNumber (LID), handbook p11 ---------------------
+    Rule(
+        id="STU-LID-BLANK",
+        element="LocalIdentificationNumber",
+        page=11,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("LocalIdentificationNumber"),
+    ),
+    # --- StateIdentificationNumber (SID), handbook p12 ----------------------
+    Rule(
+        id="STU-SID-NOT10DIGITS",
+        element="StateIdentificationNumber",
+        page=12,
+        error_text=(
+            "An error will occur when the value submitted is not exactly 10 digits."
+        ),
+        checkable=True,
+        predicate=_format_check("StateIdentificationNumber", r"\d{10}"),
+    ),
+    Rule(
+        id="STU-SID-BLANK",
+        element="StateIdentificationNumber",
+        page=12,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("StateIdentificationNumber"),
+    ),
+    Rule(
+        id="STU-SID-INVALID-ISSUED",
+        element="StateIdentificationNumber",
+        page=12,
+        error_text=(
+            "An error will occur when the State Identification Number is not "
+            "a valid number issued by NJSLEDS."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs NJSLEDS's own record of SIDs it has issued; not derivable "
+            "from the upload file alone."
+        ),
+        tags=("student-management",),
+    ),
+    Rule(
+        id="STU-SID-MISMATCH-STUDENT-MGMT",
+        element="StateIdentificationNumber",
+        page=12,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Student Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare against; the Course Roster file has no such reference "
+            "value."
+        ),
+        tags=("student-management",),
+    ),
+    # --- FirstName, handbook p13 ---------------------------------------------
+    Rule(
+        id="STU-FIRSTNAME-BLANK",
+        element="FirstName",
+        page=13,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("FirstName"),
+    ),
+    Rule(
+        id="STU-FIRSTNAME-SPECIALCHARS",
+        element="FirstName",
+        page=13,
+        error_text=(
+            "An error will occur if this data element contains any special "
+            "characters except for apostrophes (‘) and hyphens (-)."
+        ),
+        checkable=True,
+        predicate=_format_check("FirstName", _NAME_PATTERN),
+        notes=(
+            "Allowed pattern also permits a space, matching the "
+            "compound-name convention the handbook documents for LastName "
+            "('Davis Smyth'); real Newark/Camden data has legitimate "
+            "space-containing FirstName values, and disallowing space "
+            "produced false positives during validation."
+        ),
+    ),
+    Rule(
+        id="STU-FIRSTNAME-MISMATCH-STUDENT-MGMT",
+        element="FirstName",
+        page=13,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Student Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare against; not present in the Course Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- LastName, handbook p14 -----------------------------------------------
+    Rule(
+        id="STU-LASTNAME-BLANK",
+        element="LastName",
+        page=14,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("LastName"),
+    ),
+    Rule(
+        id="STU-LASTNAME-SPECIALCHARS",
+        element="LastName",
+        page=14,
+        error_text=(
+            "An error will occur if this data element contains any special "
+            "characters except for apostrophes (‘) and hyphens (-)."
+        ),
+        checkable=True,
+        predicate=_format_check("LastName", _NAME_PATTERN),
+        notes=(
+            "Allowed pattern includes a space per the handbook's own "
+            "compound-surname example ('Davis Smyth')."
+        ),
+    ),
+    Rule(
+        id="STU-LASTNAME-MISMATCH-STUDENT-MGMT",
+        element="LastName",
+        page=14,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Student Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare against; not present in the Course Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- DateOfBirth, handbook p15 --------------------------------------------
+    Rule(
+        id="STU-DOB-BLANK",
+        element="DateOfBirth",
+        page=15,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("DateOfBirth"),
+    ),
+    Rule(
+        id="STU-DOB-FORMAT",
+        element="DateOfBirth",
+        page=15,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20150128)."
+        ),
+        checkable=True,
+        predicate=_date_format_check("DateOfBirth"),
+    ),
+    Rule(
+        id="STU-DOB-REASONABLE-RANGE",
+        element="DateOfBirth",
+        page=15,
+        error_text=(
+            "An error will occur if the date falls outside of reasonable parameters (i."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "The extracted handbook text is truncated mid-sentence before "
+            "stating the actual bound ('reasonable parameters (i.' cuts "
+            "off) - no threshold is given anywhere else in the element to "
+            "encode without guessing."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STU-DOB-MISMATCH-STUDENT-MGMT",
+        element="DateOfBirth",
+        page=15,
+        error_text=(
+            "An error will occur if this field does not exactly match the "
+            "value in Student Management."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare against; not present in the Course Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- CountyCodeAssigned, handbook p16 -------------------------------------
+    Rule(
+        id="STU-COUNTYCODE-BLANK",
+        element="CountyCodeAssigned",
+        page=16,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("CountyCodeAssigned"),
+    ),
+    Rule(
+        id="STU-COUNTYCODE-NOT-IN-CDS",
+        element="CountyCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if the County Code submitted does not "
+            "conform to the codes listed for your district in the CDS list."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJSLEDS County-District-School (CDS) code list for "
+            "the submitting LEA; not present in the upload file. See "
+            "KTAF-COUNTYCODE-KNOWN for a narrower local proxy."
+        ),
+        tags=("cds-list",),
+    ),
+    Rule(
+        id="STU-COUNTYCODE-LEADINGZEROS",
+        element="CountyCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_format_check("CountyCodeAssigned", r"\d{2}"),
+        notes=(
+            "Acceptable Values gives Min/Max Length 2; read here as a "
+            "fixed-width 2-digit numeric check, which is exactly what a "
+            "missing leading zero would violate. Populated values in the "
+            "real Newark/Camden files are exclusively 2-digit numeric "
+            "('80'/'07'), consistent with this reading."
+        ),
+    ),
+    Rule(
+        id="STU-COUNTYCODE-MISALIGN-STUDENT-MGMT",
+        element="CountyCodeAssigned",
+        page=16,
+        error_text=(
+            "An error will occur if the County Code, District Code, and "
+            "School Code reported in Student Course Roster do not align "
+            "with the corresponding Student Management record for the same "
+            "student (SID)."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare the CDS triple against; not present in the Course "
+            "Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- DistrictCodeAssigned, handbook p17 -----------------------------------
+    Rule(
+        id="STU-DISTRICTCODE-BLANK",
+        element="DistrictCodeAssigned",
+        page=17,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("DistrictCodeAssigned"),
+    ),
+    Rule(
+        id="STU-DISTRICTCODE-MISMATCH-SUBMITTING",
+        element="DistrictCodeAssigned",
+        page=17,
+        error_text=(
+            "An error will occur if the District Code submitted does not "
+            "match the Submitting District."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the identity of the LEA/account that submitted the file, "
+            "which is not a column in the roster; see KTAF-DISTRICTCODE-"
+            "KNOWN for a local proxy scoped to KTAF's known Newark/Camden "
+            "district codes."
+        ),
+        tags=("submission-metadata",),
+    ),
+    Rule(
+        id="STU-DISTRICTCODE-LEADINGZEROS",
+        element="DistrictCodeAssigned",
+        page=17,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_format_check("DistrictCodeAssigned", r"\d{4}"),
+        notes=(
+            "Acceptable Values gives Min/Max Length 4; the real Newark/"
+            "Camden files are exclusively 4-digit numeric ('7325'/'1799')."
+        ),
+    ),
+    Rule(
+        id="STU-DISTRICTCODE-MISALIGN-STUDENT-MGMT",
+        element="DistrictCodeAssigned",
+        page=17,
+        error_text=(
+            "An error will occur if the County Code, District Code, and "
+            "School Code reported in Student Course Roster do not align "
+            "with the corresponding Student Management record for the same "
+            "student (SID)."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare the CDS triple against; not present in the Course "
+            "Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- SchoolCodeAssigned, handbook p18 -------------------------------------
+    Rule(
+        id="STU-SCHOOLCODE-BLANK",
+        element="SchoolCodeAssigned",
+        page=18,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("SchoolCodeAssigned"),
+    ),
+    Rule(
+        id="STU-SCHOOLCODE-NOT-IN-CDS",
+        element="SchoolCodeAssigned",
+        page=18,
+        error_text=(
+            "An error will occur if the School Code submitted does not "
+            "conform to the codes listed for your district in the CDS list."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJSLEDS County-District-School (CDS) code list for "
+            "the submitting LEA; not present in the upload file."
+        ),
+        notes=(
+            "No KTAF-known-school-code rule is included below. The "
+            "org-provided expectation (Newark school 965, Camden school "
+            "111) does not hold against the real data used to build this "
+            "catalog: the Newark file legitimately uses two School Codes "
+            "(965 and 732), and the Camden file's only School Code is 179, "
+            "not 111. Encoding either single value would misfire on real "
+            "rows, so it was left out rather than approximated - flagged in "
+            "the report for the org to confirm the correct KTAF CDS school "
+            "combinations."
+        ),
+        tags=("cds-list",),
+    ),
+    Rule(
+        id="STU-SCHOOLCODE-LEADINGZEROS",
+        element="SchoolCodeAssigned",
+        page=18,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_format_check("SchoolCodeAssigned", r"\d{3}"),
+        notes=(
+            "Acceptable Values gives Min/Max Length 3; the real Newark/"
+            "Camden files are exclusively 3-digit numeric ('965'/'732'/"
+            "'179')."
+        ),
+    ),
+    Rule(
+        id="STU-SCHOOLCODE-NONOPERATIONAL",
+        element="SchoolCodeAssigned",
+        page=18,
+        error_text=(
+            "An error will occur if a School Code designated for a "
+            "non-operational school is used."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJDOE list of school codes marked non-operational; "
+            "not present in the upload file."
+        ),
+        tags=("cds-list",),
+    ),
+    Rule(
+        id="STU-SCHOOLCODE-MISALIGN-STUDENT-MGMT",
+        element="SchoolCodeAssigned",
+        page=18,
+        error_text=(
+            "An error will occur if the County Code, District Code, and "
+            "School Code reported in Student Course Roster do not align "
+            "with the corresponding Student Management record for the same "
+            "student (SID)."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the student's Student Management (state SIS) record to "
+            "compare the CDS triple against; not present in the Course "
+            "Roster file."
+        ),
+        tags=("student-management",),
+    ),
+    # --- SectionEntryDate, handbook p20 ---------------------------------------
+    Rule(
+        id="STU-SECTIONENTRYDATE-BLANK",
+        element="SectionEntryDate",
+        page=20,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("SectionEntryDate"),
+    ),
+    Rule(
+        id="STU-SECTIONENTRYDATE-RANGE",
+        element="SectionEntryDate",
+        page=20,
+        error_text=(
+            "An error will occur if the value does not meet the acceptable "
+            "range of values."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "No date range or bound is stated in Acceptable Values beyond "
+            "format and the separately-listed current-School-Year bullet; "
+            "what distinct condition this bullet tests is not specified in "
+            "the extracted text."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STU-SECTIONENTRYDATE-FORMAT",
+        element="SectionEntryDate",
+        page=20,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20250128)."
+        ),
+        checkable=True,
+        predicate=_date_format_check("SectionEntryDate"),
+    ),
+    Rule(
+        id="STU-SECTIONENTRYDATE-AFTER-EXIT",
+        element="SectionEntryDate",
+        page=20,
+        error_text=(
+            "An error will occur if the student course entry date occurs "
+            "after the student course exit date."
+        ),
+        checkable=True,
+        predicate=_entry_date_after_exit_date,
+    ),
+    Rule(
+        id="STU-SECTIONENTRYDATE-NOT-IN-SY",
+        element="SectionEntryDate",
+        page=20,
+        error_text=(
+            "An error will occur if the SectionEntryDate does not occur in "
+            "the current School Year."
+        ),
+        checkable=True,
+        predicate=_school_year_check("SectionEntryDate"),
+    ),
+    # --- SectionExitDate, handbook p22 -----------------------------------------
+    Rule(
+        id="STU-SECTIONEXITDATE-BLANK",
+        element="SectionExitDate",
+        page=22,
+        error_text="An error will occur if this field is left blank.",
+        checkable=False,
+        uncheckable_reason=(
+            "SectionExitDate is mandatory only when the student is no "
+            "longer active in the course (per the element's Required-ness "
+            "note); whether blank is an error for a given row depends on "
+            "the student's true enrollment status in that section, which "
+            "the roster file exposes only via this same field - there is no "
+            "independent active/inactive flag to check against without "
+            "circularity."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STU-SECTIONEXITDATE-RANGE",
+        element="SectionExitDate",
+        page=22,
+        error_text=(
+            "An error will occur if the value does not meet the acceptable "
+            "range of values."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "No date range or bound is stated in Acceptable Values beyond "
+            "format and the separately-listed current-School-Year bullet; "
+            "what distinct condition this bullet tests is not specified in "
+            "the extracted text."
+        ),
+        tags=("ambiguous",),
+    ),
+    Rule(
+        id="STU-SECTIONEXITDATE-FORMAT",
+        element="SectionExitDate",
+        page=22,
+        error_text=(
+            "An error will occur if the date is not entered in YYYYMMDD "
+            "format (for example, 20250128)."
+        ),
+        checkable=True,
+        predicate=_date_format_check("SectionExitDate"),
+    ),
+    Rule(
+        id="STU-SECTIONEXITDATE-BEFORE-ENTRY",
+        element="SectionExitDate",
+        page=22,
+        error_text=(
+            "An error will occur if the student course exit date occurs "
+            "before the student course entry date."
+        ),
+        checkable=True,
+        predicate=_exit_date_before_entry_date,
+    ),
+    Rule(
+        id="STU-SECTIONEXITDATE-NOT-IN-SY",
+        element="SectionExitDate",
+        page=22,
+        error_text=(
+            "An error will occur if the SectionExitDate does not occur in "
+            "the current School Year."
+        ),
+        checkable=True,
+        predicate=_school_year_check("SectionExitDate"),
+    ),
+    Rule(
+        id="STU-SECTIONEXITDATE-FUTURE",
+        element="SectionExitDate",
+        page=22,
+        error_text=(
+            "An error will occur if the SectionExitDate is later than the "
+            "file submission date (for example, a future date)."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the actual NJSLEDS file-submission/upload date, which is "
+            "not a column in the roster file. The wall-clock date this tool "
+            "happens to run on is not a reliable stand-in for when the file "
+            "was actually submitted, so it is not used as an approximation."
+        ),
+        tags=("submission-metadata",),
+    ),
+    # --- SubjectArea, handbook p23 ---------------------------------------------
+    Rule(
+        id="STU-SUBJECTAREA-BLANK",
+        element="SubjectArea",
+        page=23,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("SubjectArea"),
+    ),
+    Rule(
+        id="STU-SUBJECTAREA-INVALID-SCED",
+        element="SubjectArea",
+        page=23,
+        error_text=(
+            "An error will occur if the value is not a valid SCED Subject Area code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJSLEDS/NCES SCED Course Codes document listing "
+            "valid Subject Area codes; not present in the upload file."
+        ),
+        tags=("sced",),
+    ),
+    # --- CourseIdentifier, handbook p24 -----------------------------------------
+    Rule(
+        id="STU-COURSEIDENTIFIER-BLANK",
+        element="CourseIdentifier",
+        page=24,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("CourseIdentifier"),
+    ),
+    Rule(
+        id="STU-COURSEIDENTIFIER-INVALID-SCED",
+        element="CourseIdentifier",
+        page=24,
+        error_text=(
+            "An error will occur if the value is not a valid SCED Course "
+            "Identifier code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJSLEDS/NCES SCED Course Codes document listing "
+            "valid Course Identifier codes; not present in the upload file."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STU-COURSEIDENTIFIER-LEADINGZEROS",
+        element="CourseIdentifier",
+        page=24,
+        error_text=(
+            "An error will occur if required leading zeros are missing, "
+            "resulting in an incorrect value format."
+        ),
+        checkable=True,
+        predicate=_format_check("CourseIdentifier", r"\d{3}"),
+    ),
+    # --- CourseLevel, handbook p25 -----------------------------------------------
+    Rule(
+        id="STU-COURSELEVEL-BLANK",
+        element="CourseLevel",
+        page=25,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("CourseLevel"),
+    ),
+    Rule(
+        id="STU-COURSELEVEL-INVALID",
+        element="CourseLevel",
+        page=25,
+        error_text=(
+            "An error will occur if the value is not a valid SCED Course Level code."
+        ),
+        checkable=True,
+        predicate=_format_check("CourseLevel", _COURSE_LEVEL_PATTERN),
+        notes=(
+            "Unlike SubjectArea/CourseIdentifier, CourseLevel's valid set "
+            "(B, G, E, H, X) is enumerated directly in the handbook's "
+            "Acceptable Values rather than deferred to an external SCED "
+            "document, so this is checkable without that list."
+        ),
+    ),
+    # --- GradeSpan, handbook p26 --------------------------------------------------
+    Rule(
+        id="STU-GRADESPAN-BLANK-PRIORSECONDARY",
+        element="GradeSpan",
+        page=26,
+        error_text=(
+            "An error will occur if the field is left blank for a course "
+            "with a Prior-To-Secondary course code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Whether a course is Prior-to-Secondary is a property of its "
+            "SubjectArea/CourseIdentifier combination on the SCED code "
+            "list; needs that list to evaluate."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STU-GRADESPAN-RANGE",
+        element="GradeSpan",
+        page=26,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_format_check("GradeSpan", _GRADE_SPAN_PATTERN),
+    ),
+    # --- AvailableCredit, handbook p27 --------------------------------------------
+    Rule(
+        id="STU-AVAILABLECREDIT-BLANK-SECONDARY",
+        element="AvailableCredit",
+        page=27,
+        error_text=(
+            "An error will occur if this field is left blank for a course "
+            "with a Secondary course code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Whether a course is Secondary is a property of its "
+            "SubjectArea/CourseIdentifier combination on the SCED code "
+            "list; needs that list to evaluate."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STU-AVAILABLECREDIT-RANGE",
+        element="AvailableCredit",
+        page=27,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_range_check("AvailableCredit", 0.0, 35.0),
+    ),
+    # --- CourseSequence, handbook p28 ----------------------------------------------
+    Rule(
+        id="STU-COURSESEQUENCE-BLANK",
+        element="CourseSequence",
+        page=28,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("CourseSequence"),
+    ),
+    Rule(
+        id="STU-COURSESEQUENCE-FIRSTDIGIT-GT-SECOND",
+        element="CourseSequence",
+        page=28,
+        error_text=(
+            "An error will occur if the value of the first digit is "
+            "greater than the value of the second digit."
+        ),
+        checkable=True,
+        predicate=_course_sequence_first_digit_exceeds_second,
+    ),
+    # --- LocalCourseTitle, handbook p29 ---------------------------------------------
+    Rule(
+        id="STU-LOCALCOURSETITLE-BLANK",
+        element="LocalCourseTitle",
+        page=29,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("LocalCourseTitle"),
+    ),
+    # --- LocalCourseCode, handbook p30 ----------------------------------------------
+    Rule(
+        id="STU-LOCALCOURSECODE-BLANK",
+        element="LocalCourseCode",
+        page=30,
+        error_text="An error will occur if this field is left blank.",
+        checkable=True,
+        predicate=_blank_check("LocalCourseCode"),
+    ),
+    # --- LocalSectionCode, handbook p31 ----------------------------------------------
+    Rule(
+        id="STU-LOCALSECTIONCODE-BLANK",
+        element="LocalSectionCode",
+        page=31,
+        error_text="An error will occur if the field is left blank.",
+        checkable=True,
+        predicate=_blank_check("LocalSectionCode"),
+    ),
+    # --- CreditsEarned, handbook p32 -------------------------------------------------
+    Rule(
+        id="STU-CREDITSEARNED-BLANK",
+        element="CreditsEarned",
+        page=32,
+        error_text="An error will occur if the field is left blank.",
+        checkable=False,
+        uncheckable_reason=(
+            "Whether blank is actually an error depends on whether the "
+            "course carries a Secondary code and the student has a "
+            "SectionExitDate (per the element's Required-ness note); the "
+            "Secondary/Prior-to-Secondary determination needs the SCED code "
+            "list."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STU-CREDITSEARNED-RANGE",
+        element="CreditsEarned",
+        page=32,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_range_check("CreditsEarned", 0.0, 35.0),
+    ),
+    Rule(
+        id="STU-CREDITSEARNED-REQUIRED-SECONDARY-EXITED",
+        element="CreditsEarned",
+        page=32,
+        error_text=(
+            "An error will occur if the value is not entered for students "
+            "who have a SectionExitDate and a Secondary course code."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Whether a course is Secondary is a property of its "
+            "SubjectArea/CourseIdentifier combination on the SCED code "
+            "list; needs that list to evaluate."
+        ),
+        tags=("sced",),
+    ),
+    Rule(
+        id="STU-CREDITSEARNED-EXCEEDS-AVAILABLE",
+        element="CreditsEarned",
+        page=32,
+        error_text=(
+            "An error will occur if CreditsEarned is greater than AvailableCredit."
+        ),
+        checkable=True,
+        predicate=_credits_earned_exceeds_available,
+    ),
+    # --- NumericGradeEarned, handbook p34 --------------------------------------------
+    Rule(
+        id="STU-NUMERICGRADEEARNED-RANGE",
+        element="NumericGradeEarned",
+        page=34,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_range_check("NumericGradeEarned", 0.0, 100.0),
+    ),
+    Rule(
+        id="STU-NUMERICGRADEEARNED-NOTWHOLE",
+        element="NumericGradeEarned",
+        page=34,
+        error_text=(
+            "An error will occur if NumericGradeEarned is not entered as a "
+            "whole number."
+        ),
+        checkable=True,
+        predicate=_numeric_grade_not_whole,
+    ),
+    # --- AlphaGradeEarned, handbook p35 -----------------------------------------------
+    Rule(
+        id="STU-ALPHAGRADEEARNED-RANGE",
+        element="AlphaGradeEarned",
+        page=35,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_format_check("AlphaGradeEarned", _ALPHA_GRADE_PATTERN),
+    ),
+    # --- CompletionStatus, handbook p36 -----------------------------------------------
+    Rule(
+        id="STU-COMPLETIONSTATUS-RANGE",
+        element="CompletionStatus",
+        page=36,
+        error_text=(
+            "An error will occur if the value does not match the "
+            "acceptable range of values."
+        ),
+        checkable=True,
+        predicate=_format_check("CompletionStatus", _COMPLETION_STATUS_PATTERN),
+    ),
+    # --- CourseType, handbook p37 --------------------------------------------------------
+    Rule(
+        id="STU-COURSETYPE-S1S2-NO-STAFF",
+        element="CourseType",
+        page=37,
+        error_text=(
+            "An error will occur if a student’s course type is S1 or "
+            "S2 and that student does not have a staff member assigned to "
+            "the course in the Staff Course Roster submission."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Course Roster submission to know which staff "
+            "are assigned to the course section; not present in the "
+            "Student Course Roster file."
+        ),
+        tags=("staff-roster",),
+    ),
+    Rule(
+        id="STU-COURSETYPE-S2-SINGLESTAFF",
+        element="CourseType",
+        page=37,
+        error_text=(
+            "An error will occur if a value of S2 is entered for a student "
+            "course that does not have more than one staff member assigned "
+            "to the course."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the Staff Course Roster submission to know how many "
+            "staff are assigned to the course section; not present in the "
+            "Student Course Roster file."
+        ),
+        tags=("staff-roster",),
+    ),
+    # --- DualInstitution, handbook p39 --------------------------------------------------
+    Rule(
+        id="STU-DUALINSTITUTION-BLANK-COURSETYPE-C",
+        element="DualInstitution",
+        page=39,
+        error_text=(
+            "An error will occur if a student’s CourseType = C and "
+            "DualInstitution is left blank."
+        ),
+        checkable=True,
+        predicate=_dual_institution_blank_for_coursetype_c,
+    ),
+    Rule(
+        id="STU-DUALINSTITUTION-POPULATED-NOT-C",
+        element="DualInstitution",
+        page=39,
+        error_text=(
+            "An error will occur if a student’s CourseType ≠ C "
+            "and DualInstitution is populated."
+        ),
+        checkable=True,
+        predicate=_dual_institution_populated_for_non_c,
+    ),
+    Rule(
+        id="STU-DUALINSTITUTION-INVALID-OPEID",
+        element="DualInstitution",
+        page=39,
+        error_text=(
+            "An error will occur if the OPE ID Code does not match a valid "
+            "code on the OPE ID List."
+        ),
+        checkable=False,
+        uncheckable_reason=(
+            "Needs the NJSLEDS OPE ID List to validate against; not "
+            "present in the upload file."
+        ),
+        tags=("ope-id",),
+    ),
+    # --- KTAF-local rules, source="ktaf" -------------------------------------------------
+    Rule(
+        id="KTAF-COUNTYCODE-KNOWN",
+        element="CountyCodeAssigned",
+        page=16,
+        error_text=(
+            "KTAF expectation, not a handbook rule: County Code, when "
+            "populated, should be one of KTAF's known operating counties "
+            "(Newark 80, Camden 07)."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_county_code_not_ktaf_known,
+        notes=(
+            "Corroborated against real data: every populated "
+            "CountyCodeAssigned value in the Newark and Camden student "
+            "files used to validate this catalog is exactly '80' or '07'. "
+            "Blank rows are not flagged here - see STU-COUNTYCODE-BLANK, a "
+            "handbook rule."
+        ),
+    ),
+    Rule(
+        id="KTAF-DISTRICTCODE-KNOWN",
+        element="DistrictCodeAssigned",
+        page=17,
+        error_text=(
+            "KTAF expectation, not a handbook rule: District Code should be "
+            "one of KTAF's known districts (Newark 7325, Camden 1799)."
+        ),
+        checkable=True,
+        source="ktaf",
+        predicate=_district_code_not_ktaf_known,
+        notes=(
+            "Corroborated against real data: every DistrictCodeAssigned "
+            "value in both the Newark and Camden student files used to "
+            "validate this catalog is exactly '7325' or '1799' "
+            "respectively, with no blanks."
+        ),
+    ),
+]

--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -166,7 +166,12 @@ if they don't match.
 
 ## Known blocker outside this scope
 
-The CDS defect is still live: 20,652 of 43,493 rows carry a bad County or School
-code, including every Camden row. The fix is the one-pass School Setup change on
-3 Newark and 5 Camden schools. A clean grade backfill does not make the file
-submittable on its own.
+**The CDS defect is fixed as of the 2026-07-31 extract.** The School Setup
+change landed, and all four files now carry the correct triple on every row —
+Newark `80`/`7325`/`965`, Camden `07`/`1799`/`111`, no blanks, no fallback
+codes. It previously affected 20,652 of 43,493 rows including every Camden row.
+
+That leaves the **ungraded worklist as the only remaining blocker**: 108
+in-scope rows have no usable grade in any source, so the gate still refuses to
+export. Those are a PowerSchool task, not a code one — see "The gate is red on
+arrival" above and run `export_worklist.py` to get the row-level list.

--- a/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-30-nj-sleds-grade-credit-backfill-design.md
@@ -400,25 +400,34 @@ staff file as well. Out of scope here, tracked separately.
 
 ## Blockers outside this scope
 
-The CDS defect identified in the June audit is **still live** in the 2026-07-29
-extract and gates the same upload:
+### CDS — RESOLVED 2026-07-31
 
-| Region | County | District | School | Rows   | Status            |
-| ------ | ------ | -------- | ------ | ------ | ----------------- |
-| Newark | `80`   | `7325`   | `965`  | 22,841 | correct           |
-| Newark | blank  | `7325`   | `732`  | 5,958  | wrong on both     |
-| Newark | `80`   | `7325`   | `732`  | 4,351  | wrong school code |
-| Camden | blank  | `1799`   | `179`  | 6,695  | wrong on both     |
-| Camden | `07`   | `1799`   | `179`  | 3,648  | wrong school code |
+The CDS defect this spec was written against **has been fixed.** The School
+Setup change landed between the 2026-07-29 and 2026-07-31 extracts, and all four
+files in the 2026-07-31 drop now carry the correct triple on every single row:
+Newark `80`/`7325`/`965`, Camden `07`/`1799`/`111`, with no blanks and no
+fallback codes.
 
-20,652 of 43,493 rows (47%) carry a bad CDS, including every Camden row. Camden
-emits `179`, which is neither the expected `111` nor the Newark-style `732`
-pattern, but fits the same root cause: an unset Alternate School Number causing
-a fallback to the internal school number prefix.
+That also settles an open item this spec carried: Camden's expected school code
+really is `111`. The corrected source emits it, so it no longer needs confirming
+against the NJDOE directory.
 
-The fix remains the one-pass School Setup change on 3 Newark and 5 Camden
-schools documented in the runbook. **A clean grade backfill does not make the
-file submittable on its own.**
+For the record, because the shape of the defect is worth keeping — as of the
+2026-07-29 extract, 20,652 of 43,493 rows (47%) carried a bad CDS, including
+every Camden row. Newark emitted `732` on 10,309 rows and Camden `179` on all
+10,343, both from the same root cause: an unset Alternate School Number causing
+a fallback to a prefix of the internal school number. Those values were the
+defect, never alternative valid codes — a distinction that matters, because two
+independent attempts to encode a CDS check later mistook them for the expected
+values and calibrated against them.
+
+### Remaining — the ungraded worklist
+
+With CDS resolved, the 108 in-scope rows that have no usable grade in any source
+are now the **only** thing between this work and a submittable student file. The
+validation gate still reports them against the 2026-07-31 data, unchanged from
+2026-07-29, because the CDS fix touched the CDS columns and not grades. See
+_What the fallback actually recovered_ and the worklist view.
 
 ## Open items to confirm during implementation
 


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request lets an analyst work out what a bare NJSLEDS error count means on the same day, instead of waiting for the state's overnight detail.

NJSLEDS has reduced its service level. It still processes Course Roster uploads, but it only generates detailed error information overnight, roughly midnight to 1am. An upload therefore returns a count with no indication of which records failed or which rules they broke. Waiting a day per iteration does not fit the submission window, and hand-checking neither scales nor tells you when you are done.

Both handbooks document every validation rule explicitly as an "An error will occur" statement. This extracts all 122 of them - 54 staff, 68 student - into machine-evaluable catalogs, evaluates them against the exact file that was uploaded, and matches the resulting per-rule counts against the state's reported total.

### What it found immediately

Run against the files submitted on 2026-07-31, the tool answers the question it was built for:

| File | Handbook violations | Rows |
| --- | --- | --- |
| Camden staff | 12 | 4 |
| Newark staff | 98 | 54 |
| Camden student | 0 checkable | 0 |
| Newark student | 0 checkable | 0 |

The staff findings are actionable as they stand: 4 Camden records carry an underscore in both name fields plus a blank date of birth, which looks like placeholder or system accounts rather than real staff; Newark has 54 blank Staff Member Identifiers, the known unregistered-staff problem.

The student result is the important one, and it took a review pass to surface properly. A heuristic added during review estimates **28,727 rows** missing all three of `NumericGradeEarned`, `AlphaGradeEarned`, and `CompletionStatus` while falling inside the handbook's required scope. That figure matches the in-scope count the grade-backfill spec derived independently through BigQuery, exactly. In other words the student file submitted this morning is the raw extract without the grade backfill from #4630 applied, and that single gap is almost certainly the dominant source of its error count.

## Approach

- **`rules.py`** - the `Rule` model and value helpers. Predicates return True on violation. Handbook rules and local KTAF expectations are strictly separated, because only handbook rules can explain a state count.
- **`rules_staff.py`** / **`rules_student.py`** - 54 and 69 handbook rules respectively, each carrying the verbatim handbook wording and page for citation, plus KTAF rules for local expectations. Rules that need an external input are marked not-checkable with the reason, so an unexplained residual points somewhere real.
- **`handbook-rules-staff.md`** / **`handbook-rules-student.md`** - the handbook text, mechanically extracted so the catalogs are built from verbatim source rather than transcription. Committing these means a fresh clone needs no PDFs; the handbooks live in gitignored scratch.
- **`attribute_errors.py`** - evaluates every checkable rule, then finds rule combinations summing to the reported count. Reports both readings of a bare count (error instances versus error rows), since the state does not document which it means.
- **`HANDOFF.md`** and a **Claude Code skill**, so this can be handed to an intern who describes the situation rather than needing the file paths.

Deliberately file-based rather than warehouse-based: the whole point is explaining errors on one specific upload, and reading the exact bytes that were sent is the only way to be sure you are explaining the right artifact.

## What the review passes caught

Two review agents verified every rule against the handbook text. Both confirmed all 122 `error_text` values byte-for-byte verbatim and every predicate's polarity. They also caught three defects of one class, which is worth recording because it recurred:

**Reference values calibrated against the broken file.** Twice, an agent took an expected value from the data instead of an authoritative source:

- The CDS rule expected Camden school code 179 because the file contained 179. It substituted that for the correct 111 on the reasoning that a rule firing on 100 percent of rows must have a bad reference value. Here 100 percent was the correct answer - 179 was the School Setup defect. The substitution would have reported a wholly non-compliant file as clean.
- The student catalog dropped its school-code rule entirely on the same reasoning.
- The staff name pattern disallowed spaces where the student one allowed them, for identically worded handbook rules, producing 17 false positives out of 29 name flags - all ordinary compound first names.

All three are fixed, the name pattern is now shared in `rules.py` so the catalogs cannot diverge again, and the principle is recorded in the module docstring with the war story attached, since the abstract version demonstrably was not enough.

**A methodology blind spot.** The catalogs were built by transcribing Validation Checks bullets. The handbook's central grade mandate lives under "Is this Data Element Required?" with no matching Validation Checks bullet, so no rule was written for it and the tool reported zero on a file that violates it nearly universally. Closed with an explicit rule, and the limit is now recorded in `rules.py` so a future maintainer reads both sections.

## Also in this PR

The CDS defect that #4630 documented as a live blocker **has been fixed**. All four files in the 2026-07-31 extract carry the correct triple on every row - Newark 80/7325/965, Camden 07/1799/111 - so the spec and README that still described it as blocking 20,652 rows are corrected here. That also closes the open item on Camden's school code: the corrected source emits 111, confirming it.

Re-running the grade-backfill gate against the 2026-07-31 data gives an identical result to 2026-07-29 - 108 ungraded rows, 50 missing credits - because the CDS fix touched CDS columns, not grades. The band-count and stored-coverage baselines both still passed, so no re-baselining was needed this cycle. That ungraded worklist is now the only remaining blocker on the student submission.

## AI Assistance

Human-directed. The author set the scope, chose the delivery shape, corrected the Camden school code when the catalog got it wrong, and pointed out that the current file has clean CDS codes - which is what surfaced that my analysis was two days stale. Claude did the extraction, the catalogs, the runner, and the review orchestration.

## Self-review

### General

- [ ] Update due date and assignee on the TEAMster Asana Project
- [x] **Claude Code Review will not fire on this PR.** `claude-code-review.yaml` triggers on `src/`, `tests/`, `scripts/`, and `mcp/` and excludes markdown; everything here is under `docs/` and `.claude/skills/`. Reviewed instead by two dispatched reviewers covering all 122 rules, plus a fix pass.

### Dagster

Skip - no Dagster changes.

### dbt

Skip - no dbt changes. No models, sources, exposures, or contracts.

### Docs

Skip - no schedule, sensor, or integration changes. New files live under `docs/superpowers/` and `.claude/skills/`, neither in the MkDocs nav.

## CI checks

- [x] **Trunk** - `trunk check --force --no-fix` clean on every changed file locally.
- [ ] **dbt Cloud** - expected to be a no-op; no dbt models modified.
- [ ] **Dagster Cloud** - not triggered; no paths in any deploy workflow are touched.

## Known limits, stated in the tool itself

- Rules needing an external input cannot be checked locally and are marked with the reason: the staff five-field combination error needs the Staff Management export, SCED validity needs the NCES code list, dual enrollment needs the NJSLEDS OPE ID list.
- A bare count is ambiguous between error rows and error instances, so both are reported.
- A rule combination summing to the target is a hypothesis, not a finding, and the report says so.
- Where several rules flag identical row sets, the tool discloses it without adjusting anything - an identical row set can mean one condition stated twice, or distinct conditions co-occurring on the same records, and it distinguishes those by predicate identity rather than guessing.
- The school-year window in `rules.py` has not been confirmed against NJDOE's own definition for reporting purposes. Flagged in the code as an open item.

Closes #4659
Refs #4630
Refs #4280


---

## Added after review: residual parameter sweep

A few of the tool's own parameters are assumptions rather than handbook facts — chiefly the school-year window, which no reviewer could find a source for. If the checkable rules explain fewer errors than the state reported, a wrong assumption could be the cause. The sweep tests that.

Given a residual, it evaluates each assumed parameter against it independently and reports which candidate values would produce a matching delta. On the current files it delivers a **negative**, which is the more useful result: every date sits inside the 7/1–6/30 window, and narrowing the start to 9/1 jumps by 884 / 2,108 / 7,722 / 26,831 depending on the file, so no small residual can be explained by the window. The report says so and redirects the analyst to the not-locally-checkable rules instead. The band-threshold fork does reproduce exactly 219 rows on the Camden student file, matching a contrived residual of 219, so the positive path is demonstrated too.

This sits one step from the `179` bug, so the distinction is written into the module docstring: tuning a value so the **file passes** hides defects and is forbidden; testing whether an assumed value explains a residual the **state already reported** fits to an external oracle, not to the file. Those look similar and are opposites.

Four bounding constraints keep it from becoming a fishing expedition, all stated in the code:

1. One parameter at a time, never a cross-product — combinations are numerology, and the combinatorics balloon.
1. Small, meaningful candidate sets, not continuous ranges. Thirteen evaluations in total.
1. Silent when there is nothing to explain.
1. Capped output, and the match count reported — several matches is weak evidence, not a menu.

There is also a hard exclusion list in code, with a reason per entry: the KTAF CDS combinations (they come from the data team and the NJDOE directory) and every handbook-enumerated domain, range, and format. That list is what tells a future maintainer why some parameters are off limits.
