### PR TITLE
feat(dbt): add is_quarter_course_failing to student course grades extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -343,6 +343,19 @@ models:
           `cumulative_y1_gpa_unweighted_change_from_prior_year`, which does not
           have that blind spot. Grade 9 carries the middle-to-high-school series
           caveat on `cumulative_y1_gpa_unweighted_prior_year`.
+      - name: is_quarter_course_failing
+        data_type: boolean
+        description: >-
+          True when `quarter_course_letter_grade` begins with `F`, which covers
+          both `F` and `F*`. `F*` marks a grade the 50 percent floor was applied
+          to; it is a real failure worth roughly a third of all failing grades,
+          so an exact match on `F` understates the failure rate by about half in
+          any single quarter. NULL rather than false on an ungraded enrolment,
+          since no grade posted is unknown rather than passing — a failure rate
+          built on this flag should divide by the count of non-null
+          `quarter_course_letter_grade`, not by all rows. The Y1 row carries the
+          Y1 letter grade in that same column, so this flag is valid at every
+          marking period without branching.
       - name: sectionid
         data_type: int64
         description: PowerSchool section id of the course enrollment.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -667,6 +667,20 @@ select
     s.gpa_band_projected_unweighted
     <= s.gpa_band_unweighted_prior_year - 1 as is_gpa_band_slide,
 
+    /* prefix match, not = 'F', because the failing domain is F and F*. F* is
+       not a PowerSchool grade — stg_powerschool__pgfinalgrades manufactures it
+       alongside the 50% floor (if percent < 0.5 then 'F*'), so an exact-equality
+       test silently drops every floored failure, roughly a third of them. This
+       matches the canonical rule the warehouse already uses for n_failing_y1.
+
+       NULL, not false, on an ungraded enrolment — no grade posted is unknown,
+       not known-to-be-passing. Consumers computing a failure rate should divide
+       by the count of non-null quarter_course_letter_grade, not by all rows.
+
+       The Y1 row carries the Y1 letter grade in this same column, so one flag
+       covers Q1-Q4 and Y1 with no marking-period branching. */
+    qg.quarter_course_letter_grade like 'F%' as is_quarter_course_failing,
+
 from student_roster as s
 left join
     course_enrollments as ce


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add one boolean column,
`is_quarter_course_failing`, to `rpt_tableau__student_course_grades`, so BI
consumers stop re-deriving the failing test for themselves.

The rule is prefix-based and matches what the warehouse already does everywhere
else:

```sql
qg.quarter_course_letter_grade like 'F%' as is_quarter_course_failing,
```

### Why this is worth a column rather than a Tableau calc

The failing domain is `F` and `F*`, and `F*` is easy to miss. It is not a
PowerSchool grade — `stg_powerschool__pgfinalgrades` manufactures it alongside
the 50 percent floor:

```sql
if(percent_decimal < 0.5, 0.5, percent_decimal) as percent_decimal_adjusted,
if(percent_decimal < 0.5, 'F*', grade)          as grade_adjusted,
```

It accounts for roughly a third of all failing grades, so an exact-equality test
on `F` understates the quarterly failure rate by about half:

| AY2025 | Exact `= 'F'` | Prefix `like 'F%'` |
| ------ | ------------: | -----------------: |
| Q1     |         1.88% |              3.55% |
| Q2     |         2.03% |              4.15% |
| Q3     |         1.98% |              4.16% |
| Q4     |         2.32% |              5.24% |
| Y1     |         5.59% |              5.59% |

Y1 is identical because `F*` resolves to plain `F` in the stored Y1 grade, which
is why the gap has gone unnoticed — the number is correct at Y1 and roughly half
at every quarter.

This is not hypothetical. The Grade and Failure Analysis workbook currently
tests with `= 'F'` in two calcs, while its stacked bar bands on
`LEFT(letter, 1)` and therefore does include `F*`. The chart and the number
beside it disagree today. That workbook is being corrected separately; this
column is so the next author does not have to know any of the above.

### Consistency

Prefix matching is already the canonical rule in four places —
`int_powerschool__gpa_term.sql:112` (`n_failing_y1`),
`int_powerschool__gpa_cumulative.sql` twice, and
`base_powerschool__final_grades.sql:311`. No dbt model anywhere compares a
letter grade with `= 'F'`. This column brings the reporting layer in line rather
than introducing a new convention.

### Null semantics

`NULL`, not `false`, on an ungraded enrolment — no grade posted is unknown, not
known-to-be-passing. A rate built on this flag should divide by the count of
non-null `quarter_course_letter_grade`, not by all rows. The column description
says so.

### Marking-period coverage

The Y1 row carries the Y1 letter grade in `quarter_course_letter_grade`, so one
flag is valid at Q1 through Q4 and Y1 with no branching. Verified: zero Y1 rows
where that column and `y1_course_letter_grade_adjusted` disagree on failing.

### Verification

Dev build against prod defer:

- **Contract passes.** View created with the new column declared.
- **Domain is closed.** Distinct `quarter_course_letter_grade` across all years
  and all school levels is `A, A+, A-, B, B+, B-, C, C+, C-, D, D+, D-, F, F*`.
  Only `F` and `F*` begin with `F`, so the prefix match is exact, not
  approximate.
- **Flag agrees with the rule.** Zero rows where the flag disagrees with
  `left(letter, 1) = 'F'`; zero graded rows carrying a null flag.
- **Rates reproduce.** Failure rates computed from the flag on the dev view
  match the independent query in the table above to the hundredth.
- **No fan-out.** Additive only; the composite uniqueness test still warns at
  12, the pre-existing `#3915` storedgrades count, unchanged from prod.

### Known gap, unchanged from before

This model still has no dbt exposure — the existing `gradebook_and_gpa_dashboard`
exposure covers the older pre-rebuild models, and the consuming workbook is not
published yet so there is no URL to point at. Same note as on #4684; not
introduced here.

## AI Assistance

Claude Code found the `F*` gap while auditing the workbook, quantified it, and
wrote the column, description, and validation queries. The decision to add a
flag rather than normalize `F*` to `F` in the reporting view was human-directed,
after weighing it against the column-name collision with
`rpt_tableau__gradebook_gpa.quarter_course_letter_grade`, which exposes the same
upstream under the same name and carries two live exposures.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated with `data_type` and `description` for the new
      column
- [ ] Exposure — not added; see "Known gap" above
- [x] **Not a breaking change.** Additive only; no renames or removals
- [x] No external sources added or modified

## CI checks

- [x] **Trunk** — `trunk check --force` clean on both changed files before push
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the
      `pull_request` paths
