### PR TITLE
fix(deps): re-lock dagster-plus-mcp for mcp 2.0 compatibility

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 [[package]]
 name = "dagster-plus-mcp"
 version = "0.1.0"
-source = { git = "https://github.com/TEAMSchools/dagster-plus-mcp.git#e4cf661163a4876e2845feba3712258f978d4d02" }
+source = { git = "https://github.com/TEAMSchools/dagster-plus-mcp.git#efc4cf90037fdd3a8553937f2643a141321a9c2d" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restore the `dagster` MCP server, which has been failing to start with `MCP error -32000: Connection closed`.

That client-side message hid the real failure. The server subprocess was dying at import:

```text
File ".venv/.../dagster_plus_mcp/server.py", line 12, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`mcp` 2.0.0 removed `mcp.server.fastmcp` (the class is now `mcp.server.mcpserver.MCPServer`). `uv.lock` moved `mcp` 1.28.1 to 2.0.0 in f0626a333 ("chore: update dependencies", Jul 30), and `dagster-plus-mcp` declared an unbounded `mcp>=1.0.0`, so the refresh resolved straight through a breaking major. `dagster-plus-mcp` is the only consumer of `mcp` here (`uv tree --invert`), so nothing else was affected. `scripts/dagster-mcp-launch.sh` and the 1Password token path were never implicated — the process died before any auth.

Rather than pin `mcp` back, the fix went upstream: TEAMSchools/dagster-plus-mcp#14 migrates the server to `MCPServer` and pins `mcp>=2,<3` so a future major cannot break the import the same way. This PR is the one-line consequence here: re-lock `dagster-plus-mcp` e4cf6611 to efc4cf90 (that merge commit). `mcp` stays at 2.0.0.

Closes #4669

## AI Assistance

AI-assisted throughout, human-directed at each decision point. Claude did the root-cause investigation (subprocess stderr, `uv.lock` version bisect, dependency inversion), the upstream migration, and the verification harnesses. The choice to migrate upstream rather than pin `mcp` back, and the decision to merge the upstream PR, were both mine.

## Self-review

### General

- [x] Reviewed the change — one line in `uv.lock`, no source changes here
- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR

### Verification

- [x] Stdio handshake against `python -m dagster_plus_mcp` at the merged commit efc4cf90: initializes and lists all 36 tools
- [x] Upstream: 45 tests pass under `mcp` 2.0.0, and the wire-format tool list (`model_dump(by_alias=True)`, 36 tools) is byte-identical to the `mcp` 1.28.1 build — no tool names, descriptions, or input schemas shift for clients
- [x] No Dagster code-location, dbt, or docs changes — those sections do not apply

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
