### PR TITLE
fix(ci): guard headless claude runs against background subagent deadlock

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -15,6 +15,25 @@
   is comment-triggered, not base-gated). A base-retarget after the parent merges
   does NOT re-fire `opened`, so `claude-code-review` does not auto-trigger then.
 - `claude.yaml` — responds to `@claude` mentions on issues/PRs.
+- **`claude-code-action` headless deadlock**: the action breaks its SDK loop on
+  the FIRST result (`base-action/src/run-claude-sdk.ts`), so a run that
+  dispatches background subagents ends with them orphaned and reports `success`
+  having posted nothing (upstream #1462 / #1499, unfixed at v1.0.183; ~8-12% of
+  fan-out runs). `Agent`, `Workflow`, `ScheduleWakeup`, `SendMessage` and
+  `Monitor` are NOT gated by `--allowedTools` — deny them via
+  `--disallowedTools` in `claude_args`. A second `--allowedTools` /
+  `--disallowedTools` ACCUMULATES with the action's own list rather than
+  replacing it (`parse-sdk-options.ts` `ACCUMULATING_FLAGS`), so adding tools
+  cannot strip `update_claude_comment`.
+- **Debugging a silent `claude-review`**: `display_report: true` appends the
+  transcript — final assistant message, denied tool calls — to the run's **job
+  summary**, the only place they appear. Not in the REST API, and not in the
+  step log (`show_full_output`-gated). Read it before theorising.
+- **Which ref a workflow runs from**: `pull_request` runs the PR's OWN copy, so
+  a workflow change tests itself on that PR. `issue_comment` (`claude.yaml`)
+  runs the DEFAULT-branch copy — an `@claude` mention cannot exercise an
+  unmerged `claude.yaml`; probe such a change through a `pull_request` workflow
+  instead.
 - `dagster-cloud-deploy.yaml` — reusable workflow (`workflow_call`) for
   multi-arch Docker builds and Dagster Cloud deploys. Called by per-location
   `deploy-prod-*.yaml` workflows. Uses `cancel-in-progress: true` grouped by
@@ -63,6 +82,10 @@
   event — use `!` negation patterns instead (e.g., `!**/*.md`).
 - YAML values should not be redundantly quoted — Trunk flags it. Only quote when
   required (e.g., `!` negation patterns need quotes).
+- Long quoted CLI args in `claude_args` belong in a folded block scalar (`>-`) —
+  prettier reflows the value, and folding turns each inserted newline back into
+  a single space, so the resolved string survives formatting unchanged. Verify
+  by parsing the YAML AFTER the fmt hook runs, not before.
 - Every external action `uses:` is pinned to a full 40-char commit SHA with a
   trailing `# vX.Y.Z` comment (Dependabot's `github-actions` ecosystem proposes
   bumps). Local reusable-workflow refs (`./.github/workflows/*.yaml`) are not

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -3,16 +3,17 @@
 ## Workflows
 
 - `claude-code-review.yaml` — auto-reviews PRs touching `src/`, `tests/`,
-  `scripts/`, `mcp/` (excludes markdown). **Gated to `base=main`
-  (`branches: [main]`)** — a **stacked PR** (base = another feature branch) gets
-  no auto-review. dbt Cloud CI is NOT base-gated: it triggers via dbt Cloud's
-  own GitHub app on PR events, independent of any GH-Actions `branches` filter,
-  so a stacked PR **does** run dbt Cloud CI (verified on #4381) alongside
-  Trunk + Dagster deploy — only `claude-code-review` is skipped. Review a
-  stacked PR via `superpowers:requesting-code-review` or an `@claude` PR comment
-  (`claude.yaml` is comment-triggered, not base-gated). A base-retarget after
-  the parent merges does NOT re-fire `opened`, so `claude-code-review` does not
-  auto-trigger then.
+  `scripts/`, `.github/workflows/` (excludes markdown). A PR editing a workflow
+  runs that PR's own copy of it, so workflow changes review themselves. **Gated
+  to `base=main` (`branches: [main]`)** — a **stacked PR** (base = another
+  feature branch) gets no auto-review. dbt Cloud CI is NOT base-gated: it
+  triggers via dbt Cloud's own GitHub app on PR events, independent of any
+  GH-Actions `branches` filter, so a stacked PR **does** run dbt Cloud CI
+  (verified on #4381) alongside Trunk + Dagster deploy — only
+  `claude-code-review` is skipped. Review a stacked PR via
+  `superpowers:requesting-code-review` or an `@claude` PR comment (`claude.yaml`
+  is comment-triggered, not base-gated). A base-retarget after the parent merges
+  does NOT re-fire `opened`, so `claude-code-review` does not auto-trigger then.
 - `claude.yaml` — responds to `@claude` mentions on issues/PRs.
 - `dagster-cloud-deploy.yaml` — reusable workflow (`workflow_call`) for
   multi-arch Docker builds and Dagster Cloud deploys. Called by per-location

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -120,4 +120,7 @@ jobs:
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
             rev-parse:*),Bash(git merge-base:*)" --disallowedTools
-            "ScheduleWakeup,SendMessage,Monitor,Workflow"
+            "ScheduleWakeup,SendMessage,Monitor,Workflow" --append-system-prompt
+            "Diagnostic probe. Begin the review comment you post with the single
+            line APPEND-PROBE-OK-7Q4 before any other content. This confirms
+            that an appended system prompt reached the session."

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -120,7 +120,4 @@ jobs:
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
             rev-parse:*),Bash(git merge-base:*)" --disallowedTools
-            "ScheduleWakeup,SendMessage,Monitor,Workflow" --append-system-prompt
-            "Diagnostic probe. Begin the review comment you post with the single
-            line APPEND-PROBE-OK-7Q4 before any other content. This confirms
-            that an appended system prompt reached the session."
+            "ScheduleWakeup,SendMessage,Monitor,Workflow"

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -87,13 +87,28 @@ jobs:
             ref()/source() wiring, incremental and materialization config, join
             grain inferred from schema, test coverage, and PII exposure. Before
             reporting a repo-convention violation, confirm the convention
-            against existing models with git grep; do not invent naming or style
-            rules the codebase does not already follow. Report every issue you
-            find, including ones you are uncertain about; do not withhold
+            against existing models with the Grep tool; do not invent naming or
+            style rules the codebase does not already follow. Report every issue
+            you find, including ones you are uncertain about; do not withhold
             lower-severity findings. Include a confidence level and a severity
             label for each finding so a human can rank them.
+
+            Execution model: this job is a single non-interactive turn sequence.
+            There is no wake-up and no second invocation — when you stop
+            producing output the process exits and any unfinished work is lost.
+            Never end a turn waiting on background work. If you dispatch review
+            subagents, dispatch them synchronously (run_in_background: false)
+            and collect their results in the same turn; otherwise review inline.
+            Posting the review with update_claude_comment must be your final
+            action, and must happen even if some checks are still incomplete.
           allowed_bots: dbt-cloud
           include_fix_links: false
           use_sticky_comment: true
           display_report: true
-          claude_args: --model sonnet --effort xhigh
+          # A second --allowedTools accumulates with the action's own list
+          # (parse-sdk-options.ts ACCUMULATING_FLAGS) rather than replacing it,
+          # so the comment-update and git-push tools stay allowed.
+          claude_args: >-
+            --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
+            diff:*),Bash(git log:*),Bash(git show:*),Bash(git
+            rev-parse:*),Bash(git merge-base:*)"

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -120,4 +120,4 @@ jobs:
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
             rev-parse:*),Bash(git merge-base:*)" --disallowedTools
-            "ScheduleWakeup,SendMessage,Monitor"
+            "ScheduleWakeup,SendMessage,Monitor,Workflow"

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -9,6 +9,10 @@ on:
       - src/**
       - tests/**
       - scripts/**
+      # A PR editing a workflow runs that PR's own version of it, so a change
+      # here reviews itself. Kept in scope anyway: CI-config defects are exactly
+      # the class this workflow was silently failing to catch.
+      - .github/workflows/**
       - "!**/*.md"
 
 jobs:

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -107,8 +107,13 @@ jobs:
           display_report: true
           # A second --allowedTools accumulates with the action's own list
           # (parse-sdk-options.ts ACCUMULATING_FLAGS) rather than replacing it,
-          # so the comment-update and git-push tools stay allowed.
+          # so the comment-update and git-push tools stay allowed. The
+          # --disallowedTools set is upstream's tested workaround for
+          # anthropics/claude-code-action#1462: these tools assume a turn can be
+          # resumed later, which a headless run cannot do. Not gated by
+          # --allowedTools, so denying them explicitly is the only guard.
           claude_args: >-
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
-            rev-parse:*),Bash(git merge-base:*)"
+            rev-parse:*),Bash(git merge-base:*)" --disallowedTools
+            "ScheduleWakeup,SendMessage,Monitor"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -56,4 +56,18 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
           track_progress: true
-          claude_args: --model sonnet --effort xhigh
+          # A second --allowedTools accumulates with the action's own list
+          # (parse-sdk-options.ts ACCUMULATING_FLAGS) rather than replacing it,
+          # so the comment-update and git-push tools stay allowed. This mode has
+          # no prompt input, so the single-shot guard rides on the system prompt.
+          claude_args: >-
+            --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
+            diff:*),Bash(git log:*),Bash(git show:*),Bash(git
+            rev-parse:*),Bash(git merge-base:*)" --append-system-prompt
+            "Execution model. This job is a single non-interactive turn sequence
+            with no wake-up and no second invocation. When you stop producing
+            output the process exits and any unfinished work is lost. Never end
+            a turn waiting on background work. Dispatch any subagents
+            synchronously and collect their results in the same turn, otherwise
+            work inline. Posting your reply with update_claude_comment must be
+            your final action."

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -68,7 +68,7 @@ jobs:
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
             rev-parse:*),Bash(git merge-base:*)" --disallowedTools
-            "ScheduleWakeup,SendMessage,Monitor" --append-system-prompt
+            "ScheduleWakeup,SendMessage,Monitor,Workflow" --append-system-prompt
             "Execution model. This job is a single non-interactive turn sequence
             with no wake-up and no second invocation. When you stop producing
             output the process exits and any unfinished work is lost. Never end

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -60,10 +60,15 @@ jobs:
           # (parse-sdk-options.ts ACCUMULATING_FLAGS) rather than replacing it,
           # so the comment-update and git-push tools stay allowed. This mode has
           # no prompt input, so the single-shot guard rides on the system prompt.
+          # The --disallowedTools set is upstream's tested workaround for
+          # anthropics/claude-code-action#1462: these tools assume a turn can be
+          # resumed later, which a headless run cannot do. Not gated by
+          # --allowedTools, so denying them explicitly is the only guard.
           claude_args: >-
             --model sonnet --effort xhigh --allowedTools "Skill,Bash(git
             diff:*),Bash(git log:*),Bash(git show:*),Bash(git
-            rev-parse:*),Bash(git merge-base:*)" --append-system-prompt
+            rev-parse:*),Bash(git merge-base:*)" --disallowedTools
+            "ScheduleWakeup,SendMessage,Monitor" --append-system-prompt
             "Execution model. This job is a single non-interactive turn sequence
             with no wake-up and no second invocation. When you stop producing
             output the process exits and any unfinished work is lost. Never end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,16 +275,20 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   comments — an initial "Reviewing…" status stub and a separate final findings
   comment — and the stub can stay stuck mid-render even after the check-run
   reports `success`. Fetch ALL issue comments and read the newest / longest, not
-  the first. It may instead EDIT its checklist stub comment in place with the
-  findings, minutes AFTER the check-run reports `success` — so a findings-poll
-  must gate on the comment's `updated_at` / body growing, not the check-run
-  conclusion or a naive length threshold (the ~500-char checklist stub trips
-  it). Trunk's check-runs are RE-CREATED on each push, so a `gh pr checks` poll
-  gating on "nothing pending" can sample the gap between them and report done
-  prematurely — re-check after a delay before calling CI complete. To get
-  `claude-review` onto code pushed after its pass, toggle draft state
-  (`gh api -X PATCH .../pulls/<n> -f draft=true`, then `false`) — that re-fires
-  `ready_for_review`.
+  the first. A re-fired run creates a NEW comment rather than updating the
+  previous one, even with `use_sticky_comment: true` — poll by enumerating
+  comments, never by a cached comment id. It may instead EDIT its checklist stub
+  comment in place with the findings, minutes AFTER the check-run reports
+  `success` — so a findings-poll must gate on the comment's `updated_at` / body
+  growing, not the check-run conclusion or a naive length threshold (the
+  ~500-char checklist stub trips it). Trunk's check-runs are RE-CREATED on each
+  push, so a `gh pr checks` poll gating on "nothing pending" can sample the gap
+  between them and report done prematurely — re-check after a delay before
+  calling CI complete. To get `claude-review` onto code pushed after its pass,
+  toggle draft state — that re-fires `ready_for_review`. REST
+  `gh api -X PATCH .../pulls/<n> -f draft=true` silently no-ops (returns
+  `draft: false`, no error); use GraphQL `convertPullRequestToDraft` then
+  `markPullRequestReadyForReview`.
 
 - **A merged PR's CI status is not evidence the change was validated** — a PR
   merged mid-CI leaves a permanent `dbt Cloud: failure` that is a cancellation,
@@ -633,6 +637,10 @@ the allowlist.
   `mcp__github__add_issue_comment` posts top-level PR comments only, not thread
   replies. Use
   `gh api -X POST repos/<owner>/<repo>/pulls/<pr>/comments/<id>/replies -f body='...'`.
+- `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha> -H 'Accept: application/vnd.github.raw'`
+  — read a third-party file at a pinned SHA (for the verify-behavior-from-source
+  rule above). The `--jq .content | base64 -d` form is hook-blocked as an
+  encoding bypass.
 - `gh api -X POST repos/<owner>/<repo>/labels -f name=... -f color=... -f description=...`
   — no `mcp__github__*` label-create tool.
 - `gh api -X POST repos/<owner>/<repo>/issues/<n>/labels -f 'labels[]=<name>'` —


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop `claude-code-review` from silently producing no review when it dispatches background subagents, and bring workflow changes into review scope.

`claude-code-review` on #4656 finished `success` in 13m12s and never posted a review. The tracking comment ([5137785791](https://github.com/TEAMSchools/teamster/pull/4656#issuecomment-5137785791)) stayed frozen at its pre-dispatch checklist. Claude's final message, recovered from the job summary of [run 30594042829](https://github.com/TEAMSchools/teamster/actions/runs/30594042829), was:

> "The three review subagents will notify me directly when they finish — no polling needed. Waiting for those now."

Those notifications can never arrive. `base-action/src/run-claude-sdk.ts` breaks out of the `query()` loop on the **first** `SDKResultMessage`, so when the dispatch turn produces a result while subagents are still running, the run ends there — subagents orphaned, follow-up turn never taken, comment never updated. The step reports `success` because a result was recorded, so the failure is completely silent.

This is a known upstream bug, unfixed as of v1.0.183:

- [anthropics/claude-code-action#1462](https://github.com/anthropics/claude-code-action/issues/1462) — headless run reports success after backgrounding work and ending its turn (`bug`, `p2`)
- [anthropics/claude-code-action#1499](https://github.com/anthropics/claude-code-action/issues/1499) — names the mechanism; reporter measured ~12% of multi-subagent runs failing. We saw 1 of the last 12 runs fail this way (~8%).

Background subagent dispatch has been the **default** since Claude Code 2.1.198, so any run that chooses to fan out is exposed. PR #4656 was the largest diff in the recent set (33 files, +3384/-313), which is what pushed it toward a 3-way parallel fan-out.

### Changes

1. **`--disallowedTools "ScheduleWakeup,SendMessage,Monitor"`** (both workflows) — upstream's tested workaround from #1462. These tools assume a turn can be resumed later. Critically they are **not** gated by `--allowedTools`, which is why the failing run called `ScheduleWakeup` and dispatched subagents despite neither being on the allowlist; an explicit deny is the only mechanical guard.
1. **Execution-model prompt guard** (both workflows) — states that the run is a single non-interactive turn sequence with no wake-up, that subagents must be dispatched synchronously, and that posting must be the final action. Defence in depth: `Agent` itself stays available and still defaults to background.
1. **`--allowedTools` adding `Skill` plus read-only git** (both workflows) — the prompts already mandate three skills and convention verification, and the run logged 9 denials for exactly these. Verified from `parse-sdk-options.ts` that a second `--allowedTools` **accumulates** with the action's own list rather than replacing it, so `mcp__github_comment__update_claude_comment` and the git-push wrapper stay allowed.
1. **`git grep` becomes the `Grep` tool** in the review prompt — `Grep` was already allowed and `Bash(git grep)` never was, so the instruction was unfollowable.
1. **`.github/workflows/` added to the review `paths` filter** — CI-config changes previously merged unreviewed, which is why this silent failure went unnoticed. Tradeoff accepted: `pull_request` runs the workflow definition from the PR's own head, so a PR editing this file executes its modified version and reviews itself. The repo is org-internal, `.github/` is CODEOWNERS-gated to `admins` and `platform`, and fork pull requests do not receive the OAuth token, so an untrusted edit fails rather than leaks. The `md` negation stays last so docs-only workflow changes still skip review.

### Verification

- Both workflows parse; `claude_args`, the prompt tail, and the `paths` list resolve to exactly the intended values, re-checked after `prettier` reflowed the quoted tool lists across lines (folded scalars make that reflow value-preserving).
- `trunk check --force` clean on both files.
- Confirmed `src/modes/tag/index.ts`, `parse-sdk-options.ts` and `run-claude-sdk.ts` are byte-identical between v1.0.182 and v1.0.183, so the action bump on `main` does not address this.

**Not verified by a live run.** Two known gaps:

- `--append-system-prompt` (used only in `claude.yaml`, which has no `prompt` input) lands in `extraArgs` while the SDK separately sets `systemPrompt` to the `claude_code` preset. The code path reads as append-to-preset, but it has not been observed working. `claude-code-review.yaml`'s guard lives in its `prompt`, which is the already-proven mechanism.
- Whether the prompt guard changes model behaviour is not statically checkable. The `--disallowedTools` guard is mechanical and does not depend on model compliance.

With change 5 in place this PR **can** now validate itself: toggling draft state re-fires `ready_for_review`, which now matches `paths`, running the fixed workflow against this PR. Worth doing before merge, given the failure is intermittent (~8-12%) rather than deterministic.

## AI Assistance

Investigation, root-cause analysis and these changes were Claude-authored, human-directed. The decisive evidence — the final assistant message in the run's job summary — was retrieved by the author from the Actions UI, since job summaries are not exposed via the REST API. Scope decisions (both fixes in one PR, guard both workflows, add the workflows review path, do not comment on the upstream issue) were the author's.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Requires a draft toggle to fire, since `ready_for_review` already passed before change 5 existed.

### Dagster

Skipped — no Dagster changes.

### dbt

Skipped — no dbt changes.

### Docs

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — passes. Also verified locally with `trunk check --force` on both changed files.
- [x] **dbt Cloud** — passes (no `src/dbt/` changes, so nothing attributable to build).
- [x] **Dagster Cloud** — not triggered (no relevant paths changed).

Closes #4661
