### PR TITLE
feat(dbt): add need_next columns to student course grades extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -503,8 +503,15 @@ models:
           negative when the grade is already secured regardless of remaining
           work, and can exceed 100 when the rung is out of reach in the time
           left — consumers should handle both rather than displaying a raw
-          percent. NULL wherever need_60 is null, meaning prior-year rows and
-          any course with no next rung.
+          percent.
+
+          NULL from two independent causes, and the second one surprises people.
+          Either need_60 is null, which is every prior-year row since need_* is
+          a live-gradebook calculation; OR there is no next rung, which is a
+          student already at the top whole letter and any course on a scale with
+          no letter ladder. The second case does NOT require need_60 to be null
+          — a student at 95 percent has a perfectly good need_60 and still gets
+          a null need_next, because there is nothing above an A to need.
       - name: category_name_code
         data_type: string
         description: Gradebook category code (e.g. F/S/W; NULL on Y1 rows).

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -462,6 +462,49 @@ models:
       - name: need_90
         data_type: float64
         description: Percent needed to reach a 90 (current-year rows only).
+      - name: need_next_letter_grade
+        data_type: string
+        description: >-
+          The next WHOLE letter grade above where the student's in-progress Y1
+          grade currently sits — one of A, B, C, D or F. Plus and minus rungs
+          are deliberately excluded, so a student sitting at C- and a student
+          sitting at C+ are both working toward the same B. NULL once the
+          student is at the top whole letter, and NULL on courses whose grade
+          scale has no letter ladder, such as the Camden Pass Fail Scale.
+
+          Read from the course's OWN grade scale, not a fixed ladder, so the
+          same letter means different cutoffs across courses — see
+          need_next_cutoff_percent.
+
+          Do NOT read the implied current rung as a pass or fail signal.
+          Dropping the minus rungs widens each whole-letter band downward, so on
+          KIPP NJ 2019 the F rung runs all the way to 62.9 and a student sitting
+          at 61 — a passing D- — shows a next letter of D. That is the correct
+          next WHOLE letter for them, but they are not failing. Use
+          is_quarter_course_failing for pass or fail.
+      - name: need_next_cutoff_percent
+        data_type: float64
+        description: >-
+          The percent cutoff for need_next_letter_grade on that course's grade
+          scale. It varies by scale and will NOT generally match the 60/70/80/90
+          targets behind need_60 through need_90 — on KIPP NJ 2019, which covers
+          most enrolments, a whole-letter D is 63 and a C is 73, while 60 and 70
+          are the D- and C- cutoffs. The two sets of columns are answering
+          different questions and are expected to disagree by a few points.
+      - name: need_next
+        data_type: float64
+        description: >-
+          Percent required in the CURRENT term for the student's YEAR-TO-DATE
+          course grade to reach need_next_cutoff_percent. It is not the percent
+          needed to earn that letter for the quarter alone.
+
+          Derived from need_60 and need_70, which are exactly linear in their
+          target, so this is an exact value rather than an interpolation. Can be
+          negative when the grade is already secured regardless of remaining
+          work, and can exceed 100 when the rung is out of reach in the time
+          left — consumers should handle both rather than displaying a raw
+          percent. NULL wherever need_60 is null, meaning prior-year rows and
+          any course with no next rung.
       - name: category_name_code
         data_type: string
         description: Gradebook category code (e.g. F/S/W; NULL on Y1 rows).

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -304,7 +304,12 @@ with
             and enr.academic_year <= {{ var("current_academic_year") }}
             /* Miami hard-excluded: region unsupported in the rebuilt
                dashboard (#4340) */
-            -- TODO(#4340): add Paterson once PS gradebook data is populated
+            /* TODO(#4340): add Paterson once PS gradebook data is populated.
+               That change also has to add a kipppaterson source to
+               int_powerschool__gradescaleitem_lookup, which unions Newark,
+               Camden and Miami only — otherwise the grade_scale_ladder join
+               below finds no scale and need_next_* stays silently null for
+               every Paterson row. */
             and enr.region in ('Newark', 'Camden')
     ),
 
@@ -720,6 +725,20 @@ select
     s.gpa_band_projected_unweighted
     - s.gpa_band_unweighted_prior_year as gpa_band_change_from_prior_year,
 
+    /* need_* is affine in the target percent — it is
+       (points_still_needed * target - points_banked) / (term_points / 100), and
+       the three non-target terms are row constants — so the need for ANY target
+       is exactly recoverable from two of the four existing columns, and the
+       CTE-internal point columns never have to cross the package boundary.
+       Reduces to need_60 + (target - 60) / 10 * (need_70 - need_60); at target
+       70 it returns need_70 identically, by construction.
+
+       Like the four it is derived from, this is the percent required IN THE
+       CURRENT TERM to land the YEAR-TO-DATE grade on the next rung — not what
+       is needed for that letter this quarter. */
+    qg.need_60
+    + (gsl.need_next_cutoff_percent - 60) / 10 * (qg.need_70 - qg.need_60) as need_next,
+
     coalesce(
         y1f.y1_course_final_letter_grade_adjusted,
         qg.y1_course_in_progress_letter_grade_adjusted
@@ -747,20 +766,6 @@ select
        The Y1 row carries the Y1 letter grade in this same column, so one flag
        covers Q1-Q4 and Y1 with no marking-period branching. */
     qg.quarter_course_letter_grade like 'F%' as is_quarter_course_failing,
-
-    /* need_* is affine in the target percent — it is
-       (points_still_needed * target - points_banked) / (term_points / 100), and
-       the three non-target terms are row constants — so the need for ANY target
-       is exactly recoverable from two of the four existing columns, and the
-       CTE-internal point columns never have to cross the package boundary.
-       Reduces to need_60 + (target - 60) / 10 * (need_70 - need_60); at target
-       70 it returns need_70 identically, by construction.
-
-       Like the four it is derived from, this is the percent required IN THE
-       CURRENT TERM to land the YEAR-TO-DATE grade on the next rung — not what
-       is needed for that letter this quarter. */
-    qg.need_60
-    + (gsl.need_next_cutoff_percent - 60) / 10 * (qg.need_70 - qg.need_60) as need_next,
 
 from student_roster as s
 left join

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -405,6 +405,8 @@ with
             need_80,
             need_90,
 
+            courses_gradescaleid,
+
         from {{ ref("base_powerschool__final_grades") }}
         where
             academic_year = {{ var("current_academic_year") }}
@@ -435,6 +437,8 @@ with
             need_70,
             need_80,
             need_90,
+
+            courses_gradescaleid,
 
         from {{ ref("base_powerschool__final_grades") }}
         where
@@ -470,10 +474,70 @@ with
             cast(null as float64) as need_80,
             cast(null as float64) as need_90,
 
+            cast(null as int64) as courses_gradescaleid,
+
         from {{ ref("stg_powerschool__storedgrades") }}
         where
             storecode in ('Q1', 'Q2', 'Q3', 'Q4', 'Y1')
             and academic_year = {{ var("current_academic_year") - 1 }}
+    ),
+
+    grade_scale_rungs as (
+        /* Whole-letter rungs only, no plus-minus, taken from each course's OWN
+           scale — so the cutoffs genuinely differ. A D is 63 on KIPP NJ 2019
+           but 60 on KIPP NJ 2016, which carries no D+/D-, and NCA 2011 has no
+           A-. A hardcoded 60/70/80/90 ladder is wrong for roughly one Newark
+           row in seven.
+
+           Bands are recomputed here rather than reusing the lookup's own
+           max_cutoffpercentage, which is unusable for this: that window
+           partitions by scale id alone, so a scale carrying two items at one
+           cutoff makes lead() repeat the value and collapses the band to
+           max = min - 0.1 (119 of 976 rows). Restricting to whole letters
+           leaves no duplicate cutoffs at all. _dbt_source_project is in the
+           partition and the join because scale ids collide across districts —
+           a bare gradescaleid join fans out about 1.8x. */
+        select
+            _dbt_source_project,
+            gradescaleid,
+            min_cutoffpercentage,
+
+            row_number() over (
+                partition by _dbt_source_project, gradescaleid
+                order by min_cutoffpercentage
+            ) as rung_number,
+
+            lead(letter_grade) over (
+                partition by _dbt_source_project, gradescaleid
+                order by min_cutoffpercentage
+            ) as need_next_letter_grade,
+
+            lead(min_cutoffpercentage) over (
+                partition by _dbt_source_project, gradescaleid
+                order by min_cutoffpercentage
+            ) as need_next_cutoff_percent,
+
+            lead(min_cutoffpercentage, 1, 1000) over (
+                partition by _dbt_source_project, gradescaleid
+                order by min_cutoffpercentage
+            )
+            - 0.1 as rung_ceiling,
+        from {{ ref("int_powerschool__gradescaleitem_lookup") }}
+        where letter_grade in ('A', 'B', 'C', 'D', 'F')
+    ),
+
+    grade_scale_ladder as (
+        /* the bottom rung floors at 0 so a percent below the F cutoff — the F*
+           range on scales that split the two — still lands on a rung */
+        select
+            _dbt_source_project,
+            gradescaleid,
+            need_next_letter_grade,
+            need_next_cutoff_percent,
+            rung_ceiling,
+
+            if(rung_number = 1, 0, min_cutoffpercentage) as rung_floor,
+        from grade_scale_rungs
     ),
 
     category_grades as (
@@ -642,6 +706,9 @@ select
     c.category_y1_percent_grade_current,
     c.category_quarter_average_all_courses,
 
+    gsl.need_next_letter_grade,
+    gsl.need_next_cutoff_percent,
+
     /* signed, so negative means the projection sits below last year's actual.
        Both inputs are student-grain, so these repeat across every quarter row
        and the Y1 row for a student, which is what makes them filterable at any
@@ -681,6 +748,20 @@ select
        covers Q1-Q4 and Y1 with no marking-period branching. */
     qg.quarter_course_letter_grade like 'F%' as is_quarter_course_failing,
 
+    /* need_* is affine in the target percent — it is
+       (points_still_needed * target - points_banked) / (term_points / 100), and
+       the three non-target terms are row constants — so the need for ANY target
+       is exactly recoverable from two of the four existing columns, and the
+       CTE-internal point columns never have to cross the package boundary.
+       Reduces to need_60 + (target - 60) / 10 * (need_70 - need_60); at target
+       70 it returns need_70 identically, by construction.
+
+       Like the four it is derived from, this is the percent required IN THE
+       CURRENT TERM to land the YEAR-TO-DATE grade on the next rung — not what
+       is needed for that letter this quarter. */
+    qg.need_60
+    + (gsl.need_next_cutoff_percent - 60) / 10 * (qg.need_70 - qg.need_60) as need_next,
+
 from student_roster as s
 left join
     course_enrollments as ce
@@ -711,4 +792,10 @@ left join
     and s._dbt_source_project = c._dbt_source_project
     and ce.sectionid = c.sectionid
     and ce._dbt_source_project = c._dbt_source_project
+left join
+    grade_scale_ladder as gsl
+    on qg._dbt_source_project = gsl._dbt_source_project
+    and qg.courses_gradescaleid = gsl.gradescaleid
+    and qg.y1_course_in_progress_percent_grade_adjusted
+    between gsl.rung_floor and gsl.rung_ceiling
 where s.quarter_start_date <= current_date('{{ var("local_timezone") }}')

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradescaleitem_lookup.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradescaleitem_lookup.yml
@@ -2,6 +2,31 @@ models:
   - name: int_powerschool__gradescaleitem_lookup
     config:
       materialized: table
+    data_tests:
+      # Guards the whole-letter ladder that rpt_tableau__student_course_grades
+      # builds for need_next_*. That ladder assumes A/B/C/D/F cutoffs are
+      # distinct within a scale, and the assumption is currently true but
+      # nothing enforced it. Two whole letters sharing a cutoff make lead()
+      # return the earlier row's own value, collapsing its band to
+      # max = min - 0.1 so it matches nothing and the range it should have
+      # covered silently reports the wrong next letter. Two IDENTICAL rows
+      # would instead fan the join out. Error, not warn: both failures are
+      # silent, and the consuming model's own key test is warn-level for the
+      # unrelated #3915 issue, so a regression there would just raise a count
+      # nobody reads.
+      #
+      # Scoped to whole letters on purpose. The unscoped model carries 119
+      # legitimately degenerate bands from plus-minus and special-code items
+      # sharing cutoffs, which no consumer range-matches against.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - _dbt_source_project
+              - gradescaleid
+              - min_cutoffpercentage
+          config:
+            where: letter_grade in ('A', 'B', 'C', 'D', 'F')
+            severity: error
     columns:
       - name: _dbt_source_relation
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will consolidate the `need_60` / `need_70` /
`need_80` / `need_90` ladder into a single "what do you need for the next
letter" answer, without removing the four. Three columns:

| Column | Type | What |
| --- | --- | --- |
| `need_next_letter_grade` | string | next WHOLE letter above the student's in-progress Y1 standing |
| `need_next_cutoff_percent` | float64 | that letter's cutoff on the course's own scale |
| `need_next` | float64 | percent required this term to get the Y1 grade there |

Whole letters only, A/B/C/D/F, per an explicit product decision — a student at
`C-` and a student at `C+` are both working toward the same `B`.

### Why the rungs come from the grade scale rather than a fixed ladder

The scales genuinely differ. Newark Q1 alone spans five:

| Scale | Rows | Quirk |
| --- | ---: | --- |
| KIPP NJ 2019 (5-12) Unweighted | 18,801 | full ladder, `D` at 63 |
| NCA 2011 | 1,465 | **no `A-`**, `D` at 60 |
| KIPP NJ 2016 (5-12) | 1,425 | **no `D+`/`D-`** — `D` at 60, jumps to `C-` |
| KIPP NJ 2019 Weighted | 759 | full ladder |
| KIPP NJ 2024 Weighted-Honors | 250 | no `F*` |

Roughly one Newark row in seven is on a non-default scale, so a hardcoded
60/70/80/90 `CASE` would be quietly wrong for them — the same class of error as
the `= 'F'` bug fixed in #4685.

### Two things this deliberately does not require

**No `src/dbt/powerschool/` change.** `courses_gradescaleid` is already
projected on `base_powerschool__final_grades`, so the extract passes it through,
and `int_powerschool__gradescaleitem_lookup` already exists at kipptaf level
carrying `_dbt_source_project`.

**No new point columns.** `need_*` is affine in its target percent — it is
`(points_still_needed * target - points_banked) / (term_points / 100)`, whose
other three terms are row constants — so the need for any target is exactly
recoverable from two of the four existing columns:

```text
need(t) = need_60 + (t - 60) / 10 * (need_70 - need_60)
```

At `t = 70` that returns `need_70` identically. The CTE-internal point columns
never have to cross the package boundary.

### Two traps this avoids, both verified

**The lookup's own bands are unusable here.** Its window partitions by scale id
alone, so a scale carrying two items at one cutoff makes `lead()` repeat the
value and collapses the band to `max = min - 0.1` — 119 of its 976 rows.
Restricting to whole letters removes every duplicate cutoff (135 rows, 135
distinct by both letter and cutoff), and the bands are recomputed locally.

**Scale ids collide across districts.** 976 rows but only 550 distinct
`gradescaleid|letter`, so a bare `gradescaleid` join fans out about 1.8x. The
join and the window both carry `_dbt_source_project`, which makes the key
exactly unique at 976.

### Verification

- **Rung coverage is total and unambiguous.** Every percent from 0 to 100 lands
  on exactly one rung for every scale — 0 violations across 3,232 scale-percent
  pairs. The KIPP NJ 2019 chain reads `F` to `D` at 63, `D` to `C` at 73, `C` to
  `B` at 83, `B` to `A` at 93, `A` to top.
- **No fan-out.** Dev and prod both return 854,245 rows and 854,209 distinct
  composite keys — exactly equal. The uniqueness test still warns at 12, the
  pre-existing `#3915` storedgrades count.
- **Contract passes** on a dev build, before and after formatting.
- **Trunk clean** on both files.

### What is not verified, and why

`need_*` is null across the entire extract today — it is a live-gradebook
calculation and AY2026 has no posted grades, so `need_next` is null everywhere
too. The arithmetic follows from the formula's linearity rather than from
observed values. **The produced numbers want a spot-check against real students
once Q1 grades land**; the rung logic and the join are verified now, the
multiplication is not.

### One documented sharp edge

Dropping the minus rungs widens each whole-letter band downward. On KIPP NJ 2019
the `F` rung therefore runs to 62.9, so a student at 61 — a passing `D-` — shows
a next letter of `D`. That is the correct next whole letter for them, but it is
not a pass-fail signal; `is_quarter_course_failing` is. Called out on the column
description.

## AI Assistance

Claude Code found the scale heterogeneity and the two join traps, derived the
linearity identity that avoids a package change, and wrote the SQL,
descriptions, and validation queries. The three product decisions were
human-directed: whole letters rather than plus-minus, a failing student's target
being `D`, and the Y1 framing.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated with `data_type` and `description` for all three
      new columns
- [ ] Exposure — still absent on this model; pre-existing, see #4685
- [x] **Not a breaking change.** Additive only; the four existing `need_*`
      columns are untouched
- [x] No external sources added or modified

## CI checks

- [x] **Trunk** — `trunk check --force` clean on both changed files before push
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the
      `pull_request` paths
