### PR TITLE
feat(dagster): midday cadence for Finalsite to Focus import

### DIFF
--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -11,7 +11,7 @@ and is validated by automated tests.
 ## What the pipeline does
 
 Each **midday** run builds four files from current Finalsite data and delivers
-them to Focus over SFTP at **12:30 p.m. ET**, matching Focus's import templates:
+them to Focus over SFTP at **12:45 p.m. ET**, matching Focus's import templates:
 
 | File               | Focus template       | Status |
 | ------------------ | -------------------- | ------ |
@@ -32,16 +32,16 @@ both:
 
 1. **Push the Finalsite SFTP export at 12:00 p.m.** Finalsite's own export runs
    overnight on a schedule that is not ours to change. Without a manual push,
-   the 12:30 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
+   the 12:45 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
    with no error and nothing on screen to notice. Push it after the noon cutoff,
    every day. **This is Miami only** — no other region needs it.
 
    **The window is 12:00 to 12:15 — push at noon or just after, not before.** An
    early push misses anything entered between it and the 12:00 cutoff, and those
    students then wait for tomorrow. The late bound is **12:15**: past that, the
-   file may not be ingested and rebuilt in time for the 12:30 delivery. From a
-   12:15 push the pipeline needs about 8 minutes to have everything rebuilt, so
-   the delivery still clears it.
+   file may not be ingested and rebuilt in time for the 12:45 delivery. From a
+   12:15 push the pipeline needs about 11 minutes to have everything rebuilt, so
+   the delivery clears it with roughly 19 minutes to spare.
 
    Nothing breaks if a push lands outside the window. A student whose record is
    only half-captured is skipped for that day, not half-imported — there is no
@@ -49,7 +49,7 @@ both:
 
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
    `incoming/` folder; nothing imports them for you. The imports themselves are
-   quick, so the 90 minutes between the 12:30 delivery and 2 p.m. is slack, not
+   quick, so the 75 minutes between the 12:45 delivery and 2 p.m. is slack, not
    time you need — a student is usable in Focus within minutes of you running
    them, typically well before 1 p.m.
 

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -47,8 +47,10 @@ both:
    half-imported.
 
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
-   `incoming/` folder; nothing imports them for you. The 12:30 delivery leaves a
-   90-minute window before 2 p.m.
+   `incoming/` folder; nothing imports them for you. The imports themselves are
+   quick, so the 90 minutes between the 12:30 delivery and 2 p.m. is slack, not
+   time you need — a student is usable in Focus within minutes of you running
+   them, typically well before 1 p.m.
 
 > **Do not re-run the delivery after you have imported.** The pipeline decides
 > what Focus already has by reading a copy of Focus taken at 12:00 p.m., not

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -39,10 +39,9 @@ both:
    **The window is 12:00 to 12:15 — push at noon or just after, not before.** An
    early push misses anything entered between it and the 12:00 cutoff, and those
    students then wait for tomorrow. The late bound is **12:15**: past that, the
-   file may not be ingested and rebuilt in time for the 12:30 delivery. Most of
-   that 15 minutes is not the pipeline being slow — the sensor watching the SFTP
-   folder polls every 10 minutes, so in the worst case your file sits unnoticed
-   for 10 minutes after you drop it.
+   file may not be ingested and rebuilt in time for the 12:30 delivery. From a
+   12:15 push the pipeline needs about 8 minutes to have everything rebuilt, so
+   the delivery still clears it.
 
    Nothing breaks if a push lands outside the window. A student whose record is
    only half-captured is skipped for that day, not half-imported — there is no

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -10,8 +10,8 @@ and is validated by automated tests.
 
 ## What the pipeline does
 
-Each **nightly** run (3 a.m.) builds four files from current Finalsite data and
-delivers them to Focus over SFTP, matching Focus's import templates:
+Each **midday** run builds four files from current Finalsite data and delivers
+them to Focus over SFTP at **12:45 p.m. ET**, matching Focus's import templates:
 
 | File               | Focus template       | Status |
 | ------------------ | -------------------- | ------ |
@@ -19,6 +19,31 @@ delivers them to Focus over SFTP, matching Focus's import templates:
 | Student Enrollment | `STUDENT_ENROLLMENT` | Active |
 | Addresses          | `ADDRESS`            | Active |
 | Contacts           | `CONTACTS`           | Active |
+
+## The 2 p.m. commitment and the two manual steps
+
+The midday timing exists to support one promise: **a student entered in
+Finalsite by 12:00 p.m. ET is usable in Focus by 2:00 p.m. ET.** The promise
+covers **new students only** — a correction made in Finalsite to a student Focus
+already has never flows, at any hour (see _Where to make corrections_ below).
+
+Two steps in that chain are done by hand, and the 2 p.m. promise depends on
+both:
+
+1. **Push the Finalsite SFTP export at 12:00 p.m.** Finalsite's own export runs
+   overnight on a schedule that is not ours to change. Without a manual push,
+   the 12:45 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
+   with no error and nothing on screen to notice. Push it after the noon cutoff,
+   every day.
+1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
+   `incoming/` folder; nothing imports them for you. The 12:45 delivery leaves a
+   75-minute window before 2 p.m.
+
+> **Do not re-run the delivery after you have imported.** The pipeline decides
+> what Focus already has by reading a copy of Focus taken at 12:25 p.m., not
+> live Focus. Re-running the delivery before the next Focus sync at 2:45 p.m.
+> sends every record a second time and duplicates it in Focus. After 2:45 p.m. a
+> re-run is safe.
 
 The pipeline is **import-once**: each run sends only records that Focus does not
 already have. Once a record has been imported, the pipeline never re-sends or

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -53,11 +53,13 @@ both:
    time you need — a student is usable in Focus within minutes of you running
    them, typically well before 1 p.m.
 
-> **Do not re-run the delivery after you have imported.** The pipeline decides
-> what Focus already has by reading a copy of Focus taken at 12:00 p.m., not
-> live Focus. Re-running the delivery before the next Focus sync at 2:45 p.m.
-> sends every record a second time and duplicates it in Focus. After 2:45 p.m. a
-> re-run is safe.
+> **Do not re-run the delivery after you have imported — ask the data team
+> first.** The pipeline decides what Focus already has by reading a copy of
+> Focus taken at 12:00 p.m., not live Focus. Re-run the delivery after you have
+> imported and it sends every record a second time, duplicating it in Focus. A
+> copy is taken again at 2:00 p.m., which normally clears it — but only if your
+> import finished before that copy was taken. If you imported late, 2:00 p.m. is
+> not enough, so check rather than assuming a time makes it safe.
 
 The pipeline is **import-once**: each run sends only records that Focus does not
 already have. Once a record has been imported, the pipeline never re-sends or

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -11,7 +11,7 @@ and is validated by automated tests.
 ## What the pipeline does
 
 Each **midday** run builds four files from current Finalsite data and delivers
-them to Focus over SFTP at **12:45 p.m. ET**, matching Focus's import templates:
+them to Focus over SFTP at **12:30 p.m. ET**, matching Focus's import templates:
 
 | File               | Focus template       | Status |
 | ------------------ | -------------------- | ------ |
@@ -32,7 +32,7 @@ both:
 
 1. **Push the Finalsite SFTP export at 12:00 p.m.** Finalsite's own export runs
    overnight on a schedule that is not ours to change. Without a manual push,
-   the 12:45 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
+   the 12:30 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
    with no error and nothing on screen to notice. Push it after the noon cutoff,
    every day. **This is Miami only** — no other region needs it.
 
@@ -42,13 +42,13 @@ both:
    Earlier than that is still safe; it only moves the cutoff earlier, and a
    student entered after it waits for tomorrow. The hard deadline is roughly
    **12:29**: past that, the file may not be ingested and rebuilt in time for
-   the 12:45 delivery. A push at an odd time never sends wrong or duplicate data
+   the 12:30 delivery. A push at an odd time never sends wrong or duplicate data
    — a student whose two halves straddle the cutoff is skipped for the day, not
    half-imported.
 
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
-   `incoming/` folder; nothing imports them for you. The 12:45 delivery leaves a
-   75-minute window before 2 p.m.
+   `incoming/` folder; nothing imports them for you. The 12:30 delivery leaves a
+   90-minute window before 2 p.m.
 
 > **Do not re-run the delivery after you have imported.** The pipeline decides
 > what Focus already has by reading a copy of Focus taken at 12:00 p.m., not

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -34,13 +34,23 @@ both:
    overnight on a schedule that is not ours to change. Without a manual push,
    the 12:45 delivery carries Finalsite data as of roughly 2:50 a.m. — silently,
    with no error and nothing on screen to notice. Push it after the noon cutoff,
-   every day.
+   every day. **This is Miami only** — no other region needs it.
+
+   **It does not have to be noon sharp.** Anything from about 11:55 to 12:05
+   lines the push up with the 12:05 Finalsite contacts pull, so both halves of a
+   student's record share one cutoff. Earlier is safe — it just moves the cutoff
+   earlier, and a student entered after it waits for tomorrow. The hard deadline
+   is roughly **12:29**: past that, the file may not be ingested and rebuilt in
+   time for the 12:45 delivery. A push at an odd time never sends wrong or
+   duplicate data — a student whose two halves straddle the cutoff is skipped
+   for the day, not half-imported.
+
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
    `incoming/` folder; nothing imports them for you. The 12:45 delivery leaves a
    75-minute window before 2 p.m.
 
 > **Do not re-run the delivery after you have imported.** The pipeline decides
-> what Focus already has by reading a copy of Focus taken at 12:15 p.m., not
+> what Focus already has by reading a copy of Focus taken at 12:05 p.m., not
 > live Focus. Re-running the delivery before the next Focus sync at 2:45 p.m.
 > sends every record a second time and duplicates it in Focus. After 2:45 p.m. a
 > re-run is safe.

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -36,15 +36,17 @@ both:
    with no error and nothing on screen to notice. Push it after the noon cutoff,
    every day. **This is Miami only** — no other region needs it.
 
-   **It does not have to be noon sharp.** Pushing a few minutes _before_ noon is
-   the cleanest — the pipeline's own Finalsite pull runs at 12:00, so a push
-   just ahead of it means both halves of a student's record share one cutoff.
-   Earlier than that is still safe; it only moves the cutoff earlier, and a
-   student entered after it waits for tomorrow. The hard deadline is roughly
-   **12:29**: past that, the file may not be ingested and rebuilt in time for
-   the 12:30 delivery. A push at an odd time never sends wrong or duplicate data
-   — a student whose two halves straddle the cutoff is skipped for the day, not
-   half-imported.
+   **The window is 12:00 to 12:15 — push at noon or just after, not before.** An
+   early push misses anything entered between it and the 12:00 cutoff, and those
+   students then wait for tomorrow. The late bound is **12:15**: past that, the
+   file may not be ingested and rebuilt in time for the 12:30 delivery. Most of
+   that 15 minutes is not the pipeline being slow — the sensor watching the SFTP
+   folder polls every 10 minutes, so in the worst case your file sits unnoticed
+   for 10 minutes after you drop it.
+
+   Nothing breaks if a push lands outside the window. A student whose record is
+   only half-captured is skipped for that day, not half-imported — there is no
+   way to send wrong or duplicate data to Focus by pushing at an odd time.
 
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
    `incoming/` folder; nothing imports them for you. The imports themselves are

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -36,21 +36,22 @@ both:
    with no error and nothing on screen to notice. Push it after the noon cutoff,
    every day. **This is Miami only** — no other region needs it.
 
-   **It does not have to be noon sharp.** Anything from about 11:55 to 12:05
-   lines the push up with the 12:05 Finalsite contacts pull, so both halves of a
-   student's record share one cutoff. Earlier is safe — it just moves the cutoff
-   earlier, and a student entered after it waits for tomorrow. The hard deadline
-   is roughly **12:29**: past that, the file may not be ingested and rebuilt in
-   time for the 12:45 delivery. A push at an odd time never sends wrong or
-   duplicate data — a student whose two halves straddle the cutoff is skipped
-   for the day, not half-imported.
+   **It does not have to be noon sharp.** Pushing a few minutes _before_ noon is
+   the cleanest — the pipeline's own Finalsite pull runs at 12:00, so a push
+   just ahead of it means both halves of a student's record share one cutoff.
+   Earlier than that is still safe; it only moves the cutoff earlier, and a
+   student entered after it waits for tomorrow. The hard deadline is roughly
+   **12:29**: past that, the file may not be ingested and rebuilt in time for
+   the 12:45 delivery. A push at an odd time never sends wrong or duplicate data
+   — a student whose two halves straddle the cutoff is skipped for the day, not
+   half-imported.
 
 1. **Run the four Focus imports.** The pipeline only delivers files to Focus's
    `incoming/` folder; nothing imports them for you. The 12:45 delivery leaves a
    75-minute window before 2 p.m.
 
 > **Do not re-run the delivery after you have imported.** The pipeline decides
-> what Focus already has by reading a copy of Focus taken at 12:05 p.m., not
+> what Focus already has by reading a copy of Focus taken at 12:00 p.m., not
 > live Focus. Re-running the delivery before the next Focus sync at 2:45 p.m.
 > sends every record a second time and duplicates it in Focus. After 2:45 p.m. a
 > re-run is safe.

--- a/docs/reference/finalsite-focus-import.md
+++ b/docs/reference/finalsite-focus-import.md
@@ -40,7 +40,7 @@ both:
    75-minute window before 2 p.m.
 
 > **Do not re-run the delivery after you have imported.** The pipeline decides
-> what Focus already has by reading a copy of Focus taken at 12:25 p.m., not
+> what Focus already has by reading a copy of Focus taken at 12:15 p.m., not
 > live Focus. Re-running the delivery before the next Focus sync at 2:45 p.m.
 > sends every record a second time and duplicates it in Focus. After 2:45 p.m. a
 > re-run is safe.

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -15,13 +15,13 @@ GCS bucket: `teamster-kippmiami`
 | ----------- | ------------- | ------------------------------------------------------- |
 | `dbt`       | dbt assets    | `AutomationConditionSensor`                             |
 | `deanslist` | API assets    | schedule (nightly)                                      |
-| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:10 ET) + couchdrop sensor |
+| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:05 ET) + couchdrop sensor |
 | `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
 | `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
 | `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
-| `dlt/focus` | dlt assets    | schedule (04:00, 12:15, 14:45 ET)                       |
+| `dlt/focus` | dlt assets    | schedule (04:00, 12:05, 14:45 ET)                       |
 
 ## Midday Focus import cycle
 
@@ -29,24 +29,31 @@ The three schedule times above are one chain, not independent cadences. It
 exists to keep a promise to stakeholders: a student entered in Finalsite by
 12:00pm ET is usable in Focus by 2:00pm ET. Order: ops manually pushes the
 Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
-to reschedule) → couchdrop sensor ingests within 10 min → contacts pull 12:10 →
-Focus dlt pull 12:15 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
-SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand** → dlt
-pull again at 14:45.
+to reschedule) → couchdrop sensor ingests within 10 min → contacts pull and
+Focus dlt pull both at 12:05 → dbt rebuild ~3.5 min → four CSVs delivered to the
+Focus SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand**
+→ dlt pull again at 14:45.
+
+**The three midday inputs run concurrently on purpose.** They share no pool and
+none gates another: the contacts API pull and the manually-pushed SFTP drop feed
+opposite sides of `int_finalsite__enrollment_lifecycle`, and the dlt pull feeds
+the import-once anti-join. Don't re-stagger them looking for an ordering that
+isn't there. `12:05` rather than `12:00` dodges top-of-hour GKE Autopilot
+step-pod scheduling waits (3-9 min) and gives ops slop around the manual push.
 
 Three constraints to preserve when touching any of these times:
 
 - **The 12:45 delivery is a plain cron — nothing gates it on the upstreams.**
   The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
-  schedule firing to the dependent staging table being rebuilt, against 30 min
-  of budget behind the Focus pull and 35 behind the Finalsite one. Spending that
-  margin (delivery earlier, upstreams later) ships a delivery built on
+  schedule firing to the dependent staging table being rebuilt, or ~16 min worst
+  case from a manual SFTP push (10 min sensor poll + 2 min ingest + 3.5 min
+  dbt), against 40 min of budget. Spending that margin ships a delivery built on
   incomplete inputs with no error raised anywhere.
 - **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
   Focus, not live Focus.** A snapshot older than the last hand-run Focus import
   makes the next delivery re-send those records and duplicate them. Three
   snapshots a day means any one of them prevents that: 14:45 catches the
-  same-day imports, 04:00 is the overnight backstop, and 12:15 is the last line
+  same-day imports, 04:00 is the overnight backstop, and 12:05 is the last line
   of defence if both failed. Don't reason about any one of them alone.
 - **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
   Tableau extract refreshes at 05:00 — moving the only pull to midday leaves

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -11,17 +11,42 @@ GCS bucket: `teamster-kippmiami`
 
 ## Active Integrations
 
-| Module      | Type          | Trigger                                    |
-| ----------- | ------------- | ------------------------------------------ |
-| `dbt`       | dbt assets    | `AutomationConditionSensor`                |
-| `deanslist` | API assets    | schedule (nightly)                         |
-| `finalsite` | API + SFTP    | schedule (contacts 4am) + couchdrop sensor |
-| `fldoe`     | SFTP assets   | `AutomationConditionSensor`                |
-| `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)        |
-| `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)      |
-| `extracts`  | BigQuery→SFTP | schedule                                   |
-| `couchdrop` | sensor only   | sensor (Google Drive watcher)              |
-| `dlt/focus` | dlt assets    | schedule (daily 04:00 ET)                  |
+| Module      | Type          | Trigger                                                 |
+| ----------- | ------------- | ------------------------------------------------------- |
+| `dbt`       | dbt assets    | `AutomationConditionSensor`                             |
+| `deanslist` | API assets    | schedule (nightly)                                      |
+| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:10 ET) + couchdrop sensor |
+| `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
+| `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
+| `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
+| `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
+| `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
+| `dlt/focus` | dlt assets    | schedule (04:00, 12:25, 14:45 ET)                       |
+
+## Midday Focus import cycle
+
+The three schedule times above are one chain, not independent cadences. It
+exists to keep a promise to stakeholders: a student entered in Finalsite by
+12:00pm ET is usable in Focus by 2:00pm ET. Order: ops manually pushes the
+Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
+to reschedule) → couchdrop sensor ingests within 10 min → contacts pull 12:10 →
+Focus dlt pull 12:25 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
+SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand** → dlt
+pull again at 14:45.
+
+Two constraints to preserve when touching any of these times:
+
+- **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
+  Focus, not live Focus.** The 14:45 pull is what makes a post-import re-run of
+  the delivery safe; drop it and a second same-day delivery duplicates every
+  record in Focus.
+- **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
+  Tableau extract refreshes at 05:00 — moving the only pull to midday leaves
+  every morning dashboard on day-old Miami data.
+
+`kippmiami__extracts__focus__asset_job_schedule` also has to be STARTED in the
+Dagster+ UI; its `defaultStatus` is STOPPED and it had never run in prod as of
+#4736.
 
 ## Florida-Specific
 

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -15,13 +15,13 @@ GCS bucket: `teamster-kippmiami`
 | ----------- | ------------- | ------------------------------------------------------- |
 | `dbt`       | dbt assets    | `AutomationConditionSensor`                             |
 | `deanslist` | API assets    | schedule (nightly)                                      |
-| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:05 ET) + couchdrop sensor |
+| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:00 ET) + couchdrop sensor |
 | `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
 | `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
 | `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
-| `dlt/focus` | dlt assets    | schedule (04:00, 12:05, 14:45 ET)                       |
+| `dlt/focus` | dlt assets    | schedule (04:00, 12:00, 14:45 ET)                       |
 
 ## Midday Focus import cycle
 
@@ -30,7 +30,7 @@ exists to keep a promise to stakeholders: a student entered in Finalsite by
 12:00pm ET is usable in Focus by 2:00pm ET. Order: ops manually pushes the
 Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
 to reschedule) → couchdrop sensor ingests within 10 min → contacts pull and
-Focus dlt pull both at 12:05 → dbt rebuild ~3.5 min → four CSVs delivered to the
+Focus dlt pull both at 12:00 → dbt rebuild ~3.5 min → four CSVs delivered to the
 Focus SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand**
 → dlt pull again at 14:45.
 
@@ -38,22 +38,25 @@ Focus SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand*
 none gates another: the contacts API pull and the manually-pushed SFTP drop feed
 opposite sides of `int_finalsite__enrollment_lifecycle`, and the dlt pull feeds
 the import-once anti-join. Don't re-stagger them looking for an ordering that
-isn't there. `12:05` rather than `12:00` dodges top-of-hour GKE Autopilot
-step-pod scheduling waits (3-9 min) and gives ops slop around the manual push.
+isn't there. Top-of-hour GKE Autopilot fan-out can add 3-9 min of step-pod
+scheduling wait, which only queues the run — against 45 min before the delivery
+that is noise, so these deliberately sit at `12:00` rather than an offset
+minute.
 
 Three constraints to preserve when touching any of these times:
 
 - **The 12:45 delivery is a plain cron — nothing gates it on the upstreams.**
   The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
   schedule firing to the dependent staging table being rebuilt, or ~16 min worst
-  case from a manual SFTP push (10 min sensor poll + 2 min ingest + 3.5 min
-  dbt), against 40 min of budget. Spending that margin ships a delivery built on
-  incomplete inputs with no error raised anywhere.
+  case from a manual SFTP push (10 min sensor poll + 2 min ingest + 3.5 min dbt)
+  plus up to 9 min of top-of-hour pod-scheduling queue, against 45 min of
+  budget. Spending that margin ships a delivery built on incomplete inputs with
+  no error raised anywhere.
 - **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
   Focus, not live Focus.** A snapshot older than the last hand-run Focus import
   makes the next delivery re-send those records and duplicate them. Three
   snapshots a day means any one of them prevents that: 14:45 catches the
-  same-day imports, 04:00 is the overnight backstop, and 12:05 is the last line
+  same-day imports, 04:00 is the overnight backstop, and 12:00 is the last line
   of defence if both failed. Don't reason about any one of them alone.
 - **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
   Tableau extract refreshes at 05:00 — moving the only pull to midday leaves

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -47,8 +47,8 @@ Three constraints to preserve when touching any of these times:
 
 - **The 12:30 delivery is a plain cron — nothing gates it on the upstreams.**
   The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
-  schedule firing to the dependent staging table being rebuilt, or ~16 min worst
-  case from a manual SFTP push (10 min sensor poll + 2 min ingest + 3.5 min dbt)
+  schedule firing to the dependent staging table being rebuilt, or ~8 min worst
+  case from a manual SFTP push (2 min sensor poll + 2m13s ingest + 3m34s dbt)
   plus up to 9 min of top-of-hour pod-scheduling queue, against 45 min of
   budget. Spending that margin ships a delivery built on incomplete inputs with
   no error raised anywhere.

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -21,7 +21,7 @@ GCS bucket: `teamster-kippmiami`
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
 | `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
-| `dlt/focus` | dlt assets    | schedule (04:00, 12:25, 14:45 ET)                       |
+| `dlt/focus` | dlt assets    | schedule (04:00, 12:15, 14:45 ET)                       |
 
 ## Midday Focus import cycle
 
@@ -30,16 +30,24 @@ exists to keep a promise to stakeholders: a student entered in Finalsite by
 12:00pm ET is usable in Focus by 2:00pm ET. Order: ops manually pushes the
 Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
 to reschedule) → couchdrop sensor ingests within 10 min → contacts pull 12:10 →
-Focus dlt pull 12:25 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
+Focus dlt pull 12:15 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
 SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand** → dlt
 pull again at 14:45.
 
-Two constraints to preserve when touching any of these times:
+Three constraints to preserve when touching any of these times:
 
+- **The 12:45 delivery is a plain cron — nothing gates it on the upstreams.**
+  The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
+  schedule firing to the dependent staging table being rebuilt, against 30 min
+  of budget behind the Focus pull and 35 behind the Finalsite one. Spending that
+  margin (delivery earlier, upstreams later) ships a delivery built on
+  incomplete inputs with no error raised anywhere.
 - **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
-  Focus, not live Focus.** The 14:45 pull is what makes a post-import re-run of
-  the delivery safe; drop it and a second same-day delivery duplicates every
-  record in Focus.
+  Focus, not live Focus.** A snapshot older than the last hand-run Focus import
+  makes the next delivery re-send those records and duplicate them. Three
+  snapshots a day means any one of them prevents that: 14:45 catches the
+  same-day imports, 04:00 is the overnight backstop, and 12:15 is the last line
+  of defence if both failed. Don't reason about any one of them alone.
 - **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
   Tableau extract refreshes at 05:00 — moving the only pull to midday leaves
   every morning dashboard on day-old Miami data.

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -19,7 +19,7 @@ GCS bucket: `teamster-kippmiami`
 | `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
 | `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
-| `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
+| `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:30 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
 | `dlt/focus` | dlt assets    | schedule (04:00, 12:00, 14:45 ET)                       |
 
@@ -31,7 +31,7 @@ exists to keep a promise to stakeholders: a student entered in Finalsite by
 Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
 to reschedule) → couchdrop sensor ingests within 10 min → contacts pull and
 Focus dlt pull both at 12:00 → dbt rebuild ~3.5 min → four CSVs delivered to the
-Focus SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand**
+Focus SFTP `incoming/` folder at 12:30 → **ops runs the Focus imports by hand**
 → dlt pull again at 14:45.
 
 **The three midday inputs run concurrently on purpose.** They share no pool and
@@ -39,13 +39,13 @@ none gates another: the contacts API pull and the manually-pushed SFTP drop feed
 opposite sides of `int_finalsite__enrollment_lifecycle`, and the dlt pull feeds
 the import-once anti-join. Don't re-stagger them looking for an ordering that
 isn't there. Top-of-hour GKE Autopilot fan-out can add 3-9 min of step-pod
-scheduling wait, which only queues the run — against 45 min before the delivery
+scheduling wait, which only queues the run — against 30 min before the delivery
 that is noise, so these deliberately sit at `12:00` rather than an offset
 minute.
 
 Three constraints to preserve when touching any of these times:
 
-- **The 12:45 delivery is a plain cron — nothing gates it on the upstreams.**
+- **The 12:30 delivery is a plain cron — nothing gates it on the upstreams.**
   The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
   schedule firing to the dependent staging table being rebuilt, or ~16 min worst
   case from a manual SFTP push (10 min sensor poll + 2 min ingest + 3.5 min dbt)

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -21,7 +21,7 @@ GCS bucket: `teamster-kippmiami`
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
 | `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
-| `dlt/focus` | dlt assets    | schedule (04:00, 12:00, 14:45 ET)                       |
+| `dlt/focus` | dlt assets    | schedule (04:00, 12:00, 14:00 ET)                       |
 
 ## Midday Focus import cycle
 
@@ -32,7 +32,7 @@ Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
 to reschedule) → couchdrop sensor ingests within 5 min → contacts pull and Focus
 dlt pull both at 12:00 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
 SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand** → dlt
-pull again at 14:45.
+pull again at 14:00.
 
 **The three midday inputs run concurrently on purpose.** They share no pool and
 none gates another: the contacts API pull and the manually-pushed SFTP drop feed
@@ -58,9 +58,12 @@ Three constraints to preserve when touching any of these times:
 - **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
   Focus, not live Focus.** A snapshot older than the last hand-run Focus import
   makes the next delivery re-send those records and duplicate them. Three
-  snapshots a day means any one of them prevents that: 14:45 catches the
+  snapshots a day means any one of them prevents that: 14:00 catches the
   same-day imports, 04:00 is the overnight backstop, and 12:00 is the last line
-  of defence if both failed. Don't reason about any one of them alone.
+  of defence if both failed. Don't reason about any one of them alone. Note
+  14:00 sits ON the 2pm commitment rather than after it, so a late import lands
+  after that snapshot — the safe rule is a dependency ("a sync has run since the
+  last import"), never a clock time, and 04:00 is what makes the next day safe.
 - **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
   Tableau extract refreshes at 05:00 — moving the only pull to midday leaves
   every morning dashboard on day-old Miami data.

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -19,7 +19,7 @@ GCS bucket: `teamster-kippmiami`
 | `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
 | `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
-| `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:30 ET)                      |
+| `extracts`  | BigQuery→SFTP | schedule (Focus delivery 12:45 ET)                      |
 | `couchdrop` | sensor only   | sensor (Google Drive watcher)                           |
 | `dlt/focus` | dlt assets    | schedule (04:00, 12:00, 14:45 ET)                       |
 
@@ -29,29 +29,32 @@ The three schedule times above are one chain, not independent cadences. It
 exists to keep a promise to stakeholders: a student entered in Finalsite by
 12:00pm ET is usable in Focus by 2:00pm ET. Order: ops manually pushes the
 Finalsite SFTP export at 12:00 (Finalsite's own export is overnight and not ours
-to reschedule) → couchdrop sensor ingests within 10 min → contacts pull and
-Focus dlt pull both at 12:00 → dbt rebuild ~3.5 min → four CSVs delivered to the
-Focus SFTP `incoming/` folder at 12:30 → **ops runs the Focus imports by hand**
-→ dlt pull again at 14:45.
+to reschedule) → couchdrop sensor ingests within 5 min → contacts pull and Focus
+dlt pull both at 12:00 → dbt rebuild ~3.5 min → four CSVs delivered to the Focus
+SFTP `incoming/` folder at 12:45 → **ops runs the Focus imports by hand** → dlt
+pull again at 14:45.
 
 **The three midday inputs run concurrently on purpose.** They share no pool and
 none gates another: the contacts API pull and the manually-pushed SFTP drop feed
 opposite sides of `int_finalsite__enrollment_lifecycle`, and the dlt pull feeds
 the import-once anti-join. Don't re-stagger them looking for an ordering that
 isn't there. Top-of-hour GKE Autopilot fan-out can add 3-9 min of step-pod
-scheduling wait, which only queues the run — against 30 min before the delivery
+scheduling wait, which only queues the run — against 45 min before the delivery
 that is noise, so these deliberately sit at `12:00` rather than an offset
 minute.
 
 Three constraints to preserve when touching any of these times:
 
-- **The 12:30 delivery is a plain cron — nothing gates it on the upstreams.**
+- **The 12:45 delivery is a plain cron — nothing gates it on the upstreams.**
   The gaps are a time budget, not a dependency. Measured need is 4-7 min from a
-  schedule firing to the dependent staging table being rebuilt, or ~8 min worst
-  case from a manual SFTP push (2 min sensor poll + 2m13s ingest + 3m34s dbt)
+  schedule firing to the dependent staging table being rebuilt, or ~11 min worst
+  case from a manual SFTP push (5 min sensor poll + 2m13s ingest + 3m34s dbt)
   plus up to 9 min of top-of-hour pod-scheduling queue, against 45 min of
-  budget. Spending that margin ships a delivery built on incomplete inputs with
-  no error raised anywhere.
+  budget. That 5-minute poll is deliberate and Miami-only — see
+  `couchdrop/sensors.py`; at the 10 min the other locations use, the ~16 min
+  worst case leaves the 12:30 freshness check on #4736 unable to tell a stalled
+  chain from one still in flight. Spending this margin ships a delivery built on
+  incomplete inputs with no error raised anywhere.
 - **`rpt_focus__*` import-once is an anti-join against the dlt SNAPSHOT of
   Focus, not live Focus.** A snapshot older than the last hand-run Focus import
   makes the next delivery re-send those records and duplicate them. Three

--- a/src/teamster/code_locations/kippmiami/couchdrop/sensors.py
+++ b/src/teamster/code_locations/kippmiami/couchdrop/sensors.py
@@ -7,7 +7,14 @@ couchdrop_sftp_sensor = build_couchdrop_sftp_sensor(
     code_location=CODE_LOCATION,
     local_timezone=LOCAL_TIMEZONE,
     asset_selection=[eoc, fast, fte, science, status_report],
-    minimum_interval_seconds=(60 * 10),
+    # 2 min, not the 10 min the other locations use: this sensor is what notices
+    # the manual midday Finalsite SFTP push, and its poll interval is the dominant
+    # term in the push-to-usable chain. At 10 min the worst case is ~16 min (poll +
+    # 2m13s ingest + 3m34s dbt), which overruns the 12:30 Focus delivery for a push
+    # at the 12:15 late bound; at 2 min it is ~8 min, leaving real margin. Raising
+    # this back to 10 min silently breaks the 12:00-12:15 push window that the 2pm
+    # commitment to stakeholders depends on. See #4736.
+    minimum_interval_seconds=(60 * 2),
     folder_id="1BLu_qlbcw_jcRZ8m9KIib0UbkPgK4uiM",
     exclude_dirs=[f"/data-team/{CODE_LOCATION}/fldoe/fsa"],
 )

--- a/src/teamster/code_locations/kippmiami/couchdrop/sensors.py
+++ b/src/teamster/code_locations/kippmiami/couchdrop/sensors.py
@@ -7,14 +7,15 @@ couchdrop_sftp_sensor = build_couchdrop_sftp_sensor(
     code_location=CODE_LOCATION,
     local_timezone=LOCAL_TIMEZONE,
     asset_selection=[eoc, fast, fte, science, status_report],
-    # 2 min, not the 10 min the other locations use: this sensor is what notices
+    # 5 min, not the 10 min the other locations use: this sensor is what notices
     # the manual midday Finalsite SFTP push, and its poll interval is the dominant
-    # term in the push-to-usable chain. At 10 min the worst case is ~16 min (poll +
-    # 2m13s ingest + 3m34s dbt), which overruns the 12:30 Focus delivery for a push
-    # at the 12:15 late bound; at 2 min it is ~8 min, leaving real margin. Raising
-    # this back to 10 min silently breaks the 12:00-12:15 push window that the 2pm
-    # commitment to stakeholders depends on. See #4736.
-    minimum_interval_seconds=(60 * 2),
+    # term in the push-to-usable chain (poll + 2m13s ingest + 3m34s dbt = ~11 min
+    # worst case at 5 min, ~16 min at 10). The 12:30 freshness check on #4736 has
+    # to be able to fire on a genuinely-stalled chain rather than one still in
+    # flight, and a push at the 12:15 late bound has to be rebuilt well before the
+    # 12:45 delivery -- 10 min breaks both. Raising this back silently erodes the
+    # push window the 2pm commitment depends on. See #4736.
+    minimum_interval_seconds=(60 * 5),
     folder_id="1BLu_qlbcw_jcRZ8m9KIib0UbkPgK4uiM",
     exclude_dirs=[f"/data-team/{CODE_LOCATION}/fldoe/fsa"],
 )

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -17,17 +17,22 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__dlt__focus__daily_asset_job_schedule",
     # 04:00 keeps the pre-dawn pull that every Focus-derived model depends on --
     # Miami enrollment, attendance, and the FRESH scaffold's Miami rows all read
-    # it, and FRESH's Tableau extract refreshes at 05:00. 12:15 and 14:45 both
-    # refresh the live-Focus snapshot that the rpt_focus__* import-once
-    # anti-joins read; a snapshot older than the last hand-run Focus import makes
-    # the next delivery re-send those records and duplicate them in Focus. Three
-    # snapshots a day means any one of them prevents that -- 14:45 catches the
-    # same-day imports, 04:00 is the overnight backstop, and 12:15 is the last
-    # line of defence if both failed. 12:15 (not 12:25) because the delivery
-    # fires at 12:45 on a plain cron with nothing gating it on this pull
-    # finishing: observed fire-to-stg_focus latency is 4-7 min, so 30 minutes of
-    # budget is ~4x the measured need. Do not narrow that gap.
-    cron_schedule=["0 4 * * *", "15 12 * * *", "45 14 * * *"],
+    # it, and FRESH's Tableau extract refreshes at 05:00.
+    #
+    # 12:05 and 14:45 both refresh the live-Focus snapshot that the rpt_focus__*
+    # import-once anti-joins read; a snapshot older than the last hand-run Focus
+    # import makes the next delivery re-send those records and duplicate them in
+    # Focus. Three snapshots a day means any one of them prevents that -- 14:45
+    # catches the same-day imports, 04:00 is the overnight backstop, and 12:05 is
+    # the last line of defence if both failed.
+    #
+    # 12:05 fires alongside the Finalsite contacts pull, not staggered behind it:
+    # they share no pool and neither gates the other. That matters because the
+    # 12:45 delivery is a plain cron with nothing gating it on this pull
+    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 40 min of
+    # budget. Do not narrow that gap. 12:05 rather than 12:00 avoids top-of-hour
+    # GKE Autopilot step-pod scheduling waits.
+    cron_schedule=["0 4 * * *", "5 12 * * *", "45 14 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -28,8 +28,8 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     #
     # 12:00 fires alongside the Finalsite contacts pull, not staggered behind it:
     # they share no pool and neither gates the other. That matters because the
-    # 12:30 delivery is a plain cron with nothing gating it on this pull
-    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 30 min of
+    # 12:45 delivery is a plain cron with nothing gating it on this pull
+    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 45 min of
     # budget; top-of-hour GKE step-pod scheduling wait (3-9 min) only queues the
     # run, so it fits too. Do not narrow that gap.
     cron_schedule=["0 4 * * *", "0 12 * * *", "45 14 * * *"],

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -19,12 +19,18 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     # Miami enrollment, attendance, and the FRESH scaffold's Miami rows all read
     # it, and FRESH's Tableau extract refreshes at 05:00.
     #
-    # 12:00 and 14:45 both refresh the live-Focus snapshot that the rpt_focus__*
+    # 12:00 and 14:00 both refresh the live-Focus snapshot that the rpt_focus__*
     # import-once anti-joins read; a snapshot older than the last hand-run Focus
     # import makes the next delivery re-send those records and duplicate them in
-    # Focus. Three snapshots a day means any one of them prevents that -- 14:45
+    # Focus. Three snapshots a day means any one of them prevents that -- 14:00
     # catches the same-day imports, 04:00 is the overnight backstop, and 12:00 is
     # the last line of defence if both failed.
+    #
+    # 14:00 sits ON the 2pm commitment rather than after it, so it is NOT a
+    # guaranteed catch: an import that runs late lands after this snapshot. The
+    # safe rule for ops is therefore a dependency, not a clock time -- do not
+    # re-run the delivery unless a Focus sync has run SINCE the last import --
+    # and the 04:00 pull is what makes tomorrow's delivery safe regardless.
     #
     # 12:00 fires alongside the Finalsite contacts pull, not staggered behind it:
     # they share no pool and neither gates the other. That matters because the
@@ -32,7 +38,7 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     # finishing. Observed fire-to-stg_focus latency is 4-7 min against 45 min of
     # budget; top-of-hour GKE step-pod scheduling wait (3-9 min) only queues the
     # run, so it fits too. Do not narrow that gap.
-    cron_schedule=["0 4 * * *", "0 12 * * *", "45 14 * * *"],
+    cron_schedule=["0 4 * * *", "0 12 * * *", "0 14 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -19,20 +19,20 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     # Miami enrollment, attendance, and the FRESH scaffold's Miami rows all read
     # it, and FRESH's Tableau extract refreshes at 05:00.
     #
-    # 12:05 and 14:45 both refresh the live-Focus snapshot that the rpt_focus__*
+    # 12:00 and 14:45 both refresh the live-Focus snapshot that the rpt_focus__*
     # import-once anti-joins read; a snapshot older than the last hand-run Focus
     # import makes the next delivery re-send those records and duplicate them in
     # Focus. Three snapshots a day means any one of them prevents that -- 14:45
-    # catches the same-day imports, 04:00 is the overnight backstop, and 12:05 is
+    # catches the same-day imports, 04:00 is the overnight backstop, and 12:00 is
     # the last line of defence if both failed.
     #
-    # 12:05 fires alongside the Finalsite contacts pull, not staggered behind it:
+    # 12:00 fires alongside the Finalsite contacts pull, not staggered behind it:
     # they share no pool and neither gates the other. That matters because the
     # 12:45 delivery is a plain cron with nothing gating it on this pull
-    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 40 min of
-    # budget. Do not narrow that gap. 12:05 rather than 12:00 avoids top-of-hour
-    # GKE Autopilot step-pod scheduling waits.
-    cron_schedule=["0 4 * * *", "5 12 * * *", "45 14 * * *"],
+    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 45 min of
+    # budget; top-of-hour GKE step-pod scheduling wait (3-9 min) only queues the
+    # run, so it fits too. Do not narrow that gap.
+    cron_schedule=["0 4 * * *", "0 12 * * *", "45 14 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -11,16 +11,23 @@ config = yaml.safe_load(config_file.read_text())
 asset_key_prefix = f"{CODE_LOCATION}/dlt/focus"
 
 focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
+    # "daily" is now three times a day. The name is kept as-is on purpose --
+    # renaming mints a NEW Dagster+ schedule object and abandons this one's
+    # status and tick history.
     name=f"{CODE_LOCATION}__dlt__focus__daily_asset_job_schedule",
     # 04:00 keeps the pre-dawn pull that every Focus-derived model depends on --
     # Miami enrollment, attendance, and the FRESH scaffold's Miami rows all read
-    # it, and FRESH's Tableau extract refreshes at 05:00. 12:25 refreshes the
-    # live-Focus state that the rpt_focus__* import-once anti-joins compare
-    # against, before the 12:45 delivery. 14:45 captures what enrollment ops
-    # imported by hand: import-once is enforced against THIS snapshot, not live
-    # Focus, so without a post-import pull a same-day re-run of the delivery
-    # would re-send every record and duplicate it in Focus.
-    cron_schedule=["0 4 * * *", "25 12 * * *", "45 14 * * *"],
+    # it, and FRESH's Tableau extract refreshes at 05:00. 12:15 and 14:45 both
+    # refresh the live-Focus snapshot that the rpt_focus__* import-once
+    # anti-joins read; a snapshot older than the last hand-run Focus import makes
+    # the next delivery re-send those records and duplicate them in Focus. Three
+    # snapshots a day means any one of them prevents that -- 14:45 catches the
+    # same-day imports, 04:00 is the overnight backstop, and 12:15 is the last
+    # line of defence if both failed. 12:15 (not 12:25) because the delivery
+    # fires at 12:45 on a plain cron with nothing gating it on this pull
+    # finishing: observed fire-to-stg_focus latency is 4-7 min, so 30 minutes of
+    # budget is ~4x the measured need. Do not narrow that gap.
+    cron_schedule=["0 4 * * *", "15 12 * * *", "45 14 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -28,8 +28,8 @@ focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     #
     # 12:00 fires alongside the Finalsite contacts pull, not staggered behind it:
     # they share no pool and neither gates the other. That matters because the
-    # 12:45 delivery is a plain cron with nothing gating it on this pull
-    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 45 min of
+    # 12:30 delivery is a plain cron with nothing gating it on this pull
+    # finishing. Observed fire-to-stg_focus latency is 4-7 min against 30 min of
     # budget; top-of-hour GKE step-pod scheduling wait (3-9 min) only queues the
     # run, so it fits too. Do not narrow that gap.
     cron_schedule=["0 4 * * *", "0 12 * * *", "45 14 * * *"],

--- a/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/schedules.py
@@ -12,7 +12,15 @@ asset_key_prefix = f"{CODE_LOCATION}/dlt/focus"
 
 focus_dlt_daily_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__dlt__focus__daily_asset_job_schedule",
-    cron_schedule="0 4 * * *",
+    # 04:00 keeps the pre-dawn pull that every Focus-derived model depends on --
+    # Miami enrollment, attendance, and the FRESH scaffold's Miami rows all read
+    # it, and FRESH's Tableau extract refreshes at 05:00. 12:25 refreshes the
+    # live-Focus state that the rpt_focus__* import-once anti-joins compare
+    # against, before the 12:45 delivery. 14:45 captures what enrollment ops
+    # imported by hand: import-once is enforced against THIS snapshot, not live
+    # Focus, so without a post-import pull a same-day re-run of the delivery
+    # would re-send every record and duplicate it in Focus.
+    cron_schedule=["0 4 * * *", "25 12 * * *", "45 14 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{asset_key_prefix}/{a['table_name']}" for a in config["assets"]],
 )

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -11,8 +11,13 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Focus by 2:00pm ET -- so this lands at 12:45pm, leaving ops a 75-minute
     # window. Upstreams that must finish first: the manual Finalsite SFTP push
     # (~12:00, ingested within 10 min by the couchdrop sensor), the midday
-    # Finalsite contacts pull (12:10), the midday Focus dlt pull (12:25), and the
+    # Finalsite contacts pull (12:10), the midday Focus dlt pull (12:15), and the
     # dbt rebuild the automation-condition sensor fires off those (~3.5 min).
+    #
+    # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
+    # time budget, not a dependency. Measured need is 4-7 min after each upstream
+    # fires; the budget is 30 min behind the Focus pull and 35 behind the Finalsite
+    # one. Moving this earlier, or an upstream later, spends that margin.
     cron_schedule="45 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -5,7 +5,15 @@ from teamster.code_locations.kippmiami.extracts.jobs import focus_extract_asset_
 
 focus_extract_assets_schedule = ScheduleDefinition(
     job=focus_extract_asset_job,
-    cron_schedule="0 5 * * *",
+    # Delivers the four Focus import CSVs to the Focus SFTP `incoming/` folder.
+    # Enrollment ops run the Focus imports BY HAND, and leadership commits to
+    # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
+    # Focus by 2:00pm ET -- so this lands at 12:45pm, leaving ops a 75-minute
+    # window. Upstreams that must finish first: the manual Finalsite SFTP push
+    # (~12:00, ingested within 10 min by the couchdrop sensor), the midday
+    # Finalsite contacts pull (12:10), the midday Focus dlt pull (12:25), and the
+    # dbt rebuild the automation-condition sensor fires off those (~3.5 min).
+    cron_schedule="45 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -8,25 +8,26 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Delivers the four Focus import CSVs to the Focus SFTP `incoming/` folder.
     # Enrollment ops run the Focus imports BY HAND, and leadership commits to
     # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
-    # Focus by 2:00pm ET -- so this lands at 12:30pm. The hand-run imports are
-    # quick, so the 90 min before 2pm is slack rather than a window being consumed;
-    # 12:30 is chosen for EARLIER usability, not to make room for the imports.
+    # Focus by 2:00pm ET. The imports are near-instant, so the 75 min between this
+    # delivery and 2pm is slack rather than a window being consumed.
+    #
     # Upstreams all run concurrently at 12:00 (nothing about them is sequential):
     # the manual Finalsite SFTP push, the Finalsite contacts pull, the Focus dlt
     # pull, and the dbt rebuild the automation-condition sensor fires off each.
     #
     # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
     # time budget, not a dependency. The binding term is the manual SFTP push, not
-    # any ordering between Finalsite and Focus: worst case ~8 min from push to
-    # rebuilt (2 min couchdrop sensor poll + 2m13s ingest + 3m34s dbt). The
-    # scheduled pulls need only 4-7 min. So the push deadline is always this time
-    # minus ~8 min, which gives ops a 12:00-12:15 push window with margin. Pushing EARLY is
-    # not a safe fallback: it misses anything entered between the push and the noon
-    # cutoff. Moving this delivery LATER is the only lever that widens that window,
-    # and there is ~90 min of slack before 2pm to spend on it if ops needs it.
-    # Anything before ~12:16 puts the late bound before noon, which contradicts the
-    # "entered by 12:00" promise outright.
-    cron_schedule="30 12 * * *",
+    # any ordering between Finalsite and Focus: worst case ~11 min from push to
+    # rebuilt (5 min couchdrop sensor poll + 2m13s ingest + 3m34s dbt); the
+    # scheduled pulls need only 4-7 min. Against 45 min of budget that leaves the
+    # 12:00-12:15 push window ~19 min of margin, and lets the 12:30 freshness check
+    # on #4736 be actionable: a push prompted by it at 12:31 is rebuilt by ~12:42
+    # and still makes this delivery.
+    #
+    # Pushing EARLY is not a safe fallback -- it misses anything entered between
+    # the push and the noon cutoff. Anything before ~12:11 puts the late bound
+    # before noon, contradicting the "entered by 12:00" promise outright.
+    cron_schedule="45 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -9,17 +9,18 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Enrollment ops run the Focus imports BY HAND, and leadership commits to
     # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
     # Focus by 2:00pm ET -- so this lands at 12:45pm, leaving ops a 75-minute
-    # window. Upstreams, all of which run concurrently: the manual Finalsite SFTP
-    # push (~12:00, ingested within 10 min by the couchdrop sensor), the Finalsite
-    # contacts pull (12:05), the Focus dlt pull (12:05), and the dbt rebuild the
+    # window. Upstreams, all of which run concurrently at 12:00: the manual
+    # Finalsite SFTP push (ingested within 10 min by the couchdrop sensor), the
+    # Finalsite contacts pull, the Focus dlt pull, and the dbt rebuild the
     # automation-condition sensor fires off each of those (~3.5 min).
     #
     # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
     # time budget, not a dependency. Measured need is 4-7 min after a schedule
     # fires, or ~16 min from a manual SFTP push in the worst case (10 min sensor
-    # poll + 2 min ingest + 3.5 min dbt). The budget is 40 min. Moving this
-    # earlier, or an upstream later, spends that margin; a push after ~12:29 is
-    # not guaranteed to make this delivery.
+    # poll + 2 min ingest + 3.5 min dbt), plus up to 9 min of top-of-hour GKE
+    # step-pod scheduling wait, which queues rather than fails. The budget is 45
+    # min. Moving this earlier, or an upstream later, spends that margin; a push
+    # after ~12:29 is not guaranteed to make this delivery.
     cron_schedule="45 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -9,15 +9,17 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Enrollment ops run the Focus imports BY HAND, and leadership commits to
     # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
     # Focus by 2:00pm ET -- so this lands at 12:45pm, leaving ops a 75-minute
-    # window. Upstreams that must finish first: the manual Finalsite SFTP push
-    # (~12:00, ingested within 10 min by the couchdrop sensor), the midday
-    # Finalsite contacts pull (12:10), the midday Focus dlt pull (12:15), and the
-    # dbt rebuild the automation-condition sensor fires off those (~3.5 min).
+    # window. Upstreams, all of which run concurrently: the manual Finalsite SFTP
+    # push (~12:00, ingested within 10 min by the couchdrop sensor), the Finalsite
+    # contacts pull (12:05), the Focus dlt pull (12:05), and the dbt rebuild the
+    # automation-condition sensor fires off each of those (~3.5 min).
     #
     # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
-    # time budget, not a dependency. Measured need is 4-7 min after each upstream
-    # fires; the budget is 30 min behind the Focus pull and 35 behind the Finalsite
-    # one. Moving this earlier, or an upstream later, spends that margin.
+    # time budget, not a dependency. Measured need is 4-7 min after a schedule
+    # fires, or ~16 min from a manual SFTP push in the worst case (10 min sensor
+    # poll + 2 min ingest + 3.5 min dbt). The budget is 40 min. Moving this
+    # earlier, or an upstream later, spends that margin; a push after ~12:29 is
+    # not guaranteed to make this delivery.
     cron_schedule="45 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -8,20 +8,21 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Delivers the four Focus import CSVs to the Focus SFTP `incoming/` folder.
     # Enrollment ops run the Focus imports BY HAND, and leadership commits to
     # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
-    # Focus by 2:00pm ET -- so this lands at 12:45pm, leaving ops a 75-minute
-    # window. Upstreams, all of which run concurrently at 12:00: the manual
-    # Finalsite SFTP push (ingested within 10 min by the couchdrop sensor), the
-    # Finalsite contacts pull, the Focus dlt pull, and the dbt rebuild the
-    # automation-condition sensor fires off each of those (~3.5 min).
+    # Focus by 2:00pm ET -- so this lands at 12:30pm, leaving ops 90 minutes.
+    # Upstreams all run concurrently at 12:00 (nothing about them is sequential):
+    # the manual Finalsite SFTP push, the Finalsite contacts pull, the Focus dlt
+    # pull, and the dbt rebuild the automation-condition sensor fires off each.
     #
     # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
-    # time budget, not a dependency. Measured need is 4-7 min after a schedule
-    # fires, or ~16 min from a manual SFTP push in the worst case (10 min sensor
-    # poll + 2 min ingest + 3.5 min dbt), plus up to 9 min of top-of-hour GKE
-    # step-pod scheduling wait, which queues rather than fails. The budget is 45
-    # min. Moving this earlier, or an upstream later, spends that margin; a push
-    # after ~12:29 is not guaranteed to make this delivery.
-    cron_schedule="45 12 * * *",
+    # time budget, not a dependency. The binding term is the manual SFTP push, not
+    # any ordering between Finalsite and Focus: worst case ~16 min from push to
+    # rebuilt (10 min couchdrop sensor poll + 2 min ingest + 3.5 min dbt). The
+    # scheduled pulls need only 4-7 min. So the push deadline is always this time
+    # minus ~16 min -- currently ~12:14. Moving this earlier tightens that
+    # deadline on ops; moving it later cuts their import window. Anything before
+    # ~12:16 makes the push deadline land before noon, which contradicts the
+    # "entered by 12:00" promise outright.
+    cron_schedule="30 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -20,10 +20,11 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # any ordering between Finalsite and Focus: worst case ~16 min from push to
     # rebuilt (10 min couchdrop sensor poll + 2 min ingest + 3.5 min dbt). The
     # scheduled pulls need only 4-7 min. So the push deadline is always this time
-    # minus ~16 min -- currently ~12:14, i.e. 14 min after the noon cutoff. Moving
-    # this LATER is the only lever that buys ops more push tolerance, and there is
-    # ~90 min of slack before 2pm to spend if they turn out to need it. Anything
-    # before ~12:16 makes the push deadline land before noon, which contradicts the
+    # minus ~16 min, which gives ops a 12:00-12:15 push window. Pushing EARLY is
+    # not a safe fallback: it misses anything entered between the push and the noon
+    # cutoff. Moving this delivery LATER is the only lever that widens that window,
+    # and there is ~90 min of slack before 2pm to spend on it if ops needs it.
+    # Anything before ~12:16 puts the late bound before noon, which contradicts the
     # "entered by 12:00" promise outright.
     cron_schedule="30 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -8,7 +8,9 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # Delivers the four Focus import CSVs to the Focus SFTP `incoming/` folder.
     # Enrollment ops run the Focus imports BY HAND, and leadership commits to
     # stakeholders that a student entered in Finalsite by 12:00pm ET is usable in
-    # Focus by 2:00pm ET -- so this lands at 12:30pm, leaving ops 90 minutes.
+    # Focus by 2:00pm ET -- so this lands at 12:30pm. The hand-run imports are
+    # quick, so the 90 min before 2pm is slack rather than a window being consumed;
+    # 12:30 is chosen for EARLIER usability, not to make room for the imports.
     # Upstreams all run concurrently at 12:00 (nothing about them is sequential):
     # the manual Finalsite SFTP push, the Finalsite contacts pull, the Focus dlt
     # pull, and the dbt rebuild the automation-condition sensor fires off each.
@@ -18,9 +20,10 @@ focus_extract_assets_schedule = ScheduleDefinition(
     # any ordering between Finalsite and Focus: worst case ~16 min from push to
     # rebuilt (10 min couchdrop sensor poll + 2 min ingest + 3.5 min dbt). The
     # scheduled pulls need only 4-7 min. So the push deadline is always this time
-    # minus ~16 min -- currently ~12:14. Moving this earlier tightens that
-    # deadline on ops; moving it later cuts their import window. Anything before
-    # ~12:16 makes the push deadline land before noon, which contradicts the
+    # minus ~16 min -- currently ~12:14, i.e. 14 min after the noon cutoff. Moving
+    # this LATER is the only lever that buys ops more push tolerance, and there is
+    # ~90 min of slack before 2pm to spend if they turn out to need it. Anything
+    # before ~12:16 makes the push deadline land before noon, which contradicts the
     # "entered by 12:00" promise outright.
     cron_schedule="30 12 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),

--- a/src/teamster/code_locations/kippmiami/extracts/schedules.py
+++ b/src/teamster/code_locations/kippmiami/extracts/schedules.py
@@ -17,10 +17,10 @@ focus_extract_assets_schedule = ScheduleDefinition(
     #
     # NOTHING GATES THIS ON THOSE UPSTREAMS -- it is a plain cron, so the gap is a
     # time budget, not a dependency. The binding term is the manual SFTP push, not
-    # any ordering between Finalsite and Focus: worst case ~16 min from push to
-    # rebuilt (10 min couchdrop sensor poll + 2 min ingest + 3.5 min dbt). The
+    # any ordering between Finalsite and Focus: worst case ~8 min from push to
+    # rebuilt (2 min couchdrop sensor poll + 2m13s ingest + 3m34s dbt). The
     # scheduled pulls need only 4-7 min. So the push deadline is always this time
-    # minus ~16 min, which gives ops a 12:00-12:15 push window. Pushing EARLY is
+    # minus ~8 min, which gives ops a 12:00-12:15 push window with margin. Pushing EARLY is
     # not a safe fallback: it misses anything entered between the push and the noon
     # cutoff. Moving this delivery LATER is the only lever that widens that window,
     # and there is ~90 min of slack before 2pm to spend on it if ops needs it.

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -8,13 +8,19 @@ finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     # tick history.
     name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
     # 04:00 stays for the overnight refresh every other Finalsite consumer reads.
-    # 12:10 feeds the midday Focus import cycle: it runs after enrollment ops push
-    # the Finalsite SFTP export at 12:00, and int_finalsite__enrollment_lifecycle
-    # needs BOTH this API pull and that SFTP drop before the rpt_focus__* extracts
-    # mean anything. Miami is the only district on a midday tick, so the
-    # finalsite_api pool is uncontended then -- at 04:00 the four districts
-    # serialize and Miami has waited up to 46 minutes for a slot.
-    cron_schedule=["0 4 * * *", "10 12 * * *"],
+    # 12:05 feeds the midday Focus import cycle, firing alongside the Focus dlt
+    # pull rather than staggered behind it: they share no pool and neither gates
+    # the other (this API pull and the manually-pushed SFTP drop feed opposite
+    # sides of int_finalsite__enrollment_lifecycle; the dlt pull feeds the
+    # import-once anti-join). 12:05 rather than 12:00 because top-of-hour GKE
+    # Autopilot fan-out is the dominant cause of step-pod scheduling waits (3-9
+    # min), and because it leaves ops a few minutes' slop around the 12:00 manual
+    # SFTP push so both sides of the join share one cutoff.
+    #
+    # Miami is the only district on a midday tick, so the finalsite_api pool
+    # (limit 1) is uncontended then -- at 04:00 the four districts serialize and
+    # Miami has waited up to 46 minutes for a slot.
+    cron_schedule=["0 4 * * *", "5 12 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{CODE_LOCATION}/finalsite/contacts"],
     # Covers a full sequential pull plus GKE step-pod scheduling wait. The

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -3,6 +3,9 @@ from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition
 from teamster.code_locations.kippmiami import CODE_LOCATION, LOCAL_TIMEZONE
 
 finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
+    # "daily" is now twice a day. The name is kept as-is on purpose -- renaming
+    # mints a NEW Dagster+ schedule object and abandons this one's status and
+    # tick history.
     name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
     # 04:00 stays for the overnight refresh every other Finalsite consumer reads.
     # 12:10 feeds the midday Focus import cycle: it runs after enrollment ops push

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -13,8 +13,8 @@ finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     # the other (this API pull and the manually-pushed SFTP drop feed opposite
     # sides of int_finalsite__enrollment_lifecycle; the dlt pull feeds the
     # import-once anti-join). Top-of-hour GKE Autopilot fan-out can add 3-9 min of
-    # step-pod scheduling wait, which only queues the run -- against 30 min before
-    # the 12:30 delivery that is noise, and the 3600s max_runtime below absorbs it.
+    # step-pod scheduling wait, which only queues the run -- against 45 min before
+    # the 12:45 delivery that is noise, and the 3600s max_runtime below absorbs it.
     #
     # Miami is the only district on a midday tick, so the finalsite_api pool
     # (limit 1) is uncontended then -- at 04:00 the four districts serialize and

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -8,19 +8,18 @@ finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     # tick history.
     name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
     # 04:00 stays for the overnight refresh every other Finalsite consumer reads.
-    # 12:05 feeds the midday Focus import cycle, firing alongside the Focus dlt
+    # 12:00 feeds the midday Focus import cycle, firing alongside the Focus dlt
     # pull rather than staggered behind it: they share no pool and neither gates
     # the other (this API pull and the manually-pushed SFTP drop feed opposite
     # sides of int_finalsite__enrollment_lifecycle; the dlt pull feeds the
-    # import-once anti-join). 12:05 rather than 12:00 because top-of-hour GKE
-    # Autopilot fan-out is the dominant cause of step-pod scheduling waits (3-9
-    # min), and because it leaves ops a few minutes' slop around the 12:00 manual
-    # SFTP push so both sides of the join share one cutoff.
+    # import-once anti-join). Top-of-hour GKE Autopilot fan-out can add 3-9 min of
+    # step-pod scheduling wait, which only queues the run -- against 45 min before
+    # the 12:45 delivery that is noise, and the 3600s max_runtime below absorbs it.
     #
     # Miami is the only district on a midday tick, so the finalsite_api pool
     # (limit 1) is uncontended then -- at 04:00 the four districts serialize and
     # Miami has waited up to 46 minutes for a slot.
-    cron_schedule=["0 4 * * *", "5 12 * * *"],
+    cron_schedule=["0 4 * * *", "0 12 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{CODE_LOCATION}/finalsite/contacts"],
     # Covers a full sequential pull plus GKE step-pod scheduling wait. The

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -13,8 +13,8 @@ finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     # the other (this API pull and the manually-pushed SFTP drop feed opposite
     # sides of int_finalsite__enrollment_lifecycle; the dlt pull feeds the
     # import-once anti-join). Top-of-hour GKE Autopilot fan-out can add 3-9 min of
-    # step-pod scheduling wait, which only queues the run -- against 45 min before
-    # the 12:45 delivery that is noise, and the 3600s max_runtime below absorbs it.
+    # step-pod scheduling wait, which only queues the run -- against 30 min before
+    # the 12:30 delivery that is noise, and the 3600s max_runtime below absorbs it.
     #
     # Miami is the only district on a midday tick, so the finalsite_api pool
     # (limit 1) is uncontended then -- at 04:00 the four districts serialize and

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -4,7 +4,14 @@ from teamster.code_locations.kippmiami import CODE_LOCATION, LOCAL_TIMEZONE
 
 finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    cron_schedule="0 4 * * *",
+    # 04:00 stays for the overnight refresh every other Finalsite consumer reads.
+    # 12:10 feeds the midday Focus import cycle: it runs after enrollment ops push
+    # the Finalsite SFTP export at 12:00, and int_finalsite__enrollment_lifecycle
+    # needs BOTH this API pull and that SFTP drop before the rpt_focus__* extracts
+    # mean anything. Miami is the only district on a midday tick, so the
+    # finalsite_api pool is uncontended then -- at 04:00 the four districts
+    # serialize and Miami has waited up to 46 minutes for a slot.
+    cron_schedule=["0 4 * * *", "10 12 * * *"],
     execution_timezone=str(LOCAL_TIMEZONE),
     target=[f"{CODE_LOCATION}/finalsite/contacts"],
     # Covers a full sequential pull plus GKE step-pod scheduling wait. The


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will move the Finalsite to Focus import onto a midday cadence so that enrollment leadership can tell stakeholders: **a student entered in Finalsite by 12:00pm ET is usable in Focus by 2:00pm ET.**

Focus imports are run by hand, so the delivery has to land early enough for ops to finish before 2pm. New chain:

| Time  | Step                                                | Change                     |
| ----- | --------------------------------------------------- | -------------------------- |
| 12:00 | Ops manually pushes the Finalsite SFTP export       | manual, ops                |
| 12:10 | Couchdrop sensor has ingested `status_report`       | none, 10 min poll          |
| 12:05 | Finalsite API `contacts` pull                       | added midday cron          |
| 12:05 | Focus dlt pull                                      | added midday cron          |
| 12:15 | dbt rebuild fires from the automation sensor        | none, measured at 3m 34s   |
| 12:45 | Four CSVs delivered to the Focus SFTP `incoming/`   | retimed from 05:00         |
| 14:00 | 2pm commitment met, after 75 min of manual importing | ops                       |
| 14:45 | Focus dlt pull number two                           | added, secondary ask       |

### Why add midday runs instead of moving the overnight ones

Miami is Focus-sourced network-wide, and Focus feeds Miami enrollment, attendance, and the FRESH scaffold's Miami rows. FRESH's Tableau extract refreshes at 05:00, so moving the only Focus pull to midday would leave every morning dashboard on day-old Miami data. A dlt pull is 3-6 min and a Finalsite pull 4-7 min, so three runs a day is cheap.

The 04:00 Finalsite `contacts` run also matters for a second reason: all four districts share the `finalsite_api` pool at limit 1, and Miami has waited up to 46 minutes for a slot at 04:00. Miami is the only district on a midday tick, so the midday tick runs uncontended.

### Why the 14:45 pull is a safety fix, not just a convenience

`rpt_focus__*` import-once is an anti-join against the dlt **snapshot** of Focus, not live Focus. Re-running the delivery after ops imports but before the next Focus sync re-sends every record and duplicates it in Focus. The 14:45 pull closes that window for the rest of the day; the doc now also states the rule for ops.

## AI Assistance

Claude Code authored the schedule changes and both doc updates. Human-directed: the 2pm commitment, the noon Finalsite cutoff, the manual-push and manual-import constraints, and the after-2pm warehouse sync ask. AI-derived: the specific times, the add-instead-of-move decision, the latency measurements from Dagster run history, and the import-once re-run hazard.

## Not in this PR

Tracked on #4736:

1. **The delivery schedule still has to be STARTED in the Dagster+ UI.** `kippmiami__extracts__focus__asset_job_schedule` is STOPPED and the four CSV assets have zero prod materializations, so this cadence is inert until someone starts it. A manual dry run into `incoming/` should come first.
1. **Freshness alert on the manual push.** The nightly Finalsite drop has been landing at 2:46, 2:50, and 2:53am ET on three consecutive days. On a day nobody pushes manually, the 12:45 delivery silently carries data as of roughly 2:50am. Wants an alert if `status_report` modified time is not from today by 12:15.
1. **A second FRESH Tableau refresh** after the midday cycle, so SRE sees the noon cutoff. The exposure refreshes at `0 5 * * *` only.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [x] Verified `ScheduleDefinition` accepts `cron_schedule: str | Sequence[str]` from the dagster source, and confirmed the loaded values: `['0 4 * * *', '10 12 * * *']`, `['0 4 * * *', '25 12 * * *', '45 14 * * *']`, `45 12 * * *`, all `America/New_York`. Schedule names are unchanged, so the existing STOPPED Dagster+ schedule is the same object.
- [ ] `uv run dagster definitions validate` and `pytest tests/test_dagster_definitions.py` — **not run.** Both fail in the codespace for `kippmiami` for reasons documented in `src/teamster/CLAUDE.md`: `dlt/focus/assets.py` resolves the Focus DB credential eagerly at module load and it is unset here. Verified instead with `py_compile` on all three files plus a direct import of the `finalsite` and `extracts` schedule modules, and an importlib load of the `dlt/focus` one that bypasses the credential-resolving package `__init__`. Worth a real validate run by a reviewer with credentials.
- [x] No new integrations; existing Library + Config pattern untouched.

### dbt

No dbt changes.

### Docs

- [ ] Regenerate the automations catalog — **not run.** `docs/CLAUDE.md` says to regenerate only where all locations load, which the codespace cannot do. Note that `docs/reference/automations.md` is already stale independent of this PR: it lists retired kippmiami PowerSchool schedules and carries none of the three schedules this PR touches.
- [x] Updated `src/teamster/code_locations/kippmiami/CLAUDE.md` — the Active Integrations trigger column plus a new section on the midday chain and the two constraints to preserve.
- [x] Updated `docs/reference/finalsite-focus-import.md` — the enrollment-team page now documents the 12:45 delivery, the two manual steps, the 2pm commitment scoped to **new students only**, and the do-not-re-run-before-14:45 rule.

## CI checks

- [ ] **Trunk** — `trunk check --force` on all five changed files came back clean after the pre-commit `fmt` pass.
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud**

Refs #4736


---

**Update (2026-08-05):** review findings addressed in `01ecd4fbf` — midday Focus pull moved 12:25 → 12:15 to widen the ungated buffer from 20 to 30 min against a measured 4-7 min need. See the [reply comment](https://github.com/TEAMSchools/teamster/pull/4737#issuecomment-5194165381) for per-finding verification.


**Update 2:** the three midday inputs now fire concurrently at **12:05** (`635c15f0a`) rather than staggered at 12:10/12:15. They share no pool and none gates another, so the stagger bought nothing; collapsing it widens the ungated budget before the 12:45 delivery from 30 to 40 min and lines the contacts cutoff up with the manual noon SFTP push. `12:05` not `12:00` to avoid top-of-hour GKE Autopilot step-pod scheduling waits.

Also documented the manual push window for the enrollment team: 11:55-12:05 ideal, ~12:29 hard deadline, and an off-cutoff push defers a student to the next day rather than half-importing them.
