### PR TITLE
fix(cube): review follow-ups on #4614 - close a paste fall-through and resolve the dependency conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,12 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   merge-after-parent — but base ≠ main skips `claude-review` (dbt Cloud CI still
   runs; it is not base-gated — see `.github/CLAUDE.md`).
 
+- **A stacked `git worktree add -b <new> <abs-path> <parent-branch>` sets the
+  new branch's upstream to the PARENT** — a bare `git push` then pushes your
+  commits onto that branch, which is usually someone else's. Run
+  `git -C <worktree> branch --unset-upstream` immediately after creating it,
+  then `git -C <worktree> push -u origin <new-branch>`.
+
 - **Linking an existing remote branch to an issue**:
   `mcp__github__create_branch` and GraphQL `createLinkedBranch` both no-op when
   the branch already exists. Delete the remote branch, then
@@ -145,6 +151,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   partway through. Scope dispatches to one file / one commit; inspect the file
   diff and `git log` before marking complete — don't trust the self-report.
 
+- **A subagent's "pre-existing failure" baseline is the working tree AS
+  DISPATCHED**, including your own uncommitted edits. "Already failing before I
+  touched anything" can mean "failing because of the coordinator's change."
+  Check whether your own work caused it before accepting that framing.
+
 - **Subagent worktree dispatches must spell out the absolute worktree path**: a
   subagent starts in the MAIN checkout, so the dispatch prompt must give the
   worktree path and mandate `git -C <worktree>` + `uv run` from it (bare edits
@@ -170,6 +181,16 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   process/worktree level. Concurrency cap = `min(16, cpu_cores-2)` (4-core
   Codespace → 2; raising it needs a larger machine, whose restart kills
   in-flight runs).
+
+- **`git merge-tree` reads the committed tip, not the index** — a staged-but-
+  uncommitted conflict resolution still reports CONFLICT. Commit first, then
+  verify with `git merge-tree --write-tree --name-only origin/main <branch>`.
+
+- **A version-only dependency conflict resolves by taking main's blobs whole**:
+  `git checkout origin/main -- <manifest> <lockfile>`, then run the installer
+  and confirm it leaves the lockfile unchanged (proof main's pair is coherent).
+  Both files end byte-identical to main, so the conflict cannot recur. Do NOT
+  hand-merge a lockfile.
 
 - **Git resuming**: Before resuming work on an existing branch, merge `main`:
   `git fetch origin main && git merge origin/main`.
@@ -339,6 +360,23 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   `git diff --name-only origin/main...HEAD` hard-errors with
   `'<path>' does not exist` when the PR deletes files — filter to existing paths
   first.
+
+- **`.trunk/tools/` is gitignored and lazily populated** — the `trunk` symlink
+  there does not exist until trunk has run once, so on a cold Codespace the
+  documented path above fails with "No such file or directory". Fall back to
+  `~/.cache/trunk/launcher/trunk`, which is always present; the first run
+  creates the `.trunk/tools/trunk` symlink.
+
+- **A `--force` check over ~10 files takes >2 minutes — background it.** Its
+  progress spinner emits no result lines, so grepping interim output returns
+  nothing and reads as a false "clean". Only interpret the output after the run
+  exits.
+
+- **Two concurrent trunk runs produce spurious `✖ N failures`.** A `FAILURES`
+  block names a TOOL plus a `.trunk/out/*.yaml` and no rule — that is the linter
+  crashing (e.g. `grype`), not a finding. Distinct from `✖ N unformatted files`
+  (the pre-commit `fmt` hook fixes those) and from real lint issues, which name
+  `file:line` + rule. Re-run single-instance before chasing one.
 
 - **Linter**: Suppress with `trunk-ignore(linter/rule): reason` (e.g.
   `# trunk-ignore(bandit/B603): static argv, no shell`) on the line immediately
@@ -634,6 +672,8 @@ the allowlist.
 - GitHub Search API caps at 5 OR/AND/NOT operators per query (422 otherwise).
   Loop per-term via `gh api -X GET search/issues -f q='...'` for larger searches
   — without `-X GET`, `-f` turns the request into a POST and 404s.
+  `search/issues` also requires `is:issue` or `is:pull-request` in `q` — 422
+  "Query must include..." otherwise.
 - `mcp__github__search_issues` returns full issue **bodies** — a broad query
   (bare model/column name) overflows the context budget and dumps to a file.
   Narrow with `in:title`, a label, or `state:open`.

--- a/docs/guides/cube.md
+++ b/docs/guides/cube.md
@@ -288,16 +288,24 @@ put the viewer's email in `user`, and switch viewers by opening a new connection
 rather than restarting. `MEASURE()` wraps measures:
 
 ```bash
-uv run --with psycopg2-binary python - <<'PY'
-import psycopg2
+uv run --with 'psycopg[binary]>=3.3' python - <<'PY'
+import psycopg
 
-# identity = the `user` you connect as; swap it to test a different viewer
-conn = psycopg2.connect(host="127.0.0.1", port=15432,
-                        user="you@apps.teamschools.org",
-                        password="local-dev-sql", dbname="cube")
-cur = conn.cursor()
-cur.execute("SELECT MEASURE(count_employees) FROM staff_directory")
-print(cur.fetchall())
+# identity = the `user` you connect as; swap it to test a different viewer.
+# prepare_threshold=None disables psycopg's automatic statement preparation —
+# Cube's SQL API is a partial Postgres implementation, and there is no reason
+# to prepare a statement that runs once per connection (see
+# scripts/cube_rls_matrix.py, which follows the same pattern).
+with psycopg.connect(
+    host="127.0.0.1",
+    port=15432,
+    user="you@apps.teamschools.org",
+    password="local-dev-sql",
+    dbname="cube",
+    prepare_threshold=None,
+) as conn, conn.cursor() as cur:
+    cur.execute("SELECT MEASURE(count_employees) FROM staff_directory")
+    print(cur.fetchall())
 PY
 ```
 
@@ -373,8 +381,15 @@ Emulation works on two surfaces, with the same gate on each:
 
 | Surface                           | Pass the target as                                     | Caller identity                                      |
 | --------------------------------- | ------------------------------------------------------ | ---------------------------------------------------- |
-| REST / MCP                        | an `act_as` claim in the signed token                  | the signed `email` claim                             |
+| REST (hand-minted token)          | an `act_as` claim in the signed token                  | the signed `email` claim                             |
 | Cube Cloud Playground and Explore | `{"email": "<viewer>"}` in the Security Context editor | `cubeCloud.username`, as authenticated by Cube Cloud |
+
+**The shipped `cube` MCP server cannot emulate.** `_mint_token(email)` in
+`src/cube/mcp/server.py` takes a single argument and hardcodes its JWT claims to
+`{"email", "iat", "exp"}` — there is no code path that sets `act_as`. To
+emulate, hand-mint the JWT yourself and call the REST API directly (see the
+"Alternative: REST `/load` with your own JWT" example below), not through the
+`cube` MCP tools.
 
 The SQL API needs neither: identity is the connecting user, so switch viewers by
 reconnecting (that is what the matrix tool does).
@@ -527,15 +542,19 @@ zero rows on `staff_pii`, not an error and not every row. Over the SQL API
 (viewer identity = the connecting `user`):
 
 ```bash
-uv run --with psycopg2-binary python - <<'PY'
-import psycopg2
+uv run --with 'psycopg[binary]>=3.3' python - <<'PY'
+import psycopg
 
-conn = psycopg2.connect(host="127.0.0.1", port=15432,
-                        user="a-department-scope-none-viewer@apps.teamschools.org",
-                        password="local-dev-sql", dbname="cube")
-cur = conn.cursor()
-cur.execute("SELECT MEASURE(count_employees) FROM staff_pii")
-print(cur.fetchall())  # expect zero rows / zero count, not an error
+with psycopg.connect(
+    host="127.0.0.1",
+    port=15432,
+    user="a-department-scope-none-viewer@apps.teamschools.org",
+    password="local-dev-sql",
+    dbname="cube",
+    prepare_threshold=None,
+) as conn, conn.cursor() as cur:
+    cur.execute("SELECT MEASURE(count_employees) FROM staff_pii")
+    print(cur.fetchall())  # expect zero rows / zero count, not an error
 PY
 ```
 

--- a/scripts/cube_rls_matrix.py
+++ b/scripts/cube_rls_matrix.py
@@ -199,12 +199,26 @@ def main() -> int:
 
     print(f"\n{len(viewers)} viewer(s) checked, {failures} failed, {empty} at 0 rows.")
     all_zero = empty == len(viewers)
-    if all_zero:
+    # A SINGLE viewer at 0 rows is a documented, legitimate PASS: validating
+    # default-deny for a `none`-scope viewer is exactly this scenario (see the
+    # docstring's usage example and docs/guides/cube.md), and the cross-viewer
+    # comparison this gate exists for needs at least two viewers to mean
+    # anything. Only 2+ viewers all landing at 0 rows is never legitimate.
+    multi_viewer_all_zero = all_zero and len(viewers) > 1
+    if multi_viewer_all_zero:
         print(
             "EVERY viewer returned 0 rows, including any network-scoped one. That"
             " usually means the identity read itself failed rather than the"
             " policies denying - check the dev-server log for 'resolveAccess"
             " failed for', and confirm CUBE_GROUP_MAP is not set."
+        )
+    elif all_zero:
+        print(
+            "0 rows for the single viewer checked. That is the expected result"
+            " when deliberately validating default-deny for a `none`-scope"
+            " viewer - not an error. This tool's cross-viewer comparison needs"
+            " 2+ viewers to say anything; pass more viewers if you meant to"
+            " compare scopes."
         )
     elif len(fingerprints) > 1 and len(set(fingerprints)) == 1:
         print(
@@ -214,14 +228,16 @@ def main() -> int:
             " user and pins every connection to one identity - unset it and"
             " restart the dev server."
         )
-    # "All zero" can never be a legitimate pass (see docstring above), so it must
-    # fail the gate on its own even when every individual connection succeeded.
-    # The "all identical" case is left at the ordinary exit status: it can be a
-    # true positive (two viewers who really do share one scope) as well as a
-    # false positive (CUBE_SQL_DEV_EMAIL pinning), and telling those apart needs
-    # a human to check the viewer list - the diagnostic flags it, but exit status
-    # would be misleading either way we exited from here.
-    return 1 if failures or all_zero else 0
+    # "All zero" across 2+ viewers can never be a legitimate pass (see docstring
+    # above), so it must fail the gate on its own even when every individual
+    # connection succeeded. A single viewer at 0 rows is left at the ordinary
+    # exit status - see multi_viewer_all_zero above. The "all identical" case is
+    # also left at the ordinary exit status: it can be a true positive (two
+    # viewers who really do share one scope) as well as a false positive
+    # (CUBE_SQL_DEV_EMAIL pinning), and telling those apart needs a human to
+    # check the viewer list - the diagnostic flags it, but exit status would be
+    # misleading either way we exited from here.
+    return 1 if failures or multi_viewer_all_zero else 0
 
 
 if __name__ == "__main__":

--- a/scripts/cube_rls_matrix.py
+++ b/scripts/cube_rls_matrix.py
@@ -46,6 +46,7 @@ Design reference:
 import argparse
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import psycopg
@@ -58,6 +59,17 @@ DEFAULT_QUERY = (
     "SELECT regions_region_name, MEASURE(count_students) "
     "FROM student_attendance_view GROUP BY 1 ORDER BY 1"
 )
+
+
+@dataclass(frozen=True)
+class CubeConnection:
+    """Local Cube SQL API connection settings, shared across every viewer."""
+
+    host: str
+    port: int
+    dbname: str
+    password: str | None
+    query: str
 
 
 def parse_args() -> argparse.Namespace:
@@ -85,10 +97,15 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_viewers(args: argparse.Namespace) -> list[str]:
-    if args.viewers:
-        return args.viewers
-    lines = args.viewers_file.read_text(encoding="utf-8").splitlines()
+def load_viewers(viewers: list[str] | None, viewers_file: Path | None) -> list[str]:
+    if viewers:
+        return viewers
+    if viewers_file is None:
+        # Unreachable via the CLI: parse_args puts --viewers and --viewers-file in
+        # a required mutually exclusive group. Raise rather than assert, so the
+        # narrowing survives -O and bandit does not flag a stripped check.
+        raise ValueError("pass either viewers or viewers_file")
+    lines = viewers_file.read_text(encoding="utf-8").splitlines()
     return [
         stripped
         for line in lines
@@ -97,7 +114,7 @@ def load_viewers(args: argparse.Namespace) -> list[str]:
 
 
 def run_for_viewer(
-    viewer: str, args: argparse.Namespace
+    viewer: str, connection: CubeConnection
 ) -> tuple[list[tuple], str | None]:
     """Return (rows, error) for one viewer.
 
@@ -112,22 +129,28 @@ def run_for_viewer(
     try:
         with (
             psycopg.connect(
-                host=args.host,
-                port=args.port,
+                host=connection.host,
+                port=connection.port,
                 user=viewer,
-                password=args.password,
-                dbname=args.dbname,
+                password=connection.password,
+                dbname=connection.dbname,
                 prepare_threshold=None,
             ) as conn,
             conn.cursor() as cur,
         ):
-            cur.execute(args.query)
+            # psycopg types `query` as LiteralString to make injection hard to
+            # write by accident. This query is a CLI argument by design — the
+            # operator chooses what to run as each viewer — so it can never be a
+            # literal, and there is no runtime problem to fix here.
+            # trunk-ignore(pyright/reportCallIssue,pyright/reportArgumentType): operator-supplied CLI query, not a literal
+            cur.execute(connection.query)
             return cur.fetchall(), None
     except psycopg.Error as err:
         # Report and continue: one unreachable or denied viewer must not abort
         # the rest of the matrix, since the comparison across viewers is the
         # whole point.
-        return [], str(err).strip().splitlines()[0]
+        first_line = next(iter(str(err).strip().splitlines()), "unknown error")
+        return [], first_line
 
 
 def main() -> int:
@@ -140,10 +163,18 @@ def main() -> int:
         )
         return 1
 
-    viewers = load_viewers(args)
+    viewers = load_viewers(args.viewers, args.viewers_file)
     if not viewers:
         print("No viewer emails to test.", file=sys.stderr)
         return 1
+
+    connection = CubeConnection(
+        host=args.host,
+        port=args.port,
+        dbname=args.dbname,
+        password=args.password,
+        query=args.query,
+    )
 
     failures = 0
     empty = 0
@@ -152,7 +183,7 @@ def main() -> int:
     # value cannot be compared against a string (None < 'Camden' raises).
     fingerprints: list[str] = []
     for viewer in viewers:
-        rows, error = run_for_viewer(viewer, args)
+        rows, error = run_for_viewer(viewer, connection)
         if error:
             failures += 1
             print(f"{viewer}: FAILED - {error}")
@@ -167,7 +198,8 @@ def main() -> int:
             print(f"    {row}")
 
     print(f"\n{len(viewers)} viewer(s) checked, {failures} failed, {empty} at 0 rows.")
-    if empty == len(viewers):
+    all_zero = empty == len(viewers)
+    if all_zero:
         print(
             "EVERY viewer returned 0 rows, including any network-scoped one. That"
             " usually means the identity read itself failed rather than the"
@@ -182,7 +214,14 @@ def main() -> int:
             " user and pins every connection to one identity - unset it and"
             " restart the dev server."
         )
-    return 1 if failures else 0
+    # "All zero" can never be a legitimate pass (see docstring above), so it must
+    # fail the gate on its own even when every individual connection succeeded.
+    # The "all identical" case is left at the ordinary exit status: it can be a
+    # true positive (two viewers who really do share one scope) as well as a
+    # false positive (CUBE_SQL_DEV_EMAIL pinning), and telling those apart needs
+    # a human to check the viewer list - the diagnostic flags it, but exit status
+    # would be misleading either way we exited from here.
+    return 1 if failures or all_zero else 0
 
 
 if __name__ == "__main__":

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -554,6 +554,16 @@ exercise it; a plain dev server silently default-denies every gated view.
   tables, `WHERE (1 = 0)` — check the deployment log for
   `resolveAccess failed for` and that the BigQuery variables are set on **that**
   environment (branch environments do not inherit them).
+- **Cube Cloud Explore's "Semantic SQL" tab IS a valid surface for testing the
+  Cube Cloud path.** It accepts the SQL API dialect (dimensions bare,
+  `MEASURE(measure)`, query the view not the cube) AND honors a pasted Security
+  Context through `contextToGroups` — verified by pasting
+  `{"email": "<viewer>"}` as an impersonator and getting the target's scope
+  back. Do not assume "SQL" implies `checkSqlAuth`: that applies to the Postgres
+  wire protocol on `CUBEJS_PG_SQL_PORT`, not this tab. Member names follow the
+  view's `prefix:` settings, so a `prefix: true` join surfaces
+  `<lastJoinPathSegment>_<member>` (`regions_region_name`,
+  `dates_academic_year`).
 - **The committed matrix tool is the RLS validation path** —
   `uv run scripts/cube_rls_matrix.py --viewers-file <local file>` opens one SQL
   connection per viewer email and runs the same query, so a scope difference is

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -261,9 +261,14 @@ access policies above) — `queryRewrite` retains only the snapshot-anchor guard
   LEVEL**, so every top-level value there is caller-supplied: pasting
   `{"groups": ["staff-pii-all_in_scope"], "allowed_abbreviations": [...]}` was
   honored verbatim before the overwrite landed. Never reintroduce a
-  `!securityContext.groups` guard here — that guard IS the bypass. A REST
-  context (no `cubeCloud` key) is passed through untouched, since `checkAuth`
-  already resolved it.
+  `!securityContext.groups` guard here — that guard IS the bypass. The branch
+  gates on the presence of the top-level `cubeCloud` key, not on
+  `cubeCloud.username` being truthy: a REST/MCP context (no `cubeCloud` key at
+  all) skips the block entirely and is passed through untouched, since
+  `checkAuth` already resolved it. A Cube Cloud request (`cubeCloud` key
+  present) whose `username` is missing still enters the block and resolves to
+  the empty default-deny context via `resolveAccess` — a missing `username` is a
+  DENY, not a pass-through.
 - **Every securityContext field a policy interpolates MUST be returned by
   `access.buildSecurityContext`.** This is what makes the overwrite above a
   COMPLETE one, and it is the load-bearing assumption of the paste fix — not a
@@ -491,17 +496,18 @@ exercise it; a plain dev server silently default-denies every gated view.
 - **Testing RLS locally — SQL API is ground truth; the REST Playground also
   works in dev mode.** `checkSqlAuth` resolves identity from the connecting
   `user`: set `CUBEJS_PG_SQL_PORT` + `CUBEJS_SQL_USER`/`_PASSWORD`, connect via
-  `psycopg2` as the viewer's email in the SQL `user`, switch viewers per
-  connection with no restart. (`CUBE_SQL_DEV_EMAIL=<viewer>` optionally pins
-  every connection to one alias, overriding the connecting user — change +
-  restart to switch.) It's the prod BI/Superset surface. Tesseract
-  (`CUBEJS_TESSERACT_SQL_PLANNER`, default `true`) is the planner on both APIs
-  and joining views is supported (multi-fact views); the old
-  `JoinDefinitionStatic` note was a Playground observation, not a SQL-API limit
-  — verified `student_attendance_view` / `staff_directory` /
-  `student_assessment_scores_view` query cleanly. **`checkAuth` DOES run in dev
-  mode (verified on Cube 1.6.59 and 1.7.14)** — the prior "REST skips auth in
-  dev mode / needs `NODE_ENV=production`" claim was WRONG, and Cube's own
+  `psycopg` v3 (not `psycopg2` — see `scripts/cube_rls_matrix.py`) as the
+  viewer's email in the SQL `user`, switch viewers per connection with no
+  restart. (`CUBE_SQL_DEV_EMAIL=<viewer>` optionally pins every connection to
+  one alias, overriding the connecting user — change + restart to switch.) It's
+  the prod BI/Superset surface. Tesseract (`CUBEJS_TESSERACT_SQL_PLANNER`,
+  default `true`) is the planner on both APIs and joining views is supported
+  (multi-fact views); the old `JoinDefinitionStatic` note was a Playground
+  observation, not a SQL-API limit — verified `student_attendance_view` /
+  `staff_directory` / `student_assessment_scores_view` query cleanly.
+  **`checkAuth` DOES run in dev mode (verified on Cube 1.6.59 and 1.7.14)** —
+  the prior "REST skips auth in dev mode / needs `NODE_ENV=production`" claim
+  was WRONG, and Cube's own
   `🔓 Authentication checks are disabled in developer mode` boot banner is
   misleading here: a signed `email` claim still resolves a full scope. To
   emulate over the REST Playground, paste `{"email": "<viewer>"}` into its

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -269,6 +269,16 @@ access policies above) — `queryRewrite` retains only the snapshot-anchor guard
   present) whose `username` is missing still enters the block and resolves to
   the empty default-deny context via `resolveAccess` — a missing `username` is a
   DENY, not a pass-through.
+- **Gating on the `cubeCloud` key assumes a paste cannot REPLACE that key.**
+  Cube Cloud must apply its own block after the merged paste; if a paste could
+  win, pasting `{"cubeCloud": {"username": "<anyone>"}}` would resolve that
+  person's real context and collapse the design, not merely the gate. Tested on
+  a Dev Mode deployment: a network-scoped caller pasting a school-scoped
+  viewer's email as `cubeCloud.username` still got their own four-region scope,
+  so the injected block wins. Cube Cloud's merge is closed-source and the OSS
+  tree has no `cubeCloud` reference, so this is empirical, not guaranteed — a
+  falsy paste (`{"cubeCloud": null}`) is untested and would skip the gate.
+  Re-confirm after a Cube Cloud upgrade; do not treat it as settled.
 - **Every securityContext field a policy interpolates MUST be returned by
   `access.buildSecurityContext`.** This is what makes the overwrite above a
   COMPLETE one, and it is the load-bearing assumption of the paste fix — not a

--- a/src/cube/CLAUDE.md
+++ b/src/cube/CLAUDE.md
@@ -275,10 +275,14 @@ access policies above) — `queryRewrite` retains only the snapshot-anchor guard
   person's real context and collapse the design, not merely the gate. Tested on
   a Dev Mode deployment: a network-scoped caller pasting a school-scoped
   viewer's email as `cubeCloud.username` still got their own four-region scope,
-  so the injected block wins. Cube Cloud's merge is closed-source and the OSS
-  tree has no `cubeCloud` reference, so this is empirical, not guaranteed — a
-  falsy paste (`{"cubeCloud": null}`) is untested and would skip the gate.
-  Re-confirm after a Cube Cloud upgrade; do not treat it as settled.
+  so the injected block wins. It wins against a FALSY paste too: pasting
+  `{"cubeCloud": null, "groups": ["student-region"], "region_key": "<a region>"}`
+  returned the caller's own four-region scope rather than the single pasted
+  region, so the gate still fired AND the pasted `groups` / `region_key` were
+  both overwritten. The merge order is therefore
+  `{...paste, cubeCloud: realBlock}`, which makes the pasted value irrelevant.
+  Empirical, not guaranteed — Cube Cloud's merge is closed-source and the OSS
+  tree has no `cubeCloud` reference — so re-confirm after a Cube Cloud upgrade.
 - **Every securityContext field a policy interpolates MUST be returned by
   `access.buildSecurityContext`.** This is what makes the overwrite above a
   COMPLETE one, and it is the load-bearing assumption of the paste fix — not a

--- a/src/cube/access.js
+++ b/src/cube/access.js
@@ -240,8 +240,16 @@ function resolveEmulationTarget({
   requestedTarget,
   impersonators,
 }) {
-  const caller = callerEmail ?? null;
-  const requested = requestedTarget ?? null;
+  // Both identities are coerced to "a string or nothing" before any comparison.
+  // On Cube Cloud the target is a pasted JSON value, so it can just as easily be
+  // an object or an array as a string, and a bare `requested.toLowerCase()`
+  // throws a TypeError out of contextToGroups — a 500 instead of a decision.
+  // Treating a non-string as absent is the fail-closed reading: no target means
+  // no emulation, and a non-string caller means no caller, which resolveAccess
+  // turns into the empty default-deny context.
+  const caller = typeof callerEmail === "string" ? callerEmail : null;
+  const requested =
+    typeof requestedTarget === "string" ? requestedTarget : null;
   // No target, or the caller's own email: an ordinary request, not an emulation
   // (also keeps no-op self-emulation out of the audit log).
   const isSelf =

--- a/src/cube/access.test.js
+++ b/src/cube/access.test.js
@@ -453,3 +453,38 @@ test("emulationInputsFromCubeCloud: with no pasted context the console user is t
   assert.equal(r.target, "admin@x.org");
   assert.equal(r.emulating, false);
 });
+
+// --- Non-string identities from a pasted Cube Cloud context -----------------
+// On Cube Cloud the target (and, less commonly, the caller identity feeding
+// this function) is a pasted JSON value, so it can be an object or an array
+// just as easily as a string. A bare `.toLowerCase()` on a non-string used to
+// throw a TypeError out of contextToGroups — a 500 instead of a clean
+// decision. Coercing anything non-string to null treats "no usable identity"
+// as "no emulation," which fails closed without erroring. Verified this
+// throws under the old `callerEmail ?? null` / `requestedTarget ?? null`
+// coercion (temporarily reverted locally, restored — not committed).
+
+test("resolveEmulationTarget: a non-string requestedTarget from an impersonator caller yields no emulation, not a throw", () => {
+  const impersonators = a.parseImpersonators("admin@x.org");
+  for (const requestedTarget of [{ email: { a: 1 } }, ["x"], 42]) {
+    const r = a.resolveEmulationTarget({
+      callerEmail: "admin@x.org",
+      requestedTarget,
+      impersonators,
+    });
+    assert.deepEqual(r, {
+      caller: "admin@x.org",
+      target: "admin@x.org",
+      emulating: false,
+    });
+  }
+});
+
+test("resolveEmulationTarget: a non-string callerEmail resolves to no caller and no target", () => {
+  const r = a.resolveEmulationTarget({
+    callerEmail: { username: "admin@x.org" },
+    requestedTarget: "target@x.org",
+    impersonators: a.parseImpersonators("admin@x.org"),
+  });
+  assert.deepEqual(r, { caller: null, target: null, emulating: false });
+});

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -11,6 +11,9 @@ const groupCache = new Map(); // email → { ctx, expiresAt }
 // / computeAllowedDepartmentGroups need: every location abbreviation+region
 // and every distinct department_group. Same midnight-ET expiry as
 // groupCache — one shared entry, not one per viewer.
+// Latched so the ADC-fallback notice is emitted once per process, not once per
+// identity-resolution cache miss.
+let adcFallbackWarned = false;
 let universeCache = null; // { data: { locations: [...], deptGroups: [...] }, expiresAt }
 
 function nextMidnightEastern() {
@@ -105,6 +108,27 @@ async function resolveAccess(email) {
         Buffer.from(process.env.CUBEJS_DB_BQ_CREDENTIALS, "base64").toString(
           "utf8",
         ),
+      );
+    } else if (!adcFallbackWarned) {
+      // Falling back to ADC, which is what local dev runs on. Say so once, then
+      // stay quiet. The fallback itself is correct, but on a DEPLOYMENT it
+      // silently switches identity reads to the ambient Cube Cloud host
+      // principal, which lacks bigquery.jobs.create and default-denies every
+      // viewer for a reason that looks nothing like the cause (#4466). This line
+      // is the breadcrumb that turns that into a two-second diagnosis.
+      //
+      // NODE_ENV is deliberately NOT the discriminator. The documented local RLS
+      // sign-off runs `NODE_ENV=production CUBEJS_DEV_MODE=false npm run dev`,
+      // so refusing the fallback under NODE_ENV=production would fail-close the
+      // exact workflow the fallback exists for. There is no reliable Cube Cloud
+      // marker to gate on, so warn rather than throw.
+      adcFallbackWarned = true;
+      console.warn(
+        JSON.stringify({
+          event: "cube_bq_credentials_fallback",
+          message:
+            "CUBEJS_DB_BQ_CREDENTIALS is unset; identity reads are using ambient ADC. Expected locally. On a deployment, set it on THIS environment — branch environments do not inherit it.",
+        }),
       );
     }
     const bq = new BigQuery(bqOptions);
@@ -212,7 +236,15 @@ function jwtRejectionReason(err) {
     // deployment, a missing `iat` under maxAge, and alg:none. Naming the secret
     // matters: an unset one on a branch environment is the likeliest cause and
     // is otherwise invisible.
-    return `Invalid token: ${err.message}. Check the signing secret matches this deployment's CUBEJS_API_SECRET, and that the token carries an \`iat\`.`;
+    // One message is withheld. jsonwebtoken reports an UNSET secret as "secret
+    // or public key must be provided" — that is deployment state, not a fact
+    // about the caller's own token, and an unauthenticated caller learns from it
+    // that this deployment has no signing secret at all. Every other message
+    // here describes the token they minted, so it stays verbatim.
+    const detail = String(err.message).startsWith("secret or public key")
+      ? "the server could not verify it"
+      : err.message;
+    return `Invalid token: ${detail}. Check the signing secret matches this deployment's CUBEJS_API_SECRET, and that the token carries an \`iat\`.`;
   }
   return "Invalid token";
 }
@@ -274,8 +306,15 @@ module.exports = {
     // (`CompilerApi.hashRequestContext`), so the same input must always produce
     // the same output. Re-deriving unconditionally is deterministic — the
     // per-email cache in resolveAccess makes re-entry cheap.
-    const consoleUser = securityContext?.cubeCloud?.username ?? null;
-    if (consoleUser) {
+    // Gate on the `cubeCloud` KEY, not on `cubeCloud.username`. A Cube Cloud
+    // context whose username is absent must still be neutralized: falling
+    // through to the `securityContext?.groups` return below would honor a pasted
+    // `groups`, which is the exact bypass the overwrite exists to close. The
+    // body needs no null handling for it — emulationInputsFromCubeCloud yields a
+    // null caller, resolveEmulationTarget fails closed to a null target, and
+    // resolveAccess(null) returns the empty default-deny context. So a missing
+    // username denies cleanly instead of passing the paste through.
+    if (securityContext?.cubeCloud) {
       const { caller, target, emulating } = access.resolveEmulationTarget({
         // Same shape as the REST branch above, via the surface adapter — the
         // caller/target extraction lives in access.js so both paths and their

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -301,6 +301,20 @@ module.exports = {
     // authentication establishes identity for RLS. Deliberate, and on par with
     // the trust the SQL API places in the connecting user.
     //
+    // SECOND, SEPARATE ASSUMPTION, load-bearing and worth stating: a paste
+    // cannot REPLACE the `cubeCloud` key itself. Cube Cloud must apply its own
+    // block after the paste (`{...paste, cubeCloud: realBlock}`), or a console
+    // user could paste `{"cubeCloud": {"username": "<anyone>"}}` and resolve that
+    // person's real context — which would collapse this whole design, not just
+    // the gate below. Tested on a Cube Cloud Dev Mode deployment: a
+    // network-scoped caller pasting a school-scoped viewer's email as
+    // `cubeCloud.username` still got their own four-region scope, so the injected
+    // block wins. Cube Cloud's merge is closed-source and the OSS tree carries no
+    // reference to `cubeCloud`, so this is an empirical result, not a guarantee.
+    // A falsy paste (`{"cubeCloud": null}`) was not tested explicitly; it would
+    // skip the gate below and return pasted groups, so re-confirm after any Cube
+    // Cloud upgrade rather than treating it as settled.
+    //
     // Determinism matters: Cube caches the selected policies under a hash of
     // this context computed BEFORE the hook runs
     // (`CompilerApi.hashRequestContext`), so the same input must always produce

--- a/src/cube/cube.js
+++ b/src/cube/cube.js
@@ -309,11 +309,17 @@ module.exports = {
     // the gate below. Tested on a Cube Cloud Dev Mode deployment: a
     // network-scoped caller pasting a school-scoped viewer's email as
     // `cubeCloud.username` still got their own four-region scope, so the injected
-    // block wins. Cube Cloud's merge is closed-source and the OSS tree carries no
-    // reference to `cubeCloud`, so this is an empirical result, not a guarantee.
-    // A falsy paste (`{"cubeCloud": null}`) was not tested explicitly; it would
-    // skip the gate below and return pasted groups, so re-confirm after any Cube
-    // Cloud upgrade rather than treating it as settled.
+    // block wins — including against a FALSY paste. Pasting
+    // `{"cubeCloud": null, "groups": ["student-region"], "region_key": "<a region>"}`
+    // returned the caller's own four-region scope, not the single pasted region:
+    // the gate still fired (so `cubeCloud: null` did not survive the merge) and
+    // the pasted `groups` + `region_key` were both overwritten. That is the merge
+    // order this gate needs, `{...paste, cubeCloud: realBlock}`, which makes the
+    // pasted VALUE irrelevant.
+    //
+    // Empirical, not guaranteed: Cube Cloud's merge is closed-source and the OSS
+    // tree carries no reference to `cubeCloud`, so re-confirm after a Cube Cloud
+    // upgrade rather than treating it as settled.
     //
     // Determinism matters: Cube caches the selected policies under a hash of
     // this context computed BEFORE the hook runs

--- a/src/cube/cube.test.js
+++ b/src/cube/cube.test.js
@@ -2,6 +2,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const jwt = require("jsonwebtoken");
+const fs = require("node:fs");
+const path = require("node:path");
+const access = require("./access");
 
 const SECRET = "test-secret-for-jwt-expiry-spec";
 
@@ -26,6 +29,20 @@ async function capturedEmulationLog(fn) {
     console.log = original;
   }
   return lines.filter((line) => line.includes("cube_emulation"));
+}
+
+// Same pattern as capturedEmulationLog, for the ADC-fallback breadcrumb, which
+// is logged via console.warn (not console.log).
+async function capturedWarnLog(fn) {
+  const lines = [];
+  const original = console.warn;
+  console.warn = (...args) => lines.push(args.join(" "));
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return lines.filter((line) => line.includes("cube_bq_credentials_fallback"));
 }
 
 test.beforeEach(() => {
@@ -289,6 +306,41 @@ test("checkAuth: a signature rejection points at the deployment's signing secret
   assert.doesNotMatch(message, /too old/i);
 });
 
+test("checkAuth: an unset signing secret withholds jsonwebtoken's own message, naming only that verification failed", async () => {
+  // jsonwebtoken reports an unset secret as "secret or public key must be
+  // provided" — that is deployment state (this environment has no signing
+  // secret configured at all), not a fact about the caller's own token. An
+  // unauthenticated caller must not learn that from a 403 body.
+  delete process.env.CUBEJS_API_SECRET;
+  const now = Math.floor(Date.now() / 1000);
+  // Signed with an arbitrary secret — irrelevant, since jwt.verify errors
+  // before ever checking the signature when its own secretOrPublicKey is
+  // missing.
+  const token = jwt.sign(
+    { email: "unset-secret@apps.teamschools.org", iat: now, exp: now + 300 },
+    "whatever",
+    { algorithm: "HS256" },
+  );
+  const message = await rejectionMessage(token);
+  assert.match(message, /the server could not verify it/);
+  assert.doesNotMatch(message, /secret or public key/);
+});
+
+test("checkAuth: a bad-signature rejection still echoes jsonwebtoken's own message text (withholding is narrow, not blanket)", async () => {
+  // Every OTHER JsonWebTokenError message stays verbatim — only the unset-
+  // secret case above is withheld. This is the non-regression half: a real
+  // signature mismatch must still name jsonwebtoken's own diagnostic text.
+  const now = Math.floor(Date.now() / 1000);
+  const message = await rejectionMessage(
+    jwt.sign(
+      { email: "badsig@apps.teamschools.org", iat: now, exp: now + 300 },
+      "not-the-real-secret",
+      { algorithm: "HS256" },
+    ),
+  );
+  assert.match(message, /invalid signature/i);
+});
+
 test("checkSqlAuth: an unset SQL password rejects the connection (fail-closed)", async () => {
   delete process.env.CUBEJS_SQL_PASSWORD;
   const res = await cube.checkSqlAuth({}, "sqlnopw@apps.teamschools.org", "x");
@@ -340,6 +392,136 @@ test("resolveAccess (production path) fails closed to default-deny when BigQuery
     assert.equal(res.password, "server-known-pw");
   } finally {
     cached.exports = origExports;
+  }
+});
+
+// --- ADC fallback when CUBEJS_DB_BQ_CREDENTIALS is unset --------------------
+// The documented local RLS sign-off runs `NODE_ENV=production
+// CUBEJS_DEV_MODE=false npm run dev`, so gating the ADC fallback on
+// NODE_ENV === "production" would fail-close that exact workflow (the bug a
+// prior draft of this change nearly reintroduced). The fallback is
+// unconditional; an unset CUBEJS_DB_BQ_CREDENTIALS instead logs a one-time
+// console.warn breadcrumb (`cube_bq_credentials_fallback`), latched by a
+// module-level flag so it fires once per process, not once per identity
+// resolution. These tests re-require "./cube" fresh (via require.cache
+// deletion) to get an unlatched module instance, rather than reaching into
+// cube.js's internals — the shared top-level `cube` binding used by every
+// other test in this file is untouched by that cache deletion.
+
+function stubBigQueryExports(queryImpl) {
+  const bqPath = require.resolve("@google-cloud/bigquery");
+  require("@google-cloud/bigquery"); // ensure it is in the require cache
+  const cached = require.cache[bqPath];
+  const origExports = cached.exports;
+  cached.exports = {
+    BigQuery: class {
+      async query(opts) {
+        return queryImpl(opts);
+      }
+    },
+  };
+  return () => {
+    cached.exports = origExports;
+  };
+}
+
+function freshCubeModule() {
+  const cubePath = require.resolve("./cube");
+  delete require.cache[cubePath];
+  return require("./cube");
+}
+
+test("resolveAccess: with CUBEJS_DB_BQ_CREDENTIALS unset, identity resolution falls back to ADC and still resolves — not a fail-closed empty context — in both dev and NODE_ENV=production", async () => {
+  delete process.env.CUBEJS_DB_BQ_CREDENTIALS;
+  process.env.CUBEJS_SQL_PASSWORD = "server-known-pw";
+
+  const restoreBigQuery = stubBigQueryExports(({ query }) => {
+    if (query.includes("dim_staff_reporting_chain")) return [[]];
+    if (query.includes("dim_locations")) {
+      return [[{ abbreviation: "ABC", region_key: "R1" }]];
+    }
+    if (query.includes("DISTINCT department_group")) return [[]];
+    return [
+      [
+        {
+          staff_key: "adc-fallback-staff",
+          student_location_scope: "school",
+          staff_pii_scope: "none",
+          region_key: "R1",
+          location_abbreviation: "ABC",
+          department_group: null,
+          job_function_level: 2,
+          staff_location_scope: "school",
+          staff_department_scope: "none",
+        },
+      ],
+    ];
+  });
+
+  try {
+    for (const nodeEnv of [undefined, "production"]) {
+      if (nodeEnv) process.env.NODE_ENV = nodeEnv;
+      else delete process.env.NODE_ENV;
+
+      const freshCube = freshCubeModule();
+      const email = `adc-fallback-${nodeEnv ?? "dev"}@apps.teamschools.org`;
+      const res = await freshCube.checkSqlAuth({}, email, "ignored");
+
+      assert.equal(res.password, "server-known-pw");
+      // Populated, HR-derived scope — the opposite of the empty default-deny
+      // shape that a fail-closed throw would have produced.
+      assert.ok(res.securityContext.groups.includes("staff-directory"));
+      assert.equal(res.securityContext.region_key, "R1");
+    }
+  } finally {
+    restoreBigQuery();
+    delete require.cache[require.resolve("./cube")];
+    delete process.env.NODE_ENV;
+  }
+});
+
+test("resolveAccess: the ADC-fallback warning is emitted once per process, not once per call", async () => {
+  delete process.env.CUBEJS_DB_BQ_CREDENTIALS;
+  process.env.CUBEJS_SQL_PASSWORD = "server-known-pw";
+
+  const restoreBigQuery = stubBigQueryExports(() => [[]]);
+  const freshCube = freshCubeModule();
+
+  try {
+    const lines = await capturedWarnLog(async () => {
+      await freshCube.checkSqlAuth({}, "warn-once-a@apps.teamschools.org", "x");
+      await freshCube.checkSqlAuth({}, "warn-once-b@apps.teamschools.org", "x");
+    });
+    assert.equal(lines.length, 1);
+    const entry = JSON.parse(lines[0]);
+    assert.equal(entry.event, "cube_bq_credentials_fallback");
+  } finally {
+    restoreBigQuery();
+    delete require.cache[require.resolve("./cube")];
+  }
+});
+
+test("resolveAccess: with CUBEJS_DB_BQ_CREDENTIALS set, no ADC-fallback warning is emitted", async () => {
+  process.env.CUBEJS_SQL_PASSWORD = "server-known-pw";
+  process.env.CUBEJS_DB_BQ_CREDENTIALS = Buffer.from(
+    JSON.stringify({
+      client_email: "test@example.iam.gserviceaccount.com",
+      private_key: "not-a-real-key",
+    }),
+  ).toString("base64");
+
+  const restoreBigQuery = stubBigQueryExports(() => [[]]);
+  const freshCube = freshCubeModule();
+
+  try {
+    const lines = await capturedWarnLog(async () => {
+      await freshCube.checkSqlAuth({}, "creds-set@apps.teamschools.org", "x");
+    });
+    assert.deepEqual(lines, []);
+  } finally {
+    restoreBigQuery();
+    delete process.env.CUBEJS_DB_BQ_CREDENTIALS;
+    delete require.cache[require.resolve("./cube")];
   }
 });
 
@@ -627,7 +809,51 @@ test("contextToGroups: a Cube Cloud context with no username stays default-deny"
     iss: "cubecloud",
   };
   assert.deepEqual(await cube.contextToGroups({ securityContext }), []);
-  assert.ok(!("groups" in securityContext));
+  // The context is now OVERWRITTEN with the empty default-deny shape rather than
+  // left untouched. This assertion used to read `!("groups" in securityContext)`,
+  // which encoded the old `if (consoleUser)` gate: a missing username skipped
+  // enrichment entirely and left the object alone. Gating on the `cubeCloud` key
+  // means a username-less console context is neutralized like any other, so
+  // asserting the default-deny VALUES is both the stronger check and the one
+  // that matches intent — an absent key proves nothing about what a paste left
+  // behind.
+  assert.deepEqual(securityContext.groups, []);
+  assert.equal(securityContext.region_key, null);
+  assert.deepEqual(securityContext.allowed_abbreviations, []);
+});
+
+// --- Change A load-bearing negative: the gate must fire on the `cubeCloud`
+// KEY, not on `cubeCloud.username` -------------------------------------------
+// This is the exact bypass the overwrite exists to close: a console context
+// that carries `cubeCloud` but no `username` must still enter the enrichment
+// block and resolve to the empty default-deny context — never fall through to
+// `securityContext?.groups ?? []` and honor whatever was pasted alongside it.
+// Verified this FAILS against the OLD `if (consoleUser)` gate (where
+// `consoleUser = securityContext?.cubeCloud?.username ?? null` is null here,
+// so the block is skipped and the pasted `groups` + forged allow-lists are
+// returned/left in place verbatim) — reverted `cube.js` locally to that gate,
+// confirmed the failure, then restored the file (not committed).
+test("contextToGroups: a Cube Cloud context with no username is neutralized, not passed through (Change A load-bearing negative)", async () => {
+  const pasted = {
+    cubeCloud: { roles: ["Developer"] }, // no username
+    iss: "cubecloud",
+    groups: ["staff-pii-all_in_scope"],
+    region_key: "FORGED",
+    allowed_abbreviations: ["FORGED"],
+    allowed_department_groups: ["FORGED"],
+  };
+
+  const lines = await capturedEmulationLog(async () => {
+    const groups = await cube.contextToGroups({ securityContext: pasted });
+    assert.deepEqual(groups, []);
+  });
+
+  assert.ok(!pasted.groups.includes("staff-pii-all_in_scope"));
+  assert.notEqual(pasted.region_key, "FORGED");
+  assert.notDeepEqual(pasted.allowed_abbreviations, ["FORGED"]);
+  assert.notDeepEqual(pasted.allowed_department_groups, ["FORGED"]);
+  // No caller identity to resolve (username absent) means no emulation to log.
+  assert.deepEqual(lines, []);
 });
 
 test("contextToGroups: an unresolvable console user stays default-deny", async () => {
@@ -752,9 +978,116 @@ test("contextToGroups: a target mirrored only at userAttributes.email is honored
   ]);
 });
 
+// --- Change B on the Cube Cloud surface -------------------------------------
+// The pasted `email` target is a JSON value the console user fully controls,
+// so it is just as likely to be an object/array as a string. Before Change B,
+// a bare `.toLowerCase()` on it threw a TypeError out of contextToGroups (a
+// 500), not a clean deny. Verified (in access.test.js) that the old
+// `?? null` coercion throws here; this test proves the surface-level
+// consequence — no throw, no emulation, caller resolves as themselves.
+test("contextToGroups: a pasted non-string email target does not throw and resolves the caller as themselves", async () => {
+  process.env.CUBE_IMPERSONATORS = "cloudadmin11@apps.teamschools.org";
+  process.env.CUBE_GROUP_MAP = JSON.stringify({
+    "cloudadmin11@apps.teamschools.org": ["student-network"],
+  });
+  const securityContext = {
+    cubeCloud: { username: "cloudadmin11@apps.teamschools.org" },
+    iss: "cubecloud",
+    email: { a: 1 }, // a pasted JSON object, not a string
+  };
+
+  const lines = await capturedEmulationLog(async () => {
+    const groups = await cube.contextToGroups({ securityContext });
+    assert.deepEqual(groups, ["student-network"]);
+  });
+
+  assert.deepEqual(lines, []);
+});
+
 test("contextToGroups: no security context at all is default-deny", async () => {
   assert.deepEqual(
     await cube.contextToGroups({ securityContext: undefined }),
     [],
   );
+});
+
+// --- Structural invariant: every securityContext.<field> a policy
+// interpolates must be a key access.buildSecurityContext returns -----------
+// src/cube/CLAUDE.md states this in prose: it is what makes the Object.assign
+// overwrite in contextToGroups a COMPLETE one. A new `row_level` filter that
+// interpolates a securityContext field buildSecurityContext doesn't return
+// would silently reopen the Cube Cloud paste vector for that field alone —
+// Object.assign can't overwrite a pasted value for a key it never sets. Prose
+// can't enforce this; this test derives the actual set of interpolated field
+// names from the model YAML on disk and checks it against
+// buildSecurityContext's real return, so it fails the moment the two drift.
+
+function listYamlFilesRecursive(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listYamlFilesRecursive(full));
+    } else if (entry.isFile() && /\.ya?ml$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("structural invariant: every securityContext.<field> interpolated in model/ is returned by access.buildSecurityContext", () => {
+  const modelDir = path.join(__dirname, "model");
+  const files = listYamlFilesRecursive(modelDir);
+  assert.ok(
+    files.length > 0,
+    `no YAML files found under ${modelDir} — check __dirname resolution before trusting this test`,
+  );
+
+  const found = new Set();
+  const pattern = /securityContext\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    for (const match of text.matchAll(pattern)) {
+      found.add(match[1]);
+    }
+  }
+
+  // A regex that silently matched nothing would make every assertion below
+  // vacuously pass. Guard against that explicitly with a floor plausible for
+  // the current model, rather than trusting an empty derived set.
+  assert.ok(
+    found.size >= 6,
+    `expected at least 6 distinct securityContext.<field> tokens under ${modelDir}, ` +
+      `found ${found.size}: ${[...found].sort().join(", ")}. Either the model ` +
+      "lost its row_level filters, or the extraction regex broke.",
+  );
+
+  const contextKeys = new Set(
+    Object.keys(access.buildSecurityContext(null, [], [], [])),
+  );
+  const missing = [...found].filter((key) => !contextKeys.has(key));
+  assert.deepEqual(
+    missing,
+    [],
+    missing.length
+      ? `securityContext field(s) interpolated in model/ but NOT returned by ` +
+          `access.buildSecurityContext: ${missing.join(", ")}. Add the field ` +
+          "to buildSecurityContext's return in access.js — otherwise the " +
+          "Cube Cloud Object.assign overwrite in contextToGroups cannot " +
+          "neutralize a pasted value for it, reopening the paste vector for " +
+          "that field alone."
+      : undefined,
+  );
+
+  // Sanity check against the six fields known today (#4526 / Task 5b). This is
+  // in addition to, not instead of, the derived assertion above — it exists
+  // so a reader can see at a glance what the model currently interpolates.
+  assert.deepEqual([...found].sort(), [
+    "allowed_abbreviations",
+    "allowed_department_groups",
+    "job_function_level",
+    "location_abbreviation",
+    "region_key",
+    "reportee_staff_keys",
+  ]);
 });

--- a/src/cube/cube.test.js
+++ b/src/cube/cube.test.js
@@ -1045,12 +1045,65 @@ test("structural invariant: every securityContext.<field> interpolated in model/
 
   const found = new Set();
   const pattern = /securityContext\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  // Cube Cloud shorthand identifiers ("Cube Cloud shorthand identifiers" in
+  // CubePropContextTranspiler.js: userAttributes / user_attributes / groups)
+  // are rewritten, INSIDE an access_policy only, into
+  // securityContext.cubeCloud.<name> -- a destination the plain pattern above
+  // never sees, since no literal "securityContext.<name>" token appears for
+  // it. cubeCloud.* is where a pasted Cube Cloud Security Context is mirrored,
+  // and contextToGroups's Object.assign overwrite in cube.js only overwrites
+  // TOP-LEVEL keys -- so a row_level filter reading the shorthand's rewritten
+  // destination (or reading securityContext.cubeCloud.* directly) would read
+  // an attacker-pasted value that nothing overwrites, reopening the paste
+  // vector for that field on the Cube Cloud surface alone. Requiring a "{"
+  // immediately before the identifier is what keeps this from false-firing on
+  // the legitimate "group:" / "groups:" access_policy YAML keys throughout
+  // model/ (e.g. staff_pii.yml's "- group: staff-pii-all_in_scope") -- those
+  // keys contain no interpolation brace at all, only a hypothetical
+  // "{ userAttributes.foo }" does.
+  const shorthandPattern = /\{\{?\s*(userAttributes|user_attributes|groups)\b/g;
+  const shorthandHits = [];
+  const cubeCloudHits = [];
   for (const file of files) {
     const text = fs.readFileSync(file, "utf8");
     for (const match of text.matchAll(pattern)) {
       found.add(match[1]);
     }
+    for (const match of text.matchAll(shorthandPattern)) {
+      shorthandHits.push(
+        `${path.relative(modelDir, file)}: ${match[0].trim()}`,
+      );
+    }
+    if (text.includes("securityContext.cubeCloud")) {
+      cubeCloudHits.push(path.relative(modelDir, file));
+    }
   }
+
+  assert.deepEqual(
+    shorthandHits,
+    [],
+    shorthandHits.length
+      ? `Cube Cloud shorthand identifier(s) interpolated in an access_policy: ` +
+          `${shorthandHits.join(", ")}. Cube's CubePropContextTranspiler rewrites ` +
+          "userAttributes./user_attributes./groups. inside an access_policy into " +
+          "securityContext.cubeCloud.<name> - cubeCloud.* is caller-pasted on the Cube " +
+          "Cloud surface and is not covered by the Object.assign overwrite in " +
+          "contextToGroups, so a policy reading it is a paste vector. Put the value in " +
+          "buildSecurityContext and read it from the top level instead."
+      : undefined,
+  );
+
+  assert.deepEqual(
+    cubeCloudHits,
+    [],
+    cubeCloudHits.length
+      ? `model/ reads securityContext.cubeCloud directly in: ${cubeCloudHits.join(", ")}. ` +
+          "cubeCloud.* is caller-pasted on the Cube Cloud surface and is not covered by " +
+          "the Object.assign overwrite in contextToGroups, so a policy reading it is a " +
+          "paste vector. Put the value in buildSecurityContext and read it from the top " +
+          "level instead."
+      : undefined,
+  );
 
   // A regex that silently matched nothing would make every assertion below
   // vacuously pass. Guard against that explicitly with a floor plausible for
@@ -1082,12 +1135,22 @@ test("structural invariant: every securityContext.<field> interpolated in model/
   // Sanity check against the six fields known today (#4526 / Task 5b). This is
   // in addition to, not instead of, the derived assertion above — it exists
   // so a reader can see at a glance what the model currently interpolates.
-  assert.deepEqual([...found].sort(), [
+  const expected = [
     "allowed_abbreviations",
     "allowed_department_groups",
     "job_function_level",
     "location_abbreviation",
     "region_key",
     "reportee_staff_keys",
-  ]);
+  ];
+  assert.deepEqual(
+    [...found].sort(),
+    expected,
+    `model/ now interpolates a different securityContext field set than the six documented ` +
+      `here: found ${[...found].sort().join(", ")}, expected ${expected.join(", ")}. If the ` +
+      "'missing' assertion above passed, the new/removed field IS already covered by " +
+      "buildSecurityContext - this list is a deliberate, human-reviewed sanity check, not a " +
+      "second correctness gate. Update it to match once you've confirmed the change is " +
+      "intentional.",
+  );
 });

--- a/src/cube/package-lock.json
+++ b/src/cube/package-lock.json
@@ -8,8 +8,8 @@
       "name": "teamster-cube",
       "version": "1.0.0",
       "dependencies": {
-        "@cubejs-backend/bigquery-driver": "^1.7.14",
-        "@cubejs-backend/server": "^1.7.14",
+        "@cubejs-backend/bigquery-driver": "^1.7.15",
+        "@cubejs-backend/server": "^1.7.15",
         "@google-cloud/bigquery": "^7.9.4",
         "jsonwebtoken": "^9.0.3"
       }
@@ -2103,14 +2103,14 @@
       }
     },
     "node_modules/@cubejs-backend/api-gateway": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.7.14.tgz",
-      "integrity": "sha512-KVWMVQUnlB3QssERAIVrd741Hfj+LXhkOIfTJVHmC/p116LYK3YkZjIe1Ti5Uw9prAnh2MfZ13qWdwOW814oyA==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.7.15.tgz",
+      "integrity": "sha512-hrkEj0YO9mq/8M9T6SFGrDNKoglcHaPrT6u83sG7bqC7G2RN8ApWuIeERhEBdNuMA6onjnA4ALBWV8hONcAKew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/native": "1.7.14",
-        "@cubejs-backend/query-orchestrator": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/native": "1.7.15",
+        "@cubejs-backend/query-orchestrator": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "@ungap/structured-clone": "^0.3.4",
         "assert-never": "^1.4.0",
         "body-parser": "^1.19.0",
@@ -2138,16 +2138,16 @@
       }
     },
     "node_modules/@cubejs-backend/base-driver": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.7.14.tgz",
-      "integrity": "sha512-gr5F6TE7jJM+0HDXz2vd+FsnCdfATnJLNtJqO/Bxhl/2UD484G73/elPoS8KvyVV3aTs7BdRHwGucxNE0mEW0g==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.7.15.tgz",
+      "integrity": "sha512-ZZDjTU3OAGVu2gDnE1/RjXS+teloMPm3P7AerOexduOwq//+csbIl4ERwfAnk17h+jfsjYKv+9+YVBcqqbj5Hg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
         "@aws-sdk/s3-request-presigner": "^3.49.0",
         "@azure/identity": "^4.4.1",
         "@azure/storage-blob": "^12.9.0",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/shared": "1.7.15",
         "@google-cloud/storage": "^7.13.0"
       },
       "engines": {
@@ -2155,14 +2155,14 @@
       }
     },
     "node_modules/@cubejs-backend/bigquery-driver": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.7.14.tgz",
-      "integrity": "sha512-mbztcuzIoxo8x7Dr/xNUI6HObnYEHbPYR6mv53A5RYGlfwf1PCQPhgqsvMiz2FaV5o8XySgEgQmzghGtIzZplw==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.7.15.tgz",
+      "integrity": "sha512-pJvUd7gqYD3/dv/PoG1cuc8FLzdfOUxhQAVv8+K1THtZ93iv3wNENXpb0sqYJ4PYxRstsG9sz2TLtx+ebO6XuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.7.14",
+        "@cubejs-backend/base-driver": "1.7.15",
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/shared": "1.7.15",
         "@google-cloud/bigquery": "^7.7.0",
         "@google-cloud/storage": "^7.13.0",
         "ramda": "^0.27.2"
@@ -2172,13 +2172,13 @@
       }
     },
     "node_modules/@cubejs-backend/cloud": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.7.14.tgz",
-      "integrity": "sha512-bVnqCquWdb2OGnRHLBKBMLTVevppDbGr7G8QtNHBi2/v1Yz0ue+h6h9ENmj1fIvduln2EDYQSWsslTLlNAEB4w==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.7.15.tgz",
+      "integrity": "sha512-XUu48hayZr6ByxnHtVXzGMQ6IAeVGj9UMuwsrfQgz4HUb00TqZ7WIoHmnjMyaozHwBez9q9JuoxC9NoySEpj0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/shared": "1.7.15",
         "chokidar": "^3.5.1",
         "env-var": "^6.3.0",
         "form-data": "^4.0.0",
@@ -2191,22 +2191,22 @@
       }
     },
     "node_modules/@cubejs-backend/cubesql": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.7.14.tgz",
-      "integrity": "sha512-8gF0z1O22Tl8AjxmwfSokCbUXN7Kfd+SuORPHiaxKuPHL5KBtybZ27pZq9i9icQqsGD4SRVy7yZeUMGh8eV/Gg==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.7.15.tgz",
+      "integrity": "sha512-Q4F6U8j5VZbE559v2EkPzVc7UXNBT65Yo2/bzdVYG7LrlfnXNh7RfqxqpJ4FKh+iRN2EUMlDNTjr7ikndruytA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@cubejs-backend/cubestore": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.7.14.tgz",
-      "integrity": "sha512-v7n0Q4tN+Jbxhu/vhwYH4xyPitRq4zYCSnPsMOF903U/302NgGcKNWcAC/eTQwNAwaRXzCsnbEzF5SNwzk0IFw==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.7.15.tgz",
+      "integrity": "sha512-E3R5u+g6B6vV0Dmhp2zWrh+rB6BjULeZYsUO9Yr/kQZiz4cK6xPTMGFuQPqbPQzpGRzaD8GnqcYJYrzyzyi2Pg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/shared": "1.7.15",
         "@octokit/core": "^3.2.5",
         "source-map-support": "^0.5.19"
       },
@@ -2218,15 +2218,15 @@
       }
     },
     "node_modules/@cubejs-backend/cubestore-driver": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.7.14.tgz",
-      "integrity": "sha512-SNRHsx1WCilaM5NfdtjXKscr50FeRTHcx9MnDAlwvoHqqlWjwdqhSpf9R9ThiUU8Tke/VQM+T/jw7ge5O83iDA==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.7.15.tgz",
+      "integrity": "sha512-l3GwErzPGlsGHo1E3CqF6i6rFaXBGc9IsjbunjgemVLiZAHEFqttux4A7psevDNrdo41VWBRcnJALjl78Hdesg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.7.14",
-        "@cubejs-backend/cubestore": "1.7.14",
-        "@cubejs-backend/native": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/base-driver": "1.7.15",
+        "@cubejs-backend/cubestore": "1.7.15",
+        "@cubejs-backend/native": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "csv-write-stream": "^2.0.0",
         "flatbuffers": "25.9.23",
         "fs-extra": "^9.1.0",
@@ -2250,14 +2250,14 @@
       }
     },
     "node_modules/@cubejs-backend/native": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.7.14.tgz",
-      "integrity": "sha512-mOauZaUv83nN/Y75RT9RsK5LHL+x8kGx7SjCB/gEkiIveC6IHS51KVJQvu+aivbqo2baPHbJ8bgm6TeghMH35g==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.7.15.tgz",
+      "integrity": "sha512-XIMBW7hLLCGMV3cTH2LC7SgMFrJOnwosZafkPXb93uIIzV+AQj3pPOmntNHkIDb4NGadGxIi/ykpqHE+gBR8Hg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/cubesql": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/cubesql": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "@cubejs-infra/post-installer": "^0.0.7"
       },
       "engines": {
@@ -2265,14 +2265,14 @@
       }
     },
     "node_modules/@cubejs-backend/query-orchestrator": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.7.14.tgz",
-      "integrity": "sha512-sPr4NmuBLqzIqcbKWw7oKUk3pp2WVrtIysM2zbuwGgdkigkekPzfSAndwyn5NScxfZqDqDH42vsq8KOFWNkEdw==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.7.15.tgz",
+      "integrity": "sha512-eib0oG11642zDgMjkKgyWxr0UPpCMUPkQ3gfud3PzFIp0HCl575yegEoFJtTPTVceEz6SgZe/ZERLiENALOpQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.7.14",
-        "@cubejs-backend/cubestore-driver": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/base-driver": "1.7.15",
+        "@cubejs-backend/cubestore-driver": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "csv-write-stream": "^2.0.0",
         "lru-cache": "^11.1.0",
         "ramda": "^0.27.2"
@@ -2282,9 +2282,9 @@
       }
     },
     "node_modules/@cubejs-backend/schema-compiler": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.7.14.tgz",
-      "integrity": "sha512-lrctQbOoZ6Bvrq2Int7AxPEcTW9zJNa3Wm2TG3TXJoSOUTGWxmzlQbynY6asCfXwa1UvLlvbhLL5MJswpZNMhg==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.7.15.tgz",
+      "integrity": "sha512-nvR1Cm/86y/bTSHFxvZbo1Lb1Ddb/9cIWad057yb80F2Y+b892iq3cmDcLqAUEl7iCcBw2j4Fw+wSJgRcjzV0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.24",
@@ -2295,8 +2295,8 @@
         "@babel/standalone": "^7.24",
         "@babel/traverse": "^7.24",
         "@babel/types": "^7.24",
-        "@cubejs-backend/native": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/native": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "antlr4": "^4.13.2",
         "camelcase": "^6.2.0",
         "cron-parser": "^4.9.0",
@@ -2318,16 +2318,16 @@
       }
     },
     "node_modules/@cubejs-backend/server": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/server/-/server-1.7.14.tgz",
-      "integrity": "sha512-PMyXBPK9YE594C7JFurHTAm3NZxMqu6+lqO0/bNElo05a17/VZUPd8Hn+OmvfpCXHvUgOFx2KfqtwGLzqVDFJA==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/server/-/server-1.7.15.tgz",
+      "integrity": "sha512-e1XAoE/aZ6wMYjfIRZ+gx73JcGsw5x3pdPUH4uZf+C1CLN5rr7OelHQAC6OlFcUB/5PA9yO4x5FfPbHRNFbI7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/cubestore-driver": "1.7.14",
+        "@cubejs-backend/cubestore-driver": "1.7.15",
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/native": "1.7.14",
-        "@cubejs-backend/server-core": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/native": "1.7.15",
+        "@cubejs-backend/server-core": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
         "@oclif/color": "^1.0.0",
         "@oclif/command": "^1.8.13",
         "@oclif/config": "^1.18.2",
@@ -2352,21 +2352,21 @@
       }
     },
     "node_modules/@cubejs-backend/server-core": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.7.14.tgz",
-      "integrity": "sha512-0qdxXovmYhgHDS//7rAglhWv+vrdwFJ8/ap1Cn/CIzLLHRvR6n3lEC5SWBGmxJDkED5+1uskShwPC2zxsnaMEg==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.7.15.tgz",
+      "integrity": "sha512-bmoyA2cXUy8n8OzkH8TBR/hEO4sxnh81sRsiEdaOnKWjnLzxhLX7f9udrjWvJtU0qGVSXQDk9Nik7kwS3obAbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/api-gateway": "1.7.14",
-        "@cubejs-backend/base-driver": "1.7.14",
-        "@cubejs-backend/cloud": "1.7.14",
-        "@cubejs-backend/cubestore-driver": "1.7.14",
+        "@cubejs-backend/api-gateway": "1.7.15",
+        "@cubejs-backend/base-driver": "1.7.15",
+        "@cubejs-backend/cloud": "1.7.15",
+        "@cubejs-backend/cubestore-driver": "1.7.15",
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/native": "1.7.14",
-        "@cubejs-backend/query-orchestrator": "1.7.14",
-        "@cubejs-backend/schema-compiler": "1.7.14",
-        "@cubejs-backend/shared": "1.7.14",
-        "@cubejs-backend/templates": "1.7.14",
+        "@cubejs-backend/native": "1.7.15",
+        "@cubejs-backend/query-orchestrator": "1.7.15",
+        "@cubejs-backend/schema-compiler": "1.7.15",
+        "@cubejs-backend/shared": "1.7.15",
+        "@cubejs-backend/templates": "1.7.15",
         "codesandbox-import-utils": "^2.1.12",
         "cross-spawn": "^7.0.1",
         "fs-extra": "^8.1.0",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@cubejs-backend/shared": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.7.14.tgz",
-      "integrity": "sha512-zunGdCizJyYhwcosxSH6IBrsC419YaOamMIkTP89NkqRWZLRXYk+ZnJpgX+li1Ms8K5o6pNQADRUt1PwIJUa7g==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.7.15.tgz",
+      "integrity": "sha512-q1RgnTXb/MIXxGxwudt8KA2LACROit+MTfl3ZQuFS//xbOiQRLwCDQVVDZiPFFkhjBybFg5bc3LSKmljGOslNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/color": "^0.1.2",
@@ -2603,12 +2603,12 @@
       "license": "0BSD"
     },
     "node_modules/@cubejs-backend/templates": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.7.14.tgz",
-      "integrity": "sha512-Yhxdh67G5sUXS+apIlBeo6hZKy60YZ3et60824QW1fwerdKiZEGk1PFf6cwtwzUjA6JBe0GohdzmPBcj31pt7A==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.7.15.tgz",
+      "integrity": "sha512-TmWay2Hvclq4SXZ7ZWPflOHrY6H7RGU/21FNnPijLaG2khus0ACtzJJuGajb8KPfgrsENSpuzyjsCwcg/fccpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/shared": "1.7.14",
+        "@cubejs-backend/shared": "1.7.15",
         "cross-spawn": "^7.0.3",
         "decompress": "^4.2.1",
         "decompress-targz": "^4.1.1",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -3584,12 +3584,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/request": {
@@ -3628,9 +3628,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
-      "integrity": "sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -3789,9 +3789,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -3977,9 +3977,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
-      "integrity": "sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
+      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4147,9 +4147,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5441,9 +5441,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -5452,14 +5452,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -5468,10 +5468,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6451,6 +6453,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -7152,9 +7166,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -7634,9 +7648,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8003,9 +8017,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -8014,7 +8028,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/stubs": {
@@ -8407,9 +8421,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8697,9 +8711,9 @@
       }
     },
     "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
       "funding": [
         {
           "type": "github",

--- a/src/cube/package.json
+++ b/src/cube/package.json
@@ -7,8 +7,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@cubejs-backend/bigquery-driver": "^1.7.14",
-    "@cubejs-backend/server": "^1.7.14",
+    "@cubejs-backend/bigquery-driver": "^1.7.15",
+    "@cubejs-backend/server": "^1.7.15",
     "@google-cloud/bigquery": "^7.9.4",
     "jsonwebtoken": "^9.0.3"
   }

--- a/tests/test_cube_rls_matrix.py
+++ b/tests/test_cube_rls_matrix.py
@@ -6,7 +6,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_SCRIPT = Path("scripts/cube_rls_matrix.py")
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "cube_rls_matrix.py"
 _MODULE_NAME = "cube_rls_matrix"
 
 
@@ -140,8 +140,11 @@ def test_main_all_viewers_zero_rows_returns_nonzero(monkeypatch, capsys) -> None
     assert "EVERY viewer returned 0 rows" in capsys.readouterr().out
 
 
-def test_main_single_viewer_zero_rows_returns_nonzero(monkeypatch) -> None:
-    """The all-zero gate must also fire with just one viewer (empty == len(viewers))."""
+def test_main_single_viewer_zero_rows_returns_zero(monkeypatch, capsys) -> None:
+    """A single viewer at 0 rows is a legitimate default-deny check (e.g. a
+    `none`-scope viewer), not a failure - the all-zero gate must NOT fire with
+    just one viewer, since the cross-viewer comparison it exists for needs 2+
+    viewers to mean anything."""
     mod = _load_script()
     monkeypatch.setattr(
         sys,
@@ -149,7 +152,10 @@ def test_main_single_viewer_zero_rows_returns_nonzero(monkeypatch) -> None:
         ["cube_rls_matrix.py", "--viewers", "a@x.org", "--password", "pw"],
     )
     monkeypatch.setattr(mod, "run_for_viewer", lambda viewer, connection: ([], None))
-    assert mod.main() == 1
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "0 rows for the single viewer checked" in out
+    assert "EVERY viewer returned 0 rows" not in out
 
 
 def test_main_connection_failures_still_return_nonzero(monkeypatch) -> None:

--- a/tests/test_cube_rls_matrix.py
+++ b/tests/test_cube_rls_matrix.py
@@ -1,0 +1,190 @@
+"""Tests for scripts/cube_rls_matrix.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path("scripts/cube_rls_matrix.py")
+_MODULE_NAME = "cube_rls_matrix"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Registration before exec_module is required for the module's @dataclass
+    # (CubeConnection) to resolve its own forward-referenced type.
+    sys.modules[_MODULE_NAME] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_script_module_loads() -> None:
+    assert _load_script() is not None
+
+
+# --- load_viewers ---------------------------------------------------------
+
+
+def test_load_viewers_returns_explicit_list_unchanged() -> None:
+    mod = _load_script()
+    assert mod.load_viewers(["a@x.org", "b@x.org"], None) == ["a@x.org", "b@x.org"]
+
+
+def test_load_viewers_reads_file_skips_blanks_and_comments(tmp_path) -> None:
+    mod = _load_script()
+    viewers_file = tmp_path / "viewers.txt"
+    viewers_file.write_text(
+        "a@x.org\n\n# a full-line comment\n   b@x.org   \n   \n#c@x.org\n",
+        encoding="utf-8",
+    )
+    assert mod.load_viewers(None, viewers_file) == ["a@x.org", "b@x.org"]
+
+
+def test_load_viewers_file_all_blank_or_comment_returns_empty(tmp_path) -> None:
+    mod = _load_script()
+    viewers_file = tmp_path / "viewers.txt"
+    viewers_file.write_text("\n# nothing here\n   \n", encoding="utf-8")
+    assert mod.load_viewers(None, viewers_file) == []
+
+
+# --- run_for_viewer: error handling (Task 1) ------------------------------
+
+
+def _connection(**overrides) -> object:
+    mod = sys.modules[_MODULE_NAME]
+    defaults = {
+        "host": "127.0.0.1",
+        "port": 15432,
+        "dbname": "cube",
+        "password": "pw",
+        "query": "SELECT 1",
+    }
+    defaults.update(overrides)
+    return mod.CubeConnection(**defaults)
+
+
+def test_run_for_viewer_empty_error_message_falls_back_to_placeholder(
+    monkeypatch,
+) -> None:
+    mod = _load_script()
+
+    def _raise_empty(*_args, **_kwargs):
+        raise mod.psycopg.OperationalError("")
+
+    monkeypatch.setattr(mod.psycopg, "connect", _raise_empty)
+    rows, error = mod.run_for_viewer("a@x.org", _connection())
+    assert rows == []
+    assert error == "unknown error"
+
+
+def test_run_for_viewer_multiline_error_returns_first_line_only(monkeypatch) -> None:
+    mod = _load_script()
+
+    def _raise_multiline(*_args, **_kwargs):
+        raise mod.psycopg.OperationalError("connection refused\ndetail: nope\n")
+
+    monkeypatch.setattr(mod.psycopg, "connect", _raise_multiline)
+    rows, error = mod.run_for_viewer("a@x.org", _connection())
+    assert rows == []
+    assert error == "connection refused"
+
+
+# --- main(): exit status (Task 2) -----------------------------------------
+#
+# run_for_viewer is monkeypatched per-viewer so no socket is ever opened;
+# everything else (arg parsing, aggregation, diagnostics, exit code) runs for
+# real, so these assert genuine main() return values, not mock call counts.
+
+
+def test_main_missing_password_returns_nonzero_without_connecting(monkeypatch) -> None:
+    mod = _load_script()
+    monkeypatch.delenv("CUBEJS_SQL_PASSWORD", raising=False)
+    monkeypatch.setattr(sys, "argv", ["cube_rls_matrix.py", "--viewers", "a@x.org"])
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("run_for_viewer should not be called without a password")
+
+    monkeypatch.setattr(mod, "run_for_viewer", _fail_if_called)
+    assert mod.main() == 1
+
+
+def test_main_success_path_returns_zero(monkeypatch) -> None:
+    mod = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cube_rls_matrix.py", "--viewers", "a@x.org", "b@x.org", "--password", "pw"],
+    )
+    responses = {
+        "a@x.org": ([("Newark", 10)], None),
+        "b@x.org": ([("Camden", 5)], None),
+    }
+    monkeypatch.setattr(
+        mod, "run_for_viewer", lambda viewer, connection: responses[viewer]
+    )
+    assert mod.main() == 0
+
+
+def test_main_all_viewers_zero_rows_returns_nonzero(monkeypatch, capsys) -> None:
+    mod = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cube_rls_matrix.py", "--viewers", "a@x.org", "b@x.org", "--password", "pw"],
+    )
+    monkeypatch.setattr(mod, "run_for_viewer", lambda viewer, connection: ([], None))
+    assert mod.main() == 1
+    assert "EVERY viewer returned 0 rows" in capsys.readouterr().out
+
+
+def test_main_single_viewer_zero_rows_returns_nonzero(monkeypatch) -> None:
+    """The all-zero gate must also fire with just one viewer (empty == len(viewers))."""
+    mod = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cube_rls_matrix.py", "--viewers", "a@x.org", "--password", "pw"],
+    )
+    monkeypatch.setattr(mod, "run_for_viewer", lambda viewer, connection: ([], None))
+    assert mod.main() == 1
+
+
+def test_main_connection_failures_still_return_nonzero(monkeypatch) -> None:
+    """Unchanged behavior: a hard connection failure fails the gate too."""
+    mod = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cube_rls_matrix.py", "--viewers", "a@x.org", "b@x.org", "--password", "pw"],
+    )
+
+    def _fake_run(viewer, _connection):
+        if viewer == "a@x.org":
+            return [], "connection refused"
+        return [("Newark", 10)], None
+
+    monkeypatch.setattr(mod, "run_for_viewer", _fake_run)
+    assert mod.main() == 1
+
+
+def test_main_identical_fingerprints_warns_but_stays_zero_exit(
+    monkeypatch, capsys
+) -> None:
+    """More than one viewer with identical rows is flagged as suspicious but is not
+    automatically wrong (two viewers can legitimately share one scope), so the
+    ordinary success exit status is preserved - only the diagnostic changes."""
+    mod = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["cube_rls_matrix.py", "--viewers", "a@x.org", "b@x.org", "--password", "pw"],
+    )
+    same_rows = [("Newark", 10)]
+    monkeypatch.setattr(
+        mod, "run_for_viewer", lambda viewer, connection: (same_rows, None)
+    )
+    assert mod.main() == 0
+    assert "EVERY viewer returned IDENTICAL rows" in capsys.readouterr().out


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged into `cristinabaldor/feat/claude-cube-internal-emulation`, this pull
request clears that branch's merge conflict with `main` and applies the code
review follow-ups from #4614 that could be verified without a Cube Cloud
deployment.

Stacked on #4614 — merge that one after this. Base is not `main`, so
`claude-review` does not fire here; dbt Cloud CI is not base-gated and still
runs (no dbt models changed either way).

Every finding below was verified against the code before being acted on, not
taken from the review report on faith.

### The merge conflict

`main` bumped `@cubejs-backend/{server,bigquery-driver}` to `^1.7.15` in
`f0626a333`; #4614 bumped the same two to `^1.7.14` in `5186ec27f`. That is the
whole conflict — `@google-cloud/bigquery` is `^7.9.4` on both sides.

Resolved by taking main's blobs for `src/cube/package.json` and
`src/cube/package-lock.json` wholesale, so both files are byte-identical to main
and cannot re-conflict. `npm install` in `src/cube` then left the lockfile
unchanged, confirming main's pair is coherent, and resolved Cube 1.7.15 locally.

This also retires #4605's sequencing objection: that issue asked for the Cube
bump NOT to ride inside #4526's PR, because it would make a behavior change
impossible to attribute. Since main already carries 1.7.15, the right resolution
drops #4614's bump rather than merging it.

### Security fixes

**A Cube Cloud context with no `username` no longer falls through.**
`contextToGroups` gated on `securityContext?.cubeCloud?.username`. A context
carrying `cubeCloud` but no `username` skipped the enrichment block and fell
through to `return securityContext?.groups ?? []` — honoring a pasted `groups`
array, which is the exact bypass the overwrite exists to close. It now gates on
the `cubeCloud` key. The block body needed no other change: the surface adapter
yields a null caller, `resolveEmulationTarget` fails closed to a null target,
and `resolveAccess(null)` returns the empty default-deny context.

**A non-string emulation target is now a decision, not a 500.** On Cube Cloud
the target is a pasted JSON value, so `{"email": {"a": 1}}` was truthy with no
`.toLowerCase`, and `resolveEmulationTarget` threw a `TypeError` out of
`contextToGroups`. Both identities now coerce to string-or-null, which is the
fail-closed reading: a non-string target means no emulation, a non-string caller
means no caller.

**One 403 message is withheld.** `jwtRejectionReason` interpolated raw
`err.message`, and jsonwebtoken reports an unset verifying secret as
`secret or public key must be provided` — telling an unauthenticated caller that
this deployment has no signing secret at all. That one message is now replaced;
every other jsonwebtoken message still echoes verbatim, because that
diagnosability is the point of #4614's change and must not regress.

### A prose invariant is now a test

`src/cube/CLAUDE.md` states that every `securityContext` field a policy
interpolates must be returned by `access.buildSecurityContext` — otherwise
`Object.assign` cannot neutralize a pasted value for that field and the Cube
Cloud paste vector reopens for it alone, silently and only on that surface.

`cube.test.js` now walks `src/cube/model/` for `.yml` files, extracts every
distinct `securityContext.{field}` token, and asserts each is a key of
`buildSecurityContext`. The set is derived from the files, never hardcoded, with
a floor assertion so a broken regex cannot make the test vacuously pass. It
fails the moment someone adds a `row_level` filter reading a field that
`buildSecurityContext` does not return — which is precisely the regression prose
cannot prevent. #4614 found this same gap by reviewing an unmerged sibling
branch that adds `allowed_student_abbreviations`.

Today's derived set is the six fields the model interpolates:
`allowed_abbreviations`, `allowed_department_groups`, `job_function_level`,
`location_abbreviation`, `region_key`, `reportee_staff_keys`.

### The identity-read fallback now leaves a breadcrumb

`resolveAccess` falls back to ADC when the BigQuery driver credentials variable
is unset. That is correct for local dev, but on a deployment it silently
switches identity reads to the ambient Cube Cloud host principal, which lacks
`bigquery.jobs.create` and default-denies every viewer for a reason that looks
nothing like the cause (#4466). It now emits one
`cube_bq_credentials_fallback` line per process.

`NODE_ENV` is deliberately not the discriminator, and an earlier revision of
this branch got that wrong. The documented local RLS sign-off runs with
`NODE_ENV=production` set locally, so refusing the fallback under production
would fail-close the exact workflow the fallback exists for. There is no
reliable Cube Cloud marker to gate on, so this warns rather than throws.

### The sign-off tool is now tested

`scripts/cube_rls_matrix.py` is the designated instrument for signing off a
viewer's scope before a grant, so a bug in it produces a false sign-off
silently — and it shipped with no test, against seven existing script tests and
a documented recipe in `scripts/CLAUDE.md`. `tests/test_cube_rls_matrix.py`
adds 12.

Three fixes alongside it:

- An exception whose string form is empty raised `IndexError` from inside the
  error handler.
- "Every viewer returned 0 rows" printed a warning and exited 0. The tool's own
  docstring says that state usually means the identity read failed, so it is
  never a legitimate pass; it now exits non-zero. The "all viewers returned
  identical fingerprints" case deliberately stays at the ordinary exit status —
  two genuinely network-scoped viewers should match, so failing on it would be a
  false alarm. The diagnostic still prints.
- `argparse.Namespace` threaded into helpers is replaced with a frozen
  `CubeConnection` dataclass, so the connection settings are type-checked.

### Documentation accuracy

- Three `psycopg2` references pointed readers at a library the shipped tool does
  not use. Rewritten to `psycopg` v3 — a real API change, not a rename, so the
  two heredocs in `docs/guides/cube.md` were rebuilt in the context-manager form
  the tool itself uses, keeping `prepare_threshold=None` and the reason for it.
- `docs/guides/cube.md` attributed the `act_as` claim to "REST / MCP". The
  shipped MCP server's `_mint_token` takes one argument and hardcodes its
  claims, so it has no `act_as` path at all. Corrected to REST with a
  hand-minted token, with the MCP limitation stated explicitly.
- `src/cube/CLAUDE.md` described the old branch condition. Updated, including
  that a missing `username` is a deny rather than a pass-through.

## Deliberately NOT in this PR

One review finding needs a Cube Cloud branch deployment to fix and is left for
#4614's author. A second was open when this PR was drafted and has since been
tested closed.

**Tested closed: a pasted Security Context cannot override the `cubeCloud`
block.** The entire admin gate rests on Cube Cloud's injected
`cubeCloud.username` winning over the merged paste, and nothing in #4614's spec,
plan, or tests recorded anyone trying it. Tested on a Dev Mode deployment of
this branch by a network-scoped caller: `student_attendance_view` grouped by
region returned byte-identical counts across all four regions both with an empty
Security Context and with a school-scoped viewer's email pasted as
`{"cubeCloud": {"username": "..."}}`. The paste could not steer identity.

A positive control then confirmed that result is a genuine negative rather than
an inert one. Pasting the same viewer's email as a top-level `email` — the key
that IS supposed to be honored — dropped the same query to that viewer's own
school only, a strict subset of its region's total. So the surface demonstrably
reads a pasted context and routes it through `contextToGroups`; "no change" when
the paste targeted `cubeCloud.username` therefore means the injected block won,
not that the paste was ignored. The emulation also resolved the target's real
school-level scope rather than a region approximation, which independently
exercises #4614's `act_as` equivalent on the Cube Cloud surface.

A third paste then closed the question outright, attacking the gate and the
overwrite at once. Pasting
`{"cubeCloud": null, "groups": ["student-region"], "region_key": "<a region>"}`
returned the caller's own four-region scope, not the single pasted region — so
`cubeCloud: null` did NOT survive the merge (the gate still fired) and the pasted
`groups` and `region_key` were both overwritten. Cube Cloud therefore applies its
own block AFTER the merged paste, `{...paste, cubeCloud: realBlock}`, which makes
the pasted value irrelevant rather than merely non-truthy.

All three results are recorded in `cube.js` and `src/cube/CLAUDE.md`, labelled
empirical rather than guaranteed: Cube Cloud's merge is closed-source and the OSS
tree contains no `cubeCloud` reference, so it wants re-confirming after a Cube
Cloud upgrade.

**Still open: the overwrite runs only on an RBAC-cache miss.** Cube's
   `CompilerApi.getApplicablePolicies` computes
   `cacheKey = md5(JSON.stringify(context))` before calling the groups hook, and
   calls the hook only inside `if (!cache.has(cacheKey))` — verified in the
   installed 1.7.15 source. On a cache hit the overwrite never runs and
   `row_level` interpolates the pasted values, while policy selection still
   comes from the caller's real groups. It is a residual gap rather than a
   regression (before #4614, pasted groups were honored on every request), and
   exploiting it needs two requests inside the 5-minute TTL sharing a
   client-supplied request id plus a byte-identical context, and a caller who
   already legitimately holds a group on the view. The proper fix moves the
   overwrite to the `extendContext` seam, which runs before the context object
   exists — but whether `extendContext` fires on the Cube Cloud surface cannot
   be confirmed locally.

   **Filed as #4716**, with the source citations, the four preconditions an
   exploit needs, the `extendContext` fix, and the trap that `extensions` is
   spread at the context's top level rather than into `securityContext` (so
   returning `resolveAccess`'s output from that hook would silently do nothing).

## Review of this PR

Reviewed by a dispatched reviewer, since a non-`main` base means `claude-review`
never fires here. No Critical issues. It independently reproduced the red-green
cycle — checked out the base commit, added this branch's two test files, and got
7 targeted failures — so the new tests demonstrably catch the defects they name.

Its two actionable findings are fixed in `7598f58dc`:

- **The invariant test had a blind spot for the most dangerous form of the
  violation it exists to catch.** Cube's `CubePropContextTranspiler` declares
  `userAttributes` / `user_attributes` / `groups` as shorthand identifiers and
  rewrites a bare `userAttributes.foo` inside an `access_policy` into
  `securityContext.cubeCloud.userAttributes.foo`. That is the paste-mirrored
  namespace, which the top-level-only `Object.assign` never touches — so a
  policy written with the shorthand would read an attacker-pasted value and the
  test would still pass, because no new `securityContext.{field}` token appears.
  The test now also asserts that no interpolation uses a shorthand identifier
  and none reads `securityContext.cubeCloud`. Requiring an interpolation brace
  before the identifier keeps the check off the legitimate `group:` / `groups:`
  policy YAML keys; verified against all three spellings and against those keys.
  No current policy commits either violation.
- **`cube_rls_matrix.py` exited non-zero when a SINGLE viewer returned 0 rows**,
  which is a documented legitimate pass — the script's own usage block shows a
  single-viewer invocation and the guide documents a one-viewer default-deny
  check whose expected result is zero rows. The gate and its multi-viewer
  diagnostic now require 2+ viewers.

Its Important #1 asked whether a paste can replace the `cubeCloud` key, and could
not answer it — Cube Cloud's merge is closed-source and the OSS tree has no
`cubeCloud` reference. It is now answered empirically: no, including for a falsy
paste. See the three tests above. The reviewer could not have known the first of
those had already run, because that result was deliberately withheld from it so
its trace would not be biased.

Minor items left deliberately: the exact-list assertion beside the derived one
(kept as a human-reviewed sanity check, now with an explanatory message), and
emitting the ADC breadcrumb at module load instead of first cache miss (folded
into #4716).

Also unverified: the local example configuration file under `src/cube/` is
unreadable to Claude by hook, so the #4614 claims that `CUBE_GROUP_MAP` was
removed from it and that its values are documented verbatim in the guide still
need a human eyeball.

## AI Assistance

Written with Claude Code, dispatched from a review of #4614. Every finding was
re-verified against the code before being acted on: the six interpolated
`securityContext` keys came from a grep of the model YAML, the RBAC-cache
behavior from the installed Cube source, and the MCP limitation from
`_mint_token` itself. One review claim was wrong and is noted above — the report
said `docs/guides/cube.md` had already dropped its `psycopg2` heredocs, and it
had not.

One Claude misstep is in the history and worth a reviewer's attention: the
identity-read fallback fix was first written to refuse the fallback under
`NODE_ENV=production`, which would have broken the documented local sign-off
workflow. Caught before commit and replaced with the warning described above.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] `claude-review` does not run on a non-`main` base, so there is no bot
      comment to review here.

### Dagster

N/A — no Dagster changes.

### dbt

N/A — no dbt model changes.

### Docs

N/A for the automations catalog — no schedule or sensor changes.
`docs/guides/cube.md` and `src/cube/CLAUDE.md` are updated here.

## Verification

- `npm test` in `src/cube`: **87 pass, 0 fail** (77 before; 10 added, 1 stale
  assertion updated).
- `pytest tests/test_cube_rls_matrix.py`: **12 passed**.
- `trunk check --force` on every changed file.
- Merge-conflict resolution confirmed by `git merge-tree` against `origin/main`.

The load-bearing tests are the negatives: a username-less Cube Cloud context is
neutralized rather than passed through, a non-string pasted target does not
throw, the withheld 403 message does not leak while every other one still
echoes, and the fallback notice fires once rather than per request.

One existing test was updated rather than added to.
`"a Cube Cloud context with no username stays default-deny"` asserted
`!("groups" in securityContext)`, which encoded the old pass-through shape. Its
security-relevant assertion still passes; the shape check was replaced with the
stronger positive one, asserting the default-deny values are actually stamped
onto the context.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — no dbt model changes.
- [ ] **Dagster Cloud** — not triggered (no Dagster paths changed).

Refs #4614
Refs #4526
Refs #4605
