### PR TITLE
feat(dbt): provision Google Workspace accounts for Miami students from Focus

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
+++ b/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
@@ -1,12 +1,21 @@
 models:
   - name: rpt_google_directory__users_import
+    description: >
+      Google Workspace student accounts to create or update, consumed by the
+      google_directory user_create and user_update assets. Rows are the union of
+      two enrollment sources — PowerSchool for the NJ regions, and Focus for
+      Miami, whose PowerSchool instance is a frozen archive. Paterson is
+      excluded. A row appears only when the account is missing (is_create) or
+      when its name, suspension state, or org unit has drifted from the source
+      of record (is_update).
     columns:
       - name: student_number
         data_type: int64
         description: >
-          PowerSchool student identifier. Populates externalIds[type='custom',
+          Student identifier populating externalIds[type='custom',
           customType='student_number'] on new Google Workspace student accounts
-          for cross-system identity lookup.
+          for cross-system identity lookup. Carries the PowerSchool student
+          number for NJ regions and the Focus-prefixed student id for Miami.
         data_tests:
           - not_null:
               config:

--- a/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
+++ b/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
@@ -8,6 +8,14 @@ models:
       excluded. A row appears only when the account is missing (is_create) or
       when its name, suspension state, or org unit has drifted from the source
       of record (is_update).
+    config:
+      meta:
+        contains_pii: true
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - primaryEmail
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
@@ -14,10 +14,57 @@ with
 
             if(enroll_status = 0, false, true) as suspended,
         from {{ ref("int_extracts__student_enrollments") }}
+        /* Paterson stays excluded: its student org units carry an empty
+        description, which is the column the org-unit join below matches on, so
+        including it would emit rows with a null orgUnitPath. Re-enable once Ops
+        populates those descriptions -- see #4513. */
         where
             rn_all = 1
             and student_email is not null
             and region not in ('Paterson', 'Miami')
+    ),
+
+    finalsite_enrolled as (
+        /* Finalsite is the admissions front door, so a newly enrolled student
+        appears here before they are imported into Focus. Sourcing them here too
+        means their account exists by the time that first import runs. */
+        select
+            l.finalsite_enrollment_id,
+            l.assigned_school,
+            l.is_transfer_out,
+
+            cast(ida.focus_student_id_prefixed as int64) as student_number,
+
+            regexp_extract(l.grade_canonical_name, r'\d+') as grade_digits,
+        from {{ ref("int_finalsite__enrollment_lifecycle") }} as l
+        inner join
+            {{ ref("int_finalsite__contact_id_attributes") }} as ida
+            on l.finalsite_enrollment_id = ida.finalsite_enrollment_id
+        where
+            l.school_year_start = {{ var("current_academic_year") }}
+            and l.assigned_school is not null
+            and l._dbt_source_project = 'kippmiami'
+    ),
+
+    focus_ranked as (
+        /* Rank every stint, not just the current year's. The PowerSchool branch
+        uses rn_all, so restricting Focus to the current academic year would hide
+        a student whose last stint predates it -- their account could never be
+        suspended. Ordering matches int_powerschool__student_enrollment_union. */
+        select
+            student_number,
+            student_first_name,
+            student_last_name,
+            school,
+            grade_level,
+            region,
+            enroll_status,
+            academic_year,
+
+            row_number() over (
+                partition by student_number order by academic_year desc, exitdate desc
+            ) as rn_all,
+        from {{ ref("int_focus__student_enrollments") }}
     ),
 
     focus_students as (
@@ -26,11 +73,11 @@ with
         Focus, so provisioning does not wait on the import-once DEMOGRAPHICS
         feed that still owes ~420 enrolled students an address (#4698). */
         select
-            e.student_number,
-            e.student_first_name as first_name,
-            e.student_last_name as last_name,
-            e.school as school_name,
-            e.grade_level,
+            r.student_number,
+            r.student_first_name as first_name,
+            r.student_last_name as last_name,
+            r.school as school_name,
+            r.grade_level,
 
             sl.google_email as student_email_google,
             sl.default_password as student_web_password,
@@ -41,14 +88,61 @@ with
             /Students/Disabled -- see the note on #4513. */
             false as is_out_of_district,
 
-            lower(e.region) as region,
+            lower(r.region) as region,
 
-            if(e.enroll_status = 0, false, true) as suspended,
-        from {{ ref("int_focus__student_enrollments") }} as e
+            if(r.enroll_status = 0, false, true) as suspended,
+        from focus_ranked as r
+        inner join
+            {{ ref("stg_people__student_logins") }} as sl
+            on r.student_number = sl.student_number
+        left join finalsite_enrolled as fe on r.student_number = fe.student_number
+        /* A stale Focus stint must not outrank a live Finalsite enrollment. A
+        returning student whose last Focus stint is a prior year, but who is
+        enrolled again for the current year, is dropped here and picked up by
+        finalsite_students as active -- otherwise the prior year's withdrawal
+        would suspend an account that should stay open. */
+        where
+            r.rn_all = 1
+            and (
+                r.academic_year = {{ var("current_academic_year") }}
+                or fe.student_number is null
+            )
+    ),
+
+    finalsite_students as (
+        select
+            e.student_number,
+            e.is_transfer_out as suspended,
+
+            c.first_name,
+            c.last_name,
+
+            /* assigned_school carries the Finalsite spelling, which does not
+            always match the Google org unit description (KIPP Miami Tech vs
+            KIPP Miami Technical High). The crosswalk normalizes it. */
+            x.location_clean_name as school_name,
+
+            sl.google_email as student_email_google,
+            sl.default_password as student_web_password,
+
+            false as is_out_of_district,
+
+            /* the lifecycle model is scoped to kippmiami above */
+            'miami' as region,
+
+            if(e.grade_digits is null, 0, cast(e.grade_digits as int64)) as grade_level,
+        from finalsite_enrolled as e
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as c
+            on e.finalsite_enrollment_id = c.finalsite_enrollment_id
+        inner join
+            {{ ref("int_people__location_crosswalk") }} as x
+            on e.assigned_school = x.location_name
         inner join
             {{ ref("stg_people__student_logins") }} as sl
             on e.student_number = sl.student_number
-        where e.academic_year = {{ var("current_academic_year") }} and e.rn_year = 1
+        left join focus_students as f on e.student_number = f.student_number
+        where f.student_number is null
     ),
 
     students as (
@@ -79,6 +173,21 @@ with
             region,
             suspended,
         from focus_students
+
+        union all
+
+        select
+            student_number,
+            first_name,
+            last_name,
+            school_name,
+            grade_level,
+            student_email_google,
+            student_web_password,
+            is_out_of_district,
+            region,
+            suspended,
+        from finalsite_students
     ),
 
     with_google as (

--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
@@ -14,14 +14,7 @@ with
 
             if(enroll_status = 0, false, true) as suspended,
         from {{ ref("int_extracts__student_enrollments") }}
-        /* Paterson stays excluded: its student org units carry an empty
-        description, which is the column the org-unit join below matches on, so
-        including it would emit rows with a null orgUnitPath. Re-enable once Ops
-        populates those descriptions -- see #4513. */
-        where
-            rn_all = 1
-            and student_email is not null
-            and region not in ('Paterson', 'Miami')
+        where rn_all = 1 and student_email is not null and region != 'Miami'
     ),
 
     finalsite_enrolled as (
@@ -191,6 +184,16 @@ with
     ),
 
     with_google as (
+        /* The org unit is named explicitly in the people__locations sheet rather
+        than matched against the org unit's free-text description. The three
+        branches above carry three different school-name vocabularies -- Focus
+        and Finalsite resolve to the sheet's name, PowerSchool keeps its own
+        (KIPP Hatch Academy vs the sheet's KIPP Hatch Middle) -- and the
+        crosswalk maps every one of them to the same row, since each row there
+        is one alias. Joining stg_google_directory__orgunits on the sheet's path
+        keeps it honest: a path that does not exist in Google resolves to null
+        and the student drops out below rather than being sent with a bad
+        orgUnitPath. */
         select
             s.*,
 
@@ -208,9 +211,11 @@ with
             {{ ref("stg_google_directory__users") }} as u
             on s.student_email_google = u.primary_email
         left join
+            {{ ref("int_people__location_crosswalk") }} as x
+            on s.school_name = x.location_name
+        left join
             {{ ref("stg_google_directory__orgunits") }} as o
-            on s.school_name = o.description
-            and o.org_unit_path like '/Students/%'
+            on x.location_google_student_org_unit_path = o.org_unit_path
     ),
 
     final as (
@@ -249,4 +254,7 @@ select
 
     if(grade_level >= 3, true, false) as `changePasswordAtNextLogin`,
 from final
-where is_create or is_update
+/* A null org unit means the school has no student org unit named in the
+locations sheet. Dropping those students is deliberate -- provisioning an
+account with no orgUnitPath would file it at the domain root. */
+where (is_create or is_update) and org_unit_path is not null

--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
@@ -1,5 +1,5 @@
 with
-    students as (
+    powerschool_students as (
         select
             student_number,
             student_first_name as first_name,
@@ -14,7 +14,71 @@ with
 
             if(enroll_status = 0, false, true) as suspended,
         from {{ ref("int_extracts__student_enrollments") }}
-        where rn_all = 1 and student_email is not null and region != 'Paterson'
+        where
+            rn_all = 1
+            and student_email is not null
+            and region not in ('Paterson', 'Miami')
+    ),
+
+    focus_students as (
+        /* Miami's PowerSchool is a frozen archive, so Focus is the enrollment
+        source. The address comes from the login generator rather than from
+        Focus, so provisioning does not wait on the import-once DEMOGRAPHICS
+        feed that still owes ~420 enrolled students an address (#4698). */
+        select
+            e.student_number,
+            e.student_first_name as first_name,
+            e.student_last_name as last_name,
+            e.school as school_name,
+            e.grade_level,
+
+            sl.google_email as student_email_google,
+            sl.default_password as student_web_password,
+
+            /* Focus surfaces no out-of-district placement field; routing is on
+            suspension alone. If a Miami student is ever placed out of district
+            they will keep an active account instead of moving to
+            /Students/Disabled -- see the note on #4513. */
+            false as is_out_of_district,
+
+            lower(e.region) as region,
+
+            if(e.enroll_status = 0, false, true) as suspended,
+        from {{ ref("int_focus__student_enrollments") }} as e
+        inner join
+            {{ ref("stg_people__student_logins") }} as sl
+            on e.student_number = sl.student_number
+        where e.academic_year = {{ var("current_academic_year") }} and e.rn_year = 1
+    ),
+
+    students as (
+        select
+            student_number,
+            first_name,
+            last_name,
+            school_name,
+            grade_level,
+            student_email_google,
+            student_web_password,
+            is_out_of_district,
+            region,
+            suspended,
+        from powerschool_students
+
+        union all
+
+        select
+            student_number,
+            first_name,
+            last_name,
+            school_name,
+            grade_level,
+            student_email_google,
+            student_web_password,
+            is_out_of_district,
+            region,
+            suspended,
+        from focus_students
     ),
 
     with_google as (

--- a/src/dbt/kipptaf/models/google/sheets/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources-external.yml
@@ -1210,7 +1210,7 @@ sources:
             format: GOOGLE_SHEETS
             uris:
               - https://docs.google.com/spreadsheets/d/1FCc28XWxFj3gSfItGGJ2tVU0C1fYD1JxKRxuSFqisMo
-            sheet_range: src_google_sheets__people__locations_v2
+            sheet_range: src_google_sheets__people__locations_v3
             skip_leading_rows: 1
         config:
           meta:
@@ -1257,6 +1257,8 @@ sources:
           - name: Postal_Code
             data_type: STRING
           - name: Focus_School_ID
+            data_type: STRING
+          - name: Google_Student_orgUnitPath
             data_type: STRING
       - name: src_google_sheets__people__campus_crosswalk
         external:

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
@@ -124,3 +124,15 @@ models:
         description: |
           Focus SIS school-number code (alphanumeric, e.g. 2332A, 1000B). The
           `SCH_ID` value for Focus SFTP enrollment imports.
+      - name: google_student_org_unit_path
+        data_type: string
+        description: |
+          Full Google Workspace org unit path for this school's student
+          accounts, e.g. `/Students/TEAM/Rise`. Ops-maintained, and the value
+          `rpt_google_directory__users_import` assigns as `orgUnitPath` when
+          provisioning. Naming the path explicitly replaces matching a school
+          name against the org unit's free-text description, which required
+          three different name vocabularies to agree with one field nobody
+          owned. Null for campuses, non-school locations, and any school with
+          no student org unit yet — a null drops that school's students from
+          provisioning rather than misfiling them.

--- a/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__people__locations.sql
+++ b/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__people__locations.sql
@@ -19,6 +19,7 @@ select
     `City` as city,
     `Postal_Code` as postal_code,
     `Focus_School_ID` as focus_school_id,
+    `Google_Student_orgUnitPath` as google_student_org_unit_path,
 
     case
         `Dagster_Code_Location`

--- a/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
+++ b/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
@@ -10,6 +10,7 @@ select
     pl.deanslist_school_id as location_deanslist_school_id,
     pl.reporting_school_id as location_reporting_school_id,
     pl.focus_school_id as location_focus_school_id,
+    pl.google_student_org_unit_path as location_google_student_org_unit_path,
     pl.is_campus as location_is_campus,
     pl.is_pathways as location_is_pathways,
     pl.dagster_code_location as location_dagster_code_location,

--- a/src/dbt/kipptaf/models/people/intermediate/properties/int_people__location_crosswalk.yml
+++ b/src/dbt/kipptaf/models/people/intermediate/properties/int_people__location_crosswalk.yml
@@ -42,6 +42,15 @@ models:
           Focus SIS school-number code (alphanumeric SCH_ID) passed through from
           stg_google_sheets__people__locations; NULL for locations not yet
           mapped to Focus.
+      - name: location_google_student_org_unit_path
+        data_type: string
+        description: |
+          Full Google Workspace org unit path for this school's student
+          accounts, passed through from stg_google_sheets__people__locations.
+          Resolving it through this model means every consumer reaches the same
+          path from whichever school-name spelling its source uses, since each
+          row here is one alias. NULL for campuses and any school with no
+          student org unit yet.
       - name: location_is_campus
         data_type: boolean
       - name: location_is_pathways

--- a/src/dbt/kipptaf/models/people/staging/properties/stg_people__student_logins.yml
+++ b/src/dbt/kipptaf/models/people/staging/properties/stg_people__student_logins.yml
@@ -11,6 +11,18 @@ models:
     columns:
       - name: student_number
         data_type: int64
+        description: >
+          Student identifier this login belongs to. The PowerSchool student
+          number for NJ regions and the Focus-prefixed student id for Miami.
+          Serves as the incremental merge key, so a duplicate here would fan out
+          every consumer that joins on it.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
       - name: username
         data_type: string
       - name: default_password


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restore Google Workspace account provisioning for KIPP Miami students, extend it to Paterson, and replace the fragile org-unit name matching that blocked Paterson in the first place.

Miami provisioning went dark when its PowerSchool became a frozen archive. `rpt_google_directory__users_import` reads `int_extracts__student_enrollments`, which is PowerSchool-backed, and every Miami row there has a null `student_email` — the login generator keys Miami on the Focus-prefixed student id while the PowerSchool hub carries bare numbers, so nothing joins and the `student_email is not null` filter silently drops all of Miami. The model never excluded Miami; the join key diverged.

This is not new provisioning. The same model and the `google_directory` assets already created 3,442 Miami accounts during the PowerSchool era — each carries an `externalIds` entry written by `user_create`.

## What changed

### Three enrollment sources instead of one

- `powerschool_students` — the NJ regions.
- `focus_students` — Miami. Ranks every stint rather than the current year only; the PowerSchool branch already uses `rn_all`, so a current-year filter would hide a student whose last stint predates it and their account could never be suspended.
- `finalsite_students` — Miami students not yet imported into Focus. Finalsite is the admissions front door, so a new enrollee appears there first; sourcing only from Focus meant no account existed at their first import.

Precedence matters between the last two. A returning student whose last Focus stint is a prior year, but who is enrolled again in Finalsite for the current year, would otherwise be suspended by the stale Focus row. `focus_students` drops those rows so `finalsite_students` claims them as active — **147 students** who would have had working accounts disabled.

Addresses and default passwords come from `stg_people__student_logins` directly rather than through the Focus DEMOGRAPHICS feed, so provisioning does not wait on the delivery gap in #4698.

Suspension needed no new derivation: `int_focus__student_enrollment` already derives `enroll_status` on the PowerSchool numeric domain from the Florida state withdrawal codes.

### Org units are named, not matched

The org-unit join matched a student's school name against the Google org unit's free-text `description`. That required three school-name vocabularies to agree with one field nobody owned — Focus and Finalsite resolve to the locations sheet's name, PowerSchool keeps its own (`KIPP Hatch Academy` vs the sheet's `KIPP Hatch Middle`). It worked only because the descriptions happened to carry PowerSchool's names for NJ and the sheet's for Miami.

Paterson was the case where nobody filled it in: all three of its student org units have an empty description, so joining on it emitted 840 rows with a null `orgUnitPath`. That — not the email gap, which was already fixed — is why Paterson was excluded.

Ops now names the path directly in the `people__locations` sheet (`Google Student orgUnitPath`, named range v3, 28 of 42 rows populated). The extract resolves it through `int_people__location_crosswalk`, so every branch reaches the same row from whichever spelling its source uses — each row there is one alias. `stg_google_directory__orgunits` is still joined, now on the path itself, so a path that does not exist in Google resolves to null rather than being sent as a bad `orgUnitPath`. Rows with a null org unit are dropped explicitly instead of being provisioned at the domain root.

**Paterson is no longer excluded.**

## Validation

Ran the compiled logic against prod with the sheet staged to a dev copy. Aggregates only, no student rows.

| Branch | Region | Creates | Updates | Dropped for null org unit |
| --- | --- | --- | --- | --- |
| focus | miami | 445 | 386 | 0 |
| finalsite | miami | 0 | 14 | 0 |
| powerschool | paterson | 389 | 454 | 0 |
| powerschool | newark | 10 | 10 | 0 |
| powerschool | camden | 6 | 5 | 0 |

Every region resolves an org unit. The v3 named range is column-only — 42 rows before and after, verified against prod.

Newark and Camden creates are warehouse drift since an earlier run in the same session (the directory pull refreshed); confirmed independently against `stg_google_directory__users`, not an effect of this change.

**The first prod run is large: roughly 1,700 API operations**, and the create path also fires a group-membership insert per new account. Notable inside the Miami updates: **68 withdrawn students whose Google accounts are still active** get suspended, and 15 suspended accounts belonging to currently-enrolled students get reactivated. The remainder are org-unit corrections and a one-time name-case normalization that settles after the first run.

## AI Assistance

Claude Code authored the model changes, the properties documentation, and the prod validation queries. Design decisions were human-directed — provisioning mechanism, `externalIds` key form, address source, password policy, the Finalsite-extends-Focus choice, and naming org units explicitly were all decided by the reviewer.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties updated for every touched model, including the new column on `stg_google_sheets__people__locations` and `int_people__location_crosswalk`.
- [x] Added `config.meta.contains_pii` and a `primaryEmail` uniqueness test to the extract, plus `unique` and `not_null` on `stg_people__student_logins.student_number` — the merge key two branches now join on, previously untested. Both pass against prod.
- [x] No exposure change — the consumer is the `google_directory` Dagster assets.
- [x] Not a breaking change: the extract's output column set is unchanged.
- [ ] **External source modified.** `sheet_range` moves to `src_google_sheets__people__locations_v3` and declares one new column. It has been staged to a dev copy for validation, but **`stage_external_sources --target staging` still needs to run** before dbt Cloud CI can see the column.

## CI checks

- [x] **Trunk** — `trunk check --force` clean on all six changed files.
- [ ] **dbt Cloud** — will fail until the external is staged to `--target staging` (see above).
- [ ] **Dagster Cloud** — not triggered; no Dagster paths changed.

Refs #4513
