### PR TITLE
feat(dbt): identify Grow teachers by job_function and exclude Paterson

### DIFF
--- a/src/dbt/kipptaf/models/extracts/schoolmint/properties/rpt_schoolmint_grow__users.yml
+++ b/src/dbt/kipptaf/models/extracts/schoolmint/properties/rpt_schoolmint_grow__users.yml
@@ -4,10 +4,13 @@ models:
       One row per Grow user, comparing the desired source-of-truth state (from
       ADP / staff roster) against the current destination state in SchoolMint
       Grow. Drives `grow_user_sync` create / update / archive / restore
-      decisions via `surrogate_key_source` vs `surrogate_key_destination`. Users
-      matching both the Coach predicate (instructional manager) and the Teacher
-      predicate (job title contains "Teacher" or "Learning") receive both roles
-      in `role_names` / `role_ids`. Admin classifications take precedence over
+      decisions via `surrogate_key_source` vs `surrogate_key_destination`.
+      Excludes Paterson staff, who do not use Grow. The Teacher predicate is ADP
+      `job_function` of "Teacher" or "Teacher in Residence", falling back to a
+      job title containing "Teacher" or "Learning" while `job_function` is null
+      on a new work assignment. Users matching both the Coach predicate
+      (instructional manager) and the Teacher predicate receive both roles in
+      `role_names` / `role_ids`. Admin classifications take precedence over
       Coach / Teacher.
     data_tests:
       - dbt_utils.expression_is_true:

--- a/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
+++ b/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
@@ -1,16 +1,27 @@
 with
+    staff as (
+        select
+            *,
+
+            /*
+                job_function (ADP codes TEACH / TIR) is not set on newly created
+                work assignments, so fall back to the job title until it fills in
+            */
+            coalesce(
+                job_function in ('Teacher', 'Teacher in Residence'),
+                job_title like '%Teacher%' or job_title like '%Learning%'
+            ) as is_teacher,
+        from {{ ref("int_people__staff_roster") }}
+        where home_work_location_dagster_code_location != 'kipppaterson'
+    ),
+
     instructional_managers as (
         select distinct sr.reports_to_employee_number,
-        from {{ ref("int_people__staff_roster") }} as sr
-        join
-            {{ ref("int_people__staff_roster") }} as srm
-            on sr.reports_to_employee_number = srm.employee_number
+        from staff as sr
+        join staff as srm on sr.reports_to_employee_number = srm.employee_number
         where
             sr.assignment_status in ('Active', 'Leave')
-            and (
-                contains_substr(sr.job_title, 'Teacher')
-                or contains_substr(sr.job_title, 'Learning Specialist')
-            )
+            and sr.is_teacher
             or srm.home_department_name
             in ('School Support', 'Student Support', 'KIPP Forward')
     ),
@@ -87,18 +98,13 @@ with
                                     'Coach',
                                     null
                                 ),
-                                if(
-                                    sr.job_title like '%Teacher%'
-                                    or sr.job_title like '%Learning%',
-                                    'Teacher',
-                                    null
-                                )
+                                if(sr.is_teacher, 'Teacher', null)
                             ]
                         ) as rn
                     where rn is not null
                 )
             ) as role_names,
-        from {{ ref("int_people__staff_roster") }} as sr
+        from staff as sr
         where
             sr.user_principal_name is not null
             and sr.home_department_name != 'Data'


### PR DESCRIPTION
## Summary and Motivation

When merged, this pull request will change how `rpt_schoolmint_grow__users` identifies teachers, and exclude Paterson staff from the SchoolMint Grow user feed.

- **Teacher role** now comes from ADP `job_function` (`Teacher` / `Teacher in Residence`) instead of a job-title pattern. `job_function` is not set on newly created work assignments, so the old title pattern (`%Teacher%` / `%Learning%`) remains as a fallback while `job_function` is null. Same shape as the existing predicate in `rpt_tableau__schoolmint_grow_observation_details`.
- **Coach role** uses the same predicate, so the two definitions stay aligned. Previously the `instructional_managers` CTE matched reports by title (`Teacher` or `Learning Specialist`).
- **Paterson** staff are filtered out in a new `staff` CTE, which is also where `is_teacher` is derived once for both predicates.

AI assistance: Claude Code wrote the SQL and ran the validation below. The teacher rule, the decision to apply it to the Coach predicate too, and the Paterson exclusion were human-directed.

### Validation

Compared the recompiled model against the deployed prod view (975 users), joined on `user_internal_id`:

| Change | Users |
| --- | --- |
| Lose the Teacher role | 12 |
| Lose the Coach role | 1 |
| Gain a role | 0 |
| Drop out of the feed entirely | 13 |

All 13 have `job_function` of `School-based Non-Instructional Staff` — 7 Teacher Aide, 3 Learning Disabilities Teacher Consultant, 2 Substitute Teacher, 1 School Psychologist. Excluding them is the intent of the change.

**Worth a decision before merge:** a user with no role drops out of the extract (the inner join to `people_roles` removes them), so `grow_user_sync` will neither update nor archive them — they stay in Grow as-is. If those 13 should be archived rather than left in place, that is a separate change to the role-fallthrough logic.

The Paterson filter is a no-op against today's data: no Paterson school name matches `stg_schoolmint_grow__schools`, so the existing inner join already excluded every Paterson employee. The filter makes the exclusion explicit and holds if Paterson schools are ever added to Grow.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties file updated — the model description now documents the `job_function` rule, the null fallback, and the Paterson exclusion
- [x] No column adds, renames, or removals, so no contract or exposure impact
- [x] No external sources touched, so no `stage_external_sources` run needed
- [x] `dbt compile --target prod` succeeds; `trunk check --force` clean on both changed files

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
