### PR TITLE
fix(dagster): load dlt replace tables as parquet so 0-row extracts succeed

### DIFF
--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -122,6 +122,22 @@ changes on existing tables.
   narrowed source to
   `DagsterDltResource.run(dlt_source=source.with_resources(*subset))` (its
   `is_subset` filter intersects with `selected_asset_keys`).
+- **`autodetect_schema=True` + `replace` requires
+  `loader_file_format="parquet"`** (passed to `dlt.run()` in the focus and
+  illuminate factories). `Extract._handle_empty_tables` writes an EMPTY file for
+  a `replace` table that received no items this run so its root still gets
+  truncated — but only once the table has **seen data** before
+  (`schema.data_tables(seen_data_only=True)`, restored from the destination). It
+  comes from the object extractor, so the default is empty `jsonl.gz`, and
+  BigQuery schema autodetection rejects that with
+  `400 Schema has no fields. Table: {table}_{uuid}_source` (dlt calls
+  `invalidQuery` transient, so it burns 5 retries first). An empty parquet
+  carries the dlt schema's columns, so autodetect resolves and the truncate load
+  succeeds. Forcing parquet changes nothing else — the pyarrow backend already
+  loads data files as parquet. Symptom to recognize: a table that loaded fine
+  for days starts failing the day its source goes to 0 rows; the destination
+  table is already correctly truncated (dlt truncates autodetect tables before
+  the load job), so there is no data to repair.
 - `replace` never changes an existing table's column **mode** (not just type):
   an all-`NULLABLE` load into a table whose column is `REQUIRED` fails with BQ
   400 "changed mode from REQUIRED to NULLABLE". Drop the table so the pipeline

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -61,11 +61,22 @@ columns.
 
 ## Empty source tables
 
-The PyArrow backend writes NO BigQuery table for a 0-row source extract (the
-asset still SUCCEEDS — no `rows_loaded`, `jobs: []`). A configured Focus table
-absent from `dagster_<district>_dlt_focus` is therefore **empty in the source**
-(Focus is mid-rollout in Miami), not an extraction failure — confirm via the
-asset materialization metadata before investigating.
+A 0-row source extract behaves differently before and after the table's first
+successful load, because dlt's empty-table handling keys off
+`seen_data_only=True`:
+
+- **Never loaded data**: the PyArrow backend writes NO BigQuery table and no
+  load jobs (the asset SUCCEEDS — no `rows_loaded`, `jobs: []`). A configured
+  Focus table absent from `dagster_<district>_dlt_focus` is therefore **empty in
+  the source** (Focus is mid-rollout in Miami), not an extraction failure —
+  confirm via the asset materialization metadata before investigating.
+- **Has loaded data before**: dlt emits an empty file so the `replace` root is
+  truncated. That file must be parquet or BigQuery autodetection fails the load
+  — hence `loader_file_format="parquet"` in `assets.py`. See _`replace`
+  write-disposition_ in `../CLAUDE.md` (#4733).
+
+So a Focus asset going quiet is not evidence the table is new, and a table
+emptying out is not a data loss — the truncate is the intended outcome.
 
 ## Testing Constraints
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -102,10 +102,9 @@ def build_focus_dlt_assets(
         op_tags=op_tags,
     )
     def _assets(context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
-        # loader_file_format="parquet": once a table has loaded data, a later 0-row
-        # extract still gets an empty file so `replace` truncates it. BigQuery
-        # schema autodetection rejects an empty jsonl file ("Schema has no
-        # fields"); an empty parquet carries the schema's columns, so it loads.
+        # loader_file_format="parquet": BigQuery schema autodetection rejects the
+        # empty jsonl file dlt writes to truncate a `replace` table whose source
+        # went to 0 rows. See `replace` write-disposition in ../CLAUDE.md (#4733).
         yield from dlt.run(
             context=context, write_disposition="replace", loader_file_format="parquet"
         )

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -102,6 +102,12 @@ def build_focus_dlt_assets(
         op_tags=op_tags,
     )
     def _assets(context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
-        yield from dlt.run(context=context, write_disposition="replace")
+        # loader_file_format="parquet": once a table has loaded data, a later 0-row
+        # extract still gets an empty file so `replace` truncates it. BigQuery
+        # schema autodetection rejects an empty jsonl file ("Schema has no
+        # fields"); an empty parquet carries the schema's columns, so it loads.
+        yield from dlt.run(
+            context=context, write_disposition="replace", loader_file_format="parquet"
+        )
 
     return _assets

--- a/src/teamster/libraries/dlt/illuminate/assets.py
+++ b/src/teamster/libraries/dlt/illuminate/assets.py
@@ -97,6 +97,12 @@ def build_illuminate_dlt_assets(
         op_tags=op_tags,
     )
     def _assets(context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
-        yield from dlt.run(context=context, write_disposition="replace")
+        # loader_file_format="parquet": once a table has loaded data, a later 0-row
+        # extract still gets an empty file so `replace` truncates it. BigQuery
+        # schema autodetection rejects an empty jsonl file ("Schema has no
+        # fields"); an empty parquet carries the schema's columns, so it loads.
+        yield from dlt.run(
+            context=context, write_disposition="replace", loader_file_format="parquet"
+        )
 
     return _assets

--- a/src/teamster/libraries/dlt/illuminate/assets.py
+++ b/src/teamster/libraries/dlt/illuminate/assets.py
@@ -97,10 +97,9 @@ def build_illuminate_dlt_assets(
         op_tags=op_tags,
     )
     def _assets(context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
-        # loader_file_format="parquet": once a table has loaded data, a later 0-row
-        # extract still gets an empty file so `replace` truncates it. BigQuery
-        # schema autodetection rejects an empty jsonl file ("Schema has no
-        # fields"); an empty parquet carries the schema's columns, so it loads.
+        # loader_file_format="parquet": BigQuery schema autodetection rejects the
+        # empty jsonl file dlt writes to truncate a `replace` table whose source
+        # went to 0 rows. See `replace` write-disposition in ../CLAUDE.md (#4733).
         yield from dlt.run(
             context=context, write_disposition="replace", loader_file_format="parquet"
         )

--- a/tests/libraries/test_dlt_replace_loader_file_format.py
+++ b/tests/libraries/test_dlt_replace_loader_file_format.py
@@ -1,0 +1,106 @@
+"""Unit tests for `loader_file_format="parquet"` on the dlt `replace` factories (#4733).
+
+Focus and Illuminate both pair `autodetect_schema=True` with
+`write_disposition="replace"`. Once such a table has loaded data, dlt writes an
+EMPTY file for it on any later run that yields no items, so the `replace` root
+still gets truncated. That file comes from the object extractor, so it defaults
+to `jsonl.gz` — and BigQuery schema autodetection cannot infer a schema from an
+empty jsonl file, failing the load with
+`400 Schema has no fields. Table: {table}_{uuid}_source`.
+
+An empty parquet carries the dlt schema's columns, so autodetect resolves. These
+tests guard the kwarg itself: the mechanism lives in dlt, but silently dropping
+`loader_file_format` here would re-break the pipeline the next time a source
+table goes empty.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from dlt.common.configuration.specs import ConnectionStringCredentials
+
+from teamster.libraries.dlt.focus.assets import build_focus_dlt_assets
+from teamster.libraries.dlt.illuminate.assets import build_illuminate_dlt_assets
+
+CREDENTIALS = ConnectionStringCredentials("postgresql+psycopg://localhost:5432/db")
+
+
+class _RecordingDltResource:
+    """Stand-in for `DagsterDltResource` that captures the `run()` kwargs."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def run(self, **kwargs: Any) -> Iterator[Any]:
+        self.kwargs = kwargs
+        return iter(())
+
+
+def _run_kwargs(assets: Any) -> dict[str, Any]:
+    """Invoke the asset body with a recording resource and return its run kwargs.
+
+    Nothing in the body touches the context or opens a connection before
+    `dlt.run()`, so no live database and no Dagster instance are needed.
+    """
+    dlt_resource = _RecordingDltResource()
+
+    # consume the generator so the `yield from dlt.run(...)` line executes
+    list(assets.op.compute_fn.decorated_fn(context=None, dlt=dlt_resource))
+
+    return dlt_resource.kwargs
+
+
+@pytest.fixture(name="focus_assets")
+def fixture_focus_assets() -> Any:
+    return build_focus_dlt_assets(
+        sql_database_credentials=CREDENTIALS,
+        code_location="kippmiami",
+        table_name="discipline_referrals",
+    )
+
+
+@pytest.fixture(name="illuminate_assets")
+def fixture_illuminate_assets() -> Any:
+    return build_illuminate_dlt_assets(
+        sql_database_credentials=CREDENTIALS,
+        code_location="kipptaf",
+        schema="dna_assessments",
+        table_name="agg_student_responses",
+    )
+
+
+def test_focus_factory_loads_as_parquet(focus_assets: Any) -> None:
+    kwargs = _run_kwargs(focus_assets)
+
+    assert kwargs["loader_file_format"] == "parquet"
+    assert kwargs["write_disposition"] == "replace"
+
+
+def test_illuminate_factory_loads_as_parquet(illuminate_assets: Any) -> None:
+    kwargs = _run_kwargs(illuminate_assets)
+
+    assert kwargs["loader_file_format"] == "parquet"
+    assert kwargs["write_disposition"] == "replace"
+
+
+def test_dlt_run_accepts_loader_file_format() -> None:
+    """`DagsterDltResource.run` forwards `**kwargs` to `Pipeline.run`.
+
+    Without this, passing `loader_file_format` would raise `TypeError` at
+    runtime instead of taking effect — the kwarg reaches dlt only because the
+    wrapper is signature-agnostic and `Pipeline.run` declares the parameter.
+    """
+    import inspect
+
+    from dagster_dlt import DagsterDltResource
+    from dlt.pipeline.pipeline import Pipeline
+
+    wrapper_params = inspect.signature(DagsterDltResource.run).parameters
+    pipeline_params = inspect.signature(Pipeline.run).parameters
+
+    assert any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in wrapper_params.values()
+    ), "DagsterDltResource.run no longer accepts **kwargs"
+
+    assert "loader_file_format" in pipeline_params


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop Focus and Illuminate dlt assets from failing the day their source table goes to 0 rows.

`kippmiami/dlt/focus/discipline_referrals` has failed every daily run since 2026-08-05 (run `4e789338-8bea-485f-ad2a-bd3960615e35`) with:

```text
google.api_core.exceptions.BadRequest: 400 Schema has no fields.
Table: discipline_referrals_44973609_8769_4441_9dc0_2c7e6ad89cf0_source
```

Root cause: once a `replace` table has loaded data, `Extract._handle_empty_tables` writes an EMPTY file for it on any later run that yields no items, so the table's root still gets truncated. That file comes from the object extractor, so it defaults to `jsonl.gz` — and BigQuery schema autodetection (`autodetect_schema=True`) cannot infer a schema from an empty jsonl file. dlt classes the resulting `invalidQuery` as transient, so it burns 5 identical retries before failing the step.

Passing `loader_file_format="parquet"` fixes it: an empty parquet carries the dlt schema's columns, so autodetect resolves and the truncate load succeeds. The pyarrow backend already loads data files as parquet, so nothing else about the load changes.

Both factories pair `autodetect_schema=True` with `write_disposition="replace"`, so both get the fix.

No data repair needed: dlt truncates autodetect tables before the load job, so `dagster_kippmiami_dlt_focus.discipline_referrals` is already correctly at 0 rows.

### Verification

Two local reproductions on dlt 1.29.1, neither needing Focus DB or warehouse access:

1. Extract plus normalize only, BigQuery destination — confirms which file dlt emits for the 0-row pass:

   | loader_file_format  | pass-2 job file                                        | fields |
   | ------------------- | ------------------------------------------------------ | ------ |
   | destination default | `discipline_referrals.{id}.0.jsonl.gz`, empty payload  | 0      |
   | `parquet`           | `discipline_referrals.{id}.0.parquet`                  | 3      |

1. Full `pipeline.run(write_disposition='replace', loader_file_format='parquet')` against duckdb — the empty-parquet job completes and the destination table ends at 0 rows, so the truncate still happens.

### AI Assistance

Claude Code performed the investigation, wrote both reproductions, and authored the code and docs changes. Human-directed: the choice of fix among three candidates (the alternatives were catching the load error, or dropping `autodetect_schema=True`).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [ ] `uv run dagster definitions validate` — **not runnable in the Codespace**: both `kippmiami` and `kipptaf` resolve their dlt credential specs eagerly at module load, so validate and `tests/test_dagster_definitions.py` fail on unset credentials regardless of this change (documented in `src/teamster/CLAUDE.md`). Verified instead with `py_compile` on both edited files plus the two dlt reproductions above; the Dagster Cloud branch deployment is the real check.
- [x] No new integration — this changes two existing library factories only.

### Docs

- [x] Corrected the "Empty source tables" section of `libraries/dlt/focus/CLAUDE.md`, which claimed a 0-row extract always succeeds. That holds only until the table has loaded data once.
- [x] Documented the mechanism under _`replace` write-disposition_ in `libraries/dlt/CLAUDE.md`, since it applies to both factories.
- [x] No schedule or sensor change, so no automations-catalog regeneration.

## CI checks

- [ ] **Trunk** — `trunk check --force` on all 4 changed files reports no issues.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — `libraries/dlt/` is shared, so every consuming code location redeploys.

Refs #4733
