### PR TITLE
fix(dbt): resolve the Focus CONTACT address from the guardian household linkage

### DIFF
--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -163,13 +163,18 @@ does not already have it, and nothing is ever overwritten:
   drop code) is filled in once onto that student-year's **open** Focus
   enrollment when it has neither yet — never onto one Focus already shows as
   closed.
-- **Addresses and Contacts** — sent only once the student is **enrolled**, Focus
-  does not already have the record for that student, **and** Finalsite points to
-  a single address for them (a named contact, for Contacts). For Contacts, it's
-  the **student's** enrolled status that gates the feed, not the guardian
-  contact's own. An address Finalsite cannot narrow to one is held back; a
-  partial address is now sent rather than held, so it can be spotted and
-  corrected in Focus.
+- **Addresses** — sent only once the student is **enrolled**, Focus does not
+  already have the address record for that student, **and** Finalsite points to
+  a single address for them. An address Finalsite cannot narrow to one is held
+  back entirely; a partial address (missing city, state, or ZIP) is sent rather
+  than held, so it can be spotted and corrected in Focus.
+- **Contacts** — sent only once the student is **enrolled**, Focus does not
+  already have the record for that student, **and** the contact has a name. It
+  is the **student's** enrolled status that gates the feed, not the guardian
+  contact's own. A guardian's address does not gate whether the contact is sent:
+  when Finalsite can't narrow it to one, or the guardian has no street address
+  on file at all, the contact still goes out with the rest of their details and
+  the address is simply left blank.
 
 ### Forward-moving enrollments are protected
 
@@ -197,7 +202,8 @@ Because addresses and contacts are import-once, a record sent before Finalsite
 can resolve it would be locked in — a student imported with no address at all
 would keep that gap in Focus even after a real one is entered, because
 import-once never sends them again. To prevent that, the pipeline **holds a
-record back when it cannot tell which address to send**:
+student's address record back when it cannot tell which address to send**. A
+guardian's address works differently — see the Contacts bullet below.
 
 - **Addresses** — a student's address is sent once Finalsite points to a single
   address for them. The pipeline reads the households the student is linked to,
@@ -209,11 +215,19 @@ record back when it cannot tell which address to send**:
   back flows the first run Finalsite resolves to a single address.
 - **Contacts** — a contact is sent only once it has a name. A nameless contact
   is skipped and flows once the name is filled in. A guardian's address is
-  resolved the same way a student's is, but from the guardian's own households:
-  when Finalsite links them to more than one address, the contact is still sent
-  with the rest of their details and the address is left blank rather than
-  guessed. Guardians are usually linked to more households than their children,
-  so this is more common on the contact record than on the student.
+  resolved from the guardian's own households only, with no fallback: when
+  Finalsite links them to more than one address, or to no street address at all,
+  the contact still goes out with the rest of their details and the address is
+  simply left blank. Guardians are usually linked to more households than their
+  children, so this is more common on the contact record than on the student.
+
+  **A guardian's blank address is not held back the way a student's is — it is
+  permanent.** A student's address record waits until Finalsite resolves it,
+  then sends a real address the first run it can. A guardian's contact record
+  does not wait: it imports as soon as it has a name, blank address and all, and
+  once that student's contacts have imported, a later Finalsite fix — retiring
+  the extra household, or adding a street where none existed — is never re-sent.
+  A guardian's address gap has to be filled in Focus by hand.
 
 > **A student can be enrolled in Focus with no address yet.** That is expected
 > when Finalsite has no street address on file for them, when it has several and

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -164,10 +164,12 @@ does not already have it, and nothing is ever overwritten:
   enrollment when it has neither yet — never onto one Focus already shows as
   closed.
 - **Addresses and Contacts** — sent only once the student is **enrolled**, Focus
-  does not already have the record for that student, **and** the record is
-  complete (a full address; a named contact). For Contacts, it's the
-  **student's** enrolled status that gates the feed, not the guardian contact's
-  own. Blank or incomplete records are held back until populated (see below).
+  does not already have the record for that student, **and** Finalsite points to
+  a single address for them (a named contact, for Contacts). For Contacts, it's
+  the **student's** enrolled status that gates the feed, not the guardian
+  contact's own. An address Finalsite cannot narrow to one is held back; a
+  partial address is now sent rather than held, so it can be spotted and
+  corrected in Focus.
 
 ### Forward-moving enrollments are protected
 
@@ -207,7 +209,12 @@ until it is complete**:
   student is skipped that run and flows the first run Finalsite resolves to a
   single complete address.
 - **Contacts** — a contact is sent only once it has a name. A nameless contact
-  is skipped and flows once the name is filled in.
+  is skipped and flows once the name is filled in. A guardian's address is
+  resolved the same way a student's is, but from the guardian's own households:
+  when Finalsite links them to more than one address, the contact is still sent
+  with the rest of their details and the address is left blank rather than
+  guessed. Guardians are usually linked to more households than their children,
+  so this is more common on the contact record than on the student.
 
 > **A student can be enrolled in Focus with no address yet.** That is expected
 > when Finalsite has no complete address for them, when it has several and none
@@ -281,6 +288,10 @@ pipeline will not reconcile them for you.
   current one — cannot be resolved automatically, because Finalsite does not
   mark which of the two is the one to use. Retiring the stale household fixes it
   for that family.
+- **A partial address now imports rather than waiting.** An address missing its
+  city, state, or ZIP is sent to Focus so you can see and fix it there, instead
+  of the student silently having no address. An address Finalsite cannot narrow
+  down to one is still held back — that one cannot be guessed safely.
 - **A student needs a primary contact (Parent 1) designated in Finalsite before
   an address can flow.** With no Parent 1, there's no fallback household to
   check when the student's own linkage isn't decisive — the student is missing

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -188,26 +188,25 @@ consistent:
   **truly empty**, not a stray space.
 - The **state is upper-cased** (e.g. `fl` becomes `FL`).
 
-This is formatting only — whether a record is complete enough to send is covered
-next.
+This is formatting only — what decides whether a record is sent at all is
+covered next.
 
 ### Blank addresses and nameless contacts are held back
 
-Because addresses and contacts are import-once, an incomplete record sent now
-would be locked in — a student imported with a blank address would keep that
-empty address in Focus even after a real one is entered, because import-once
-never sends them again. To prevent that, the pipeline **holds a record back
-until it is complete**:
+Because addresses and contacts are import-once, a record sent before Finalsite
+can resolve it would be locked in — a student imported with no address at all
+would keep that gap in Focus even after a real one is entered, because
+import-once never sends them again. To prevent that, the pipeline **holds a
+record back when it cannot tell which address to send**:
 
-- **Addresses** — a student's address is sent only once Finalsite points to
-  exactly one complete address for them. Two things can hold it back. The
-  address may be **incomplete** — street, city, state, and ZIP must all be
-  present. Or Finalsite may hold **more than one** address for the student: the
-  pipeline reads the households the student is linked to, falls back to the
-  households their primary contact is linked to when the student's own linkage
-  is not decisive, and sends nothing when neither narrows to one. Either way the
-  student is skipped that run and flows the first run Finalsite resolves to a
-  single complete address.
+- **Addresses** — a student's address is sent once Finalsite points to a single
+  address for them. The pipeline reads the households the student is linked to,
+  falls back to the households their primary contact is linked to when the
+  student's own linkage is not decisive, and sends nothing when neither narrows
+  to one. A household with no street line is not treated as an address at all; a
+  household that has a street but is missing its city, state, or ZIP **is**
+  sent, so the gap is visible in Focus and can be fixed there. A student held
+  back flows the first run Finalsite resolves to a single address.
 - **Contacts** — a contact is sent only once it has a name. A nameless contact
   is skipped and flows once the name is filled in. A guardian's address is
   resolved the same way a student's is, but from the guardian's own households:
@@ -217,14 +216,14 @@ until it is complete**:
   so this is more common on the contact record than on the student.
 
 > **A student can be enrolled in Focus with no address yet.** That is expected
-> when Finalsite has no complete address for them, when it has several and none
-> is marked as the one to use, or when the student has no Parent 1 designated —
-> with no primary contact to fall back on, the student doesn't reach this part
-> of the pipeline at all. Fix it in Finalsite — fill in the missing address,
-> retire the household the family no longer lives at, or designate a primary
-> contact (Parent 1) — and it flows on the next run. (Demographics is not held
-> back this way; a student's demographics import as soon as the student is
-> enrolled in Finalsite and new to Focus.)
+> when Finalsite has no street address on file for them, when it has several and
+> none is marked as the one to use, or when the student has no Parent 1
+> designated — with no primary contact to fall back on, the student doesn't
+> reach this part of the pipeline at all. Fix it in Finalsite — fill in the
+> missing address, retire the household the family no longer lives at, or
+> designate a primary contact (Parent 1) — and it flows on the next run.
+> (Demographics is not held back this way; a student's demographics import as
+> soon as the student is enrolled in Finalsite and new to Focus.)
 
 ## Where to make corrections
 
@@ -277,12 +276,11 @@ pipeline will not reconcile them for you.
   feeds now require Finalsite to mark the student **enrolled** — a student who
   is only accepted, in progress, or assigned a school does not appear in any of
   them yet.
-- **One complete address is required before it imports.** A student whose
-  Finalsite address is blank or partial gets no address in Focus — by design,
-  since an empty one would lock in. So does a student Finalsite links to more
-  than one address, where there is no way to tell which one to send. Enter the
-  full street/city/state/ZIP, or retire the household the family has moved out
-  of, and it flows next run; likewise a contact needs a name before it is sent.
+- **One address is required before it imports.** A student Finalsite links to
+  more than one address gets no address in Focus, because there is no way to
+  tell which one to send. Retire the household the family has moved out of and
+  it flows next run. A student with no street on file anywhere is skipped the
+  same way; likewise a contact needs a name before it is sent.
 - **Duplicate households are the common cause of a missing address.** A family
   with two live household records in Finalsite — usually an old address and a
   current one — cannot be resolved automatically, because Finalsite does not

--- a/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
+++ b/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
@@ -1,0 +1,2606 @@
+# Focus CONTACTS Address Resolution and Emergency Contacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve each Focus `CONTACTS` guardian address from that guardian's
+own Finalsite household linkage instead of an arbitrary array position, then
+append emergency-contact rows from the `emrg_1..4` custom-field slots.
+
+**Architecture:** A new `finalsite` package intermediate,
+`int_finalsite__contact_address_of_record`, applies the address-resolution rule
+at contact grain. `int_finalsite__student_address_of_record` refactors onto it
+so both Focus feeds share one rule. kipptaf reaches the new model through a
+`union_relations` wrapper over four regional sources, and `rpt_focus__contacts`
+joins it. A second, stacked branch then unions emergency-slot rows into
+`rpt_focus__contacts` and re-derives `sort_order` over the combined set.
+
+**Tech Stack:** dbt (BigQuery), `dbt_utils`, dbt unit tests, trunk (sqlfluff /
+yamllint / markdownlint), `gh` CLI.
+
+**Design spec:**
+`docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md`
+— read it before Task 1. Every measured figure quoted below comes from it.
+
+## Global Constraints
+
+- Worktree for branch 1:
+  `/workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record`
+  (branch `cbini/fix/claude-focus-contacts-address-of-record`, already created).
+  All Read / Edit / Write use paths under that worktree. All git commands use
+  `git -C <worktree>`.
+- Run `uv run dbt deps --project-dir <worktree>/src/dbt/kippmiami` once before
+  the first dbt command — a fresh worktree has no `dbt_packages/`.
+- Every dbt invocation is `uv run dbt`, never bare `dbt`.
+- `--state` paths are absolute and point at the MAIN repo
+  (`/workspaces/teamster/src/dbt/kippmiami/target/prod`), never the worktree.
+- SQL follows `src/dbt/CLAUDE.md`: max one level of function nesting, no
+  `ORDER BY`, no `QUALIFY`, no subqueries against tables or CTEs, no lateral
+  column aliases, no `GROUP BY ALL`, no pass-through import CTEs, trailing
+  commas in `SELECT`, single-quoted strings, 88-char lines, ST06 column ordering
+  (plain refs by table in join order, then constants, simple functions, nested
+  functions, logicals, `CASE`, window functions).
+- Every new or modified model needs a `description:` on the model and on every
+  column, plus a uniqueness test.
+- PII columns (`address_1`, `address_2`, `city`, `zip`, phone, email, names)
+  carry `config: meta: contains_pii: true`.
+- Never emit real address, name, phone, or email values into a commit message,
+  PR body, or issue comment. Validation output stays local.
+- Lint with
+  `/workspaces/teamster/.trunk/tools/trunk check --force --no-fix <paths> </dev/null`,
+  run with cwd set to the worktree.
+- Address resolution rule, verbatim from the spec: candidates are households
+  where `address_1 is not null`; identity is `address_1`, `address_2`, `city`,
+  `state`, `zip` compared case- and punctuation-insensitively with ZIP truncated
+  to 5; a contact resolves only when exactly one distinct address remains; the
+  projected values are the RAW text from the lowest-`household_id` row.
+
+---
+
+## Branch 1 — #4651
+
+### Task 1: `int_finalsite__contact_address_of_record`
+
+**Files:**
+
+- Create:
+  `src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql`
+- Create:
+  `src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml`
+
+**Interfaces:**
+
+- Consumes: `int_finalsite__contacts__households` (`finalsite_enrollment_id`,
+  `household_id`, `address_1`, `address_2`, `city`, `state`, `zip`, `country`,
+  `is_complete_address`) and `stg_finalsite__contacts`
+  (`finalsite_enrollment_id`, used as the contact spine).
+- Produces: one row per `finalsite_enrollment_id` with columns
+  `finalsite_enrollment_id` (string), `address_1`, `address_2`, `city`, `state`,
+  `zip`, `country` (string), `is_complete_address` (boolean), `candidate_count`
+  (int64), `resolution_status` (string, one of `resolved` / `ambiguous` /
+  `no_street`). Tasks 2, 3, and 4 all depend on these exact names.
+
+- [ ] **Step 1: Write the model SQL**
+
+Create
+`src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql`:
+
+```sql
+with
+    households_stripped as (
+        -- Any household carrying a street line is a candidate. Completeness is
+        -- deliberately NOT a gate: an incomplete address is visibly wrong in
+        -- Focus and can be corrected there, whereas withholding it is silent.
+        -- Households with no street at all ARE excluded — Miami holds 94 such
+        -- city/state/ZIP fragments, and each would otherwise count as its own
+        -- candidate and manufacture ambiguity that is not real.
+        select
+            finalsite_enrollment_id,
+            household_id,
+            address_1,
+            address_2,
+            city,
+            state,
+            zip,
+            country,
+            is_complete_address,
+
+            upper(city) as city_key,
+            left(zip, 5) as zip_key,
+
+            regexp_replace(address_1, r'[^A-Za-z0-9]', '') as address_1_stripped,
+            regexp_replace(address_2, r'[^A-Za-z0-9]', '') as address_2_stripped,
+        from {{ ref("int_finalsite__contacts__households") }}
+        where address_1 is not null
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    candidate_households as (
+        select
+            finalsite_enrollment_id,
+            household_id,
+            address_1,
+            address_2,
+            city,
+            state,
+            zip,
+            country,
+            is_complete_address,
+            city_key,
+            zip_key,
+
+            upper(address_1_stripped) as address_1_key,
+            upper(address_2_stripped) as address_2_key,
+        from households_stripped
+    ),
+
+    address_candidates as (
+        -- One row per (contact, distinct address). The key normalizes case and
+        -- punctuation so `123 Main St.` and `123 MAIN ST` are one address, and
+        -- truncates ZIP+4 to five digits. Normalization is for GROUPING only —
+        -- the projected address is the raw text from the lowest-household_id
+        -- row, so Focus receives properly formatted values. country and
+        -- is_complete_address are not part of the identity, so they come from
+        -- that same canonical row rather than being aggregated across rows,
+        -- which would blend values from different households.
+        {{
+            dbt_utils.deduplicate(
+                relation="candidate_households",
+                partition_by=(
+                    "finalsite_enrollment_id, address_1_key, address_2_key,"
+                    " city_key, state, zip_key"
+                ),
+                order_by="household_id asc",
+            )
+        }}
+    ),
+
+    candidate_counts as (
+        select finalsite_enrollment_id, count(*) as candidate_count,
+        from address_candidates
+        group by finalsite_enrollment_id
+    ),
+
+    resolved_candidates as (
+        -- Only a contact with exactly one distinct address gets an address at
+        -- all. Two or more means Finalsite does not say which one to use, and
+        -- the feed is import-once, so a guess would be permanent.
+        select
+            a.finalsite_enrollment_id,
+            a.address_1,
+            a.address_2,
+            a.city,
+            a.state,
+            a.zip,
+            a.country,
+            a.is_complete_address,
+        from address_candidates as a
+        inner join
+            candidate_counts as c
+            on a.finalsite_enrollment_id = c.finalsite_enrollment_id
+        where c.candidate_count = 1
+    ),
+
+    counted as (
+        -- Spined on the full contact list so a contact with no street-bearing
+        -- household still gets a row, with candidate_count 0.
+        select
+            c.finalsite_enrollment_id,
+
+            r.address_1,
+            r.address_2,
+            r.city,
+            r.state,
+            r.zip,
+            r.country,
+            r.is_complete_address,
+            r.finalsite_enrollment_id as resolved_contact_id,
+
+            coalesce(cc.candidate_count, 0) as candidate_count,
+        from {{ ref("stg_finalsite__contacts") }} as c
+        left join
+            candidate_counts as cc
+            on c.finalsite_enrollment_id = cc.finalsite_enrollment_id
+        left join
+            resolved_candidates as r
+            on c.finalsite_enrollment_id = r.finalsite_enrollment_id
+    )
+
+select
+    finalsite_enrollment_id,
+    address_1,
+    address_2,
+    city,
+    state,
+    zip,
+    country,
+    is_complete_address,
+    candidate_count,
+
+    case
+        when resolved_contact_id is not null
+        then 'resolved'
+        when candidate_count = 0
+        then 'no_street'
+        else 'ambiguous'
+    end as resolution_status,
+from counted
+```
+
+- [ ] **Step 2: Write the properties file with unit tests**
+
+Create
+`src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml`:
+
+```yaml
+models:
+  - name: int_finalsite__contact_address_of_record
+    description:
+      One row per Finalsite contact — students and adults alike — carrying that
+      contact's resolved address, or nulls plus a flag when it cannot be
+      resolved. A household is a candidate when it has a street line; an
+      incomplete address is deliberately still a candidate, because an
+      incomplete address is visibly wrong in a receiving system and can be
+      corrected there, whereas withholding it is silent. Households with no
+      street at all are excluded, since each would otherwise count as its own
+      candidate and manufacture ambiguity. Address identity is `address_1`,
+      `address_2`, `city`, `state`, and `zip` compared without regard to case or
+      punctuation and with `zip` truncated to five digits, so the same address
+      recorded two ways collapses to one candidate while a genuine apartment,
+      city, state, or ZIP difference stays distinct. A contact resolves only
+      when exactly one distinct address remains; the emitted values are the raw
+      text from the lowest `household_id` in that group. SIS-agnostic — no
+      enrollment, status, or academic-year scoping.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              (resolution_status = 'resolved' and address_1 is not null)
+              or (
+                  resolution_status != 'resolved'
+                  and address_1 is null
+                  and address_2 is null
+                  and city is null
+                  and state is null
+                  and zip is null
+              )
+          config:
+            severity: error
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              (resolution_status = 'resolved' and candidate_count = 1)
+              or (resolution_status = 'no_street' and candidate_count = 0)
+              or (resolution_status = 'ambiguous' and candidate_count > 1)
+          config:
+            severity: error
+    columns:
+      - name: finalsite_enrollment_id
+        data_type: string
+        description: Finalsite contact UUID; the grain.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: resolution_status
+        data_type: string
+        description:
+          Why this contact does or does not have an address — `resolved`
+          (exactly one distinct address), `ambiguous` (several, with nothing in
+          Finalsite saying which to use), or `no_street` (no household carries a
+          street line).
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - resolved
+                  - ambiguous
+                  - no_street
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: candidate_count
+        data_type: int64
+        description:
+          Number of distinct addresses on this contact's household linkage after
+          normalization. One resolves; zero means no household carries a street;
+          more than one is ambiguous.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: address_1
+        data_type: string
+        description:
+          Street address line 1 of the resolved address, as raw text; null when
+          unresolved.
+        config:
+          meta:
+            contains_pii: true
+      - name: address_2
+        data_type: string
+        description:
+          Street address line 2 (apartment or unit) of the resolved address.
+          Legitimately null when the household has no unit line, and null
+          whenever the address is unresolved.
+        config:
+          meta:
+            contains_pii: true
+      - name: city
+        data_type: string
+        description:
+          City of the resolved address; null when unresolved, and possibly null
+          on a resolved but incomplete address.
+        config:
+          meta:
+            contains_pii: true
+      - name: state
+        data_type: string
+        description:
+          State code of the resolved address, uppercased upstream; null when
+          unresolved, and possibly null on a resolved but incomplete address.
+      - name: zip
+        data_type: string
+        description:
+          ZIP code of the resolved address; null when unresolved, and possibly
+          null on a resolved but incomplete address.
+        config:
+          meta:
+            contains_pii: true
+      - name: country
+        data_type: string
+        description:
+          Country of the resolved address as Finalsite stores it. Not part of
+          the address identity, so it is carried from the canonical household
+          rather than compared.
+      - name: is_complete_address
+        data_type: boolean
+        description:
+          Whether the resolved address carries street, city, state, and ZIP. A
+          resolved address may be incomplete — this flag is what makes that
+          visible to consumers. Null when unresolved.
+
+unit_tests:
+  - name: test_contact_address_formatting_duplicates_collapse
+    description:
+      Two households recording the same address with different punctuation,
+      case, and a ZIP+4 collapse to one candidate, so the contact resolves. The
+      emitted values are the raw text of the lowest household_id, not the
+      normalized key.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-1 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-1' as finalsite_enrollment_id,
+            'hh-1' as household_id,
+            '123 Main St.' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33101' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-1', 'hh-2', '123 MAIN ST', null, 'MIAMI', 'FL',
+            '33101-4402', 'US', true
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-1,
+            address_1: 123 Main St.,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: "33101",
+            country: US,
+            is_complete_address: true,
+            candidate_count: 1,
+            resolution_status: resolved,
+          }
+
+  - name: test_contact_address_real_differences_stay_ambiguous
+    description:
+      Households sharing a street line but differing by apartment or by city
+      stay distinct candidates, so the contact is ambiguous and no address is
+      emitted. This is the case an address_1-only key would wrongly collapse.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-2 }
+          - { finalsite_enrollment_id: con-3 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-2' as finalsite_enrollment_id,
+            'hh-3' as household_id,
+            '222 Bay St' as address_1,
+            'Apt 1' as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33106' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-2', 'hh-4', '222 Bay St', 'Apt 2', 'Miami', 'FL', '33106',
+            'US', true
+          union all
+          select 'con-3', 'hh-5', '400 Palm Way', null, 'Miami', 'FL', '33101',
+            'US', true
+          union all
+          select 'con-3', 'hh-6', '400 Palm Way', null, 'Hialeah', 'FL', '33012',
+            'US', true
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-2,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+        - {
+            finalsite_enrollment_id: con-3,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+
+  - name: test_contact_address_incomplete_resolves_and_fragments_excluded
+    description:
+      A household with a street but no ZIP still resolves, flagged incomplete —
+      completeness is not a gate. A household carrying only city and ZIP with no
+      street is not a candidate, so a contact holding only fragments reports
+      no_street. A contact with no household rows at all also reports no_street.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-4 }
+          - { finalsite_enrollment_id: con-5 }
+          - { finalsite_enrollment_id: con-6 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-4' as finalsite_enrollment_id,
+            'hh-7' as household_id,
+            '9 Nowhere Ln' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            cast(null as string) as zip,
+            'US' as country,
+            false as is_complete_address
+          union all
+          select 'con-4', 'hh-8', null, null, 'Miami', 'FL', '33101', 'US', false
+          union all
+          select 'con-5', 'hh-9', null, null, 'Miami', 'FL', '33108', 'US', false
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-4,
+            address_1: 9 Nowhere Ln,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: null,
+            country: US,
+            is_complete_address: false,
+            candidate_count: 1,
+            resolution_status: resolved,
+          }
+        - {
+            finalsite_enrollment_id: con-5,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 0,
+            resolution_status: no_street,
+          }
+        - {
+            finalsite_enrollment_id: con-6,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 0,
+            resolution_status: no_street,
+          }
+```
+
+- [ ] **Step 3: Install packages in the worktree**
+
+Run:
+
+```bash
+uv run dbt deps --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kippmiami
+```
+
+Expected: packages installed, no error. Skip if already run.
+
+- [ ] **Step 4: Run the unit tests**
+
+Run:
+
+```bash
+uv run dbt test \
+  --select int_finalsite__contact_address_of_record,test_type:unit \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kippmiami \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
+```
+
+Expected: 3 unit tests PASS. If
+`test_contact_address_formatting_duplicates_collapse` returns the `hh-2` values
+instead of `hh-1`, the `order_by` in the deduplicate call is wrong. If `con-4`
+comes back `no_street`, the `where address_1 is not null` filter was written as
+`where is_complete_address`.
+
+- [ ] **Step 5: Build the model against dev and check the counts**
+
+Run:
+
+```bash
+uv run dbt build \
+  --select int_finalsite__contact_address_of_record \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kippmiami \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
+```
+
+Expected: model builds; `unique`, `not_null`, `accepted_values`, and both
+`expression_is_true` tests pass.
+
+Then query the dev table (BigQuery MCP, schema `zz_cbini_kippmiami_finalsite`)
+and confirm against the spec:
+
+```sql
+select resolution_status, count(*) as n
+from `teamster-332318.zz_cbini_kippmiami_finalsite.int_finalsite__contact_address_of_record`
+group by 1
+order by 1
+```
+
+Expected: 6,405 rows total for Miami, and the guardian-scoped feed slice
+resolving to 2,081 rows in Task 4. A total row count other than 6,405 means the
+spine join fanned out.
+
+- [ ] **Step 6: Lint**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml \
+  </dev/null
+```
+
+Expected: no issues. Fix any sqlfluff ST06 ordering or line-length findings and
+re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "feat(dbt): resolve a Finalsite contact address of record at contact grain
+
+Refs #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Refactor `int_finalsite__student_address_of_record`
+
+**Files:**
+
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql`
+  (full rewrite of the CTE chain)
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml`
+  (model description, one `expression_is_true` test, three column descriptions,
+  one new column, all four unit tests)
+
+**Interfaces:**
+
+- Consumes: `int_finalsite__contact_address_of_record` from Task 1 —
+  `finalsite_enrollment_id`, `candidate_count`, `address_1`, `address_2`,
+  `city`, `state`, `zip`, `country`, `is_complete_address`.
+- Produces: the same column set as today plus `is_complete_address` (boolean).
+  `address_source`, `resolution_status`, `student_candidate_count`,
+  `primary_contact_candidate_count`, and `primary_contact_phone` keep their
+  existing names and meanings. `rpt_focus__addresses` reads `address_source`,
+  the five address fields, and `primary_contact_phone` and must keep working
+  unchanged.
+
+- [ ] **Step 1: Update the existing unit tests to fail against the new rule**
+
+The four unit tests in
+`src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml`
+currently mock `ref('int_finalsite__contacts__households')`. After the refactor
+the model no longer reads that relation, so every `given` block must mock
+`ref('int_finalsite__contact_address_of_record')` instead. Dedup behavior is no
+longer this model's responsibility — Task 1 covers it — so these tests shrink to
+the pick logic.
+
+Replace the entire `unit_tests:` block with:
+
+```yaml
+unit_tests:
+  - name: test_address_of_record_student_linkage_decisive
+    description:
+      A student whose own linkage resolves takes their own address, even though
+      their primary contact's linkage is ambiguous.
+    model: int_finalsite__student_address_of_record
+    given:
+      - input: ref("stg_finalsite__contact_relationships")
+        rows:
+          - { finalsite_enrollment_id: stu-1, rel_id: par-1, is_primary: true }
+          - { finalsite_enrollment_id: par-1, rel_id: stu-1, is_primary: null }
+      - input: ref("int_finalsite__contact_address_of_record")
+        format: sql
+        rows: |
+          select
+            'stu-1' as finalsite_enrollment_id,
+            '123 Main St' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33101' as zip,
+            'US' as country,
+            true as is_complete_address,
+            1 as candidate_count,
+            'resolved' as resolution_status
+          union all
+          select 'par-1', null, null, null, null, null, null, null, 2,
+            'ambiguous'
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: stu-1, phone_1_number: null }
+          - { finalsite_enrollment_id: par-1, phone_1_number: "+13055550101" }
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: stu-1,
+            student_candidate_count: 1,
+            primary_contact_candidate_count: 2,
+            address_source: student_household,
+            address_1: 123 Main St,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: "33101",
+            country: US,
+            is_complete_address: true,
+            primary_contact_phone: "+13055550101",
+            resolution_status: student_household,
+          }
+
+  - name: test_address_of_record_primary_contact_fallback
+    description:
+      A student whose own linkage is ambiguous falls through to their primary
+      contact, whose linkage resolves.
+    model: int_finalsite__student_address_of_record
+    given:
+      - input: ref("stg_finalsite__contact_relationships")
+        rows:
+          - { finalsite_enrollment_id: stu-2, rel_id: par-2, is_primary: true }
+      - input: ref("int_finalsite__contact_address_of_record")
+        format: sql
+        rows: |
+          select
+            'stu-2' as finalsite_enrollment_id,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            cast(null as string) as country,
+            cast(null as bool) as is_complete_address,
+            2 as candidate_count,
+            'ambiguous' as resolution_status
+          union all
+          select 'par-2', '111 Palm Way', null, 'Miami', 'FL', '33103', 'US',
+            true, 1, 'resolved'
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: stu-2, phone_1_number: null }
+          - { finalsite_enrollment_id: par-2, phone_1_number: "+13055550102" }
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: stu-2,
+            student_candidate_count: 2,
+            primary_contact_candidate_count: 1,
+            address_source: primary_contact_household,
+            address_1: 111 Palm Way,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: "33103",
+            country: US,
+            is_complete_address: true,
+            primary_contact_phone: "+13055550102",
+            resolution_status: primary_contact_household,
+          }
+
+  - name: test_address_of_record_both_sides_ambiguous
+    description:
+      When neither the student nor their primary contact resolves, no address is
+      emitted and the row is flagged ambiguous.
+    model: int_finalsite__student_address_of_record
+    given:
+      - input: ref("stg_finalsite__contact_relationships")
+        rows:
+          - { finalsite_enrollment_id: stu-3, rel_id: par-3, is_primary: true }
+      - input: ref("int_finalsite__contact_address_of_record")
+        format: sql
+        rows: |
+          select
+            'stu-3' as finalsite_enrollment_id,
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            cast(null as string) as country,
+            cast(null as bool) as is_complete_address,
+            2 as candidate_count,
+            'ambiguous' as resolution_status
+          union all
+          select 'par-3', null, null, null, null, null, null, null, 3,
+            'ambiguous'
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: stu-3, phone_1_number: null }
+          - { finalsite_enrollment_id: par-3, phone_1_number: "+13055550103" }
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: stu-3,
+            student_candidate_count: 2,
+            primary_contact_candidate_count: 3,
+            address_source: null,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            primary_contact_phone: "+13055550103",
+            resolution_status: ambiguous,
+          }
+
+  - name: test_address_of_record_incomplete_address_is_emitted
+    description:
+      A student absent from the contact-address model entirely counts as zero
+      candidates and falls through to their primary contact. A resolved but
+      incomplete address is emitted rather than withheld, carrying
+      is_complete_address false — the behavior change this refactor introduces.
+    model: int_finalsite__student_address_of_record
+    given:
+      - input: ref("stg_finalsite__contact_relationships")
+        rows:
+          - { finalsite_enrollment_id: stu-4, rel_id: par-4, is_primary: true }
+          - { finalsite_enrollment_id: stu-5, rel_id: par-5, is_primary: true }
+      - input: ref("int_finalsite__contact_address_of_record")
+        format: sql
+        rows: |
+          select
+            'par-4' as finalsite_enrollment_id,
+            '555 Coral Dr' as address_1,
+            'Unit 7' as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33104' as zip,
+            'US' as country,
+            true as is_complete_address,
+            1 as candidate_count,
+            'resolved' as resolution_status
+          union all
+          select 'stu-5', '666 Reef Ln', null, 'Miami', 'FL', null, 'US', false,
+            1, 'resolved'
+          union all
+          select 'par-5', null, null, null, null, null, null, null, 0,
+            'no_street'
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: par-4, phone_1_number: "+13055550104" }
+          - { finalsite_enrollment_id: par-5, phone_1_number: "+13055550105" }
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: stu-4,
+            student_candidate_count: 0,
+            primary_contact_candidate_count: 1,
+            address_source: primary_contact_household,
+            address_1: 555 Coral Dr,
+            address_2: Unit 7,
+            city: Miami,
+            state: FL,
+            zip: "33104",
+            country: US,
+            is_complete_address: true,
+            primary_contact_phone: "+13055550104",
+            resolution_status: primary_contact_household,
+          }
+        - {
+            finalsite_enrollment_id: stu-5,
+            student_candidate_count: 1,
+            primary_contact_candidate_count: 0,
+            address_source: student_household,
+            address_1: 666 Reef Ln,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: null,
+            country: US,
+            is_complete_address: false,
+            primary_contact_phone: "+13055550105",
+            resolution_status: student_household,
+          }
+```
+
+- [ ] **Step 2: Run the unit tests to verify they fail**
+
+Run:
+
+```bash
+uv run dbt test \
+  --select int_finalsite__student_address_of_record,test_type:unit \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kippmiami \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
+```
+
+Expected: FAIL. The model still reads `int_finalsite__contacts__households`, so
+the mocked `int_finalsite__contact_address_of_record` input is unused and the
+tests produce empty or wrong output. A parse error naming an unused `given`
+input is also an acceptable failure here.
+
+- [ ] **Step 3: Rewrite the model SQL**
+
+Replace the whole body of
+`src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql`
+with:
+
+```sql
+with
+    student_primary_contacts as (
+        -- One row per student record. `relationships.primary` is a per-record
+        -- singleton that is true or NULL (never false), and only child/student
+        -- records carry it, so a bare `where is_primary` selects exactly the
+        -- student rows and `rel_id` is that student's Parent 1. A second primary
+        -- on one student would surface as a duplicate and fail this model's
+        -- uniqueness test, which is the intended loud failure. No SIS scoping —
+        -- receivers filter to enrolled students downstream.
+        select finalsite_enrollment_id, rel_id as primary_contact_id,
+        from {{ ref("stg_finalsite__contact_relationships") }}
+        where is_primary
+    ),
+
+    counted as (
+        -- Candidate counting and address identity live in
+        -- int_finalsite__contact_address_of_record, so both Focus feeds resolve
+        -- an address by one rule. A contact absent from that model has no
+        -- household rows at all, which counts as zero candidates.
+        select
+            spc.finalsite_enrollment_id,
+            spc.primary_contact_id,
+
+            coalesce(sa.candidate_count, 0) as student_candidate_count,
+            coalesce(pa.candidate_count, 0) as primary_contact_candidate_count,
+        from student_primary_contacts as spc
+        left join
+            {{ ref("int_finalsite__contact_address_of_record") }} as sa
+            on spc.finalsite_enrollment_id = sa.finalsite_enrollment_id
+        left join
+            {{ ref("int_finalsite__contact_address_of_record") }} as pa
+            on spc.primary_contact_id = pa.finalsite_enrollment_id
+    ),
+
+    sourced as (
+        -- The student's household linkage is a subset of their primary
+        -- contact's and is the disambiguating signal, so it is tried first.
+        -- Parents carry more household rows than students, so anchoring on the
+        -- parent unconditionally would move the pick onto the record with more
+        -- competing addresses.
+        select
+            finalsite_enrollment_id,
+            primary_contact_id,
+            student_candidate_count,
+            primary_contact_candidate_count,
+
+            case
+                when student_candidate_count = 1
+                then 'student_household'
+                when primary_contact_candidate_count = 1
+                then 'primary_contact_household'
+            end as address_source,
+            case
+                when student_candidate_count = 1
+                then finalsite_enrollment_id
+                when primary_contact_candidate_count = 1
+                then primary_contact_id
+            end as address_contact_id,
+        from counted
+    )
+
+select
+    s.finalsite_enrollment_id,
+    s.student_candidate_count,
+    s.primary_contact_candidate_count,
+    s.address_source,
+
+    a.address_1,
+    a.address_2,
+    a.city,
+    a.state,
+    a.zip,
+    a.country,
+    a.is_complete_address,
+
+    pc.phone_1_number as primary_contact_phone,
+
+    coalesce(s.address_source, 'ambiguous') as resolution_status,
+from sourced as s
+-- address_contact_id is only ever set to a contact whose candidate_count is
+-- exactly 1, so this join cannot fan out; when it is null (an unresolved
+-- address) nothing matches and the address fields stay null.
+left join
+    {{ ref("int_finalsite__contact_address_of_record") }} as a
+    on s.address_contact_id = a.finalsite_enrollment_id
+left join
+    {{ ref("stg_finalsite__contacts") }} as pc
+    on s.primary_contact_id = pc.finalsite_enrollment_id
+```
+
+- [ ] **Step 4: Update the model description, the completeness test, and column
+      docs**
+
+In the same properties file, make these four edits.
+
+Replace the model `description:` with:
+
+```yaml
+description:
+  One row per Finalsite student record — the student's resolved address of
+  record, or a flag when it cannot be resolved. Grain is
+  `finalsite_enrollment_id` for contacts that carry a `primary` relationship,
+  which is how a student record is identified without reaching for a
+  SIS-specific field; contacts with no primary link are absent entirely.
+  Resolution takes the student's own household linkage when
+  `int_finalsite__contact_address_of_record` resolves it to exactly one address,
+  falls back to their primary contact's when it does, and otherwise emits no
+  address. Address identity and the candidate rule live in that model, so this
+  feed and the contact feed resolve addresses the same way. An emitted address
+  is not guaranteed complete — check `is_complete_address`. SIS-agnostic — no
+  enrollment, status, or academic-year scoping; receivers filter downstream.
+```
+
+Replace the model-level `dbt_utils.expression_is_true` `expression:` with:
+
+```yaml
+expression: |
+  (address_source is not null and address_1 is not null)
+  or (
+      address_source is null
+      and address_1 is null
+      and address_2 is null
+      and city is null
+      and state is null
+      and zip is null
+  )
+```
+
+Replace the `address_source` description with:
+
+```yaml
+description:
+  Which record supplied the address — `student_household` or
+  `primary_contact_household`. Null when no address was resolved; a non-null
+  value guarantees `address_1` is populated, but not that the rest of the
+  address is.
+```
+
+Replace the `student_candidate_count` and `primary_contact_candidate_count`
+descriptions with:
+
+```yaml
+- name: student_candidate_count
+  data_type: int64
+  description:
+    Number of distinct addresses on the student's own household linkage, from
+    `int_finalsite__contact_address_of_record`. One means the student's own
+    records decide the address; anything else means the pick falls through to
+    the primary contact. Zero means no household linked to the student carries a
+    street line.
+- name: primary_contact_candidate_count
+  data_type: int64
+  description:
+    Number of distinct addresses on the primary contact's household linkage.
+    Used only when the student's own count is not one.
+```
+
+Add this column entry immediately after the `country` column:
+
+```yaml
+- name: is_complete_address
+  data_type: boolean
+  description:
+    Whether the resolved address carries street, city, state, and ZIP. An
+    incomplete address is emitted rather than withheld, so consumers that
+    require a mailable address must check this flag. Null when unresolved.
+```
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+Run the same command as Step 2.
+
+Expected: 4 unit tests PASS.
+
+- [ ] **Step 6: Build and prove parity against prod**
+
+Run:
+
+```bash
+uv run dbt build \
+  --select int_finalsite__contact_address_of_record int_finalsite__student_address_of_record \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kippmiami \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
+```
+
+Expected: both build, all data tests pass.
+
+Then run this parity query (BigQuery MCP) and read it carefully:
+
+```sql
+with
+    dev as (
+        select
+            finalsite_enrollment_id,
+            format(
+                '%T|%T|%T|%T|%T|%T', address_1, address_2, city, state, zip,
+                address_source
+            ) as tup
+        from `teamster-332318.zz_cbini_kippmiami_finalsite.int_finalsite__student_address_of_record`
+    ),
+    prd as (
+        select
+            finalsite_enrollment_id,
+            format(
+                '%T|%T|%T|%T|%T|%T', address_1, address_2, city, state, zip,
+                address_source
+            ) as tup
+        from `teamster-332318.kippmiami_finalsite.int_finalsite__student_address_of_record`
+    )
+select
+    countif(p.finalsite_enrollment_id is null) as only_in_dev,
+    countif(d.finalsite_enrollment_id is null) as only_in_prod,
+    countif(d.tup != p.tup) as changed_rows,
+    countif(d.tup != p.tup and p.tup like '%|NULL') as changed_from_unresolved,
+    count(*) as total
+from dev as d
+full join prd as p using (finalsite_enrollment_id)
+```
+
+Expected: `only_in_dev` 0, `only_in_prod` 0, `changed_rows` 6, and all 6 of
+those `changed_from_unresolved` — the students the normalization newly resolves.
+Any row that changed from one resolved address to a different one is a refactor
+bug; stop and diagnose before continuing.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml \
+  </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql \
+  src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "refactor(dbt): resolve the student address of record from the shared contact model
+
+Refs #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Expose the new model to kipptaf
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml`
+- Modify: `src/dbt/kipptaf/models/finalsite/sources-kippnewark.yml`
+- Modify: `src/dbt/kipptaf/models/finalsite/sources-kippcamden.yml`
+- Modify: `src/dbt/kipptaf/models/finalsite/sources-kipppaterson.yml`
+- Create:
+  `src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql`
+- Create:
+  `src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml`
+
+**Interfaces:**
+
+- Consumes: the four regional `int_finalsite__contact_address_of_record` sources
+  created in Task 1.
+- Produces: kipptaf-level `int_finalsite__contact_address_of_record` with every
+  package column plus `_dbt_source_relation` and `_dbt_source_project`. Task 4
+  joins it on `finalsite_enrollment_id`.
+
+- [ ] **Step 1: Add the source entry to all four regional source files**
+
+Append this block to the `tables:` list in each of the four files, changing
+`kipp<region>` to match the file. For
+`src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml`:
+
+```yaml
+- name: int_finalsite__contact_address_of_record
+  config:
+    meta:
+      dagster:
+        group: finalsite
+        asset_key:
+          - kippmiami
+          - finalsite
+          - int_finalsite__contact_address_of_record
+```
+
+Repeat with `kippnewark`, `kippcamden`, and `kipppaterson` as the first
+`asset_key` element in the respective files. Do not touch the `schema:`
+expression — the `dev` / `staging` / prod branch is already present on all four.
+
+- [ ] **Step 2: Write the union wrapper**
+
+Create
+`src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql`:
+
+```sql
+-- All four regions are unioned here, matching
+-- int_finalsite__student_address_of_record. Focus is the Miami consumer and the
+-- NJ regions carry no Focus student id, so the `rpt_focus__*` filter on
+-- `focus_student_id_prefixed` keeps their rows out of the Focus feeds.
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippcamden_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kippmiami_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kippnewark_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kipppaterson_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                ]
+            )
+        }}
+    )
+
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
+from union_relations
+```
+
+- [ ] **Step 3: Write the wrapper properties file**
+
+Create
+`src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml`:
+
+```yaml
+models:
+  - name: int_finalsite__contact_address_of_record
+    description:
+      Network-wide union of the per-region Finalsite
+      `int_finalsite__contact_address_of_record` models — one row per Finalsite
+      contact with its resolved address, or a `resolution_status` explaining why
+      it has none. Includes all four regions; Focus is the Miami consumer and
+      the NJ regions carry no Focus student id, so the `rpt_focus__*` filter on
+      `focus_student_id_prefixed` keeps their rows out of the Focus feeds.
+      Column documentation lives on the package model. Carries
+      `_dbt_source_relation` and the derived `_dbt_source_project`.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: finalsite_enrollment_id
+        data_type: string
+        description: Finalsite contact UUID; the grain.
+        data_tests:
+          - unique
+          - not_null
+```
+
+- [ ] **Step 4: Verify the wrapper parses and resolves its columns**
+
+Run:
+
+```bash
+uv run dbt compile \
+  --select int_finalsite__contact_address_of_record \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kipptaf \
+  --target staging
+```
+
+Expected: compiles. Read
+`<worktree>/src/dbt/kipptaf/target/compiled/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql`
+and confirm the column list expanded — an EMPTY expansion still compiles clean
+and means the `zz_stg_*` relations do not yet hold the model. That is expected
+at this point and is what Task 5 fixes; re-read this file after Task 5.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kippnewark.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kippcamden.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kipppaterson.yml \
+  src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql \
+  src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml \
+  </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kippnewark.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kippcamden.yml \
+  src/dbt/kipptaf/models/finalsite/sources-kipppaterson.yml \
+  src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql \
+  src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "feat(dbt): union the Finalsite contact address of record into kipptaf
+
+Refs #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Join the resolved address into `rpt_focus__contacts`
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql:21-25,64-77`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml`
+  (five column descriptions, the model description, and the unit test's
+  `stg_finalsite__contacts` fixture)
+
+**Interfaces:**
+
+- Consumes: kipptaf `int_finalsite__contact_address_of_record` from Task 3.
+- Produces: no contract change. The 50-column `CONTACTS_LAYOUT` output is
+  unchanged in name, order, and type; only the values behind `address`,
+  `address2`, `city`, `state`, and `zipcode` move.
+
+- [ ] **Step 1: Change the address projection and add the join**
+
+In `src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql`, replace
+lines 21-25:
+
+```sql
+    g.address_1 as address,
+    g.address_2 as address2,
+    g.city,
+    g.state,
+    g.zip as zipcode,
+```
+
+with:
+
+```sql
+    aor.address_1 as address,
+    aor.address_2 as address2,
+    aor.city,
+    aor.state,
+    aor.zip as zipcode,
+```
+
+Then add this join immediately after the `int_finalsite__contact_id_attributes`
+join and before the second `stg_finalsite__contacts` join:
+
+```sql
+-- the guardian's own household linkage decides their address; array position
+-- does not identify Finalsite's primary household. Unresolved keeps the row and
+-- nulls the address — the feed is import-once, so a wrong address is permanent,
+-- while the name, relationship, email, and phones are still worth sending.
+left join
+    {{ ref("int_finalsite__contact_address_of_record") }} as aor
+    on rel.rel_id = aor.finalsite_enrollment_id
+```
+
+- [ ] **Step 2: Update the five address column descriptions**
+
+In `src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml`,
+replace the five address column descriptions:
+
+```yaml
+- name: address
+  data_type: string
+  description:
+    Line 1 of the guardian's resolved address from
+    `int_finalsite__contact_address_of_record`. Null when the guardian's
+    household linkage does not resolve to exactly one address; the row is still
+    sent.
+- name: address2
+  data_type: string
+  description:
+    Line 2 (apartment or unit) of the guardian's resolved address. Legitimately
+    null when the household has no unit line, and null whenever the address is
+    unresolved.
+- name: city
+  data_type: string
+  description:
+    City of the guardian's resolved address. Null when unresolved, and possibly
+    null on a resolved but incomplete address.
+- name: state
+  data_type: string
+  description:
+    State of the guardian's resolved address. Null when unresolved, and possibly
+    null on a resolved but incomplete address.
+- name: zipcode
+  data_type: string
+  description:
+    ZIP code of the guardian's resolved address. Null when unresolved, and
+    possibly null on a resolved but incomplete address.
+```
+
+- [ ] **Step 3: Update the model description**
+
+Replace the sentence `Phone slots \`CONTACT1__\` and \`CONTACT2__\` map the
+guardian's two
+phones;`... through the end of that sentence, and insert an address sentence. The model`description:`
+becomes:
+
+```yaml
+description:
+  One row per (student, guardian) reshaped into the Focus `CONTACTS` SFTP
+  template layout. Fans out guardian contact rows from
+  `stg_finalsite__contact_relationships` (adult relationship types — parent,
+  guardian, grandparent, stepparent, relative, aunt/uncle) inner-joined to
+  `stg_finalsite__contacts` for guardian attributes, gated to in-scope students
+  via `int_finalsite__enrollment_lifecycle`. The student's Focus id
+  (`student_id`) is inner-joined from `int_finalsite__contact_id_attributes`,
+  excluding students without a minted Focus id. A second join to
+  `stg_finalsite__contacts` on the student's own `finalsite_enrollment_id`
+  restricts the feed to guardians of students whose own `status` is `enrolled` —
+  the guardian's own status is not considered. The address comes from
+  `int_finalsite__contact_address_of_record`, resolved from the guardian's own
+  household linkage; a guardian whose linkage does not resolve keeps their row
+  and gets a null address. Produces 50 columns in `CONTACTS_LAYOUT` order.
+  `SORT_ORDER` ranks guardians per student by `is_primary desc` so the primary
+  contact sorts first. Phone slots `CONTACT1_*` and `CONTACT2_*` map the
+  guardian's two phones; `CONTACT3` through `CONTACT7` are always null. Focus
+  column header casing is applied at transport time via
+  `file_config.format.header_replacements`; dbt column names remain lowercase
+  snake_case.
+```
+
+- [ ] **Step 4: Update the unit test fixtures**
+
+The unit test's `stg_finalsite__contacts` rows currently supply the guardian
+addresses. Remove `address_1`, `address_2`, `city`, `state`, and `zip` from the
+three guardian rows (`enr-grd-pri`, `enr-grd-sec`, `enr-grd-003`) so they carry
+only names, email, and phones, and add a new mocked input.
+
+Add this `given` input after the `int_finalsite__contact_id_attributes` block:
+
+```yaml
+- input: ref("int_finalsite__contact_address_of_record")
+  format: sql
+  rows: |
+    select
+      'enr-grd-pri' as finalsite_enrollment_id,
+      '100 Main St' as address_1,
+      cast(null as string) as address_2,
+      'Miami' as city,
+      'FL' as state,
+      '33101' as zip
+    union all
+    select 'enr-grd-sec', '200 Oak Ave', null, 'Miami', 'FL', '33102'
+```
+
+The `expect` rows keep their existing `address` / `address2` / `city` / `state`
+/ `zipcode` values — the point of the test is that the layout is unchanged. Note
+that `enr-grd-003` is deliberately absent from the new input; that guardian
+belongs to a non-enrolled student and is excluded from the feed anyway.
+
+- [ ] **Step 5: Run the whole Focus unit-test directory**
+
+Run:
+
+```bash
+uv run dbt test \
+  --select "test_type:unit,extracts.focus" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kipptaf \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: PASS. Run the whole directory, not just this model — sibling Focus
+models mock the same refs and a fixture change can break them.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql \
+  src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml \
+  </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql \
+  src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "fix(dbt): resolve the Focus CONTACT address from the guardian household linkage
+
+Closes #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Seed the staging copies and fix the stale address comment
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql:28-31`
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces:
+  `zz_stg_kipp{miami,newark,camden,paterson}_finalsite.int_finalsite__contact_address_of_record`
+  in BigQuery, which dbt Cloud CI reads to resolve the Task 3 union's column
+  list.
+
+- [ ] **Step 1: Correct the now-false completeness comment**
+
+In `src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql`, replace
+lines 28-31:
+
+```sql
+-- an unresolved address is withheld, not exported blank: the feed is
+-- import-once with no overwrite path, so a blank or wrong address of record is
+-- permanent. address_source is not null guarantees a complete address.
+where stu.status = 'enrolled' and aor.address_source is not null
+```
+
+with:
+
+```sql
+-- an unresolved address is withheld, not exported blank: the feed is
+-- import-once with no overwrite path, so a blank or wrong address of record is
+-- permanent. address_source is not null guarantees a street line, not a
+-- complete address — an incomplete one is exported for Ops to correct in Focus,
+-- since a missing field is visible there in a way a wrong pick is not.
+where stu.status = 'enrolled' and aor.address_source is not null
+```
+
+- [ ] **Step 2: Ask the user to authorize the staging builds**
+
+STOP. These four commands write to shared `zz_stg_*` datasets. Ask the user to
+authorize them by name before running:
+
+> "Ready to seed the four `zz_stg_<district>_finalsite` staging copies by
+> running
+> `dbt build --select int_finalsite__contact_address_of_record --target staging`
+> against kippmiami, kippnewark, kippcamden, and kipppaterson. Confirm?"
+
+Wait for their answer. Do not run Step 3 without it.
+
+- [ ] **Step 3: Build the new model into each district's staging schema**
+
+Run once per district, substituting `kippmiami`, `kippnewark`, `kippcamden`,
+`kipppaterson`:
+
+```bash
+uv run dbt build \
+  --select int_finalsite__contact_address_of_record \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/<district> \
+  --target staging
+```
+
+Expected: four successful builds. `dbt clone` is NOT an option here — the model
+is absent from the prod manifest, so a clone skips it silently.
+
+- [ ] **Step 4: Confirm the union now expands**
+
+Re-run the Task 3 Step 4 compile and re-read the compiled SQL. Expected: the
+column list is now populated with the package model's columns across all four
+regional relations.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "docs(dbt): correct the ADDRESS feed completeness guarantee
+
+Refs #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Validate branch 1 against prod, update the ops doc, open the PR
+
+**Files:**
+
+- Modify: `docs/reference/finalsite-focus-import.md` (the "Blank addresses and
+  nameless contacts are held back" section and the "What the enrollment team
+  should watch for" list)
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1-5.
+- Produces: PR against `main` closing #4651.
+
+- [ ] **Step 1: Measure the feed against prod**
+
+Build the extract into dev and compare it to the live prod view:
+
+```bash
+uv run dbt build \
+  --select rpt_focus__contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record/src/dbt/kipptaf \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Then run this comparison (BigQuery MCP), replacing the dev schema if it differs:
+
+```sql
+with
+    dev as (
+        select
+            student_id,
+            sort_order,
+            format('%T|%T|%T|%T|%T', address, address2, city, state, zipcode)
+            as tup
+        from `teamster-332318.zz_cbini_kipptaf_extracts.rpt_focus__contacts`
+    ),
+    prd as (
+        select
+            student_id,
+            sort_order,
+            format('%T|%T|%T|%T|%T', address, address2, city, state, zipcode)
+            as tup
+        from `teamster-332318.kipptaf_extracts.rpt_focus__contacts`
+    )
+select
+    count(*) as total_rows,
+    countif(d.student_id is null) as only_in_prod,
+    countif(p.student_id is null) as only_in_dev,
+    countif(d.tup not like 'NULL|%') as rows_with_address,
+    countif(
+        d.tup != p.tup and d.tup not like 'NULL|%' and p.tup not like 'NULL|%'
+    ) as address_values_changed,
+    countif(d.tup not like 'NULL|%' and p.tup like 'NULL|%') as newly_enabled,
+    countif(d.tup like 'NULL|%' and p.tup not like 'NULL|%') as newly_withheld
+from dev as d
+full join prd as p using (student_id, sort_order)
+```
+
+Expected, from the spec: `total_rows` 2,601, `only_in_prod` 0, `only_in_dev` 0,
+`rows_with_address` 2,081, `address_values_changed` **0**, `newly_enabled` 42,
+`newly_withheld` 436. A non-zero `address_values_changed` means an address moved
+rather than being withheld — stop and diagnose. Small drift in the totals is
+possible if Finalsite data moved since 2026-07-31; a change in
+`address_values_changed` is not.
+
+Keep this output local. Do not paste address values anywhere.
+
+- [ ] **Step 2: Update the ops doc**
+
+In `docs/reference/finalsite-focus-import.md`, replace the `- **Contacts**`
+bullet in the "Blank addresses and nameless contacts are held back" section
+with:
+
+```markdown
+- **Contacts** — a contact is sent only once it has a name. A nameless contact
+  is skipped and flows once the name is filled in. A guardian's address is
+  resolved the same way a student's is, but from the guardian's own households:
+  when Finalsite links them to more than one address, the contact is still sent
+  with the rest of their details and the address is left blank rather than
+  guessed. Guardians are usually linked to more households than their children,
+  so this is more common on the contact record than on the student.
+```
+
+In the same file, replace this sentence in the "What gets sent" list item for
+Addresses and Contacts:
+
+```markdown
+- **Addresses and Contacts** — sent only once the student is **enrolled**, Focus
+  does not already have the record for that student, **and** the record is
+  complete (a full address; a named contact). For Contacts, it's the
+  **student's** enrolled status that gates the feed, not the guardian contact's
+  own. Blank or incomplete records are held back until populated (see below).
+```
+
+with:
+
+```markdown
+- **Addresses and Contacts** — sent only once the student is **enrolled**, Focus
+  does not already have the record for that student, **and** Finalsite points to
+  a single address for them (a named contact, for Contacts). For Contacts, it's
+  the **student's** enrolled status that gates the feed, not the guardian
+  contact's own. An address Finalsite cannot narrow to one is held back; a
+  partial address is now sent rather than held, so it can be spotted and
+  corrected in Focus.
+```
+
+Add this bullet to the "What the enrollment team should watch for" list, after
+the duplicate-households bullet:
+
+```markdown
+- **A partial address now imports rather than waiting.** An address missing its
+  city, state, or ZIP is sent to Focus so you can see and fix it there, instead
+  of the student silently having no address. An address Finalsite cannot narrow
+  down to one is still held back — that one cannot be guessed safely.
+```
+
+- [ ] **Step 3: Lint the doc and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/reference/finalsite-focus-import.md </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record add \
+  docs/reference/finalsite-focus-import.md
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record commit -m "docs: describe contact address resolution for the enrollment team
+
+Refs #4651
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Push and open the PR as a draft**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-focus-contacts-address-of-record push -u origin cbini/fix/claude-focus-contacts-address-of-record
+```
+
+Open the PR with `mcp__github__create_pull_request`, base `main`, `draft: true`,
+body built from `.github/pull_request_template.md`. The body must state the
+measured deltas from Step 1, note that editing four `sources-kipp*.yml` files
+fans `state:modified+` across every kipptaf model reading finalsite, and record
+that the four `zz_stg` staging copies were seeded in Task 5. Avoid `&` and `"`
+in the title. Include `Closes #4651`.
+
+- [ ] **Step 5: Wait for CI, then mark ready for review**
+
+Poll both surfaces — dbt Cloud is a commit status, Trunk and CodeQL are check
+runs:
+
+```bash
+gh pr checks <pr-number> --json name,bucket,state
+```
+
+When everything is green, fetch dbt Cloud warnings with
+`mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)` and treat
+warnings unchanged from `main` as pre-existing. Then mark the PR ready via
+GraphQL `markPullRequestReadyForReview` so `claude-review` fires. Do not use the
+REST `draft=false` PATCH — it silently no-ops.
+
+---
+
+## Branch 2 — #4652
+
+### Task 7: Create the stacked branch and worktree
+
+**Files:** none.
+
+**Interfaces:**
+
+- Consumes: branch 1's committed work.
+- Produces: worktree
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency`
+  on branch `cbini/feat/claude-focus-contacts-emergency`, based on branch 1.
+
+- [ ] **Step 1: Ask the user to confirm the stacked branch**
+
+STOP. Branch creation needs explicit consent in the immediately preceding
+message, because the auto-classifier cannot see earlier approvals. Ask:
+
+> "Ready to create the stacked branch
+> `cbini/feat/claude-focus-contacts-emergency` off
+> `cbini/fix/claude-focus-contacts-address-of-record` for #4652, with its own
+> worktree. Confirm?"
+
+- [ ] **Step 2: Create the linked branch and worktree**
+
+```bash
+gh issue develop 4652 \
+  --name cbini/feat/claude-focus-contacts-emergency \
+  --base cbini/fix/claude-focus-contacts-address-of-record
+git fetch origin cbini/feat/claude-focus-contacts-emergency
+git worktree add \
+  /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency \
+  cbini/feat/claude-focus-contacts-emergency
+uv run dbt deps --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency/src/dbt/kipptaf
+```
+
+Expected: branch created and linked to #4652, worktree checked out, packages
+installed.
+
+Every path in Tasks 8-10 is relative to this second worktree, not branch 1's.
+
+---
+
+### Task 8: Union emergency rows into `rpt_focus__contacts`
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql` (full
+  restructure)
+
+**Interfaces:**
+
+- Consumes: kipptaf `int_finalsite__contact_custom_attributes` — columns
+  `finalsite_enrollment_id`, and for each `N` in 1..4: `emrg_N_name_first_name`,
+  `emrg_N_name_last_name`, `emrg_N_email`, `emrg_N_relationship_ss`,
+  `emrg_N_relationship_txt`, `emrg_N_custody_yn`, `emrg_N_lives_with_yn`,
+  `emrg_N_pickup_yn`, and `emrg_N_phone_{1,2,3}_{type,number}`.
+  `emrg_N_name_middle_name` exists for N in 1..2 ONLY — slots 3 and 4 have no
+  middle-name field in the pivot.
+- Produces: the same 50 columns in the same order. No contract change.
+
+- [ ] **Step 1: Restructure the model**
+
+Rewrite `src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql` as a
+`guardians` CTE, a four-branch `emergency_long` CTE, an `all_contacts` union
+that assigns `sort_order`, and a final projection of the 50 layout columns.
+
+The `guardians` CTE is the current query minus `sort_order`, plus two ordering
+columns and the four flag columns as nulls:
+
+```sql
+with
+    guardians as (
+        select
+            rel.relationship_id,
+            rel.rel_type as student_relation,
+
+            g.first_name,
+            g.middle_name,
+            g.last_name,
+            g.email,
+            g.phone_1_type as contact1_type,
+            g.phone_1_number as contact1_value,
+            g.phone_2_type as contact2_type,
+            g.phone_2_number as contact2_value,
+
+            ida.focus_student_id_prefixed as student_id,
+
+            aor.address_1 as address,
+            aor.address_2 as address2,
+            aor.city,
+            aor.state,
+            aor.zip as zipcode,
+
+            0 as contact_group,
+
+            cast(null as string) as resides_with_stud,
+            cast(null as string) as custody,
+            cast(null as string) as emergency,
+            cast(null as string) as pickup,
+            cast(null as string) as contact3_type,
+            cast(null as string) as contact3_value,
+
+            if(rel.is_primary, 0, 1) as group_rank,
+        from {{ ref("stg_finalsite__contact_relationships") }} as rel
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as g
+            on rel.rel_id = g.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+            on rel.finalsite_enrollment_id = l.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as ida
+            on rel.finalsite_enrollment_id = ida.finalsite_enrollment_id
+            and ida.focus_student_id_prefixed is not null
+        left join
+            {{ ref("int_finalsite__contact_address_of_record") }} as aor
+            on rel.rel_id = aor.finalsite_enrollment_id
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as stu
+            on rel.finalsite_enrollment_id = stu.finalsite_enrollment_id
+            and stu.status = 'enrolled'
+        where
+            rel.rel_type in (
+                'parent',
+                'guardian',
+                'grandparent',
+                'stepparent',
+                'relative',
+                'aunt/uncle'
+            )
+    ),
+```
+
+`if(rel.is_primary, 0, 1)` returns NULL when `is_primary` is NULL, which would
+sort last under `order by group_rank`. That is the existing behavior of
+`order by rel.is_primary desc` and is intentional — do not "fix" it with a
+`coalesce`.
+
+The `emergency_long` CTE has four `union all` branches. Write branch 1 as shown
+below, then produce branches 2, 3, and 4 by copying it whole and applying
+exactly these substitutions — nothing else changes:
+
+| Branch | Column prefix | `group_rank` literal | `middle_name` expression              |
+| ------ | ------------- | -------------------- | ------------------------------------- |
+| 1      | `emrg_1_`     | `1`                  | `a.emrg_1_name_middle_name`           |
+| 2      | `emrg_2_`     | `2`                  | `a.emrg_2_name_middle_name`           |
+| 3      | `emrg_3_`     | `3`                  | `cast(null as string) as middle_name` |
+| 4      | `emrg_4_`     | `4`                  | `cast(null as string) as middle_name` |
+
+`1 as contact_group` and `'Y' as emergency` stay literal in all four. Slots 3
+and 4 have no `emrg_N_name_middle_name` field in the pivot, which is why their
+`middle_name` is a cast null; moving it out of the plain-ref group and into the
+simple-function group also keeps ST06 satisfied. `relationship_id` is `STRING`
+in `stg_finalsite__contact_relationships`, so `cast(null as string)` unions
+cleanly with the guardian branch.
+
+Note that the file's existing
+`-- trunk-ignore(sqlfluff/ST06): column order fixed by Focus CONTACTS contract`
+covers only the `select` on the line immediately after it. Keep it on the FINAL
+projection, where the contract fixes the order, and order columns inside every
+CTE properly: plain refs grouped by source table in join order, then constants,
+then simple functions, then logicals.
+
+```sql
+    emergency_long as (
+        -- Positional passthrough: emergency_N is the emrg_N custom-field set
+        -- as-is. Finalsite emergency contacts are custom fields on the
+        -- student's own record, not relationship rows, so they never reach the
+        -- relationship-type filter above. The shape here mirrors
+        -- int_finalsite__student_contacts, which cannot be ref'd — it excludes
+        -- Miami to avoid double-counting against the PowerSchool branch of
+        -- int_students__contacts.
+        select
+            a.emrg_1_name_first_name as first_name,
+            a.emrg_1_name_middle_name as middle_name,
+            a.emrg_1_name_last_name as last_name,
+            a.emrg_1_email as email,
+            a.emrg_1_phone_1_type as contact1_type,
+            a.emrg_1_phone_1_number as contact1_value,
+            a.emrg_1_phone_2_type as contact2_type,
+            a.emrg_1_phone_2_number as contact2_value,
+            a.emrg_1_phone_3_type as contact3_type,
+            a.emrg_1_phone_3_number as contact3_value,
+
+            ida.focus_student_id_prefixed as student_id,
+
+            1 as contact_group,
+            1 as group_rank,
+            'Y' as emergency,
+
+            cast(null as string) as relationship_id,
+            cast(null as string) as address,
+            cast(null as string) as address2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zipcode,
+
+            coalesce(
+                a.emrg_1_relationship_ss, a.emrg_1_relationship_txt
+            ) as student_relation,
+
+            if(a.emrg_1_lives_with_yn, 'Y', null) as resides_with_stud,
+            if(a.emrg_1_custody_yn, 'Y', null) as custody,
+            if(a.emrg_1_pickup_yn, 'Y', null) as pickup,
+        from {{ ref("int_finalsite__contact_custom_attributes") }} as a
+        inner join
+            {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+            on a.finalsite_enrollment_id = l.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as ida
+            on a.finalsite_enrollment_id = ida.finalsite_enrollment_id
+            and ida.focus_student_id_prefixed is not null
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as stu
+            on a.finalsite_enrollment_id = stu.finalsite_enrollment_id
+            and stu.status = 'enrolled'
+        where
+            a.emrg_1_name_first_name is not null
+            and a.emrg_1_name_first_name != ''
+
+        union all
+
+        -- ... repeat for emrg_2 (group_rank 2), emrg_3 (group_rank 3, null
+        -- middle_name), emrg_4 (group_rank 4, null middle_name)
+    ),
+```
+
+The `all_contacts` CTE unions the two, listing every column explicitly in both
+branches (a `select *` inside a `UNION ALL` trips sqlfluff CV03), and derives
+`sort_order`:
+
+```sql
+    all_contacts as (
+        select
+            student_id,
+            relationship_id,
+            student_relation,
+            first_name,
+            middle_name,
+            last_name,
+            email,
+            contact1_type,
+            contact1_value,
+            contact2_type,
+            contact2_value,
+            contact3_type,
+            contact3_value,
+            address,
+            address2,
+            city,
+            state,
+            zipcode,
+            resides_with_stud,
+            custody,
+            emergency,
+            pickup,
+            contact_group,
+            group_rank,
+        from guardians
+
+        union all
+
+        select
+            student_id,
+            relationship_id,
+            student_relation,
+            first_name,
+            middle_name,
+            last_name,
+            email,
+            contact1_type,
+            contact1_value,
+            contact2_type,
+            contact2_value,
+            contact3_type,
+            contact3_value,
+            address,
+            address2,
+            city,
+            state,
+            zipcode,
+            resides_with_stud,
+            custody,
+            emergency,
+            pickup,
+            contact_group,
+            group_rank,
+        from emergency_long
+    ),
+
+    ranked as (
+        -- Guardians hold ranks 1..N in their existing order, then emergency
+        -- slots follow in emrg_1..4 order. Miami populates no
+        -- emrg_N_priority_ss at all, so there is nothing to interleave on.
+        -- relationship_id is the final tiebreak so two guardians sharing
+        -- is_primary and both names get a stable rank between runs.
+        select
+            *,
+
+            row_number() over (
+                partition by student_id
+                order by
+                    contact_group asc,
+                    group_rank asc,
+                    last_name asc,
+                    first_name asc,
+                    relationship_id asc
+            ) as sort_order,
+        from all_contacts
+    )
+```
+
+The final `SELECT` lists the 50 layout columns in `CONTACTS_LAYOUT` order —
+identical to the current model's projection — reading from `ranked` instead of
+the join chain, and keeps the existing
+`-- trunk-ignore(sqlfluff/ST06): column order fixed by Focus CONTACTS contract`
+comment on the line above `select`.
+
+- [ ] **Step 2: Build and check the row counts**
+
+```bash
+uv run dbt build \
+  --select rpt_focus__contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency/src/dbt/kipptaf \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: builds, and the
+`dbt_utils.unique_combination_of_columns(student_id, sort_order)` test passes. A
+failure there means `row_number()` is partitioned or ordered wrongly.
+
+Then confirm the shape:
+
+```sql
+select
+    countif(emergency is null) as guardian_rows,
+    countif(emergency = 'Y') as emergency_rows,
+    count(distinct if(emergency = 'Y', student_id, null)) as students_with_emergency,
+    countif(emergency = 'Y' and contact3_value is not null) as emergency_third_phones,
+    countif(emergency = 'Y' and address is not null) as emergency_rows_with_address,
+    count(*) as total_rows
+from `teamster-332318.zz_cbini_kipptaf_extracts.rpt_focus__contacts`
+```
+
+Expected: `guardian_rows` 2,601, `emergency_rows` 923, `students_with_emergency`
+464, `emergency_rows_with_address` **0**, `total_rows` 3,524.
+
+Also confirm the ordering rule holds — no emergency row may outrank a guardian
+row for the same student:
+
+```sql
+with
+    boundaries as (
+        select
+            student_id,
+            max(if(emergency is null, sort_order, 0)) as last_guardian,
+            min(if(emergency = 'Y', sort_order, 9999)) as first_emergency
+        from `teamster-332318.zz_cbini_kipptaf_extracts.rpt_focus__contacts`
+        group by student_id
+    )
+select countif(first_emergency < last_guardian) as violations
+from boundaries
+```
+
+Expected: `violations` 0.
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency add \
+  src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency commit -m "feat(dbt): append Finalsite emergency contacts to the Focus CONTACTS feed
+
+Refs #4652
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Document the emergency rows and add a unit test
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml`
+
+**Interfaces:**
+
+- Consumes: Task 8's output columns.
+- Produces: no schema change; documentation and one new unit test.
+
+- [ ] **Step 1: Update the four flag column descriptions**
+
+Replace the `resides_with_stud`, `custody`, `emergency`, and `pickup` column
+descriptions:
+
+```yaml
+      - name: resides_with_stud
+        data_type: string
+        description:
+          `Y` when the emergency contact is recorded as living with the student
+          (`emrg_N_lives_with_yn`), else null. Always null on guardian rows — the
+          relationship grain carries no equivalent field. Null in KIPP Miami
+          today, where the emergency form does not collect it.
+      - name: custody
+        data_type: string
+        description:
+          `Y` when the emergency contact is recorded as having custody
+          (`emrg_N_custody_yn`), else null. Always null on guardian rows. Null in
+          KIPP Miami today, where the emergency form does not collect it.
+      - name: emergency
+        data_type: string
+        description:
+          `Y` on rows sourced from a Finalsite `emrg_N` emergency-contact slot,
+          null on guardian rows. Derived, not sourced from a Finalsite field.
+      - name: pickup
+        data_type: string
+        description:
+          `Y` when the emergency contact is authorized for pickup
+          (`emrg_N_pickup_yn`), else null. Always null on guardian rows. Null in
+          KIPP Miami today, where the emergency form does not collect it. The
+          separate `pickup_1..3` and `nonpickup_1..3` Finalsite blocks are
+          deliberately not sourced — they are name-only, and `nonpickup` names
+          people barred from pickup, which this layout cannot express.
+```
+
+- [ ] **Step 2: Update the `contact3_*`, `sort_order`, and model descriptions**
+
+Replace the `contact3_type` and `contact3_value` descriptions:
+
+```yaml
+- name: contact3_type
+  data_type: string
+  description:
+    Type label of the emergency contact's third phone (`emrg_N_phone_3_type`).
+    Null on guardian rows, which carry two phones.
+- name: contact3_value
+  data_type: string
+  description:
+    Number of the emergency contact's third phone (`emrg_N_phone_3_number`).
+    Null on guardian rows.
+```
+
+Replace the `sort_order` description:
+
+```yaml
+- name: sort_order
+  data_type: int64
+  description:
+    Ordinal rank of this contact within the student. Guardian rows come first,
+    ordered by `is_primary desc` then last and first name, with
+    `relationship_id` as a stable tiebreak; emergency-slot rows follow in
+    `emrg_1` through `emrg_4` order. KIPP Miami populates no
+    `emrg_N_priority_ss`, so emergency rows are not interleaved by priority.
+```
+
+In the model `description:`, replace the sentence `Phone slots \`CONTACT1__\`
+and \`CONTACT2__\` map the guardian's two phones; \`CONTACT3\` through
+\`CONTACT7\` are always null.` with:
+
+```text
+      Emergency contacts are appended from the four `emrg_N` slots on
+      `int_finalsite__contact_custom_attributes` — they are custom fields on the
+      student's own record rather than relationship rows, so the relationship
+      filter never sees them. Phone slots `CONTACT1_*` and `CONTACT2_*` map a
+      guardian's two phones; an emergency row additionally fills `CONTACT3_*`
+      from its third phone. `CONTACT4` through `CONTACT7` are always null.
+```
+
+Also change the opening sentence from `One row per (student, guardian)` to
+`One row per (student, contact) — guardians plus emergency-contact slots —`.
+
+- [ ] **Step 3: Add the emergency unit test**
+
+Append this to the `unit_tests:` block:
+
+```yaml
+- name: test_contacts_guardians_then_emergency_slots
+  description:
+    One student with two guardians and two populated emergency slots. Guardians
+    take SORT_ORDER 1 and 2 by is_primary then name; emergency slots take 3 and
+    4 in emrg_N order. Emergency rows carry EMERGENCY `Y`, a null address, and a
+    third phone; guardian rows carry a null EMERGENCY and no third phone. An
+    emrg_3 slot with a blank first name produces no row.
+  model: rpt_focus__contacts
+  given:
+    - input: ref("int_finalsite__enrollment_lifecycle")
+      rows:
+        - { finalsite_enrollment_id: enr-stu-001 }
+    - input: ref("stg_finalsite__contact_relationships")
+      rows:
+        - {
+            finalsite_enrollment_id: enr-stu-001,
+            relationship_id: rel-001,
+            rel_id: enr-grd-pri,
+            rel_name: Alice Johnson,
+            rel_type: parent,
+            is_primary: true,
+            is_financial: true,
+            has_portal_access: true,
+          }
+        - {
+            finalsite_enrollment_id: enr-stu-001,
+            relationship_id: rel-002,
+            rel_id: enr-grd-sec,
+            rel_name: Bob Smith,
+            rel_type: guardian,
+            is_primary: false,
+            is_financial: false,
+            has_portal_access: false,
+          }
+    - input: ref("stg_finalsite__contacts")
+      rows:
+        - { finalsite_enrollment_id: enr-stu-001, status: enrolled }
+        - {
+            finalsite_enrollment_id: enr-grd-pri,
+            first_name: Alice,
+            middle_name: B,
+            last_name: Johnson,
+            email: alice@example.com,
+            phone_1_type: Home,
+            phone_1_number: "+13055550100",
+            phone_2_type: Cell,
+            phone_2_number: "+13055550101",
+          }
+        - {
+            finalsite_enrollment_id: enr-grd-sec,
+            first_name: Bob,
+            middle_name: null,
+            last_name: Smith,
+            email: bob@example.com,
+            phone_1_type: Work,
+            phone_1_number: "+13055550200",
+            phone_2_type: null,
+            phone_2_number: null,
+          }
+    - input: ref("int_finalsite__contact_id_attributes")
+      format: sql
+      rows: |
+        select
+          'enr-stu-001' as finalsite_enrollment_id,
+          '84002002002' as focus_student_id_prefixed
+    - input: ref("int_finalsite__contact_address_of_record")
+      format: sql
+      rows: |
+        select
+          'enr-grd-pri' as finalsite_enrollment_id,
+          '100 Main St' as address_1,
+          cast(null as string) as address_2,
+          'Miami' as city,
+          'FL' as state,
+          '33101' as zip
+        union all
+        select 'enr-grd-sec', '200 Oak Ave', null, 'Miami', 'FL', '33102'
+    - input: ref("int_finalsite__contact_custom_attributes")
+      format: sql
+      rows: |
+        select
+          'enr-stu-001' as finalsite_enrollment_id,
+          'Carla' as emrg_1_name_first_name,
+          cast(null as string) as emrg_1_name_middle_name,
+          'Reyes' as emrg_1_name_last_name,
+          'carla@example.com' as emrg_1_email,
+          'Aunt' as emrg_1_relationship_ss,
+          cast(null as string) as emrg_1_relationship_txt,
+          true as emrg_1_custody_yn,
+          true as emrg_1_lives_with_yn,
+          true as emrg_1_pickup_yn,
+          'Cell' as emrg_1_phone_1_type,
+          '+13055550301' as emrg_1_phone_1_number,
+          'Home' as emrg_1_phone_2_type,
+          '+13055550302' as emrg_1_phone_2_number,
+          'Work' as emrg_1_phone_3_type,
+          '+13055550303' as emrg_1_phone_3_number,
+          'Dan' as emrg_2_name_first_name,
+          cast(null as string) as emrg_2_name_middle_name,
+          'Ortiz' as emrg_2_name_last_name,
+          cast(null as string) as emrg_2_email,
+          cast(null as string) as emrg_2_relationship_ss,
+          'Neighbor' as emrg_2_relationship_txt,
+          cast(null as bool) as emrg_2_custody_yn,
+          cast(null as bool) as emrg_2_lives_with_yn,
+          cast(null as bool) as emrg_2_pickup_yn,
+          'Cell' as emrg_2_phone_1_type,
+          '+13055550401' as emrg_2_phone_1_number,
+          cast(null as string) as emrg_2_phone_2_type,
+          cast(null as string) as emrg_2_phone_2_number,
+          cast(null as string) as emrg_2_phone_3_type,
+          cast(null as string) as emrg_2_phone_3_number,
+          '' as emrg_3_name_first_name,
+          cast(null as string) as emrg_3_name_last_name,
+          cast(null as string) as emrg_3_email,
+          cast(null as string) as emrg_3_relationship_ss,
+          cast(null as string) as emrg_3_relationship_txt,
+          cast(null as bool) as emrg_3_custody_yn,
+          cast(null as bool) as emrg_3_lives_with_yn,
+          cast(null as bool) as emrg_3_pickup_yn,
+          cast(null as string) as emrg_3_phone_1_type,
+          cast(null as string) as emrg_3_phone_1_number,
+          cast(null as string) as emrg_3_phone_2_type,
+          cast(null as string) as emrg_3_phone_2_number,
+          cast(null as string) as emrg_3_phone_3_type,
+          cast(null as string) as emrg_3_phone_3_number,
+          cast(null as string) as emrg_4_name_first_name,
+          cast(null as string) as emrg_4_name_last_name,
+          cast(null as string) as emrg_4_email,
+          cast(null as string) as emrg_4_relationship_ss,
+          cast(null as string) as emrg_4_relationship_txt,
+          cast(null as bool) as emrg_4_custody_yn,
+          cast(null as bool) as emrg_4_lives_with_yn,
+          cast(null as bool) as emrg_4_pickup_yn,
+          cast(null as string) as emrg_4_phone_1_type,
+          cast(null as string) as emrg_4_phone_1_number,
+          cast(null as string) as emrg_4_phone_2_type,
+          cast(null as string) as emrg_4_phone_2_number,
+          cast(null as string) as emrg_4_phone_3_type,
+          cast(null as string) as emrg_4_phone_3_number
+  expect:
+    rows:
+      - {
+          student_id: "84002002002",
+          sort_order: 1,
+          student_relation: parent,
+          first_name: Alice,
+          last_name: Johnson,
+          emergency: null,
+          custody: null,
+          pickup: null,
+          resides_with_stud: null,
+          address: 100 Main St,
+          contact1_value: "+13055550100",
+          contact3_value: null,
+        }
+      - {
+          student_id: "84002002002",
+          sort_order: 2,
+          student_relation: guardian,
+          first_name: Bob,
+          last_name: Smith,
+          emergency: null,
+          custody: null,
+          pickup: null,
+          resides_with_stud: null,
+          address: 200 Oak Ave,
+          contact1_value: "+13055550200",
+          contact3_value: null,
+        }
+      - {
+          student_id: "84002002002",
+          sort_order: 3,
+          student_relation: Aunt,
+          first_name: Carla,
+          last_name: Reyes,
+          emergency: "Y",
+          custody: "Y",
+          pickup: "Y",
+          resides_with_stud: "Y",
+          address: null,
+          contact1_value: "+13055550301",
+          contact3_value: "+13055550303",
+        }
+      - {
+          student_id: "84002002002",
+          sort_order: 4,
+          student_relation: Neighbor,
+          first_name: Dan,
+          last_name: Ortiz,
+          emergency: "Y",
+          custody: null,
+          pickup: null,
+          resides_with_stud: null,
+          address: null,
+          contact1_value: "+13055550401",
+          contact3_value: null,
+        }
+```
+
+Every `expect` row must list the same columns — dbt builds them as `UNION ALL`
+and does not null-fill omitted keys. If dbt rejects the partial column list,
+extend every row to the full 50 columns rather than varying them.
+
+- [ ] **Step 4: Run the whole Focus unit-test directory**
+
+```bash
+uv run dbt test \
+  --select "test_type:unit,extracts.focus" \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency/src/dbt/kipptaf \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kipptaf/target/prod
+```
+
+Expected: all Focus unit tests PASS, including the pre-existing
+`test_contacts_two_guardians`, whose expected `sort_order` values are unchanged
+because it mocks no emergency slots.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml </dev/null
+```
+
+Then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency add \
+  src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency commit -m "docs(dbt): document the Focus CONTACTS emergency rows and sort order
+
+Closes #4652
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Validate branch 2, update the ops doc, open the stacked PR
+
+**Files:**
+
+- Modify: `docs/reference/finalsite-focus-import.md`
+
+**Interfaces:**
+
+- Consumes: Tasks 8 and 9.
+- Produces: PR against `cbini/fix/claude-focus-contacts-address-of-record`
+  closing #4652.
+
+- [ ] **Step 1: Confirm the kippmiami wrapper needs no change**
+
+The kippmiami wrapper
+`src/dbt/kippmiami/models/extracts/focus/rpt_focus__contacts.sql` lists all 50
+columns explicitly and its anti-join is on `student_id`. Adding rows changes
+neither. Verify by building it:
+
+```bash
+uv run dbt build \
+  --select rpt_focus__contacts \
+  --project-dir /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency/src/dbt/kippmiami \
+  --target dev \
+  --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
+```
+
+Expected: builds unchanged. Confirm the sendable set still excludes the students
+Focus already holds and that emergency rows survive the name gate — every
+emergency row has a first name by construction, so none should be dropped:
+
+```sql
+select
+    countif(emergency = 'Y') as sendable_emergency_rows,
+    count(*) as sendable_rows
+from `teamster-332318.zz_cbini_kippmiami_extracts.rpt_focus__contacts`
+```
+
+Expected: `sendable_emergency_rows` close to 923, minus only the rows belonging
+to the ~13 students already present in Focus.
+
+- [ ] **Step 2: Update the ops doc**
+
+Add this subsection to `docs/reference/finalsite-focus-import.md` immediately
+after the "Blank addresses and nameless contacts are held back" section:
+
+```markdown
+### Emergency contacts
+
+The Contacts file now carries the student's emergency contacts alongside their
+parents and guardians. They come from the four emergency-contact slots on the
+student's Finalsite record — not from the family relationships — and they are
+sent after the guardians, in the order the slots appear in Finalsite. Each one
+carries its name, relationship, email, and up to three phone numbers, and is
+flagged in Focus as an emergency contact. Emergency contacts have no household
+in Finalsite, so they arrive with no address; that is expected, not a gap.
+
+The custody, pickup, and lives-with checkboxes are sent when Finalsite has them.
+KIPP Miami's emergency form does not currently collect them, so those three
+columns arrive blank today and will populate on their own if the form starts
+asking.
+
+> **Emergency contacts only reach a student Focus does not already have.** The
+> import-once rule matches on the student, not the individual contact — once any
+> contact for a student has been imported, none of that student's other contacts
+> are ever sent, including emergency contacts added later. Add them in Focus
+> directly for students already imported.
+```
+
+- [ ] **Step 3: Lint, commit, push, and open the stacked PR**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  docs/reference/finalsite-focus-import.md </dev/null
+```
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency add \
+  docs/reference/finalsite-focus-import.md
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency commit -m "docs: describe Focus emergency contacts for the enrollment team
+
+Refs #4652
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency push -u origin cbini/feat/claude-focus-contacts-emergency
+```
+
+Open the PR with `mcp__github__create_pull_request`, base
+`cbini/fix/claude-focus-contacts-address-of-record`, body from
+`.github/pull_request_template.md`, including `Closes #4652`. State in the body
+that `claude-review` does not fire on a non-`main` base, that the PR cannot
+merge until #4651's does, and that three of the four newly-populated layout
+columns ship null in KIPP Miami because the emergency form does not collect
+them.
+
+- [ ] **Step 4: Rebase onto `main` after branch 1 merges**
+
+Once #4651's PR is squash-merged, the stacked branch's base disappears. Retarget
+it:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency fetch origin main
+git -C /workspaces/teamster/.worktrees/cbini/feat/claude-focus-contacts-emergency rebase origin/main
+```
+
+Resolve any conflict in `rpt_focus__contacts.sql` in favor of branch 2's
+restructure with branch 1's address join retained, then force-push and change
+the PR base to `main` with `mcp__github__update_pull_request`. Changing the base
+to `main` also lets `claude-review` fire — toggle draft state via GraphQL
+`convertPullRequestToDraft` then `markPullRequestReadyForReview` to trigger it.

--- a/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
+++ b/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
@@ -593,9 +593,11 @@ group by 1
 order by 1
 ```
 
-Expected: 6,405 rows total for Miami, and the guardian-scoped feed slice
-resolving to 2,081 rows in Task 4. A total row count other than 6,405 means the
-spine join fanned out.
+Expected: one row per contact in `stg_finalsite__contacts` — 7,522 for Miami —
+and the guardian-scoped feed slice resolving to 2,081 rows in Task 4. A total
+that differs from `select count(*) from stg_finalsite__contacts` means the spine
+join fanned out; compare against that query rather than a hardcoded number,
+since Finalsite data moves.
 
 - [ ] **Step 6: Lint**
 

--- a/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
+++ b/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
@@ -2394,68 +2394,63 @@ Append this to the `unit_tests:` block:
           cast(null as string) as emrg_4_phone_3_type,
           cast(null as string) as emrg_4_phone_3_number
   expect:
-    rows:
-      - {
-          student_id: "84002002002",
-          sort_order: 1,
-          student_relation: parent,
-          first_name: Alice,
-          last_name: Johnson,
-          emergency: null,
-          custody: null,
-          pickup: null,
-          resides_with_stud: null,
-          address: 100 Main St,
-          contact1_value: "+13055550100",
-          contact3_value: null,
-        }
-      - {
-          student_id: "84002002002",
-          sort_order: 2,
-          student_relation: guardian,
-          first_name: Bob,
-          last_name: Smith,
-          emergency: null,
-          custody: null,
-          pickup: null,
-          resides_with_stud: null,
-          address: 200 Oak Ave,
-          contact1_value: "+13055550200",
-          contact3_value: null,
-        }
-      - {
-          student_id: "84002002002",
-          sort_order: 3,
-          student_relation: Aunt,
-          first_name: Carla,
-          last_name: Reyes,
-          emergency: "Y",
-          custody: "Y",
-          pickup: "Y",
-          resides_with_stud: "Y",
-          address: null,
-          contact1_value: "+13055550301",
-          contact3_value: "+13055550303",
-        }
-      - {
-          student_id: "84002002002",
-          sort_order: 4,
-          student_relation: Neighbor,
-          first_name: Dan,
-          last_name: Ortiz,
-          emergency: "Y",
-          custody: null,
-          pickup: null,
-          resides_with_stud: null,
-          address: null,
-          contact1_value: "+13055550401",
-          contact3_value: null,
-        }
+    format: sql
+    rows: |
+      select
+        '84002002002' as student_id,
+        'parent' as student_relation,
+        1 as sort_order,
+        'Alice' as first_name,
+        'B' as middle_name,
+        'Johnson' as last_name,
+        -- ... every remaining layout column, in CONTACTS_LAYOUT order
+      union all
+      select '84002002002', 'guardian', 2, 'Bob', null, 'Smith', ...
 ```
 
-Every `expect` row must list the same columns — dbt builds them as `UNION ALL`
-and does not null-fill omitted keys. If dbt rejects the partial column list,
-extend every row to the full 50 columns rather than varying them.
+The `expect` block MUST list all 50 output columns. dbt compares the fixture
+against the model output with `except distinct` in both directions, so a shorter
+column list fails on a column-count mismatch rather than narrowing the
+comparison. Every unit test in this repo lists the full set, and the sibling
+`int_finalsite__student_contacts` tests use `format: sql` for exactly this
+reason — it is far more compact here than 4 x 50 dict keys.
+
+Write the four expected rows as one `select ... union all ...`, the first branch
+aliasing all 50 columns and the later branches positional. The column order is
+the model's final `SELECT` order; copy the sequence from the existing
+`test_contacts_two_guardians` expect rows in the same file. The asserted values:
+
+| Column              | Row 1        | Row 2        | Row 3        | Row 4        |
+| ------------------- | ------------ | ------------ | ------------ | ------------ |
+| `student_id`        | 84002002002  | 84002002002  | 84002002002  | 84002002002  |
+| `student_relation`  | parent       | guardian     | Aunt         | Neighbor     |
+| `sort_order`        | 1            | 2            | 3            | 4            |
+| `first_name`        | Alice        | Bob          | Carla        | Dan          |
+| `middle_name`       | B            | null         | null         | null         |
+| `last_name`         | Johnson      | Smith        | Reyes        | Ortiz        |
+| `resides_with_stud` | null         | null         | Y            | null         |
+| `custody`           | null         | null         | Y            | null         |
+| `emergency`         | null         | null         | Y            | Y            |
+| `pickup`            | null         | null         | Y            | null         |
+| `address`           | 100 Main St  | 200 Oak Ave  | null         | null         |
+| `address2`          | null         | null         | null         | null         |
+| `city`              | Miami        | Miami        | null         | null         |
+| `state`             | FL           | FL           | null         | null         |
+| `zipcode`           | 33101        | 33102        | null         | null         |
+| `email`             | alice@…      | bob@…        | carla@…      | null         |
+| `contact1_type`     | Home         | Work         | Cell         | Cell         |
+| `contact1_value`    | +13055550100 | +13055550200 | +13055550301 | +13055550401 |
+| `contact2_type`     | Cell         | null         | Home         | null         |
+| `contact2_value`    | +13055550101 | null         | +13055550302 | null         |
+| `contact3_type`     | null         | null         | Work         | null         |
+| `contact3_value`    | null         | null         | +13055550303 | null         |
+
+Use the full email addresses from the `given` fixtures, not the elided forms
+above. Every remaining column — `contact1_blocked` / `_unlisted` / `_callout`,
+the same three for `contact2`, and all of `contact3_blocked` through
+`contact7_unlisted` — is null in all four rows. Use `cast(null as string)` on
+the first branch so BigQuery types each column, and bare `null` on the later
+ones.
 
 - [ ] **Step 4: Run the whole Focus unit-test directory**
 

--- a/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
+++ b/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
@@ -52,10 +52,11 @@ yamllint / markdownlint), `gh` CLI.
   `/workspaces/teamster/.trunk/tools/trunk check --force --no-fix <paths> </dev/null`,
   run with cwd set to the worktree.
 - Address resolution rule, verbatim from the spec: candidates are households
-  where `address_1 is not null`; identity is `address_1`, `address_2`, `city`,
-  `state`, `zip` compared case- and punctuation-insensitively with ZIP truncated
-  to 5; a contact resolves only when exactly one distinct address remains; the
-  projected values are the RAW text from the lowest-`household_id` row.
+  where `address_1 is not null`; identity is an exact match on `address_1`,
+  `address_2`, `city`, `state`, `zip` — no case-folding, punctuation-stripping,
+  or ZIP+4 truncation; a contact resolves only when exactly one distinct address
+  remains; the projected values are the RAW text from the lowest-`household_id`
+  row.
 
 ---
 
@@ -89,7 +90,8 @@ Create
 
 ```sql
 with
-    households_stripped as (
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    candidate_households as (
         -- Any household carrying a street line is a candidate. Completeness is
         -- deliberately NOT a gate: an incomplete address is visibly wrong in
         -- Focus and can be corrected there, whereas withholding it is silent.
@@ -106,51 +108,26 @@ with
             zip,
             country,
             is_complete_address,
-
-            upper(city) as city_key,
-            left(zip, 5) as zip_key,
-
-            regexp_replace(address_1, r'[^A-Za-z0-9]', '') as address_1_stripped,
-            regexp_replace(address_2, r'[^A-Za-z0-9]', '') as address_2_stripped,
         from {{ ref("int_finalsite__contacts__households") }}
         where address_1 is not null
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    candidate_households as (
-        select
-            finalsite_enrollment_id,
-            household_id,
-            address_1,
-            address_2,
-            city,
-            state,
-            zip,
-            country,
-            is_complete_address,
-            city_key,
-            zip_key,
-
-            upper(address_1_stripped) as address_1_key,
-            upper(address_2_stripped) as address_2_key,
-        from households_stripped
-    ),
-
     address_candidates as (
-        -- One row per (contact, distinct address). The key normalizes case and
-        -- punctuation so `123 Main St.` and `123 MAIN ST` are one address, and
-        -- truncates ZIP+4 to five digits. Normalization is for GROUPING only —
-        -- the projected address is the raw text from the lowest-household_id
-        -- row, so Focus receives properly formatted values. country and
-        -- is_complete_address are not part of the identity, so they come from
-        -- that same canonical row rather than being aggregated across rows,
-        -- which would blend values from different households.
+        -- One row per (contact, distinct address). Address identity is an
+        -- exact match on the five mailing fields — no case-folding, no
+        -- punctuation-stripping, no ZIP+4 truncation. Two spellings of the
+        -- same address (`123 Main St.` vs `123 MAIN ST`) therefore stay
+        -- distinct candidates, and the contact is withheld as ambiguous rather
+        -- than guessed at. country and is_complete_address are not part of the
+        -- identity, so they come from the canonical lowest-household_id row
+        -- rather than being aggregated across rows, which would blend values
+        -- from different households.
         {{
             dbt_utils.deduplicate(
                 relation="candidate_households",
                 partition_by=(
-                    "finalsite_enrollment_id, address_1_key, address_2_key,"
-                    " city_key, state, zip_key"
+                    "finalsite_enrollment_id, address_1, address_2, city,"
+                    " state, zip"
                 ),
                 order_by="household_id asc",
             )
@@ -245,14 +222,14 @@ models:
       incomplete address is visibly wrong in a receiving system and can be
       corrected there, whereas withholding it is silent. Households with no
       street at all are excluded, since each would otherwise count as its own
-      candidate and manufacture ambiguity. Address identity is `address_1`,
-      `address_2`, `city`, `state`, and `zip` compared without regard to case or
-      punctuation and with `zip` truncated to five digits, so the same address
-      recorded two ways collapses to one candidate while a genuine apartment,
-      city, state, or ZIP difference stays distinct. A contact resolves only
-      when exactly one distinct address remains; the emitted values are the raw
-      text from the lowest `household_id` in that group. SIS-agnostic — no
-      enrollment, status, or academic-year scoping.
+      candidate and manufacture ambiguity. Address identity is an exact match on
+      `address_1`, `address_2`, `city`, `state`, and `zip` — no case-folding,
+      punctuation-stripping, or ZIP+4 truncation, so two spellings of the same
+      address stay distinct candidates and the contact is withheld rather than
+      guessed at. A contact resolves only when exactly one distinct address
+      remains; the emitted values are the raw text from the lowest
+      `household_id` in that group. SIS-agnostic — no enrollment, status, or
+      academic-year scoping.
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:
@@ -309,9 +286,9 @@ models:
       - name: candidate_count
         data_type: int64
         description:
-          Number of distinct addresses on this contact's household linkage after
-          normalization. One resolves; zero means no household carries a street;
-          more than one is ambiguous.
+          Number of distinct addresses on this contact's household linkage. One
+          resolves; zero means no household carries a street; more than one is
+          ambiguous.
         data_tests:
           - not_null:
               config:
@@ -368,12 +345,12 @@ models:
           visible to consumers. Null when unresolved.
 
 unit_tests:
-  - name: test_contact_address_formatting_duplicates_collapse
+  - name: test_contact_address_formatting_variants_stay_distinct
     description:
-      Two households recording the same address with different punctuation,
-      case, and a ZIP+4 collapse to one candidate, so the contact resolves. The
-      emitted values are the raw text of the lowest household_id, not the
-      normalized key.
+      Exact matching is deliberate — two households recording the same address
+      with different punctuation, case, and a ZIP+4 are two distinct candidates,
+      not one. A formatting variant is treated as a second candidate and the
+      address is withheld as ambiguous rather than guessed at.
     model: int_finalsite__contact_address_of_record
     given:
       - input: ref("stg_finalsite__contacts")
@@ -399,15 +376,58 @@ unit_tests:
       rows:
         - {
             finalsite_enrollment_id: con-1,
-            address_1: 123 Main St.,
+            address_1: null,
             address_2: null,
-            city: Miami,
-            state: FL,
-            zip: "33101",
-            country: US,
-            is_complete_address: true,
-            candidate_count: 1,
-            resolution_status: resolved,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+
+  - name: test_contact_address_null_field_is_a_distinct_candidate
+    description:
+      Dropping the completeness gate means a null field groups as its own value
+      rather than matching a populated one — two households on the same street
+      where one carries a ZIP and the other has a null ZIP are two distinct
+      candidates, so the contact is ambiguous rather than resolving to either
+      one.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-7 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-7' as finalsite_enrollment_id,
+            'hh-10' as household_id,
+            '55 Coral Way' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33134' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-7', 'hh-11', '55 Coral Way', null, 'Miami', 'FL', null,
+            'US', false
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-7,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
           }
 
   - name: test_contact_address_real_differences_stay_ambiguous
@@ -562,11 +582,11 @@ uv run dbt test \
   --defer --state /workspaces/teamster/src/dbt/kippmiami/target/prod
 ```
 
-Expected: 3 unit tests PASS. If
-`test_contact_address_formatting_duplicates_collapse` returns the `hh-2` values
-instead of `hh-1`, the `order_by` in the deduplicate call is wrong. If `con-4`
-comes back `no_street`, the `where address_1 is not null` filter was written as
-`where is_complete_address`.
+Expected: 4 unit tests PASS. If
+`test_contact_address_formatting_variants_stay_distinct` resolves instead of
+coming back `ambiguous`, the model is folding case/punctuation instead of
+comparing the five raw fields exactly. If `con-4` comes back `no_street`, the
+`where address_1 is not null` filter was written as `where is_complete_address`.
 
 - [ ] **Step 5: Build the model against dev and check the counts**
 
@@ -594,7 +614,7 @@ order by 1
 ```
 
 Expected: one row per contact in `stg_finalsite__contacts` — 7,522 for Miami —
-and the guardian-scoped feed slice resolving to 2,081 rows in Task 4. A total
+and the guardian-scoped feed slice resolving to 2,071 rows in Task 4. A total
 that differs from `select count(*) from stg_finalsite__contacts` means the spine
 join fanned out; compare against that query rather than a hardcoded number,
 since Finalsite data moves.
@@ -1126,10 +1146,13 @@ from dev as d
 full join prd as p using (finalsite_enrollment_id)
 ```
 
-Expected: `only_in_dev` 0, `only_in_prod` 0, `changed_rows` 6, and all 6 of
-those `changed_from_unresolved` — the students the normalization newly resolves.
-Any row that changed from one resolved address to a different one is a refactor
-bug; stop and diagnose before continuing.
+Expected: `only_in_dev` 0, `only_in_prod` 0, `changed_rows` 1 — one contact
+whose `address_source` flips from one resolved value to the other while the five
+mailing fields stay identical on both sides (both already agreed on the same
+address). Focus never observes this flip, since `rpt_focus__addresses` only
+tests `address_source is not null`. Any row that changed from one resolved
+address to a genuinely different one is a refactor bug; stop and diagnose before
+continuing.
 
 - [ ] **Step 7: Lint and commit**
 
@@ -1660,34 +1683,15 @@ full join prd as p using (student_id, sort_order)
 ```
 
 Expected, from the spec: `total_rows` 2,601, `only_in_prod` 0, `only_in_dev` 0,
-`rows_with_address` 2,081, `newly_enabled` 42, `newly_withheld` ~426-436. Small
-drift in the totals is normal — Finalsite data moves.
+`rows_with_address` 2,071, `newly_enabled` 42, `newly_withheld` 436. Small drift
+in the totals is normal — Finalsite data moves.
 
-`address_values_changed` counts raw string differences, so it is NOT expected to
-be zero. Normalization makes a guardian with formatting-variant duplicate
-households resolve where they previously did not, and the model then projects
-the raw text of the lowest `household_id` — which can differ in punctuation or
-case from whatever `households[safe_offset(0)]` happened to hold. Same physical
-address, different spelling.
-
-The bar that MUST hold is that no row changes to a genuinely DIFFERENT address.
-Re-compare the changed rows under the normalized key to separate the two:
-
-```sql
--- over the changed rows only, from the query above
-countif(
-    upper(regexp_replace(d.address, r'[^A-Za-z0-9]', ''))
-    = upper(regexp_replace(p.address, r'[^A-Za-z0-9]', ''))
-    and upper(d.city) = upper(p.city)
-    and d.state = p.state
-    and left(d.zipcode, 5) = left(p.zipcode, 5)
-) as same_address_formatting_only
-```
-
-Every changed row must fall in `same_address_formatting_only`. A row that does
-not is an address that MOVED — stop and diagnose, because this feed is
-import-once. Measured on 2026-07-31: 2 changed rows, both formatting-only, zero
-genuinely different.
+`address_values_changed` is expected to be **zero**. The key is an exact match,
+so a guardian's resolved address is either identical to whatever
+`households[safe_offset(0)]` already held, or the guardian is withheld as
+ambiguous — there is no formatting-driven merge that could shift the raw text.
+Measured on 2026-07-31: 0 changed rows. Any nonzero count here is a bug; stop
+and diagnose before continuing, since this feed is import-once.
 
 Keep this output local. Do not paste address values anywhere.
 

--- a/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
+++ b/docs/superpowers/plans/2026-07-31-focus-contacts-address-and-emergency.md
@@ -1660,11 +1660,34 @@ full join prd as p using (student_id, sort_order)
 ```
 
 Expected, from the spec: `total_rows` 2,601, `only_in_prod` 0, `only_in_dev` 0,
-`rows_with_address` 2,081, `address_values_changed` **0**, `newly_enabled` 42,
-`newly_withheld` 436. A non-zero `address_values_changed` means an address moved
-rather than being withheld — stop and diagnose. Small drift in the totals is
-possible if Finalsite data moved since 2026-07-31; a change in
-`address_values_changed` is not.
+`rows_with_address` 2,081, `newly_enabled` 42, `newly_withheld` ~426-436. Small
+drift in the totals is normal — Finalsite data moves.
+
+`address_values_changed` counts raw string differences, so it is NOT expected to
+be zero. Normalization makes a guardian with formatting-variant duplicate
+households resolve where they previously did not, and the model then projects
+the raw text of the lowest `household_id` — which can differ in punctuation or
+case from whatever `households[safe_offset(0)]` happened to hold. Same physical
+address, different spelling.
+
+The bar that MUST hold is that no row changes to a genuinely DIFFERENT address.
+Re-compare the changed rows under the normalized key to separate the two:
+
+```sql
+-- over the changed rows only, from the query above
+countif(
+    upper(regexp_replace(d.address, r'[^A-Za-z0-9]', ''))
+    = upper(regexp_replace(p.address, r'[^A-Za-z0-9]', ''))
+    and upper(d.city) = upper(p.city)
+    and d.state = p.state
+    and left(d.zipcode, 5) = left(p.zipcode, 5)
+) as same_address_formatting_only
+```
+
+Every changed row must fall in `same_address_formatting_only`. A row that does
+not is an address that MOVED — stop and diagnose, because this feed is
+import-once. Measured on 2026-07-31: 2 changed rows, both formatting-only, zero
+genuinely different.
 
 Keep this output local. Do not paste address values anywhere.
 

--- a/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
+++ b/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
@@ -44,9 +44,9 @@ address entirely. Measured comparison, over 2,601 rows:
 | Student's address of record          | 2,197                | 66             | 53            | 321            |
 | Omit entirely                        | 0                    | —              | —             | 2,465          |
 
-Those figures hold the identity rule at #4618's strict five-field key, so the
-anchor choice is compared on its own. The next section changes the key, which
-raises the chosen option from 2,071 to 2,081.
+Those figures already reflect the strict five-field key used throughout — the
+next section explains why the key stays strict rather than normalized, so the
+anchor choice above is final, not provisional.
 
 Two measurements decided it. Anchoring on the guardian changes **zero** existing
 address values — whenever a guardian's linkage resolves to exactly one distinct
@@ -61,7 +61,7 @@ Unlike the `ADDRESS` feed, an unresolved guardian keeps their row and gets a
 null address. The CONTACT row still carries the name, relationship, email, and
 phones, which are the reason the record exists.
 
-### Address identity: street-present filter, normalized five-field key
+### Address identity: street-present filter, strict five-field key
 
 The candidate filter is `address_1 is not null`, replacing
 `is_complete_address`. Withholding on incompleteness is dropped: an incomplete
@@ -71,37 +71,39 @@ address is visibly wrong in a way a wrongly-picked complete address is not.
 Removing the filter entirely is worse, not better. 94 Miami households carry a
 city/state/ZIP fragment with no street; each would count as a distinct candidate
 and manufacture ambiguity that is not real, dropping resolution to 2,024 rows.
-Exactly 1 household has a street but is incomplete, so the filter swap admits
-one extra household today and changes the rule for future data.
 
-Address identity is all five mailing fields compared case- and
-punctuation-insensitively with ZIP truncated to 5. Normalization applies to
-**grouping only** — the address projected to Focus is the raw values from the
-lowest-`household_id` row of the group, so Focus receives properly formatted
-text.
+Dropping the completeness gate itself, measured at the guardian-feed level:
+**zero rows gained, zero rows lost.** It is a forward-looking rule change with
+no effect on today's data, not one that rescues rows today — it matters the day
+an incomplete-but-street-bearing household becomes the difference between
+resolved and ambiguous.
 
-Loosening the key to `address_1` alone was rejected. The two changes price
-separately:
+Address identity is an exact match on all five mailing fields — no case-folding,
+punctuation-stripping, or ZIP+4 truncation. Two spellings of the same address
+(`123 Main St.` vs `123 MAIN ST`) stay distinct candidates, and the contact is
+withheld as ambiguous rather than guessed at. The address projected to Focus is
+the raw values from the lowest-`household_id` row of the group.
 
-| Rule                           | CONTACT rows | Delta | What the delta is                       |
-| ------------------------------ | ------------ | ----- | --------------------------------------- |
-| Five-field key, raw comparison | 2,071        | —     | baseline                                |
-| Five-field key, normalized     | 2,081        | +10   | formatting-only merges — same address   |
-| `address_1` key, normalized    | 2,093        | +12   | genuinely different addresses collapsed |
-
-The 12 rows the `address_1` key buys come from 8 guardians: **5 differ by
-city**, 2 by apartment number, 1 by ZIP. Collapsing them means choosing a
-household by `household_id` order — a stable but meaningless ordering, the same
-class of defect as `safe_offset(0)`. Only 1 of the 8 (apartment vs. blank
-apartment) is plausibly one address recorded twice.
+Loosening the key to `address_1` alone was rejected too. Collapsing to just that
+one field would gain about 12 rows over the chosen key, from 8 guardians who
+share a street line but differ elsewhere: **5 differ by city**, 2 by apartment
+number, 1 by ZIP. Collapsing them means choosing a household by `household_id`
+order — a stable but meaningless ordering, the same class of defect as
+`safe_offset(0)`. Only 1 of the 8 (apartment vs. blank apartment) is plausibly
+one address recorded twice.
 
 The asymmetry that settles it: an incomplete address in Focus is detectable by a
 human, so the "consumers correct it" mechanism works. A wrongly-picked complete
 address looks correct and is permanent, so it does not.
 
-Net effect of the chosen rule: CONTACT 2,081 rows with an address, ADDRESS 1,270
-students (up from 1,264), and **zero exported address values change on either
-feed**.
+Net effect of the chosen rule: CONTACT 2,071 rows with an address and **zero
+exported address values change on either feed**. On the ADDRESS feed
+(`int_finalsite__student_address_of_record`, 3,428 student records), the strict
+key produces zero mailing-field changes, zero feed-membership changes, and zero
+phone changes against prod; exactly one contact's internal `address_source`
+label flips, and `rpt_focus__addresses` never observes it, since that model only
+tests `address_source is not null`. The ADDRESS feed's exported output is
+unchanged.
 
 ### Emergency rows append after guardians, ordered by slot
 
@@ -144,14 +146,12 @@ Applies the resolution rule above at contact grain — the same rule
 primary-contact fallback.
 
 1. Read `int_finalsite__contacts__households` where `address_1 is not null`.
-1. Derive the normalized grouping key as named columns in a CTE (uppercased,
-   non-alphanumerics stripped from `address_1` / `address_2`, uppercased `city`,
-   `state`, `left(zip, 5)`) — not inline, so the `dbt_utils.deduplicate` call
-   partitions on plain columns.
 1. Dedupe to one row per (contact, distinct address) with
-   `dbt_utils.deduplicate`, `order_by="household_id asc"`, so `country` and the
-   raw address values come from one canonical row rather than being blended
-   across households.
+   `dbt_utils.deduplicate`, partitioning on the five raw mailing fields
+   (`finalsite_enrollment_id, address_1, address_2, city, state, zip`) — an
+   exact match, no case-folding or truncation — `order_by="household_id asc"`,
+   so `country` and the address values come from one canonical row rather than
+   being blended across households.
 1. Count candidates per contact.
 1. Project the address only when the count is exactly 1.
 
@@ -178,8 +178,8 @@ primary contact's. The student-first-then-primary-contact pick, the
 `address_source` / `resolution_status` outputs, and the `primary_contact_phone`
 passthrough are unchanged.
 
-This refactor is required rather than cosmetic: if the identity rule normalized
-for contacts but not for students, the two feeds would resolve addresses by
+This refactor is required rather than cosmetic: if the identity rule differed
+between contacts and students, the two feeds would resolve addresses by
 different rules again, which is the defect #4651 exists to close.
 
 ### kipptaf wiring
@@ -295,9 +295,12 @@ Both feeds are import-once, so everything is validated against production before
 either PR leaves draft.
 
 - Refactor parity — `int_finalsite__student_address_of_record` dev vs prod:
-  identical row count and identical `format('%T', ...)` tuple set except exactly
-  the 6 newly-resolving students. Any other delta is a refactor bug.
-- CONTACT feed — 2,601 rows, 2,081 with an address, 0 changed values against the
+  identical row count and identical `format('%T', ...)` tuple set across every
+  mailing field and phone. The one exception is `address_source`, which flips
+  label on exactly 1 of 3,428 rows and never reaches Focus, since
+  `rpt_focus__addresses` only tests `address_source is not null`. Any other
+  delta is a refactor bug.
+- CONTACT feed — 2,601 rows, 2,071 with an address, 0 changed values against the
   current prod feed; on branch 2, 923 emergency rows across 464 students.
 - Grain — `unique_combination_of_columns(student_id, sort_order)` on the built
   model, not on paper.

--- a/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
+++ b/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
@@ -44,6 +44,10 @@ address entirely. Measured comparison, over 2,601 rows:
 | Student's address of record          | 2,197                | 66             | 53            | 321            |
 | Omit entirely                        | 0                    | —              | —             | 2,465          |
 
+Those figures hold the identity rule at #4618's strict five-field key, so the
+anchor choice is compared on its own. The next section changes the key, which
+raises the chosen option from 2,071 to 2,081.
+
 Two measurements decided it. Anchoring on the guardian changes **zero** existing
 address values — whenever a guardian's linkage resolves to exactly one distinct
 complete address, offset 0 already equals it, so the entire effect is
@@ -158,6 +162,13 @@ Columns: `finalsite_enrollment_id`, the five address fields, `country`,
 Not contract-enforced (the `api/intermediate` directory default), but every
 column carries a `data_type` per convention. Uniqueness test on
 `finalsite_enrollment_id`.
+
+This model's `resolution_status` is contact-grain and describes the linkage
+(`resolved` / `ambiguous` / `no_street`). It is distinct from the same-named
+column on `int_finalsite__student_address_of_record`, which is student-grain and
+names which record the address came from (`student_household` /
+`primary_contact_household` / `ambiguous`). Both keep their existing meanings;
+the student model aliases its two joins to this one.
 
 ### `int_finalsite__student_address_of_record` (refactor)
 

--- a/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
+++ b/docs/superpowers/specs/2026-07-31-focus-contacts-address-and-emergency-design.md
@@ -1,0 +1,318 @@
+# Focus CONTACTS — address resolution and emergency contacts
+
+Design for [#4651](https://github.com/TEAMSchools/teamster/issues/4651) (fix)
+and [#4652](https://github.com/TEAMSchools/teamster/issues/4652) (feature). Both
+edit `rpt_focus__contacts`, so #4651 lands first and #4652 stacks on it.
+
+Continues the work of
+[#4613](https://github.com/TEAMSchools/teamster/issues/4613) /
+[PR #4618](https://github.com/TEAMSchools/teamster/pull/4618), which resolved
+the same arbitrary-household defect for the Focus `ADDRESS` feed.
+
+All figures below were measured against production on 2026-07-31, over the
+1,505-student / 2,601-row enrolled Miami CONTACT feed.
+
+## Problem
+
+`rpt_focus__contacts` projects each guardian's address from
+`stg_finalsite__contacts`, whose scalar `address_*` columns flatten
+`households[safe_offset(0)]`. Array position does not identify Finalsite's
+primary household — that designation is set in the UI and exposed by no API
+field. Whichever household sits at offset 0 becomes the contact's address in
+Focus.
+
+The feed is import-once with no overwrite path, so a wrong pick is permanent.
+Only 13 students currently have a person record in Focus, so ~99% of the
+population is still prospective — the same posture the `ADDRESS` fix had.
+
+Separately, Finalsite emergency contacts never reach the feed at all. They are
+custom fields on the student's own contact record (`emrg_1..4_*`), not
+relationship rows, so the adult-relationship-type filter cannot see them. Four
+Focus layout columns are hardcoded null in consequence.
+
+## Decisions
+
+### The CONTACT address resolves from the guardian's own household linkage
+
+Rejected: inheriting the student's resolved address of record, and omitting the
+address entirely. Measured comparison, over 2,601 rows:
+
+| Option                               | Rows with an address | Values changed | Newly enabled | Newly withheld |
+| ------------------------------------ | -------------------- | -------------- | ------------- | -------------- |
+| Today (`households[safe_offset(0)]`) | 2,465                | —              | —             | —              |
+| Guardian's own linkage               | 2,071                | 0              | 42            | 436            |
+| Student's address of record          | 2,197                | 66             | 53            | 321            |
+| Omit entirely                        | 0                    | —              | —             | 2,465          |
+
+Two measurements decided it. Anchoring on the guardian changes **zero** existing
+address values — whenever a guardian's linkage resolves to exactly one distinct
+complete address, offset 0 already equals it, so the entire effect is
+withholding rows that are currently coin flips. And where the guardian's own
+linkage and the student's address of record both resolve, they **agree on 1,961
+rows and disagree on 12** — the cross-feed inconsistency #4651 describes is a
+12-row problem, not a systemic one, and does not justify asserting that a
+guardian lives where the student lives.
+
+Unlike the `ADDRESS` feed, an unresolved guardian keeps their row and gets a
+null address. The CONTACT row still carries the name, relationship, email, and
+phones, which are the reason the record exists.
+
+### Address identity: street-present filter, normalized five-field key
+
+The candidate filter is `address_1 is not null`, replacing
+`is_complete_address`. Withholding on incompleteness is dropped: an incomplete
+address should reach Focus and be corrected by consumers, since an incomplete
+address is visibly wrong in a way a wrongly-picked complete address is not.
+
+Removing the filter entirely is worse, not better. 94 Miami households carry a
+city/state/ZIP fragment with no street; each would count as a distinct candidate
+and manufacture ambiguity that is not real, dropping resolution to 2,024 rows.
+Exactly 1 household has a street but is incomplete, so the filter swap admits
+one extra household today and changes the rule for future data.
+
+Address identity is all five mailing fields compared case- and
+punctuation-insensitively with ZIP truncated to 5. Normalization applies to
+**grouping only** — the address projected to Focus is the raw values from the
+lowest-`household_id` row of the group, so Focus receives properly formatted
+text.
+
+Loosening the key to `address_1` alone was rejected. The two changes price
+separately:
+
+| Rule                           | CONTACT rows | Delta | What the delta is                       |
+| ------------------------------ | ------------ | ----- | --------------------------------------- |
+| Five-field key, raw comparison | 2,071        | —     | baseline                                |
+| Five-field key, normalized     | 2,081        | +10   | formatting-only merges — same address   |
+| `address_1` key, normalized    | 2,093        | +12   | genuinely different addresses collapsed |
+
+The 12 rows the `address_1` key buys come from 8 guardians: **5 differ by
+city**, 2 by apartment number, 1 by ZIP. Collapsing them means choosing a
+household by `household_id` order — a stable but meaningless ordering, the same
+class of defect as `safe_offset(0)`. Only 1 of the 8 (apartment vs. blank
+apartment) is plausibly one address recorded twice.
+
+The asymmetry that settles it: an incomplete address in Focus is detectable by a
+human, so the "consumers correct it" mechanism works. A wrongly-picked complete
+address looks correct and is permanent, so it does not.
+
+Net effect of the chosen rule: CONTACT 2,081 rows with an address, ADDRESS 1,270
+students (up from 1,264), and **zero exported address values change on either
+feed**.
+
+### Emergency rows append after guardians, ordered by slot
+
+`emrg_N_priority_ss` is null for all 6,405 Miami contacts, so interleaving by
+priority has nothing to sort on and every row would fall through to a slot
+tiebreak anyway. Guardians keep ranks 1..N in their existing order; emergency
+slots follow in `emrg_1..4` order.
+
+### Guardian rows keep null custody / pickup / resides-with flags
+
+The relationship grain carries no equivalent fields. Import-once makes a blanket
+assumption permanent and unfixable from the pipeline, and Focus treats null as
+"not asserted" rather than "no". Only `emergency` gets a value, and only on
+emergency-slot rows.
+
+### Emergency rows that name-match a guardian are still sent
+
+61 of the 923 emergency rows name-match a guardian row for the same student.
+Both are sent. The two rows carry different data — the guardian row has the
+relationship and household address, the emergency row has up to three typed
+phones and the emergency designation. Suppressing by name match is a fuzzy
+identity test that would drop the emergency flag for exactly the people most
+likely to be the emergency contact.
+
+### Pickup-only and barred-pickup blocks are out of scope
+
+`pickup_1..3_*` and `nonpickup_1..3_*` are name-only — no phone, no
+relationship, no email. A pickup-only row would create a permanent Focus person
+record carrying nothing but a name. `nonpickup` names people **barred** from
+pickup, and the Focus `CONTACTS` layout has no way to express that, so importing
+them as contacts would invert their meaning.
+
+## Design — #4651
+
+### `int_finalsite__contact_address_of_record` (new)
+
+`src/dbt/finalsite/models/api/intermediate/`. One row per Finalsite contact.
+Applies the resolution rule above at contact grain — the same rule
+`int_finalsite__student_address_of_record` applies, without the student-specific
+primary-contact fallback.
+
+1. Read `int_finalsite__contacts__households` where `address_1 is not null`.
+1. Derive the normalized grouping key as named columns in a CTE (uppercased,
+   non-alphanumerics stripped from `address_1` / `address_2`, uppercased `city`,
+   `state`, `left(zip, 5)`) — not inline, so the `dbt_utils.deduplicate` call
+   partitions on plain columns.
+1. Dedupe to one row per (contact, distinct address) with
+   `dbt_utils.deduplicate`, `order_by="household_id asc"`, so `country` and the
+   raw address values come from one canonical row rather than being blended
+   across households.
+1. Count candidates per contact.
+1. Project the address only when the count is exactly 1.
+
+Columns: `finalsite_enrollment_id`, the five address fields, `country`,
+`candidate_count`, `is_complete_address`, and `resolution_status` (`resolved` /
+`ambiguous` / `no_street`).
+
+Not contract-enforced (the `api/intermediate` directory default), but every
+column carries a `data_type` per convention. Uniqueness test on
+`finalsite_enrollment_id`.
+
+### `int_finalsite__student_address_of_record` (refactor)
+
+Its `complete_households` / `address_candidates` / `candidate_counts` CTEs are
+replaced by two joins to the new model — once on the student's id, once on the
+primary contact's. The student-first-then-primary-contact pick, the
+`address_source` / `resolution_status` outputs, and the `primary_contact_phone`
+passthrough are unchanged.
+
+This refactor is required rather than cosmetic: if the identity rule normalized
+for contacts but not for students, the two feeds would resolve addresses by
+different rules again, which is the defect #4651 exists to close.
+
+### kipptaf wiring
+
+Add `int_finalsite__contact_address_of_record` to the four
+`kipptaf/models/finalsite/sources-kipp*.yml` files (the `zz_stg_` staging branch
+is already present on all four), and add a `union_relations` passthrough at
+`kipptaf/models/finalsite/intermediate/`, following
+`int_finalsite__student_address_of_record` — all four regions unioned, since the
+`rpt_focus__*` filter on `focus_student_id_prefixed is not null` keeps non-Miami
+rows out of the Focus feeds.
+
+### `rpt_focus__contacts`
+
+Replace `g.address_1 … g.zip` with the resolved columns, `left join`ed on the
+guardian's `finalsite_enrollment_id`. The relationship-type filter, the three
+gating joins, `sort_order`, and the 50-column contract are untouched.
+
+## Design — #4652
+
+### Structure
+
+Three CTEs plus a final projection:
+
+- `guardians` — the #4651 query, plus `0 as contact_group` and
+  `if(is_primary, 0, 1) as group_rank`. The `row_number()` moves out.
+- `emergency_long` — four `union all` branches over
+  `int_finalsite__contact_custom_attributes`, one per `emrg_N`, each gated
+  `emrg_N_name_first_name is not null and emrg_N_name_first_name != ''`. Carries
+  `1 as contact_group` and `N as group_rank`. Transfers the shape from
+  `int_finalsite__student_contacts`, which cannot be `ref`'d here — it excludes
+  Miami to avoid double-counting against the PowerSchool branch of
+  `int_students__contacts`.
+- `all_contacts` — the union, with a single
+  `row_number() over (partition by student_id order by contact_group, group_rank, last_name, first_name, relationship_id)`
+  as `sort_order`.
+
+`relationship_id` is a new final tiebreak. Today two guardians sharing
+`(is_primary, last_name, first_name)` get a rank that can flip between runs;
+making it stable is free.
+
+`dbt_utils.unique_combination_of_columns(student_id, sort_order)` holds by
+construction — one `row_number()` over one partition — and stays as-is.
+
+### Emergency row column mapping
+
+| Focus column                                | Source                                                      |
+| ------------------------------------------- | ----------------------------------------------------------- |
+| `student_relation`                          | `coalesce(emrg_N_relationship_ss, emrg_N_relationship_txt)` |
+| `first_name` / `last_name`                  | `emrg_N_name_first_name` / `_last_name`                     |
+| `middle_name`                               | `emrg_N_name_middle_name` for slots 1–2; null for 3–4       |
+| `emergency`                                 | `'Y'`                                                       |
+| `custody`                                   | `if(emrg_N_custody_yn, 'Y', null)`                          |
+| `resides_with_stud`                         | `if(emrg_N_lives_with_yn, 'Y', null)`                       |
+| `pickup`                                    | `if(emrg_N_pickup_yn, 'Y', null)`                           |
+| `email`                                     | `emrg_N_email`                                              |
+| `contact1_*` / `contact2_*` / `contact3_*`  | `emrg_N_phone_1..3_type` and `_number`                      |
+| address / address2 / city / state / zipcode | null — emergency contacts carry no household linkage        |
+| `contact4_*`–`contact7_*`, all flag columns | null, unchanged                                             |
+
+The pivot has no middle-name field for slots 3 and 4, hence the split. Guardian
+rows keep `contact3_*` null; extending them to a third phone is out of scope.
+
+### Two assumptions on the record
+
+`'Y'` or null, never `'N'`. Focus's `students_join_people` holds only `'Y'` and
+null across its 22 existing rows, so an explicitly-false Finalsite flag maps to
+null. Worth an Ops confirmation, not a blocker.
+
+Miami ships three of the four columns still null. `emrg_N_custody_yn`,
+`_pickup_yn`, `_lives_with_yn`, and `_priority_ss` are **100% null across all
+6,405 Miami contacts**. They are well populated in Newark (6,916 of 6,923),
+Camden, and Paterson — but Miami is the only Focus region. The mapping is wired
+correctly and populates the moment Miami's form collects the fields.
+
+### Scale and the import-once ceiling
+
+923 emergency rows across 464 students join the 2,601 guardian rows. `emrg_3`
+and `emrg_4` are unpopulated in Miami but populated in all three NJ regions, so
+all four slots are built.
+
+The kippmiami wrapper's anti-join is on `student_id`, not on the contact — once
+a student has any person in Focus, none of their contacts ever flow again. Today
+that is 13 students, so emergency rows reach essentially the whole population.
+Every student imported before this ships permanently loses their emergency
+contacts, which argues for landing both branches promptly and needs a line in
+the ops doc.
+
+## Rollout
+
+Worktree off `main` for #4651; #4652 stacked on it via
+`gh issue develop 4652 --base <branch-1>`. Branch 2's PR will not get
+`claude-review` (it fires only on a `main` base) and cannot merge until branch 1
+does.
+
+The new model is new, so `dbt clone` cannot seed it — it is absent from the prod
+manifest and gets skipped silently. Each district needs a real
+`dbt build --select int_finalsite__contact_address_of_record --target staging --project-dir src/dbt/<district>`
+before push, or kipptaf CI cannot resolve the union's column list. That writes
+to shared `zz_stg_*` datasets and needs explicit user authorization naming the
+operation.
+
+The `int_finalsite__student_address_of_record` refactor needs no re-staging —
+same column set, values only.
+
+Editing four `sources-kipp*.yml` marks the whole finalsite source
+`state:modified`, so CI fans out across every kipptaf model reading finalsite.
+Expect the wide run PR #4618 saw; pre-existing warn-test noise is pre-existing.
+
+## Validation
+
+Both feeds are import-once, so everything is validated against production before
+either PR leaves draft.
+
+- Refactor parity — `int_finalsite__student_address_of_record` dev vs prod:
+  identical row count and identical `format('%T', ...)` tuple set except exactly
+  the 6 newly-resolving students. Any other delta is a refactor bug.
+- CONTACT feed — 2,601 rows, 2,081 with an address, 0 changed values against the
+  current prod feed; on branch 2, 923 emergency rows across 464 students.
+- Grain — `unique_combination_of_columns(student_id, sort_order)` on the built
+  model, not on paper.
+- Unit tests — the whole `test_type:unit,extracts.focus` directory, since
+  sibling Focus models mock the same refs. Both new inputs must use
+  `format: sql`; `int_finalsite__contact_address_of_record` will not exist in
+  the warehouse when the unit test compiles, so dict-format `given` rows fail
+  introspection.
+- `trunk check --force` from inside the worktree on every changed SQL and YAML.
+
+## Documentation
+
+`docs/reference/finalsite-focus-import.md` gains the CONTACT address behavior
+and the emergency-contact rows. Its existing claim that a student's address is
+held back when incomplete no longer holds for contacts, and the
+`rpt_focus__addresses` inline comment asserting that
+`address_source is not null` guarantees a complete address becomes false — both
+are corrected.
+
+## Deliberately not in scope
+
+- Duplicate Finalsite households, the cause of the ~205 unresolvable Miami
+  guardians. Retiring them is Miami ops work.
+- Asserting the `is_primary` singleton at its source
+  ([#4616](https://github.com/TEAMSchools/teamster/issues/4616)) and students
+  with no `primary` relationship
+  ([#4617](https://github.com/TEAMSchools/teamster/issues/4617)).
+- A third phone slot for guardian rows.
+- An Ops-facing surface listing unresolvable duplicate households.

--- a/src/dbt/finalsite/CLAUDE.md
+++ b/src/dbt/finalsite/CLAUDE.md
@@ -35,12 +35,18 @@ models/
   contract-widened column on `stg_finalsite__contacts` rather than the raw
   source directly; not contract-enforced (the `api/intermediate` directory
   default), though every column still carries a `data_type` per convention.
+- `int_finalsite__contact_address_of_record` — one row per Finalsite contact
+  (students and adults alike) carrying that contact's resolved address: exactly
+  one distinct address, else nulls and an `ambiguous`/`no_street` flag. A
+  household is a candidate once it has a street line — completeness is
+  deliberately not required, so an incomplete address can still resolve.
 - `int_finalsite__student_address_of_record` — one row per student record (a
   contact carrying a `primary` relationship) with the resolved address of
   record: the student's own household linkage when it yields exactly one
-  distinct complete address, else their primary contact's when it does, else no
-  address and an `ambiguous` flag. Also carries the primary contact's phone,
-  since student records almost never hold one.
+  distinct address (via `int_finalsite__contact_address_of_record`), else their
+  primary contact's when it does, else no address and an `ambiguous` flag. Also
+  carries the primary contact's phone, since student records almost never hold
+  one.
 - `int_finalsite__contact_id_attributes` — pivots every `id_attributes` field to
   its own column, aliased to the original field name (`power_school_contact_id`,
   `powerschool_student_number`, `focus_student_id`). The PIVOT enumerates fields

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql
@@ -1,5 +1,6 @@
 with
-    households_stripped as (
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    candidate_households as (
         -- Any household carrying a street line is a candidate. Completeness is
         -- deliberately NOT a gate: an incomplete address is visibly wrong in
         -- Focus and can be corrected there, whereas withholding it is silent.
@@ -16,51 +17,26 @@ with
             zip,
             country,
             is_complete_address,
-
-            upper(city) as city_key,
-            left(zip, 5) as zip_key,
-
-            regexp_replace(address_1, r'[^A-Za-z0-9]', '') as address_1_stripped,
-            regexp_replace(address_2, r'[^A-Za-z0-9]', '') as address_2_stripped,
         from {{ ref("int_finalsite__contacts__households") }}
         where address_1 is not null
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    candidate_households as (
-        select
-            finalsite_enrollment_id,
-            household_id,
-            address_1,
-            address_2,
-            city,
-            state,
-            zip,
-            country,
-            is_complete_address,
-            city_key,
-            zip_key,
-
-            upper(address_1_stripped) as address_1_key,
-            upper(address_2_stripped) as address_2_key,
-        from households_stripped
-    ),
-
     address_candidates as (
-        -- One row per (contact, distinct address). The key normalizes case and
-        -- punctuation so `123 Main St.` and `123 MAIN ST` are one address, and
-        -- truncates ZIP+4 to five digits. Normalization is for GROUPING only —
-        -- the projected address is the raw text from the lowest-household_id
-        -- row, so Focus receives properly formatted values. country and
-        -- is_complete_address are not part of the identity, so they come from
-        -- that same canonical row rather than being aggregated across rows,
-        -- which would blend values from different households.
+        -- One row per (contact, distinct address). Address identity is an
+        -- exact match on the five mailing fields — no case-folding, no
+        -- punctuation-stripping, no ZIP+4 truncation. Two spellings of the
+        -- same address (`123 Main St.` vs `123 MAIN ST`) therefore stay
+        -- distinct candidates, and the contact is withheld as ambiguous rather
+        -- than guessed at. country and is_complete_address are not part of the
+        -- identity, so they come from the canonical lowest-household_id row
+        -- rather than being aggregated across rows, which would blend values
+        -- from different households.
         {{
             dbt_utils.deduplicate(
                 relation="candidate_households",
                 partition_by=(
-                    "finalsite_enrollment_id, address_1_key, address_2_key,"
-                    " city_key, state, zip_key"
+                    "finalsite_enrollment_id, address_1, address_2, city,"
+                    " state, zip"
                 ),
                 order_by="household_id asc",
             )

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_address_of_record.sql
@@ -1,0 +1,139 @@
+with
+    households_stripped as (
+        -- Any household carrying a street line is a candidate. Completeness is
+        -- deliberately NOT a gate: an incomplete address is visibly wrong in
+        -- Focus and can be corrected there, whereas withholding it is silent.
+        -- Households with no street at all ARE excluded — Miami holds 94 such
+        -- city/state/ZIP fragments, and each would otherwise count as its own
+        -- candidate and manufacture ambiguity that is not real.
+        select
+            finalsite_enrollment_id,
+            household_id,
+            address_1,
+            address_2,
+            city,
+            state,
+            zip,
+            country,
+            is_complete_address,
+
+            upper(city) as city_key,
+            left(zip, 5) as zip_key,
+
+            regexp_replace(address_1, r'[^A-Za-z0-9]', '') as address_1_stripped,
+            regexp_replace(address_2, r'[^A-Za-z0-9]', '') as address_2_stripped,
+        from {{ ref("int_finalsite__contacts__households") }}
+        where address_1 is not null
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    candidate_households as (
+        select
+            finalsite_enrollment_id,
+            household_id,
+            address_1,
+            address_2,
+            city,
+            state,
+            zip,
+            country,
+            is_complete_address,
+            city_key,
+            zip_key,
+
+            upper(address_1_stripped) as address_1_key,
+            upper(address_2_stripped) as address_2_key,
+        from households_stripped
+    ),
+
+    address_candidates as (
+        -- One row per (contact, distinct address). The key normalizes case and
+        -- punctuation so `123 Main St.` and `123 MAIN ST` are one address, and
+        -- truncates ZIP+4 to five digits. Normalization is for GROUPING only —
+        -- the projected address is the raw text from the lowest-household_id
+        -- row, so Focus receives properly formatted values. country and
+        -- is_complete_address are not part of the identity, so they come from
+        -- that same canonical row rather than being aggregated across rows,
+        -- which would blend values from different households.
+        {{
+            dbt_utils.deduplicate(
+                relation="candidate_households",
+                partition_by=(
+                    "finalsite_enrollment_id, address_1_key, address_2_key,"
+                    " city_key, state, zip_key"
+                ),
+                order_by="household_id asc",
+            )
+        }}
+    ),
+
+    candidate_counts as (
+        select finalsite_enrollment_id, count(*) as candidate_count,
+        from address_candidates
+        group by finalsite_enrollment_id
+    ),
+
+    resolved_candidates as (
+        -- Only a contact with exactly one distinct address gets an address at
+        -- all. Two or more means Finalsite does not say which one to use, and
+        -- the feed is import-once, so a guess would be permanent.
+        select
+            a.finalsite_enrollment_id,
+            a.address_1,
+            a.address_2,
+            a.city,
+            a.state,
+            a.zip,
+            a.country,
+            a.is_complete_address,
+        from address_candidates as a
+        inner join
+            candidate_counts as c
+            on a.finalsite_enrollment_id = c.finalsite_enrollment_id
+        where c.candidate_count = 1
+    ),
+
+    counted as (
+        -- Spined on the full contact list so a contact with no street-bearing
+        -- household still gets a row, with candidate_count 0.
+        select
+            c.finalsite_enrollment_id,
+
+            r.address_1,
+            r.address_2,
+            r.city,
+            r.state,
+            r.zip,
+            r.country,
+            r.is_complete_address,
+            r.finalsite_enrollment_id as resolved_contact_id,
+
+            coalesce(cc.candidate_count, 0) as candidate_count,
+        from {{ ref("stg_finalsite__contacts") }} as c
+        left join
+            candidate_counts as cc
+            on c.finalsite_enrollment_id = cc.finalsite_enrollment_id
+        left join
+            resolved_candidates as r
+            on c.finalsite_enrollment_id = r.finalsite_enrollment_id
+    )
+
+select
+    finalsite_enrollment_id,
+    address_1,
+    address_2,
+    city,
+    state,
+    zip,
+    country,
+    is_complete_address,
+    candidate_count,
+
+    case
+        when resolved_contact_id is not null
+        then 'resolved'
+        when candidate_count = 0
+        then 'no_street'
+        else 'ambiguous'
+    end as resolution_status,
+from counted

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql
@@ -12,64 +12,31 @@ with
         where is_primary
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    complete_households as (
-        select
-            finalsite_enrollment_id,
-            household_id,
-            address_1,
-            address_2,
-            city,
-            state,
-            zip,
-            country,
-        from {{ ref("int_finalsite__contacts__households") }}
-        where is_complete_address
-    ),
-
-    address_candidates as (
-        -- One row per (contact, distinct complete address). Address identity is
-        -- the five mailing fields including address_2 — an apartment difference
-        -- is a different mailing address. country is NOT part of the identity,
-        -- so it comes from the canonical lowest-household_id row rather than
-        -- being aggregated across rows, which would blend values from
-        -- different households.
-        {{
-            dbt_utils.deduplicate(
-                relation="complete_households",
-                partition_by="finalsite_enrollment_id, address_1, address_2, city, state, zip",
-                order_by="household_id asc",
-            )
-        }}
-    ),
-
-    candidate_counts as (
-        select finalsite_enrollment_id, count(*) as candidate_count,
-        from address_candidates
-        group by finalsite_enrollment_id
-    ),
-
     counted as (
+        -- Candidate counting and address identity live in
+        -- int_finalsite__contact_address_of_record, so both Focus feeds resolve
+        -- an address by one rule. A contact absent from that model has no
+        -- household rows at all, which counts as zero candidates.
         select
             spc.finalsite_enrollment_id,
             spc.primary_contact_id,
 
-            coalesce(sc.candidate_count, 0) as student_candidate_count,
-            coalesce(pcc.candidate_count, 0) as primary_contact_candidate_count,
+            coalesce(sa.candidate_count, 0) as student_candidate_count,
+            coalesce(pa.candidate_count, 0) as primary_contact_candidate_count,
         from student_primary_contacts as spc
         left join
-            candidate_counts as sc
-            on spc.finalsite_enrollment_id = sc.finalsite_enrollment_id
+            {{ ref("int_finalsite__contact_address_of_record") }} as sa
+            on spc.finalsite_enrollment_id = sa.finalsite_enrollment_id
         left join
-            candidate_counts as pcc
-            on spc.primary_contact_id = pcc.finalsite_enrollment_id
+            {{ ref("int_finalsite__contact_address_of_record") }} as pa
+            on spc.primary_contact_id = pa.finalsite_enrollment_id
     ),
 
     sourced as (
-        -- The student's household linkage is a subset of their primary contact's
-        -- and is the disambiguating signal, so it is tried first. Parents carry
-        -- more household rows than students, so anchoring on the parent
-        -- unconditionally would move the pick onto the record with more
+        -- The student's household linkage is a subset of their primary
+        -- contact's and is the disambiguating signal, so it is tried first.
+        -- Parents carry more household rows than students, so anchoring on the
+        -- parent unconditionally would move the pick onto the record with more
         -- competing addresses.
         select
             finalsite_enrollment_id,
@@ -104,6 +71,7 @@ select
     a.state,
     a.zip,
     a.country,
+    a.is_complete_address,
 
     pc.phone_1_number as primary_contact_phone,
 
@@ -112,7 +80,9 @@ from sourced as s
 -- address_contact_id is only ever set to a contact whose candidate_count is
 -- exactly 1, so this join cannot fan out; when it is null (an unresolved
 -- address) nothing matches and the address fields stay null.
-left join address_candidates as a on s.address_contact_id = a.finalsite_enrollment_id
+left join
+    {{ ref("int_finalsite__contact_address_of_record") }} as a
+    on s.address_contact_id = a.finalsite_enrollment_id
 left join
     {{ ref("stg_finalsite__contacts") }} as pc
     on s.primary_contact_id = pc.finalsite_enrollment_id

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
@@ -8,17 +8,14 @@ models:
       incomplete address is visibly wrong in a receiving system and can be
       corrected there, whereas withholding it is silent. Households with no
       street at all are excluded, since each would otherwise count as its own
-      candidate and manufacture ambiguity. Address identity is `address_1`,
-      `address_2`, `city`, `state`, and `zip` — `address_1` and `address_2` are
-      stripped of punctuation and compared case-insensitively, `city` is
-      compared case-insensitively but stays punctuation-sensitive, `state` is
-      compared as-is (safe only because it is upper-cased upstream), and `zip`
-      is truncated to five digits — so the same address recorded two ways
-      collapses to one candidate while a genuine apartment, city, state, or ZIP
-      difference stays distinct. A contact resolves only when exactly one
-      distinct address remains; the emitted values are the raw text from the
-      lowest `household_id` in that group. SIS-agnostic — no enrollment, status,
-      or academic-year scoping.
+      candidate and manufacture ambiguity. Address identity is an exact match on
+      `address_1`, `address_2`, `city`, `state`, and `zip` — no case-folding,
+      punctuation-stripping, or ZIP+4 truncation, so two spellings of the same
+      address stay distinct candidates and the contact is withheld rather than
+      guessed at. A contact resolves only when exactly one distinct address
+      remains; the emitted values are the raw text from the lowest
+      `household_id` in that group. SIS-agnostic — no enrollment, status, or
+      academic-year scoping.
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:
@@ -134,12 +131,12 @@ models:
           visible to consumers. Null when unresolved.
 
 unit_tests:
-  - name: test_contact_address_formatting_duplicates_collapse
+  - name: test_contact_address_formatting_variants_stay_distinct
     description:
-      Two households recording the same address with different punctuation,
-      case, and a ZIP+4 collapse to one candidate, so the contact resolves. The
-      emitted values are the raw text of the lowest household_id, not the
-      normalized key.
+      Exact matching is deliberate — two households recording the same address
+      with different punctuation, case, and a ZIP+4 are two distinct candidates,
+      not one. A formatting variant is treated as a second candidate and the
+      address is withheld as ambiguous rather than guessed at.
     model: int_finalsite__contact_address_of_record
     given:
       - input: ref("stg_finalsite__contacts")
@@ -165,15 +162,58 @@ unit_tests:
       rows:
         - {
             finalsite_enrollment_id: con-1,
-            address_1: 123 Main St.,
+            address_1: null,
             address_2: null,
-            city: Miami,
-            state: FL,
-            zip: "33101",
-            country: US,
-            is_complete_address: true,
-            candidate_count: 1,
-            resolution_status: resolved,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+
+  - name: test_contact_address_null_field_is_a_distinct_candidate
+    description:
+      Dropping the completeness gate means a null field groups as its own value
+      rather than matching a populated one — two households on the same street
+      where one carries a ZIP and the other has a null ZIP are two distinct
+      candidates, so the contact is ambiguous rather than resolving to either
+      one.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-7 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-7' as finalsite_enrollment_id,
+            'hh-10' as household_id,
+            '55 Coral Way' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33134' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-7', 'hh-11', '55 Coral Way', null, 'Miami', 'FL', null,
+            'US', false
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-7,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
           }
 
   - name: test_contact_address_real_differences_stay_ambiguous

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
@@ -1,0 +1,303 @@
+models:
+  - name: int_finalsite__contact_address_of_record
+    description:
+      One row per Finalsite contact — students and adults alike — carrying that
+      contact's resolved address, or nulls plus a flag when it cannot be
+      resolved. A household is a candidate when it has a street line; an
+      incomplete address is deliberately still a candidate, because an
+      incomplete address is visibly wrong in a receiving system and can be
+      corrected there, whereas withholding it is silent. Households with no
+      street at all are excluded, since each would otherwise count as its own
+      candidate and manufacture ambiguity. Address identity is `address_1`,
+      `address_2`, `city`, `state`, and `zip` compared without regard to case or
+      punctuation and with `zip` truncated to five digits, so the same address
+      recorded two ways collapses to one candidate while a genuine apartment,
+      city, state, or ZIP difference stays distinct. A contact resolves only
+      when exactly one distinct address remains; the emitted values are the raw
+      text from the lowest `household_id` in that group. SIS-agnostic — no
+      enrollment, status, or academic-year scoping.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              (resolution_status = 'resolved' and address_1 is not null)
+              or (
+                  resolution_status != 'resolved'
+                  and address_1 is null
+                  and address_2 is null
+                  and city is null
+                  and state is null
+                  and zip is null
+              )
+          config:
+            severity: error
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              (resolution_status = 'resolved' and candidate_count = 1)
+              or (resolution_status = 'no_street' and candidate_count = 0)
+              or (resolution_status = 'ambiguous' and candidate_count > 1)
+          config:
+            severity: error
+    columns:
+      - name: finalsite_enrollment_id
+        data_type: string
+        description: Finalsite contact UUID; the grain.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: resolution_status
+        data_type: string
+        description:
+          Why this contact does or does not have an address — `resolved`
+          (exactly one distinct address), `ambiguous` (several, with nothing in
+          Finalsite saying which to use), or `no_street` (no household carries a
+          street line).
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - resolved
+                  - ambiguous
+                  - no_street
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: candidate_count
+        data_type: int64
+        description:
+          Number of distinct addresses on this contact's household linkage after
+          normalization. One resolves; zero means no household carries a street;
+          more than one is ambiguous.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: address_1
+        data_type: string
+        description:
+          Street address line 1 of the resolved address, as raw text; null when
+          unresolved.
+        config:
+          meta:
+            contains_pii: true
+      - name: address_2
+        data_type: string
+        description:
+          Street address line 2 (apartment or unit) of the resolved address.
+          Legitimately null when the household has no unit line, and null
+          whenever the address is unresolved.
+        config:
+          meta:
+            contains_pii: true
+      - name: city
+        data_type: string
+        description:
+          City of the resolved address; null when unresolved, and possibly null
+          on a resolved but incomplete address.
+        config:
+          meta:
+            contains_pii: true
+      - name: state
+        data_type: string
+        description:
+          State code of the resolved address, uppercased upstream; null when
+          unresolved, and possibly null on a resolved but incomplete address.
+      - name: zip
+        data_type: string
+        description:
+          ZIP code of the resolved address; null when unresolved, and possibly
+          null on a resolved but incomplete address.
+        config:
+          meta:
+            contains_pii: true
+      - name: country
+        data_type: string
+        description:
+          Country of the resolved address as Finalsite stores it. Not part of
+          the address identity, so it is carried from the canonical household
+          rather than compared.
+      - name: is_complete_address
+        data_type: boolean
+        description:
+          Whether the resolved address carries street, city, state, and ZIP. A
+          resolved address may be incomplete — this flag is what makes that
+          visible to consumers. Null when unresolved.
+
+unit_tests:
+  - name: test_contact_address_formatting_duplicates_collapse
+    description:
+      Two households recording the same address with different punctuation,
+      case, and a ZIP+4 collapse to one candidate, so the contact resolves. The
+      emitted values are the raw text of the lowest household_id, not the
+      normalized key.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-1 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-1' as finalsite_enrollment_id,
+            'hh-1' as household_id,
+            '123 Main St.' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33101' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-1', 'hh-2', '123 MAIN ST', null, 'MIAMI', 'FL',
+            '33101-4402', 'US', true
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-1,
+            address_1: 123 Main St.,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: "33101",
+            country: US,
+            is_complete_address: true,
+            candidate_count: 1,
+            resolution_status: resolved,
+          }
+
+  - name: test_contact_address_real_differences_stay_ambiguous
+    description:
+      Households sharing a street line but differing by apartment or by city
+      stay distinct candidates, so the contact is ambiguous and no address is
+      emitted. This is the case an address_1-only key would wrongly collapse.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-2 }
+          - { finalsite_enrollment_id: con-3 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-2' as finalsite_enrollment_id,
+            'hh-3' as household_id,
+            '222 Bay St' as address_1,
+            'Apt 1' as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33106' as zip,
+            'US' as country,
+            true as is_complete_address
+          union all
+          select 'con-2', 'hh-4', '222 Bay St', 'Apt 2', 'Miami', 'FL', '33106',
+            'US', true
+          union all
+          select 'con-3', 'hh-5', '400 Palm Way', null, 'Miami', 'FL', '33101',
+            'US', true
+          union all
+          select 'con-3', 'hh-6', '400 Palm Way', null, 'Hialeah', 'FL', '33012',
+            'US', true
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-2,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+        - {
+            finalsite_enrollment_id: con-3,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 2,
+            resolution_status: ambiguous,
+          }
+
+  - name: test_contact_address_incomplete_resolves_and_fragments_excluded
+    description:
+      A household with a street but no ZIP still resolves, flagged incomplete —
+      completeness is not a gate. A household carrying only city and ZIP with no
+      street is not a candidate, so a contact holding only fragments reports
+      no_street. A contact with no household rows at all also reports no_street.
+    model: int_finalsite__contact_address_of_record
+    given:
+      - input: ref("stg_finalsite__contacts")
+        rows:
+          - { finalsite_enrollment_id: con-4 }
+          - { finalsite_enrollment_id: con-5 }
+          - { finalsite_enrollment_id: con-6 }
+      - input: ref("int_finalsite__contacts__households")
+        format: sql
+        rows: |
+          select
+            'con-4' as finalsite_enrollment_id,
+            'hh-7' as household_id,
+            '9 Nowhere Ln' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            cast(null as string) as zip,
+            'US' as country,
+            false as is_complete_address
+          union all
+          select 'con-4', 'hh-8', null, null, 'Miami', 'FL', '33101', 'US', false
+          union all
+          select 'con-5', 'hh-9', null, null, 'Miami', 'FL', '33108', 'US', false
+    expect:
+      rows:
+        - {
+            finalsite_enrollment_id: con-4,
+            address_1: 9 Nowhere Ln,
+            address_2: null,
+            city: Miami,
+            state: FL,
+            zip: null,
+            country: US,
+            is_complete_address: false,
+            candidate_count: 1,
+            resolution_status: resolved,
+          }
+        - {
+            finalsite_enrollment_id: con-5,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 0,
+            resolution_status: no_street,
+          }
+        - {
+            finalsite_enrollment_id: con-6,
+            address_1: null,
+            address_2: null,
+            city: null,
+            state: null,
+            zip: null,
+            country: null,
+            is_complete_address: null,
+            candidate_count: 0,
+            resolution_status: no_street,
+          }

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
@@ -9,13 +9,16 @@ models:
       corrected there, whereas withholding it is silent. Households with no
       street at all are excluded, since each would otherwise count as its own
       candidate and manufacture ambiguity. Address identity is `address_1`,
-      `address_2`, `city`, `state`, and `zip` compared without regard to case or
-      punctuation and with `zip` truncated to five digits, so the same address
-      recorded two ways collapses to one candidate while a genuine apartment,
-      city, state, or ZIP difference stays distinct. A contact resolves only
-      when exactly one distinct address remains; the emitted values are the raw
-      text from the lowest `household_id` in that group. SIS-agnostic — no
-      enrollment, status, or academic-year scoping.
+      `address_2`, `city`, `state`, and `zip` — `address_1` and `address_2` are
+      stripped of punctuation and compared case-insensitively, `city` is
+      compared case-insensitively but stays punctuation-sensitive, `state` is
+      compared as-is (safe only because it is upper-cased upstream), and `zip`
+      is truncated to five digits — so the same address recorded two ways
+      collapses to one candidate while a genuine apartment, city, state, or ZIP
+      difference stays distinct. A contact resolves only when exactly one
+      distinct address remains; the emitted values are the raw text from the
+      lowest `household_id` in that group. SIS-agnostic — no enrollment, status,
+      or academic-year scoping.
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
@@ -6,28 +6,23 @@ models:
       `finalsite_enrollment_id` for contacts that carry a `primary`
       relationship, which is how a student record is identified without reaching
       for a SIS-specific field; contacts with no primary link are absent
-      entirely. Resolution takes the student's own household linkage when it
-      yields exactly one distinct complete address, falls back to their primary
-      contact's household linkage when it does, and otherwise emits no address.
-      Address identity is `address_1`, `address_2`, `city`, `state`, and `zip` —
-      an apartment difference counts as a different address. Every emitted
-      address is complete by construction, so consumers need no completeness
-      filter of their own. SIS-agnostic — no enrollment, status, or
+      entirely. Resolution takes the student's own household linkage when
+      `int_finalsite__contact_address_of_record` resolves it to exactly one
+      address, falls back to their primary contact's when it does, and otherwise
+      emits no address. Address identity and the candidate rule live in that
+      model, so this feed and the contact feed resolve addresses the same way.
+      An emitted address is not guaranteed complete — check
+      `is_complete_address`. SIS-agnostic — no enrollment, status, or
       academic-year scoping; receivers filter downstream.
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:
             expression: |
-              (
-                  address_source is not null
-                  and address_1 is not null
-                  and city is not null
-                  and state is not null
-                  and zip is not null
-              )
+              (address_source is not null and address_1 is not null)
               or (
                   address_source is null
                   and address_1 is null
+                  and address_2 is null
                   and city is null
                   and state is null
                   and zip is null
@@ -70,8 +65,8 @@ models:
         description:
           Which record supplied the address — `student_household` or
           `primary_contact_household`. Null when no address was resolved; a
-          non-null value guarantees the address fields are populated and
-          complete.
+          non-null value guarantees `address_1` is populated, but not that the
+          rest of the address is.
         data_tests:
           - accepted_values:
               arguments:
@@ -83,15 +78,16 @@ models:
       - name: student_candidate_count
         data_type: int64
         description:
-          Number of distinct complete addresses on the student's own household
-          linkage. One means the student's own records decide the address; more
-          than one means the pick falls through to the primary contact; zero
-          means the student is linked to no household with a mailable address.
+          Number of distinct addresses on the student's own household linkage,
+          from `int_finalsite__contact_address_of_record`. One means the
+          student's own records decide the address; anything else means the pick
+          falls through to the primary contact. Zero means no household linked
+          to the student carries a street line.
       - name: primary_contact_candidate_count
         data_type: int64
         description:
-          Number of distinct complete addresses on the primary contact's
-          household linkage. Used only when the student's own count is not one.
+          Number of distinct addresses on the primary contact's household
+          linkage. Used only when the student's own count is not one.
       - name: address_1
         data_type: string
         description:
@@ -129,6 +125,12 @@ models:
         description:
           Country of the resolved address as Finalsite stores it. Not part of
           the address identity, so it is carried through rather than compared.
+      - name: is_complete_address
+        data_type: boolean
+        description:
+          Whether the resolved address carries street, city, state, and ZIP. An
+          incomplete address is emitted rather than withheld, so consumers that
+          require a mailable address must check this flag. Null when unresolved.
       - name: primary_contact_phone
         data_type: string
         description:
@@ -144,42 +146,32 @@ models:
 unit_tests:
   - name: test_address_of_record_student_linkage_decisive
     description:
-      A student whose own household linkage yields exactly one distinct complete
-      address resolves from it, even though their primary contact carries two.
-      Duplicate household rows carrying the same address collapse to one
-      candidate, and an incomplete household is not a candidate at all.
+      A student whose own linkage resolves takes their own address, even though
+      their primary contact's linkage is ambiguous.
     model: int_finalsite__student_address_of_record
     given:
-      - input: ref('stg_finalsite__contact_relationships')
+      - input: ref("stg_finalsite__contact_relationships")
         rows:
           - { finalsite_enrollment_id: stu-1, rel_id: par-1, is_primary: true }
           - { finalsite_enrollment_id: par-1, rel_id: stu-1, is_primary: null }
-      - input: ref('int_finalsite__contacts__households')
+      - input: ref("int_finalsite__contact_address_of_record")
         format: sql
         rows: |
           select
             'stu-1' as finalsite_enrollment_id,
-            'hh-1' as household_id,
             '123 Main St' as address_1,
             cast(null as string) as address_2,
             'Miami' as city,
             'FL' as state,
             '33101' as zip,
             'US' as country,
-            true as is_complete_address
+            true as is_complete_address,
+            1 as candidate_count,
+            'resolved' as resolution_status
           union all
-          select 'stu-1', 'hh-2', '123 Main St', null, 'Miami', 'FL', '33101',
-            'US', true
-          union all
-          select 'stu-1', 'hh-3', '9 Nowhere Ln', null, 'Miami', 'FL', null,
-            'US', false
-          union all
-          select 'par-1', 'hh-1', '123 Main St', null, 'Miami', 'FL', '33101',
-            'US', true
-          union all
-          select 'par-1', 'hh-4', '400 Elsewhere Ave', null, 'Miami', 'FL',
-            '33199', 'US', true
-      - input: ref('stg_finalsite__contacts')
+          select 'par-1', null, null, null, null, null, null, null, 2,
+            'ambiguous'
+      - input: ref("stg_finalsite__contacts")
         rows:
           - { finalsite_enrollment_id: stu-1, phone_1_number: null }
           - { finalsite_enrollment_id: par-1, phone_1_number: "+13055550101" }
@@ -196,39 +188,38 @@ unit_tests:
             state: FL,
             zip: "33101",
             country: US,
+            is_complete_address: true,
             primary_contact_phone: "+13055550101",
             resolution_status: student_household,
           }
 
   - name: test_address_of_record_primary_contact_fallback
     description:
-      A student whose own linkage offers two competing complete addresses falls
-      through to their primary contact, whose linkage yields exactly one.
+      A student whose own linkage is ambiguous falls through to their primary
+      contact, whose linkage resolves.
     model: int_finalsite__student_address_of_record
     given:
-      - input: ref('stg_finalsite__contact_relationships')
+      - input: ref("stg_finalsite__contact_relationships")
         rows:
           - { finalsite_enrollment_id: stu-2, rel_id: par-2, is_primary: true }
-      - input: ref('int_finalsite__contacts__households')
+      - input: ref("int_finalsite__contact_address_of_record")
         format: sql
         rows: |
           select
             'stu-2' as finalsite_enrollment_id,
-            'hh-5' as household_id,
-            '456 Oak Ave' as address_1,
+            cast(null as string) as address_1,
             cast(null as string) as address_2,
-            'Miami' as city,
-            'FL' as state,
-            '33102' as zip,
-            'US' as country,
-            true as is_complete_address
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            cast(null as string) as country,
+            cast(null as bool) as is_complete_address,
+            2 as candidate_count,
+            'ambiguous' as resolution_status
           union all
-          select 'stu-2', 'hh-6', '789 Pine Rd', null, 'Miami', 'FL', '33105',
-            'US', true
-          union all
-          select 'par-2', 'hh-7', '111 Palm Way', null, 'Miami', 'FL', '33103',
-            'US', true
-      - input: ref('stg_finalsite__contacts')
+          select 'par-2', '111 Palm Way', null, 'Miami', 'FL', '33103', 'US',
+            true, 1, 'resolved'
+      - input: ref("stg_finalsite__contacts")
         rows:
           - { finalsite_enrollment_id: stu-2, phone_1_number: null }
           - { finalsite_enrollment_id: par-2, phone_1_number: "+13055550102" }
@@ -245,47 +236,38 @@ unit_tests:
             state: FL,
             zip: "33103",
             country: US,
+            is_complete_address: true,
             primary_contact_phone: "+13055550102",
             resolution_status: primary_contact_household,
           }
 
   - name: test_address_of_record_both_sides_ambiguous
     description:
-      When neither the student nor their primary contact resolves to exactly one
-      complete address, no address is emitted and the row is flagged ambiguous.
-      The student's two candidates differ only by apartment line, confirming
-      `address_2` participates in the address identity.
+      When neither the student nor their primary contact resolves, no address is
+      emitted and the row is flagged ambiguous.
     model: int_finalsite__student_address_of_record
     given:
-      - input: ref('stg_finalsite__contact_relationships')
+      - input: ref("stg_finalsite__contact_relationships")
         rows:
           - { finalsite_enrollment_id: stu-3, rel_id: par-3, is_primary: true }
-      - input: ref('int_finalsite__contacts__households')
+      - input: ref("int_finalsite__contact_address_of_record")
         format: sql
         rows: |
           select
             'stu-3' as finalsite_enrollment_id,
-            'hh-8' as household_id,
-            '222 Bay St' as address_1,
-            'Apt 1' as address_2,
-            'Miami' as city,
-            'FL' as state,
-            '33106' as zip,
-            'US' as country,
-            true as is_complete_address
+            cast(null as string) as address_1,
+            cast(null as string) as address_2,
+            cast(null as string) as city,
+            cast(null as string) as state,
+            cast(null as string) as zip,
+            cast(null as string) as country,
+            cast(null as bool) as is_complete_address,
+            2 as candidate_count,
+            'ambiguous' as resolution_status
           union all
-          select 'stu-3', 'hh-9', '222 Bay St', 'Apt 2', 'Miami', 'FL', '33106',
-            'US', true
-          union all
-          select 'par-3', 'hh-8', '222 Bay St', 'Apt 1', 'Miami', 'FL', '33106',
-            'US', true
-          union all
-          select 'par-3', 'hh-9', '222 Bay St', 'Apt 2', 'Miami', 'FL', '33106',
-            'US', true
-          union all
-          select 'par-3', 'hh-10', '333 Gull Ct', null, 'Miami', 'FL', '33107',
-            'US', true
-      - input: ref('stg_finalsite__contacts')
+          select 'par-3', null, null, null, null, null, null, null, 3,
+            'ambiguous'
+      - input: ref("stg_finalsite__contacts")
         rows:
           - { finalsite_enrollment_id: stu-3, phone_1_number: null }
           - { finalsite_enrollment_id: par-3, phone_1_number: "+13055550103" }
@@ -302,41 +284,44 @@ unit_tests:
             state: null,
             zip: null,
             country: null,
+            is_complete_address: null,
             primary_contact_phone: "+13055550103",
             resolution_status: ambiguous,
           }
 
-  - name: test_address_of_record_no_student_households
+  - name: test_address_of_record_incomplete_address_is_emitted
     description:
-      A student linked to no household at all falls through to their primary
-      contact, and a student whose only household is incomplete is flagged
-      ambiguous with both candidate counts at zero.
+      A student absent from the contact-address model entirely counts as zero
+      candidates and falls through to their primary contact. A resolved but
+      incomplete address is emitted rather than withheld, carrying
+      is_complete_address false — the behavior change this refactor introduces.
     model: int_finalsite__student_address_of_record
     given:
-      - input: ref('stg_finalsite__contact_relationships')
+      - input: ref("stg_finalsite__contact_relationships")
         rows:
           - { finalsite_enrollment_id: stu-4, rel_id: par-4, is_primary: true }
           - { finalsite_enrollment_id: stu-5, rel_id: par-5, is_primary: true }
-      - input: ref('int_finalsite__contacts__households')
+      - input: ref("int_finalsite__contact_address_of_record")
         format: sql
         rows: |
           select
             'par-4' as finalsite_enrollment_id,
-            'hh-11' as household_id,
             '555 Coral Dr' as address_1,
             'Unit 7' as address_2,
             'Miami' as city,
             'FL' as state,
             '33104' as zip,
             'US' as country,
-            true as is_complete_address
+            true as is_complete_address,
+            1 as candidate_count,
+            'resolved' as resolution_status
           union all
-          select 'stu-5', 'hh-12', '666 Reef Ln', null, 'Miami', 'FL', null,
-            'US', false
+          select 'stu-5', '666 Reef Ln', null, 'Miami', 'FL', null, 'US', false,
+            1, 'resolved'
           union all
-          select 'par-5', 'hh-13', null, null, 'Miami', 'FL', '33108', 'US',
-            false
-      - input: ref('stg_finalsite__contacts')
+          select 'par-5', null, null, null, null, null, null, null, 0,
+            'no_street'
+      - input: ref("stg_finalsite__contacts")
         rows:
           - { finalsite_enrollment_id: par-4, phone_1_number: "+13055550104" }
           - { finalsite_enrollment_id: par-5, phone_1_number: "+13055550105" }
@@ -353,20 +338,22 @@ unit_tests:
             state: FL,
             zip: "33104",
             country: US,
+            is_complete_address: true,
             primary_contact_phone: "+13055550104",
             resolution_status: primary_contact_household,
           }
         - {
             finalsite_enrollment_id: stu-5,
-            student_candidate_count: 0,
+            student_candidate_count: 1,
             primary_contact_candidate_count: 0,
-            address_source: null,
-            address_1: null,
+            address_source: student_household,
+            address_1: 666 Reef Ln,
             address_2: null,
-            city: null,
-            state: null,
+            city: Miami,
+            state: FL,
             zip: null,
-            country: null,
+            country: US,
+            is_complete_address: false,
             primary_contact_phone: "+13055550105",
-            resolution_status: ambiguous,
+            resolution_status: student_household,
           }

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
@@ -45,9 +45,9 @@ models:
         description:
           How the address was resolved — `student_household`,
           `primary_contact_household`, or `ambiguous`. `ambiguous` covers both a
-          student whose records offer several competing complete addresses and
-          one whose records hold no complete address at all; the candidate
-          counts distinguish the two.
+          student whose records offer several competing addresses and one whose
+          records hold no street-bearing household at all; the candidate counts
+          distinguish the two.
         data_tests:
           - accepted_values:
               arguments:

--- a/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__addresses.yml
+++ b/src/dbt/kippmiami/models/extracts/focus/properties/rpt_focus__addresses.yml
@@ -3,11 +3,10 @@ models:
     description: >-
       Address export for Focus SIS — import-once: emits a student's address only
       when the student has no address linked in Focus yet (anti-join on
-      stg_focus__students_join_address) and the mailable address is complete
-      (address, city, state, zipcode all present). The completeness gate keeps a
-      blank address from being imported once and then locking out the real one.
-      Existing Focus addresses are never overwritten; enrollment ops harmonize
-      post-import changes manually.
+      stg_focus__students_join_address) and the address carries a street line.
+      The street-line gate keeps a blank address from being imported once and
+      then locking out the real one. Existing Focus addresses are never
+      overwritten; enrollment ops harmonize post-import changes manually.
     columns:
       - name: student_id
         data_type: string
@@ -37,10 +36,12 @@ models:
 unit_tests:
   - name: addresses_import_once_suppresses_existing
     description: >-
-      Import-once plus completeness gate — a student with a complete address and
+      Import-once plus street-line gate — a student with a complete address and
       no Focus address is kept; a student already in Focus is suppressed; a
       student with a blank address is suppressed so an empty record is not
-      imported once and locked in.
+      imported once and locked in; a student whose address has a street line but
+      no city, state, or zipcode is kept, since the street line is the bar, not
+      completeness.
     model: rpt_focus__addresses
     given:
       - input: source("kipptaf_extracts", "rpt_focus__addresses")
@@ -72,6 +73,15 @@ unit_tests:
               cast(null as string) as mail_address,
               cast(null as string) as mail_address2,
               cast(null as string) as mail_city, cast(null as string) as mail_state
+          union all
+          select
+              '8400000004' as student_id, '3 Palm Ave' as address,
+              cast(null as string) as address2, cast(null as string) as city,
+              cast(null as string) as state, cast(null as string) as zipcode,
+              cast(null as string) as phone, cast(null as string) as mailing,
+              cast(null as string) as mail_address,
+              cast(null as string) as mail_address2,
+              cast(null as string) as mail_city, cast(null as string) as mail_state
       - input: ref("stg_focus__students_join_address")
         format: sql
         rows: |
@@ -84,6 +94,15 @@ unit_tests:
             cast(null as string) as address2, 'Miami' as city,
             'FL' as state, '33101' as zipcode, cast(null as string) as phone,
             cast(null as string) as mailing,
+            cast(null as string) as mail_address,
+            cast(null as string) as mail_address2,
+            cast(null as string) as mail_city, cast(null as string) as mail_state
+        union all
+        select
+            '8400000004' as student_id, '3 Palm Ave' as address,
+            cast(null as string) as address2, cast(null as string) as city,
+            cast(null as string) as state, cast(null as string) as zipcode,
+            cast(null as string) as phone, cast(null as string) as mailing,
             cast(null as string) as mail_address,
             cast(null as string) as mail_address2,
             cast(null as string) as mail_city, cast(null as string) as mail_state

--- a/src/dbt/kippmiami/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kippmiami/models/extracts/focus/rpt_focus__addresses.sql
@@ -11,14 +11,13 @@ with
         left join focus_address as f on d.student_id = f.student_id
         where
             f.student_id is null
-            -- don't import a blank/partial address: presence-based import-once
-            -- would create an empty Focus address record and then suppress the
-            -- student forever, so the real address never syncs. Defer until the
-            -- mailable address is complete. See #4320.
+            -- don't import a blank address: presence-based import-once would
+            -- create an empty Focus address record and then suppress the
+            -- student forever, so the real address never syncs. A street line
+            -- is the bar — an address missing its city, state, or ZIP is sent
+            -- so the gap is visible in Focus and can be corrected there, the
+            -- way a blank record cannot. See #4320.
             and d.address is not null
-            and d.city is not null
-            and d.state is not null
-            and d.zipcode is not null
     )
 
 select

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -149,7 +149,8 @@ PII-tagged package model must re-declare it. Model level suffices for a
 ### Finalsite contact unions
 
 `int_finalsite__student_contacts` / `int_finalsite__contact_id_attributes` /
-`int_finalsite__student_address_of_record` are kipptaf `union_relations` views
+`int_finalsite__student_address_of_record` /
+`int_finalsite__contact_address_of_record` are kipptaf `union_relations` views
 over per-region finalsite sources.
 
 - **Union CUTOVER regions, not merely api-enabled ones.** Miami has the

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -191,7 +191,7 @@ pass-throughs — they are the reconciliation layer (import-once / diff against
 current Focus via the `focus` package, which only kippmiami has). kipptaf
 `rpt_focus__*` are desired-state (all rows); the **kippmiami** output is the
 actual SFTP feed. Per feed: addresses/contacts/demographics import-once
-(presence anti-join, with a null/completeness gate #4320); enrollment diffs and
+(presence anti-join, with a null/street-line gate #4320); enrollment diffs and
 additionally reads Focus in kipptaf via a BQ-native source (#4319). Spec:
 `docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md`.
 

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -276,13 +276,20 @@ models:
 unit_tests:
   - name: test_contacts_two_guardians
     description:
-      Verifies the 50-column CONTACTS layout for one student with two guardian
-      relationships — primary guardian sorts to SORT_ORDER 1, non-primary to 2.
-      Asserts STUDENT_RELATION, FIRST_NAME, LAST_NAME, and CONTACT1_VALUE.
-      STUDENT_ID is sourced from int_finalsite__contact_id_attributes for the
-      student and is identical across both guardian rows. A second student whose
-      own `stg_finalsite__contacts.status` is not `enrolled` is included to
-      assert their guardian is excluded from the feed.
+      Verifies the 50-column CONTACTS layout for one student with three guardian
+      relationships — primary guardian sorts to SORT_ORDER 1, non-primary to 2,
+      and a third guardian whose household linkage does not resolve in
+      `int_finalsite__contact_address_of_record` to 3. Asserts STUDENT_RELATION,
+      FIRST_NAME, LAST_NAME, and CONTACT1_VALUE. STUDENT_ID is sourced from
+      int_finalsite__contact_id_attributes for the student and is identical
+      across all three guardian rows. The third guardian has no matching row in
+      the address mock — this proves the join to
+      `int_finalsite__contact_address_of_record` is a LEFT join, since the row
+      survives with a null address rather than being dropped, which is the
+      entire reason the model uses LEFT over INNER (an INNER join would silently
+      drop this guardian from the import-once feed). A second student whose own
+      `stg_finalsite__contacts.status` is not `enrolled` is included to assert
+      their guardian is excluded from the feed.
     model: rpt_focus__contacts
     given:
       - input: ref('int_finalsite__enrollment_lifecycle')
@@ -307,6 +314,16 @@ unit_tests:
               rel_id: enr-grd-sec,
               rel_name: Bob Smith,
               rel_type: guardian,
+              is_primary: false,
+              is_financial: false,
+              has_portal_access: false,
+            }
+          - {
+              finalsite_enrollment_id: enr-stu-001,
+              relationship_id: rel-004,
+              rel_id: enr-grd-unresolved,
+              rel_name: Dana Turner,
+              rel_type: grandparent,
               is_primary: false,
               is_financial: false,
               has_portal_access: false,
@@ -343,6 +360,17 @@ unit_tests:
               email: bob@example.com,
               phone_1_type: Work,
               phone_1_number: "+13055550200",
+              phone_2_type: null,
+              phone_2_number: null,
+            }
+          - {
+              finalsite_enrollment_id: enr-grd-unresolved,
+              first_name: Dana,
+              middle_name: null,
+              last_name: Turner,
+              email: dana@example.com,
+              phone_1_type: Home,
+              phone_1_number: "+13055550400",
               phone_2_type: null,
               phone_2_number: null,
             }
@@ -453,6 +481,58 @@ unit_tests:
             email: bob@example.com,
             contact1_type: Work,
             contact1_value: "+13055550200",
+            contact1_blocked: null,
+            contact1_unlisted: null,
+            contact1_callout: null,
+            contact2_type: null,
+            contact2_value: null,
+            contact2_blocked: null,
+            contact2_unlisted: null,
+            contact2_callout: null,
+            contact3_type: null,
+            contact3_value: null,
+            contact3_blocked: null,
+            contact3_unlisted: null,
+            contact3_callout: null,
+            contact4_type: null,
+            contact4_value: null,
+            contact4_blocked: null,
+            contact4_unlisted: null,
+            contact4_callout: null,
+            contact5_type: null,
+            contact5_value: null,
+            contact5_blocked: null,
+            contact5_unlisted: null,
+            contact5_callout: null,
+            contact6_type: null,
+            contact6_value: null,
+            contact6_blocked: null,
+            contact6_unlisted: null,
+            contact6_callout: null,
+            contact7_type: null,
+            contact7_value: null,
+            contact7_blocked: null,
+            contact7_unlisted: null,
+          }
+        - {
+            student_id: "84002002002",
+            student_relation: grandparent,
+            sort_order: 3,
+            first_name: Dana,
+            middle_name: null,
+            last_name: Turner,
+            resides_with_stud: null,
+            custody: null,
+            emergency: null,
+            pickup: null,
+            address: null,
+            address2: null,
+            city: null,
+            state: null,
+            zipcode: null,
+            email: dana@example.com,
+            contact1_type: Home,
+            contact1_value: "+13055550400",
             contact1_blocked: null,
             contact1_unlisted: null,
             contact1_callout: null,

--- a/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/focus/properties/rpt_focus__contacts.yml
@@ -12,13 +12,16 @@ models:
       minted Focus id. A second join to `stg_finalsite__contacts` on the
       student's own `finalsite_enrollment_id` restricts the feed to guardians of
       students whose own `status` is `enrolled` — the guardian's own status is
-      not considered. Produces 50 columns in `CONTACTS_LAYOUT` order.
-      `SORT_ORDER` ranks guardians per student by `is_primary desc` so the
-      primary contact sorts first. Phone slots `CONTACT1_*` and `CONTACT2_*` map
-      the guardian's two phones; `CONTACT3` through `CONTACT7` are always null.
-      Focus column header casing is applied at transport time via
-      `file_config.format.header_replacements`; dbt column names remain
-      lowercase snake_case.
+      not considered. The address comes from
+      `int_finalsite__contact_address_of_record`, resolved from the guardian's
+      own household linkage; a guardian whose linkage does not resolve keeps
+      their row and gets a null address. Produces 50 columns in
+      `CONTACTS_LAYOUT` order. `SORT_ORDER` ranks guardians per student by
+      `is_primary desc` so the primary contact sorts first. Phone slots
+      `CONTACT1_*` and `CONTACT2_*` map the guardian's two phones; `CONTACT3`
+      through `CONTACT7` are always null. Focus column header casing is applied
+      at transport time via `file_config.format.header_replacements`; dbt column
+      names remain lowercase snake_case.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -79,19 +82,32 @@ models:
           Authorized pickup flag; not sourced from Finalsite — always null.
       - name: address
         data_type: string
-        description: Line 1 of the guardian's household address (`address_1`).
+        description:
+          Line 1 of the guardian's resolved address from
+          `int_finalsite__contact_address_of_record`. Null when the guardian's
+          household linkage does not resolve to exactly one address; the row is
+          still sent.
       - name: address2
         data_type: string
-        description: Line 2 of the guardian's household address (`address_2`).
+        description:
+          Line 2 (apartment or unit) of the guardian's resolved address.
+          Legitimately null when the household has no unit line, and null
+          whenever the address is unresolved.
       - name: city
         data_type: string
-        description: City of the guardian's household address.
+        description:
+          City of the guardian's resolved address. Null when unresolved, and
+          possibly null on a resolved but incomplete address.
       - name: state
         data_type: string
-        description: State of the guardian's household address.
+        description:
+          State of the guardian's resolved address. Null when unresolved, and
+          possibly null on a resolved but incomplete address.
       - name: zipcode
         data_type: string
-        description: ZIP code of the guardian's household address.
+        description:
+          ZIP code of the guardian's resolved address. Null when unresolved, and
+          possibly null on a resolved but incomplete address.
       - name: email
         data_type: string
         description:
@@ -318,11 +334,6 @@ unit_tests:
               phone_1_number: "+13055550100",
               phone_2_type: Cell,
               phone_2_number: "+13055550101",
-              address_1: 100 Main St,
-              address_2: null,
-              city: Miami,
-              state: FL,
-              zip: "33101",
             }
           - {
               finalsite_enrollment_id: enr-grd-sec,
@@ -334,11 +345,6 @@ unit_tests:
               phone_1_number: "+13055550200",
               phone_2_type: null,
               phone_2_number: null,
-              address_1: 200 Oak Ave,
-              address_2: null,
-              city: Miami,
-              state: FL,
-              zip: "33102",
             }
           - { finalsite_enrollment_id: enr-stu-002, status: applied }
           - {
@@ -351,11 +357,6 @@ unit_tests:
               phone_1_number: "+13055550300",
               phone_2_type: null,
               phone_2_number: null,
-              address_1: 300 Palm Rd,
-              address_2: null,
-              city: Miami,
-              state: FL,
-              zip: "33103",
             }
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
@@ -367,6 +368,18 @@ unit_tests:
           select
             'enr-stu-002' as finalsite_enrollment_id,
             '84003003003' as focus_student_id_prefixed
+      - input: ref('int_finalsite__contact_address_of_record')
+        format: sql
+        rows: |
+          select
+            'enr-grd-pri' as finalsite_enrollment_id,
+            '100 Main St' as address_1,
+            cast(null as string) as address_2,
+            'Miami' as city,
+            'FL' as state,
+            '33101' as zip
+          union all
+          select 'enr-grd-sec', '200 Oak Ave', null, 'Miami', 'FL', '33102'
     expect:
       rows:
         - {

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__addresses.sql
@@ -27,5 +27,7 @@ inner join
     and ida.focus_student_id_prefixed is not null
 -- an unresolved address is withheld, not exported blank: the feed is
 -- import-once with no overwrite path, so a blank or wrong address of record is
--- permanent. address_source is not null guarantees a complete address.
+-- permanent. address_source is not null guarantees a street line, not a
+-- complete address — an incomplete one is exported for Ops to correct in Focus,
+-- since a missing field is visible there in a way a wrong pick is not.
 where stu.status = 'enrolled' and aor.address_source is not null

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
@@ -18,11 +18,11 @@ select
     cast(null as string) as emergency,
     cast(null as string) as pickup,
 
-    g.address_1 as address,
-    g.address_2 as address2,
-    g.city,
-    g.state,
-    g.zip as zipcode,
+    aor.address_1 as address,
+    aor.address_2 as address2,
+    aor.city,
+    aor.state,
+    aor.zip as zipcode,
     g.email,
     g.phone_1_type as contact1_type,
     g.phone_1_number as contact1_value,
@@ -71,6 +71,13 @@ inner join
     {{ ref("int_finalsite__contact_id_attributes") }} as ida
     on rel.finalsite_enrollment_id = ida.finalsite_enrollment_id
     and ida.focus_student_id_prefixed is not null
+-- the guardian's own household linkage decides their address; array position
+-- does not identify Finalsite's primary household. Unresolved keeps the row and
+-- nulls the address — the feed is import-once, so a wrong address is permanent,
+-- while the name, relationship, email, and phones are still worth sending.
+left join
+    {{ ref("int_finalsite__contact_address_of_record") }} as aor
+    on rel.rel_id = aor.finalsite_enrollment_id
 inner join
     {{ ref("stg_finalsite__contacts") }} as stu
     on rel.finalsite_enrollment_id = stu.finalsite_enrollment_id

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_address_of_record.sql
@@ -1,0 +1,32 @@
+-- All four regions are unioned here, matching
+-- int_finalsite__student_address_of_record. Focus is the Miami consumer and the
+-- NJ regions carry no Focus student id, so the `rpt_focus__*` filter on
+-- `focus_student_id_prefixed` keeps their rows out of the Focus feeds.
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippcamden_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kippmiami_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kippnewark_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                    source(
+                        "kipppaterson_finalsite",
+                        "int_finalsite__contact_address_of_record",
+                    ),
+                ]
+            )
+        }}
+    )
+
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_address_of_record.yml
@@ -1,0 +1,21 @@
+models:
+  - name: int_finalsite__contact_address_of_record
+    description:
+      Network-wide union of the per-region Finalsite
+      `int_finalsite__contact_address_of_record` models — one row per Finalsite
+      contact with its resolved address, or a `resolution_status` explaining why
+      it has none. Includes all four regions; Focus is the Miami consumer and
+      the NJ regions carry no Focus student id, so the `rpt_focus__*` filter on
+      `focus_student_id_prefixed` keeps their rows out of the Focus feeds.
+      Column documentation lives on the package model. Carries
+      `_dbt_source_relation` and the derived `_dbt_source_project`.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: finalsite_enrollment_id
+        data_type: string
+        description: Finalsite contact UUID; the grain.
+        data_tests:
+          - unique
+          - not_null

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_address_of_record.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_address_of_record.yml
@@ -5,7 +5,7 @@ models:
       `int_finalsite__student_address_of_record` models — one row per Finalsite
       student record with its resolved address of record, or an `ambiguous` flag
       when neither the student's nor their primary contact's household linkage
-      yields exactly one complete address. Includes all four regions; Focus is
+      yields exactly one distinct address. Includes all four regions; Focus is
       the Miami consumer and the NJ regions carry no Focus student id, so the
       `rpt_focus__*` filter on `focus_student_id_prefixed` keeps their rows out
       of the Focus feeds. Column documentation lives on the package model.

--- a/src/dbt/kipptaf/models/finalsite/sources-kippcamden.yml
+++ b/src/dbt/kipptaf/models/finalsite/sources-kippcamden.yml
@@ -40,3 +40,12 @@ sources:
                 - kippcamden
                 - finalsite
                 - int_finalsite__student_address_of_record
+      - name: int_finalsite__contact_address_of_record
+        config:
+          meta:
+            dagster:
+              group: finalsite
+              asset_key:
+                - kippcamden
+                - finalsite
+                - int_finalsite__contact_address_of_record

--- a/src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml
+++ b/src/dbt/kipptaf/models/finalsite/sources-kippmiami.yml
@@ -67,3 +67,12 @@ sources:
                 - kippmiami
                 - finalsite
                 - int_finalsite__contact_custom_attributes
+      - name: int_finalsite__contact_address_of_record
+        config:
+          meta:
+            dagster:
+              group: finalsite
+              asset_key:
+                - kippmiami
+                - finalsite
+                - int_finalsite__contact_address_of_record

--- a/src/dbt/kipptaf/models/finalsite/sources-kippnewark.yml
+++ b/src/dbt/kipptaf/models/finalsite/sources-kippnewark.yml
@@ -40,3 +40,12 @@ sources:
                 - kippnewark
                 - finalsite
                 - int_finalsite__student_address_of_record
+      - name: int_finalsite__contact_address_of_record
+        config:
+          meta:
+            dagster:
+              group: finalsite
+              asset_key:
+                - kippnewark
+                - finalsite
+                - int_finalsite__contact_address_of_record

--- a/src/dbt/kipptaf/models/finalsite/sources-kipppaterson.yml
+++ b/src/dbt/kipptaf/models/finalsite/sources-kipppaterson.yml
@@ -41,3 +41,12 @@ sources:
                 - kipppaterson
                 - finalsite
                 - int_finalsite__student_address_of_record
+      - name: int_finalsite__contact_address_of_record
+        config:
+          meta:
+            dagster:
+              group: finalsite
+              asset_key:
+                - kipppaterson
+                - finalsite
+                - int_finalsite__contact_address_of_record


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...resolve each Focus `CONTACTS` guardian address from that guardian's own
Finalsite household linkage instead of an arbitrary array position, and put both
Focus address feeds on one shared resolution rule.

Closes #4651. Follows #4613 / PR #4618, which fixed the same defect for the
`ADDRESS` feed only.

### The problem

`rpt_focus__contacts` took each guardian's address from
`stg_finalsite__contacts`, whose scalar address columns flatten
`households[safe_offset(0)]`. Array position does not identify Finalsite's
primary household — that designation is set in the UI and exposed by no API
field. Whichever household sat at offset 0 became the contact's address in
Focus. The feed is import-once with no overwrite path, so a wrong pick is
permanent. Only 13 students are currently in Focus, so roughly 99% of the
population was still prospective.

### The change

New `finalsite` package model `int_finalsite__contact_address_of_record`, one
row per contact. A household is a candidate when it carries a street line;
address identity is an **exact match on the five mailing fields** — no
case-folding, punctuation-stripping, or ZIP+4 truncation; a contact resolves
only when exactly one distinct address remains, and the exported values are the
raw text of the lowest `household_id` in that group.
`int_finalsite__student_address_of_record` was refactored onto it so the two
feeds cannot drift apart again — that was the actual defect #4651 describes.

Two spellings of one address stay distinct candidates and the contact is
withheld rather than guessed at. A looser key was considered and rejected:
collapsing on `address_1` alone would gain about 12 rows from 8 guardians, of
whom 5 differ by city — that is choosing a household by surrogate-key order,
the same class of defect as `safe_offset(0)`.

Completeness is deliberately not a candidacy gate, so an address missing its
city, state, or ZIP can still resolve. Measured at the guardian-feed level that
change is a **no-op today: zero rows gained, zero lost.** It is a forward-looking
rule change, not one that rescues rows now. Households carrying only a
city/state/ZIP fragment with no street are still excluded — Miami holds 94 of
them, and each would otherwise count as its own candidate and manufacture
ambiguity that is not real.

### Measured against production

| Measure | CONTACTS | ADDRESS |
| --- | --- | --- |
| Rows or students exported | 2,601 rows / 2,071 with an address | unchanged |
| Exported values changed | 0 | 0 |
| Newly enabled | 42 | 0 |
| Newly withheld | 436 | 0 |

The `ADDRESS` feed is a genuine no-op: across all 3,428 student records there
are zero mailing-field changes, zero feed-membership changes, and zero phone
changes. Exactly one contact's internal `address_source` label flips, and
`rpt_focus__addresses` never observes it because that model only tests
`address_source is not null`.

### Scope note — this also touches the ADDRESS feed's gate

The kippmiami `rpt_focus__addresses` wrapper carried a #4320 gate requiring a
complete address, which silently defeated the loosened candidacy rule on that
feed. It is now a street-line gate. Zero rows change today. The advisory review
recommended keeping this in the same PR rather than splitting it, since it is a
three-line change sharing the root cause being fixed here; happy to split it out
if a reviewer disagrees.

### The trade being made, stated plainly

436 guardian rows lose an address they previously had. They are **not withheld**
— every contact row still ships with name, relationship, email, and phones; only
the address fields are blank. Because CONTACTS import-once keys on the student
rather than the contact, those blanks are permanent, exactly as the arbitrary
offset-0 addresses they replace were permanent. The judgement is that a blank
prompts a human while a wrong address looks correct.

225 students end up with no guardian contact row carrying an address. All 225
still receive an address through the `ADDRESS` feed on their own student record,
so **zero students end up with no address anywhere in Focus.**

### Advisory review findings

All four findings from the automated review were verified against the code
rather than taken on trust:

1. **Stale properties description (Important) — fixed.** The kippmiami
   `rpt_focus__addresses.yml` description still documented the completeness gate
   this PR deletes; `git log` confirmed no commit here had touched it. It now
   describes the street-line gate, and its unit test gained a case proving a
   street-only address is included.
1. **NULL field groups as a distinct candidate (Important) — real, zero
   incidence, now tested.** A household missing a ZIP does not match one that
   has it, so two households on the same street could count as two candidates.
   Measured against production: zero such contacts exist today. A unit test now
   documents the behavior deliberately rather than leaving it undefined.
1. **ZIP+4 exports raw (Minor) — pre-existing, not fixed here.** True before this
   PR and still true. Worth its own issue if Focus wants a fixed-width ZIP;
   widening this PR for it is not warranted.
1. **Doc lint unverified (Minor) — already satisfied.** `trunk check --force`
   was run on both new documents and is clean. The review sandbox had no trunk
   binary.

### Staging environment note for reviewers

`stg_finalsite__contacts` was missing the `households` array in all four
`zz_stg_*_finalsite` schemas — PR #4618 added that column but its staging copies
were never seeded, because it cloned the finished
`int_finalsite__student_address_of_record` table, which never needed the
upstream column. Newark, Camden, and Paterson were two further columns behind.
All four are now reseeded from prod, plus both address-of-record models built
into each. This was pre-existing breakage that any PR touching this chain would
have hit.

### AI Assistance

Claude Code implemented this under human direction, task by task, with a review
after each task and a whole-branch review before this PR. Human-directed: the
resolution rule (anchor on the guardian's own linkage; keep the key a strict
exact match; drop the completeness gate), the decision to loosen the kippmiami
ADDRESS gate rather than document around it, and accepting the permanent-blank
trade. AI-authored: the SQL, properties YAML, unit tests, ops documentation, and
the production measurements above.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [x] Review the **Claude Code Review** comment posted on this PR — all four
      findings verified and addressed or explained above.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] **Breaking change?** No columns renamed or removed. The 50-column
      `CONTACTS_LAYOUT` and 12-column `ADDRESS_LAYOUT` contracts are unchanged;
      only rows and values move. `int_finalsite__student_address_of_record`
      gains `is_complete_address`, an additive change on a non-contracted
      intermediate.
- [x] No external sources added or modified. The four district staging schemas
      were seeded manually — see the staging note above.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — expect a wide run. Editing the four `sources-kipp*.yml`
      files marks the whole finalsite source `state:modified`, so
      `state:modified+` fans out across every kipptaf model reading finalsite.
      Treat pre-existing warn-level test noise as pre-existing.
- [ ] **Dagster Cloud** — not triggered; the `pull_request` paths exclude
      `src/dbt/**`.
