### PR TITLE
fix(tableau): add morning extract refresh to Attendance Dashboard

### DIFF
--- a/src/dbt/kipptaf/models/exposures/tableau.yml
+++ b/src/dbt/kipptaf/models/exposures/tableau.yml
@@ -310,7 +310,9 @@ exposures:
           asset:
             metadata:
               id: 87c13e78-a912-40a4-95dd-33248fc1cbd3
-              cron_schedule: 0 15 * * *
+              cron_schedule:
+                - 0 6 * * *
+                - 0 15 * * *
   - name: literacy_dashboard
     label: Literacy Dashboard
     type: dashboard


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will add an 06:00 ET extract refresh to the
Attendance Dashboard, so the prior day's attendance-call data is published ahead
of the morning review instead of at 15:08.

Closes #4717

### Why

The Attendance Dashboard publishes once daily at 15:08 ET. Yesterday's data is
already complete in the warehouse by 00:09 ET, but users cannot see it until that
afternoon's refresh — so from midnight until roughly 3:10pm the dashboard serves
the previous afternoon's snapshot. Reported by Newark ops via Zendesk ticket
458782.

Verified cadences (all times ET):

| Component | Source | Refresh |
| --- | --- | --- |
| Successful calls (numerator) | DeansList comm_log | 2x/day; pulls at 00:00 and 14:00, `stg_deanslist__comm_log` rebuilds at 00:09 and 14:08 |
| Absences (denominator) | PowerSchool attendance | every 15 min (intraday sensor) |
| Dashboard publish | Tableau extract | 1x/day at 15:08 |

The workbook refresh asset declares `deps` but no `automation_condition`, so it
fires only on its cron and never when upstream data lands.

### AI assistance

Claude investigated the ticket, verified the cadences against Dagster
materialization history and BigQuery, and authored this change. Scope, direction,
and the decision to fix via cron rather than `automation_condition` were
human-directed.

### Rollback

Revert to a single `cron_schedule: 0 15 * * *`. No model, schema, or SQL changes,
and no data is rewritten.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR

### Dagster

- [x] No Dagster code changed. The schedule is generated from this exposure's
      metadata by `code_locations/kipptaf/tableau/schedules.py`, which already
      passes `cron_schedule` straight through to `ScheduleDefinition`
- [ ] **`docs/reference/automations.md` still needs regeneration**
      (`uv run scripts/gen-automations-doc.py`). The row for
      `kipptaf__tableau__attendance_dashboard_extract_refresh_schedule` should
      read `At 06:00 AM; At 03:00 PM`. Deliberately not done in this PR: per
      `docs/CLAUDE.md` the generator silently SKIPS code locations that fail to
      import, which is exactly what happens in a Codespace (missing dbt
      manifests, unset dlt credentials), so running it here would drop locations
      from the catalog. Needs a full environment.

### dbt

- [x] Exposure updated — this is an exposure-only change
- [x] No new models, and no contracted columns renamed or removed
- [x] No external sources added or modified

## CI checks

- [ ] **Trunk** — `trunk check --force` passes locally on the changed file
- [ ] **dbt Cloud** — expected to pass trivially. An exposure-only change selects
      no models under `state:modified+`, so a green check here is **not**
      validation of this change.
- [ ] **Dagster Cloud** — not triggered. The `deploy-prod-*.yaml` `pull_request`
      paths exclude `src/dbt/**`.

## Verification notes

The multi-value `cron_schedule` pattern is already in production and proven:
`kipptaf__tableau__schoolmint_grow_dashboard_extract_refresh_schedule` carries
three values, and its tick history shows successful ticks at 06:00, 14:30 and
16:15 ET.

This schedule is currently STOPPED for the summer dashboard pause, so the change
lands inert and takes effect whenever it is re-enabled for the school year.
Please confirm re-enablement before school opens.
