### PR TITLE
docs: fold st-cyr-bradley session findings into assessment direction files

### DIFF
--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -16,7 +16,9 @@ because a request looks urgent or simple. When a question turns on a data-usage
 convention (a field meaning, a Cube quirk, a settled default), route to the
 matching section of `assessment-cube-reference.md`. When it turns on a
 convention that has not been ratified by instructional leadership, do not decide
-it yourself — flag it per Flag, don't invent, and keep going.
+it yourself — flag it per Flag, don't invent, and keep going. When a request
+goes past retrieval into modeling, projection, or a document that will leave the
+chat, also apply Modeling, projections, and deliverables below.
 
 ## The standing protocol
 
@@ -105,11 +107,53 @@ leadership:
   alone, or weighted by how many students are non-proficient and by
   prerequisite/transfer value. A session applied its own framework twice; it
   reads as authoritative and is not.
+- how "predict" or "expected proficiency" should be operationalized for a
+  cross-instrument question — a correlation, a fitted regression, something else
+  — and which benchmark round is the network's leading indicator ahead of spring
+  state testing
+- whether NJSLA results either side of the spring 2026 computer-adaptive
+  transition may be compared at all (see `assessment-cube-reference.md`, NJ
+  state) — a scale change would make the comparison invalid regardless of method
+- what "growth" means for a vendor diagnostic: movement between placement bands
+  or a scale-score delta. The two give different answers and neither is ratified
+- which sitting is authoritative when a student tests more than once inside a
+  single benchmark window (common — about 15% in one measured window).
+  Most-recent-by-date is the working convention, not policy
 
 Some individual fields also carry their own narrower open question (for example,
 which count measure is the default for a count/share question) — those are
 called out inline in `assessment-cube-reference.md`; flag them the same way when
 you hit one.
+
+## Modeling, projections, and deliverables
+
+Sessions now go beyond retrieval — fitting models, projecting unreleased
+results, and producing documents that leave the chat. The rules below apply
+whenever you compute something the cube does not measure, and whenever output
+becomes a file.
+
+- **Name your own methodology as your own.** A correlation, a regression, a
+  weighting scheme, a bias correction, a band-ordinal scale — if you chose it,
+  say so in the answer, state that the network has not ratified it, and
+  recommend a statistical review before it informs planning or is held against a
+  school. Sound arithmetic on a self-selected method still produces an
+  unratified number.
+- **Distinguish an unreleased result from a future one.** Estimating a state
+  score that has been administered but not yet published is filling a reporting
+  gap, not forecasting. Say which you are doing; the caveats differ, and calling
+  a release lag a "forecast" overstates the uncertainty in one direction and
+  understates it in the other.
+- **Caveats travel onto the deliverable.** Every confidence rating, flagged
+  cell, unratified method, and comparability warning that applies to a figure
+  must appear on the document containing it — not only in the chat that produced
+  it. Documents outlive conversations and get forwarded without them. Mark any
+  document built on unratified methodology as internal to the working group.
+- **Flag cells the model cannot support.** Small denominators, values outside
+  the range the model was fit on, and cases where two methods disagree sharply
+  get marked on the artifact itself, not just mentioned once.
+- **Fonts.** KTAF's Whitney / Calibri / Verdana are unavailable in this
+  environment. Substitute a clean sans-serif and tell the participant you did,
+  so they know to restyle before the document goes anywhere formal.
 
 ## Routing
 
@@ -186,9 +230,19 @@ log — write the final log to the shared Drive folder (`parentId`
 `disableConversionToGoogleType: true`, so it stays a real `.md` file instead of
 being converted to a Google Doc.
 
-Search that folder for the filename FIRST. If it already exists, this is a
-re-file: create it as `..._rev2.md` (then `_rev3`) and say which one is
-authoritative. Never create a second file under the identical name.
+Search that folder for the filename FIRST. If it already exists, read it and
+compare before writing anything:
+
+- **Unchanged content — do not write.** Tell the participant it is already filed
+  and give them the existing link. A re-file that adds nothing is permanent
+  clutter nobody can remove, and it leaves two files that a later reader has to
+  diff to tell apart. This has already happened once.
+- **Changed content — file as `..._rev2.md`** (then `_rev3`), and put the
+  supersession note **in the file's own header**, not only in the filename:
+  which revision this is, that it supersedes the earlier filing of the same
+  session, and that this one is authoritative. A reader who lands on either copy
+  must be able to tell from the file alone. Never create a second file under the
+  identical name.
 
 Write once per session, at the end — not per query. The connector can only
 create, never update or delete, so every extra write is permanent clutter that

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -36,6 +36,15 @@ Apply to every assessment source unless a source section overrides them.
   scope-bound — meaningful only within one source/subject/grade; pooling them
   across sources returns a valid-looking but meaningless number. Use
   `pct_proficient` / `is_mastery` for any cross-source comparison.
+- **A cross-instrument gap is a calibration artifact until proven otherwise.**
+  Two instruments measuring the same students in the same year routinely
+  disagree by double digits, because each carries its own proficiency definition
+  and cut-score. This holds for every pairing — internal-vs-state,
+  internal-vs-vendor, and vendor-vs-state alike. Report the two rates side by
+  side, label the difference as a gap between instruments rather than a gap in
+  achievement, and flag it for team review instead of presenting it as a
+  finding. (A logged session had to extend this reasoning by analogy because it
+  was documented for internal-vs-state only; it applies generally.)
 - **Grain.** `count_scores` is additive and resilient (scored-response count) —
   it succeeded across every logged session. `count_students` is a distinct
   student count and is heavier and historically fragile at fine (standard) grain
@@ -109,6 +118,13 @@ Apply to every assessment source unless a source section overrides them.
   `Outside Round` sittings lose roughly a third. So a Cube count will not
   reconcile to a vendor or state report, and the gap is expected, not a bug. Say
   which one you are quoting.
+- **Region coverage is uneven, and Paterson is the outlier.** Paterson carries
+  Illuminate and DIBELS for 2025-26 only, plus NJSLA and NJSLA-Science for
+  2022-23 and 2023-24 — and no i-Ready, STAR, or NJGPA at all. Its state history
+  therefore reaches back further than its internal history, the reverse of every
+  other region (Newark and Camden run Illuminate from 2014-15). A narrow
+  Paterson result is expected coverage, not a load failure; say which regions a
+  "network-wide" answer actually covers.
 - **Open decisions — flag, never assume a value** (per the orchestrator):
   minimum-sample suppression threshold; intervention tier cut-scores;
   pool-vs-per-instrument for multi-module "overall mastery"; which subjects
@@ -125,6 +141,13 @@ Apply to every assessment source unless a source section overrides them.
 - **Module types:** `module_type` / `module_code` cover QA (Quick Assessments),
   MQQ (Multiple-Choice Quick Questions), and CRQ (Constructed Response
   Questions); `module_code` looks like `QA1`, `QA3`.
+- **`module_code` is not a subject filter — always pair it with
+  `academic_subject`.** One module code spans every subject assessed in that
+  round. `QA3` in 2025-26 covers 21 distinct `academic_subject` values across
+  25,842 `overall` scores, of which `Mathematics` is 7,854 — under a third.
+  Filtering `module_code = 'QA3'` alone and calling the result "QA3 math" mixes
+  Text Study, Science, Social Studies, the `English 100`–`400` and AP courses,
+  and the HS math courses into one number.
 - **Measures:** `pct_proficient_formative` pools all three formative module
   types (QA + MQQ + CRQ); `pct_proficient_crq` isolates CRQ. (Whether to pool
   across module types or report per-instrument is an open decision — flag it.)
@@ -171,6 +194,13 @@ Apply to every assessment source unless a source section overrides them.
   above grade level", and it is roughly half of all proficient scores. If a
   participant means the stricter definition, filter `proficiency_level` directly
   instead of using `pct_proficient`.
+- **EOY is administered _after_ NJSLA, so it cannot be a leading indicator for
+  the same year's state test.** Median math test dates in 2024-25: BOY
+  2024-09-04, MOY 2025-01-15, **NJSLA Math 2025-05-14**, EOY 2025-06-04. MOY is
+  the last named round that precedes the state test. Any "does i-Ready predict
+  NJSLA" framing must therefore use MOY (or a prior-year EOY); an EOY-vs-NJSLA
+  comparison within one year is concurrent-or-trailing, not predictive. Say
+  which it is — the direction of the claim depends on it.
 - **Region coverage: Newark, Camden, and Miami only — there is no i-Ready data
   for Paterson.** A "compare i-Ready across all regions" question therefore
   returns three of the four regions; say so rather than implying network-wide
@@ -187,7 +217,13 @@ Apply to every assessment source unless a source section overrides them.
 - **`is_replacement` is Illuminate-only by design** — null for i-Ready (and all
   vendor/state sources), not a gap. Genuine multiple sittings occur even within
   a single benchmark window, so dedup to the most recent `date_taken` per
-  student per window before computing anything student-level.
+  student per window before computing anything student-level. This is common,
+  not exceptional: in one measured window (Camden grade 6 ELA, MOY 2025-26) 30
+  of 195 students — 15.4% — had more than one sitting. It is genuine repeat
+  testing, not a section-join fan-out. Skipping the dedup inflates any
+  student-level count or growth figure. (Which sitting is _authoritative_ for
+  reporting is an open decision; most-recent-by-date is the working convention,
+  not ratified policy.)
 - **Query this view, not the upstream i-Ready model.** i-Ready arrives with
   fiscal-year re-pull duplicates — the same physical test landing under two
   partitions. The mart collapses them, so counts here are right; a query
@@ -246,6 +282,30 @@ Apply to every assessment source unless a source section overrides them.
 - **Time:** `academic_year` / `academic_year_label` now resolve for state
   (derived from the test date) — filter the school year with them.
   `administration_period` is the testing season (Fall / Winter / Spring).
+- **Spring 2026 onward, NJSLA and NJGPA are computer-adaptive — and this view
+  cannot tell you which form a score came from.** NJDOE, with Cambium, launched
+  NJSLA-Adaptive (ELA/Math) and NJGPA-Adaptive; announced August 2025, first
+  operational windows spring 2026 (NJGPA-A March 16-20 2026; NJSLA-A April 27 to
+  May 22 2026). NJSLA-Science is not part of the transition. `assessment_type`
+  carries one value per state test and each resolves to a single `title`, so
+  **no field distinguishes adaptive from fixed-form**. Any NJSLA or NJGPA
+  comparison that crosses the spring 2026 boundary may therefore be comparing
+  two different scales. Flag that every time, and never present a cross-year NJ
+  state trend spanning the boundary as settled. Whether NJDOE reset
+  achievement-level cut-scores for the adaptive forms is an open question for
+  instructional leadership — it is not answerable from this view.
+- **A Fall NJGPA slice is the routine retake window, not adaptive field-test
+  data.** Small Fall administrations appear every year alongside the main Spring
+  one (193 scores in October 2024; 137 in October 2025). The prior-year
+  precedent settles it — do not read a Fall slice as an anomaly, and do not
+  attribute it to the adaptive rollout.
+- **A missing current-year NJSLA is a release lag, not a defect.** State results
+  land well after the testing window closes; as of this writing 2025-26 NJSLA
+  and NJSLA-Science carried no rows in any NJ region while 2025-26 NJGPA did.
+  Absence here means "not yet released," so do not log it as a data-quality
+  defect or build a workaround around it — and do not describe estimating those
+  values as forecasting a future event, because the test itself has already been
+  given.
 - **Student identifier:** for NJ, `lea_student_identifier` (KIPP's SIS number)
   is the canonical student number; `district_student_identifier` is null for NJ
   (host-district IDs are Miami-only). `state_student_identifier` is the


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...fold the findings from the sixth logged pilot session into the two assessment
direction files, and add two filing-hygiene rules learned from the shared log
folder itself.

This is the third update-loop pass. The source is
`WG_LOG_2026-07-27_2024_st-cyr-bradley_rev2.md` — a 16-query session that went
from coverage discovery through cross-instrument comparison to a fitted
regression and two stakeholder one-pagers. It exercised territory no prior
session touched, so most of the additions here are new rather than refinements.

### `assessment-cube-reference.md`

- **NJ state — the computer-adaptive transition.** NJSLA and NJGPA moved to
  computer-adaptive forms (NJSLA-A, NJGPA-A) for spring 2026, and **no field on
  this view distinguishes adaptive from fixed-form**: one `assessment_type` value
  per test, one `title` each. Any NJ state comparison crossing that boundary may
  be comparing two scales. Documented with the operational windows, plus the open
  question of whether NJDOE reset achievement-level cut-scores.
- **NJ state — a Fall NJGPA slice is the routine retake window.** The source log
  flagged a small Fall 2025-26 NJGPA slice as possibly adaptive field-test data
  it could not disambiguate. Prior-year precedent settles it (193 scores in
  October 2024; 137 in October 2025). Documented so the false lead does not
  spread.
- **NJ state — a missing current-year NJSLA is a release lag, not a defect.**
  Three separate logs filed this as a data-quality item, one at High priority.
- **i-Ready — EOY is administered after NJSLA.** Median 2024-25 math dates: BOY
  2024-09-04, MOY 2025-01-15, NJSLA Math 2025-05-14, EOY 2025-06-04. MOY is the
  last named round preceding the state test, so an EOY-vs-NJSLA comparison within
  one year is concurrent-or-trailing, not predictive.
- **i-Ready — multiple sittings inside one window are common, not exceptional.**
  Measured at 15.4% in one window (Camden grade 6 ELA, MOY 2025-26); genuine
  repeat testing, not a section-join fan-out.
- **Illuminate — `module_code` is not a subject filter.** `QA3` in 2025-26 spans
  21 `academic_subject` values across 25,842 overall scores; `Mathematics` is
  7,854 of them, under a third.
- **Shared — a cross-instrument gap is a calibration artifact until proven
  otherwise.** Previously documented for internal-vs-state only, which forced a
  session to extend it by analogy. Now stated generally.
- **Shared — region coverage, with Paterson corrected.** Paterson carries
  Illuminate and DIBELS for 2025-26 only, plus NJSLA and NJSLA-Science for
  2022-23 and 2023-24, and no i-Ready, STAR, or NJGPA. Its state history reaches
  back further than its internal history, the reverse of every other region.

### `assessment-cube-orchestrator.md`

- **New section: Modeling, projections, and deliverables.** The session fitted a
  regression, computed correlations, applied an enrollment weighting and a
  bias correction, and put the results into two PDFs. It labeled its own methods
  as unreviewed and marked the documents internal-only on its own initiative —
  this codifies that rather than leaving it to chance. Covers naming
  self-selected methodology, distinguishing an unreleased result from a future
  one, carrying caveats onto the document itself, marking cells the model cannot
  support, and disclosing the font substitution.
- **Four new open decisions**: how to operationalize predict / expected
  proficiency and which round is the leading indicator; whether NJSLA may be
  compared across the adaptive boundary at all; what growth means for a vendor
  diagnostic; and which sitting is authoritative when a student tests twice in
  one window.
- **Drive re-filing hygiene.** Two rules, both from the log folder's own state:
  do not re-file unchanged content (the connector cannot delete, so a no-op
  re-file is permanent clutter — this has already happened once), and put the
  supersession note in the file header rather than only in the filename.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude-authored, human-directed. Every figure above was verified against the
warehouse rather than transcribed from the log — which is how the two
corrections surfaced. The NJ adaptive rollout was confirmed against NJDOE
sources, since the log sourced it from a web search. The three claims flagged for
verification before landing (multiple-sitting rate, Paterson coverage, the grade
6 to 7 proficiency drop) were all checked: two confirmed exactly, Paterson
corrected.

The grade 6 to 7 Newark i-Ready math drop reproduces exactly as logged (grade 6
41.5%, grade 7 26.1%, grade 8 25.8%, weighted) and holds at all five Newark
schools individually. It is an instructional finding for the working group, not a
data defect, so it is not documented here.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
      — n/a, no Asana task
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)
      — `claude-code-review` excludes markdown, so it will not fire on this PR

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

Skipped — no dbt changes. Documentation only; no models, columns, or contracts
touched.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — `trunk check --force` clean on both files
- [x] **dbt Cloud** — n/a, no dbt changes
- [x] **Dagster Cloud** — n/a, no Dagster paths changed

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
