### PR TITLE
fix(clever): scope all six extract feeds to Newark, Camden and Paterson

### DIFF
--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
@@ -14,7 +14,8 @@ inner join
     and s.enroll_status in (0, -1)
 where
     cc.dateleft >= current_date('{{ var("local_timezone") }}')
-    and cc._dbt_source_relation not like '%kipppaterson%'
+    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
+    and cc._dbt_source_relation not like '%kippmiami%'
 
 union all
 
@@ -30,4 +31,4 @@ select
 
     student_number as student_id,
 from {{ ref("stg_powerschool__students") }}
-where enroll_status in (0, -1) and _dbt_source_relation not like '%kipppaterson%'
+where enroll_status in (0, -1) and _dbt_source_relation not like '%kippmiami%'

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__schools.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__schools.sql
@@ -22,7 +22,9 @@ select
 from {{ ref("stg_powerschool__schools") }}
 where
     /* filter out summer school and graduated students */
-    state_excludefromreporting = 0 and _dbt_source_relation not like '%kipppaterson%'
+    state_excludefromreporting = 0
+    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
+    and _dbt_source_relation not like '%kippmiami%'
 
 union all
 

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
@@ -2,6 +2,7 @@ with
     dsos as (
         select
             sr.powerschool_teacher_number,
+            sr.home_work_location_dagster_code_location,
 
             coalesce(
                 ccw.powerschool_school_id, sr.home_work_location_powerschool_school_id
@@ -13,12 +14,33 @@ with
             and not ccw.is_pathways
         where
             sr.assignment_status != 'Terminated'
+            -- Miami rosters into Clever directly from Focus; excluded from all
+            -- six feeds
+            and sr.home_work_location_dagster_code_location != 'kippmiami'
             and sr.job_title in (
                 'Director of Campus Operations',
                 'Director Campus Operations',
                 'Director School Operations',
                 'School Leader'
             )
+    ),
+
+    schools as (
+        -- Matches rpt_clever__schools' filters so an auto-generated ENR section
+        -- can never reference a school that schools.csv omits.
+        select
+            abbreviation,
+            low_grade,
+            high_grade,
+            school_number,
+
+            regexp_extract(
+                _dbt_source_relation, r'(kipp\w+)_'
+            ) as dagster_code_location,
+        from {{ ref("stg_powerschool__schools") }}
+        where
+            state_excludefromreporting = 0
+            and _dbt_source_relation not like '%kippmiami%'
     ),
 
     teachers_long as (
@@ -89,7 +111,9 @@ with
             and st._dbt_source_project = t._dbt_source_project
         where
             sec.terms_yearid = ({{ var("current_academic_year") - 1990 }})
-            and sec._dbt_source_relation not like '%kipppaterson%'
+            -- Miami rosters into Clever directly from Focus; excluded from all
+            -- six feeds
+            and sec._dbt_source_relation not like '%kippmiami%'
 
         union all
 
@@ -132,8 +156,9 @@ with
             'Homeroom/advisory' as `subject`,
         from dsos
         inner join
-            {{ ref("stg_powerschool__schools") }} as s
+            schools as s
             on dsos.school_id = s.school_number
+            and dsos.home_work_location_dagster_code_location = s.dagster_code_location
         cross join unnest(generate_array(s.low_grade, s.high_grade)) as grade_level
     ),
 

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -17,8 +17,9 @@ with
         where
             not is_prestart
             and worker_status_code != 'Terminated'
-            -- Paterson gated from Clever until #4193; drop with the sibling feeds
-            and home_work_location_dagster_code_location != 'kipppaterson'
+            -- Miami rosters into Clever directly from Focus; excluded from all
+            -- six feeds
+            and home_work_location_dagster_code_location != 'kippmiami'
 
         union all
 
@@ -37,7 +38,7 @@ with
             department as home_department_name,
             title as job_title,
         from {{ ref("int_people__temp_staff") }}
-        where dagster_code_location != 'kipppaterson'
+        where dagster_code_location != 'kippmiami'
     ),
 
     schools as (
@@ -52,7 +53,7 @@ with
         from {{ ref("stg_powerschool__schools") }}
         where
             state_excludefromreporting = 0
-            and _dbt_source_relation not like '%kipppaterson%'
+            and _dbt_source_relation not like '%kippmiami%'
     ),
 
     assignments as (

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
@@ -50,6 +50,9 @@ select
     sr.gifted_and_talented as ext__gifted,
     sr.cumulative_y1_gpa as weighted_gpa,
     sr.cumulative_y1_gpa_unweighted as unweighted_gpa,
+    -- every region left in this feed is NJ, so the FL education id (fleid) that
+    -- Miami reported here is no longer reachable
+    sr.state_studentnumber as state_id,
 
     c.contact_name,
     c.relationship as contact_relationship,
@@ -79,7 +82,6 @@ select
 
     if(sr.lep_status, 'Y', 'N') as ell_status,
     if(sr.spedlep in ('SPED', 'SPED SPEECH'), 'Y', 'N') as iep_status,
-    if(sr.region = 'Miami', sr.fleid, sr.state_studentnumber) as state_id,
     if(sr.grade_level = 0, 'Kindergarten', cast(sr.grade_level as string)) as grade,
 from {{ ref("int_extracts__student_enrollments") }} as sr
 left join
@@ -91,4 +93,5 @@ where
     and sr.rn_year = 1
     and not sr.is_out_of_district
     and sr.enroll_status in (0, -1)
-    and sr._dbt_source_relation not like '%kipppaterson%'
+    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
+    and sr._dbt_source_relation not like '%kippmiami%'

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
@@ -19,6 +19,8 @@ where
     and not is_prestart
     and employee_number is not null
     and home_work_location_powerschool_school_id is not null
+    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
+    and home_work_location_dagster_code_location != 'kippmiami'
 
 union all
 
@@ -40,3 +42,4 @@ select
 
     null as `password`,
 from {{ ref("int_people__temp_staff") }}
+where dagster_code_location != 'kippmiami'

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -378,3 +378,35 @@ data_tests:
         dagster:
           ref:
             name: int_people__staff_roster
+
+  - name: rpt_clever__school_id_resolves_to_schools_feed
+    description: >-
+      Cross-feed referential integrity for the six Clever SFTP extracts -- every
+      school_id in enrollments, sections, teachers and staff must exist in
+      schools. The six feeds each carry their own region filter, so a region
+      added to or removed from one but not the others ships rows referencing
+      schools Clever was never sent, which it silently drops or misroutes rather
+      than rejecting. Errors rather than warns: this is the gate on restarting
+      the hourly Clever schedule, and an orphan here means the roster Clever
+      receives is internally inconsistent.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: rpt_clever__schools
+
+  - name: rpt_clever__enrollments__student_id_resolves_to_students_feed
+    description: >-
+      Cross-feed referential integrity for the six Clever SFTP extracts -- every
+      student_id in enrollments must exist in students. students is scoped to
+      the current academic year and enrollments is not, so a region whose SIS is
+      frozen at a prior year keeps shipping course enrollments for students that
+      no longer appear in the student feed. Errors rather than warns for the
+      same reason as the school_id check.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: rpt_clever__students

--- a/src/dbt/kipptaf/tests/rpt_clever__enrollments__student_id_resolves_to_students_feed.sql
+++ b/src/dbt/kipptaf/tests/rpt_clever__enrollments__student_id_resolves_to_students_feed.sql
@@ -1,0 +1,22 @@
+-- Every student_id shipped in enrollments.csv must resolve to a row in
+-- students.csv. students.csv is scoped to the current academic year while
+-- enrollments.csv is not, so a region whose SIS is frozen at a prior year keeps
+-- shipping enrollments against students Clever no longer has -- the failure mode
+-- that left Miami with live enrollment rows and zero students.
+with
+    enrollment_students as (
+        select cast(student_id as string) as student_id,
+        from {{ ref("rpt_clever__enrollments") }}
+    ),
+
+    feed_students as (
+        -- grain projection: students.csv is one row per student per contact slot
+        -- per phone type; project it back to the student grain it rosters
+        select distinct student_id, from {{ ref("rpt_clever__students") }}
+    )
+
+select e.student_id, count(*) as orphan_rows,
+from enrollment_students as e
+left join feed_students as s on e.student_id = s.student_id
+where s.student_id is null
+group by e.student_id

--- a/src/dbt/kipptaf/tests/rpt_clever__school_id_resolves_to_schools_feed.sql
+++ b/src/dbt/kipptaf/tests/rpt_clever__school_id_resolves_to_schools_feed.sql
@@ -1,0 +1,32 @@
+-- Every school_id shipped in the enrollments, sections, teachers and staff
+-- Clever feeds must resolve to a row in schools.csv. A region filtered out of
+-- one feed but not another lands here, which is exactly how the Paterson and
+-- Miami leaks shipped rows pointing at schools Clever had never been told about.
+-- school_id 0 is a valid target -- rpt_clever__schools supplies the District
+-- Office via its hardcoded union branch.
+with
+    feed_school_ids as (
+        select 'enrollments' as feed, cast(school_id as string) as school_id,
+        from {{ ref("rpt_clever__enrollments") }}
+
+        union all
+
+        select 'sections' as feed, cast(school_id as string) as school_id,
+        from {{ ref("rpt_clever__sections") }}
+
+        union all
+
+        select 'teachers' as feed, cast(school_id as string) as school_id,
+        from {{ ref("rpt_clever__teachers") }}
+
+        union all
+
+        select 'staff' as feed, cast(school_id as string) as school_id,
+        from {{ ref("rpt_clever__staff") }}
+    )
+
+select f.feed, f.school_id, count(*) as orphan_rows,
+from feed_school_ids as f
+left join {{ ref("rpt_clever__schools") }} as sch on f.school_id = sch.school_id
+where sch.school_id is null
+group by f.feed, f.school_id


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will make all six `rpt_clever__*` extract feeds
agree on which regions they cover — Newark, Camden and Paterson in, Miami out —
and add tests that fail if they ever disagree again.

Each feed carried its own region filter, so they diverged and shipped orphaned
rows. Per the decisions recorded on #4653, the filters invert: Miami rosters into
Clever directly from Focus so it leaves all six feeds; Paterson's dlt sync and
staff roster are healthy so its gate comes off.

Feed contents before and after, from a local dev build against live prod
upstreams:

| feed          | Newark | Camden |    Miami |     Paterson |
| ------------- | -----: | -----: | -------: | -----------: |
| `students`    | 24,915 |  5,942 | 0 (same) | 0 to 3,016   |
| `enrollments` | 27,505 | 10,974 | 1,114 to 0 | 0 to 4,796 |
| `schools`     |     12 |      5 | 2 to 0   | 0 to 2       |
| `sections`    |  1,687 |    565 | 10 to 0  | 9 (same)     |
| `teachers`    |    834 |    271 | 97 to 0  | 90 (same)    |
| `staff`       |  3,436 |    740 | 308 to 0 | 0 to 240     |

Paterson's `school_number` 2 and 1234 both carry
`state_excludefromreporting = 0`, so they appear in `schools.csv` and Paterson's
existing teacher and section rows now resolve. The Miami ids `30200805`,
`30200806` and `30200807` that 35 staff and 35 teacher rows pointed at do not
exist in `stg_powerschool__schools` at all; the Miami exclusion clears them.

Also in this change:

- `rpt_clever__students`: collapses the now-dead
  `if(region = 'Miami', fleid, state_studentnumber)` branch.
- `rpt_clever__sections`: the auto-generated ENR branch joined
  `stg_powerschool__schools` on `school_number` alone. Adds the code-location
  predicate (a latent cross-district collision that turning Paterson on would
  widen) and the `state_excludefromreporting` filter, so an ENR section can no
  longer reference a school `schools.csv` omits. No cross-region
  `school_number` collisions exist in the post-change school set, so Paterson's
  ids are unambiguous.

Two new singular tests assert cross-feed referential integrity: every
`school_id` in enrollments, sections, teachers and staff resolves to schools,
and every `student_id` in enrollments resolves to students. Both run at
`severity: error`.

**Please confirm one side effect before merging.** Filtering the staff roster on
`home_work_location_dagster_code_location != 'kippmiami'` drops Miami-homed
people from the NJ rows they also appeared in, not just from Miami rows:

- 5 Miami-homed network staff (KTAF Inc. business unit, Teaching and Learning /
  Data / Executive) lose their `staff.csv` rows for every Newark and Camden
  school — 85 rows, via the CMO cross-join branch.
- 60 Miami-homed staff lose their `teachers.csv` row at `school_id` 0, the
  District Office.

That follows the decision as written, and everything removed is a Miami-homed
person. If those people should keep NJ access, the surgical alternative is to
keep the roster-side Miami filter only on the primary-school assignment branch
and let the CMO and all-NJ branches keep filtering via the already
Miami-excluded `schools` CTE. Say the word and I'll adjust.

Restarting `kipptaf__extracts__clever__asset_job_schedule` is deliberately not
part of this PR — handing that back per the issue.

## AI Assistance

Claude-authored. Human-directed: both gating decisions (Miami out, Paterson in)
were made by Charlie and recorded on #4653 before implementation. Claude
re-verified the issue's row counts against prod, wrote the model changes and
tests, and ran the verification below.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties files exist for all six models; the two new singular tests have
      `tests/properties.yml` entries with descriptions and `meta.dagster.ref`.
- [x] No exposure change needed — these feed the Dagster BigQuery-to-SFTP
      extract assets, not a dashboard.
- [x] **Not a breaking change** — no columns renamed or removed. `state_id` keeps
      its name and type; only its derivation is simplified. Rollback is a plain
      revert, since nothing downstream reads these views.
- [x] No external source added or modified.

## Verification

Local dev build of all six models plus their tests, deferred to prod
upstreams with `--favor-state`:

```text
uv run dbt build --select "path:models/extracts/clever" --target dev \
  --defer --favor-state --state src/dbt/kipptaf/target/prod
Done. PASS=11 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=11
```

Negative control — the same two tests run against the unfixed prod views fail,
confirming they catch the bug rather than passing vacuously:

```text
Failure in test rpt_clever__enrollments__student_id_resolves_to_students_feed
  Got 1114 results, configured to fail if != 0
Failure in test rpt_clever__school_id_resolves_to_schools_feed
  Got 10 results, configured to fail if != 0
```

Predicted post-merge orphan count for Paterson was checked ahead of the change:
840 students in the enrollments branch against 840 in the students feed, zero
orphans.

`trunk check --force` on all nine changed files reports no issues after the
commit-time `fmt` pass.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes. This PR is kipptaf-only, so CI's
      `state:modified+` selection genuinely builds these six models and both new
      tests.
- [ ] **Dagster Cloud** — not triggered; the `pull_request` paths exclude
      `src/dbt/`.

Refs #4653