### PR TITLE
feat(dbt): add teacher manager and cumulative GPA slide columns to rpt_tableau__student_course_grades

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -295,6 +295,44 @@ models:
         description: >-
           True when `gpa_needed_for_cumulative_3_0` is at or below the
           credit-weighted max achievable this year (current-year rows only).
+      - name: cumulative_y1_gpa_unweighted_prior_year
+        data_type: float64
+        description: >-
+          Final unweighted cumulative GPA at the end of the prior academic year,
+          the actual value rather than a projection of it. Student-grain, so it
+          repeats across every quarter and the Y1 row. Current-year rows only.
+      - name: gpa_band_projected_unweighted
+        data_type: int64
+        description: >-
+          KIPP GPA Band of `cumulative_y1_gpa_projected_unweighted`, on the
+          five-band unweighted scale — 5 at or above 3.50, 4 from 3.00, 3 from
+          2.50, 2 from 2.00, 1 below 2.00. Band 5 is open-ended, since
+          unweighted GPA exceeds the scale's documented 4.00 ceiling. NULL when
+          the projection is NULL.
+      - name: gpa_band_unweighted_prior_year
+        data_type: int64
+        description: >-
+          KIPP GPA Band of `cumulative_y1_gpa_unweighted_prior_year`, on the
+          same five-band unweighted scale as `gpa_band_projected_unweighted`.
+      - name: cumulative_y1_gpa_unweighted_change_from_prior_year
+        data_type: float64
+        description: >-
+          Projected unweighted cumulative GPA minus the prior year's final
+          unweighted cumulative GPA. Negative means the projection sits below
+          where the student finished last year.
+      - name: gpa_band_change_from_prior_year
+        data_type: int64
+        description: >-
+          `gpa_band_projected_unweighted` minus
+          `gpa_band_unweighted_prior_year`. Negative means the student is
+          projected into a lower band than they finished last year.
+      - name: is_gpa_band_slide
+        data_type: boolean
+        description: >-
+          True when the projected unweighted cumulative GPA falls at least one
+          KIPP GPA Band below where the student finished the prior year. NULL
+          when either band is missing, since an unbanded student is unknown
+          rather than known to be holding steady.
       - name: sectionid
         data_type: int64
         description: PowerSchool section id of the course enrollment.
@@ -331,6 +369,16 @@ models:
       - name: teacher_tableau_username
         data_type: string
         description: Teacher Tableau username (row-level security).
+      - name: manager
+        data_type: string
+        description: >-
+          Formatted name of the teacher's manager, from the staff roster's
+          reports-to relationship. NULL when the teacher has no roster match.
+      - name: report_to_sam_account_name
+        data_type: string
+        description: >-
+          Account name of the teacher's manager, for filtering a teacher list to
+          one manager's reports.
       - name: tutoring_nj
         data_type: boolean
         description:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -301,6 +301,11 @@ models:
           Final unweighted cumulative GPA at the end of the prior academic year,
           the actual value rather than a projection of it. Student-grain, so it
           repeats across every quarter and the Y1 row. Current-year rows only.
+          Cumulative GPA accumulates per student-school upstream, which splits
+          the middle- and high-school series — for a grade 9 student this
+          baseline is their middle-school cumulative, not a high-school one, so
+          any comparison against it spans two series rather than measuring
+          movement within one.
       - name: gpa_band_projected_unweighted
         data_type: int64
         description: >-
@@ -332,7 +337,12 @@ models:
           True when the projected unweighted cumulative GPA falls at least one
           KIPP GPA Band below where the student finished the prior year. NULL
           when either band is missing, since an unbanded student is unknown
-          rather than known to be holding steady.
+          rather than known to be holding steady. Bands 1 and 5 are open-ended,
+          so movement inside them is invisible here — a student falling from
+          1.99 to 0.10 never trips this. Read it alongside
+          `cumulative_y1_gpa_unweighted_change_from_prior_year`, which does not
+          have that blind spot. Grade 9 carries the middle-to-high-school series
+          caveat on `cumulative_y1_gpa_unweighted_prior_year`.
       - name: sectionid
         data_type: int64
         description: PowerSchool section id of the course enrollment.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -75,6 +75,27 @@ with
         from prior_year_gpa_rollup
     ),
 
+    prior_year_cumulative as (
+        /* prior-year FINAL unweighted cumulative GPA — the baseline the
+           in-progress projection is measured against. is_projected is true only
+           for the year in progress, so filtering it out yields the actual
+           end-of-year value rather than a projection of it.
+
+           Grain is one row per student per year from AY2023 on. AY2019-AY2022
+           carried a second row for 11-29 students a year (dual-school
+           enrollment) whose values genuinely differ, so a recurrence would fan
+           this model out — the composite uniqueness test catches that loudly
+           rather than silently averaging two records. */
+        select
+            studentid,
+            _dbt_source_project,
+
+            cumulative_y1_gpa_unweighted as cumulative_y1_gpa_unweighted_prior_year,
+        from {{ ref("int_powerschool__gpa_cumulative_year") }}
+        where
+            academic_year = {{ var("current_academic_year") - 1 }} and not is_projected
+    ),
+
     student_roster as (
         select
             enr._dbt_source_relation,
@@ -155,6 +176,8 @@ with
 
             pyg.gpa_y1_prior_year,
 
+            pyc.cumulative_y1_gpa_unweighted_prior_year,
+
             enr.academic_year
             = {{ var("current_academic_year") }} as is_current_academic_year,
 
@@ -169,6 +192,37 @@ with
             if(
                 term.quarter = 'Y1', gty.n_failing_y1, gtq.n_failing_y1
             ) as gpa_n_failing_y1,
+
+            /* KIPP GPA Band, the KIPP Foundation five-band unweighted scale
+               documented in models/students/CLAUDE.md. Band 5 is open-ended
+               rather than capped at the documented 4.00 because unweighted GPA
+               reaches 4.33 and a closed upper bound leaves those rows unbanded.
+               The trailing is-not-null arm keeps a null GPA out of band 1. */
+            case
+                when gc.cumulative_y1_gpa_projected_unweighted >= 3.50
+                then 5
+                when gc.cumulative_y1_gpa_projected_unweighted >= 3.00
+                then 4
+                when gc.cumulative_y1_gpa_projected_unweighted >= 2.50
+                then 3
+                when gc.cumulative_y1_gpa_projected_unweighted >= 2.00
+                then 2
+                when gc.cumulative_y1_gpa_projected_unweighted is not null
+                then 1
+            end as gpa_band_projected_unweighted,
+
+            case
+                when pyc.cumulative_y1_gpa_unweighted_prior_year >= 3.50
+                then 5
+                when pyc.cumulative_y1_gpa_unweighted_prior_year >= 3.00
+                then 4
+                when pyc.cumulative_y1_gpa_unweighted_prior_year >= 2.50
+                then 3
+                when pyc.cumulative_y1_gpa_unweighted_prior_year >= 2.00
+                then 2
+                when pyc.cumulative_y1_gpa_unweighted_prior_year is not null
+                then 1
+            end as gpa_band_unweighted_prior_year,
 
         from {{ ref("int_extracts__student_enrollments") }} as enr
         inner join
@@ -222,6 +276,14 @@ with
             on enr.studentid = pyg.studentid
             and enr._dbt_source_project = pyg._dbt_source_project
             and enr.academic_year = {{ var("current_academic_year") }}
+        /* gated to the current year in ON, matching gc — the projection it is
+           compared against is a current-year-only measure, so a prior-year row
+           would carry a baseline with nothing to measure it against */
+        left join
+            prior_year_cumulative as pyc
+            on enr.studentid = pyc.studentid
+            and enr._dbt_source_project = pyc._dbt_source_project
+            and enr.academic_year = {{ var("current_academic_year") }}
         where
             enr.rn_year = 1
             and not enr.is_out_of_district
@@ -261,6 +323,8 @@ with
             f.nj_student_tier,
 
             r.sam_account_name as teacher_tableau_username,
+            r.reports_to_formatted_name as manager,
+            r.reports_to_sam_account_name as report_to_sam_account_name,
         from {{ ref("base_powerschool__course_enrollments") }} as m
         left join
             {{ ref("int_extracts__student_enrollments_subjects") }} as f
@@ -525,6 +589,9 @@ select
     s.potential_gpa_credits_current_year,
     s.gpa_needed_for_cumulative_3_0,
     s.is_cumulative_3_0_attainable,
+    s.cumulative_y1_gpa_unweighted_prior_year,
+    s.gpa_band_projected_unweighted,
+    s.gpa_band_unweighted_prior_year,
 
     ce.sectionid,
     ce.sections_dcid,
@@ -538,6 +605,8 @@ select
     ce.teacher_number,
     ce.teacher_name,
     ce.teacher_tableau_username,
+    ce.manager,
+    ce.report_to_sam_account_name,
     ce.tutoring_nj,
     ce.nj_student_tier,
 
@@ -566,6 +635,17 @@ select
     c.category_y1_percent_grade_current,
     c.category_quarter_average_all_courses,
 
+    /* signed, so negative means the projection sits below last year's actual.
+       Both inputs are student-grain, so these repeat across every quarter row
+       and the Y1 row for a student, which is what makes them filterable at any
+       marking period. */
+    s.cumulative_y1_gpa_projected_unweighted
+    - s.cumulative_y1_gpa_unweighted_prior_year
+    as cumulative_y1_gpa_unweighted_change_from_prior_year,
+
+    s.gpa_band_projected_unweighted
+    - s.gpa_band_unweighted_prior_year as gpa_band_change_from_prior_year,
+
     coalesce(
         y1f.y1_course_final_letter_grade_adjusted,
         qg.y1_course_in_progress_letter_grade_adjusted
@@ -574,6 +654,11 @@ select
     if(
         s.grade_level < 9, ce.section_number, ce.external_expression
     ) as section_or_period,
+
+    /* NULL rather than false when either side is missing — an unbanded student
+       is unknown, not known-to-be-holding-steady */
+    s.gpa_band_projected_unweighted
+    <= s.gpa_band_unweighted_prior_year - 1 as is_gpa_band_slide,
 
 from student_roster as s
 left join

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -81,11 +81,18 @@ with
            for the year in progress, so filtering it out yields the actual
            end-of-year value rather than a projection of it.
 
-           Grain is one row per student per year from AY2023 on. AY2019-AY2022
-           carried a second row for 11-29 students a year (dual-school
-           enrollment) whose values genuinely differ, so a recurrence would fan
-           this model out — the composite uniqueness test catches that loudly
-           rather than silently averaging two records. */
+           Upstream accumulates per student-school and its uniqueness key is
+           (studentid, schoolid, academic_year), so a student at two schools in
+           one year legitimately produces two rows and would fan this CTE out.
+           AY2023 onward has none; AY2019-AY2022 had 11-29 a year, values
+           genuinely differing. A recurrence would NOT fail CI — this model's
+           own key test is severity warn for the unrelated #3915 storedgrades
+           issue, so it would only inflate that warn count. Compare the count
+           against prod rather than trusting a green build.
+
+           That same per-school accumulation splits the middle- and high-school
+           series, so a grade 9 row pairs a high-school projection with a
+           middle-school baseline. See the column descriptions. */
         select
             studentid,
             _dbt_source_project,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add eight columns to
`rpt_tableau__student_course_grades`, supporting the school-level Grade and
Failure Analysis dashboard.

**Teacher manager**, from the staff-roster join the model already makes — no new
join:

- `manager`
- `report_to_sam_account_name`

**Cumulative GPA slide**, comparing the in-progress projected unweighted
cumulative GPA against the student's actual unweighted cumulative GPA at the end
of the prior year:

- `cumulative_y1_gpa_unweighted_prior_year`
- `gpa_band_projected_unweighted`
- `gpa_band_unweighted_prior_year`
- `cumulative_y1_gpa_unweighted_change_from_prior_year`
- `gpa_band_change_from_prior_year`
- `is_gpa_band_slide`

Bands use the KIPP Foundation five-band unweighted scale documented in
`models/students/CLAUDE.md`. `rpt_tableau__gpa_cumulative_year` already bands on
the same thresholds as string labels (`gpa_band_label`); these are integer ranks
because `gpa_band_change_from_prior_year` is arithmetic and string labels cannot
be subtracted. Band 5 is open-ended rather than capped at the
documented 4.00, because unweighted GPA reaches 4.33 and a closed bound would
leave roughly 1,574 rows unbanded.

The prior-year baseline comes from a new join to
`int_powerschool__gpa_cumulative_year` filtered to `not is_projected`, which is
the actual end-of-year value rather than a projection of it. Both sides are
student-grain, so every new column repeats across each quarter row and the Y1
row and is filterable at any marking period.

### Verification

- **No fan-out.** Duplicate groups on the model's composite key are unchanged
  from prod — 12 groups, 36 extra rows, both before and after. That is the
  pre-existing `#3915` storedgrades warn, not a regression.
- **Contract passes.** `dbt build --target dev` creates the view with all eight
  columns declared.
- **Band arithmetic validated** on the AY2024-to-AY2025 pair, where real
  year-over-year movement exists: every negative band change flags, every flat
  or positive change does not, and the 211 students missing either band return
  null rather than false.

### Two things a reviewer should know

**The flag reads all-false today.** AY2026 has no posted grades, so the
projection still equals the prior-year actual for essentially every student —
35,458 of 35,538 populated rows have a change of exactly zero, and the remaining
80 differ by 0.01 from rounding drift between the two source models. It begins
producing signal once Q1 grades post. Nothing to fix; worth not mistaking for a
broken join.

**A band comparison cannot see movement inside bands 1 and 5**, which are
open-ended. A student falling from 1.99 to 0.10 never trips
`is_gpa_band_slide`. That is inherent to banding, and it is why
`cumulative_y1_gpa_unweighted_change_from_prior_year` ships alongside the flag
rather than behind it.

### Known gap, deliberately not in this PR

This model is read by two Tableau dashboards but has **no dbt exposure** — the
existing `gradebook_and_gpa_dashboard` exposure covers the older pre-rebuild
models. Adding one is worth doing, but the consuming workbook is not published
yet so there is no URL to point at. Flagged in #4683 rather than guessed at
here.

## AI Assistance

Claude Code authored the SQL, properties entries, and validation queries. The
three requirements, the choice of the five-band scale over the KTAF four-band
scale, and the decision to scope this to buildable-today columns were
human-directed.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated with `data_type` and `description` for all eight
      new columns
- [ ] Exposure — not added; see "Known gap" above
- [x] **Not a breaking change.** Additive only; no renames or removals, so
      existing consumers are unaffected
- [x] No external sources added or modified

## CI checks

- [ ] **Trunk** — `trunk check --force` clean on both changed files before push
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the
      `pull_request` paths

Refs #4683
