### PR TITLE
fix(clever): exclude terminated staff from the teachers extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -38,7 +38,12 @@ with
             department as home_department_name,
             title as job_title,
         from {{ ref("int_people__temp_staff") }}
-        where dagster_code_location != 'kippmiami'
+        where
+            dagster_code_location != 'kippmiami'
+            -- int_people__temp_staff gates on idauto_status and the AD account
+            -- flag, neither of which flips on offboarding. A populated
+            -- idauto_person_term_date is the only termination signal it carries.
+            and idauto_person_term_date is null
     ),
 
     schools as (

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
@@ -17,6 +17,10 @@ from {{ ref("int_people__staff_roster") }}
 where
     uac_account_disable = 0
     and not is_prestart
+    -- an enabled AD account does not imply active employment; offboarding can
+    -- leave the account enabled indefinitely, so gate on worker status the way
+    -- rpt_clever__staff does
+    and worker_status_code != 'Terminated'
     and employee_number is not null
     and home_work_location_powerschool_school_id is not null
     -- Miami rosters into Clever directly from Focus; excluded from all six feeds

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
@@ -46,4 +46,9 @@ select
 
     null as `password`,
 from {{ ref("int_people__temp_staff") }}
-where dagster_code_location != 'kippmiami'
+where
+    dagster_code_location != 'kippmiami'
+    -- int_people__temp_staff gates on idauto_status and the AD account flag,
+    -- neither of which flips on offboarding. A populated
+    -- idauto_person_term_date is the only termination signal it carries.
+    and idauto_person_term_date is null


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will stop `teachers.csv` and `staff.csv` shipping
terminated and offboarded staff to Clever.

`rpt_clever__teachers` gated only on `uac_account_disable = 0`, with no worker
status filter, so a terminated employee kept shipping for as long as their AD
account stayed enabled. It was the outlier among the people feeds:

| feed                       | termination filter                    |
| -------------------------- | ------------------------------------- |
| `rpt_clever__staff`        | `worker_status_code != 'Terminated'`  |
| `rpt_clever__sections` DSO | `assignment_status != 'Terminated'`   |
| `rpt_clever__teachers`     | none, until this change               |

As of today that shipped **10 rows for terminated staff**, termination dates
reaching back to 2019. Two of the ten terminated today, which is ordinary
processing lag; the other eight are stale. Two point at live schools rather than
the District Office sentinel, so terminated staff held teacher records against
active school rosters.

The fix adds `worker_status_code != 'Terminated'` to the
`int_people__staff_roster` branch, matching `rpt_clever__staff`.

### Temp staff: also fixed here, after a correction

An earlier version of this description said `int_people__temp_staff` "carries no
worker-status or termination column (only `idauto_status` and
`uac_account_disable`)". **That was wrong**, and `claude-review` caught it. The
model carries `idauto_person_term_date` and `idauto_person_end_date`. My
`INFORMATION_SCHEMA` probe filtered column names on `%terminat%` / `%status%` /
`%disable%` / `%active%` — none of which match `term_date` or `end_date` — so a
too-narrow filter produced a false negative I then asserted as fact.

It was a live leak, not a theoretical one: of the 21 temp-staff rows in
`teachers.csv`, one carried a term date from October 2022 while `idauto_status`
was still `A` and the AD account still enabled. `int_people__temp_staff` gates
only on `idauto_status` and `uac_account_disable`, neither of which flips on
offboarding.

Both Clever temp branches are now filtered on `idauto_person_term_date is null`,
so `teachers.csv` and `staff.csv` cannot disagree about the same person.

Two scoping decisions worth stating:

- **Not filtered in `int_people__temp_staff` itself**, though that is the tidier
  altitude. That model also feeds `rpt_illuminate__roles`,
  `rpt_illuminate__users`, `rpt_powerschool__autocomm_teachers` and
  `rpt_littlesis__enrollments`. Changing four unrelated outbound integrations from
  inside a Clever-scoped PR is a worse trade than one duplicated predicate.
  Normalizing the string to a DATE upstream and applying it network-wide stays
  scoped in #4674.
- **Presence of a term date is the signal**, rather than parsing it and comparing
  to today. The field is sparsely maintained — 1 of 26 rows populated, and
  `idauto_person_end_date` entirely null — so a date comparison would add parsing
  plus a CTE restructure for no behavioral difference on any current row. Noted in
  #4674.

### Not fixed here, and not a data problem

All 10 removed rows have `uac_account_disable = 0`, meaning enabled accounts
after termination, one since 2019. That reaches beyond Clever to anything keyed
on the account, so it is a People Operations and IT question. Written up in
#4674 rather than papered over in dbt.

Found while reviewing the drop-off list from #4667, where one terminated staff
member was removed by the Miami region filter — incidentally, for the wrong
reason.

## AI Assistance

Claude-authored, human-directed. Charlie spotted that the person in question was
terminated, which is what surfaced the missing filter; Claude traced the cause,
quantified the population, and made the change.

## Self-review

### dbt

- [x] No new model, so no new properties file. No contract or column change —
      this is a `where`-clause predicate only.
- [x] No exposure change; this feeds the Dagster BigQuery-to-SFTP extract asset.
- [x] **Not a breaking change** — no columns added, renamed or removed. Rollback
      is a plain revert.
- [x] No external source added or modified.

## Verification

Local dev build of all six clever models plus their tests, deferred to prod
upstreams:

```text
uv run dbt build --select "path:models/extracts/clever" --target dev \
  --defer --favor-state --state src/dbt/kipptaf/target/prod
Done. PASS=11 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=11
```

Row-level diff of the current prod feed against the dev build, which confirms the
change is surgical:

| feed       | prod rows | dev rows | removed                                  |
| ---------- | --------: | -------: | ---------------------------------------- |
| `teachers` |     1,460 |    1,449 | 10 roster (10 people) + 1 temp (1 person) |
| `staff`    |     4,416 |    4,404 | 12 temp rows, one person across 12 schools |

Rows added: **0**. Terminated roster rows remaining in either feed: **0**. Temp
rows carrying a term date remaining in either feed: **0**.

NULL-safety of `!=` checked as well: **0 rows** in `int_people__staff_roster`
have a NULL `worker_status_code` while meeting this model's other predicates, so
the `!=` comparison drops nothing beyond the intended `Terminated` set.

`trunk check --force` on the changed file reports no issues.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes, zero warnings (run `70403219144192`).
- [x] **Dagster Cloud** — not triggered; the `pull_request` paths exclude
      `src/dbt/`.

## Re-review

The temp-staff commit landed after `claude-review` passed, and that check does not
re-fire on `synchronize`. Toggling draft state would re-trigger it if a second
pass is wanted before merge.

## Gate

`kipptaf__extracts__clever__asset_job_schedule` is confirmed still STOPPED. This
should land before it is switched on, otherwise the first hourly sync pushes all
10 terminated staff — including the two at live schools — plus the offboarded temp
staffer.

Closes #4674
Refs #4653
