### PR TITLE
fix(dagster): add delayed retry policy to kipptaf google_sheet dbt assets

### DIFF
--- a/src/teamster/code_locations/kipptaf/dbt/assets.py
+++ b/src/teamster/code_locations/kipptaf/dbt/assets.py
@@ -1,6 +1,6 @@
 import json
 
-from dagster import AssetSpec
+from dagster import AssetSpec, Backoff, Jitter, RetryPolicy
 
 from teamster.code_locations.kipptaf import CODE_LOCATION, DBT_PROJECT, LOCAL_TIMEZONE
 from teamster.code_locations.kipptaf.adp.payroll.assets import (
@@ -58,6 +58,17 @@ google_sheet_dbt_assets = build_dbt_assets(
             }
         }
     },
+    # BigQuery reads of a Google Sheets external table intermittently fail with
+    # `Resources exceeded during query execution: Google Sheets service
+    # overloaded for spreadsheet id: ...`. dbt-bigquery cannot retry it: reason
+    # `resourcesExceeded` maps to HTTP 400 and is in neither BigQuery's
+    # `_RETRYABLE_REASONS` nor its `job_retry_reasons`, so `job_retries` in
+    # profiles.yml never applies. The delay is the point -- the sheets asset
+    # sensor fires because someone just edited the spreadsheet, so an immediate
+    # retry re-reads it inside the same overload window.
+    retry_policy=RetryPolicy(
+        max_retries=3, delay=120, backoff=Backoff.EXPONENTIAL, jitter=Jitter.PLUS_MINUS
+    ),
 )
 
 asset_specs = [

--- a/src/teamster/libraries/dbt/assets.py
+++ b/src/teamster/libraries/dbt/assets.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from dagster import AssetExecutionContext
+from dagster import AssetExecutionContext, RetryPolicy
 from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
 
 
@@ -13,6 +13,7 @@ def build_dbt_assets(
     partitions_def=None,
     name: str | None = None,
     op_tags: dict[str, object] | None = None,
+    retry_policy: RetryPolicy | None = None,
 ):
     sources = manifest["sources"]
 
@@ -24,6 +25,7 @@ def build_dbt_assets(
         partitions_def=partitions_def,
         dagster_dbt_translator=dagster_dbt_translator,
         op_tags=op_tags,
+        retry_policy=retry_policy,
     )
     def _assets(context: AssetExecutionContext, dbt_cli: DbtCliResource):
         # get upstream nodes for asset selection

--- a/tests/test_dbt_assets_retry_policy.py
+++ b/tests/test_dbt_assets_retry_policy.py
@@ -1,0 +1,36 @@
+from dagster import Backoff, Jitter
+
+from teamster.code_locations.kipptaf.dbt.assets import (
+    core_dbt_assets,
+    google_sheet_dbt_assets,
+)
+
+
+def test_google_sheet_dbt_assets_has_delayed_retry_policy():
+    """Google Sheets external tables intermittently fail the whole dbt build with
+    BigQuery reason `resourcesExceeded` ("Google Sheets service overloaded for
+    spreadsheet id: ..."). dbt-bigquery cannot retry it -- `resourcesExceeded`
+    maps to HTTP 400 and is in neither `_RETRYABLE_REASONS` nor
+    `job_retry_reasons` -- so the step needs its own retry.
+    """
+    retry_policy = google_sheet_dbt_assets.op.retry_policy
+
+    assert retry_policy is not None
+    assert retry_policy.max_retries >= 3
+
+    # The delay is the whole point. Dagster's run-level auto-retry already fires
+    # on this failure but has no delay, so it re-reads the spreadsheet inside the
+    # same overload window and fails identically.
+    assert retry_policy.delay is not None
+    assert retry_policy.delay >= 60
+
+    assert retry_policy.backoff == Backoff.EXPONENTIAL
+    assert retry_policy.jitter == Jitter.PLUS_MINUS
+
+
+def test_core_dbt_assets_has_no_retry_policy():
+    """The retry is scoped to the Google Sheets step. `core_dbt_assets` excludes
+    `tag:google_sheet`, so it never reads a spreadsheet and a blanket retry there
+    would re-run the whole warehouse build on any failure.
+    """
+    assert core_dbt_assets.op.retry_policy is None


### PR DESCRIPTION
# Pull Request

Closes #4711

## Summary & Motivation

When merged, this pull request will make the `kipptaf__dbt_assets__google_sheets`
step retry itself, with a delay, when BigQuery fails a Google Sheets external
table read as transiently overloaded.

Triggering failure — run
[612a1092](https://kipptaf.dagster.cloud/prod/runs/612a1092-23c9-48f2-be80-177431c40ee2):

```text
Database Error in model stg_google_sheets__reporting__terms
Resources exceeded during query execution: Google Sheets service overloaded for spreadsheet id: 1azcq9...
```

Three retry layers exist and none could catch it:

| Layer                            | Configured                          | Why it missed                                                                                                                                                                                                                                       |
| -------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| dbt-bigquery `job_retries` | `3` in `src/dbt/kipptaf/profiles.yml` | BigQuery reason `resourcesExceeded` maps to HTTP 400 and is in neither `_RETRYABLE_REASONS` (`rateLimitExceeded`, `backendError`, `internalError`, `badGateway`) nor `job_retry_reasons` (`jobBackendError`, `jobInternalError`, `jobRateLimitExceeded`). `_job_should_retry` returns False, so dbt fails the model on attempt 1. |
| Dagster run-level auto-retry     | max 1, no delay                     | It fired (`retry_number: 1`), but the retry run was created 9 seconds after the parent failed and landed in the same overload window. Failed identically.                                                                                            |
| Op-level `RetryPolicy`     | none anywhere in `src/teamster/`     | This is the gap this PR fills.                                                                                                                                                                                                                       |

The delay is the load-bearing part. `kipptaf__google__sheets__asset_sensor`
materializes the asset *because* the spreadsheet's `modifiedTime` just advanced,
so BigQuery reads it while an editor is live in the document — the worst moment
to read it. A 2-minute first delay moves the read out of that window.

Ruled out as causes:

- The three other sources on spreadsheet `1azcq9...`
  (`gradebook_expectations`, `gradebook_flags`, `graduation_path_combos`) are all
  `enabled: false`, so nothing in-run competed for that spreadsheet.
- The failing `dbt build` selected only
  `stg_google_sheets__reporting__terms`, so dbt thread concurrency was not a
  factor either.

Changes:

- `build_dbt_assets()` takes an optional `retry_policy` and forwards it to
  `@dbt_assets`, which already accepts one.
- `google_sheet_dbt_assets` sets
  `RetryPolicy(max_retries=3, delay=120, backoff=EXPONENTIAL, jitter=PLUS_MINUS)`.
  Scoped to that group only — `core_dbt_assets` excludes `tag:google_sheet` and
  never reads a spreadsheet, so a blanket retry there would re-run the whole
  warehouse build on any failure.
- `tests/test_dbt_assets_retry_policy.py` asserts the policy is attached with a
  non-zero delay, and asserts `core_dbt_assets` still has none.

Tradeoffs worth naming:

- A step retry re-runs `stage_external_sources` plus every selected sheet model,
  not just the failed one. Sheet models are seconds-cheap, so this is fine.
- Worst-case retry budget within one run is roughly 120 + 240 + 480 seconds of
  delay plus four query attempts, about 27 minutes. No `dagster/max_runtime` tag
  applies to `__ASSET_JOB`, so nothing truncates it. If all three op retries are
  exhausted, the run-level auto-retry then starts a **new** run where the op's
  attempt counter resets and the same 120/240/480 sequence runs again — so
  on-call should expect up to roughly **55 minutes** before the asset stops
  retrying and the failure is final.
- Not in scope: re-architecting the 88 Google Sheets external sources into
  Dagster-ingested native BigQuery tables. This failure is rare — the triggering
  incident and its own auto-retry are the only
  `kipptaf__automation_condition_sensor` failures in the preceding four days — so
  a retry is the proportionate fix.

## AI Assistance

Claude Code performed the root-cause investigation (Dagster run logs, tracing
the retry predicates through the installed `google-cloud-bigquery` and
`dbt-bigquery` sources), wrote the failing test first, and implemented the fix.
Human-directed: the question "is there a way we could handle these transient
errors?", and the decision to scope the fix to a retry rather than re-architect
sheet ingestion.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location — 4 passed (`kipptaf`, `kippnewark`, `kippcamden`,
      `kipppaterson`). `kippmiami` deselected: no local dbt manifest, and it
      fails at module load in a codespace on the Focus dlt credential spec
      regardless of this change.
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager — not applicable, no new
      integration.

### dbt

No dbt changes. `src/dbt/kipptaf/profiles.yml` is referenced in the analysis but
not modified.

### Docs

No schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — `trunk check --force` clean locally on all three changed files.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — this touches `libraries/dbt/`, a shared library, so all
      five code locations redeploy.
