### PR TITLE
feat(extracts): add Fellow School Operations Director to lattice user extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -53,6 +53,7 @@ Any one of these qualifies:
   - Director Campus Operations
   - Managing Director of School Operations
   - Managing Director of Operations
+  - Fellow School Operations Director
 - **Newark or Camden** — anyone in the **Technology** or **Marketing, Comms, and
   Enrollment** department.
 - **Any entity** — job title contains "Head of School." The ADP title is "Head

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -35,7 +35,8 @@ with
                         'Director School Operations',
                         'Director Campus Operations',
                         'Managing Director of School Operations',
-                        'Managing Director of Operations'
+                        'Managing Director of Operations',
+                        'Fellow School Operations Director'
                     )
                 )
                 or (


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will give staff titled `Fellow School Operations Director` in Newark and Camden a Lattice account.

Newark and Camden gate Lattice access on an explicit operations job-title list in `rpt_lattice__users`, and that list omitted `Fellow School Operations Director`. Miami holders of the same title already qualify through the Miami rule that matches any title containing `Director`, so this only affects Newark and Camden.

Effect on today's data: **2 rows added, 0 removed** (both active Newark staff). Five active people network-wide hold the title; the three in Miami were already included.

The lattice README was updated in the same commit to keep the documented criteria in sync.

## AI Assistance

Human-directed: the title to add, and the decision to scope this to that one title (a similar gap on `Associate Director of School Operations` was raised and intentionally left out of scope). AI-assisted: locating the gate, verifying holders of the title against the staff roster, the edit, and the dev-vs-prod row-delta validation.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] No new models, no column changes, no contract changes — value-level filter change to an existing view.
- [x] No exposure change needed; the existing lattice extract asset is unchanged.
- [x] Not a breaking change — no columns renamed or removed.
- [x] No external sources added or modified.

Local validation from a worktree, target `dev` with `--defer --favor-state` against the prod manifest:

```text
dbt build --select rpt_lattice__users  -> PASS=2 WARN=0 ERROR=0
unique_rpt_lattice__users_external_user_id -> PASS
prod_rows=331  dev_rows=333  added=2  removed=0
trunk check --force (SQL + README) -> No issues
```

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
