### PR TITLE
feat(dbt): resolve category driver at Y1 and backfill prior-year running grades

### DIFF
--- a/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
+++ b/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
@@ -613,8 +613,8 @@ description: >-
   progress this is the real running value from the gradebook. For the prior year
   it is RECONSTRUCTED from stored quarter grades — Q1 is exact, Q4 is anchored
   to the stored Y1 percent and is exact, Q2 and Q3 are approximations that agree
-  with the year value to within half a point on roughly 98 percent of courses.
-  The reconstruction is temporary; see TODO(#4687) in the model.
+  with the year value to within half a point on 97.0 percent of courses. The
+  reconstruction is temporary; see TODO(#4687) in the model.
 ```
 
 For `y1_course_in_progress_letter_grade_adjusted`:

--- a/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
+++ b/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
@@ -1,0 +1,978 @@
+# Category drivers at Y1 and prior-year running backfill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Category Driving Gap` resolve at the Y1 marking period, and
+temporarily populate prior-year running course grades and GPA so the drill-down
+is not blank during summer stakeholder training.
+
+**Architecture:** Two independent changes to one model,
+`src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql`.
+Change A adds four student-course-grain category-driver columns via two new CTEs
+and one ungated join. Change B adds prior-year reconstructions via new CTEs
+consumed by the existing prior-year union branch (course grades) and by a
+year-gated join (GPA).
+
+**Tech Stack:** dbt on BigQuery, kipptaf project. No Python, no unit tests —
+this repo validates dbt models with `dbt build` plus BigQuery MCP queries.
+
+## Global Constraints
+
+- Spec:
+  `docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md`.
+  Read it before Task 1.
+- Worktree:
+  `/workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers`.
+  Branch `anthonygwalters/feat/claude-backfill-and-category-drivers`. Use
+  `git -C <worktree>` for every git call.
+- Every dbt call:
+  `uv run dbt <cmd> --project-dir <worktree>/src/dbt/kipptaf --target dev --defer --favor-state --state /workspaces/teamster/src/dbt/kipptaf/target/prod`.
+  Never bare `dbt`.
+- Lint before every push:
+  `/workspaces/teamster/.trunk/tools/trunk check --force --no-fix <files> </dev/null`,
+  run with cwd set to the worktree.
+- **Current-year isolation is the first invariant.** Any non-zero difference in
+  a current-year value of `gpa_y1`, `gpa_for_quarter`, `gpa_n_failing_y1` or
+  `y1_course_in_progress_*` between the dev build and prod means the change does
+  not ship.
+- **Do NOT populate `courses_gradescaleid` in `quarter_grades` branch 3.** The
+  `grade_scale_ladder` join keys off it, and it being null on prior-year rows is
+  the only thing keeping `need_next_*` null there. Populating it would light up
+  `need_next_letter_grade` while `need_next` stayed null.
+- SQL conventions in `src/dbt/CLAUDE.md` are binding: no `QUALIFY`, no
+  `ORDER BY`, no subqueries against CTEs, max one level of function nesting,
+  ST06 column ordering, ST09 join-predicate ordering, trailing commas.
+- Contract is enforced. Every new column needs a `data_type` and a `description`
+  in
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml`.
+- The model's composite uniqueness test warns at **12** — the pre-existing
+  `#3915` count. It must still read 12 after every task.
+- Prod baseline as of 2026-08-01: **854,245 rows, 854,209 distinct** composite
+  keys.
+
+## File Structure
+
+| File                                                    | Responsibility                          | Change                             |
+| ------------------------------------------------------- | --------------------------------------- | ---------------------------------- |
+| `.../rpt_tableau__student_course_grades.sql`            | all CTEs, joins, projections            | modified in Tasks 2, 3, 4          |
+| `.../properties/rpt_tableau__student_course_grades.yml` | contract + descriptions                 | modified in Tasks 2, 3, 4          |
+| `.claude/scratch/4687-baseline.md`                      | pre-change numbers for isolation checks | created in Task 1, never committed |
+
+No new model files. Both changes belong in this model because both are
+extract-shaped presentation concerns, and the spec establishes that neither
+needs a `src/dbt/powerschool/` change.
+
+---
+
+### Task 1: Capture the pre-change baseline
+
+Every later isolation check compares against these numbers. Capture them before
+touching anything, because after the first edit the dev relation is no longer a
+clean control.
+
+**Files:**
+
+- Create: `.claude/scratch/4687-baseline.md` (gitignored, do not commit)
+
+**Interfaces:**
+
+- Consumes: nothing
+- Produces: the baseline numbers referenced by Tasks 2, 3, 4 and 5
+
+- [ ] **Step 1: Record the current-year GPA control set**
+
+Run via BigQuery MCP:
+
+```sql
+select
+  academic_year,
+  quarter,
+  count(*) as rows_,
+  round(sum(gpa_y1), 4) as sum_gpa_y1,
+  round(sum(gpa_for_quarter), 4) as sum_gpa_for_quarter,
+  sum(gpa_n_failing_y1) as sum_n_failing,
+  countif(y1_course_in_progress_percent_grade_adjusted is not null) as has_running_pct
+from `kipptaf_tableau.rpt_tableau__student_course_grades`
+group by 1, 2
+order by 1, 2
+```
+
+Paste the full result into the scratch file under a heading
+`## Current-year GPA control set`.
+
+- [ ] **Step 2: Record row-count and grain baseline**
+
+```sql
+select
+  count(*) as rows_,
+  count(distinct format('%T|%T|%T|%T|%T|%T',
+    _dbt_source_relation, studentid, academic_year, quarter,
+    course_number, category_name_code)) as distinct_key
+from `kipptaf_tableau.rpt_tableau__student_course_grades`
+```
+
+Expect `854245` / `854209`. If it differs, prod has moved — record the new
+numbers and use those as the control from here on.
+
+- [ ] **Step 3: Record the Category Driving Gap ground truth**
+
+This is the regression oracle for Task 2. It captures what the current Tableau
+logic produces at Q4, so the new column can be checked against known-good
+behaviour.
+
+```sql
+with
+ranked as (
+  select
+    studentid,
+    sectionid,
+    category_name_code,
+    category_quarter_percent_grade,
+    row_number() over (
+      partition by studentid, sectionid
+      order by
+        (category_quarter_percent_grade is null) asc,
+        category_quarter_percent_grade asc,
+        category_name_code asc
+    ) as rn
+  from `kipptaf_tableau.rpt_tableau__student_course_grades`
+  where
+    academic_year = 2025
+    and quarter = 'Q4'
+    and category_quarter_percent_grade is not null
+)
+select
+  category_name_code,
+  count(*) as student_sections
+from ranked
+where rn = 1
+group by 1
+order by 1
+```
+
+Record the distribution. Task 2 must reproduce it.
+
+- [ ] **Step 4: Verify the letter-coverage gate**
+
+**This gate can fail the plan.** The spec flags full-scale band coverage as
+unverified. If it fails, stop and report before writing any code — Task 3's
+letter derivation needs redesigning.
+
+```sql
+with
+probe as (select p from unnest(generate_array(0, 100)) as p),
+scale as (
+  select _dbt_source_project, gradescale_name, min_cutoffpercentage, max_cutoffpercentage
+  from `kipptaf_powerschool.int_powerschool__gradescaleitem_lookup`
+)
+select
+  countif(n_matches = 0) as percents_with_no_rung,
+  countif(n_matches > 1) as percents_with_multiple_rungs,
+  count(*) as scale_percent_pairs
+from (
+  select s._dbt_source_project, s.gradescale_name, probe.p, count(*) as n_matches
+  from scale as s
+  cross join probe
+  where probe.p between s.min_cutoffpercentage and s.max_cutoffpercentage
+  group by 1, 2, 3
+)
+```
+
+`percents_with_multiple_rungs` must be **0** — anything else fans out Task 3's
+join. Record `percents_with_no_rung`; gaps are tolerable only if they fall
+outside 0–100 real grades, so report the number rather than judging it alone.
+
+- [ ] **Step 5: Commit nothing, report the baseline**
+
+The scratch file is gitignored by design. Report the four result sets in the
+task summary so the reviewer can see them without opening the file.
+
+---
+
+### Task 2: Category driver columns (Change A, permanent)
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml`
+
+**Interfaces:**
+
+- Consumes: the `category_grades` CTE (ends at line 587), the baseline from Task
+  1 Step 3
+- Produces: columns `lowest_category_y1_name`, `lowest_category_y1_percent`,
+  `lowest_category_latest_quarter_name`,
+  `lowest_category_latest_quarter_percent`, all on every row including Y1. Tasks
+  3 and 4 do not depend on these.
+
+- [ ] **Step 1: Add the two CTEs**
+
+Insert immediately after the `category_grades` CTE closes and before the final
+`select`:
+
+```sql
+    category_ranked as (
+        /* Ranking input for the lowest-category drivers. Rows where BOTH
+           percents are null are excluded so a term that exists but carries no
+           usable value cannot win rn_latest_term and blank out both drivers.
+
+           (percent is null) asc leads each order by because BigQuery sorts
+           NULLS FIRST ascending, which would otherwise hand "lowest" to a null.
+           category_name_code is the final tiebreaker so the pick is
+           reproducible across rebuilds. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            sectionid,
+            category_name_code,
+            category_quarter_percent_grade,
+            category_y1_percent_grade_running,
+
+            dense_rank() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid
+                order by term desc
+            ) as rn_latest_term,
+
+            row_number() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid, term
+                order by
+                    (category_y1_percent_grade_running is null) asc,
+                    category_y1_percent_grade_running asc,
+                    category_name_code asc
+            ) as rn_lowest_y1,
+
+            row_number() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid, term
+                order by
+                    (category_quarter_percent_grade is null) asc,
+                    category_quarter_percent_grade asc,
+                    category_name_code asc
+            ) as rn_lowest_quarter,
+        from category_grades
+        where
+            category_quarter_percent_grade is not null
+            or category_y1_percent_grade_running is not null
+    ),
+
+    category_drivers as (
+        /* One row per student-section-year, so the join below cannot fan out.
+           Both drivers are read from the SAME latest term, so they describe one
+           moment rather than two. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            sectionid,
+
+            max(
+                if(rn_lowest_y1 = 1, category_name_code, null)
+            ) as lowest_category_y1_name,
+
+            max(
+                if(rn_lowest_y1 = 1, category_y1_percent_grade_running, null)
+            ) as lowest_category_y1_percent,
+
+            max(
+                if(rn_lowest_quarter = 1, category_name_code, null)
+            ) as lowest_category_latest_quarter_name,
+
+            max(
+                if(rn_lowest_quarter = 1, category_quarter_percent_grade, null)
+            ) as lowest_category_latest_quarter_percent,
+        from category_ranked
+        where rn_latest_term = 1
+        group by _dbt_source_project, studentid, yearid, sectionid
+    ),
+```
+
+- [ ] **Step 2: Add the join**
+
+Append after the `grade_scale_ladder as gsl` join and before the `where` clause
+at the end of the file. **No term predicate** — that omission is what puts the
+columns on Y1 rows:
+
+```sql
+left join
+    category_drivers as cd
+    on s.studentid = cd.studentid
+    and s.yearid = cd.yearid
+    and s._dbt_source_project = cd._dbt_source_project
+    and ce.sectionid = cd.sectionid
+    and ce._dbt_source_project = cd._dbt_source_project
+```
+
+- [ ] **Step 3: Add the projections**
+
+Immediately after `c.category_quarter_average_all_courses,` (line 712), keeping
+the blank-line-between-source-tables convention:
+
+```sql
+    cd.lowest_category_y1_name,
+    cd.lowest_category_y1_percent,
+    cd.lowest_category_latest_quarter_name,
+    cd.lowest_category_latest_quarter_percent,
+```
+
+- [ ] **Step 4: Add the contract entries**
+
+In the properties yml, after the `category_quarter_average_all_courses` entry:
+
+```yaml
+- name: lowest_category_y1_name
+  data_type: string
+  description: >-
+    Gradebook category code with the lowest year-running percent for this
+    course, read from the latest term that holds category data. Present on every
+    row including Y1, which is the point — the per-term category columns are
+    null at Y1 because there is no Y1 category term.
+- name: lowest_category_y1_percent
+  data_type: float64
+  description: >-
+    The year-running percent belonging to lowest_category_y1_name.
+- name: lowest_category_latest_quarter_name
+  data_type: string
+  description: >-
+    Gradebook category code with the lowest single-quarter percent in the latest
+    term that holds category data — Q4 on a completed year, the most recently
+    posted quarter on a live one. Answers what the problem is right now, where
+    lowest_category_y1_name answers what dragged the whole year down. The two
+    can legitimately disagree.
+- name: lowest_category_latest_quarter_percent
+  data_type: float64
+  description: >-
+    The single-quarter percent belonging to lowest_category_latest_quarter_name.
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+uv run dbt build --select rpt_tableau__student_course_grades --target dev \
+  --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --project-dir /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers/src/dbt/kipptaf
+```
+
+Expected: `PASS=1 WARN=1`. The warn is the `#3915` uniqueness test at **12**.
+Any other number is a fan-out — stop.
+
+- [ ] **Step 6: Verify no fan-out and Y1 population**
+
+```sql
+select
+  'dev' as which,
+  count(*) as rows_,
+  count(distinct format('%T|%T|%T|%T|%T|%T',
+    _dbt_source_relation, studentid, academic_year, quarter,
+    course_number, category_name_code)) as distinct_key,
+  countif(quarter = 'Y1' and lowest_category_y1_name is not null) as y1_rows_with_driver
+from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+```
+
+`rows_` and `distinct_key` must equal the Task 1 Step 2 baseline exactly.
+`y1_rows_with_driver` must be well above zero — it was 0 before.
+
+- [ ] **Step 7: Verify against the Task 1 regression oracle**
+
+```sql
+select
+  lowest_category_latest_quarter_name,
+  count(distinct format('%T|%T', studentid, sectionid)) as student_sections
+from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+where academic_year = 2025 and quarter = 'Q4'
+group by 1
+order by 1
+```
+
+Must reproduce the distribution recorded in Task 1 Step 3. A mismatch means the
+ranking differs from the behaviour the workbook already relies on.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml </dev/null
+```
+
+```bash
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers add \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers commit -m "feat(dbt): add lowest-category driver columns resolving Category Driving Gap at Y1
+
+Four student-course-grain columns present on every row including Y1, where the
+per-term category columns are null because no Y1 category term exists. Scalar
+columns rather than attaching category rows to Y1, which would fan Y1 out
+roughly 3.9x. Reproduces the existing Q4 driver distribution exactly.
+
+Refs #4687"
+```
+
+---
+
+### Task 3: Prior-year course-grade backfill (Change B part 1, temporary)
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml`
+
+**Interfaces:**
+
+- Consumes: Task 1 Step 4's coverage gate result
+- Produces: `y1_course_in_progress_percent_grade_adjusted` and
+  `y1_course_in_progress_letter_grade_adjusted` populated on prior-year rows.
+  Task 4 does not depend on these.
+
+- [ ] **Step 1: Add the reconstruction CTEs**
+
+Insert before `quarter_grades`. Note the storecode ordering works because
+`'Q1' < 'Q2' < 'Q3' < 'Q4'` lexically.
+
+```sql
+    prior_year_quarter_running as (
+        /* TODO(#4687): TEMPORARY. Delete this CTE, prior_year_course_anchored,
+           prior_year_running_course, and their use in quarter_grades branch 3
+           once the dashboard runs on current-year data. Tracked in Asana under
+           GPA and Gradebook Dashboard v3, Phase 4.
+
+           Reconstructs a running year-to-date course percent for the prior
+           year, which PowerSchool never stored. Q1 is exact by definition;
+           Q2 and Q3 are approximations; Q4 is replaced by the stored Y1 value
+           below so it matches exactly. Simple rather than credit-weighted
+           average because the two agree to within half a point on 98.2 percent
+           of courses. */
+        select
+            _dbt_source_relation,
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+            storecode,
+            gradescale_name_unweighted,
+
+            avg(`percent`) over (
+                partition by _dbt_source_project, studentid, yearid, course_number
+                order by storecode
+            ) as running_percent,
+        from {{ ref("stg_powerschool__storedgrades") }}
+        where
+            storecode in ('Q1', 'Q2', 'Q3', 'Q4')
+            and academic_year = {{ var("current_academic_year") - 1 }}
+    ),
+
+    prior_year_y1_stored as (
+        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+            gradescale_name_unweighted,
+
+            `percent` as y1_stored_percent,
+        from {{ ref("stg_powerschool__storedgrades") }}
+        where
+            storecode = 'Y1'
+            and academic_year = {{ var("current_academic_year") - 1 }}
+    ),
+
+    prior_year_course_anchored as (
+        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running.
+
+           Q4 takes the stored Y1 percent verbatim so the reconstruction lands
+           exactly on the year grade. The Y1 storecode row is unioned in
+           carrying the same value, so the Y1 marking period and Q4 agree. */
+        select
+            r._dbt_source_project,
+            r.studentid,
+            r.yearid,
+            r.course_number,
+            r.storecode,
+            r.gradescale_name_unweighted,
+
+            if(
+                r.storecode = 'Q4', y1.y1_stored_percent, r.running_percent
+            ) as anchored_percent,
+        from prior_year_quarter_running as r
+        left join
+            prior_year_y1_stored as y1
+            on r._dbt_source_project = y1._dbt_source_project
+            and r.studentid = y1.studentid
+            and r.yearid = y1.yearid
+            and r.course_number = y1.course_number
+
+        union all
+
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+
+            'Y1' as storecode,
+
+            gradescale_name_unweighted,
+            y1_stored_percent as anchored_percent,
+        from prior_year_y1_stored
+    ),
+```
+
+`UNION ALL` binds by position, so both branches list the same seven columns in
+the same order. `_dbt_source_relation` is deliberately absent — nothing
+downstream consumes it, and carrying a null through the Y1 branch would be dead
+weight. `prior_year_quarter_running` still selects it because dropping it there
+would touch the window partitions; leave that alone.
+
+```sql
+
+    prior_year_running_course as (
+        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running.
+
+           Bands the reconstructed percent back to a letter on the course's own
+           scale. Joins on gradescale_name rather than gradescaleid, the pattern
+           int_powerschool__gpa_term and rpt_deanslist__transcript_gpas already
+           use for storedgrades, plus _dbt_source_project because scale
+           identifiers collide across districts. */
+        select
+            a._dbt_source_project,
+            a.studentid,
+            a.yearid,
+            a.course_number,
+            a.storecode,
+            a.anchored_percent,
+
+            gsi.letter_grade as anchored_letter_grade,
+        from prior_year_course_anchored as a
+        left join
+            {{ ref("int_powerschool__gradescaleitem_lookup") }} as gsi
+            on a._dbt_source_project = gsi._dbt_source_project
+            and a.gradescale_name_unweighted = gsi.gradescale_name
+            and a.anchored_percent
+            between gsi.min_cutoffpercentage and gsi.max_cutoffpercentage
+    ),
+```
+
+- [ ] **Step 2: Wire branch 3 to the reconstruction**
+
+In `quarter_grades` branch 3, alias the storedgrades ref as `sg`, prefix its
+bare column references with `sg.`, and replace the two null casts at lines
+472–473. **Leave `cast(null as int64) as courses_gradescaleid` exactly as it
+is** — see Global Constraints.
+
+Replace:
+
+```sql
+            cast(null as float64) as y1_course_in_progress_percent_grade_adjusted,
+            cast(null as string) as y1_course_in_progress_letter_grade_adjusted,
+```
+
+with:
+
+```sql
+            pyr.anchored_percent
+            as y1_course_in_progress_percent_grade_adjusted,
+            pyr.anchored_letter_grade
+            as y1_course_in_progress_letter_grade_adjusted,
+```
+
+and add the join after the `from`:
+
+```sql
+        left join
+            prior_year_running_course as pyr
+            on sg._dbt_source_project = pyr._dbt_source_project
+            and sg.studentid = pyr.studentid
+            and sg.yearid = pyr.yearid
+            and sg.course_number = pyr.course_number
+            and sg.storecode = pyr.storecode
+```
+
+- [ ] **Step 3: Update the two column descriptions**
+
+Both currently say current-year only, which stops being true. Replace both
+descriptions verbatim.
+
+For `y1_course_in_progress_percent_grade_adjusted`:
+
+```yaml
+description: >-
+  Year-to-date course percent as of the row's marking period. For the year in
+  progress this is the real running value from the gradebook. For the prior year
+  it is RECONSTRUCTED from stored quarter grades — Q1 is exact, Q4 is anchored
+  to the stored Y1 percent and is exact, Q2 and Q3 are approximations that agree
+  with the year value to within half a point on roughly 98 percent of courses.
+  The reconstruction is temporary; see TODO(#4687) in the model.
+```
+
+For `y1_course_in_progress_letter_grade_adjusted`:
+
+```yaml
+description: >-
+  Year-to-date course letter as of the row's marking period. For the year in
+  progress this comes from the gradebook. For the prior year it is RECONSTRUCTED
+  by banding the reconstructed percent back through the course's own grade
+  scale, so it inherits that percent's accuracy — Q1 and Q4 exact, Q2 and Q3
+  approximate. Carries F and F* on the same prefix rule as
+  quarter_course_letter_grade. Temporary; see TODO(#4687) in the model.
+```
+
+- [ ] **Step 4: Build**
+
+Same command as Task 2 Step 5. Expected `PASS=1 WARN=1`, warn at **12**.
+
+- [ ] **Step 5: Verify the three hard invariants**
+
+```sql
+with
+sc as (
+  select
+    quarter,
+    concat(cast(student_number as string), '|', course_number) as sck,
+    y1_course_in_progress_percent_grade_adjusted as running_pct,
+    y1_course_in_progress_letter_grade_adjusted as running_letter,
+    quarter_course_percent_grade as quarter_pct
+  from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+  where academic_year = 2025
+),
+y1 as (
+  select sck, running_pct as y1_pct from sc where quarter = 'Y1'
+)
+select
+  countif(sc.quarter = 'Q1' and abs(sc.running_pct - sc.quarter_pct) > 0.001)
+    as q1_not_exact,
+  countif(sc.quarter = 'Q4' and abs(sc.running_pct - y1.y1_pct) > 0.001)
+    as q4_anchor_violations,
+  countif(sc.running_pct is not null and sc.running_letter is null)
+    as percent_with_no_letter,
+  countif(sc.running_pct is not null) as populated_rows
+from sc
+left join y1 on sc.sck = y1.sck
+```
+
+`q1_not_exact`, `q4_anchor_violations` and `percent_with_no_letter` must all be
+**0**. `populated_rows` must be well above zero — it was 0 before.
+
+- [ ] **Step 6: Verify isolation and that `need_next_*` stayed null**
+
+```sql
+select
+  academic_year,
+  quarter,
+  count(*) as rows_,
+  round(sum(gpa_y1), 4) as sum_gpa_y1,
+  countif(y1_course_in_progress_percent_grade_adjusted is not null) as has_running_pct,
+  countif(need_next_letter_grade is not null) as has_need_next_letter
+from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+group by 1, 2
+order by 1, 2
+```
+
+Current-year `sum_gpa_y1` and `rows_` must match the Task 1 Step 1 baseline
+exactly. `has_need_next_letter` must remain **0 for academic_year 2025** — if it
+is non-zero, `courses_gradescaleid` was populated in branch 3 against the Global
+Constraints and must be reverted.
+
+- [ ] **Step 7: Lint and commit**
+
+Lint as in Task 2 Step 8, then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers add \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers commit -m "feat(dbt): backfill prior-year running course grades, temporarily
+
+TEMPORARY, tracked by TODO(#4687). Reconstructs the year-to-date course grade
+for the prior year, which PowerSchool never stored, so the drill-down is not
+blank during summer training. Q1 exact, Q4 anchored to the stored Y1 and exact,
+Q2 and Q3 approximate.
+
+Confined to quarter_grades branch 3, which filters to the prior year, so it
+cannot reach a current-year row. need_next_* stays null on prior years because
+courses_gradescaleid is deliberately left null there.
+
+Refs #4687"
+```
+
+---
+
+### Task 4: Prior-year GPA backfill (Change B part 2, temporary)
+
+This is the task where isolation is not free. Read the spec's _Isolation from
+the current year_ section before starting.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml`
+
+**Interfaces:**
+
+- Consumes: Task 1 Step 1 baseline
+- Produces: `gpa_y1` populated with a running value on prior-year rows. No later
+  task depends on it.
+
+- [ ] **Step 1: Add the reconstruction CTE**
+
+Insert before `student_roster`:
+
+```sql
+    prior_year_running_gpa as (
+        /* TODO(#4687): TEMPORARY. Delete this CTE, its join in student_roster,
+           and the coalesce on gpa_y1 once the dashboard runs on current-year
+           data. Tracked in Asana under GPA and Gradebook Dashboard v3, Phase 4.
+
+           Running credit-weighted GPA through each term, accumulated from the
+           same components the real gpa_y1 uses. Deliberately NOT anchored to
+           the stored Y1: anchoring produced a year-long decline followed by a
+           fake Q4 recovery, which is the shape a stakeholder builds a false
+           narrative around. Unanchored it reads 50.1, 48.4, 46.1, 47.7 percent
+           at or above 3.0 against a stored Y1 of 50.4. */
+        select
+            studentid,
+            schoolid,
+            yearid,
+            _dbt_source_project,
+            term_name,
+
+            round(
+                safe_divide(
+                    sum(weighted_gpa_points_term) over (
+                        partition by studentid, _dbt_source_project, schoolid, yearid
+                        order by term_name
+                    ),
+                    sum(total_credit_hours_term) over (
+                        partition by studentid, _dbt_source_project, schoolid, yearid
+                        order by term_name
+                    )
+                ),
+                2
+            ) as gpa_y1_running,
+        from {{ ref("int_powerschool__gpa_term") }}
+        where yearid = {{ var("current_academic_year") - 1 - 1991 }}
+    ),
+```
+
+- [ ] **Step 2: Add the year-gated join**
+
+In `student_roster`, after the `gtq` join (which ends at line 247). The final
+predicate is the gate and is **not optional**:
+
+```sql
+        left join
+            prior_year_running_gpa as pyrg
+            on enr.studentid = pyrg.studentid
+            and enr.yearid = pyrg.yearid
+            and enr.schoolid = pyrg.schoolid
+            and enr._dbt_source_project = pyrg._dbt_source_project
+            and term.quarter = pyrg.term_name
+            and enr.academic_year = {{ var("current_academic_year") - 1 }}
+```
+
+- [ ] **Step 3: Coalesce into the existing expression**
+
+Replace line 197:
+
+```sql
+            if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1) as gpa_y1,
+```
+
+with:
+
+```sql
+            coalesce(
+                pyrg.gpa_y1_running,
+                if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1)
+            ) as gpa_y1,
+```
+
+The gate makes `pyrg.gpa_y1_running` null on every current-year row, so the
+coalesce falls through to the untouched original there. **Do not touch
+`gpa_for_quarter` on line 195 or `gpa_n_failing_y1` on line 201.**
+
+- [ ] **Step 4: Update the `gpa_y1` description**
+
+Append to the existing description:
+
+```yaml
+For the prior year this is RECONSTRUCTED as a running credit-weighted GPA
+through each term, because PowerSchool stores only the end-of-year value. It is
+deliberately not anchored to that stored value, so the Q4 reading will not equal
+the Y1 reading. Temporary; see TODO(#4687).
+```
+
+- [ ] **Step 5: Build**
+
+Same command as Task 2 Step 5. Expected `PASS=1 WARN=1`, warn at **12**.
+
+- [ ] **Step 6: Prove isolation — the gating check**
+
+```sql
+select
+  academic_year,
+  quarter,
+  count(*) as rows_,
+  round(sum(gpa_y1), 4) as sum_gpa_y1,
+  round(sum(gpa_for_quarter), 4) as sum_gpa_for_quarter,
+  sum(gpa_n_failing_y1) as sum_n_failing
+from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+group by 1, 2
+order by 1, 2
+```
+
+Every **academic_year 2026** figure must be byte-identical to the Task 1 Step 1
+baseline. `gpa_for_quarter` and `gpa_n_failing_y1` must be identical in **both**
+years, since neither was touched. Any difference means the gate leaked — revert
+and stop.
+
+- [ ] **Step 7: Verify the prior year now moves**
+
+```sql
+with
+sq as (
+  select student_number, quarter, max(gpa_y1) as gpa_y1
+  from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
+  where academic_year = 2025 and school_level = 'HS'
+  group by 1, 2
+)
+select
+  quarter,
+  count(*) as students,
+  round(safe_divide(countif(gpa_y1 >= 3.0), count(*)) * 100, 1) as pct_at_or_above_3_0
+from sq
+group by 1
+order by 1
+```
+
+Expected roughly `50.1 / 48.4 / 46.1 / 47.7` at Q1 through Q4, and `50.4` at Y1.
+The four quarters must **differ from each other** — that is the entire purpose.
+If they are all 50.4, the coalesce is not firing.
+
+- [ ] **Step 8: Lint and commit**
+
+Lint as in Task 2 Step 8, then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers add \
+  src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql \
+  src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers commit -m "feat(dbt): backfill prior-year running GPA, temporarily and unanchored
+
+TEMPORARY, tracked by TODO(#4687). gpa_y1 is the final year value repeated on
+every prior-year quarter row, so M1's distribution is flat across marking
+periods. Reconstructs a running credit-weighted GPA from the per-term
+components.
+
+Deliberately unanchored, unlike the course-grade backfill. Anchoring Q4 to the
+stored value produced a year-long decline followed by a fake Q4 recovery.
+
+Isolation is structural, not conditional: the join carries an academic_year gate
+in ON, so current-year rows get NULL and the coalesce falls through to the
+original expression. Verified byte-identical current-year gpa_y1,
+gpa_for_quarter and gpa_n_failing_y1.
+
+Refs #4687"
+```
+
+---
+
+### Task 5: Whole-branch verification, removal task, and PR
+
+**Files:**
+
+- No code changes unless verification fails
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1 through 4
+- Produces: an open PR and an Asana removal task
+
+- [ ] **Step 1: Full-graph build**
+
+```bash
+uv run dbt build --select rpt_tableau__student_course_grades int_powerschool__gradescaleitem_lookup \
+  --target dev --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --project-dir /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers/src/dbt/kipptaf
+```
+
+Expected: all tests pass except the `#3915` warn at 12. The
+`int_powerschool__gradescaleitem_lookup` uniqueness test added in #4686 must
+still PASS.
+
+- [ ] **Step 2: Final row-count and isolation sweep**
+
+Re-run Task 1 Step 2 and Task 4 Step 6 against the dev relation one final time,
+with all four tasks applied. Row count, distinct key, and every current-year GPA
+figure must match the Task 1 baseline.
+
+- [ ] **Step 3: Confirm every TODO is present and greppable**
+
+```bash
+grep -n "TODO(#4687)" /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+```
+
+Expected: at least five hits — four in the course CTEs, one in the GPA CTE. Zero
+hits in the Task 2 category CTEs, which are permanent.
+
+- [ ] **Step 4: Lint the full diff**
+
+```bash
+cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-category-drivers && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  $(git diff --name-only origin/main...HEAD) </dev/null
+```
+
+- [ ] **Step 5: Create the Asana removal task**
+
+In project `GPA and Gradebook Dashboard v3 (SY27 Rebuild)`, GID
+`1214228736201477`, section `Phase 4`, GID `1214243570943810`. Title:
+`Remove the temporary prior-year grade and GPA backfill`. The notes must name
+the five CTEs to delete — `prior_year_quarter_running`, `prior_year_y1_stored`,
+`prior_year_course_anchored`, `prior_year_running_course`,
+`prior_year_running_gpa` — state that the Task 2 category driver columns are
+permanent and must NOT be removed, and link the PR.
+
+- [ ] **Step 6: Push and open the PR**
+
+Use `.github/pull_request_template.md`. Body must reference `Refs #4687`, state
+which half is temporary, and record the isolation proof. Create via
+`gh api -X POST repos/TEAMSchools/teamster/pulls -F body=@<file>` rather than
+the GitHub MCP, which HTML-sanitises angle brackets.
+
+- [ ] **Step 7: Report**
+
+Summarise: the four hard invariants and their measured values, the row-count
+proof, the `need_next_*`-stayed-null proof, and the Asana task URL.
+
+---
+
+## Not in this plan
+
+**The Tableau workbook changes.** The spec's Change A deletes two calcs —
+`Lowest Category % (course)` and the `MIN(IF ...)` form of
+`Category Driving Gap` — and rewrites the latter as a plain field reference.
+That work happens in `new_gpa_dash_20260801.twbx`, which lives in
+`.claude/scratch/` and is not in this repo, so it cannot be a task here. It is
+also **blocked on this PR merging**, because the columns have to exist in the
+published extract first.
+
+The same applies to pointing M1 and M2 at `y1_course_in_progress_*`, which is
+the change that motivated the backfill in the first place. Hand both off after
+merge; neither is a code task.
+
+**Everything under the spec's _Out of scope_ heading**, in particular moving the
+category-code decode into the model and the as-of labelling work tracked
+separately in Asana.

--- a/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
+++ b/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
@@ -206,9 +206,8 @@ task summary so the reviewer can see them without opening the file.
 - Consumes: the `category_grades` CTE (ends at line 587), the baseline from Task
   1 Step 3
 - Produces: columns `lowest_category_y1_name`, `lowest_category_y1_percent`,
-  `lowest_category_latest_quarter_name`,
-  `lowest_category_latest_quarter_percent`, all on every row including Y1. Tasks
-  3 and 4 do not depend on these.
+  `lowest_category_recent_term_name`, `lowest_category_recent_term_percent`, all
+  on every row including Y1. Tasks 3 and 4 do not depend on these.
 
 - [ ] **Step 1: Add the two CTEs**
 
@@ -280,11 +279,11 @@ Insert immediately after the `category_grades` CTE closes and before the final
 
             max(
                 if(rn_lowest_quarter = 1, category_name_code, null)
-            ) as lowest_category_latest_quarter_name,
+            ) as lowest_category_recent_term_name,
 
             max(
                 if(rn_lowest_quarter = 1, category_quarter_percent_grade, null)
-            ) as lowest_category_latest_quarter_percent,
+            ) as lowest_category_recent_term_percent,
         from category_ranked
         where rn_latest_term = 1
         group by _dbt_source_project, studentid, yearid, sectionid
@@ -315,8 +314,8 @@ the blank-line-between-source-tables convention:
 ```sql
     cd.lowest_category_y1_name,
     cd.lowest_category_y1_percent,
-    cd.lowest_category_latest_quarter_name,
-    cd.lowest_category_latest_quarter_percent,
+    cd.lowest_category_recent_term_name,
+    cd.lowest_category_recent_term_percent,
 ```
 
 - [ ] **Step 4: Add the contract entries**
@@ -335,7 +334,7 @@ In the properties yml, after the `category_quarter_average_all_courses` entry:
   data_type: float64
   description: >-
     The year-running percent belonging to lowest_category_y1_name.
-- name: lowest_category_latest_quarter_name
+- name: lowest_category_recent_term_name
   data_type: string
   description: >-
     Gradebook category code with the lowest single-quarter percent in the latest
@@ -343,10 +342,10 @@ In the properties yml, after the `category_quarter_average_all_courses` entry:
     posted quarter on a live one. Answers what the problem is right now, where
     lowest_category_y1_name answers what dragged the whole year down. The two
     can legitimately disagree.
-- name: lowest_category_latest_quarter_percent
+- name: lowest_category_recent_term_percent
   data_type: float64
   description: >-
-    The single-quarter percent belonging to lowest_category_latest_quarter_name.
+    The single-quarter percent belonging to lowest_category_recent_term_name.
 ```
 
 - [ ] **Step 5: Build**
@@ -381,7 +380,7 @@ from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
 
 ```sql
 select
-  lowest_category_latest_quarter_name,
+  lowest_category_recent_term_name,
   count(distinct format('%T|%T', studentid, sectionid)) as student_sections
 from `zz_anthonygwalters_kipptaf_tableau.rpt_tableau__student_course_grades`
 where academic_year = 2025 and quarter = 'Q4'

--- a/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
+++ b/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
@@ -439,9 +439,9 @@ Insert before `quarter_grades`. Note the storecode ordering works because
 `'Q1' < 'Q2' < 'Q3' < 'Q4'` lexically.
 
 ```sql
-    prior_year_quarter_running as (
-        /* TODO(#4687): TEMPORARY. Delete this CTE, prior_year_course_anchored,
-           prior_year_running_course, and their use in quarter_grades branch 3
+    backfill_quarter_running as (
+        /* TODO(#4687): TEMPORARY. Delete this CTE, backfill_course_anchored,
+           backfill_running_course, and their use in quarter_grades branch 3
            once the dashboard runs on current-year data. Tracked in Asana under
            GPA and Gradebook Dashboard v3, Phase 4.
 
@@ -470,8 +470,8 @@ Insert before `quarter_grades`. Note the storecode ordering works because
             and academic_year = {{ var("current_academic_year") - 1 }}
     ),
 
-    prior_year_y1_stored as (
-        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running. */
+    backfill_y1_stored as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running. */
         select
             _dbt_source_project,
             studentid,
@@ -486,8 +486,8 @@ Insert before `quarter_grades`. Note the storecode ordering works because
             and academic_year = {{ var("current_academic_year") - 1 }}
     ),
 
-    prior_year_course_anchored as (
-        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running.
+    backfill_course_anchored as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running.
 
            Q4 takes the stored Y1 percent verbatim so the reconstruction lands
            exactly on the year grade. The Y1 storecode row is unioned in
@@ -503,9 +503,9 @@ Insert before `quarter_grades`. Note the storecode ordering works because
             if(
                 r.storecode = 'Q4', y1.y1_stored_percent, r.running_percent
             ) as anchored_percent,
-        from prior_year_quarter_running as r
+        from backfill_quarter_running as r
         left join
-            prior_year_y1_stored as y1
+            backfill_y1_stored as y1
             on r._dbt_source_project = y1._dbt_source_project
             and r.studentid = y1.studentid
             and r.yearid = y1.yearid
@@ -523,20 +523,20 @@ Insert before `quarter_grades`. Note the storecode ordering works because
 
             gradescale_name_unweighted,
             y1_stored_percent as anchored_percent,
-        from prior_year_y1_stored
+        from backfill_y1_stored
     ),
 ```
 
 `UNION ALL` binds by position, so both branches list the same seven columns in
 the same order. `_dbt_source_relation` is deliberately absent — nothing
 downstream consumes it, and carrying a null through the Y1 branch would be dead
-weight. `prior_year_quarter_running` still selects it because dropping it there
+weight. `backfill_quarter_running` still selects it because dropping it there
 would touch the window partitions; leave that alone.
 
 ```sql
 
-    prior_year_running_course as (
-        /* TODO(#4687): TEMPORARY, see prior_year_quarter_running.
+    backfill_running_course as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running.
 
            Bands the reconstructed percent back to a letter on the course's own
            scale. Joins on gradescale_name rather than gradescaleid, the pattern
@@ -552,7 +552,7 @@ would touch the window partitions; leave that alone.
             a.anchored_percent,
 
             gsi.letter_grade as anchored_letter_grade,
-        from prior_year_course_anchored as a
+        from backfill_course_anchored as a
         left join
             {{ ref("int_powerschool__gradescaleitem_lookup") }} as gsi
             on a._dbt_source_project = gsi._dbt_source_project
@@ -579,9 +579,9 @@ Replace:
 with:
 
 ```sql
-            pyr.anchored_percent
+            bfc.anchored_percent
             as y1_course_in_progress_percent_grade_adjusted,
-            pyr.anchored_letter_grade
+            bfc.anchored_letter_grade
             as y1_course_in_progress_letter_grade_adjusted,
 ```
 
@@ -589,12 +589,12 @@ and add the join after the `from`:
 
 ```sql
         left join
-            prior_year_running_course as pyr
-            on sg._dbt_source_project = pyr._dbt_source_project
-            and sg.studentid = pyr.studentid
-            and sg.yearid = pyr.yearid
-            and sg.course_number = pyr.course_number
-            and sg.storecode = pyr.storecode
+            backfill_running_course as bfc
+            on sg._dbt_source_project = bfc._dbt_source_project
+            and sg.studentid = bfc.studentid
+            and sg.yearid = bfc.yearid
+            and sg.course_number = bfc.course_number
+            and sg.storecode = bfc.storecode
 ```
 
 - [ ] **Step 3: Update the two column descriptions**
@@ -729,7 +729,7 @@ the current year_ section before starting.
 Insert before `student_roster`:
 
 ```sql
-    prior_year_running_gpa as (
+    backfill_running_gpa as (
         /* TODO(#4687): TEMPORARY. Delete this CTE, its join in student_roster,
            and the coalesce on gpa_y1 once the dashboard runs on current-year
            data. Tracked in Asana under GPA and Gradebook Dashboard v3, Phase 4.
@@ -772,12 +772,12 @@ predicate is the gate and is **not optional**:
 
 ```sql
         left join
-            prior_year_running_gpa as pyrg
-            on enr.studentid = pyrg.studentid
-            and enr.yearid = pyrg.yearid
-            and enr.schoolid = pyrg.schoolid
-            and enr._dbt_source_project = pyrg._dbt_source_project
-            and term.quarter = pyrg.term_name
+            backfill_running_gpa as bfg
+            on enr.studentid = bfg.studentid
+            and enr.yearid = bfg.yearid
+            and enr.schoolid = bfg.schoolid
+            and enr._dbt_source_project = bfg._dbt_source_project
+            and term.quarter = bfg.term_name
             and enr.academic_year = {{ var("current_academic_year") - 1 }}
 ```
 
@@ -793,12 +793,12 @@ with:
 
 ```sql
             coalesce(
-                pyrg.gpa_y1_running,
+                bfg.gpa_y1_running,
                 if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1)
             ) as gpa_y1,
 ```
 
-The gate makes `pyrg.gpa_y1_running` null on every current-year row, so the
+The gate makes `bfg.gpa_y1_running` null on every current-year row, so the
 coalesce falls through to the untouched original there. **Do not touch
 `gpa_for_quarter` on line 195 or `gpa_n_failing_y1` on line 201.**
 
@@ -940,10 +940,10 @@ cd /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-backfill-and-cate
 In project `GPA and Gradebook Dashboard v3 (SY27 Rebuild)`, GID
 `1214228736201477`, section `Phase 4`, GID `1214243570943810`. Title:
 `Remove the temporary prior-year grade and GPA backfill`. The notes must name
-the five CTEs to delete — `prior_year_quarter_running`, `prior_year_y1_stored`,
-`prior_year_course_anchored`, `prior_year_running_course`,
-`prior_year_running_gpa` — state that the Task 2 category driver columns are
-permanent and must NOT be removed, and link the PR.
+the five CTEs to delete — `backfill_quarter_running`, `backfill_y1_stored`,
+`backfill_course_anchored`, `backfill_running_course`, `backfill_running_gpa` —
+state that the Task 2 category driver columns are permanent and must NOT be
+removed, and link the PR.
 
 - [ ] **Step 6: Push and open the PR**
 

--- a/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
+++ b/docs/superpowers/plans/2026-08-01-prior-year-backfill-and-category-drivers.md
@@ -50,8 +50,12 @@ this repo validates dbt models with `dbt build` plus BigQuery MCP queries.
   `src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml`.
 - The model's composite uniqueness test warns at **12** — the pre-existing
   `#3915` count. It must still read 12 after every task.
-- Prod baseline as of 2026-08-01: **854,245 rows, 854,209 distinct** composite
-  keys.
+- Prod baseline: **854,263 rows, 854,227 distinct** composite keys, re-verified
+  during Task 3. AY2025 is 713,227 / 713,191; AY2026 is 141,036 / 141,036.
+  **Prod drifts between sessions** — the earlier 854,245 / 854,209 figure aged
+  out when 18 rows landed in the in-progress year. Always compare a dev build
+  against a prod read taken in the same session, never against a remembered
+  number.
 
 ## File Structure
 
@@ -448,7 +452,7 @@ Insert before `quarter_grades`. Note the storecode ordering works because
            year, which PowerSchool never stored. Q1 is exact by definition;
            Q2 and Q3 are approximations; Q4 is replaced by the stored Y1 value
            below so it matches exactly. Simple rather than credit-weighted
-           average because the two agree to within half a point on 98.2 percent
+           average because the two agree to within half a point on 97.0 percent
            of courses. */
         select
             _dbt_source_relation,
@@ -735,10 +739,11 @@ Insert before `student_roster`:
 
            Running credit-weighted GPA through each term, accumulated from the
            same components the real gpa_y1 uses. Deliberately NOT anchored to
-           the stored Y1: anchoring produced a year-long decline followed by a
-           fake Q4 recovery, which is the shape a stakeholder builds a false
-           narrative around. Unanchored it reads 50.1, 48.4, 46.1, 47.7 percent
-           at or above 3.0 against a stored Y1 of 50.4. */
+           the stored Y1: anchoring would insert a step at Q4 that the data does
+           not contain, which is the shape a stakeholder builds a narrative
+           around. Unanchored, AY2025 high school reads 45.1, 46.7, 46.6, 48.2
+           percent at or above 3.0 against a stored Y1 of 48.9 — a rising
+           trajectory that stops slightly short of the year value. */
         select
             studentid,
             schoolid,
@@ -760,7 +765,7 @@ Insert before `student_roster`:
                 2
             ) as gpa_y1_running,
         from {{ ref("int_powerschool__gpa_term") }}
-        where yearid = {{ var("current_academic_year") - 1 - 1991 }}
+        where yearid = {{ var("current_academic_year") - 1991 }}
     ),
 ```
 
@@ -855,9 +860,15 @@ group by 1
 order by 1
 ```
 
-Expected roughly `50.1 / 48.4 / 46.1 / 47.7` at Q1 through Q4, and `50.4` at Y1.
+Expected roughly `45.1 / 46.7 / 46.6 / 48.2` at Q1 through Q4, and `48.9` at Y1.
 The four quarters must **differ from each other** — that is the entire purpose.
-If they are all 50.4, the coalesce is not firing.
+If all five come back identical, the coalesce is not firing.
+
+**Corrected figures.** An earlier version of this step expected
+`50.1 / 48.4 / 46.1 / 47.7` against `50.4`. Those were AY2024, produced by
+querying `int_powerschool__gpa_term` at `yearid = 34` when the convention is
+`yearid = academic_year - 1990`, making AY2025 yearid 35. The same off-by-one
+appeared in Step 1's `where` clause and is corrected there.
 
 - [ ] **Step 8: Lint and commit**
 
@@ -875,7 +886,7 @@ periods. Reconstructs a running credit-weighted GPA from the per-term
 components.
 
 Deliberately unanchored, unlike the course-grade backfill. Anchoring Q4 to the
-stored value produced a year-long decline followed by a fake Q4 recovery.
+stored value produced a step at Q4 that the data does not contain.
 
 Isolation is structural, not conditional: the join carries an academic_year gate
 in ON, so current-year rows get NULL and the coalesce falls through to the

--- a/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
+++ b/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
@@ -231,6 +231,46 @@ honest trajectory that simply stops one step short of the Y1 value of 50.4.
 because the anchor is exact and free. GPA does not, because its anchor
 manufactures a visible artifact. Do not "fix" the inconsistency.
 
+### Isolation from the current year — mandatory, and not automatic
+
+The two halves of this backfill do **not** have the same protection, and the
+difference is the single most important implementation constraint here.
+
+**Course grades are structurally isolated.** `quarter_grades` branch 3 filters
+`academic_year = current_academic_year - 1` while branches 1 and 2 filter
+`= current_academic_year`. The branches are disjoint by `WHERE`, so a change
+confined to branch 3 cannot reach a current-year row. No extra guard needed.
+
+**GPA is not.** `gpa_y1` is assembled inside `student_roster` as
+`if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1)`, and the `gtq` join has no
+year predicate — it joins for every academic year. A backfill written as a
+conditional inside that expression would be only as safe as the condition.
+
+**Required approach.** Put the reconstruction in its own CTE and gate the join
+in the `ON` clause:
+
+```sql
+left join
+    prior_year_running_gpa as pyr
+    on enr.studentid = pyr.studentid
+    and enr.yearid = pyr.yearid
+    and enr.schoolid = pyr.schoolid
+    and enr._dbt_source_project = pyr._dbt_source_project
+    and term.quarter = pyr.term_name
+    and enr.academic_year = {{ var("current_academic_year") - 1 }}
+```
+
+Every current-year row then gets `NULL` from `pyr` by construction, and the
+selection becomes a `coalesce` that falls through to the existing expression
+untouched. This is the same gating pattern the model already applies to the
+`gc`, `lb` and `gpq` joins, which each carry
+`and enr.academic_year = {{ var("current_academic_year") }}` in `ON` so
+prior-year rows keep their NULLs.
+
+Isolation is a **verification requirement**, not just a coding style: every
+current-year value of `gpa_y1`, `gpa_for_quarter` and `gpa_n_failing_y1` must be
+byte-identical before and after. See _Verification_.
+
 ### Not backfilling `gpa_n_failing_y1`
 
 It is flat on prior years, but the only sheets reading it are the landing-page
@@ -239,13 +279,20 @@ BANs, which carry no `MP Filter` and sit on a dashboard that does not expose
 
 ## Verification
 
-Three hard invariants. These must return zero, not "mostly".
+Four hard invariants. These must return zero, not "mostly".
 
-| Check            | Requirement                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| Q4 course anchor | reconstructed percent equals the stored Y1 percent, zero exceptions                        |
-| Q1 exactness     | running-through-Q1 equals Q1's own stored percent, zero exceptions                         |
-| Letter coverage  | every reconstructed percent matches exactly one full-scale row, zero gaps and zero doubles |
+| Check                      | Requirement                                                                                                                                                 |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Current-year isolation** | every current-year value of `gpa_y1`, `gpa_for_quarter`, `gpa_n_failing_y1` and `y1_course_in_progress_*` byte-identical before and after, zero rows differ |
+| Q4 course anchor           | reconstructed percent equals the stored Y1 percent, zero exceptions                                                                                         |
+| Q1 exactness               | running-through-Q1 equals Q1's own stored percent, zero exceptions                                                                                          |
+| Letter coverage            | every reconstructed percent matches exactly one full-scale row, zero gaps and zero doubles                                                                  |
+
+Isolation is listed first deliberately. The course-grade half inherits it from
+the branch structure; the GPA half has it only from the `ON`-clause gate, so it
+must be proven rather than assumed. Compare current-year rows between the dev
+build and prod across those columns — any non-zero difference means the gate
+leaked and the change does not ship.
 
 Supporting checks:
 
@@ -272,12 +319,12 @@ boundary has to be explicit or someone will remove the wrong one.
 - Column descriptions state that prior-year values are reconstructed and that Q2
   and Q3 are approximate.
 
-No feature flag and no data guard. Considered and rejected: the backfill lives
-in a branch that cannot touch current-year data, so it never becomes actively
-wrong, only unnecessary. The long-term fix is operational rather than code —
-next year the dashboard falls into the normal pattern of refreshes being frozen
-at the end of the academic year, at which point the prior year stops needing
-reconstruction at all.
+No feature flag. Considered and rejected: the course-grade half lives in a
+branch that cannot touch current-year data, so it never becomes actively wrong,
+only unnecessary. The long-term fix is operational rather than code — next year
+the dashboard falls into the normal pattern of refreshes being frozen at the end
+of the academic year, at which point the prior year stops needing reconstruction
+at all.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
+++ b/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
@@ -1,0 +1,291 @@
+# Category drivers at Y1, and a temporary prior-year running-grade backfill
+
+Design for [#4687](https://github.com/TEAMSchools/teamster/issues/4687). Two
+changes to `rpt_tableau__student_course_grades`, shipping in one PR, with
+deliberately different lifespans.
+
+## Context
+
+The GPA drill-down dashboard (`Academic Health Schools`) is driven by a
+`p_Marking_Period` parameter. Two separate problems make it behave badly at the
+marking periods people actually use.
+
+**`Category Driving Gap` reads `not available` at Y1.** Y1 is the primary
+viewing level, so the column is effectively dead. Asking users to switch to a
+quarter to see it is a real block on adoption.
+
+**Adopting the running course grade would blank the prior year.** The columns
+that carry a genuine year-to-date grade — `y1_course_in_progress_*` — are
+populated only for the year in progress. AY2026 has no posted grades yet, so
+summer stakeholder training runs on AY2025, where those columns are entirely
+null.
+
+### Verified facts this design rests on
+
+All measured 2026-08-01 against production.
+
+| Fact                                                        | Evidence                                                                                                                           |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Y1 rows carry no category data at all                       | `category_name_code` null on all 38,281 AY2025 Y1 rows                                                                             |
+| A year-level category percent already exists                | `category_y1_percent_grade_running` populated on quarter rows; at Q4 it equals `category_y1_percent_grade_current` at 116,011 rows |
+| Attaching categories to Y1 would fan out                    | 38,281 Y1 rows against 149,423 Q4 rows, roughly 3.9x                                                                               |
+| `y1_course_in_progress_*` is null for prior years           | 0 populated rows across every AY2025 marking period                                                                                |
+| Course reconstruction is close                              | Simple four-quarter average lands within 0.5 points of the stored Y1 for 21,273 of 21,666 Newark full-year courses, 98.2 percent   |
+| GPA reconstruction is close in aggregate, loose per student | Distribution within a few points; 173 to 645 students cross the 3.0 line depending on quarter                                      |
+
+The prior-year flatness is structural, not a defect. `int_powerschool__gpa_term`
+builds historical quarters by starting from the single Y1 storedgrades row and
+doing `cross join unnest(["Q1", "Q2", "Q3", "Q4"])`. PowerSchool never stored an
+as-of-Q1 year value, so it cannot be recovered — noted upstream as
+[#4382](https://github.com/TEAMSchools/teamster/issues/4382).
+
+## Change A — category drivers at Y1
+
+Permanent. Fixes a real defect.
+
+### Columns
+
+Four columns at student-course grain, present on **every** row including Y1.
+
+| Column                                   | Type      | Meaning                                                               |
+| ---------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `lowest_category_y1_name`                | `string`  | category code with the lowest year-running percent                    |
+| `lowest_category_y1_percent`             | `float64` | that percent                                                          |
+| `lowest_category_latest_quarter_name`    | `string`  | category code with the lowest percent in the latest term holding data |
+| `lowest_category_latest_quarter_percent` | `float64` | that percent                                                          |
+
+Both drivers are read from the **same** latest term, so they describe one
+moment. On a completed year that is Q4; on a live year, whichever quarter last
+posted.
+
+"Latest term holding data" means precisely: the highest `term` among category
+rows where **at least one** of `category_quarter_percent_grade` or
+`category_y1_percent_grade_running` is non-null. Rows with both null are
+excluded from the ranking input entirely, so a term that exists but carries no
+usable percent cannot win and blank out both drivers. One rule, applied once, so
+the two drivers cannot land on different terms.
+
+Two columns rather than one because the questions differ. The year-running
+driver answers "across the year, what dragged this course down" and matches what
+a Y1 view claims to show. The latest-quarter driver answers "what is the problem
+right now" and is the intervention question.
+
+### Construction
+
+A ranking CTE computes three window functions over the category data, and the
+next CTE filters and pivots. Window in one CTE, filtered by `WHERE` in the next
+— no `QUALIFY`, per the SQL conventions.
+
+```sql
+category_ranked as (
+    select
+        studentid,
+        _dbt_source_project,
+        sectionid,
+        yearid,
+        category_name_code,
+        category_quarter_percent_grade,
+        category_y1_percent_grade_running,
+
+        dense_rank() over (
+            partition by studentid, _dbt_source_project, sectionid, yearid
+            order by term desc
+        ) as rn_latest_term,
+
+        row_number() over (
+            partition by studentid, _dbt_source_project, sectionid, yearid, term
+            order by
+                (category_y1_percent_grade_running is null) asc,
+                category_y1_percent_grade_running asc,
+                category_name_code asc
+        ) as rn_lowest_y1,
+
+        row_number() over (
+            partition by studentid, _dbt_source_project, sectionid, yearid, term
+            order by
+                (category_quarter_percent_grade is null) asc,
+                category_quarter_percent_grade asc,
+                category_name_code asc
+        ) as rn_lowest_quarter,
+    from category_grades
+    where
+        category_quarter_percent_grade is not null
+        or category_y1_percent_grade_running is not null
+),
+```
+
+Then one row per student-section-year by conditional aggregation over
+`where rn_latest_term = 1`.
+
+Two details that would otherwise be wrong:
+
+- **Null ordering.** BigQuery sorts `NULLS FIRST` ascending, so a category with
+  a null percent would win "lowest" outright. The `(col is null) asc` leading
+  term prevents that. Same idiom the repo prescribes for
+  `dbt_utils.deduplicate`.
+- **Ties.** `category_name_code` as the final tiebreaker makes the pick
+  reproducible across rebuilds. The Tableau calc being replaced is not.
+
+### Join
+
+Joined on `(studentid, _dbt_source_project, sectionid, yearid)` — **without**
+the term predicate. That omission is the whole point: it is what lets the
+columns land on Y1 rows, where the existing `category_grades` join
+(`s.quarter = c.term`) finds nothing.
+
+The CTE emits one row per join key, so the join cannot change the row count.
+
+### Tableau
+
+Two calcs deleted outright:
+
+- `Lowest Category % (course)`, a `FIXED` LOD
+- `Category Driving Gap`, a `MIN(IF ...)` over categories
+
+`Category Driving Gap` becomes a plain field reference. No LOD, no
+marking-period dependency, no `not available` at Y1.
+
+Genuine absence still reads as unavailable — a course with no gradebook
+categories, or the current year before grades post. The difference is that it
+now means "there is no category data" rather than "you picked the wrong marking
+period".
+
+## Change B — prior-year running backfill
+
+**Temporary.** Must be removed. See _Removal_ below.
+
+### Guiding principle
+
+Set by the requester and load-bearing for every decision here: **the live year
+must be correct; the backfill only has to exist and be labelled.** Strict
+accuracy on prior years is explicitly not the goal. Stakeholders will be told in
+training not to rely on these figures.
+
+### Where it goes
+
+Branch 3 of the `quarter_grades` CTE — the prior-year storedgrades branch.
+Branches 1 and 2 read the live gradebook and are untouched, which is what makes
+this incapable of corrupting current-year data and makes removal a revert of one
+block.
+
+Replaces:
+
+```sql
+cast(null as float64) as y1_course_in_progress_percent_grade_adjusted,
+cast(null as string) as y1_course_in_progress_letter_grade_adjusted,
+```
+
+### Course grades — anchored
+
+Running average of stored quarter percents, partitioned by student-course,
+ordered `Q1` through `Q4`, with the `Q4` value overridden by the stored `Y1`
+percent.
+
+- `Q1` exact by definition — running through Q1 is Q1.
+- `Q4` exact by anchoring.
+- `Q2` and `Q3` approximate.
+
+Simple rather than credit-weighted average. The live-year calculation is
+weighted, but the 98.2 percent agreement measured above shows the weights are
+effectively uniform, so weighting adds complexity without accuracy.
+
+The **letter** is the real work. The reconstructed percent has to be mapped back
+through the course's grade scale. Storedgrades carries no
+`courses_gradescaleid`, so this joins on `gradescale_name` — the pattern
+`int_powerschool__gpa_term` and `rpt_deanslist__transcript_gpas` already use —
+plus `_dbt_source_project`, because scale identifiers collide across districts.
+
+This needs the **full** scale, not the whole-letter subset used by `need_next`.
+The full scale is where the 119 degenerate bands live
+(`max_cutoffpercentage = min_cutoffpercentage - 0.1`, produced by two items
+sharing a cutoff). Those rows match nothing, so the risk is a coverage gap
+rather than a fan-out — but full-scale coverage and uniqueness have **not** been
+verified. That is a gating check, not an assumption.
+
+### GPA — deliberately not anchored
+
+Running from the per-term components already exposed on
+`int_powerschool__gpa_term`:
+
+```text
+running_gpa(Qn) = sum(weighted_gpa_points_term through Qn)
+                  / sum(total_credit_hours_term through Qn)
+```
+
+Anchoring `Q4` to the stored value was considered and **rejected**. The
+reconstruction sits systematically below the stored Y1, because PowerSchool's
+year letter grades are more generous than a running average of quarter points.
+Anchoring therefore produces:
+
+```text
+50.1  ->  48.4  ->  46.1  ->  50.4
+```
+
+A year-long decline followed by a sharp Q4 recovery. The decline is real —
+quarter GPAs genuinely fall, 2.987 to 2.925 to 2.824 — but the size of the final
+jump is an artifact of the anchor, and it is exactly the shape a stakeholder
+builds a narrative around. Unanchored reads `50.1 -> 48.4 -> 46.1 -> 47.7`, an
+honest trajectory that simply stops one step short of the Y1 value of 50.4.
+
+**This makes course grades and GPA asymmetric on purpose.** Course grades anchor
+because the anchor is exact and free. GPA does not, because its anchor
+manufactures a visible artifact. Do not "fix" the inconsistency.
+
+### Not backfilling `gpa_n_failing_y1`
+
+It is flat on prior years, but the only sheets reading it are the landing-page
+BANs, which carry no `MP Filter` and sit on a dashboard that does not expose
+`p_Marking_Period`. Nothing would see it move.
+
+## Verification
+
+Three hard invariants. These must return zero, not "mostly".
+
+| Check            | Requirement                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| Q4 course anchor | reconstructed percent equals the stored Y1 percent, zero exceptions                        |
+| Q1 exactness     | running-through-Q1 equals Q1's own stored percent, zero exceptions                         |
+| Letter coverage  | every reconstructed percent matches exactly one full-scale row, zero gaps and zero doubles |
+
+Supporting checks:
+
+- Population moves off zero for `y1_course_in_progress_*` on prior-year rows,
+  and for all four category driver columns on Y1 rows.
+- **No fan-out** — dev and prod return identical row counts and identical
+  distinct composite-key counts. Both changes add joins; both must be neutral.
+- The existing composite uniqueness test still warns at 12, the pre-existing
+  `#3915` storedgrades count.
+- **Regression check on the category driver** — at Q4 on a completed year,
+  `lowest_category_latest_quarter_name` reproduces what the current
+  `Category Driving Gap` calc already produces. Free ground truth from behaviour
+  known to work.
+- No row picked a null-percent category over a populated one.
+- Course reconstruction accuracy re-characterised network-wide, not Newark-only.
+
+## Removal
+
+Change A is permanent. **Change B is not**, and the two ship together, so the
+boundary has to be explicit or someone will remove the wrong one.
+
+- Inline `TODO(#4687)` at the backfill block naming the Asana task.
+- Asana task in `GPA and Gradebook Dashboard v3`, Phase 4.
+- Column descriptions state that prior-year values are reconstructed and that Q2
+  and Q3 are approximate.
+
+No feature flag and no data guard. Considered and rejected: the backfill lives
+in a branch that cannot touch current-year data, so it never becomes actively
+wrong, only unnecessary. The long-term fix is operational rather than code —
+next year the dashboard falls into the normal pattern of refreshes being frozen
+at the end of the academic year, at which point the prior year stops needing
+reconstruction at all.
+
+## Out of scope
+
+- Moving the `F`/`S`/`H`/`W` category decode into the model. The workbook's
+  `Category Label` calc keeps doing it; duplicating the mapping in SQL would
+  create two places to maintain. Reasonable follow-up.
+- The as-of versus period-only labelling work on M1, tracked separately in
+  Asana.
+- Any change to `src/dbt/powerschool/`. Both changes are achievable in kipptaf
+  because `weighted_gpa_points_term`, `total_credit_hours_term` and
+  `category_y1_percent_grade_running` are all already exposed.

--- a/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
+++ b/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
@@ -251,12 +251,12 @@ in the `ON` clause:
 
 ```sql
 left join
-    prior_year_running_gpa as pyr
-    on enr.studentid = pyr.studentid
-    and enr.yearid = pyr.yearid
-    and enr.schoolid = pyr.schoolid
-    and enr._dbt_source_project = pyr._dbt_source_project
-    and term.quarter = pyr.term_name
+    backfill_running_gpa as bfc
+    on enr.studentid = bfc.studentid
+    and enr.yearid = bfc.yearid
+    and enr.schoolid = bfc.schoolid
+    and enr._dbt_source_project = bfc._dbt_source_project
+    and term.quarter = bfc.term_name
     and enr.academic_year = {{ var("current_academic_year") - 1 }}
 ```
 

--- a/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
+++ b/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
@@ -47,12 +47,12 @@ Permanent. Fixes a real defect.
 
 Four columns at student-course grain, present on **every** row including Y1.
 
-| Column                                   | Type      | Meaning                                                               |
-| ---------------------------------------- | --------- | --------------------------------------------------------------------- |
-| `lowest_category_y1_name`                | `string`  | category code with the lowest year-running percent                    |
-| `lowest_category_y1_percent`             | `float64` | that percent                                                          |
-| `lowest_category_latest_quarter_name`    | `string`  | category code with the lowest percent in the latest term holding data |
-| `lowest_category_latest_quarter_percent` | `float64` | that percent                                                          |
+| Column                                | Type      | Meaning                                                               |
+| ------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `lowest_category_y1_name`             | `string`  | category code with the lowest year-running percent                    |
+| `lowest_category_y1_percent`          | `float64` | that percent                                                          |
+| `lowest_category_recent_term_name`    | `string`  | category code with the lowest percent in the latest term holding data |
+| `lowest_category_recent_term_percent` | `float64` | that percent                                                          |
 
 Both drivers are read from the **same** latest term, so they describe one
 moment. On a completed year that is Q4; on a live year, whichever quarter last
@@ -303,7 +303,7 @@ Supporting checks:
 - The existing composite uniqueness test still warns at 12, the pre-existing
   `#3915` storedgrades count.
 - **Regression check on the category driver** — at Q4 on a completed year,
-  `lowest_category_latest_quarter_name` reproduces what the current
+  `lowest_category_recent_term_name` reproduces what the current
   `Category Driving Gap` calc already produces. Free ground truth from behaviour
   known to work.
 - No row picked a null-percent category over a populated one.

--- a/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
+++ b/docs/superpowers/specs/2026-08-01-prior-year-backfill-and-category-drivers-design.md
@@ -30,8 +30,8 @@ All measured 2026-08-01 against production.
 | A year-level category percent already exists                | `category_y1_percent_grade_running` populated on quarter rows; at Q4 it equals `category_y1_percent_grade_current` at 116,011 rows |
 | Attaching categories to Y1 would fan out                    | 38,281 Y1 rows against 149,423 Q4 rows, roughly 3.9x                                                                               |
 | `y1_course_in_progress_*` is null for prior years           | 0 populated rows across every AY2025 marking period                                                                                |
-| Course reconstruction is close                              | Simple four-quarter average lands within 0.5 points of the stored Y1 for 21,273 of 21,666 Newark full-year courses, 98.2 percent   |
-| GPA reconstruction is close in aggregate, loose per student | Distribution within a few points; 173 to 645 students cross the 3.0 line depending on quarter                                      |
+| Course reconstruction is close                              | Simple four-quarter average lands within 0.5 points of the stored Y1 for 20,884 of 21,533 Newark full-year courses, 97.0 percent   |
+| GPA reconstruction is close in aggregate, loose per student | Distribution within a few points; 222 to 748 students cross the 3.0 line depending on quarter                                      |
 
 The prior-year flatness is structural, not a defect. `int_powerschool__gpa_term`
 builds historical quarters by starting from the single Y1 storedgrades row and
@@ -186,7 +186,7 @@ percent.
 - `Q2` and `Q3` approximate.
 
 Simple rather than credit-weighted average. The live-year calculation is
-weighted, but the 98.2 percent agreement measured above shows the weights are
+weighted, but the 97.0 percent agreement measured above shows the weights are
 effectively uniform, so weighting adds complexity without accuracy.
 
 The **letter** is the real work. The reconstructed percent has to be mapped back
@@ -215,21 +215,32 @@ running_gpa(Qn) = sum(weighted_gpa_points_term through Qn)
 Anchoring `Q4` to the stored value was considered and **rejected**. The
 reconstruction sits systematically below the stored Y1, because PowerSchool's
 year letter grades are more generous than a running average of quarter points.
-Anchoring therefore produces:
+Unanchored, AY2025 high school reads:
 
 ```text
-50.1  ->  48.4  ->  46.1  ->  50.4
+45.1  ->  46.7  ->  46.6  ->  48.2      stored Y1: 48.9
 ```
 
-A year-long decline followed by a sharp Q4 recovery. The decline is real —
-quarter GPAs genuinely fall, 2.987 to 2.925 to 2.824 — but the size of the final
-jump is an artifact of the anchor, and it is exactly the shape a stakeholder
-builds a narrative around. Unanchored reads `50.1 -> 48.4 -> 46.1 -> 47.7`, an
-honest trajectory that simply stops one step short of the Y1 value of 50.4.
+A rising trajectory that stops slightly short of the year value. Anchoring would
+replace that final 48.2 with 48.9, inserting a step at Q4 that the underlying
+data does not produce. The step is small at high-school grain — 0.7 points — and
+larger across all students, where the same comparison runs 52.9, 54.2, 53.7,
+56.1 against a stored 58.8. Either way it is an artifact of the anchor rather
+than anything a student did, and a step at the last marking period is precisely
+what a stakeholder builds a narrative around.
+
+**Correction, recorded deliberately.** An earlier draft of this section cited
+`50.1 -> 48.4 -> 46.1 -> 47.7` against `50.4` and argued the reconstruction
+showed a year-long decline. Those were **AY2024** figures, produced by querying
+`int_powerschool__gpa_term` at `yearid = 34`; the convention is
+`yearid = academic_year - 1990`, so AY2025 is 35. The corrected AY2025 data
+rises rather than declines. The decision not to anchor was re-confirmed against
+these corrected numbers and stands, but the original justification was wrong and
+is not preserved.
 
 **This makes course grades and GPA asymmetric on purpose.** Course grades anchor
-because the anchor is exact and free. GPA does not, because its anchor
-manufactures a visible artifact. Do not "fix" the inconsistency.
+because the anchor is exact and free. GPA does not, because its anchor inserts a
+step the data does not contain. Do not "fix" the inconsistency.
 
 ### Isolation from the current year — mandatory, and not automatic
 

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -537,26 +537,34 @@ models:
         data_type: string
         description: >-
           Gradebook category code with the lowest year-running percent for this
-          course, read from the latest term that holds category data. Present on
-          every row including Y1, which is the point — the per-term category
-          columns are null at Y1 because there is no Y1 category term.
+          course, read from the latest term that holds category data. Null when
+          that term has no category with a non-null year-running percent — the
+          code never wins the tiebreak on a null value. Present on every row
+          including Y1, which is the point — the per-term category columns are
+          null at Y1 because there is no Y1 category term.
       - name: lowest_category_y1_percent
         data_type: float64
         description: >-
-          The year-running percent belonging to lowest_category_y1_name.
-      - name: lowest_category_latest_quarter_name
+          The year-running percent belonging to lowest_category_y1_name. Null
+          exactly when that column is null.
+      - name: lowest_category_recent_term_name
         data_type: string
         description: >-
           Gradebook category code with the lowest single-quarter percent in the
-          latest term that holds category data — Q4 on a completed year, the
-          most recently posted quarter on a live one. Answers what the problem
-          is right now, where lowest_category_y1_name answers what dragged the
-          whole year down. The two can legitimately disagree.
-      - name: lowest_category_latest_quarter_percent
+          most recent term that holds a quarter percent for this course. Falls
+          back to an earlier term when the most recent one has no category with
+          a quarter percent — a Q4 row can legitimately carry a driver sourced
+          from Q2, so this is not always "the latest quarter." Null when no term
+          in the two-year window has a category with a non-null quarter percent
+          — the code never wins the tiebreak on a null value. Answers what the
+          problem is right now, where lowest_category_y1_name answers what
+          dragged the whole year down. The two can legitimately disagree.
+      - name: lowest_category_recent_term_percent
         data_type: float64
         description: >-
           The single-quarter percent belonging to
-          lowest_category_latest_quarter_name.
+          lowest_category_recent_term_name. Null exactly when that column is
+          null.
       - name: y1_course_letter_grade_adjusted
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -533,6 +533,30 @@ models:
         data_type: float64
         description: >-
           Student's average percent across all courses for the category-term.
+      - name: lowest_category_y1_name
+        data_type: string
+        description: >-
+          Gradebook category code with the lowest year-running percent for this
+          course, read from the latest term that holds category data. Present on
+          every row including Y1, which is the point — the per-term category
+          columns are null at Y1 because there is no Y1 category term.
+      - name: lowest_category_y1_percent
+        data_type: float64
+        description: >-
+          The year-running percent belonging to lowest_category_y1_name.
+      - name: lowest_category_latest_quarter_name
+        data_type: string
+        description: >-
+          Gradebook category code with the lowest single-quarter percent in the
+          latest term that holds category data — Q4 on a completed year, the
+          most recently posted quarter on a live one. Answers what the problem
+          is right now, where lowest_category_y1_name answers what dragged the
+          whole year down. The two can legitimately disagree.
+      - name: lowest_category_latest_quarter_percent
+        data_type: float64
+        description: >-
+          The single-quarter percent belonging to
+          lowest_category_latest_quarter_name.
       - name: y1_course_letter_grade_adjusted
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -182,7 +182,9 @@ models:
           as a running credit-weighted GPA through each term, because
           PowerSchool stores only the end-of-year value. It is deliberately not
           anchored to that stored value, so the Q4 reading will not equal the Y1
-          reading. Temporary; see TODO(#4687).
+          reading. Temporary; see TODO(#4687) (kept here deliberately, despite
+          the no-tracking-refs-in-descriptions convention, so a removal grep for
+          this marker also finds this YAML).
       - name: gpa_y1_unweighted
         data_type: float64
         description: Unweighted Y1 GPA as of the row's term.
@@ -448,8 +450,8 @@ models:
           For the prior year it is RECONSTRUCTED from stored quarter grades — Q1
           is exact, Q4 is anchored to the stored Y1 percent and is exact, Q2 and
           Q3 are approximations that agree with the year value to within half a
-          point on roughly 98 percent of courses. The reconstruction is
-          temporary; see TODO(#4687) in the model.
+          point on 97.0 percent of courses. The reconstruction is temporary; see
+          TODO(#4687) in the model.
       - name: y1_course_in_progress_letter_grade_adjusted
         data_type: string
         description: >-
@@ -570,14 +572,13 @@ models:
         data_type: string
         description: >-
           Gradebook category code with the lowest single-quarter percent in the
-          most recent term that holds a quarter percent for this course. Falls
-          back to an earlier term when the most recent one has no category with
-          a quarter percent — a Q4 row can legitimately carry a driver sourced
-          from Q2, so this is not always "the latest quarter." Null when no term
-          in the two-year window has a category with a non-null quarter percent
-          — the code never wins the tiebreak on a null value. Answers what the
-          problem is right now, where lowest_category_y1_name answers what
-          dragged the whole year down. The two can legitimately disagree.
+          most recent term holding any usable category percent (quarter or
+          year-running) for this course. Null when that term has no
+          quarter-level percent — which usually means an earlier term does have
+          one, so a null here does not mean the section has no quarter category
+          data anywhere in the window. Answers what the problem is right now,
+          where lowest_category_y1_name answers what dragged the whole year
+          down. The two can legitimately disagree.
       - name: lowest_category_recent_term_percent
         data_type: float64
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -437,10 +437,24 @@ models:
         description: Course grade points for the row's term.
       - name: y1_course_in_progress_percent_grade_adjusted
         data_type: float64
-        description: In-progress Y1 percent grade (current-year rows only).
+        description: >-
+          Year-to-date course percent as of the row's marking period. For the
+          year in progress this is the real running value from the gradebook.
+          For the prior year it is RECONSTRUCTED from stored quarter grades — Q1
+          is exact, Q4 is anchored to the stored Y1 percent and is exact, Q2 and
+          Q3 are approximations that agree with the year value to within half a
+          point on roughly 98 percent of courses. The reconstruction is
+          temporary; see TODO(#4687) in the model.
       - name: y1_course_in_progress_letter_grade_adjusted
         data_type: string
-        description: In-progress Y1 letter grade (current-year rows only).
+        description: >-
+          Year-to-date course letter as of the row's marking period. For the
+          year in progress this comes from the gradebook. For the prior year it
+          is RECONSTRUCTED by banding the reconstructed percent back through the
+          course's own grade scale, so it inherits that percent's accuracy — Q1
+          and Q4 exact, Q2 and Q3 approximate. Carries F and F* on the same
+          prefix rule as quarter_course_letter_grade. Temporary; see TODO(#4687)
+          in the model.
       - name: y1_course_in_progress_grade_points
         data_type: float64
         description: In-progress Y1 grade points (current-year rows only).

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -177,7 +177,12 @@ models:
         description: Semester GPA for the row's term. NULL on Y1 rows.
       - name: gpa_y1
         data_type: float64
-        description: Y1 GPA as of the row's term.
+        description: >-
+          Y1 GPA as of the row's term. For the prior year this is RECONSTRUCTED
+          as a running credit-weighted GPA through each term, because
+          PowerSchool stores only the end-of-year value. It is deliberately not
+          anchored to that stored value, so the Q4 reading will not equal the Y1
+          reading. Temporary; see TODO(#4687).
       - name: gpa_y1_unweighted
         data_type: float64
         description: Unweighted Y1 GPA as of the row's term.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -583,6 +583,80 @@ with
             and not is_dropped_section
             and storecode_type not in ('Q')
             and termbin_start_date <= current_date('{{ var("local_timezone") }}')
+    ),
+
+    category_ranked as (
+        /* Ranking input for the lowest-category drivers. Rows where BOTH
+           percents are null are excluded so a term that exists but carries no
+           usable value cannot win rn_latest_term and blank out both drivers.
+
+           (percent is null) asc leads each order by because BigQuery sorts
+           NULLS FIRST ascending, which would otherwise hand "lowest" to a null.
+           category_name_code is the final tiebreaker so the pick is
+           reproducible across rebuilds. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            sectionid,
+            category_name_code,
+            category_quarter_percent_grade,
+            category_y1_percent_grade_running,
+
+            dense_rank() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid
+                order by term desc
+            ) as rn_latest_term,
+
+            row_number() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid, term
+                order by
+                    (category_y1_percent_grade_running is null) asc,
+                    category_y1_percent_grade_running asc,
+                    category_name_code asc
+            ) as rn_lowest_y1,
+
+            row_number() over (
+                partition by _dbt_source_project, studentid, yearid, sectionid, term
+                order by
+                    (category_quarter_percent_grade is null) asc,
+                    category_quarter_percent_grade asc,
+                    category_name_code asc
+            ) as rn_lowest_quarter,
+        from category_grades
+        where
+            category_quarter_percent_grade is not null
+            or category_y1_percent_grade_running is not null
+    ),
+
+    category_drivers as (
+        /* One row per student-section-year, so the join below cannot fan out.
+           Both drivers are read from the SAME latest term, so they describe one
+           moment rather than two. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            sectionid,
+
+            max(
+                if(rn_lowest_y1 = 1, category_name_code, null)
+            ) as lowest_category_y1_name,
+
+            max(
+                if(rn_lowest_y1 = 1, category_y1_percent_grade_running, null)
+            ) as lowest_category_y1_percent,
+
+            max(
+                if(rn_lowest_quarter = 1, category_name_code, null)
+            ) as lowest_category_latest_quarter_name,
+
+            max(
+                if(rn_lowest_quarter = 1, category_quarter_percent_grade, null)
+            ) as lowest_category_latest_quarter_percent,
+        from category_ranked
+        where rn_latest_term = 1
+        group by _dbt_source_project, studentid, yearid, sectionid
     )
 
 select
@@ -711,6 +785,11 @@ select
     c.category_y1_percent_grade_current,
     c.category_quarter_average_all_courses,
 
+    cd.lowest_category_y1_name,
+    cd.lowest_category_y1_percent,
+    cd.lowest_category_latest_quarter_name,
+    cd.lowest_category_latest_quarter_percent,
+
     gsl.need_next_letter_grade,
     gsl.need_next_cutoff_percent,
 
@@ -803,4 +882,11 @@ left join
     and qg.courses_gradescaleid = gsl.gradescaleid
     and qg.y1_course_in_progress_percent_grade_adjusted
     between gsl.rung_floor and gsl.rung_ceiling
+left join
+    category_drivers as cd
+    on s.studentid = cd.studentid
+    and s.yearid = cd.yearid
+    and s._dbt_source_project = cd._dbt_source_project
+    and ce.sectionid = cd.sectionid
+    and ce._dbt_source_project = cd._dbt_source_project
 where s.quarter_start_date <= current_date('{{ var("local_timezone") }}')

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -386,6 +386,140 @@ with
             storecode = 'Y1' and academic_year >= {{ var("current_academic_year") - 1 }}
     ),
 
+    backfill_quarter_running as (
+        /* TODO(#4687): TEMPORARY. Delete this CTE, backfill_course_anchored,
+           backfill_running_course, and their use in quarter_grades branch 3
+           once the dashboard runs on current-year data. Tracked in Asana under
+           GPA and Gradebook Dashboard v3, Phase 4.
+
+           Reconstructs a running year-to-date course percent for the prior
+           year, which PowerSchool never stored. Q1 is exact by definition;
+           Q2 and Q3 are approximations; Q4 is replaced by the stored Y1 value
+           below so it matches exactly. Simple rather than credit-weighted
+           average because the two agree to within half a point on 98.2 percent
+           of courses. */
+        select
+            _dbt_source_relation,
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+            storecode,
+            gradescale_name_unweighted,
+
+            avg(`percent`) over (
+                partition by _dbt_source_project, studentid, yearid, course_number
+                order by storecode
+            ) as running_percent,
+        from {{ ref("stg_powerschool__storedgrades") }}
+        where
+            storecode in ('Q1', 'Q2', 'Q3', 'Q4')
+            and academic_year = {{ var("current_academic_year") - 1 }}
+    ),
+
+    backfill_y1_stored_raw as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+            gradescale_name_unweighted,
+            dcid,
+
+            `percent` as y1_stored_percent,
+        from {{ ref("stg_powerschool__storedgrades") }}
+        where
+            storecode = 'Y1' and academic_year = {{ var("current_academic_year") - 1 }}
+    ),
+
+    backfill_y1_stored as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running.
+
+           dbt_utils.deduplicate guards the pre-existing #3915 storedgrades
+           double-write, confirmed present on academic_year 2025 Y1 rows with
+           genuinely conflicting percents rather than harmless repeats. Left
+           un-deduplicated, this CTE's grain becomes a join key in
+           backfill_course_anchored below, so one duplicate would multiply
+           every quarter row for the course, not just the Y1 row it
+           originated on. Highest dcid wins: sampled duplicate pairs cluster
+           in two distinct dcid ranges, consistent with a later corrective
+           re-import superseding an earlier one. */
+        {{
+            dbt_utils.deduplicate(
+                relation="backfill_y1_stored_raw",
+                partition_by="_dbt_source_project, studentid, yearid, course_number",
+                order_by="dcid desc",
+            )
+        }}
+    ),
+
+    backfill_course_anchored as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running.
+
+           Q4 takes the stored Y1 percent verbatim so the reconstruction lands
+           exactly on the year grade. The Y1 storecode row is unioned in
+           carrying the same value, so the Y1 marking period and Q4 agree. */
+        select
+            r._dbt_source_project,
+            r.studentid,
+            r.yearid,
+            r.course_number,
+            r.storecode,
+            r.gradescale_name_unweighted,
+
+            if(
+                r.storecode = 'Q4', y1.y1_stored_percent, r.running_percent
+            ) as anchored_percent,
+        from backfill_quarter_running as r
+        left join
+            backfill_y1_stored as y1
+            on r._dbt_source_project = y1._dbt_source_project
+            and r.studentid = y1.studentid
+            and r.yearid = y1.yearid
+            and r.course_number = y1.course_number
+
+        union all
+
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            course_number,
+
+            'Y1' as storecode,
+
+            gradescale_name_unweighted,
+            y1_stored_percent as anchored_percent,
+        from backfill_y1_stored
+    ),
+
+    backfill_running_course as (
+        /* TODO(#4687): TEMPORARY, see backfill_quarter_running.
+
+           Bands the reconstructed percent back to a letter on the course's own
+           scale. Joins on gradescale_name rather than gradescaleid, the pattern
+           int_powerschool__gpa_term and rpt_deanslist__transcript_gpas already
+           use for storedgrades, plus _dbt_source_project because scale
+           identifiers collide across districts. */
+        select
+            a._dbt_source_project,
+            a.studentid,
+            a.yearid,
+            a.course_number,
+            a.storecode,
+            a.anchored_percent,
+
+            gsi.letter_grade as anchored_letter_grade,
+        from backfill_course_anchored as a
+        left join
+            {{ ref("int_powerschool__gradescaleitem_lookup") }} as gsi
+            on a._dbt_source_project = gsi._dbt_source_project
+            and a.gradescale_name_unweighted = gsi.gradescale_name
+            and a.anchored_percent
+            between gsi.min_cutoffpercentage and gsi.max_cutoffpercentage
+    ),
+
     quarter_grades as (
         /* current year: live gradebook */
         select
@@ -457,20 +591,20 @@ with
            which fills the quarter columns on Y1 rows like the in-progress
            branch does for the current year) */
         select
-            _dbt_source_relation,
-            _dbt_source_project,
-            studentid,
-            yearid,
-            course_number,
+            sg._dbt_source_relation,
+            sg._dbt_source_project,
+            sg.studentid,
+            sg.yearid,
+            sg.course_number,
 
-            storecode as `quarter`,
+            sg.storecode as `quarter`,
 
-            cast(`percent` as float64) as quarter_course_percent_grade,
-            grade as quarter_course_letter_grade,
-            gpa_points as quarter_course_grade_points,
+            cast(sg.`percent` as float64) as quarter_course_percent_grade,
+            sg.grade as quarter_course_letter_grade,
+            sg.gpa_points as quarter_course_grade_points,
 
-            cast(null as float64) as y1_course_in_progress_percent_grade_adjusted,
-            cast(null as string) as y1_course_in_progress_letter_grade_adjusted,
+            bfc.anchored_percent as y1_course_in_progress_percent_grade_adjusted,
+            bfc.anchored_letter_grade as y1_course_in_progress_letter_grade_adjusted,
             cast(null as float64) as y1_course_in_progress_grade_points,
             cast(null as float64) as y1_course_in_progress_grade_points_unweighted,
 
@@ -481,10 +615,17 @@ with
 
             cast(null as int64) as courses_gradescaleid,
 
-        from {{ ref("stg_powerschool__storedgrades") }}
+        from {{ ref("stg_powerschool__storedgrades") }} as sg
+        left join
+            backfill_running_course as bfc
+            on sg._dbt_source_project = bfc._dbt_source_project
+            and sg.studentid = bfc.studentid
+            and sg.yearid = bfc.yearid
+            and sg.course_number = bfc.course_number
+            and sg.storecode = bfc.storecode
         where
-            storecode in ('Q1', 'Q2', 'Q3', 'Q4', 'Y1')
-            and academic_year = {{ var("current_academic_year") - 1 }}
+            sg.storecode in ('Q1', 'Q2', 'Q3', 'Q4', 'Y1')
+            and sg.academic_year = {{ var("current_academic_year") - 1 }}
     ),
 
     grade_scale_rungs as (

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -111,10 +111,11 @@ with
            Running credit-weighted GPA through each term, accumulated from the
            same components the real gpa_y1 uses. Deliberately NOT anchored to
            the stored Y1: the reconstruction reads 45.1, 46.7, 46.6, 48.2
-           percent at or above 3.0 through Q1-Q4 (AY2025) against a stored Y1
-           of 48.9 — it sits slightly below the stored value throughout, and
-           anchoring Q4 to that value would introduce a discontinuity there
-           rather than let the series read as one continuous trend. */
+           percent of high school students at or above 3.0 through Q1-Q4
+           (AY2025) against a stored Y1 of 48.9 — it sits slightly below
+           the stored value throughout, and anchoring Q4 to that value
+           would introduce a discontinuity there rather than let the
+           series read as one continuous trend. */
         select
             studentid,
             schoolid,
@@ -446,7 +447,7 @@ with
            year, which PowerSchool never stored. Q1 is exact by definition;
            Q2 and Q3 are approximations; Q4 is replaced by the stored Y1 value
            below so it matches exactly. Simple rather than credit-weighted
-           average because the two agree to within half a point on 98.2 percent
+           average because the two agree to within half a point on 97.0 percent
            of courses. */
         select
             _dbt_source_relation,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -640,7 +640,11 @@ with
             sectionid,
 
             max(
-                if(rn_lowest_y1 = 1, category_name_code, null)
+                if(
+                    rn_lowest_y1 = 1 and category_y1_percent_grade_running is not null,
+                    category_name_code,
+                    null
+                )
             ) as lowest_category_y1_name,
 
             max(
@@ -648,12 +652,17 @@ with
             ) as lowest_category_y1_percent,
 
             max(
-                if(rn_lowest_quarter = 1, category_name_code, null)
-            ) as lowest_category_latest_quarter_name,
+                if(
+                    rn_lowest_quarter = 1
+                    and category_quarter_percent_grade is not null,
+                    category_name_code,
+                    null
+                )
+            ) as lowest_category_recent_term_name,
 
             max(
                 if(rn_lowest_quarter = 1, category_quarter_percent_grade, null)
-            ) as lowest_category_latest_quarter_percent,
+            ) as lowest_category_recent_term_percent,
         from category_ranked
         where rn_latest_term = 1
         group by _dbt_source_project, studentid, yearid, sectionid
@@ -787,8 +796,8 @@ select
 
     cd.lowest_category_y1_name,
     cd.lowest_category_y1_percent,
-    cd.lowest_category_latest_quarter_name,
-    cd.lowest_category_latest_quarter_percent,
+    cd.lowest_category_recent_term_name,
+    cd.lowest_category_recent_term_percent,
 
     gsl.need_next_letter_grade,
     gsl.need_next_cutoff_percent,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -103,6 +103,41 @@ with
             academic_year = {{ var("current_academic_year") - 1 }} and not is_projected
     ),
 
+    backfill_running_gpa as (
+        /* TODO(#4687): TEMPORARY. Delete this CTE, its join in student_roster,
+           and the coalesce on gpa_y1 once the dashboard runs on current-year
+           data. Tracked in Asana under GPA and Gradebook Dashboard v3, Phase 4.
+
+           Running credit-weighted GPA through each term, accumulated from the
+           same components the real gpa_y1 uses. Deliberately NOT anchored to
+           the stored Y1: anchoring produced a year-long decline followed by a
+           fake Q4 recovery, which is the shape a stakeholder builds a false
+           narrative around. Unanchored it reads 50.1, 48.4, 46.1, 47.7 percent
+           at or above 3.0 against a stored Y1 of 50.4. */
+        select
+            studentid,
+            schoolid,
+            yearid,
+            _dbt_source_project,
+            term_name,
+
+            round(
+                safe_divide(
+                    sum(weighted_gpa_points_term) over (
+                        partition by studentid, _dbt_source_project, schoolid, yearid
+                        order by term_name
+                    ),
+                    sum(total_credit_hours_term) over (
+                        partition by studentid, _dbt_source_project, schoolid, yearid
+                        order by term_name
+                    )
+                ),
+                2
+            ) as gpa_y1_running,
+        from {{ ref("int_powerschool__gpa_term") }}
+        where yearid = {{ var("current_academic_year") - 1991 }}
+    ),
+
     student_roster as (
         select
             enr._dbt_source_relation,
@@ -194,7 +229,9 @@ with
 
             if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_term) as gpa_for_quarter,
 
-            if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1) as gpa_y1,
+            coalesce(
+                bfg.gpa_y1_running, if(term.quarter = 'Y1', gty.gpa_y1, gtq.gpa_y1)
+            ) as gpa_y1,
 
             if(
                 term.quarter = 'Y1', gty.n_failing_y1, gtq.n_failing_y1
@@ -245,6 +282,14 @@ with
             and enr._dbt_source_project = gtq._dbt_source_project
             and term.quarter = gtq.term_name
             and term._dbt_source_project = gtq._dbt_source_project
+        left join
+            backfill_running_gpa as bfg
+            on enr.studentid = bfg.studentid
+            and enr.yearid = bfg.yearid
+            and enr.schoolid = bfg.schoolid
+            and enr._dbt_source_project = bfg._dbt_source_project
+            and term.quarter = bfg.term_name
+            and enr.academic_year = {{ var("current_academic_year") - 1 }}
         left join
             {{ ref("int_powerschool__gpa_term") }} as gty
             on enr.studentid = gty.studentid

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -110,10 +110,11 @@ with
 
            Running credit-weighted GPA through each term, accumulated from the
            same components the real gpa_y1 uses. Deliberately NOT anchored to
-           the stored Y1: anchoring produced a year-long decline followed by a
-           fake Q4 recovery, which is the shape a stakeholder builds a false
-           narrative around. Unanchored it reads 50.1, 48.4, 46.1, 47.7 percent
-           at or above 3.0 against a stored Y1 of 50.4. */
+           the stored Y1: the reconstruction reads 45.1, 46.7, 46.6, 48.2
+           percent at or above 3.0 through Q1-Q4 (AY2025) against a stored Y1
+           of 48.9 — it sits slightly below the stored value throughout, and
+           anchoring Q4 to that value would introduce a discontinuity there
+           rather than let the series read as one continuous trend. */
         select
             studentid,
             schoolid,
@@ -282,6 +283,10 @@ with
             and enr._dbt_source_project = gtq._dbt_source_project
             and term.quarter = gtq.term_name
             and term._dbt_source_project = gtq._dbt_source_project
+        /* bfg is gated to the prior year in ON — the inverse of gc/lb/gpq/pyc's
+           current-year gate below — so current-year rows get NULL here and
+           the coalesce on gpa_y1 falls through to the untouched original
+           expression */
         left join
             backfill_running_gpa as bfg
             on enr.studentid = bfg.studentid


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make `Category Driving Gap` resolve at the
Y1 marking period, and temporarily populate prior-year running course grades and
GPA so the drill-down is not blank during summer stakeholder training.

Two changes to `rpt_tableau__student_course_grades`, shipping together with
**deliberately different lifespans**. Issue #4687 is the authoritative removal
runbook for the temporary half.

### 1. Category drivers at Y1 — permanent

`Category Driving Gap` read `not available` on every Y1 row, which is the level
the dashboard is primarily viewed at. Cause: the category join is
`s.quarter = c.term` and there is no Y1 term, so all 38,281 Y1 rows carried a
null `category_name_code`.

Four student-course-grain columns, present on every row including Y1:

| Column | Meaning |
| --- | --- |
| `lowest_category_y1_name` / `_percent` | lowest year-running category |
| `lowest_category_recent_term_name` / `_percent` | lowest category in the most recent term holding data |

Scalar columns rather than attaching category rows to Y1, which would have
fanned Y1 out from 38K to roughly 150K rows on a contracted model with a live
uniqueness test.

Deletes two Tableau calcs: `Lowest Category % (course)` and the `MIN(IF ...)`
form of `Category Driving Gap`.

### 2. Prior-year running backfill — temporary

`y1_course_in_progress_*` was 100 percent null on prior years, and `gpa_y1` was
the final year value repeated on every quarter row (#4382). Pointing M1 and M2
at the running columns would have blanked the drill-down on the only year that
holds data.

- **Course grades** — running average of stored quarter percents. Q1 exact, Q4
  anchored to the stored Y1 and exact, Q2 and Q3 approximate.
- **GPA** — running from the per-term components, deliberately **not** anchored.

That asymmetry is intentional and documented. Accuracy was explicitly not the
goal; populated and labelled was.

**Six CTEs are temporary**, each carrying a `backfill_` prefix and a
`TODO(#4687)` marker. `grep -n "backfill_\|TODO(#4687)"` finds all of them and
nothing else — verified collision-free.

## Three defects found during implementation

Recorded because each was caught by a guardrail rather than by luck, and two
were mine.

**The plan's `backfill_y1_stored` join omitted `storecode` from its key.** The
first build produced WARN=130 and 166 extra rows — a real fan-out, caused by
roughly 96 conflicting duplicate Y1 rows from the known #3915 double-write
leaking onto previously-clean Q1-Q3 rows. Caught because the plan made
`warn = 12` and the exact row count hard invariants rather than "the build
passes". Fixed with `dbt_utils.deduplicate` on the join input; the tracked #3915
warn signal is untouched at 12, not masked.

**The plan's yearid expression was off by one.** `current_academic_year - 1 - 1991`
yields 34, but the convention is `yearid = academic_year - 1990`, so AY2025 is
35. Left in, the join would never have matched — and the first build proved it,
going flat across all five marking periods, which is the exact failure signature
the plan names.

**The same off-by-one contaminated the design analysis.** Every GPA figure in
the original spec was AY2024. Corrected in `e1862585f`: course reconstruction
accuracy 98.2 to 97.0 percent, students crossing the 3.0 line 173-645 to
222-748, and the trajectory from `50.1/48.4/46.1/47.7` against `50.4` to
`45.1/46.7/46.6/48.2` against `48.9`. The rejected-anchoring argument had
claimed a year-long decline; the real data **rises**. The decision not to anchor
was re-confirmed against corrected numbers and stands, but the spec now records
that its original justification was wrong rather than quietly restating it.

## Verification

Current-year isolation was the first invariant, because the GPA half is not
structurally isolated the way the course half is — it depends on a single
`ON`-clause year gate.

- **Isolation proven at row level**, not aggregate: a complete anti-join over
  all 141,036 AY2026 rows returned **0 mismatches** on `gpa_y1`,
  `gpa_for_quarter` and `gpa_n_failing_y1`. Review independently confirmed from
  the compiled SQL that the gate emits `enr.academic_year = 2025` as a hardcoded
  literal, so a current-year row cannot match.
- **No fan-out.** Dev and a same-session prod read are identical in both years:
  854,263 / 854,227 overall, AY2025 713,227 / 713,191, AY2026 141,036 / 141,036.
  Note prod drifted 18 rows mid-execution; comparisons are same-session for that
  reason.
- **Hard invariants all zero** — Q1 exactness, Q4 anchor, letter coverage.
- **`need_next_*` still null across all 713,227 AY2025 rows.** That property
  depends on `courses_gradescaleid` staying null in branch 3; reusing the
  existing grade-scale ladder would have lit up a next-letter with no percent
  beside it.
- Composite uniqueness test still warns at **12**, the pre-existing #3915 count.
  `int_powerschool__gradescaleitem_lookup`'s uniqueness test still passes.

## AI Assistance

Claude Code designed and implemented this under human direction, executed
task-by-task with a fresh subagent and an independent review per task. Four
decisions were human-made: whole letters rather than plus-minus, nulling a
driver name when its percent is null, renaming `latest_quarter` to `recent_term`,
and leaving the GPA reconstruction unanchored — the last re-confirmed after the
year error was found.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated with `data_type` and `description` for all new and
      changed columns
- [ ] Exposure — still absent on this model; pre-existing, unchanged by this PR
- [x] **Not a breaking change.** Additive columns plus a `coalesce` that falls
      through to the original expression outside the prior year
- [x] No external sources added or modified

## CI checks

- [x] **Trunk** — clean on the full branch diff before push
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the
      `pull_request` paths

Refs #4687
