### PR TITLE
refactor(extracts): move ParentSquare delivery to the kippnewark code location

### DIFF
--- a/docs/superpowers/specs/2026-07-29-parentsquare-newark-extracts-design.md
+++ b/docs/superpowers/specs/2026-07-29-parentsquare-newark-extracts-design.md
@@ -275,6 +275,12 @@ All seven files sent. `Yes*` = one of email/phone required.
 
 ## Delivery
 
+- **Owned by the `kippnewark` code location**, not `kipptaf` — see _Delivery
+  moved to the kippnewark code location_ under _Implementation notes_. The seven
+  `rpt_parentsquare__*` views stay in `kipptaf` and now cover all three
+  PowerSchool NJ regions; `kippnewark` holds thin wrappers, the SFTP resource,
+  the job, and the schedule. Every reference to `kipptaf` owning the config,
+  resource, job, or schedule earlier in this document is superseded.
 - Server `sftp3.parentsquare.com`, **district-level single connection** (one set
   of files covering all Newark schools). Password or SSH key — created in the
   ParentSquare admin UI, which issues the username.
@@ -421,12 +427,78 @@ with the rest of the row. This drops 6 emergency-contact rows whose only phone
 is a 9-digit typo and which carry no email — an upstream Finalsite data-entry
 fix for Ops, not a modelling problem.
 
-### No exposure
+### Exposure — reversed once delivery moved regional
 
-Every SFTP extract feed in the repo omits one and the extract asset already
-depends on the dbt model's asset key, so lineage is intact. Adding a lone
-`sftp.yml` exposure for ParentSquare would be inconsistent with clever,
-illuminate, idauto, coupa, and egencia.
+The original call was to omit one, on the grounds that every SFTP extract feed
+in the repo omits one (clever, illuminate, idauto, coupa, egencia). That survey
+missed the one feed this build now resembles: `powerschool_autocomm`, which is
+delivered from the regional projects and **does** carry an exposure, in the
+regional project. Moving ParentSquare delivery to `kippnewark` put it on that
+side of the line, so `src/dbt/kippnewark/models/exposures/parentsquare.yml`
+exists and mirrors `powerschool.yml`.
+
+### Delivery moved to the kippnewark code location
+
+Issue #4735, a follow-up after #4668 merged. The feed is Newark-only, so the
+Newark Dagster instance owns delivery — following the `extracts/powerschool/`
+autocomm precedent rather than the Clever one this build originally copied.
+
+| Layer                                              | Before                            | After                                |
+| -------------------------------------------------- | --------------------------------- | ------------------------------------ |
+| 7 `rpt_parentsquare__*` views, descriptions, tests | kipptaf                           | kipptaf (unchanged home)             |
+| Region filter                                      | inside each kipptaf view          | each district's thin wrapper         |
+| Extract config, assets, job, schedule              | kipptaf                           | kippnewark                           |
+| `SSH_RESOURCE_PARENTSQUARE` + 3 variable mappings  | kipptaf                           | kippnewark                           |
+| Asset keys                                         | `kipptaf/extracts/parentsquare/*` | `kippnewark/extracts/parentsquare/*` |
+
+The model logic could not move. `rpt_parentsquare__staff` joins
+`stg_ldap__group`, `stg_ldap__user_person` and `int_people__staff_roster`,
+`rpt_parentsquare__sections` reads the staff feed, and `int_students__contacts`
+/ `int_extracts__student_enrollments` are kipptaf-level cross-region models.
+
+Pushing the region filter down widened the views from Newark to the three
+PowerSchool NJ regions — Miami excluded, since it rosters from Focus rather than
+PowerSchool, the same carve-out `rpt_clever__*` makes — and exposed a
+`code_location` column each wrapper filters on, named to match
+`rpt_powerschool__autocomm_students`. A future Camden or Paterson feed is then a
+copy of the wrappers plus config, with no kipptaf SQL change.
+
+Two consequences of widening needed real changes, not just a filter swap:
+
+- **The staff school fan-out is now region-keyed.** A bare `cross join` would
+  put every Newark leader at every NJ school. The join mirrors the "all region"
+  assignment branch of `rpt_clever__staff`.
+- **The section owner is picked per region.** `min(staff_id)` over the whole
+  staff feed would assign one leader network-wide, dangling in every other
+  region's file — and the single-column `relationships` test on `staff_id` would
+  still have passed, because it only proves the id exists somewhere in the feed.
+  `section_owner` now groups by `code_location`; the join to it is a LEFT join
+  so an emptied Ops group still trips the `not_null` guard rather than silently
+  dropping that region's sections; and a new singular test
+  `rpt_parentsquare__sections__staff_id_resolves_at_its_own_school` asserts the
+  `(school_id, staff_id)` pair resolves. The Clever feeds shipped this same
+  class of cross-region leak before.
+
+Widening was checked against prod data before implementing, since it changes the
+population 33 error-severity tests run over: no school-number collisions across
+the three NJ regions, `student_number` unique across them (7,894 of 7,894),
+every NJ grade level inside 0..12 (so the `-4`..`12` `accepted_values` test
+still holds), and every NJ region carrying at least one Ops leader with no
+missing `google_email` (Newark 8, Camden 2, Paterson 1). A local `dbt build` of
+the seven views then ran 48/48 green with no warnings, and Newark's row counts
+came out identical to the pre-change prod views, file for file, measured in the
+same moment — the absolute figures drift from the table below as enrollment
+changes.
+
+NJ-wide counts, for contrast with the Newark figures below — `schools` 19,
+`students` 9,821, `parents` 12,982, `emergency_contacts` 20,593, `staff` 108,
+`sections` 86, `rosters` 9,821.
+
+The wrappers read prod `kipptaf_extracts` (their source carries no
+target-conditional schema, same as the autocomm wrappers), so they cannot be
+built locally until the widened kipptaf views reach prod. Post-merge ordering
+comes from the `sources.yml` `asset_key` mapping, which makes each kipptaf view
+an upstream of its wrapper in the Dagster asset graph.
 
 ### Verified output (current academic year, prod data)
 

--- a/src/dbt/kippnewark/models/exposures/parentsquare.yml
+++ b/src/dbt/kippnewark/models/exposures/parentsquare.yml
@@ -1,0 +1,19 @@
+exposures:
+  - name: parentsquare
+    label: ParentSquare
+    type: application
+    owner:
+      name: Data Team
+    depends_on:
+      - ref("rpt_parentsquare__emergency_contacts")
+      - ref("rpt_parentsquare__parents")
+      - ref("rpt_parentsquare__rosters")
+      - ref("rpt_parentsquare__schools")
+      - ref("rpt_parentsquare__sections")
+      - ref("rpt_parentsquare__staff")
+      - ref("rpt_parentsquare__students")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - parentsquare

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
@@ -1,0 +1,17 @@
+models:
+  - name: rpt_parentsquare__emergency_contacts
+    columns:
+      - name: contact_id
+        data_type: string
+      - name: student_id
+        data_type: string
+      - name: school_id
+        data_type: string
+      - name: first_name
+        data_type: string
+      - name: last_name
+        data_type: string
+      - name: phone
+        data_type: string
+      - name: email
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_parentsquare__emergency_contacts
+    config:
+      meta:
+        contains_pii: true
     columns:
       - name: contact_id
         data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
@@ -1,0 +1,19 @@
+models:
+  - name: rpt_parentsquare__parents
+    columns:
+      - name: student_id
+        data_type: string
+      - name: school_id
+        data_type: string
+      - name: first_name
+        data_type: string
+      - name: last_name
+        data_type: string
+      - name: relationship
+        data_type: string
+      - name: mobile
+        data_type: string
+      - name: secondary_phone
+        data_type: string
+      - name: email
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_parentsquare__parents
+    config:
+      meta:
+        contains_pii: true
     columns:
       - name: student_id
         data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__rosters.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__rosters.yml
@@ -1,0 +1,9 @@
+models:
+  - name: rpt_parentsquare__rosters
+    columns:
+      - name: student_id
+        data_type: string
+      - name: section_id
+        data_type: string
+      - name: school_id
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__schools.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__schools.yml
@@ -1,0 +1,23 @@
+models:
+  - name: rpt_parentsquare__schools
+    columns:
+      - name: school_id
+        data_type: string
+      - name: school_name
+        data_type: string
+      - name: school_zip
+        data_type: string
+      - name: school_address
+        data_type: string
+      - name: school_city
+        data_type: string
+      - name: school_state
+        data_type: string
+      - name: principal_email
+        data_type: string
+      - name: school_phone
+        data_type: string
+      - name: principal_first_name
+        data_type: string
+      - name: principal_last_name
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__sections.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__sections.yml
@@ -1,0 +1,15 @@
+models:
+  - name: rpt_parentsquare__sections
+    columns:
+      - name: section_id
+        data_type: string
+      - name: school_id
+        data_type: string
+      - name: staff_id
+        data_type: string
+      - name: section_number
+        data_type: string
+      - name: is_primary
+        data_type: string
+      - name: course_name
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
@@ -1,0 +1,15 @@
+models:
+  - name: rpt_parentsquare__staff
+    columns:
+      - name: staff_id
+        data_type: string
+      - name: school_id
+        data_type: string
+      - name: email
+        data_type: string
+      - name: title
+        data_type: string
+      - name: first_name
+        data_type: string
+      - name: last_name
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_parentsquare__staff
+    config:
+      meta:
+        contains_pii: true
     columns:
       - name: staff_id
         data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
@@ -1,0 +1,15 @@
+models:
+  - name: rpt_parentsquare__students
+    columns:
+      - name: student_id
+        data_type: string
+      - name: school_id
+        data_type: string
+      - name: grade_level
+        data_type: string
+      - name: first_name
+        data_type: string
+      - name: last_name
+        data_type: string
+      - name: status
+        data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_parentsquare__students
+    config:
+      meta:
+        contains_pii: true
     columns:
       - name: student_id
         data_type: string

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__emergency_contacts.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__emergency_contacts.sql
@@ -1,0 +1,3 @@
+select contact_id, student_id, school_id, first_name, last_name, phone, email,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__emergency_contacts") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__parents.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__parents.sql
@@ -1,0 +1,11 @@
+select
+    student_id,
+    school_id,
+    first_name,
+    last_name,
+    relationship,
+    mobile,
+    secondary_phone,
+    email,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__parents") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__rosters.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__rosters.sql
@@ -1,0 +1,3 @@
+select student_id, section_id, school_id,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__rosters") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__schools.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__schools.sql
@@ -1,0 +1,13 @@
+select
+    school_id,
+    school_name,
+    school_zip,
+    school_address,
+    school_city,
+    school_state,
+    principal_email,
+    school_phone,
+    principal_first_name,
+    principal_last_name,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__schools") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__sections.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__sections.sql
@@ -1,0 +1,3 @@
+select section_id, school_id, staff_id, section_number, is_primary, course_name,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__sections") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__staff.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__staff.sql
@@ -1,0 +1,3 @@
+select staff_id, school_id, email, title, first_name, last_name,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__staff") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__students.sql
+++ b/src/dbt/kippnewark/models/extracts/parentsquare/rpt_parentsquare__students.sql
@@ -1,0 +1,3 @@
+select student_id, school_id, grade_level, first_name, last_name, `status`,
+from {{ source("kipptaf_extracts", "rpt_parentsquare__students") }}
+where code_location = '{{ project_name }}'

--- a/src/dbt/kippnewark/models/extracts/sources.yml
+++ b/src/dbt/kippnewark/models/extracts/sources.yml
@@ -28,3 +28,66 @@ sources:
                 - kipptaf
                 - extracts
                 - rpt_powerschool__autocomm_students_iep
+      - name: rpt_parentsquare__schools
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__schools
+      - name: rpt_parentsquare__students
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__students
+      - name: rpt_parentsquare__parents
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__parents
+      - name: rpt_parentsquare__emergency_contacts
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__emergency_contacts
+      - name: rpt_parentsquare__staff
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__staff
+      - name: rpt_parentsquare__sections
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__sections
+      - name: rpt_parentsquare__rosters
+        config:
+          meta:
+            dagster:
+              group: extracts
+              asset_key:
+                - kipptaf
+                - extracts
+                - rpt_parentsquare__rosters

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -178,13 +178,29 @@ over per-region finalsite sources.
 data, and push to their own PowerSchool instance. Exposures live in regional
 projects, not kipptaf.
 
-This cross-project shape generalizes (e.g. finalsite→focus): the heavy `rpt_*`
-view lives in kipptaf sourcing district data via `source()`, and each district
-has a thin wrapper sourcing `kipptaf_extracts`. The wrapper is
-contract-columns-only — NO data tests or descriptions (those live on the kipptaf
-view). A new kipptaf region source (`sources-kipp*.yml`) needs the
-`dev`/`staging` (`zz_stg_`)/prod schema branch, or single-PR cross-project CI
-can't read it.
+This cross-project shape generalizes (e.g. finalsite→focus,
+`extracts/parentsquare/`): the heavy `rpt_*` view lives in kipptaf sourcing
+district data via `source()`, and each district has a thin wrapper sourcing
+`kipptaf_extracts`. The wrapper is contract-columns-only — NO data tests or
+descriptions (those live on the kipptaf view). A new kipptaf region source
+(`sources-kipp*.yml`) needs the `dev`/`staging` (`zz_stg_`)/prod schema branch,
+or single-PR cross-project CI can't read it.
+
+**The wrapper's region filter is a `code_location` column** the kipptaf view
+exposes (`_dbt_source_project as code_location`, or the roster's
+`home_work_location_dagster_code_location` for staff feeds) — the wrapper then
+filters `where code_location = '{{ project_name }}'` and does NOT project it.
+Don't expose `_dbt_source_project` under its own name for this; `code_location`
+is what `rpt_powerschool__autocomm_students` and `rpt_parentsquare__*` use.
+
+**Widening a Newark-only view to NJ is not just a filter swap** — a bare
+`cross join` to schools fans a region's staff across every NJ school, and an
+ungrouped `min()` pick over a sibling feed assigns one owner network-wide that
+dangles in every other region's file while a single-column `relationships` test
+still passes. Region-key both, and check school-number / `student_number`
+collisions and enum-domain tests (e.g. grade level) against prod before
+implementing, since widening changes the population every error-severity test
+runs over.
 
 **finalsite→focus exception**: the kippmiami `rpt_focus__*` are NOT thin
 pass-throughs — they are the reconciliation layer (import-once / diff against

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__emergency_contacts.yml
@@ -1,9 +1,11 @@
 models:
   - name: rpt_parentsquare__emergency_contacts
     description:
-      ParentSquare `emergency_contacts.csv` for KIPP Newark — one row per
-      emergency contact of a currently-enrolled student, drawn from the
-      Finalsite emergency-contact slots 1 through 4. Delivered as a full
+      ParentSquare `emergency_contacts.csv` for the KIPP NJ regions — one row
+      per emergency contact of a currently-enrolled student, drawn from the
+      Finalsite emergency-contact slots 1 through 4. Each district's thin
+      `extracts/parentsquare` wrapper slices this to its own `code_location`,
+      and that wrapper is what ParentSquare receives. Delivered as a full
       snapshot each run. Rows carrying neither an email nor a phone are dropped,
       since ParentSquare cannot reach them. Emergency contacts receive only
       Smart and Urgent Alerts and get no ParentSquare account.
@@ -16,7 +18,8 @@ models:
           `finalsite_contact_id` because emergency contacts are scalar custom
           fields on the student's own Finalsite record — not linked contact
           records — so `finalsite_contact_id` is null for every one of them and
-          (student, slot) is the true grain.
+          (student, slot) is the true grain. No region component is needed —
+          `student_number` is unique across the NJ regions this view covers.
         data_tests:
           - unique:
               config:
@@ -35,6 +38,17 @@ models:
         description:
           PowerSchool `school_number` of the student's school, as a string.
           Matches a `rpt_parentsquare__schools` row.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region; it is not part of the ParentSquare file and no
+          wrapper projects it.
         data_tests:
           - not_null:
               config:

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
@@ -1,14 +1,16 @@
 models:
   - name: rpt_parentsquare__parents
     description:
-      ParentSquare `parents.csv` for KIPP Newark — one row per household parent
-      of a currently-enrolled student, drawn from the Finalsite Household 1
-      Parent 1 and Parent 2 slots. Delivered as a full snapshot each run. Rows
-      carrying neither an email nor a mobile number are dropped, since
-      ParentSquare cannot create a contactable account without one. `parent_id`
-      is deliberately not emitted — ParentSquare then matches a parent across
-      their children by email and phone, which keeps one account per person
-      instead of one per child.
+      ParentSquare `parents.csv` for the KIPP NJ regions — one row per household
+      parent of a currently-enrolled student, drawn from the Finalsite Household
+      1 Parent 1 and Parent 2 slots. Each district's thin
+      `extracts/parentsquare` wrapper slices this to its own `code_location`,
+      and that wrapper is what ParentSquare receives. Delivered as a full
+      snapshot each run. Rows carrying neither an email nor a mobile number are
+      dropped, since ParentSquare cannot create a contactable account without
+      one. `parent_id` is deliberately not emitted — ParentSquare then matches a
+      parent across their children by email and phone, which keeps one account
+      per person instead of one per child.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -33,6 +35,17 @@ models:
         description:
           PowerSchool `school_number` of the child's school, as a string.
           Matches a `rpt_parentsquare__schools` row.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region; it is not part of the ParentSquare file and no
+          wrapper projects it.
         data_tests:
           - not_null:
               config:

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__rosters.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__rosters.yml
@@ -1,9 +1,11 @@
 models:
   - name: rpt_parentsquare__rosters
     description:
-      ParentSquare `rosters.csv` for KIPP Newark — one row per enrolled student,
-      placing them in their school-and-grade section. Together with
-      `rpt_parentsquare__sections` this satisfies ParentSquare's roster
+      ParentSquare `rosters.csv` for the KIPP NJ regions — one row per enrolled
+      student, placing them in their school-and-grade section. Each district's
+      thin `extracts/parentsquare` wrapper slices this to its own
+      `code_location`, and that wrapper is what ParentSquare receives. Together
+      with `rpt_parentsquare__sections` this satisfies ParentSquare's roster
       requirement at the school-and-grade granularity the Integration Planner
       specified, without any teacher-classroom data. Both models read the same
       enrollment filter and build `section_id` the same way, so every row
@@ -61,5 +63,16 @@ models:
               arguments:
                 to: ref('rpt_parentsquare__schools')
                 field: school_id
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region; it is not part of the ParentSquare file and no
+          wrapper projects it.
+        data_tests:
+          - not_null:
               config:
                 severity: error

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__schools.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__schools.yml
@@ -1,7 +1,11 @@
 models:
   - name: rpt_parentsquare__schools
     description:
-      ParentSquare `schools.csv` for KIPP Newark — one row per reporting school.
+      ParentSquare `schools.csv` for the KIPP NJ regions — one row per reporting
+      school. Miami is excluded because it rosters from Focus rather than
+      PowerSchool. Each district's thin `extracts/parentsquare` wrapper slices
+      this to its own `code_location`, and that wrapper is what ParentSquare
+      receives; this view is the shared export format, not a delivered file.
       Delivered as a full snapshot each run; ParentSquare reconciles adds and
       removals on its side. `state_excludefromreporting` filters out the summer
       school, graduated-students, and non-operating placeholder schools, leaving
@@ -18,6 +22,17 @@ models:
           - unique:
               config:
                 severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region; it is not part of the ParentSquare file and no
+          wrapper projects it.
+        data_tests:
           - not_null:
               config:
                 severity: error

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__sections.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__sections.yml
@@ -1,10 +1,12 @@
 models:
   - name: rpt_parentsquare__sections
     description:
-      ParentSquare `sections.csv` for KIPP Newark — one synthetic section per
-      (school, grade). The Integration Planner sets granularity at school and
-      grade level only and excludes teacher-classroom rostering, so these stand
-      in for real course sections — they give ParentSquare the grade-level
+      ParentSquare `sections.csv` for the KIPP NJ regions — one synthetic
+      section per (school, grade). Each district's thin `extracts/parentsquare`
+      wrapper slices this to its own `code_location`, and that wrapper is what
+      ParentSquare receives. The Integration Planner sets granularity at school
+      and grade level only and excludes teacher-classroom rostering, so these
+      stand in for real course sections — they give ParentSquare the grade-level
       grouping that `sections.csv` and `rosters.csv` require without importing a
       single teacher. Sections are derived from the (school, grade) pairs
       students are actually enrolled in, so none is empty. `term_id` is omitted
@@ -45,18 +47,21 @@ models:
         description:
           The Operations leader who owns the section. Which one owns it is a
           formality — their access comes from their staff rows, not from section
-          membership — so one is picked deterministically from the staff feed,
-          which also guarantees the value resolves in `staff.csv`.
+          membership — so one is picked deterministically from the staff feed of
+          the section's own region, which guarantees the value resolves in that
+          region's `staff.csv` and at that section's own school.
         data_tests:
           # `severity: error` matters more here than it looks. The owner comes
-          # from `min(staff_id)` over the staff feed, and an ungrouped aggregate
-          # over an empty input returns one row holding NULL rather than no rows
-          # — so if the Ops group is ever renamed or emptied, staff.csv goes to
-          # zero rows (which the extract factory skips, leaving ParentSquare on a
-          # stale file) while sections.csv still ships every section with a null
-          # owner. The relationships test below cannot catch that: dbt's
-          # relationships test filters nulls out of the child side, so it passes
-          # vacuously. This is the guard that fires.
+          # from `min(staff_id)` grouped by region over the staff feed, joined
+          # back with a LEFT join. A region whose Ops group is renamed or emptied
+          # contributes no owner row, so its staff.csv goes to zero rows (which
+          # the extract factory skips, leaving ParentSquare on a stale file) while
+          # sections.csv still ships every section — with a null owner. The LEFT
+          # join is deliberate for exactly that reason: an inner join would drop
+          # the sections instead and nothing would fail. The relationships test
+          # below cannot catch it either, because dbt's relationships test filters
+          # nulls out of the child side, so it passes vacuously. This is the guard
+          # that fires.
           - not_null:
               config:
                 severity: error
@@ -64,6 +69,18 @@ models:
               arguments:
                 to: ref('rpt_parentsquare__staff')
                 field: staff_id
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region, and it is also the key the section owner is
+          picked per; it is not part of the ParentSquare file and no wrapper
+          projects it.
+        data_tests:
+          - not_null:
               config:
                 severity: error
       - name: section_number

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__staff.yml
@@ -1,20 +1,24 @@
 models:
   - name: rpt_parentsquare__staff
     description:
-      ParentSquare `staff.csv` for KIPP Newark — one row per (Operations leader,
-      school). Membership is the hand-curated `TS-DL-Regional Ops Leaders`
-      distribution list, scoped to active Newark regional-office Operations
-      staff, which is the user population the Integration Planner designates —
-      no school staff and no teachers. Sourcing from the group rather than a
-      hardcoded list of individuals means Ops owns the roster and it tracks role
-      changes without a code change; no job-title or job-function rule
-      reproduces the same set. Each leader is emitted once per operating school
+      ParentSquare `staff.csv` for the KIPP NJ regions — one row per (Operations
+      leader, operating school in that leader's own region). Each district's
+      thin `extracts/parentsquare` wrapper slices this to its own
+      `code_location`, and that wrapper is what ParentSquare receives.
+      Membership is the hand-curated `TS-DL-Regional Ops Leaders` distribution
+      list, scoped to active regional-office Operations staff, which is the user
+      population the Integration Planner designates — no school staff and no
+      teachers. Sourcing from the group rather than a hardcoded list of
+      individuals means Ops owns the roster and it tracks role changes without a
+      code change; no job-title or job-function rule reproduces the same set.
+      Each leader is emitted once per operating school in their own region
       because ParentSquare's staff file is per-school and a staff member may
       appear at more than one, which is what grants them school-level access
       everywhere and what makes every `rpt_parentsquare__sections.staff_id`
-      resolve at its own school. No district-office row is emitted — the schools
-      feed carries only the twelve operating schools, so a `school_id` of 0
-      would have nothing to match.
+      resolve at its own school. The region-keyed join is what keeps a leader
+      out of another region's file. No district-office row is emitted — the
+      schools feed carries only operating schools, so a `school_id` of 0 would
+      have nothing to match.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -47,6 +51,18 @@ models:
               arguments:
                 to: ref('rpt_parentsquare__schools')
                 field: school_id
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to — the leader's
+          `home_work_location_dagster_code_location`, which also scopes the
+          school fan-out. Present so each district's thin
+          `extracts/parentsquare` wrapper can slice the feed to its own region;
+          it is not part of the ParentSquare file and no wrapper projects it.
+        data_tests:
+          - not_null:
               config:
                 severity: error
       - name: email

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__students.yml
@@ -1,14 +1,17 @@
 models:
   - name: rpt_parentsquare__students
     description:
-      ParentSquare `students.csv` for KIPP Newark — one row per student enrolled
-      in the current academic year, including pre-registered students, who
-      ParentSquare represents as incoming. Delivered as a full snapshot each
-      run. Every value is emitted as a string because ParentSquare ingests all
-      fields as text. Two optional spec fields are deliberately absent — student
-      email, because populating it makes ParentSquare mail an account-creation
-      invitation to every student in the file and student logins are out of
-      scope, and the state student id, which has no ParentSquare consumer.
+      ParentSquare `students.csv` for the KIPP NJ regions — one row per student
+      enrolled in the current academic year, including pre-registered students,
+      who ParentSquare represents as incoming. Each district's thin
+      `extracts/parentsquare` wrapper slices this to its own `code_location`,
+      and that wrapper is what ParentSquare receives. Delivered as a full
+      snapshot each run. Every value is emitted as a string because ParentSquare
+      ingests all fields as text. Two optional spec fields are deliberately
+      absent — student email, because populating it makes ParentSquare mail an
+      account-creation invitation to every student in the file and student
+      logins are out of scope, and the state student id, which has no
+      ParentSquare consumer.
     columns:
       - name: student_id
         data_type: string
@@ -47,8 +50,8 @@ models:
         data_type: string
         description:
           The student's grade level as a string. ParentSquare's scale runs -4 to
-          12 with kindergarten as 0, which the Newark grade domain of 0 through
-          12 already satisfies, so no remapping is applied.
+          12 with kindergarten as 0, which the NJ grade domain of 0 through 12
+          already satisfies, so no remapping is applied.
         data_tests:
           - not_null:
               config:
@@ -80,6 +83,17 @@ models:
                   - "10"
                   - "11"
                   - "12"
+              config:
+                severity: error
+      - name: code_location
+        data_type: string
+        description:
+          Dagster code location of the region this row belongs to. Present so
+          each district's thin `extracts/parentsquare` wrapper can slice the
+          feed to its own region; it is not part of the ParentSquare file and no
+          wrapper projects it.
+        data_tests:
+          - not_null:
               config:
                 severity: error
       - name: first_name

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__emergency_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__emergency_contacts.sql
@@ -1,9 +1,17 @@
 with
     students as (
-        select student_number, cast(schoolid as string) as school_id,
+        select
+            student_number,
+            _dbt_source_project as code_location,
+
+            cast(schoolid as string) as school_id,
         from {{ ref("int_extracts__student_enrollments") }}
         where
-            _dbt_source_project = 'kippnewark'
+            -- Every NJ region is in scope and each district wrapper filters this
+            -- view down to its own `code_location`. Miami is excluded because it
+            -- rosters from Focus rather than PowerSchool — the same carve-out the
+            -- six rpt_clever__* feeds make.
+            _dbt_source_project != 'kippmiami'
             and academic_year = {{ var("current_academic_year") }}
             and rn_year = 1
             and not is_out_of_district
@@ -20,10 +28,11 @@ with
             contact_first_name,
             contact_last_name,
             email_current,
+            _dbt_source_project as code_location,
 
             coalesce(phone_mobile, phone_home, phone_work, phone_primary) as phone_best,
         from {{ ref("int_students__contacts") }}
-        where _dbt_source_project = 'kippnewark' and contact_slot like 'emergency_%'
+        where _dbt_source_project != 'kippmiami' and contact_slot like 'emergency_%'
     ),
 
     contact_digits as (
@@ -36,6 +45,7 @@ with
             contact_first_name,
             contact_last_name,
             email_current,
+            code_location,
 
             nullif(regexp_replace(phone_best, r'[^0-9]', ''), '') as phone_digits,
         from contact_source
@@ -50,6 +60,7 @@ with
             contact_first_name,
             contact_last_name,
             email_current,
+            code_location,
 
             left(regexp_replace(phone_digits, r'^1', ''), 10) as phone_candidate,
         from contact_digits
@@ -59,7 +70,9 @@ with
         -- `contact_id` is keyed on (student, slot) rather than on
         -- `finalsite_contact_id`, which is null for every emergency row: these
         -- are scalar custom fields on the student's own Finalsite record, not
-        -- linked contact records, so (student, slot) is the true grain.
+        -- linked contact records, so (student, slot) is the true grain. The key
+        -- needs no region component — `student_number` is unique across the NJ
+        -- regions this view covers.
         --
         -- ParentSquare requires exactly 10 digits. A shorter value is an upstream
         -- data-entry typo, so drop the number rather than send one ParentSquare
@@ -69,6 +82,7 @@ with
             contact_first_name,
             contact_last_name,
             email_current,
+            code_location,
 
             {{ dbt_utils.generate_surrogate_key(["student_number", "contact_slot"]) }}
             as contact_id,
@@ -85,10 +99,14 @@ select
     c.email_current as email,
 
     s.school_id,
+    s.code_location,
 
     cast(s.student_number as string) as student_id,
 from contacts as c
-inner join students as s on c.student_number = s.student_number
+inner join
+    students as s
+    on c.student_number = s.student_number
+    and c.code_location = s.code_location
 -- ParentSquare needs an email or a phone to reach an emergency contact with Smart
 -- and Urgent Alerts, so a contact carrying neither is dropped.
 where c.email_current is not null or c.phone is not null

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__parents.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__parents.sql
@@ -1,9 +1,17 @@
 with
     students as (
-        select student_number, cast(schoolid as string) as school_id,
+        select
+            student_number,
+            _dbt_source_project as code_location,
+
+            cast(schoolid as string) as school_id,
         from {{ ref("int_extracts__student_enrollments") }}
         where
-            _dbt_source_project = 'kippnewark'
+            -- Every NJ region is in scope and each district wrapper filters this
+            -- view down to its own `code_location`. Miami is excluded because it
+            -- rosters from Focus rather than PowerSchool — the same carve-out the
+            -- six rpt_clever__* feeds make.
+            _dbt_source_project != 'kippmiami'
             and academic_year = {{ var("current_academic_year") }}
             and rn_year = 1
             and not is_out_of_district
@@ -21,11 +29,12 @@ with
             relationship,
             email_current,
             phone_mobile,
+            _dbt_source_project as code_location,
 
             coalesce(phone_home, phone_work) as phone_secondary,
         from {{ ref("int_students__contacts") }}
         where
-            _dbt_source_project = 'kippnewark'
+            _dbt_source_project != 'kippmiami'
             and contact_slot in ('contact_1', 'contact_2')
     ),
 
@@ -40,6 +49,7 @@ with
             contact_last_name,
             relationship,
             email_current,
+            code_location,
 
             nullif(
                 regexp_replace(phone_mobile, r'[^0-9]', ''), ''
@@ -59,6 +69,7 @@ with
             contact_last_name,
             relationship,
             email_current,
+            code_location,
 
             left(
                 regexp_replace(phone_mobile_digits, r'^1', ''), 10
@@ -79,6 +90,7 @@ with
             contact_last_name,
             relationship,
             email_current,
+            code_location,
 
             if(length(mobile_candidate) = 10, mobile_candidate, null) as mobile,
             if(
@@ -96,10 +108,14 @@ select
     c.email_current as email,
 
     s.school_id,
+    s.code_location,
 
     cast(s.student_number as string) as student_id,
 from contacts as c
-inner join students as s on c.student_number = s.student_number
+inner join
+    students as s
+    on c.student_number = s.student_number
+    and c.code_location = s.code_location
 -- ParentSquare needs an email or a mobile number to create a contactable parent
 -- account, so a parent carrying neither is not deliverable and is dropped.
 where c.email_current is not null or c.mobile is not null

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__rosters.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__rosters.sql
@@ -1,9 +1,18 @@
 with
     enrolled as (
-        select student_number, grade_level, cast(schoolid as string) as school_id,
+        select
+            student_number,
+            grade_level,
+            _dbt_source_project as code_location,
+
+            cast(schoolid as string) as school_id,
         from {{ ref("int_extracts__student_enrollments") }}
         where
-            _dbt_source_project = 'kippnewark'
+            -- Every NJ region is in scope and each district wrapper filters this
+            -- view down to its own `code_location`. Miami is excluded because it
+            -- rosters from Focus rather than PowerSchool — the same carve-out the
+            -- six rpt_clever__* feeds make.
+            _dbt_source_project != 'kippmiami'
             and academic_year = {{ var("current_academic_year") }}
             and rn_year = 1
             and not is_out_of_district
@@ -14,6 +23,7 @@ with
         select
             student_number,
             school_id,
+            code_location,
 
             lpad(cast(grade_level as string), 2, '0') as grade_padded,
         from enrolled
@@ -25,6 +35,7 @@ with
 -- section by construction; the relationships test on section_id enforces it.
 select
     school_id,
+    code_location,
 
     cast(student_number as string) as student_id,
 

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__schools.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__schools.sql
@@ -23,6 +23,7 @@ with
             schoolstate as school_state,
             schoolzip as school_zip,
             principalemail as principal_email,
+            _dbt_source_project as code_location,
 
             cast(school_number as string) as school_id,
             lower(principalemail) as principal_email_match,
@@ -31,7 +32,11 @@ with
             -- dash-separated); ParentSquare wants 10 digits.
             regexp_replace(schoolphone, r'[^0-9]', '') as school_phone,
         from {{ ref("stg_powerschool__schools") }}
-        where _dbt_source_project = 'kippnewark' and state_excludefromreporting = 0
+        -- Every NJ region is in scope and each district wrapper filters this view
+        -- down to its own `code_location`. Miami is excluded because it rosters
+        -- from Focus rather than PowerSchool — the same carve-out the six
+        -- rpt_clever__* feeds make.
+        where _dbt_source_project != 'kippmiami' and state_excludefromreporting = 0
     )
 
 select
@@ -43,6 +48,7 @@ select
     s.school_state,
     s.principal_email,
     s.school_phone,
+    s.code_location,
 
     p.principal_first_name,
     p.principal_last_name,

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
@@ -1,9 +1,17 @@
 with
     enrolled as (
-        select grade_level, cast(schoolid as string) as school_id,
+        select
+            grade_level,
+            _dbt_source_project as code_location,
+
+            cast(schoolid as string) as school_id,
         from {{ ref("int_extracts__student_enrollments") }}
         where
-            _dbt_source_project = 'kippnewark'
+            -- Every NJ region is in scope and each district wrapper filters this
+            -- view down to its own `code_location`. Miami is excluded because it
+            -- rosters from Focus rather than PowerSchool — the same carve-out the
+            -- six rpt_clever__* feeds make.
+            _dbt_source_project != 'kippmiami'
             and academic_year = {{ var("current_academic_year") }}
             and rn_year = 1
             and not is_out_of_district
@@ -17,13 +25,14 @@ with
         -- guaranteed a section to point at.
         -- grain projection: every selected column is functionally determined by
         -- the partition key; not a mask for upstream duplicates.
-        select distinct school_id, grade_level, from enrolled
+        select distinct school_id, grade_level, code_location, from enrolled
     ),
 
     section_attributes as (
         select
             school_id,
             grade_level,
+            code_location,
 
             cast(grade_level as string) as grade_str,
             lpad(cast(grade_level as string), 2, '0') as grade_padded,
@@ -37,7 +46,14 @@ with
         -- rpt_parentsquare__staff rows, not from section membership — so this
         -- picks one deterministically. Reading it from the staff feed rather than
         -- restating the leader list guarantees the value resolves in staff.csv.
-        select min(staff_id) as staff_id, from {{ ref("rpt_parentsquare__staff") }}
+        --
+        -- Grouping by region is what makes it resolve at the section's OWN
+        -- school: rpt_parentsquare__staff fans a leader across the schools of
+        -- their region only, so a single owner picked network-wide would dangle
+        -- in every other region's file.
+        select code_location, min(staff_id) as staff_id,
+        from {{ ref("rpt_parentsquare__staff") }}
+        group by code_location
     )
 
 -- One synthetic section per (school, grade). The Integration Planner sets
@@ -46,8 +62,16 @@ with
 -- give ParentSquare the grade-level grouping it needs to satisfy sections.csv and
 -- rosters.csv without importing any teacher. Mirrors the auto-generated ENR
 -- section pattern in rpt_clever__sections.
+--
+-- The owner join is a LEFT join deliberately. `section_owner` groups by region, so
+-- a region whose Ops group is emptied or renamed contributes no owner row — an
+-- inner join would silently drop that region's sections entirely, and a zero-row
+-- sections.csv is skipped by the extract factory, leaving ParentSquare on a stale
+-- file with nothing failing. Preserving the section with a null owner is what lets
+-- the `not_null` test on staff_id fire instead.
 select
     a.school_id,
+    a.code_location,
     a.grade_str as section_number,
 
     o.staff_id,
@@ -58,4 +82,4 @@ select
 
     if(a.grade_level = 0, 'Kindergarten', concat('Grade ', a.grade_str)) as course_name,
 from section_attributes as a
-cross join section_owner as o
+left join section_owner as o on a.code_location = o.code_location

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__staff.sql
@@ -2,9 +2,12 @@ with
     schools as (
         -- Same filter as rpt_parentsquare__schools so a staff row can never
         -- reference a school the schools feed omits.
-        select cast(school_number as string) as school_id,
+        select
+            _dbt_source_project as code_location,
+
+            cast(school_number as string) as school_id,
         from {{ ref("stg_powerschool__schools") }}
-        where _dbt_source_project = 'kippnewark' and state_excludefromreporting = 0
+        where _dbt_source_project != 'kippmiami' and state_excludefromreporting = 0
     ),
 
     ops_leaders as (
@@ -20,8 +23,9 @@ with
         -- gap that would silently add or drop them.
         --
         -- The group spans all four regions and both regional and school-based
-        -- staff, so the scoping below is what reduces it to Newark regional
-        -- Operations. LDAP join shape follows rpt_clever__staff.
+        -- staff. The scoping below reduces it to regional-office Operations, and
+        -- `code_location` carries each leader's region so the fan-out below stays
+        -- inside it. LDAP join shape follows rpt_clever__staff.
         -- `google_email` (@apps.teamschools.org), NOT the roster's `mail` /
         -- `user_principal_name`, which are the AD/Exchange addresses
         -- (@kippnj.org, @kippteamandfamily.org). The two never coincide for any
@@ -35,6 +39,7 @@ with
             r.given_name,
             r.family_name_1,
             r.google_email,
+            r.home_work_location_dagster_code_location as code_location,
         from {{ ref("stg_ldap__group") }} as g
         cross join unnest(g.member) as group_member_distinguished_name
         inner join
@@ -47,18 +52,20 @@ with
             g.cn = 'TS-DL-Regional Ops Leaders'
             and r.worker_status_code != 'Terminated'
             and not r.is_prestart
-            and r.home_work_location_dagster_code_location = 'kippnewark'
+            and r.home_work_location_dagster_code_location != 'kippmiami'
             and r.home_work_location_powerschool_school_id = 0
             and r.home_department_name = 'Operations'
     )
 
--- One row per (leader, school). ParentSquare's staff file is per-school and its
--- spec states a staff member "can be at more than one school", so fanning the
--- leaders across every Newark school is what grants them school-level access
--- everywhere — and it is what makes every rpt_parentsquare__sections.staff_id
--- resolve at its own school. No district-office row is emitted because
--- schools.csv carries only the twelve operating schools, so a school_id of 0
--- would dangle.
+-- One row per (leader, school within their own region). ParentSquare's staff file
+-- is per-school and its spec states a staff member "can be at more than one
+-- school", so fanning a leader across every school in their region is what grants
+-- them school-level access everywhere — and it is what makes every
+-- rpt_parentsquare__sections.staff_id resolve at its own school. The join is
+-- region-keyed rather than a bare cross join, which matches the "all region"
+-- assignment branch in rpt_clever__staff and keeps a leader out of another
+-- region's feed. No district-office row is emitted because schools.csv carries
+-- only operating schools, so a school_id of 0 would dangle.
 select
     o.job_title as title,
     o.given_name as first_name,
@@ -66,7 +73,8 @@ select
     o.google_email as email,
 
     s.school_id,
+    s.code_location,
 
     cast(o.employee_number as string) as staff_id,
 from ops_leaders as o
-cross join schools as s
+inner join schools as s on o.code_location = s.code_location

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__students.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__students.sql
@@ -7,14 +7,15 @@
 select
     student_first_name as first_name,
     student_last_name as last_name,
+    _dbt_source_project as code_location,
 
     cast(schoolid as string) as school_id,
     cast(student_number as string) as student_id,
 
-    -- ParentSquare's grade scale runs -4..12 with K = 0, which the Newark
-    -- grade_level domain (0..12) already satisfies, so this is a plain cast. A
-    -- PreK grade would need a mapping (PreK1 = -4, PreK2 = -3, Junior K = -2,
-    -- Transitional K = -1); Newark operates none.
+    -- ParentSquare's grade scale runs -4..12 with K = 0, which the NJ grade_level
+    -- domain (0..12) already satisfies, so this is a plain cast. A PreK grade
+    -- would need a mapping (PreK1 = -4, PreK2 = -3, Junior K = -2, Transitional
+    -- K = -1); no NJ region operates one.
     cast(grade_level as string) as grade_level,
 
     -- ParentSquare reads 1 as active and 0 as incoming, which is what a
@@ -23,7 +24,11 @@ select
     if(enroll_status = 0, '1', '0') as `status`,
 from {{ ref("int_extracts__student_enrollments") }}
 where
-    _dbt_source_project = 'kippnewark'
+    -- Every NJ region is in scope and each district wrapper filters this view
+    -- down to its own `code_location`. Miami is excluded because it rosters from
+    -- Focus rather than PowerSchool — the same carve-out the six rpt_clever__*
+    -- feeds make.
+    _dbt_source_project != 'kippmiami'
     and academic_year = {{ var("current_academic_year") }}
     and rn_year = 1
     and not is_out_of_district

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -411,6 +411,25 @@ data_tests:
           ref:
             name: rpt_clever__students
 
+  - name: rpt_parentsquare__sections__staff_id_resolves_at_its_own_school
+    description: >-
+      Every ParentSquare section's owner must hold a staff row at that section's
+      own school, not merely somewhere in staff.csv. The relationships test on
+      sections.staff_id is single-column, so an owner drawn from another region
+      satisfies it while dangling in this region's file -- and these views span
+      every NJ region, with each district wrapper slicing one region out. The
+      staff feed fans a leader across the schools of their own region only, so
+      (school_id, staff_id) is the pair that has to resolve. Errors rather than
+      warns: ParentSquare rejects a section naming a staff member it has no
+      record of at that school, which fails the whole sections import rather
+      than one row.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: rpt_parentsquare__sections
+
   - name: rpt_parentsquare__students__every_student_has_a_roster_row
     description: >-
       Every student in the ParentSquare students feed must also appear in the

--- a/src/dbt/kipptaf/tests/rpt_parentsquare__sections__staff_id_resolves_at_its_own_school.sql
+++ b/src/dbt/kipptaf/tests/rpt_parentsquare__sections__staff_id_resolves_at_its_own_school.sql
@@ -1,0 +1,20 @@
+-- A section's owner must hold a staff row at that section's OWN school, not
+-- merely somewhere in staff.csv. The relationships test on sections.staff_id is
+-- single-column, so it passes as long as the employee number appears anywhere in
+-- the staff feed — and these views span every NJ region, so an owner drawn from
+-- another region would satisfy it while dangling in this region's file.
+-- rpt_parentsquare__staff fans each Operations leader across the schools of their
+-- own region only, so (school_id, staff_id) is the pair that has to resolve. The
+-- Clever feeds shipped exactly this class of cross-region leak before — see
+-- rpt_clever__school_id_resolves_to_schools_feed.
+--
+-- Null owners are excluded: that is the not_null test's job on
+-- rpt_parentsquare__sections.staff_id, and reporting them here would double-count
+-- the same failure.
+select s.school_id, s.section_id, s.staff_id,
+from {{ ref("rpt_parentsquare__sections") }} as s
+left join
+    {{ ref("rpt_parentsquare__staff") }} as f
+    on s.school_id = f.school_id
+    and s.staff_id = f.staff_id
+where s.staff_id is not null and f.staff_id is null

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -187,6 +187,21 @@ locations:
                   secretKeyRef:
                     name: op-finalsite-api-kippnewark
                     key: password
+              - name: PARENTSQUARE_SFTP_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
+                    key: URL
+              - name: PARENTSQUARE_SFTP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
+                    key: password
+              - name: PARENTSQUARE_SFTP_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
+                    key: username
         run_k8s_config:
           container_config:
             env:
@@ -344,4 +359,19 @@ locations:
                 valueFrom:
                   secretKeyRef:
                     name: op-amplify-sftp-kipptaf
+                    key: username
+              - name: PARENTSQUARE_SFTP_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
+                    key: URL
+              - name: PARENTSQUARE_SFTP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
+                    key: password
+              - name: PARENTSQUARE_SFTP_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: op-parentsquare-sftp
                     key: username

--- a/src/teamster/code_locations/kippnewark/definitions.py
+++ b/src/teamster/code_locations/kippnewark/definitions.py
@@ -25,7 +25,10 @@ from teamster.code_locations.kippnewark import (
     renlearn,
     titan,
 )
-from teamster.code_locations.kippnewark.resources import FINALSITE_RESOURCE
+from teamster.code_locations.kippnewark.resources import (
+    FINALSITE_RESOURCE,
+    SSH_RESOURCE_PARENTSQUARE,
+)
 from teamster.core.freshness import apply_freshness_policies
 from teamster.core.resources import (
     BIGQUERY_RESOURCE,
@@ -105,6 +108,7 @@ defs = Definitions(
         "ssh_couchdrop": SSH_COUCHDROP,
         "ssh_edplan": SSH_EDPLAN,
         "ssh_iready": SSH_IREADY,
+        "ssh_parentsquare": SSH_RESOURCE_PARENTSQUARE,
         "ssh_powerschool": get_powerschool_ssh_resource(),
         "ssh_renlearn": SSH_RENLEARN,
         "ssh_titan": SSH_TITAN,

--- a/src/teamster/code_locations/kippnewark/extracts/assets.py
+++ b/src/teamster/code_locations/kippnewark/extracts/assets.py
@@ -7,6 +7,13 @@ from teamster.libraries.extracts.assets import build_bigquery_query_sftp_asset
 
 config_dir = pathlib.Path(__file__).parent / "config"
 
+parentsquare_extract_assets = [
+    build_bigquery_query_sftp_asset(
+        code_location=CODE_LOCATION, timezone=LOCAL_TIMEZONE, **a
+    )
+    for a in config_from_files([f"{config_dir}/parentsquare.yaml"])["assets"]
+]
+
 powerschool_extract_assets = [
     build_bigquery_query_sftp_asset(
         code_location=CODE_LOCATION, timezone=LOCAL_TIMEZONE, **a
@@ -15,5 +22,6 @@ powerschool_extract_assets = [
 ]
 
 assets = [
+    *parentsquare_extract_assets,
     *powerschool_extract_assets,
 ]

--- a/src/teamster/code_locations/kippnewark/extracts/config/parentsquare.yaml
+++ b/src/teamster/code_locations/kippnewark/extracts/config/parentsquare.yaml
@@ -3,62 +3,76 @@ assets:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__schools
-          schema: kipptaf_extracts
     file_config:
       stem: schools
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__students
-          schema: kipptaf_extracts
     file_config:
       stem: students
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__parents
-          schema: kipptaf_extracts
     file_config:
       stem: parents
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__emergency_contacts
-          schema: kipptaf_extracts
     file_config:
       stem: emergency_contacts
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__staff
-          schema: kipptaf_extracts
     file_config:
       stem: staff
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__sections
-          schema: kipptaf_extracts
     file_config:
       stem: sections
       suffix: csv
+    destination_config:
+      name: parentsquare
   - query_config:
       type: schema
       value:
         table:
+          schema: kippnewark_extracts
           name: rpt_parentsquare__rosters
-          schema: kipptaf_extracts
     file_config:
       stem: rosters
       suffix: csv
+    destination_config:
+      name: parentsquare

--- a/src/teamster/code_locations/kippnewark/extracts/jobs.py
+++ b/src/teamster/code_locations/kippnewark/extracts/jobs.py
@@ -2,7 +2,13 @@ from dagster import define_asset_job
 
 from teamster.code_locations.kippnewark import CODE_LOCATION
 from teamster.code_locations.kippnewark.extracts.assets import (
+    parentsquare_extract_assets,
     powerschool_extract_assets,
+)
+
+parentsquare_extract_asset_job = define_asset_job(
+    name=f"{CODE_LOCATION}__extracts__parentsquare__asset_job",
+    selection=parentsquare_extract_assets,
 )
 
 powerschool_extract_asset_job = define_asset_job(

--- a/src/teamster/code_locations/kippnewark/extracts/schedules.py
+++ b/src/teamster/code_locations/kippnewark/extracts/schedules.py
@@ -1,8 +1,18 @@
-from dagster import ScheduleDefinition
+from dagster import DefaultScheduleStatus, ScheduleDefinition
 
 from teamster.code_locations.kippnewark import LOCAL_TIMEZONE
 from teamster.code_locations.kippnewark.extracts.jobs import (
+    parentsquare_extract_asset_job,
     powerschool_extract_asset_job,
+)
+
+# Ships STOPPED: no SFTP round-trip has been attempted and the upload path is
+# unconfirmed. Un-pause once a one-file round-trip is verified with Ops.
+parentsquare_extract_assets_schedule = ScheduleDefinition(
+    job=parentsquare_extract_asset_job,
+    cron_schedule="0 18 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+    default_status=DefaultScheduleStatus.STOPPED,
 )
 
 powerschool_extract_assets_schedule = ScheduleDefinition(
@@ -12,5 +22,6 @@ powerschool_extract_assets_schedule = ScheduleDefinition(
 )
 
 schedules = [
+    parentsquare_extract_assets_schedule,
     powerschool_extract_assets_schedule,
 ]

--- a/src/teamster/code_locations/kippnewark/resources.py
+++ b/src/teamster/code_locations/kippnewark/resources.py
@@ -2,9 +2,26 @@ from dagster import EnvVar
 
 from teamster.code_locations.kippnewark import CODE_LOCATION
 from teamster.libraries.finalsite.api.resources import FinalsiteResource
+from teamster.libraries.ssh.resources import SSHResource
 
 FINALSITE_RESOURCE = FinalsiteResource(
     server=CODE_LOCATION,
     credential_id=EnvVar("FINALSITE_CREDENTIAL_ID"),
     secret=EnvVar("FINALSITE_SECRET"),
+)
+
+# ParentSquare's district-level SFTP endpoint is sftp3.parentsquare.com; the
+# username is issued when the connection is created in the ParentSquare admin UI.
+# All three variables map to the `op-parentsquare-sftp` Secret at both
+# dagster-cloud.yaml insertion points. That Secret is synced by the
+# OnePasswordItem in .k8s/1password/items.yaml, which is applied by hand — a
+# secretKeyRef whose Secret or key does not exist fails container creation for
+# the whole code server, so the apply and a key-name check both precede any
+# deploy carrying these mappings. The Secret is shared across code locations, so
+# moving these mappings here needed no new 1Password work.
+SSH_RESOURCE_PARENTSQUARE = SSHResource(
+    remote_host=EnvVar("PARENTSQUARE_SFTP_HOST"),
+    remote_port=22,
+    username=EnvVar("PARENTSQUARE_SFTP_USERNAME"),
+    password=EnvVar("PARENTSQUARE_SFTP_PASSWORD"),
 )

--- a/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
@@ -230,16 +230,6 @@ locations:
                   secretKeyRef:
                     name: op-littlesis-sftp
                     key: username
-              - name: PARENTSQUARE_SFTP_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: password
-              - name: PARENTSQUARE_SFTP_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: username
               - name: SCHOOLMINT_GROW_CLIENT_ID
                 valueFrom:
                   secretKeyRef:
@@ -360,11 +350,6 @@ locations:
                   secretKeyRef:
                     name: op-littlesis-sftp
                     key: port
-              - name: PARENTSQUARE_SFTP_HOST
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: URL
               - name: TABLEAU_SERVER_ADDRESS
                 valueFrom:
                   secretKeyRef:
@@ -613,16 +598,6 @@ locations:
                   secretKeyRef:
                     name: op-littlesis-sftp
                     key: username
-              - name: PARENTSQUARE_SFTP_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: password
-              - name: PARENTSQUARE_SFTP_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: username
               - name: SCHOOLMINT_GROW_CLIENT_ID
                 valueFrom:
                   secretKeyRef:
@@ -758,11 +733,6 @@ locations:
                   secretKeyRef:
                     name: op-littlesis-sftp
                     key: port
-              - name: PARENTSQUARE_SFTP_HOST
-                valueFrom:
-                  secretKeyRef:
-                    name: op-parentsquare-sftp
-                    key: URL
               - name: TABLEAU_SERVER_ADDRESS
                 valueFrom:
                   secretKeyRef:

--- a/src/teamster/code_locations/kipptaf/definitions.py
+++ b/src/teamster/code_locations/kipptaf/definitions.py
@@ -134,7 +134,6 @@ defs = Definitions(
         "ssh_illuminate": resources.SSH_RESOURCE_ILLUMINATE,
         "ssh_lattice": resources.SSH_RESOURCE_LATTICE,
         "ssh_littlesis": resources.SSH_RESOURCE_LITTLESIS,
-        "ssh_parentsquare": resources.SSH_RESOURCE_PARENTSQUARE,
         "tableau": resources.TABLEAU_SERVER_RESOURCE,
         "zendesk": ZENDESK_RESOURCE,
     },

--- a/src/teamster/code_locations/kipptaf/extracts/assets.py
+++ b/src/teamster/code_locations/kipptaf/extracts/assets.py
@@ -191,16 +191,6 @@ littlesis_extract = build_bigquery_query_sftp_asset(
     destination_config={"name": "littlesis"},
 )
 
-parentsquare_extract_assets = [
-    build_bigquery_query_sftp_asset(
-        code_location=CODE_LOCATION,
-        timezone=LOCAL_TIMEZONE,
-        destination_config={"name": "parentsquare"},
-        **a,
-    )
-    for a in config_from_files([f"{config_dir}/parentsquare.yaml"])["assets"]
-]
-
 assets = [
     coupa_extract,
     deanslist_continuous_extract,
@@ -212,5 +202,4 @@ assets = [
     *clever_extract_assets,
     *deanslist_annual_extract_assets,
     *illuminate_extract_assets,
-    *parentsquare_extract_assets,
 ]

--- a/src/teamster/code_locations/kipptaf/extracts/jobs.py
+++ b/src/teamster/code_locations/kipptaf/extracts/jobs.py
@@ -11,7 +11,6 @@ from teamster.code_locations.kipptaf.extracts.assets import (
     illuminate_extract_assets,
     lattice_extract,
     littlesis_extract,
-    parentsquare_extract_assets,
 )
 
 coupa_extract_asset_job = define_asset_job(
@@ -57,9 +56,4 @@ deanslist_annual_extract_asset_job = define_asset_job(
 illuminate_extract_asset_job = define_asset_job(
     name=f"{CODE_LOCATION}__extracts__illuminate__asset_job",
     selection=illuminate_extract_assets,
-)
-
-parentsquare_extract_asset_job = define_asset_job(
-    name=f"{CODE_LOCATION}__extracts__parentsquare__asset_job",
-    selection=parentsquare_extract_assets,
 )

--- a/src/teamster/code_locations/kipptaf/extracts/schedules.py
+++ b/src/teamster/code_locations/kipptaf/extracts/schedules.py
@@ -1,4 +1,4 @@
-from dagster import DefaultScheduleStatus, ScheduleDefinition
+from dagster import ScheduleDefinition
 
 from teamster.code_locations.kipptaf import LOCAL_TIMEZONE
 from teamster.code_locations.kipptaf.extracts.jobs import (
@@ -11,7 +11,6 @@ from teamster.code_locations.kipptaf.extracts.jobs import (
     illuminate_extract_asset_job,
     lattice_extract_asset_job,
     littlesis_extract_asset_job,
-    parentsquare_extract_asset_job,
 )
 
 clever_extract_assets_schedule = ScheduleDefinition(
@@ -68,19 +67,6 @@ littlesis_extract_assets_schedule = ScheduleDefinition(
     execution_timezone=str(LOCAL_TIMEZONE),
 )
 
-# ParentSquare recommends sending roster files in the early evening rather than
-# the 3am slot the other extracts use. `default_status` is spelled out because
-# this schedule must NOT start on deploy: the ParentSquare SFTP credentials do
-# not exist yet, so a tick would fail on an unresolvable environment variable.
-# Start it by hand once the credentials land and a one-file round-trip is
-# verified.
-parentsquare_extract_assets_schedule = ScheduleDefinition(
-    job=parentsquare_extract_asset_job,
-    cron_schedule="0 18 * * *",
-    execution_timezone=str(LOCAL_TIMEZONE),
-    default_status=DefaultScheduleStatus.STOPPED,
-)
-
 schedules = [
     clever_extract_assets_schedule,
     coupa_extract_assets_schedule,
@@ -91,5 +77,4 @@ schedules = [
     illuminate_extract_assets_schedule,
     lattice_extract_assets_schedule,
     littlesis_extract_assets_schedule,
-    parentsquare_extract_assets_schedule,
 ]

--- a/src/teamster/code_locations/kipptaf/resources.py
+++ b/src/teamster/code_locations/kipptaf/resources.py
@@ -145,18 +145,3 @@ SSH_RESOURCE_LITTLESIS = SSHResource(
     username=EnvVar("LITTLESIS_SFTP_USERNAME"),
     password=EnvVar("LITTLESIS_SFTP_PASSWORD"),
 )
-
-# ParentSquare's district-level SFTP endpoint is sftp3.parentsquare.com; the
-# username is issued when the connection is created in the ParentSquare admin UI.
-# All three variables map to the `op-parentsquare-sftp` Secret at both
-# dagster-cloud.yaml insertion points. That Secret is synced by the
-# OnePasswordItem in .k8s/1password/items.yaml, which is applied by hand — a
-# secretKeyRef whose Secret or key does not exist fails container creation for
-# the whole code server, so the apply and a key-name check both precede any
-# deploy carrying these mappings.
-SSH_RESOURCE_PARENTSQUARE = SSHResource(
-    remote_host=EnvVar("PARENTSQUARE_SFTP_HOST"),
-    remote_port=22,
-    username=EnvVar("PARENTSQUARE_SFTP_USERNAME"),
-    password=EnvVar("PARENTSQUARE_SFTP_PASSWORD"),
-)


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will move ParentSquare outbound delivery from the `kipptaf` code location to `kippnewark`. The feed is Newark-only, so the Newark Dagster instance owns delivery. Follow-up to #4668.

Refs #4735
Refs #4480

This follows the `extracts/powerschool/` autocomm precedent rather than the Clever one #4668 originally copied: the heavy `rpt_` views stay in kipptaf, each district adds a thin contract-columns-only wrapper over `kipptaf_extracts`, and the district owns the SFTP assets, job, and schedule.

### What moved, and what did not

| Layer | Before | After |
| --- | --- | --- |
| 7 `rpt_parentsquare__*` views, descriptions, tests | kipptaf | kipptaf (unchanged home) |
| Region filter | inside each kipptaf view | each district's thin wrapper |
| Extract config, assets, job, schedule | kipptaf | kippnewark |
| `SSH_RESOURCE_PARENTSQUARE` plus 3 variable mappings | kipptaf | kippnewark |
| Asset keys | `kipptaf/extracts/parentsquare/*` | `kippnewark/extracts/parentsquare/*` |

The model logic could not move. `rpt_parentsquare__staff` joins `stg_ldap__group`, `stg_ldap__user_person` and `int_people__staff_roster`; `rpt_parentsquare__sections` reads the staff feed; `int_students__contacts` and `int_extracts__student_enrollments` are kipptaf-level cross-region models.

Pushing the region filter down widened the views from Newark to the three PowerSchool NJ regions (Miami excluded, since it rosters from Focus rather than PowerSchool, the same carve-out `rpt_clever__*` makes) and exposed a `code_location` column each wrapper filters on, named to match `rpt_powerschool__autocomm_students`. A future Camden or Paterson feed is then a copy of the wrappers plus config, with no kipptaf SQL change.

### Widening needed two real changes, not just a filter swap

- **The staff school fan-out is now region-keyed.** A bare `cross join` would put every Newark leader at every NJ school. The join mirrors the 'all region' assignment branch of `rpt_clever__staff`.
- **The section owner is picked per region.** `min(staff_id)` over the whole staff feed would assign one leader network-wide, dangling in every other region's file, while the single-column `relationships` test on `staff_id` still passed, because it only proves the id exists somewhere in the feed. `section_owner` now groups by `code_location`; the join to it is a LEFT join so an emptied Ops group still trips the `not_null` guard instead of silently dropping that region's sections; and a new singular test `rpt_parentsquare__sections__staff_id_resolves_at_its_own_school` asserts the (`school_id`, `staff_id`) pair resolves. The Clever feeds shipped this same class of cross-region leak before.

### Validation

Widening changes the population that 33 error-severity tests run over, so it was checked against prod data before implementing:

- no school-number collisions across the three NJ regions
- `student_number` unique across them, 7894 of 7894
- every NJ grade level inside 0 to 12, so the `-4` to `12` `accepted_values` test still holds
- every NJ region carrying at least one Ops leader with no missing `google_email` (Newark 8, Camden 2, Paterson 1)

Then:

- `dbt build` of the 7 views, target dev with defer to prod: **48 pass, 0 warn, 0 error**
- **Newark row counts identical to the pre-change prod views, file for file**, measured in the same moment: schools 12, students 6790, parents 9287, emergency_contacts 15462, staff 96, sections 53, rosters 6790. NJ-wide totals are 19 / 9821 / 12982 / 20593 / 108 / 86 / 9821.
- `trunk check --force` over all 47 changed files: no issues
- `dagster definitions validate` passes for kippnewark; asset keys confirmed as `kippnewark/extracts/parentsquare/*`, kipptaf down to 42 extract assets and 9 schedules with no ParentSquare
- both `dagster-cloud.yaml` files re-parsed after editing; 3 ParentSquare mappings in each kippnewark block

The kippnewark wrappers cannot be built locally: their source carries no target-conditional schema (same as the autocomm wrappers), so they read prod `kipptaf_extracts`, which will not have `code_location` until the widened kipptaf views deploy. They compile clean, and post-merge ordering comes from the `sources.yml` `asset_key` mapping, which makes each kipptaf view an upstream of its wrapper in the Dagster graph.

### Not done here

`docs/reference/automations.md` is **not** regenerated. `kipptaf.definitions` cannot import in a codespace (dlt credentials) and the generator silently drops locations that fail, so running it here would delete kipptaf's whole section. It already omitted ParentSquare before this change, so this PR shrinks the existing gap rather than adding one. It needs one regeneration run in a full environment to pick up the new `kippnewark__extracts__parentsquare__asset_job_schedule` row.

The schedule still ships stopped. No SFTP round-trip has been attempted and the upload path is still unconfirmed.

### AI Assistance

AI-assisted throughout, human-directed on the two decisions that shaped it: choosing to move delivery to kippnewark (against an initial recommendation to keep it in kipptaf on the Clever precedent), and choosing to push the region filter down into the wrappers rather than leave it in kipptaf. Camden and Paterson ParentSquare remains unconfirmed with Ops, which is why the wrappers-plus-config expansion path was preferred.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location. 4 passed, 2 failed: `kippmiami` on the documented `FOCUS_DB` dlt credential and `test_definitions_all` on the same, both pre-existing in a codespace and unrelated to this change. `kipptaf` and `kippnewark`, the two locations touched here, both pass.
- [x] New integrations follow the Library plus Config pattern with the correct asset key format and IO manager

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application. Added `src/dbt/kippnewark/models/exposures/parentsquare.yml`, mirroring `powerschool.yml`. This reverses the 'no exposure' call in the design spec, which surveyed only the kipptaf-delivered feeds and missed `powerschool_autocomm`, the regionally-delivered one this now resembles.
- [x] **Breaking change?** Yes, but contained. `code_location` is an additive contract column on the 7 kipptaf views, and their row sets widen from Newark to NJ. The only consumers are the new kippnewark wrappers, which filter back to Newark, so Newark output is unchanged (verified above). Rollback is a revert; nothing outside this repo reads these views yet, since the schedule has never run.
- [x] If adding or modifying an external source, run `stage_external_sources` with `--target staging`. Not applicable, no external sources touched.

### Docs

- [ ] If adding or changing a schedule or sensor, regenerate the automations catalog: `uv run scripts/gen-automations-doc.py`. **Deliberately not done here**, see Not done here above.
- [x] If adding a new integration to a code location, update that location's `CLAUDE.md`. Updated `src/dbt/kipptaf/CLAUDE.md` with the `code_location` wrapper-filter convention and the widening pitfalls.

## CI checks

- [ ] **Trunk** passes
- [ ] **dbt Cloud** passes
- [ ] **Dagster Cloud** passes or not triggered
