### PR TITLE
fix(focus): map Postgres interval columns to int64 microseconds

### DIFF
--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -27,6 +27,9 @@ backend.
 - Uses `reflection_level="full_with_precision"` + `remove_nullability_adapter`
   (forces all columns `NULLABLE` so upstream `NOT NULL` changes don't break the
   `replace` load — see `focus/CLAUDE.md`)
+- `interval_to_microseconds_adapter` maps Postgres `interval` to INT64
+  microseconds; without it dlt rejects the inferred `duration[us]` (see
+  `focus/CLAUDE.md`)
 - Factory:
   `build_focus_dlt_assets(sql_database_credentials, code_location, table_name)`
 

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -48,6 +48,17 @@ obvious check silently matches nothing. It imports only from
 Unlike the nullability adapter, this one needs no table drop: the new column
 arrives NULLABLE, which `replace` may add.
 
+**An all-NULL `interval` column loads fine and is silently dropped**, so absence
+from BigQuery does NOT mean the column is new. pyarrow infers arrow `null`,
+which dlt maps to no `data_type` and omits from the destination; the load breaks
+only when the FIRST non-null value lands. That is why #4676's asset succeeded at
+08:04 UTC and failed at 22:31 on the same commit — one assignment populated
+`time_limit` at 13:23. Two consequences: don't date a schema change from the
+BigQuery column set, and other Focus tables may hold unpopulated `interval`
+columns that break on first use, which you cannot enumerate from BigQuery. Hence
+the adapter keys off the reflected type for every table rather than naming
+columns.
+
 ## Empty source tables
 
 The PyArrow backend writes NO BigQuery table for a 0-row source extract (the

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -7,12 +7,12 @@ default).
 
 ## Differences from Illuminate
 
-| Aspect              | Illuminate                              | Focus                        |
-| ------------------- | --------------------------------------- | ---------------------------- |
-| Schema dimension    | Multi-schema (asset key includes it)    | Single `public` schema       |
-| Type adapters       | `unbounded_numeric_adapter`             | None                         |
-| Query callbacks     | `filter_date_taken_callback` (optional) | None                         |
-| Nullability adapter | `remove_nullability_adapter`            | `remove_nullability_adapter` |
+| Aspect              | Illuminate                              | Focus                              |
+| ------------------- | --------------------------------------- | ---------------------------------- |
+| Schema dimension    | Multi-schema (asset key includes it)    | Single `public` schema             |
+| Type adapters       | `unbounded_numeric_adapter`             | `interval_to_microseconds_adapter` |
+| Query callbacks     | `filter_date_taken_callback` (optional) | None                               |
+| Nullability adapter | `remove_nullability_adapter`            | `remove_nullability_adapter`       |
 
 ## Nullability adapter (required)
 
@@ -25,6 +25,28 @@ mode. BigQuery forbids both adding a `REQUIRED` column and relaxing an existing
 same fix Illuminate uses. Adding/removing this adapter against existing tables
 that already have `REQUIRED` columns requires dropping those tables first
 (`replace` repopulates them on the next run).
+
+## Interval adapter (required)
+
+Postgres `interval` matches none of the branches in dlt's
+`sqla_col_to_column_schema`, so the reflected column carries no `data_type`, the
+PyArrow backend infers `duration[us]` from the `timedelta` values, and the load
+dies with `UnsupportedArrowTypeException` (#4676 —
+`gradebook_assignments.time_limit`).
+`type_adapter_callback=interval_to_microseconds_adapter` declares `BigInteger`,
+so **every Focus `interval` column lands as BigQuery INT64 microseconds** —
+divide by `1e6` for seconds when consuming one downstream.
+
+Not `Time`: dlt converts duration to `time64` by reinterpreting the buffer,
+which silently corrupts intervals of 24 hours or more and negative intervals.
+
+`_AbstractInterval` is the isinstance check —
+`isinstance(postgresql.INTERVAL(), sqltypes.Interval)` is `False`, so the
+obvious check silently matches nothing. It imports only from
+`sqlalchemy.sql.sqltypes`.
+
+Unlike the nullability adapter, this one needs no table drop: the new column
+arrives NULLABLE, which `replace` may add.
 
 ## Empty source tables
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -49,8 +49,9 @@ def interval_to_microseconds_adapter(col_type: TypeEngine) -> TypeEngine | None:
 
     ``BigInteger`` rather than ``Time``: dlt converts duration to ``time64`` by
     reinterpreting the underlying buffer, which silently corrupts intervals of
-    24 hours or more and negative intervals. Microseconds are lossless for any
-    interval Postgres can hold.
+    24 hours or more and negative intervals. int64 microseconds spans roughly
+    292,000 years — lossless for any realistic interval, though narrower than
+    Postgres ``interval``'s full +/-178,000,000-year range.
 
     Note the check is ``_AbstractInterval``, the only base shared by
     ``postgresql.INTERVAL`` and ``sqltypes.Interval`` —

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -7,6 +7,9 @@ from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
 from dlt.sources.sql_database import remove_nullability_adapter, sql_database
+from sqlalchemy import BigInteger
+from sqlalchemy.sql.sqltypes import _AbstractInterval
+from sqlalchemy.types import TypeEngine
 
 
 class FocusDagsterDltTranslator(DagsterDltTranslator):
@@ -34,6 +37,33 @@ class FocusDagsterDltTranslator(DagsterDltTranslator):
         return asset_spec
 
 
+def interval_to_microseconds_adapter(col_type: TypeEngine) -> TypeEngine | None:
+    """Map Postgres ``interval`` columns to int64 microseconds.
+
+    Postgres ``interval`` matches none of the branches in dlt's
+    ``sqla_col_to_column_schema``, so the reflected column carries no
+    ``data_type``, the PyArrow backend infers ``duration[us]`` from the
+    ``timedelta`` values, and dlt rejects the load with
+    ``UnsupportedArrowTypeException``. Declaring ``BigInteger`` makes dlt cast
+    the duration to int64 microseconds instead.
+
+    ``BigInteger`` rather than ``Time``: dlt converts duration to ``time64`` by
+    reinterpreting the underlying buffer, which silently corrupts intervals of
+    24 hours or more and negative intervals. Microseconds are lossless for any
+    interval Postgres can hold.
+
+    Note the check is ``_AbstractInterval``, the only base shared by
+    ``postgresql.INTERVAL`` and ``sqltypes.Interval`` —
+    ``isinstance(INTERVAL(), sqltypes.Interval)`` is ``False``.
+
+    See https://dlthub.com/docs/dlt-ecosystem/verified-sources/arrow-pandas#supported-arrow-data-types
+    """
+    if isinstance(col_type, _AbstractInterval):
+        return BigInteger()
+
+    return col_type
+
+
 def build_focus_dlt_assets(
     sql_database_credentials: ConnectionStringCredentials,
     code_location: str,
@@ -51,6 +81,7 @@ def build_focus_dlt_assets(
         backend="pyarrow",
         reflection_level="full_with_precision",
         table_adapter_callback=remove_nullability_adapter,
+        type_adapter_callback=interval_to_microseconds_adapter,
     )
 
     dlt_pipeline = pipeline(

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -13,11 +13,14 @@ dlt casts the duration to int64 microseconds instead.
 from datetime import timedelta
 
 import pytest
+from dagster_dlt.constants import META_KEY_SOURCE
+from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.libs.pyarrow import (
     UnsupportedArrowTypeException,
     py_arrow_to_table_schema_columns,
 )
 from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.sources.sql_database import remove_nullability_adapter
 from dlt.sources.sql_database.arrow_helpers import row_tuples_to_arrow
 from dlt.sources.sql_database.schema_types import (
     TTypeAdapter,
@@ -27,7 +30,10 @@ from sqlalchemy import BigInteger, Column, Integer, MetaData, String, Table
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.sql import sqltypes
 
-from teamster.libraries.dlt.focus.assets import interval_to_microseconds_adapter
+from teamster.libraries.dlt.focus.assets import (
+    build_focus_dlt_assets,
+    interval_to_microseconds_adapter,
+)
 
 
 def _gradebook_assignments_table() -> Table:
@@ -73,6 +79,33 @@ def test_adapter_maps_generic_interval_to_bigint():
 )
 def test_adapter_passes_other_types_through_unchanged(col_type):
     assert interval_to_microseconds_adapter(col_type) is col_type
+
+
+def test_factory_wires_both_adapters_into_the_dlt_source():
+    """Guard the wiring, not just the adapter function.
+
+    Every other test in this module would still pass if `build_focus_dlt_assets`
+    dropped `type_adapter_callback=`, since they call the adapter directly. This
+    asserts the factory-built source actually carries it. `defer_table_reflect`
+    means no connection is opened, so no live Focus database is needed.
+    """
+    assets = build_focus_dlt_assets(
+        sql_database_credentials=ConnectionStringCredentials(
+            "postgresql+psycopg://localhost:5432/focus"
+        ),
+        code_location="kippmiami",
+        table_name="gradebook_assignments",
+    )
+
+    dlt_source = next(iter(assets.specs)).metadata[META_KEY_SOURCE]
+    explicit_args = dlt_source.resources["gradebook_assignments"].explicit_args
+
+    assert explicit_args["type_adapter_callback"] is interval_to_microseconds_adapter
+
+    # the interval adapter must not have displaced the nullability adapter
+    assert explicit_args["table_adapter_callback"] is remove_nullability_adapter
+    assert explicit_args["reflection_level"] == "full_with_precision"
+    assert explicit_args["backend"] == "pyarrow"
 
 
 def test_interval_column_without_adapter_reproduces_prod_failure():

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -1,0 +1,127 @@
+"""Unit tests for the Focus dlt `interval` type adapter (issue #4676).
+
+Focus added an `interval` column (`time_limit`) to `public.gradebook_assignments`,
+which dlt cannot map: the reflected type matches none of the branches in
+`sqla_col_to_column_schema`, so the column gets no `data_type`, the PyArrow
+backend infers `duration[us]` from the `timedelta` values, and dlt raises
+`UnsupportedArrowTypeException`.
+
+`interval_to_microseconds_adapter` declares `BigInteger` for those columns so
+dlt casts the duration to int64 microseconds instead.
+"""
+
+from datetime import timedelta
+
+import pytest
+from dlt.common.libs.pyarrow import (
+    UnsupportedArrowTypeException,
+    py_arrow_to_table_schema_columns,
+)
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.sources.sql_database.arrow_helpers import row_tuples_to_arrow
+from dlt.sources.sql_database.schema_types import (
+    TTypeAdapter,
+    sqla_col_to_column_schema,
+)
+from sqlalchemy import BigInteger, Column, Integer, MetaData, String, Table
+from sqlalchemy.dialects.postgresql import INTERVAL
+from sqlalchemy.sql import sqltypes
+
+from teamster.libraries.dlt.focus.assets import interval_to_microseconds_adapter
+
+
+def _gradebook_assignments_table() -> Table:
+    """Minimal stand-in for the reflected Focus `gradebook_assignments` table."""
+    return Table(
+        "gradebook_assignments",
+        MetaData(),
+        Column("assignment_id", Integer, nullable=False),
+        Column("title", String, nullable=True),
+        Column("time_limit", INTERVAL(), nullable=True),
+    )
+
+
+def _reflect_columns(
+    table: Table, type_adapter_callback: TTypeAdapter | None = None
+) -> TTableSchemaColumns:
+    """Reflect a table into dlt column schemas the way `sql_database` does."""
+    columns: TTableSchemaColumns = {}
+
+    for col in table.columns:
+        column_schema = sqla_col_to_column_schema(
+            col, "full_with_precision", type_adapter_callback=type_adapter_callback
+        )
+
+        assert column_schema is not None, f"no column schema reflected for {col.name}"
+
+        columns[col.name] = column_schema
+
+    return columns
+
+
+def test_adapter_maps_postgres_interval_to_bigint():
+    assert isinstance(interval_to_microseconds_adapter(INTERVAL()), BigInteger)
+
+
+def test_adapter_maps_generic_interval_to_bigint():
+    """`postgresql.INTERVAL` and `sqltypes.Interval` share only `_AbstractInterval`."""
+    assert isinstance(interval_to_microseconds_adapter(sqltypes.Interval()), BigInteger)
+
+
+@pytest.mark.parametrize(
+    "col_type", [Integer(), String(), sqltypes.Numeric(38, 9), sqltypes.DateTime()]
+)
+def test_adapter_passes_other_types_through_unchanged(col_type):
+    assert interval_to_microseconds_adapter(col_type) is col_type
+
+
+def test_interval_column_without_adapter_reproduces_prod_failure():
+    """Regression guard: this is the exact prod error the adapter fixes."""
+    columns = _reflect_columns(_gradebook_assignments_table())
+
+    # dlt cannot type the interval column, so it carries no `data_type` hint
+    assert columns["time_limit"].get("data_type") is None
+
+    arrow_table = row_tuples_to_arrow(
+        [(1, "Quiz 1", timedelta(minutes=45))], columns=columns, tz="UTC"
+    )
+
+    assert str(arrow_table.schema.field("time_limit").type) == "duration[us]"
+
+    with pytest.raises(UnsupportedArrowTypeException):
+        py_arrow_to_table_schema_columns(arrow_table.schema)
+
+
+def test_interval_column_with_adapter_loads_as_bigint_microseconds():
+    columns = _reflect_columns(
+        _gradebook_assignments_table(),
+        type_adapter_callback=interval_to_microseconds_adapter,
+    )
+
+    assert columns["time_limit"].get("data_type") == "bigint"
+
+    arrow_table = row_tuples_to_arrow(
+        [
+            (1, "Quiz 1", timedelta(minutes=45)),
+            (2, "Quiz 2", None),
+            # `Time` would silently corrupt these two; `bigint` holds them exactly
+            (3, "Take-home", timedelta(hours=48)),
+            (4, "Adjustment", timedelta(minutes=-30)),
+        ],
+        columns=columns,
+        tz="UTC",
+    )
+
+    assert str(arrow_table.schema.field("time_limit").type) == "int64"
+
+    # the schema computation that raised in prod now succeeds
+    dlt_columns = py_arrow_to_table_schema_columns(arrow_table.schema)
+
+    assert dlt_columns["time_limit"].get("data_type") == "bigint"
+
+    assert arrow_table.column("time_limit").to_pylist() == [
+        45 * 60 * 1_000_000,
+        None,
+        48 * 60 * 60 * 1_000_000,
+        -30 * 60 * 1_000_000,
+    ]


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop `kippmiami/dlt/focus/gradebook_assignments` from failing on every nightly run, by mapping Postgres `interval` columns to BigQuery INT64 microseconds.

Focus added an `interval` column named `time_limit` to `public.gradebook_assignments` mid-day on 2026-07-31. dlt cannot map it, so the load dies at the extract step:

```text
dlt.common.libs.pyarrow.UnsupportedArrowTypeException: Arrow type `duration[us]`
for field `time_limit` in table `gradebook_assignments` is unsupported by dlt
```

Not a code regression — the asset succeeded at 08:04 UTC and failed at 22:31 UTC on the same commit `c0663b51a`. Failing runs: [5baaace7](https://kipptaf.dagster.cloud/prod/runs/5baaace7-4a07-4dcf-a4bd-cbe110f4ac16) (76 of 77 steps succeeded) and its auto-retry [4ed9f0fa](https://kipptaf.dagster.cloud/prod/runs/4ed9f0fa-ab52-4d51-8f11-05d0cbb1863e), which failed identically with `will_retry: false`.

**Root cause chain**, traced through the installed dlt:

1. Postgres `interval` reflects as `postgresql.INTERVAL`, matching none of the branches in dlt's `sqla_col_to_column_schema`. It falls to the `else`, logs a warning, and emits a column schema with no `data_type`.
1. With no type hint, `row_tuples_to_arrow` infers the arrow type from the Python `timedelta` values, producing `duration[us]`.
1. `_compute_tables` calls `py_arrow_to_table_schema_columns`, whose `get_column_type_from_py_arrow` has no `duration` branch, so it raises.

**The fix** adds `interval_to_microseconds_adapter` as the Focus `type_adapter_callback` — the same hook Illuminate already uses for `unbounded_numeric_adapter`. Focus previously passed only `table_adapter_callback=remove_nullability_adapter`; the two arguments are independent, so both coexist. The adapter keys off the reflected type rather than a column name, so any future Focus `interval` column is covered rather than just this one.

`BigInteger` over the alternatives, measured against dlt's actual conversion path:

| adapter target | arrow type | 45-minute interval | verdict |
| --- | --- | --- | --- |
| none (current) | `duration[us]` | n/a | reproduces the prod exception |
| `BigInteger` | `int64` | `2700000000` | lossless microseconds |
| `Text` | `string` | `'2700000000'` | microseconds as a string |
| `Time` | `time64[us]` | `time(0, 45)` | unsafe past 24h or negative |

`Time` looks natural for a duration but dlt converts it by reinterpreting the underlying buffer, so an interval of 24 hours or more, or a negative one, corrupts silently. Microseconds are lossless for anything Postgres can hold. Consumers divide by `1e6` for seconds; the unit is documented in the docstring and in `focus/CLAUDE.md`.

Gotcha recorded in both the docstring and `focus/CLAUDE.md`: `isinstance(INTERVAL(), sqltypes.Interval)` is `False`. `_AbstractInterval` is the only base shared by `postgresql.INTERVAL` and `sqltypes.Interval`, so the obvious check silently matches nothing.

**No manual table drop needed** — `remove_nullability_adapter` makes the new column NULLABLE, and adding a NULLABLE column is permitted under the `replace` write disposition. `time_limit` is consumed by nothing today (`stg_focus__gradebook_assignments.sql` does not select it), so there is no downstream contract to update.

Deliberately out of scope: the same adapter for Illuminate (no `interval` column observed there) and adding `time_limit` to the dbt staging contract (no consumer asked for it).

Refs #4676

## AI Assistance

Claude-authored, human-directed. The user supplied the failing run URL; Claude did the diagnosis, chose the candidate set, and wrote the fix, tests, and docs. The user made three calls: `BigInteger` microseconds as the target type, issue-plus-worktree for branch setup, and skipping a formal brainstorming pass.

Claude verified the root cause by reproducing the exact prod exception locally (Focus itself is unreachable from a Codespace — IP allowlist) and confirmed all three candidate mappings against dlt's real conversion functions rather than reasoning about them.

**Not yet verified against the live Focus database.** The reproduction drives dlt's `sqla_col_to_column_schema` / `row_tuples_to_arrow` / `py_arrow_to_table_schema_columns` with a hand-built `INTERVAL` column, which is the code path that raised, but it does not prove the real `time_limit` column reflects as `postgresql.INTERVAL`. It is the only Postgres type that infers to `duration[us]`, so this is very likely, but a branch deployment materializing the asset would settle it — see CI checks below.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

**The first two are left unchecked because they cannot pass in a Codespace, not because they were skipped.** `kippmiami.definitions` fails at module load there regardless of this change — it resolves the Focus credential spec eagerly and the variable is unset locally, a pre-existing constraint documented in `src/teamster/CLAUDE.md`. Verified instead by:

- `uv run pytest tests/libraries/test_dlt_focus_type_adapter.py` — 8 passed, including a guard that reproduces the prod `UnsupportedArrowTypeException` and a case asserting 48-hour and negative intervals survive the mapping exactly.
- Calling `build_focus_dlt_assets` with the real `postgresql+psycopg` dialect: constructs cleanly, asset key `kippmiami/dlt/focus/gradebook_assignments`.
- Asserting `sql_database` propagates `type_adapter_callback` and `table_adapter_callback` together, with `reflection_level` and `backend` intact.
- `uv run pytest tests/libraries/` — 82 passed, 3 failed. All 3 failures are in `tests/libraries/powerschool/sis/odbc/` and reproduce identically on a clean `main` checkout, so they are pre-existing and unrelated.

No schedule, sensor, or new integration, so the Docs section does not apply. No dbt changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

`trunk check --force` was run on all four changed files after the format hook: no issues. dbt Cloud selects zero models here.

**Recommended pre-merge validation.** This PR is opened ready-for-review specifically so the branch deployment builds. Focus is IP-allowlisted and unreachable from a Codespace, so materializing `kippmiami/dlt/focus/gradebook_assignments` in the branch deployment is the only way to confirm the real `time_limit` column loads. Note that branch-deployment dlt runs write to the **prod** dataset `dagster_kippmiami_dlt_focus` — no isolation — which here is the desired outcome, since it repairs the broken table directly.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
