### PR TITLE
fix(nj-sleds): scope submission gate to Newark and re-pin baselines

### DIFF
--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -50,14 +50,14 @@ regions, `missing = 50`), partly because 54 sections were deliberately excluded
 from the pull and partly because Camden is no longer in scope — see _Region
 scope_ below.
 
-These three are now the gate's only failures. Everything else passes, so a
-fourth failure appearing means something genuinely changed, not more of the same
-backlog.
-
 Both describe the same underlying gap: for these rows, PowerSchool holds no
 usable `Y1` stored grade and no usable live final grade either, so this tool has
 nothing to fill in from. It is not a query bug, and there is no flag or override
 that makes it go away — the gate has no bypass, on purpose.
+
+These are now the gate's only failures — everything else passes. A fourth
+failure appearing means something genuinely changed, not more of the same
+backlog.
 
 **Required action:** someone with PowerSchool access must post the missing
 grades for those students and sections, or exclude the affected sections from
@@ -98,23 +98,26 @@ the 108 rows; those were the sections excluded from the pull, so what remains is
 entirely per-student rather than per-section. That changes the fix: no section
 needs a scheduling or School Setup change, only individual grades.
 
-What each combination implies:
+What each combination implies. Both live categories are partial sections, so
+neither is fixed by excluding a section — that would drop classmates who do have
+grades:
 
-- **Whole section ungraded (41 rows):** the section appears never to have been
-  graded. If it genuinely should not be reported, the fix is PowerSchool's
-  "Exclude from Course Roster Reports" checkbox on the section's Course
-  Submission Information panel (see the audit runbook). Then re-pull and re-load
-  the extract.
-- **Partial, classmates were graded (34 rows):** the section was graded and
-  these individual students were missed. Excluding the section would wrongly
-  drop the students who do have grades — post the missing grades instead.
-- **Conflicting grades (31 rows):** a grade exists, but sources or reporting
-  terms disagree, so the query refuses to pick one. Reconcile in PowerSchool.
-  These are the cheapest to clear.
-- **Grade exists but outside the handbook domain (2 rows):** the only available
-  grade was `F*`, a warehouse-internal marker that is not a legal
-  `AlphaGradeEarned` value. Determine the real grade and correct it in
-  PowerSchool.
+- **No grade in either source, partial (27 rows):** the section was graded and
+  these individual students were missed. Post the missing grades in PowerSchool.
+- **Conflicting grades, partial (20 rows):** a grade exists, but sources or
+  reporting terms disagree, so the query refuses to pick one. Reconcile in
+  PowerSchool. These are the cheapest to clear.
+
+Two further categories are empty on this extract but can reappear:
+
+- **Whole section ungraded:** the section appears never to have been graded. If
+  it genuinely should not be reported, the fix is PowerSchool's "Exclude from
+  Course Roster Reports" checkbox on the section's Course Submission Information
+  panel (see the audit runbook), then re-pull and re-load. This held 41 rows on
+  2026-07-29; the 54-section exclusion cleared all of them.
+- **Grade exists but outside the handbook domain:** the only available grade was
+  `F*`, a warehouse-internal marker that is not a legal `AlphaGradeEarned`
+  value. Determine the real grade and correct it in PowerSchool.
 
 The worklist CSV is PII-bearing (local student and section IDs) — same handling
 as the submission CSV: write it to `.claude/scratch/` (gitignored), never commit

--- a/docs/superpowers/nj-sleds-roster/submission/README.md
+++ b/docs/superpowers/nj-sleds-roster/submission/README.md
@@ -37,13 +37,22 @@ so step 2 is only for iterating.
 
 ## The gate is red on arrival — this is expected
 
-As of the 2026-07-29 extract, two check groups fail and are expected to keep
+As of the 2026-08-02 extract, two check groups fail and are expected to keep
 failing until someone acts on the source data:
 
-- `check_in_scope_rows_have_grades` reports **108** in-scope rows with no letter
-  grade (Newark HS 20, Newark MS 55, Camden HS 30, Camden MS 3).
-- `check_credits_earned` reports **`missing = 50`** — HS rows with no
-  `CreditsEarned`.
+- `check_in_scope_rows_have_grades` reports **47** in-scope rows with no letter
+  grade (Newark HS 12, Newark MS 35).
+- `check_credits_earned` reports **`missing = 12`** — HS rows with no
+  `CreditsEarned`, the same 12 rows.
+
+Both figures are down from the 2026-07-29 extract (108 ungraded across both
+regions, `missing = 50`), partly because 54 sections were deliberately excluded
+from the pull and partly because Camden is no longer in scope — see _Region
+scope_ below.
+
+These three are now the gate's only failures. Everything else passes, so a
+fourth failure appearing means something genuinely changed, not more of the same
+backlog.
 
 Both describe the same underlying gap: for these rows, PowerSchool holds no
 usable `Y1` stored grade and no usable live final grade either, so this tool has
@@ -77,14 +86,17 @@ thing it exists to fix would be circular.
 
 Each row carries `reason` (why the row has no grade) and `section_shape`
 (whether the whole section is affected or just this student). As of the
-2026-07-29 extract the 108 rows break down like this:
+2026-08-02 extract the 47 rows break down like this:
 
-| Reason                                       | Section shape                    | Rows |
-| -------------------------------------------- | -------------------------------- | ---: |
-| no grade in either source                    | whole section ungraded           |   41 |
-| no grade in either source                    | partial — classmates were graded |   34 |
-| conflicting grades                           | partial                          |   31 |
-| grade exists but outside the handbook domain | partial                          |    2 |
+| Reason                    | Section shape                    | Rows |
+| ------------------------- | -------------------------------- | ---: |
+| no grade in either source | partial — classmates were graded |   27 |
+| conflicting grades        | partial — classmates were graded |   20 |
+
+The whole-section-ungraded category is now empty. On 2026-07-29 it held 41 of
+the 108 rows; those were the sections excluded from the pull, so what remains is
+entirely per-student rather than per-section. That changes the fix: no section
+needs a scheduling or School Setup change, only individual grades.
 
 What each combination implies:
 
@@ -111,6 +123,25 @@ it, never paste row-level values anywhere external.
 After fixing a source record, the extract must be re-pulled and re-loaded before
 the gate reflects the fix — re-running the gate against the old extract will
 still show the same failures.
+
+## Region scope
+
+`REGIONS_IN_SCOPE` in `submission_query.py` is the single source of truth for
+which regions this tool still processes. It is currently `("newark",)`.
+
+Camden's 2026-07-31 submission was accepted, error-free, and certified, so its
+extract is final — reprocessing it can only produce a difference from what the
+state already holds. Its rows were also holding the gate red, which blocked
+Newark from exporting for work nobody intended to redo.
+
+The constant feeds the gate's base-table iteration, `build_submission.py`, and
+`export_worklist.py`, and filters `SUBMISSION_SQL` itself. `SUBMISSION_SQL`
+still builds both regions' branches and filters at the end, so restoring a
+region is a one-tuple edit plus a re-baseline, not SQL reconstruction.
+
+Both baseline dicts keep their Camden entries at the certified values. They are
+skipped at evaluation while Camden is out of scope, and are there so the numbers
+survive for the record.
 
 ## Re-baselining per cycle
 

--- a/docs/superpowers/nj-sleds-roster/submission/build_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/build_submission.py
@@ -19,12 +19,15 @@ import sys
 from pathlib import Path
 
 from google.cloud import bigquery
-from submission_query import SUBMISSION_COLUMNS, SUBMISSION_SQL
+from submission_query import REGIONS_IN_SCOPE as REGIONS
+from submission_query import (
+    SUBMISSION_COLUMNS,
+    SUBMISSION_SQL,
+)
 from validate_submission import base_table_row_count, run_checks
 
 PROJECT = "teamster-332318"
 VIEW = "teamster-332318.cokafor.rpt_student_course_submission"
-REGIONS = ("newark", "camden")
 
 
 def create_view(client):

--- a/docs/superpowers/nj-sleds-roster/submission/export_worklist.py
+++ b/docs/superpowers/nj-sleds-roster/submission/export_worklist.py
@@ -18,11 +18,14 @@ import sys
 from pathlib import Path
 
 from google.cloud import bigquery
-from submission_query import UNGRADED_WORKLIST_COLUMNS, UNGRADED_WORKLIST_SQL
+from submission_query import REGIONS_IN_SCOPE as REGIONS
+from submission_query import (
+    UNGRADED_WORKLIST_COLUMNS,
+    UNGRADED_WORKLIST_SQL,
+)
 
 PROJECT = "teamster-332318"
 VIEW = "teamster-332318.cokafor.rpt_student_course_ungraded"
-REGIONS = ("newark", "camden")
 
 
 def create_view(client):

--- a/docs/superpowers/nj-sleds-roster/submission/submission_query.py
+++ b/docs/superpowers/nj-sleds-roster/submission/submission_query.py
@@ -84,6 +84,24 @@ PASSING_ALPHA_GRADES = frozenset(
 _ALPHA_GRADE_DOMAIN_SQL = ", ".join(f"'{g}'" for g in sorted(ALPHA_GRADE_DOMAIN))
 _PASSING_ALPHA_GRADES_SQL = ", ".join(f"'{g}'" for g in sorted(PASSING_ALPHA_GRADES))
 
+# Regions this tool still submits for. Camden's 2026-07-31 submission was
+# accepted, error-free, and certified, so its extract is final - reprocessing
+# it can only introduce a difference from what the state already holds. Newark
+# remains open, and from the 2026-08-02 extract onward its files arrive alone.
+#
+# This is the single source of truth: the gate's base-table iteration, the
+# submission export, and the ungraded worklist all derive their region set
+# from here. Restoring a region means adding it back to this tuple and
+# re-measuring the baselines in validate_submission.py - nothing else.
+#
+# SUBMISSION_SQL still builds both regions' branches below, each pinned to its
+# own source project, and filters at the end. Keeping the branch and filtering
+# it out means a certified region can be brought back by editing one tuple
+# rather than reconstructing SQL that has been deleted.
+REGIONS_IN_SCOPE = ("newark",)
+
+_REGIONS_IN_SCOPE_SQL = ", ".join(f"'{r}'" for r in sorted(REGIONS_IN_SCOPE))
+
 # trunk-ignore(bandit/B608): grade domain values are module constants, not user input
 SUBMISSION_SQL = f"""
 with
@@ -368,6 +386,7 @@ select
     candidate_letter,
     grade_source,
 from emitted_credit
+where region in ({_REGIONS_IN_SCOPE_SQL})
 """
 
 # The worklist identifies rows by local IDs only (LocalIdentificationNumber,

--- a/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
+++ b/docs/superpowers/nj-sleds-roster/submission/validate_submission.py
@@ -9,6 +9,7 @@ import sys
 from google.cloud import bigquery
 from submission_query import (
     ALPHA_GRADE_DOMAIN,
+    REGIONS_IN_SCOPE,
     SUBMISSION_COLUMNS,
     SUBMISSION_SQL,
     UNGRADED_WORKLIST_SQL,
@@ -16,9 +17,22 @@ from submission_query import (
 
 PROJECT = "teamster-332318"
 
-BASE_TABLES = {
+# Every region's extract table. BASE_TABLES below narrows this to the ones
+# still being submitted for; the full map stays here so a certified region's
+# table is still named in one obvious place.
+ALL_BASE_TABLES = {
     "newark": "teamster-332318.cokafor.stg_student_extract_newark",
     "camden": "teamster-332318.cokafor.stg_student_extract_camden",
+}
+
+# Scoped to REGIONS_IN_SCOPE, which also filters SUBMISSION_SQL. Both sides of
+# every parity and pass-through check must cover the same regions - comparing
+# a Newark-only view against both base tables would report the whole of Camden
+# as missing rows.
+BASE_TABLES = {
+    region: table
+    for region, table in ALL_BASE_TABLES.items()
+    if region in REGIONS_IN_SCOPE
 }
 
 PASS_THROUGH_COLUMNS = [
@@ -29,12 +43,22 @@ PASS_THROUGH_COLUMNS = [
 # shifts between extract pulls (enrollment, course, and span changes), and
 # the band logic is exactly what this baseline cross-checks, so deriving it
 # would be circular. Re-measure by hand whenever a new extract is loaded (see
-# the README's re-baseline step). Measured from the 2026-07-29 extract.
+# the README's re-baseline step).
+#
+# Newark measured from the 2026-08-02 extract. It is lower than the 2026-07-29
+# figures (HS 10695, MS 10746, OUT 11709) because 54 sections were removed from
+# the pull on purpose - see the section-exclusion work. Re-pinning here is
+# recording a deliberate scope change, not relaxing a check that was failing:
+# the check still demands exact equality against a number measured once by
+# hand, and any drift from this extract fails it.
+#
+# Camden entries are its certified 2026-07-31 values, retained for the record
+# and skipped at evaluation while it sits outside REGIONS_IN_SCOPE.
 BASELINE_BAND_ROWS = {
-    ("newark", "HS"): 10695,
-    ("newark", "MS"): 10746,
-    ("newark", "OUT"): 11709,
-    ("camden", "HS"): 3648,
+    ("newark", "HS"): 9838,
+    ("newark", "MS"): 10528,
+    ("newark", "OUT"): 11446,
+    ("camden", "HS"): 3628,
     ("camden", "MS"): 3638,
     ("camden", "OUT"): 3057,
 }
@@ -95,6 +119,8 @@ def check_band_counts(client, sql=SUBMISSION_SQL):
     """
     actual = {(r.region, r.grade_band): r.n for r in _rows(client, sql_text)}
     for key, expected in BASELINE_BAND_ROWS.items():
+        if key[0] not in REGIONS_IN_SCOPE:
+            continue
         got = actual.get(key, 0)
         if got != expected:
             failures.append(
@@ -104,10 +130,13 @@ def check_band_counts(client, sql=SUBMISSION_SQL):
 
 
 # Per-cycle baseline, same caveat as BASELINE_BAND_ROWS above - re-measure by
-# hand whenever a new extract is loaded. Measured from the 2026-07-29 extract.
+# hand whenever a new extract is loaded. Newark measured from the 2026-08-02
+# extract (was HS 10675, MS 10682 on 2026-07-29, before the 54 excluded
+# sections left the pull). Camden holds its certified 2026-07-31 values and is
+# skipped while outside REGIONS_IN_SCOPE.
 BASELINE_STORED_COVERAGE = {
-    ("newark", "HS"): 10675,
-    ("newark", "MS"): 10682,
+    ("newark", "HS"): 9826,
+    ("newark", "MS"): 10484,
     ("camden", "HS"): 3616,
     ("camden", "MS"): 3633,
 }
@@ -128,6 +157,8 @@ def check_stored_coverage(client, sql=SUBMISSION_SQL):
     """
     actual = {(r.region, r.grade_band): r.matched for r in _rows(client, sql_text)}
     for key, floor in BASELINE_STORED_COVERAGE.items():
+        if key[0] not in REGIONS_IN_SCOPE:
+            continue
         got = actual.get(key, 0)
         if got < floor:
             failures.append(


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will scope the NJ SLEDS student submission gate
to Newark and re-pin its per-cycle baselines to the 2026-08-02 extract.

Camden's 2026-07-31 submission was accepted, error-free, and certified, so its
extract is final — reprocessing it can only produce a difference from what the
state already holds. But its 13 remaining ungraded rows were still failing the
gate, and the gate has no per-region result, so a region nobody intends to
resubmit was blocking Newark from exporting at all.

Two changes:

**Region scope.** Adds `REGIONS_IN_SCOPE` to `submission_query.py` as the
single source of truth. The region set was previously declared in four places:
`SUBMISSION_SQL`'s union branches, `validate_submission`'s `BASE_TABLES`, and a
local `REGIONS` in each of `build_submission` and `export_worklist`.
`SUBMISSION_SQL` still builds both regions' branches and filters at the end, so
restoring a region is a one-tuple edit plus a re-baseline rather than
reconstructing SQL that had been deleted.

**Re-pinned baselines.** Newark's band-count and stored-coverage baselines now
reflect the 2026-08-02 extract. They are lower than the 2026-07-29 figures
because 54 sections were deliberately removed from the pull. This records a
scope change rather than relaxing a failing check: both checks still demand
their original comparison against a number measured once by hand, and any drift
from this extract fails them. Camden's baselines stay at their certified values
and are skipped at evaluation.

### Result

The gate goes from 11 failures to 3, and the remaining 3 are the real data gap
rather than tooling drift:

```text
FAILED (3 issue(s)):
  - 12 in-scope row(s) in newark/HS have no grade
  - 35 in-scope row(s) in newark/MS have no grade
  - 12 HS row(s) missing CreditsEarned
```

Those 47 ungraded rows are down from 108 on 2026-07-29. More usefully, the
whole-section-ungraded category is now empty — it held 41 rows before, and
those were the excluded sections. Everything left is per-student, so the fix is
posting individual grades rather than changing any section's setup.

The gate still has no bypass, and `build_submission.py` still refuses to export
and exits 1 while these 3 remain.

## AI Assistance

AI-assisted throughout, human-directed. The decision to drop Camden from scope
was the user's, based on knowledge this repo does not contain — that Camden's
submission had been certified. Claude located the four separate region
declarations, implemented the single source of truth, measured and re-pinned
the baselines, and verified the result. Claude also flagged the mixed-vintage
risk before the extract reload, which is what surfaced the scoping problem.

Verification run before opening: self-test passes, gate returns the 3 failures
above, `export_worklist.py` exports Newark only (47 rows, 1 region), and
`build_submission.py` refuses with exit code 1. Trunk clean on all five files.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

No Dagster, dbt, or schedule/sensor changes — those sections do not apply.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.
