### PR TITLE
feat(dagster): create empty BigQuery tables for zero-row Focus tables

### DIFF
--- a/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
+++ b/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
@@ -1027,9 +1027,21 @@ Not part of the PR, but the plan is incomplete without it.
 
 1. Confirm the `kippmiami` code location has LOADED the merge commit
    (`mcp__dagster__get_location_load_history`).
-1. Confirm no Focus dbt build is imminent — the migration drops each table
-   before reloading it, and Focus staging models fail if they build in that
-   window.
+1. **Pick the window deliberately — this is the riskiest step in the plan.**
+   Focus dlt runs at 04:00, 12:00, and 14:00 ET, feeding the midday import chain
+   documented in `code_locations/kippmiami/CLAUDE.md`. Two hazards while a table
+   is dropped or mid-reload:
+   - Focus dbt staging models fail outright if they build in that window.
+   - Worse, and silent: `rpt_focus__*` import-once is an **anti-join against the
+     dlt snapshot of Focus**. A snapshot reading empty makes the 12:45 delivery
+     treat already-imported records as new and re-send them, duplicating them in
+     Focus once ops runs the import by hand. That delivery is a plain cron —
+     nothing gates it on the upstreams, so it fires mid-migration regardless.
+
+   Run the migration **after the 14:00 ET pull finishes and well before 04:00**
+   — never inside 11:00-15:00 ET — and confirm every table is repopulated before
+   the next 12:45 delivery.
+
 1. Launch the Focus asset job with run config:
 
    ```yaml

--- a/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
+++ b/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
@@ -1,0 +1,1050 @@
+# Focus Empty-Table Materialization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A configured Focus table with zero rows in the source is created in
+BigQuery as an empty, correctly typed table, so its dbt staging model can be
+written before any data arrives.
+
+**Architecture:** Replace the `sql_database` source in the Focus factory with a
+thin resource that drives dlt's exported `table_rows` generator directly, so it
+can yield `dlt.mark.materialize_table_schema()` when the table produced no data.
+Because that marker travels dlt's object path — which always injects `_dlt_id`
+and `_dlt_load_id` as REQUIRED — the arrow data path must inject them too, via
+dlt's `parquet_normalizer` knobs. Existing populated tables cannot gain REQUIRED
+columns in place, so the op also accepts a `refresh` run-config field used once,
+post-merge, to drop and recreate them.
+
+**Tech Stack:** Python 3.13, dlt 1.29.1, `dagster-dlt`, SQLAlchemy 2, PyArrow,
+BigQuery, pytest, uv.
+
+Spec:
+`docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md`
+
+## Global Constraints
+
+- Worktree:
+  `/workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize`.
+  Branch `cbini/feat/claude-focus-empty-table-materialize`. Use
+  `git -C <worktree>` for every git call and run Python from inside the
+  worktree.
+- Scope is the pipeline change plus the migration mechanism. **No dbt changes in
+  this PR** — the 11 staging models are a separate follow-up.
+- Illuminate and PowerSchool must not be touched.
+- The dlt source name stays `"focus"`. It determines the dlt schema name, which
+  the destination's stored schema, pipeline state, and `seen-data` markers are
+  keyed on; renaming it would orphan them.
+- `build_focus_dlt_assets(...)` keeps its current signature — the code location
+  `src/teamster/code_locations/kippmiami/dlt/focus/assets.py` calls it with
+  `sql_database_credentials`, `code_location`, `table_name`, `op_tags` and must
+  not need edits.
+- Keep `reflection_level="full_with_precision"`,
+  `table_adapter_callback=remove_nullability_adapter`, and
+  `type_adapter_callback=interval_to_microseconds_adapter`. Dropping any of them
+  regresses #4676 (Postgres `interval`) or the REQUIRED-mode breakage that
+  `remove_nullability_adapter` exists to prevent.
+- Keep `loader_file_format="parquet"` on `dlt.run()` (#4733).
+- **Never write `dlt.config[...]` inside the op body.** The op's resource
+  parameter is named `dlt`, which shadows the module, and `DagsterDltResource`
+  has no `.config` attribute — the line raises `AttributeError`. Import the
+  accessor directly instead: `from dlt import config as dlt_config` (verified to
+  be the same object as `dlt.config`).
+- `table_rows` has no defaults except `table_loader_class`; pass every argument
+  explicitly, per `libraries/dlt/CLAUDE.md`.
+- Python: always `uv run`. Never bare `python`.
+- Run
+  `/workspaces/teamster/.trunk/tools/trunk check --force --no-fix <files> </dev/null`
+  with cwd set to the worktree before pushing.
+
+---
+
+## File Structure
+
+| File                                                              | Responsibility                                                                     |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `src/teamster/libraries/dlt/focus/assets.py` (modify)             | Focus factory: resource wrapper, source, translator, op config, knobs              |
+| `tests/libraries/test_dlt_focus_materialize_empty.py` (create)    | Empty-vs-populated resource behavior; emitted-file shape via sqlite                |
+| `tests/libraries/test_dlt_focus_type_adapter.py` (modify)         | Existing wiring test asserts `explicit_args`, which the new resource does not have |
+| `tests/libraries/test_dlt_replace_loader_file_format.py` (modify) | Its `_run_kwargs` helper calls the op body, whose signature gains `config`         |
+| `src/teamster/libraries/dlt/focus/CLAUDE.md` (modify)             | Document the new empty-table behavior and the row-id columns                       |
+| `src/teamster/libraries/dlt/CLAUDE.md` (modify)                   | Cross-reference from the shared `replace` section                                  |
+
+The factory stays one file: it is ~110 lines today and the change adds ~50. The
+adapters, translator, and factory all change together for one reason.
+
+---
+
+### Task 1: Resource wrapper that materializes the schema of an empty table
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/focus/assets.py`
+- Create: `tests/libraries/test_dlt_focus_materialize_empty.py`
+- Modify: `tests/libraries/test_dlt_focus_type_adapter.py:88-113`
+  (`test_factory_wires_both_adapters_into_the_dlt_source`)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `_build_focus_resource(sql_database_credentials: ConnectionStringCredentials, table_name: str, db_schema: str | None) -> Callable[[], Iterator]`
+    — returns the `@dlt.resource`-decorated generator function, named
+    `table_name`.
+  - `build_focus_source(sql_database_credentials: ConnectionStringCredentials, table_name: str, db_schema: str | None = FOCUS_DB_SCHEMA) -> DltSource`
+    — the `@dlt.source(name="focus")` wrapper. `db_schema` exists so tests can
+    pass `None` for sqlite, which has no `public` schema.
+  - Module constants `FOCUS_SOURCE_NAME = "focus"`,
+    `FOCUS_DB_SCHEMA = "public"`, `FOCUS_CHUNK_SIZE = 50000`.
+  - `FocusDagsterDltTranslator` keys assets off `data.resource.name`.
+
+- [ ] **Step 1: Write the failing test for the empty and populated cases**
+
+Create `tests/libraries/test_dlt_focus_materialize_empty.py`:
+
+```python
+"""The Focus resource materializes a never-loaded table's schema (#4740).
+
+A configured Focus table with no rows produced nothing at all before, so dlt
+dropped the load package and BigQuery never got a table. The resource now yields
+`materialize_table_schema()` in that case, which creates the table from the
+reflected schema.
+
+sqlite stands in for Focus Postgres: the item shapes `table_rows` yields and the
+files dlt normalizes from them are backend-generic, and the Codespace cannot
+reach Focus (IP allowlist).
+"""
+
+import pathlib
+import tempfile
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.extract.extractors import MaterializedEmptyList
+from dlt.extract.items import DataItemWithMeta
+
+from teamster.libraries.dlt.focus.assets import _build_focus_resource
+
+
+@pytest.fixture(name="sqlite_url")
+def fixture_sqlite_url() -> Iterator[str]:
+    """A sqlite file with a `referrals` table whose row count the test sets."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield f"sqlite:///{pathlib.Path(tmp) / 'focus.db'}"
+
+
+def _seed(url: str, rows: int) -> None:
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "create table referrals ("
+                "referral_id integer not null, comment text)"
+            )
+        )
+        for i in range(rows):
+            conn.execute(
+                sa.text("insert into referrals values (:i, 'c')"), {"i": i}
+            )
+    engine.dispose()
+
+
+def _items(url: str) -> list[Any]:
+    resource = _build_focus_resource(
+        sql_database_credentials=ConnectionStringCredentials(url),
+        table_name="referrals",
+        db_schema=None,
+    )
+    return list(resource())
+
+
+def test_empty_table_yields_materialize_marker(sqlite_url: str) -> None:
+    _seed(sqlite_url, rows=0)
+
+    items = _items(sqlite_url)
+
+    assert isinstance(items[-1], MaterializedEmptyList), (
+        "a 0-row table must end with materialize_table_schema() so the table"
+        " is created"
+    )
+
+
+def test_populated_table_yields_no_materialize_marker(sqlite_url: str) -> None:
+    _seed(sqlite_url, rows=3)
+
+    items = _items(sqlite_url)
+
+    assert not any(isinstance(i, MaterializedEmptyList) for i in items)
+
+    data_items = [i for i in items if not isinstance(i, DataItemWithMeta)]
+    assert [i.num_rows for i in data_items] == [3]
+
+
+def test_reflection_hints_precede_the_marker(sqlite_url: str) -> None:
+    """The hints marker must come first, or the created table has no columns.
+
+    dlt registers the reflected columns from the `HintsMeta` item; a
+    `materialize_table_schema()` that arrived before it would create a table
+    holding only the `_dlt_*` columns.
+    """
+    _seed(sqlite_url, rows=0)
+
+    items = _items(sqlite_url)
+
+    assert isinstance(items[0], DataItemWithMeta)
+    assert type(items[0].meta).__name__ == "HintsMeta"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_materialize_empty.py -v
+```
+
+Expected: all three FAIL at import with
+`ImportError: cannot import name '_build_focus_resource'`.
+
+- [ ] **Step 3: Replace the `sql_database` source with the wrapper resource**
+
+In `src/teamster/libraries/dlt/focus/assets.py`, add these imports to the
+existing block:
+
+```python
+import sqlalchemy as sa
+from dlt.extract.items import DataItemWithMeta
+from dlt.extract.source import DltSource
+from dlt.sources.sql_database.helpers import table_rows
+```
+
+Remove the now-unused `from dlt.sources.sql_database import sql_database`, but
+KEEP `remove_nullability_adapter` from that module.
+
+Add the constants above `FocusDagsterDltTranslator`:
+
+```python
+FOCUS_SOURCE_NAME = "focus"
+FOCUS_DB_SCHEMA = "public"
+FOCUS_CHUNK_SIZE = 50000
+```
+
+Add the resource builder and source below `interval_to_microseconds_adapter`:
+
+```python
+def _build_focus_resource(
+    sql_database_credentials: ConnectionStringCredentials,
+    table_name: str,
+    db_schema: str | None = FOCUS_DB_SCHEMA,
+):
+    """Build one full-replace dlt resource for a Focus table.
+
+    Drives the exported ``table_rows`` generator rather than wrapping
+    ``sql_table``, so the resource can append
+    ``dlt.mark.materialize_table_schema()`` when the source yielded no data. A
+    table with 0 rows otherwise produces nothing dlt can act on, normalize drops
+    the package, and BigQuery never gets a table — leaving no target for a dbt
+    staging model (#4740). Same ``table_rows`` pattern as
+    ``libraries/dlt/powerschool/``.
+
+    The engine is created inside the generator, at extract time: the factory runs
+    at module import in the code location, which must not open a connection.
+    """
+
+    @dlt.resource(name=table_name, write_disposition="replace", parallelized=True)
+    def _focus_table() -> Iterator:
+        engine = sa.create_engine(
+            sql_database_credentials.to_native_representation()
+        )
+        try:
+            saw_data = False
+
+            for item in table_rows(
+                engine=engine,
+                table=table_name,
+                metadata=sa.MetaData(schema=db_schema),
+                chunk_size=FOCUS_CHUNK_SIZE,
+                backend="pyarrow",
+                incremental=None,
+                table_adapter_callback=remove_nullability_adapter,
+                reflection_level="full_with_precision",
+                backend_kwargs={},
+                type_adapter_callback=interval_to_microseconds_adapter,
+                included_columns=None,
+                excluded_columns=None,
+                query_adapter_callback=None,
+                resolve_foreign_keys=False,
+            ):
+                # table_rows opens with a HintsMeta item carrying the reflected
+                # schema, then yields arrow tables. Only the latter is data.
+                if not isinstance(item, DataItemWithMeta):
+                    saw_data = True
+
+                yield item
+
+            if not saw_data:
+                yield dlt.mark.materialize_table_schema()
+        finally:
+            engine.dispose()
+
+    return _focus_table
+
+
+@dlt.source(name=FOCUS_SOURCE_NAME)
+def build_focus_source(
+    sql_database_credentials: ConnectionStringCredentials,
+    table_name: str,
+    db_schema: str | None = FOCUS_DB_SCHEMA,
+) -> Iterator:
+    """One-resource source. The name must stay `focus` — it is the dlt schema
+    name the destination's stored schema and state are keyed on."""
+    yield _build_focus_resource(
+        sql_database_credentials=sql_database_credentials,
+        table_name=table_name,
+        db_schema=db_schema,
+    )
+```
+
+In `build_focus_dlt_assets`, replace the
+`dlt_source = sql_database.with_args(...)` block with:
+
+```python
+    dlt_source: DltSource = build_focus_source(
+        sql_database_credentials=sql_database_credentials, table_name=table_name
+    )
+```
+
+In `FocusDagsterDltTranslator.get_asset_spec`, replace
+`data.resource.explicit_args["table"]` with `data.resource.name`. The resource
+is named `table_name`, so the asset key is unchanged — but `explicit_args`
+exists only on `sql_database`-built resources and would now raise.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_materialize_empty.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Update the existing wiring test, which asserts `explicit_args`**
+
+`test_factory_wires_both_adapters_into_the_dlt_source` reads
+`dlt_source.resources["gradebook_assignments"].explicit_args`, which the new
+resource does not have. Replace that one test function with two that assert the
+same wiring behaviorally — the asset key still resolves, and the adapters are
+actually invoked during extract:
+
+```python
+def test_factory_builds_a_source_with_the_table_named_resource():
+    """Guard the wiring the translator depends on.
+
+    The asset key comes from `data.resource.name`, so a resource named anything
+    else silently changes every Focus asset key.
+    """
+    assets = build_focus_dlt_assets(
+        sql_database_credentials=ConnectionStringCredentials(
+            "postgresql+psycopg://localhost:5432/focus"
+        ),
+        code_location="kippmiami",
+        table_name="gradebook_assignments",
+    )
+
+    dlt_source = next(iter(assets.specs)).metadata[META_KEY_SOURCE]
+
+    assert list(dlt_source.resources) == ["gradebook_assignments"]
+    assert dlt_source.name == "focus"
+    assert next(iter(assets.specs)).key.path == [
+        "kippmiami",
+        "dlt",
+        "focus",
+        "gradebook_assignments",
+    ]
+
+
+def test_extract_invokes_both_adapters(monkeypatch, tmp_path):
+    """The adapters must reach `table_rows`, not merely exist.
+
+    Uses sqlite (the Codespace cannot reach Focus) and records each adapter call,
+    so a factory that stops passing one fails here.
+    """
+    import sqlalchemy as sa
+
+    from teamster.libraries.dlt.focus import assets as focus_assets
+
+    url = f"sqlite:///{tmp_path / 'focus.db'}"
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(sa.text("create table t (id integer not null, note text)"))
+    engine.dispose()
+
+    type_calls: list[object] = []
+    table_calls: list[object] = []
+
+    original_type_adapter = focus_assets.interval_to_microseconds_adapter
+    original_table_adapter = focus_assets.remove_nullability_adapter
+
+    def spy_type_adapter(col_type):
+        type_calls.append(col_type)
+        return original_type_adapter(col_type)
+
+    def spy_table_adapter(table):
+        table_calls.append(table)
+        return original_table_adapter(table)
+
+    monkeypatch.setattr(
+        focus_assets, "interval_to_microseconds_adapter", spy_type_adapter
+    )
+    monkeypatch.setattr(
+        focus_assets, "remove_nullability_adapter", spy_table_adapter
+    )
+
+    resource = focus_assets._build_focus_resource(
+        sql_database_credentials=ConnectionStringCredentials(url),
+        table_name="t",
+        db_schema=None,
+    )
+    list(resource())
+
+    assert type_calls, "type_adapter_callback was not passed to table_rows"
+    assert table_calls, "table_adapter_callback was not passed to table_rows"
+```
+
+Keep every other test in that file unchanged — the direct adapter unit tests and
+the `interval` regression tests still apply.
+
+- [ ] **Step 6: Run the whole focus test file**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_type_adapter.py \
+    tests/libraries/test_dlt_focus_materialize_empty.py -v
+```
+
+Expected: all pass. If `test_extract_invokes_both_adapters` fails with the
+adapters never called, the factory is still passing the module-level function
+objects captured at import — read them through the module inside
+`_build_focus_resource` (the code in Step 3 does, since it references the bare
+names at call time).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  git add src/teamster/libraries/dlt/focus/assets.py \
+    tests/libraries/test_dlt_focus_materialize_empty.py \
+    tests/libraries/test_dlt_focus_type_adapter.py && \
+  git commit -m "feat(dagster): materialize the schema of an empty Focus table
+
+Drives dlt's table_rows generator directly so the resource can yield
+materialize_table_schema() when a configured Focus table has no rows, which
+creates the BigQuery table from the reflected schema. A never-loaded table
+previously produced no load package at all, leaving no target for a dbt
+staging model.
+
+The asset key now comes from the resource name; explicit_args exists only on
+sql_database-built resources.
+
+Refs #4740"
+```
+
+---
+
+### Task 2: Row-id columns and the migration's `refresh` run config
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/focus/assets.py`
+- Create: `tests/libraries/test_dlt_focus_op_config.py`
+- Modify: `tests/libraries/test_dlt_replace_loader_file_format.py` (its
+  `_run_kwargs` helper calls the op body, which gains a `config` parameter)
+
+**Interfaces:**
+
+- Consumes: `build_focus_dlt_assets` from Task 1, unchanged signature.
+- Produces:
+  - `class FocusDltConfig(Config)` with `refresh: str | None = None`.
+  - The op body signature
+    `(context: AssetExecutionContext, config: FocusDltConfig, dlt: DagsterDltResource)`.
+  - `dlt.run()` receives `refresh=<value>` only when `config.refresh` is set.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/libraries/test_dlt_focus_op_config.py`:
+
+```python
+"""Focus op wiring: row-id knobs and the migration's refresh run config (#4740).
+
+The knobs are load-bearing. `materialize_table_schema()` travels dlt's object
+path, which injects `_dlt_id` / `_dlt_load_id` as REQUIRED; without the knobs the
+arrow data path omits them and BigQuery rejects the first real load into an
+empty-created table with `Field _dlt_load_id is missing in new schema`.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from dlt import config as dlt_config
+from dlt.common.configuration.specs import ConnectionStringCredentials
+
+from teamster.libraries.dlt.focus.assets import (
+    FocusDltConfig,
+    build_focus_dlt_assets,
+)
+
+CREDENTIALS = ConnectionStringCredentials("postgresql+psycopg://localhost:5432/db")
+
+ADD_DLT_ID = "normalize.parquet_normalizer.add_dlt_id"
+ADD_DLT_LOAD_ID = "normalize.parquet_normalizer.add_dlt_load_id"
+
+
+class _RecordingDltResource:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def run(self, **kwargs: Any) -> Iterator[Any]:
+        self.kwargs = kwargs
+        return iter(())
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def info(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class _StubContext:
+    """The op logs the refresh mode, so the context needs a `.log`.
+
+    Nothing else on the context is touched before `dlt.run()`.
+    """
+
+    def __init__(self) -> None:
+        self.log = _StubLog()
+
+
+@pytest.fixture(name="focus_assets")
+def fixture_focus_assets() -> Any:
+    return build_focus_dlt_assets(
+        sql_database_credentials=CREDENTIALS,
+        code_location="kippmiami",
+        table_name="discipline_referrals",
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_knobs() -> Iterator[None]:
+    """Leave dlt's in-memory config as it was; it is process-global."""
+    yield
+    dlt_config[ADD_DLT_ID] = False
+    dlt_config[ADD_DLT_LOAD_ID] = False
+
+
+def _run(
+    focus_assets: Any, config: FocusDltConfig, context: Any = None
+) -> dict[str, Any]:
+    dlt_resource = _RecordingDltResource()
+
+    list(
+        focus_assets.op.compute_fn.decorated_fn(
+            context=context or _StubContext(), config=config, dlt=dlt_resource
+        )
+    )
+
+    return dlt_resource.kwargs
+
+
+def test_op_sets_both_row_id_knobs(focus_assets: Any) -> None:
+    dlt_config[ADD_DLT_ID] = False
+    dlt_config[ADD_DLT_LOAD_ID] = False
+
+    _run(focus_assets, FocusDltConfig())
+
+    assert dlt_config[ADD_DLT_ID] is True
+    assert dlt_config[ADD_DLT_LOAD_ID] is True
+
+
+def test_refresh_is_omitted_by_default(focus_assets: Any) -> None:
+    kwargs = _run(focus_assets, FocusDltConfig())
+
+    assert "refresh" not in kwargs
+    assert kwargs["write_disposition"] == "replace"
+    assert kwargs["loader_file_format"] == "parquet"
+
+
+def test_refresh_is_forwarded_when_set(focus_assets: Any) -> None:
+    kwargs = _run(focus_assets, FocusDltConfig(refresh="drop_resources"))
+
+    assert kwargs["refresh"] == "drop_resources"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_op_config.py -v
+```
+
+Expected: FAIL at import with
+`ImportError: cannot import name 'FocusDltConfig'`.
+
+- [ ] **Step 3: Add the config and the knobs**
+
+In `src/teamster/libraries/dlt/focus/assets.py`, extend the dagster import to
+include `Config`, and add the accessor import:
+
+```python
+from dagster import AssetExecutionContext, AssetKey, AssetSpec, Config
+from dlt import config as dlt_config
+```
+
+`from dlt import config as dlt_config` is REQUIRED rather than `dlt.config`: the
+op's resource parameter is named `dlt`, shadowing the module, and
+`DagsterDltResource` has no `.config` attribute, so `dlt.config[...]` inside the
+body raises `AttributeError`. (`libraries/dlt/powerschool/assets.py:306` has
+this latent bug; do not copy it.)
+
+Add above `FocusDagsterDltTranslator`:
+
+```python
+class FocusDltConfig(Config):
+    """Run config for the Focus dlt op.
+
+    `refresh` is unset on every scheduled run. It exists for the one-time
+    migration that recreates already-populated tables so they gain the
+    `_dlt_id` / `_dlt_load_id` columns — BigQuery refuses to add REQUIRED
+    columns to an existing table, so they must be dropped and reloaded
+    (`drop_resources`, #4740).
+    """
+
+    refresh: str | None = None
+```
+
+Replace the op body:
+
+```python
+    def _assets(
+        context: AssetExecutionContext,
+        config: FocusDltConfig,
+        dlt: DagsterDltResource,
+    ) -> Iterator:
+        # Both knobs make the arrow data path carry `_dlt_id` / `_dlt_load_id`,
+        # which dlt's object path injects as REQUIRED when
+        # `materialize_table_schema()` creates an empty table. Without them the
+        # first real load into such a table fails with
+        # `Field _dlt_load_id is missing in new schema` (#4740). Set here, not at
+        # import: each step runs in its own pod, so it cannot leak to another
+        # pipeline. NOT `dlt.config` — `dlt` is the resource parameter here.
+        dlt_config["normalize.parquet_normalizer.add_dlt_id"] = True
+        dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = True
+
+        # loader_file_format="parquet": BigQuery schema autodetection rejects the
+        # empty jsonl file dlt writes to truncate a `replace` table whose source
+        # went to 0 rows. See `replace` write-disposition in ../CLAUDE.md (#4733).
+        run_kwargs: dict[str, object] = {
+            "write_disposition": "replace",
+            "loader_file_format": "parquet",
+        }
+
+        if config.refresh is not None:
+            context.log.info(f"dlt refresh mode: {config.refresh}")
+            run_kwargs["refresh"] = config.refresh
+
+        yield from dlt.run(context=context, **run_kwargs)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_op_config.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Fix the existing loader-format test for the new op signature**
+
+`tests/libraries/test_dlt_replace_loader_file_format.py::_run_kwargs` calls
+`assets.op.compute_fn.decorated_fn(context=None, dlt=dlt_resource)`, which now
+misses the required `config` argument. Update that helper only:
+
+```python
+def _run_kwargs(assets: Any, config: Any = None) -> dict[str, Any]:
+    """Invoke the asset body with a recording resource and return its run kwargs.
+
+    Nothing in the body touches the context or opens a connection before
+    `dlt.run()`, so no live database and no Dagster instance are needed.
+    """
+    dlt_resource = _RecordingDltResource()
+
+    kwargs: dict[str, Any] = {"context": None, "dlt": dlt_resource}
+
+    # the focus op takes run config; the illuminate op does not
+    if "config" in assets.op.compute_fn.decorated_fn.__annotations__:
+        from teamster.libraries.dlt.focus.assets import FocusDltConfig
+
+        kwargs["config"] = config or FocusDltConfig()
+
+    list(assets.op.compute_fn.decorated_fn(**kwargs))
+
+    return dlt_resource.kwargs
+```
+
+- [ ] **Step 6: Run every dlt library test**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/ -v -k "dlt"
+```
+
+Expected: all pass, including the Illuminate assertions in
+`test_dlt_replace_loader_file_format.py` (Illuminate is untouched, so its op
+body still takes no `config`).
+
+- [ ] **Step 7: Verify the import path of the changed module**
+
+`kippmiami.definitions` cannot be imported in the Codespace (it resolves Focus
+credentials eagerly), so check the edited module alone:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run python -c "
+import teamster.libraries.dlt.focus.assets as m
+print('imported:', m.__file__)
+print('config field:', m.FocusDltConfig().refresh)
+print('source name:', m.FOCUS_SOURCE_NAME)
+"
+```
+
+Expected: prints the worktree path, `None`, and `focus`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  git add src/teamster/libraries/dlt/focus/assets.py \
+    tests/libraries/test_dlt_focus_op_config.py \
+    tests/libraries/test_dlt_replace_loader_file_format.py && \
+  git commit -m "feat(dagster): add Focus row-id columns and a refresh run config
+
+Enables dlt's parquet_normalizer row-id knobs so the arrow data path carries
+_dlt_id and _dlt_load_id, which the object path injects as REQUIRED when it
+creates an empty table. Without them the first real load into such a table
+fails with 'Field _dlt_load_id is missing in new schema'.
+
+Adds FocusDltConfig.refresh so the one-time migration that recreates
+already-populated tables is a run-config launch rather than a temporary code
+change. Unset on every scheduled run.
+
+Refs #4740"
+```
+
+---
+
+### Task 3: Close the typed-empty-table verification gap
+
+**Files:**
+
+- Create: `tests/libraries/test_dlt_focus_empty_load_package.py`
+
+**Interfaces:**
+
+- Consumes: `build_focus_source` and `_build_focus_resource` from Task 1;
+  `FocusDltConfig` from Task 2.
+- Produces: nothing later tasks rely on.
+
+The spec records one gap: the BigQuery lifecycle probe ran with a resource that
+had no column hints, so its empty table started with only the `_dlt_*` columns.
+This task proves the production shape — that an empty table is created **with
+its reflected data columns** — without warehouse access, by inspecting the
+normalized load package.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/libraries/test_dlt_focus_empty_load_package.py`:
+
+```python
+"""The empty-table load package carries the reflected columns, not just `_dlt_*`.
+
+If `materialize_table_schema()` reached dlt before the reflection hints, the
+created BigQuery table would hold only `_dlt_load_id` and `_dlt_id`, and every
+later load would have to ADD the real columns. This asserts the emitted parquet
+already has them.
+
+Extract plus normalize only — no BigQuery credentials are used.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import dlt
+import pyarrow.parquet as pq
+import sqlalchemy as sa
+from dlt import config as dlt_config
+from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.destinations import bigquery
+
+from teamster.libraries.dlt.focus.assets import build_focus_source
+
+
+def test_empty_table_package_carries_reflected_columns(tmp_path) -> None:
+    url = f"sqlite:///{tmp_path / 'focus.db'}"
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "create table referrals ("
+                "referral_id integer not null, comment text, entry_date date)"
+            )
+        )
+    engine.dispose()
+
+    dlt_config["normalize.parquet_normalizer.add_dlt_id"] = True
+    dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = True
+
+    pipelines_dir = tempfile.mkdtemp(prefix="focus-empty-")
+    try:
+        pipeline = dlt.pipeline(
+            pipeline_name="focus_empty_package_test",
+            destination=bigquery(autodetect_schema=True),
+            dataset_name="test",
+            pipelines_dir=pipelines_dir,
+        )
+
+        pipeline.extract(
+            build_focus_source(
+                sql_database_credentials=ConnectionStringCredentials(url),
+                table_name="referrals",
+                db_schema=None,
+            ),
+            loader_file_format="parquet",
+        )
+        pipeline.normalize()
+
+        package = pipeline.list_normalized_load_packages()[-1]
+        info = pipeline.get_load_package_info(package)
+
+        jobs = [
+            j for j in info.jobs["new_jobs"]
+            if j.job_file_info.table_name == "referrals"
+        ]
+
+        assert len(jobs) == 1, "the empty table must produce exactly one job"
+
+        path = Path(jobs[0].file_path)
+        assert path.suffix == ".parquet"
+
+        names = pq.read_schema(path).names
+
+        assert "referral_id" in names
+        assert "comment" in names
+        assert "entry_date" in names
+        assert "_dlt_load_id" in names
+        assert "_dlt_id" in names
+    finally:
+        shutil.rmtree(pipelines_dir, ignore_errors=True)
+        dlt_config["normalize.parquet_normalizer.add_dlt_id"] = False
+        dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = False
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/test_dlt_focus_empty_load_package.py -v
+```
+
+Expected: PASS if the yields are correctly ordered. If it fails on a missing
+`referral_id`, the marker is reaching dlt before the hints — in
+`_build_focus_resource`, make sure `yield item` happens for the `HintsMeta` item
+BEFORE `materialize_table_schema()` is yielded, which the Task 1 code does.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  git add tests/libraries/test_dlt_focus_empty_load_package.py && \
+  git commit -m "test(dagster): assert the empty Focus package keeps reflected columns
+
+Closes the gap the design flagged: the BigQuery lifecycle probe ran without
+column hints, so it never proved an empty-created table is typed. Asserts the
+normalized parquet carries the reflected columns alongside the row-id columns.
+
+Refs #4740"
+```
+
+---
+
+### Task 4: Document the behavior
+
+**Files:**
+
+- Modify: `src/teamster/libraries/dlt/focus/CLAUDE.md` (the _Empty source
+  tables_ section, lines 62-79)
+- Modify: `src/teamster/libraries/dlt/CLAUDE.md` (the `replace`
+  write-disposition section)
+
+**Interfaces:**
+
+- Consumes: the shipped behavior from Tasks 1 to 3.
+- Produces: nothing.
+
+- [ ] **Step 1: Rewrite the Focus _Empty source tables_ section**
+
+Replace the whole section with:
+
+```markdown
+## Empty source tables
+
+A configured table with 0 rows in Focus is **created empty** in BigQuery: the
+resource in `assets.py` appends `dlt.mark.materialize_table_schema()` when
+`table_rows` yielded no data, so the table exists from the reflected schema and
+a staging model can be written before any data arrives (#4740).
+
+Consequences to know:
+
+- **Every Focus table carries `_dlt_id` and `_dlt_load_id`.** The materialize
+  marker travels dlt's object path, which injects both as REQUIRED, so the arrow
+  data path must supply them too — hence the two
+  `normalize.parquet_normalizer.add_dlt_*` knobs set in the op body. Turning
+  either off breaks the first real load into an empty-created table with
+  `Field _dlt_load_id is missing in new schema`.
+- **Adding those columns to an existing table is impossible** (BigQuery:
+  `Cannot add required fields to an existing schema`), which is why the rollout
+  recreated all populated tables once via run config `refresh: drop_resources`.
+  Any future table created outside this path needs the same treatment.
+- **Column order differs** between a table created empty (`_dlt_*` first) and
+  one created by a data load (`_dlt_*` last). Cosmetic — loads match by name and
+  every staging model projects explicitly.
+- A table absent from `dagster_<district>_dlt_focus` now means a **config or
+  load problem**, not an empty source. That is the diagnostic this change buys.
+- A table that empties out AFTER loading is truncated, not dropped — see
+  `replace` write-disposition in `../CLAUDE.md` (#4733).
+```
+
+- [ ] **Step 2: Add the cross-reference in the shared dlt CLAUDE.md**
+
+Append to the `autodetect_schema=True` bullet in the `replace` write-disposition
+section:
+
+```markdown
+- **Focus additionally materializes never-loaded tables** — its resource yields
+  `materialize_table_schema()` when the source has 0 rows, which requires the
+  `normalize.parquet_normalizer.add_dlt_*` knobs and made every Focus table gain
+  `_dlt_id` / `_dlt_load_id` (see `focus/CLAUDE.md`, #4740). Illuminate does NOT
+  do this: its one absent table is absorbed by the
+  `illuminate_repository_unpivot` macro's empty fallback.
+```
+
+- [ ] **Step 3: Lint both files**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+    src/teamster/libraries/dlt/focus/CLAUDE.md \
+    src/teamster/libraries/dlt/CLAUDE.md </dev/null
+```
+
+Expected: no issues beyond prettier reformatting, which the pre-commit hook
+fixes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  git add src/teamster/libraries/dlt/focus/CLAUDE.md \
+    src/teamster/libraries/dlt/CLAUDE.md && \
+  git commit -m "docs(dagster): document Focus empty-table materialization
+
+Refs #4740"
+```
+
+---
+
+### Task 5: Lint, push, and open the PR
+
+**Files:** none changed.
+
+- [ ] **Step 1: Lint every changed file**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+    $(git diff --name-only origin/main...HEAD | while read -r f; do [ -f "$f" ] && printf '%s ' "$f"; done) </dev/null
+```
+
+Expected: no issues. This takes more than two minutes over this many files — run
+it in the background and read the output file after it exits.
+
+- [ ] **Step 2: Run the full library test suite**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize && \
+  uv run pytest tests/libraries/ -v
+```
+
+Expected: all pass. `tests/test_dagster_definitions.py` is NOT expected to pass
+in a worktree without dbt manifests — do not treat it as a regression.
+
+- [ ] **Step 3: Push**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini-feat-claude-focus-empty-table-materialize push
+```
+
+- [ ] **Step 4: Open the PR**
+
+Use `.github/pull_request_template.md`. The body must state:
+
+- What changed and why, linking `Refs #4740` and the spec path.
+- That the 11 staging models are a deliberate follow-up, and why (contract types
+  need materialized tables).
+- The verification table from the spec, plus the offline test list.
+- **The migration is a required post-merge step**, not optional: launch the
+  Focus asset job once with run config `refresh: drop_resources` at a quiet
+  hour, then confirm all 77 tables. Until it runs, populated tables keep loading
+  exactly as today, and the 11 empty ones cannot be created — so the PR is inert
+  but safe if the migration is delayed.
+- In the Dagster self-review section, note that
+  `uv run dagster definitions validate` is not runnable in the Codespace for
+  `kippmiami` (Focus credentials resolve eagerly at module load) and that the
+  branch deployment is the real check.
+
+---
+
+## Post-merge migration runbook
+
+Not part of the PR, but the plan is incomplete without it.
+
+1. Confirm the `kippmiami` code location has LOADED the merge commit
+   (`mcp__dagster__get_location_load_history`).
+1. Confirm no Focus dbt build is imminent — the migration drops each table
+   before reloading it, and Focus staging models fail if they build in that
+   window.
+1. Launch the Focus asset job with run config:
+
+   ```yaml
+   ops:
+     kippmiami__dlt__focus__<table>:
+       config:
+         refresh: drop_resources
+   ```
+
+   One op block per selected asset. Launching the whole job at once keeps drop
+   and load adjacent per table.
+
+1. Confirm afterward: all 77 configured tables exist in
+   `dagster_kippmiami_dlt_focus`; the 66 previously-populated ones hold row
+   counts consistent with the prior day; the 11 new ones exist with 0 rows and
+   their reflected columns; every table now has `_dlt_id` and `_dlt_load_id`.
+1. Rebuild the existing Focus staging models.
+1. Only then start the follow-up PR for the 11 new staging models.

--- a/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
+++ b/docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md
@@ -1009,11 +1009,15 @@ Use `.github/pull_request_template.md`. The body must state:
 - That the 11 staging models are a deliberate follow-up, and why (contract types
   need materialized tables).
 - The verification table from the spec, plus the offline test list.
-- **The migration is a required post-merge step**, not optional: launch the
-  Focus asset job once with run config `refresh: drop_resources` at a quiet
-  hour, then confirm all 77 tables. Until it runs, populated tables keep loading
-  exactly as today, and the 11 empty ones cannot be created — so the PR is inert
-  but safe if the migration is delayed.
+- **The migration is a required post-merge step, and deferring it is an
+  outage.** Launch the Focus asset job once with run config
+  `refresh: drop_resources`, then confirm all 77 tables. Until it runs, every
+  already-populated table FAILS to load: the knobs are pipeline-wide, the arrow
+  normalizer stamps both row-id columns non-nullable into every load file, and
+  dlt's BigQuery load job sets `ALLOW_FIELD_ADDITION` without
+  `ALLOW_FIELD_RELAXATION`, so BigQuery rejects each one with
+  `Cannot add required fields to an existing schema` — row 1 of the verification
+  table. Merge immediately before the migration window, not "whenever".
 - In the Dagster self-review section, note that
   `uv run dagster definitions validate` is not runnable in the Codespace for
   `kippmiami` (Focus credentials resolve eagerly at module load) and that the

--- a/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
+++ b/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
@@ -107,9 +107,10 @@ Every scheduled run keeps the default and behaves exactly as today.
   explicitly, and the 3 that use `select *` read through a source CTE and then
   project explicitly (`stg_focus__address`, `stg_focus__students_join_people`,
   `stg_focus__students_join_address`).
-- Column **order** differs between a table created empty (`_dlt_*` first) and
-  one created by a data load (`_dlt_*` last). BigQuery matches load files by
-  name, and every staging model projects explicitly, so this is cosmetic.
+- Column **order matches** between a table created empty and one created by a
+  data load — both emit the row-id columns last. An earlier draft of this spec
+  claimed they differ; that came from a probe whose resource carried no column
+  hints, and the real paths agree.
 - During the migration a table is dropped before it reloads. Focus dbt staging
   models fail if they build in that window, so the run wants a quiet hour, and
   drop plus load must be the same run.

--- a/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
+++ b/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
@@ -151,35 +151,24 @@ hints before relying on it.
 - `dbt build` the Focus staging models against the migrated dataset before the
   new staging models are written.
 
-## Sequencing hazard for the same-PR staging models
+## Scope: two PRs
 
-The 11 staging models are contract-enforced, so their `properties.yml` needs
-exact column names and BigQuery types — which normally come from the
-materialized table. That creates an ordering problem:
+**Decided: the staging models ship separately.** This PR carries the pipeline
+change plus the migration. The 11 staging models follow in a second PR, written
+against the tables once they exist.
 
-- The tables do not exist until the new code runs.
-- Creating them early from a branch deployment writes to the **prod** dataset
-  (dlt has no branch-deployment redirect, per `focus/CLAUDE.md`), and once
-  created they carry REQUIRED `_dlt_*` columns. Prod is still running the old
-  code, whose loads omit those columns, so the next scheduled Focus run would
-  fail on those tables until this PR merges.
+The reason is a sequencing hazard. Those models are contract-enforced, so their
+`properties.yml` needs exact column names and BigQuery types, which normally
+come from the materialized table — and the tables do not exist until this code
+runs. Creating them early from a branch deployment is not a way out: dlt has no
+branch-deployment redirect (`focus/CLAUDE.md`), so it writes to the **prod**
+dataset, and the new tables carry REQUIRED `_dlt_*` columns that prod's
+still-old code omits, breaking the next scheduled Focus run until this merges.
 
-Three ways to resolve, to be decided before implementation:
-
-1. Split the work: pipeline change plus migration in this PR, staging models in
-   a follow-up written against real materialized tables. Removes the hazard
-   entirely.
-1. Keep one PR and derive the contract types from the reflected Postgres schema
-   (dlt's type mapping is deterministic, and `remove_nullability_adapter` plus
-   `interval_to_microseconds_adapter` fix the two non-obvious cases). Verify by
-   building the staging models immediately after the post-merge migration; a
-   mistyped column fails the build, not the load.
-1. Keep one PR and capture the reflected schema first via a throwaway
-   branch-deployment run that logs column names and types without creating
-   tables, then write contracts from that log.
-
-Option 1 is recommended. Option 2 is viable but front-loads type risk into
-review; option 3 costs throwaway code.
+Splitting removes the hazard rather than managing it. The alternative — deriving
+contract types from the reflected Postgres schema and letting the post-merge
+build catch mistakes — was considered and rejected as front-loading type risk
+into review for no schedule gain.
 
 ## Out of scope
 
@@ -194,20 +183,13 @@ review; option 3 costs throwaway code.
 
 ## Rollout
 
-Current decision is one PR containing both the pipeline change and the 11
-staging models, so their contract types come from the reflected Postgres schema
-(_Sequencing hazard_, option 2) and are proven by the post-merge build.
-
-1. Merge the PR.
+1. Merge this PR (pipeline change plus migration mechanism).
 1. Confirm the `kippmiami` code location loads the new commit.
 1. Launch the Focus asset job once with run config `refresh: drop_resources`, at
    a quiet hour. All 66 populated tables are recreated with the row-id columns
    and the 11 empty ones are created in the same run.
 1. Confirm all 77 tables exist, the 66 retain their row counts, and the 11 are
    empty with the expected column sets.
-1. Build the Focus staging models, including the 11 new ones. A mistyped
-   contract column fails here, which is the intended catch point for option 2.
-
-If the hazard decision moves to option 1 instead, steps 1 through 4 carry the
-pipeline change alone and the staging models follow in a second PR written
-against the now-materialized tables.
+1. Rebuild the existing Focus staging models against the migrated dataset.
+1. Second PR: staging models for the 11 new tables, with contracts read from the
+   materialized schemas.

--- a/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
+++ b/docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md
@@ -1,0 +1,213 @@
+# Focus empty-table materialization — design
+
+Issue: [#4740](https://github.com/TEAMSchools/teamster/issues/4740). Builds on
+[#4733](https://github.com/TEAMSchools/teamster/issues/4733).
+
+## Problem
+
+11 of the 77 configured Focus tables are absent from
+`dagster_kippmiami_dlt_focus` because they hold no rows in Focus yet:
+
+`attendance_day`, `attendance_notes`, `attendance_period`,
+`discipline_incidents`, `discipline_incidents_join_referrals`,
+`gradebook_grades`, `referral_code_offenses`, `student_groups`,
+`student_standard_grades`, `students_join_groups`, `students_join_students`.
+
+All 11 are already declared in
+`src/dbt/focus/models/staging/sources-bigquery.yml`, but none has a staging
+model — a contract-enforced staging model cannot be built against a table that
+does not exist. Only 64 of 77 configured tables are staged, and every
+newly-populated Focus table needs a dbt change before its data is usable.
+
+### Cause
+
+`dlt/extract/extract.py::_handle_empty_tables` writes an empty file only for a
+`replace` table that has previously **seen data**
+(`schema.data_tables(seen_data_only=True)`). A never-loaded table produces no
+file at all, normalize drops the package, and nothing reaches BigQuery. The
+asset succeeds with `jobs: []` — an absence, not a failure.
+
+## Goal
+
+A configured Focus table with zero source rows exists in BigQuery as an empty,
+correctly typed table, so its staging model can be written before its data
+arrives.
+
+Non-goals: changing how populated tables load, and any Illuminate or PowerSchool
+behavior (see _Out of scope_).
+
+## Approach
+
+Three coupled changes, all in `src/teamster/libraries/dlt/focus/assets.py`
+except the migration.
+
+### 1. Materialize the schema for a never-loaded table
+
+`sql_database` opens every table by yielding
+`dlt.mark.with_hints([], dlt.mark.make_hints(**hints))` — a plain empty list
+that registers the reflected schema and is then discarded. Yielding
+`dlt.mark.materialize_table_schema()` instead makes dlt create the table from
+those same hints.
+
+Reaching that yield means driving the exported `table_rows` generator inside our
+own resource rather than calling `sql_database`, which is the pattern
+`libraries/dlt/powerschool/` already uses and `libraries/dlt/CLAUDE.md`
+documents. The wrapper must keep `reflection_level="full_with_precision"`,
+`table_adapter_callback=remove_nullability_adapter`, and
+`type_adapter_callback=interval_to_microseconds_adapter`, or reflected types and
+nullability regress.
+
+### 2. Enable dlt's row-id columns
+
+```python
+dlt.config["normalize.parquet_normalizer.add_dlt_id"] = True
+dlt.config["normalize.parquet_normalizer.add_dlt_load_id"] = True
+```
+
+Set in the op body, not at module import: each step runs in its own pod, so this
+cannot leak into another pipeline. `libraries/dlt/powerschool/` sets
+`dlt.config["extract.workers"]` the same way.
+
+This is load-bearing, not tidying. `materialize_table_schema()` runs through
+dlt's **object** path, which always injects `_dlt_id` and `_dlt_load_id` as
+REQUIRED. With the knobs at their defaults the arrow data path omits both, so
+the first real load into an empty-created table fails terminally with
+`Field _dlt_load_id is missing in new schema`.
+
+### 3. One-time migration of the 66 populated tables
+
+BigQuery rejects adding a REQUIRED column to an existing table
+(`Cannot add required fields to an existing schema`), so the populated tables
+must be recreated rather than altered. Passing `refresh="drop_resources"` to
+`dlt.run()` makes dlt drop and recreate the tables of the resources in that run
+— no hand-written DDL, and no warehouse access needed by a person.
+`drop_resources` rather than `drop_sources` because each Focus asset runs one
+resource against a shared `focus` pipeline; `drop_sources` would also discard
+the pipeline's stored schema and state for tables the run does not select.
+
+Cost is one full reload from Focus, which `replace` already performs daily.
+
+**Mechanism**: the op takes a Dagster `Config` with a `refresh` field defaulting
+to `None`, and forwards it to `dlt.run()` only when set. The migration is then a
+one-off launch with run config, not a code change that must be deployed and
+reverted. `libraries/dlt/powerschool/` already uses op run-config this way
+(`PowerSchoolDltConfig`).
+
+```python
+class FocusDltConfig(Config):
+    refresh: str | None = None
+```
+
+Every scheduled run keeps the default and behaves exactly as today.
+
+## Consequences
+
+- Every Focus table permanently gains `_dlt_id` (a per-row hash) and
+  `_dlt_load_id`. No contract breaks: 61 of 64 staging models enumerate columns
+  explicitly, and the 3 that use `select *` read through a source CTE and then
+  project explicitly (`stg_focus__address`, `stg_focus__students_join_people`,
+  `stg_focus__students_join_address`).
+- Column **order** differs between a table created empty (`_dlt_*` first) and
+  one created by a data load (`_dlt_*` last). BigQuery matches load files by
+  name, and every staging model projects explicitly, so this is cosmetic.
+- During the migration a table is dropped before it reloads. Focus dbt staging
+  models fail if they build in that window, so the run wants a quiet hour, and
+  drop plus load must be the same run.
+
+## Verification already performed
+
+Probes against BigQuery in a scratch dataset, dlt 1.29.1. Scripts are in
+`.claude/scratch/` (`probe_a2_bigquery.py`, `probe_migration_lifecycle.py`).
+
+| Sequence                                | Knobs off                             | Knobs on |
+| --------------------------------------- | ------------------------------------- | -------- |
+| Add row-id columns to an existing table | rejected — cannot add required fields | n/a      |
+| Create empty, then load first real data | rejected — `_dlt_load_id` is missing  | passes   |
+| Recreated table: load, reload, go empty | passes                                | passes   |
+| Created empty: data, empty, data again  | fails at first data                   | passes   |
+
+Local extract-plus-normalize probes (no credentials) additionally showed the
+materialize path and the arrow path emit **identical types and modes for every
+shared column**, so an empty-created table accepts the later load on type
+grounds as well as column-set grounds.
+
+One gap, to close during implementation: the lifecycle probe's resource carried
+no column hints, so its empty table started with only the `_dlt_*` columns and
+the first data load _added_ the data columns. Production reflects real hints, so
+the empty table is typed from the start. Re-run the lifecycle probe with column
+hints before relying on it.
+
+## Testing
+
+- Extend `tests/libraries/` with offline factory-wiring tests, in the style of
+  `test_dlt_replace_loader_file_format.py`: assert the wrapper resource yields
+  `materialize_table_schema()` when `table_rows` produces nothing, and that both
+  `dlt.config` knobs are set when the asset body runs.
+- Extend the local extract-plus-normalize probe with the typed-empty-table case
+  named above.
+- Post-migration warehouse checks: all 77 configured tables present; the 66
+  previously-populated tables retain row counts within normal daily drift; the
+  11 new tables exist with 0 rows and their reflected column sets.
+- `dbt build` the Focus staging models against the migrated dataset before the
+  new staging models are written.
+
+## Sequencing hazard for the same-PR staging models
+
+The 11 staging models are contract-enforced, so their `properties.yml` needs
+exact column names and BigQuery types — which normally come from the
+materialized table. That creates an ordering problem:
+
+- The tables do not exist until the new code runs.
+- Creating them early from a branch deployment writes to the **prod** dataset
+  (dlt has no branch-deployment redirect, per `focus/CLAUDE.md`), and once
+  created they carry REQUIRED `_dlt_*` columns. Prod is still running the old
+  code, whose loads omit those columns, so the next scheduled Focus run would
+  fail on those tables until this PR merges.
+
+Three ways to resolve, to be decided before implementation:
+
+1. Split the work: pipeline change plus migration in this PR, staging models in
+   a follow-up written against real materialized tables. Removes the hazard
+   entirely.
+1. Keep one PR and derive the contract types from the reflected Postgres schema
+   (dlt's type mapping is deterministic, and `remove_nullability_adapter` plus
+   `interval_to_microseconds_adapter` fix the two non-obvious cases). Verify by
+   building the staging models immediately after the post-merge migration; a
+   mistyped column fails the build, not the load.
+1. Keep one PR and capture the reflected schema first via a throwaway
+   branch-deployment run that logs column names and types without creating
+   tables, then write contracts from that log.
+
+Option 1 is recommended. Option 2 is viable but front-loads type risk into
+review; option 3 costs throwaway code.
+
+## Out of scope
+
+- **Illuminate** — exactly one configured table is absent
+  (`dna_repositories.repository_463`), and `illuminate_repository_unpivot`
+  already emits a typed empty `SELECT` when the source is missing, so its asset
+  is healthy. Applying this design there would let that `{% if cols %}` fallback
+  be deleted; that is a follow-up, not part of this work.
+- **PowerSchool** — omits `autodetect_schema=True`, so its loads carry a
+  dlt-managed schema and an empty file loads without BigQuery inference. It
+  never had this failure mode and needs no change.
+
+## Rollout
+
+Current decision is one PR containing both the pipeline change and the 11
+staging models, so their contract types come from the reflected Postgres schema
+(_Sequencing hazard_, option 2) and are proven by the post-merge build.
+
+1. Merge the PR.
+1. Confirm the `kippmiami` code location loads the new commit.
+1. Launch the Focus asset job once with run config `refresh: drop_resources`, at
+   a quiet hour. All 66 populated tables are recreated with the row-id columns
+   and the 11 empty ones are created in the same run.
+1. Confirm all 77 tables exist, the 66 retain their row counts, and the 11 are
+   empty with the expected column sets.
+1. Build the Focus staging models, including the 11 new ones. A mistyped
+   contract column fails here, which is the intended catch point for option 2.
+
+If the hazard decision moves to option 1 instead, steps 1 through 4 carry the
+pipeline change alone and the staging models follow in a second PR written
+against the now-materialized tables.

--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -138,6 +138,12 @@ changes on existing tables.
   for days starts failing the day its source goes to 0 rows; the destination
   table is already correctly truncated (dlt truncates autodetect tables before
   the load job), so there is no data to repair.
+- **Focus additionally materializes never-loaded tables** — its resource yields
+  `materialize_table_schema()` when the source has 0 rows, which requires the
+  `normalize.parquet_normalizer.add_dlt_*` knobs and made every Focus table gain
+  `_dlt_id` / `_dlt_load_id` (see `focus/CLAUDE.md`, #4740). Illuminate does NOT
+  do this: its one absent table is absorbed by the
+  `illuminate_repository_unpivot` macro's empty fallback.
 - `replace` never changes an existing table's column **mode** (not just type):
   an all-`NULLABLE` load into a table whose column is `REQUIRED` fails with BQ
   400 "changed mode from REQUIRED to NULLABLE". Drop the table so the pipeline

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -61,22 +61,36 @@ columns.
 
 ## Empty source tables
 
-A 0-row source extract behaves differently before and after the table's first
-successful load, because dlt's empty-table handling keys off
-`seen_data_only=True`:
+A configured table with 0 rows in Focus is **created empty** in BigQuery: the
+resource in `assets.py` appends `dlt.mark.materialize_table_schema()` when
+`table_rows` yielded no data, so the table exists from the reflected schema and
+a staging model can be written before any data arrives (#4740).
 
-- **Never loaded data**: the PyArrow backend writes NO BigQuery table and no
-  load jobs (the asset SUCCEEDS — no `rows_loaded`, `jobs: []`). A configured
-  Focus table absent from `dagster_<district>_dlt_focus` is therefore **empty in
-  the source** (Focus is mid-rollout in Miami), not an extraction failure —
-  confirm via the asset materialization metadata before investigating.
-- **Has loaded data before**: dlt emits an empty file so the `replace` root is
-  truncated. That file must be parquet or BigQuery autodetection fails the load
-  — hence `loader_file_format="parquet"` in `assets.py`. See _`replace`
-  write-disposition_ in `../CLAUDE.md` (#4733).
+Consequences to know:
 
-So a Focus asset going quiet is not evidence the table is new, and a table
-emptying out is not a data loss — the truncate is the intended outcome.
+- **Every Focus table carries `_dlt_id` and `_dlt_load_id`.** The materialize
+  marker travels dlt's object path, which injects both as REQUIRED, so the arrow
+  data path must supply them too — hence the two
+  `normalize.parquet_normalizer.add_dlt_*` knobs set in the op body. Turning
+  either off breaks the first real load into an empty-created table with
+  `Field _dlt_load_id is missing in new schema`.
+- **Adding those columns to an existing table is impossible** (BigQuery:
+  `Cannot add required fields to an existing schema`), which is why the rollout
+  recreated all populated tables once via run config `refresh: drop_resources`.
+  Any future table created outside this path needs the same treatment.
+- **Column order differs** between a table created empty (`_dlt_*` first) and
+  one created by a data load (`_dlt_*` last). Cosmetic — loads match by name and
+  every staging model projects explicitly.
+- A table absent from `dagster_<district>_dlt_focus` now means a **config or
+  load problem**, not an empty source. That is the diagnostic this change buys.
+- A table that empties out AFTER loading is truncated, not dropped — see
+  `replace` write-disposition in `../CLAUDE.md` (#4733).
+
+The resource yields hints defensively before the marker so reflection items
+reach dlt in a single batch — that ordering simplifies the architecture but the
+columns survive either way (dlt absorbs hints that arrive later too). Columns
+are lost only when `table_rows` never yields any items at all, so no reflection
+reaches dlt.
 
 ## Testing Constraints
 

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -75,9 +75,10 @@ Consequences to know:
   either off breaks the first real load into an empty-created table with
   `Field _dlt_load_id is missing in new schema`.
 - **Adding those columns to an existing table is impossible** (BigQuery:
-  `Cannot add required fields to an existing schema`), which is why the rollout
-  recreated all populated tables once via run config `refresh: drop_resources`.
-  Any future table created outside this path needs the same treatment.
+  `Cannot add required fields to an existing schema`), so every table that was
+  already populated has to be recreated once, by launching the Focus asset job
+  with run config `refresh: drop_resources`. Any table that predates that
+  migration, or is created outside this path, needs the same treatment.
 - **Column order differs** between a table created empty (`_dlt_*` first) and
   one created by a data load (`_dlt_*` last). Cosmetic — loads match by name and
   every staging model projects explicitly.

--- a/src/teamster/libraries/dlt/focus/CLAUDE.md
+++ b/src/teamster/libraries/dlt/focus/CLAUDE.md
@@ -79,9 +79,12 @@ Consequences to know:
   already populated has to be recreated once, by launching the Focus asset job
   with run config `refresh: drop_resources`. Any table that predates that
   migration, or is created outside this path, needs the same treatment.
-- **Column order differs** between a table created empty (`_dlt_*` first) and
-  one created by a data load (`_dlt_*` last). Cosmetic — loads match by name and
-  every staging model projects explicitly.
+- **Until that migration runs, every already-populated table FAILS to load.**
+  The knobs are pipeline-wide: the arrow normalizer stamps both columns
+  non-nullable into every load file, and dlt's BigQuery load job sets
+  `ALLOW_FIELD_ADDITION` without `ALLOW_FIELD_RELAXATION`, so BigQuery rejects
+  each one. Deploying this code and deferring the migration is a prod outage,
+  not a no-op — sequence the two together.
 - A table absent from `dagster_<district>_dlt_focus` now means a **config or
   load problem**, not an empty source. That is the diagnostic this change buys.
 - A table that empties out AFTER loading is truncated, not dropped — see

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,9 +1,11 @@
 from collections.abc import Iterator
+from typing import Any
 
 import dlt
 import sqlalchemy as sa
-from dagster import AssetExecutionContext, AssetKey, AssetSpec
+from dagster import AssetExecutionContext, AssetKey, AssetSpec, Config
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
+from dlt import config as dlt_config
 from dlt import pipeline
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
@@ -20,6 +22,19 @@ from sqlalchemy.types import TypeEngine
 FOCUS_SOURCE_NAME = "focus"
 FOCUS_DB_SCHEMA = "public"
 FOCUS_CHUNK_SIZE = 50000
+
+
+class FocusDltConfig(Config):
+    """Run config for the Focus dlt op.
+
+    `refresh` is unset on every scheduled run. It exists for the one-time
+    migration that recreates already-populated tables so they gain the
+    `_dlt_id` / `_dlt_load_id` columns — BigQuery refuses to add REQUIRED
+    columns to an existing table, so they must be dropped and reloaded
+    (`drop_resources`, #4740).
+    """
+
+    refresh: str | None = None
 
 
 class FocusDagsterDltTranslator(DagsterDltTranslator):
@@ -197,12 +212,33 @@ def build_focus_dlt_assets(
         pool=f"dlt_focus_{code_location}",
         op_tags=op_tags,
     )
-    def _assets(context: AssetExecutionContext, dlt: DagsterDltResource) -> Iterator:
+    def _assets(
+        context: AssetExecutionContext,
+        config: FocusDltConfig,
+        dlt: DagsterDltResource,
+    ) -> Iterator:
+        # Both knobs make the arrow data path carry `_dlt_id` / `_dlt_load_id`,
+        # which dlt's object path injects as REQUIRED when
+        # `materialize_table_schema()` creates an empty table. Without them the
+        # first real load into such a table fails with
+        # `Field _dlt_load_id is missing in new schema` (#4740). Set here, not at
+        # import: each step runs in its own pod, so it cannot leak to another
+        # pipeline. NOT `dlt.config` — `dlt` is the resource parameter here.
+        dlt_config["normalize.parquet_normalizer.add_dlt_id"] = True
+        dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = True
+
         # loader_file_format="parquet": BigQuery schema autodetection rejects the
         # empty jsonl file dlt writes to truncate a `replace` table whose source
         # went to 0 rows. See `replace` write-disposition in ../CLAUDE.md (#4733).
-        yield from dlt.run(
-            context=context, write_disposition="replace", loader_file_format="parquet"
-        )
+        run_kwargs: dict[str, Any] = {
+            "write_disposition": "replace",
+            "loader_file_format": "parquet",
+        }
+
+        if config.refresh is not None:
+            context.log.info(f"dlt refresh mode: {config.refresh}")
+            run_kwargs["refresh"] = config.refresh
+
+        yield from dlt.run(context=context, **run_kwargs)
 
     return _assets

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,15 +1,24 @@
 from collections.abc import Iterator
 
+import dlt
+import sqlalchemy as sa
 from dagster import AssetExecutionContext, AssetKey, AssetSpec
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dlt import pipeline
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
-from dlt.sources.sql_database import remove_nullability_adapter, sql_database
+from dlt.extract.items import DataItemWithMeta
+from dlt.extract.source import DltSource
+from dlt.sources.sql_database import remove_nullability_adapter
+from dlt.sources.sql_database.helpers import table_rows
 from sqlalchemy import BigInteger
 from sqlalchemy.sql.sqltypes import _AbstractInterval
 from sqlalchemy.types import TypeEngine
+
+FOCUS_SOURCE_NAME = "focus"
+FOCUS_DB_SCHEMA = "public"
+FOCUS_CHUNK_SIZE = 50000
 
 
 class FocusDagsterDltTranslator(DagsterDltTranslator):
@@ -26,7 +35,7 @@ class FocusDagsterDltTranslator(DagsterDltTranslator):
                     self.code_location,
                     "dlt",
                     "focus",
-                    data.resource.explicit_args["table"],
+                    data.resource.name,
                 ]
             ),
             deps=[],
@@ -65,6 +74,77 @@ def interval_to_microseconds_adapter(col_type: TypeEngine) -> TypeEngine | None:
     return col_type
 
 
+def _build_focus_resource(
+    sql_database_credentials: ConnectionStringCredentials,
+    table_name: str,
+    db_schema: str | None = FOCUS_DB_SCHEMA,
+):
+    """Build one full-replace dlt resource for a Focus table.
+
+    Drives the exported ``table_rows`` generator rather than wrapping
+    ``sql_table``, so the resource can append
+    ``dlt.mark.materialize_table_schema()`` when the source yielded no data. A
+    table with 0 rows otherwise produces nothing dlt can act on, normalize drops
+    the package, and BigQuery never gets a table — leaving no target for a dbt
+    staging model (#4740). Same ``table_rows`` pattern as
+    ``libraries/dlt/powerschool/``.
+
+    The engine is created inside the generator, at extract time: the factory runs
+    at module import in the code location, which must not open a connection.
+    """
+
+    @dlt.resource(name=table_name, write_disposition="replace", parallelized=True)
+    def _focus_table() -> Iterator:
+        engine = sa.create_engine(sql_database_credentials.to_native_representation())
+        try:
+            saw_data = False
+
+            for item in table_rows(
+                engine=engine,
+                table=table_name,
+                metadata=sa.MetaData(schema=db_schema),
+                chunk_size=FOCUS_CHUNK_SIZE,
+                backend="pyarrow",
+                incremental=None,
+                table_adapter_callback=remove_nullability_adapter,
+                reflection_level="full_with_precision",
+                backend_kwargs={},
+                type_adapter_callback=interval_to_microseconds_adapter,
+                included_columns=None,
+                excluded_columns=None,
+                query_adapter_callback=None,
+                resolve_foreign_keys=False,
+            ):
+                # table_rows opens with a HintsMeta item carrying the reflected
+                # schema, then yields arrow tables. Only the latter is data.
+                if not isinstance(item, DataItemWithMeta):
+                    saw_data = True
+
+                yield item
+
+            if not saw_data:
+                yield dlt.mark.materialize_table_schema()
+        finally:
+            engine.dispose()
+
+    return _focus_table
+
+
+@dlt.source(name=FOCUS_SOURCE_NAME)
+def build_focus_source(
+    sql_database_credentials: ConnectionStringCredentials,
+    table_name: str,
+    db_schema: str | None = FOCUS_DB_SCHEMA,
+) -> Iterator:
+    """One-resource source. The name must stay `focus` — it is the dlt schema
+    name the destination's stored schema and state are keyed on."""
+    yield _build_focus_resource(
+        sql_database_credentials=sql_database_credentials,
+        table_name=table_name,
+        db_schema=db_schema,
+    )
+
+
 def build_focus_dlt_assets(
     sql_database_credentials: ConnectionStringCredentials,
     code_location: str,
@@ -74,15 +154,8 @@ def build_focus_dlt_assets(
     if op_tags is None:
         op_tags = {}
 
-    dlt_source = sql_database.with_args(name="focus", parallelized=True)(
-        credentials=sql_database_credentials,
-        schema="public",
-        table_names=[table_name],
-        defer_table_reflect=True,
-        backend="pyarrow",
-        reflection_level="full_with_precision",
-        table_adapter_callback=remove_nullability_adapter,
-        type_adapter_callback=interval_to_microseconds_adapter,
+    dlt_source: DltSource = build_focus_source(
+        sql_database_credentials=sql_database_credentials, table_name=table_name
     )
 
     dlt_pipeline = pipeline(

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, get_args
 
 import dlt
 import sqlalchemy as sa
@@ -9,6 +9,7 @@ from dlt import config as dlt_config
 from dlt import pipeline
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
+from dlt.common.typing import TRefreshMode
 from dlt.destinations import bigquery
 from dlt.extract.items import DataItemWithMeta
 from dlt.extract.resource import DltResource
@@ -22,6 +23,18 @@ from sqlalchemy.types import TypeEngine
 FOCUS_SOURCE_NAME = "focus"
 FOCUS_DB_SCHEMA = "public"
 FOCUS_CHUNK_SIZE = 50000
+
+REFRESH_MODES = frozenset(get_args(TRefreshMode))
+"""dlt's accepted `refresh` values, read from dlt so this cannot drift.
+
+The config field is a plain `str`, not this `Literal`: Dagster's Pythonic config
+cannot resolve one (`DagsterInvalidConfigDefinitionError: ... cannot be
+resolved`), so the op validates the string against this set instead. Without
+that guard dlt treats ANY unrecognized value as `drop_resources`
+(`dlt/pipeline/helpers.py::prepare_refresh_source` compares only against
+`drop_sources` and `drop_data`), so a typo would silently drop and recreate
+every table in the run.
+"""
 
 
 class FocusDltConfig(Config):
@@ -236,6 +249,13 @@ def build_focus_dlt_assets(
         }
 
         if config.refresh is not None:
+            if config.refresh not in REFRESH_MODES:
+                raise ValueError(
+                    f"refresh must be one of {sorted(REFRESH_MODES)}, got"
+                    f" {config.refresh!r} — dlt would silently treat that as"
+                    " drop_resources and recreate every table in this run"
+                )
+
             context.log.info(f"dlt refresh mode: {config.refresh}")
             run_kwargs["refresh"] = config.refresh
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import dlt
 import sqlalchemy as sa
@@ -74,58 +74,80 @@ def interval_to_microseconds_adapter(col_type: TypeEngine) -> TypeEngine | None:
     return col_type
 
 
+def _focus_table_items(
+    sql_database_credentials: ConnectionStringCredentials,
+    table_name: str,
+    db_schema: str | None,
+) -> Iterator:
+    """Yield one Focus table's items, appending a materialize marker if empty.
+
+    A plain generator (not `@dlt.resource`-wrapped) so tests can iterate the
+    real item stream directly — `DltResource.__iter__` unconditionally unwraps
+    `DataItemWithMeta` (and flattens empty-list markers like
+    `MaterializedEmptyList`) down to their `.data` payload before a caller ever
+    sees them (`PipeIterator._get_source_item`, dlt 1.29.1), so a resource built
+    from this can never expose the markers themselves via direct iteration.
+
+    The engine is created here, at extract time: the factory that calls this
+    runs at module import in the code location, which must not open a
+    connection.
+    """
+    engine = sa.create_engine(sql_database_credentials.to_native_representation())
+    try:
+        saw_data = False
+
+        for item in table_rows(
+            engine=engine,
+            table=table_name,
+            metadata=sa.MetaData(schema=db_schema),
+            chunk_size=FOCUS_CHUNK_SIZE,
+            backend="pyarrow",
+            incremental=None,
+            table_adapter_callback=remove_nullability_adapter,
+            reflection_level="full_with_precision",
+            backend_kwargs={},
+            type_adapter_callback=interval_to_microseconds_adapter,
+            included_columns=None,
+            excluded_columns=None,
+            query_adapter_callback=None,
+            resolve_foreign_keys=False,
+        ):
+            # table_rows opens with a HintsMeta item carrying the reflected
+            # schema, then yields arrow tables. Only the latter is data.
+            if not isinstance(item, DataItemWithMeta):
+                saw_data = True
+
+            yield item
+
+        if not saw_data:
+            yield dlt.mark.materialize_table_schema()
+    finally:
+        engine.dispose()
+
+
 def _build_focus_resource(
     sql_database_credentials: ConnectionStringCredentials,
     table_name: str,
     db_schema: str | None = FOCUS_DB_SCHEMA,
-):
+) -> Callable[[], Iterator]:
     """Build one full-replace dlt resource for a Focus table.
 
-    Drives the exported ``table_rows`` generator rather than wrapping
-    ``sql_table``, so the resource can append
+    Drives the exported ``table_rows`` generator (via `_focus_table_items`)
+    rather than wrapping ``sql_table``, so the resource can append
     ``dlt.mark.materialize_table_schema()`` when the source yielded no data. A
     table with 0 rows otherwise produces nothing dlt can act on, normalize drops
     the package, and BigQuery never gets a table — leaving no target for a dbt
     staging model (#4740). Same ``table_rows`` pattern as
     ``libraries/dlt/powerschool/``.
-
-    The engine is created inside the generator, at extract time: the factory runs
-    at module import in the code location, which must not open a connection.
     """
 
     @dlt.resource(name=table_name, write_disposition="replace", parallelized=True)
     def _focus_table() -> Iterator:
-        engine = sa.create_engine(sql_database_credentials.to_native_representation())
-        try:
-            saw_data = False
-
-            for item in table_rows(
-                engine=engine,
-                table=table_name,
-                metadata=sa.MetaData(schema=db_schema),
-                chunk_size=FOCUS_CHUNK_SIZE,
-                backend="pyarrow",
-                incremental=None,
-                table_adapter_callback=remove_nullability_adapter,
-                reflection_level="full_with_precision",
-                backend_kwargs={},
-                type_adapter_callback=interval_to_microseconds_adapter,
-                included_columns=None,
-                excluded_columns=None,
-                query_adapter_callback=None,
-                resolve_foreign_keys=False,
-            ):
-                # table_rows opens with a HintsMeta item carrying the reflected
-                # schema, then yields arrow tables. Only the latter is data.
-                if not isinstance(item, DataItemWithMeta):
-                    saw_data = True
-
-                yield item
-
-            if not saw_data:
-                yield dlt.mark.materialize_table_schema()
-        finally:
-            engine.dispose()
+        yield from _focus_table_items(
+            sql_database_credentials=sql_database_credentials,
+            table_name=table_name,
+            db_schema=db_schema,
+        )
 
     return _focus_table
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 
 import dlt
 import sqlalchemy as sa
@@ -9,6 +9,7 @@ from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
 from dlt.extract.items import DataItemWithMeta
+from dlt.extract.resource import DltResource
 from dlt.extract.source import DltSource
 from dlt.sources.sql_database import remove_nullability_adapter
 from dlt.sources.sql_database.helpers import table_rows
@@ -129,7 +130,7 @@ def _build_focus_resource(
     sql_database_credentials: ConnectionStringCredentials,
     table_name: str,
     db_schema: str | None = FOCUS_DB_SCHEMA,
-) -> Callable[[], Iterator]:
+) -> DltResource:
     """Build one full-replace dlt resource for a Focus table.
 
     Drives the exported ``table_rows`` generator (via `_focus_table_items`)

--- a/tests/libraries/test_dlt_focus_empty_load_package.py
+++ b/tests/libraries/test_dlt_focus_empty_load_package.py
@@ -1,0 +1,83 @@
+"""The empty-table load package carries the reflected columns, not just `_dlt_*`.
+
+If `materialize_table_schema()` reached dlt before the reflection hints, the
+created BigQuery table would hold only `_dlt_load_id` and `_dlt_id`, and every
+later load would have to ADD the real columns. This asserts the emitted parquet
+already has them.
+
+Extract plus normalize only — no BigQuery credentials are used.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import dlt
+import pyarrow.parquet as pq
+import sqlalchemy as sa
+from dlt import config as dlt_config
+from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.destinations import bigquery
+
+from teamster.libraries.dlt.focus.assets import build_focus_source
+
+
+def test_empty_table_package_carries_reflected_columns(tmp_path: Path) -> None:
+    url = f"sqlite:///{tmp_path / 'focus.db'}"
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "create table referrals ("
+                "referral_id integer not null, comment text, entry_date date)"
+            )
+        )
+    engine.dispose()
+
+    dlt_config["normalize.parquet_normalizer.add_dlt_id"] = True
+    dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = True
+
+    pipelines_dir = tempfile.mkdtemp(prefix="focus-empty-")
+    try:
+        pipeline = dlt.pipeline(
+            pipeline_name="focus_empty_package_test",
+            destination=bigquery(autodetect_schema=True),
+            dataset_name="test",
+            pipelines_dir=pipelines_dir,
+        )
+
+        pipeline.extract(
+            build_focus_source(
+                sql_database_credentials=ConnectionStringCredentials(url),
+                table_name="referrals",
+                db_schema=None,
+            ),
+            loader_file_format="parquet",
+        )
+        pipeline.normalize()
+
+        package = pipeline.list_normalized_load_packages()[-1]
+        info = pipeline.get_load_package_info(package)
+
+        jobs = [
+            j
+            for j in info.jobs["new_jobs"]
+            if j.job_file_info.table_name == "referrals"
+        ]
+
+        assert len(jobs) == 1, "the empty table must produce exactly one job"
+
+        path = Path(jobs[0].file_path)
+        assert path.suffix == ".parquet"
+
+        names = pq.read_schema(path).names
+
+        assert "referral_id" in names
+        assert "comment" in names
+        assert "entry_date" in names
+        assert "_dlt_load_id" in names
+        assert "_dlt_id" in names
+    finally:
+        shutil.rmtree(pipelines_dir, ignore_errors=True)
+        dlt_config["normalize.parquet_normalizer.add_dlt_id"] = False
+        dlt_config["normalize.parquet_normalizer.add_dlt_load_id"] = False

--- a/tests/libraries/test_dlt_focus_materialize_empty.py
+++ b/tests/libraries/test_dlt_focus_materialize_empty.py
@@ -9,29 +9,27 @@ sqlite stands in for Focus Postgres: the item shapes `table_rows` yields and the
 files dlt normalizes from them are backend-generic, and the Codespace cannot
 reach Focus (IP allowlist).
 
-These tests exercise a real `dlt.pipeline().extract()` + `.normalize()` against
-a `filesystem` destination (no extra deps, no live server) rather than iterating
-the built resource directly with `list(resource())`. dlt's `DltResource.__iter__`
-unconditionally unwraps `DataItemWithMeta` (and empty-list markers like
-`MaterializedEmptyList`) down to their `.data` payload before handing items to
-the caller (`PipeIterator._get_source_item`, dlt 1.29.1) — so a naive
+These tests call `_focus_table_items` directly — a plain generator, not the
+`@dlt.resource`-wrapped one — because dlt's `DltResource.__iter__`
+unconditionally unwraps `DataItemWithMeta` (and flattens empty-list markers
+like `MaterializedEmptyList`) down to their `.data` payload before a caller
+ever sees them (`PipeIterator._get_source_item`, dlt 1.29.1). A naive
 `list(resource())` can never observe the marker objects themselves, for ANY
-`dlt.resource`-wrapped generator, regardless of what it yields. The markers only
-have effect inside the real extract/normalize machinery, which is what these
-tests exercise.
+`dlt.resource`-wrapped generator — so the marker/ordering assertions below have
+to run against the plain generator directly.
 """
 
 import pathlib
 import tempfile
 from collections.abc import Iterator
 
-import dlt
 import pytest
 import sqlalchemy as sa
 from dlt.common.configuration.specs import ConnectionStringCredentials
-from dlt.pipeline.pipeline import Pipeline
+from dlt.extract.extractors import MaterializedEmptyList
+from dlt.extract.items import DataItemWithMeta
 
-from teamster.libraries.dlt.focus.assets import build_focus_source
+from teamster.libraries.dlt.focus.assets import _focus_table_items
 
 
 @pytest.fixture(name="sqlite_url")
@@ -54,78 +52,56 @@ def _seed(url: str, rows: int) -> None:
     engine.dispose()
 
 
-def _extract_and_normalize(url: str, pipelines_dir: pathlib.Path) -> Pipeline:
-    """Build the real Focus source and run it through extract + normalize.
-
-    `filesystem` needs no extra dependency and no live server, unlike `duckdb`
-    (not installed in this venv) or `bigquery` (needs GCP credentials) — but it
-    still exercises the same `Extractor`/normalizer code path that
-    `HintsMeta`/`materialize_table_schema()` are designed for, unlike direct
-    resource iteration.
-    """
-    source = build_focus_source(
-        sql_database_credentials=ConnectionStringCredentials(url),
-        table_name="referrals",
-        db_schema=None,
+def _items(url: str) -> list:
+    return list(
+        _focus_table_items(
+            sql_database_credentials=ConnectionStringCredentials(url),
+            table_name="referrals",
+            db_schema=None,
+        )
     )
 
-    pipeline = dlt.pipeline(
-        pipeline_name="focus_materialize_empty_test",
-        destination="filesystem",
-        dataset_name="focus_materialize_empty_test",
-        pipelines_dir=str(pipelines_dir),
-    )
-    pipeline.extract(source)
-    pipeline.normalize()
 
-    return pipeline
-
-
-def test_empty_table_yields_materialize_marker(
-    sqlite_url: str, tmp_path: pathlib.Path
-) -> None:
-    """A 0-row table must still normalize into a job, or the table is created.
-
-    Without `dlt.mark.materialize_table_schema()`, a resource that produced no
-    items is dropped entirely — `referrals` would be absent from
-    `row_counts`, exactly the prod bug (#4740).
-    """
+def test_empty_table_yields_materialize_marker(sqlite_url: str) -> None:
     _seed(sqlite_url, rows=0)
 
-    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+    items = _items(sqlite_url)
 
-    row_counts = pipeline.last_trace.last_normalize_info.row_counts
-    assert row_counts.get("referrals") == 0, (
-        "a 0-row table must still produce a normalized job so the table is created"
+    assert isinstance(items[-1], MaterializedEmptyList), (
+        "a 0-row table must end with materialize_table_schema() so the table is created"
     )
 
 
-def test_populated_table_yields_no_materialize_marker(
-    sqlite_url: str, tmp_path: pathlib.Path
-) -> None:
+def test_populated_table_yields_no_materialize_marker(sqlite_url: str) -> None:
     _seed(sqlite_url, rows=3)
 
-    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+    items = _items(sqlite_url)
 
-    row_counts = pipeline.last_trace.last_normalize_info.row_counts
-    assert row_counts.get("referrals") == 3
+    assert not any(isinstance(i, MaterializedEmptyList) for i in items)
+
+    data_items = [i for i in items if not isinstance(i, DataItemWithMeta)]
+    assert [i.num_rows for i in data_items] == [3]
 
 
-def test_reflection_hints_precede_the_marker(
-    sqlite_url: str, tmp_path: pathlib.Path
-) -> None:
+def test_reflection_hints_precede_the_marker(sqlite_url: str) -> None:
     """The hints marker must come first, or the created table has no columns.
 
     dlt registers the reflected columns from the `HintsMeta` item; a
     `materialize_table_schema()` that arrived before it would create a table
-    holding only the `_dlt_*` columns.
+    holding only the `_dlt_*` columns. Asserted by index, not by checking
+    `items[0]` alone, so a reordered implementation (marker yielded before the
+    hints) fails this test even if it still yields both items.
     """
     _seed(sqlite_url, rows=0)
 
-    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+    items = _items(sqlite_url)
 
-    columns = pipeline.default_schema.tables["referrals"]["columns"]
-    assert {"referral_id", "comment"} <= set(columns), (
-        "the reflected source columns must be registered, not just dlt's"
-        " internal _dlt_* columns"
+    hints_index = next(
+        i for i, item in enumerate(items) if isinstance(item, DataItemWithMeta)
     )
+    marker_index = next(
+        i for i, item in enumerate(items) if isinstance(item, MaterializedEmptyList)
+    )
+
+    assert hints_index < marker_index
+    assert type(items[hints_index].meta).__name__ == "HintsMeta"

--- a/tests/libraries/test_dlt_focus_materialize_empty.py
+++ b/tests/libraries/test_dlt_focus_materialize_empty.py
@@ -1,0 +1,131 @@
+"""The Focus resource materializes a never-loaded table's schema (#4740).
+
+A configured Focus table with no rows produced nothing at all before, so dlt
+dropped the load package and BigQuery never got a table. The resource now yields
+`materialize_table_schema()` in that case, which creates the table from the
+reflected schema.
+
+sqlite stands in for Focus Postgres: the item shapes `table_rows` yields and the
+files dlt normalizes from them are backend-generic, and the Codespace cannot
+reach Focus (IP allowlist).
+
+These tests exercise a real `dlt.pipeline().extract()` + `.normalize()` against
+a `filesystem` destination (no extra deps, no live server) rather than iterating
+the built resource directly with `list(resource())`. dlt's `DltResource.__iter__`
+unconditionally unwraps `DataItemWithMeta` (and empty-list markers like
+`MaterializedEmptyList`) down to their `.data` payload before handing items to
+the caller (`PipeIterator._get_source_item`, dlt 1.29.1) — so a naive
+`list(resource())` can never observe the marker objects themselves, for ANY
+`dlt.resource`-wrapped generator, regardless of what it yields. The markers only
+have effect inside the real extract/normalize machinery, which is what these
+tests exercise.
+"""
+
+import pathlib
+import tempfile
+from collections.abc import Iterator
+
+import dlt
+import pytest
+import sqlalchemy as sa
+from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.pipeline.pipeline import Pipeline
+
+from teamster.libraries.dlt.focus.assets import build_focus_source
+
+
+@pytest.fixture(name="sqlite_url")
+def fixture_sqlite_url() -> Iterator[str]:
+    """A sqlite file with a `referrals` table whose row count the test sets."""
+    with tempfile.TemporaryDirectory() as tmp:
+        yield f"sqlite:///{pathlib.Path(tmp) / 'focus.db'}"
+
+
+def _seed(url: str, rows: int) -> None:
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "create table referrals (referral_id integer not null, comment text)"
+            )
+        )
+        for i in range(rows):
+            conn.execute(sa.text("insert into referrals values (:i, 'c')"), {"i": i})
+    engine.dispose()
+
+
+def _extract_and_normalize(url: str, pipelines_dir: pathlib.Path) -> Pipeline:
+    """Build the real Focus source and run it through extract + normalize.
+
+    `filesystem` needs no extra dependency and no live server, unlike `duckdb`
+    (not installed in this venv) or `bigquery` (needs GCP credentials) — but it
+    still exercises the same `Extractor`/normalizer code path that
+    `HintsMeta`/`materialize_table_schema()` are designed for, unlike direct
+    resource iteration.
+    """
+    source = build_focus_source(
+        sql_database_credentials=ConnectionStringCredentials(url),
+        table_name="referrals",
+        db_schema=None,
+    )
+
+    pipeline = dlt.pipeline(
+        pipeline_name="focus_materialize_empty_test",
+        destination="filesystem",
+        dataset_name="focus_materialize_empty_test",
+        pipelines_dir=str(pipelines_dir),
+    )
+    pipeline.extract(source)
+    pipeline.normalize()
+
+    return pipeline
+
+
+def test_empty_table_yields_materialize_marker(
+    sqlite_url: str, tmp_path: pathlib.Path
+) -> None:
+    """A 0-row table must still normalize into a job, or the table is created.
+
+    Without `dlt.mark.materialize_table_schema()`, a resource that produced no
+    items is dropped entirely — `referrals` would be absent from
+    `row_counts`, exactly the prod bug (#4740).
+    """
+    _seed(sqlite_url, rows=0)
+
+    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+
+    row_counts = pipeline.last_trace.last_normalize_info.row_counts
+    assert row_counts.get("referrals") == 0, (
+        "a 0-row table must still produce a normalized job so the table is created"
+    )
+
+
+def test_populated_table_yields_no_materialize_marker(
+    sqlite_url: str, tmp_path: pathlib.Path
+) -> None:
+    _seed(sqlite_url, rows=3)
+
+    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+
+    row_counts = pipeline.last_trace.last_normalize_info.row_counts
+    assert row_counts.get("referrals") == 3
+
+
+def test_reflection_hints_precede_the_marker(
+    sqlite_url: str, tmp_path: pathlib.Path
+) -> None:
+    """The hints marker must come first, or the created table has no columns.
+
+    dlt registers the reflected columns from the `HintsMeta` item; a
+    `materialize_table_schema()` that arrived before it would create a table
+    holding only the `_dlt_*` columns.
+    """
+    _seed(sqlite_url, rows=0)
+
+    pipeline = _extract_and_normalize(sqlite_url, tmp_path)
+
+    columns = pipeline.default_schema.tables["referrals"]["columns"]
+    assert {"referral_id", "comment"} <= set(columns), (
+        "the reflected source columns must be registered, not just dlt's"
+        " internal _dlt_* columns"
+    )

--- a/tests/libraries/test_dlt_focus_op_config.py
+++ b/tests/libraries/test_dlt_focus_op_config.py
@@ -104,3 +104,15 @@ def test_refresh_is_forwarded_when_set(focus_assets: Any) -> None:
     kwargs = _run(focus_assets, FocusDltConfig(refresh="drop_resources"))
 
     assert kwargs["refresh"] == "drop_resources"
+
+
+def test_unrecognized_refresh_raises(focus_assets: Any) -> None:
+    """A typo must fail loudly, not silently mean `drop_resources`.
+
+    dlt's `prepare_refresh_source` compares only against `drop_sources` and
+    `drop_data`, so any other non-None value takes the `drop_resources` branch
+    and recreates every table in the run. Dagster cannot validate this at launch
+    (its Pythonic config rejects a `Literal`), so the op guards it.
+    """
+    with pytest.raises(ValueError, match="refresh must be one of"):
+        _run(focus_assets, FocusDltConfig(refresh="drop_resource"))

--- a/tests/libraries/test_dlt_focus_op_config.py
+++ b/tests/libraries/test_dlt_focus_op_config.py
@@ -1,0 +1,106 @@
+"""Focus op wiring: row-id knobs and the migration's refresh run config (#4740).
+
+The knobs are load-bearing. `materialize_table_schema()` travels dlt's object
+path, which injects `_dlt_id` / `_dlt_load_id` as REQUIRED; without the knobs the
+arrow data path omits them and BigQuery rejects the first real load into an
+empty-created table with `Field _dlt_load_id is missing in new schema`.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from dlt import config as dlt_config
+from dlt.common.configuration.specs import ConnectionStringCredentials
+
+from teamster.libraries.dlt.focus.assets import (
+    FocusDltConfig,
+    build_focus_dlt_assets,
+)
+
+CREDENTIALS = ConnectionStringCredentials("postgresql+psycopg://localhost:5432/db")
+
+ADD_DLT_ID = "normalize.parquet_normalizer.add_dlt_id"
+ADD_DLT_LOAD_ID = "normalize.parquet_normalizer.add_dlt_load_id"
+
+
+class _RecordingDltResource:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def run(self, **kwargs: Any) -> Iterator[Any]:
+        self.kwargs = kwargs
+        return iter(())
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def info(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class _StubContext:
+    """The op logs the refresh mode, so the context needs a `.log`.
+
+    Nothing else on the context is touched before `dlt.run()`.
+    """
+
+    def __init__(self) -> None:
+        self.log = _StubLog()
+
+
+@pytest.fixture(name="focus_assets")
+def fixture_focus_assets() -> Any:
+    return build_focus_dlt_assets(
+        sql_database_credentials=CREDENTIALS,
+        code_location="kippmiami",
+        table_name="discipline_referrals",
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_knobs() -> Iterator[None]:
+    """Leave dlt's in-memory config as it was; it is process-global."""
+    yield
+    dlt_config[ADD_DLT_ID] = False
+    dlt_config[ADD_DLT_LOAD_ID] = False
+
+
+def _run(
+    focus_assets: Any, config: FocusDltConfig, context: Any = None
+) -> dict[str, Any]:
+    dlt_resource = _RecordingDltResource()
+
+    list(
+        focus_assets.op.compute_fn.decorated_fn(
+            context=context or _StubContext(), config=config, dlt=dlt_resource
+        )
+    )
+
+    return dlt_resource.kwargs
+
+
+def test_op_sets_both_row_id_knobs(focus_assets: Any) -> None:
+    dlt_config[ADD_DLT_ID] = False
+    dlt_config[ADD_DLT_LOAD_ID] = False
+
+    _run(focus_assets, FocusDltConfig())
+
+    assert dlt_config[ADD_DLT_ID] is True
+    assert dlt_config[ADD_DLT_LOAD_ID] is True
+
+
+def test_refresh_is_omitted_by_default(focus_assets: Any) -> None:
+    kwargs = _run(focus_assets, FocusDltConfig())
+
+    assert "refresh" not in kwargs
+    assert kwargs["write_disposition"] == "replace"
+    assert kwargs["loader_file_format"] == "parquet"
+
+
+def test_refresh_is_forwarded_when_set(focus_assets: Any) -> None:
+    kwargs = _run(focus_assets, FocusDltConfig(refresh="drop_resources"))
+
+    assert kwargs["refresh"] == "drop_resources"

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -20,7 +20,6 @@ from dlt.common.libs.pyarrow import (
     py_arrow_to_table_schema_columns,
 )
 from dlt.common.schema.typing import TTableSchemaColumns
-from dlt.sources.sql_database import remove_nullability_adapter
 from dlt.sources.sql_database.arrow_helpers import row_tuples_to_arrow
 from dlt.sources.sql_database.schema_types import (
     TTypeAdapter,

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -11,6 +11,7 @@ dlt casts the duration to int64 microseconds instead.
 """
 
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from dagster_dlt.constants import META_KEY_SOURCE
@@ -20,6 +21,7 @@ from dlt.common.libs.pyarrow import (
     py_arrow_to_table_schema_columns,
 )
 from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.sources.sql_database import remove_nullability_adapter
 from dlt.sources.sql_database.arrow_helpers import row_tuples_to_arrow
 from dlt.sources.sql_database.schema_types import (
     TTypeAdapter,
@@ -150,6 +152,45 @@ def test_extract_invokes_both_adapters(monkeypatch, tmp_path):
 
     assert type_calls, "type_adapter_callback was not passed to table_rows"
     assert table_calls, "table_adapter_callback was not passed to table_rows"
+
+
+def test_reflection_settings_reach_table_rows(monkeypatch):
+    """Pin the extract settings, not just the adapters.
+
+    `reflection_level="full_with_precision"` is what preserves Postgres
+    precision and scale; a silent regression to `"minimal"` would widen or
+    truncate every Focus column with nothing else failing. `backend="pyarrow"`
+    is what the interval adapter and the parquet loader assume.
+    """
+    from teamster.libraries.dlt.focus import assets as focus_assets
+
+    captured: dict[str, Any] = {}
+
+    def spy_table_rows(**kwargs):
+        captured.update(kwargs)
+        return iter(())
+
+    monkeypatch.setattr(focus_assets, "table_rows", spy_table_rows)
+
+    resource = focus_assets._build_focus_resource(
+        sql_database_credentials=ConnectionStringCredentials("sqlite://"),
+        table_name="gradebook_assignments",
+        db_schema="public",
+    )
+    list(resource())
+
+    assert captured["reflection_level"] == "full_with_precision"
+    assert captured["backend"] == "pyarrow"
+    assert captured["table_adapter_callback"] is remove_nullability_adapter
+    assert captured["type_adapter_callback"] is interval_to_microseconds_adapter
+    assert captured["table"] == "gradebook_assignments"
+    assert captured["metadata"].schema == "public"
+
+    # table_rows takes no defaults but `table_loader_class`; a dropped kwarg
+    # would silently change extract behavior
+    assert captured["incremental"] is None
+    assert captured["query_adapter_callback"] is None
+    assert captured["resolve_foreign_keys"] is False
 
 
 def test_interval_column_without_adapter_reproduces_prod_failure():

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -81,13 +81,11 @@ def test_adapter_passes_other_types_through_unchanged(col_type):
     assert interval_to_microseconds_adapter(col_type) is col_type
 
 
-def test_factory_wires_both_adapters_into_the_dlt_source():
-    """Guard the wiring, not just the adapter function.
+def test_factory_builds_a_source_with_the_table_named_resource():
+    """Guard the wiring the translator depends on.
 
-    Every other test in this module would still pass if `build_focus_dlt_assets`
-    dropped `type_adapter_callback=`, since they call the adapter directly. This
-    asserts the factory-built source actually carries it. `defer_table_reflect`
-    means no connection is opened, so no live Focus database is needed.
+    The asset key comes from `data.resource.name`, so a resource named anything
+    else silently changes every Focus asset key.
     """
     assets = build_focus_dlt_assets(
         sql_database_credentials=ConnectionStringCredentials(
@@ -98,14 +96,61 @@ def test_factory_wires_both_adapters_into_the_dlt_source():
     )
 
     dlt_source = next(iter(assets.specs)).metadata[META_KEY_SOURCE]
-    explicit_args = dlt_source.resources["gradebook_assignments"].explicit_args
 
-    assert explicit_args["type_adapter_callback"] is interval_to_microseconds_adapter
+    assert list(dlt_source.resources) == ["gradebook_assignments"]
+    assert dlt_source.name == "focus"
+    assert next(iter(assets.specs)).key.path == [
+        "kippmiami",
+        "dlt",
+        "focus",
+        "gradebook_assignments",
+    ]
 
-    # the interval adapter must not have displaced the nullability adapter
-    assert explicit_args["table_adapter_callback"] is remove_nullability_adapter
-    assert explicit_args["reflection_level"] == "full_with_precision"
-    assert explicit_args["backend"] == "pyarrow"
+
+def test_extract_invokes_both_adapters(monkeypatch, tmp_path):
+    """The adapters must reach `table_rows`, not merely exist.
+
+    Uses sqlite (the Codespace cannot reach Focus) and records each adapter call,
+    so a factory that stops passing one fails here.
+    """
+    import sqlalchemy as sa
+
+    from teamster.libraries.dlt.focus import assets as focus_assets
+
+    url = f"sqlite:///{tmp_path / 'focus.db'}"
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(sa.text("create table t (id integer not null, note text)"))
+    engine.dispose()
+
+    type_calls: list[object] = []
+    table_calls: list[object] = []
+
+    original_type_adapter = focus_assets.interval_to_microseconds_adapter
+    original_table_adapter = focus_assets.remove_nullability_adapter
+
+    def spy_type_adapter(col_type):
+        type_calls.append(col_type)
+        return original_type_adapter(col_type)
+
+    def spy_table_adapter(table):
+        table_calls.append(table)
+        return original_table_adapter(table)
+
+    monkeypatch.setattr(
+        focus_assets, "interval_to_microseconds_adapter", spy_type_adapter
+    )
+    monkeypatch.setattr(focus_assets, "remove_nullability_adapter", spy_table_adapter)
+
+    resource = focus_assets._build_focus_resource(
+        sql_database_credentials=ConnectionStringCredentials(url),
+        table_name="t",
+        db_schema=None,
+    )
+    list(resource())
+
+    assert type_calls, "type_adapter_callback was not passed to table_rows"
+    assert table_calls, "table_adapter_callback was not passed to table_rows"
 
 
 def test_interval_column_without_adapter_reproduces_prod_failure():

--- a/tests/libraries/test_dlt_replace_loader_file_format.py
+++ b/tests/libraries/test_dlt_replace_loader_file_format.py
@@ -37,7 +37,7 @@ class _RecordingDltResource:
         return iter(())
 
 
-def _run_kwargs(assets: Any) -> dict[str, Any]:
+def _run_kwargs(assets: Any, config: Any = None) -> dict[str, Any]:
     """Invoke the asset body with a recording resource and return its run kwargs.
 
     Nothing in the body touches the context or opens a connection before
@@ -45,8 +45,16 @@ def _run_kwargs(assets: Any) -> dict[str, Any]:
     """
     dlt_resource = _RecordingDltResource()
 
+    kwargs: dict[str, Any] = {"context": None, "dlt": dlt_resource}
+
+    # the focus op takes run config; the illuminate op does not
+    if "config" in assets.op.compute_fn.decorated_fn.__annotations__:
+        from teamster.libraries.dlt.focus.assets import FocusDltConfig
+
+        kwargs["config"] = config or FocusDltConfig()
+
     # consume the generator so the `yield from dlt.run(...)` line executes
-    list(assets.op.compute_fn.decorated_fn(context=None, dlt=dlt_resource))
+    list(assets.op.compute_fn.decorated_fn(**kwargs))
 
     return dlt_resource.kwargs
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make dlt create a Focus table in BigQuery even when it holds zero rows in the source, so a contract-enforced dbt staging model can be written for it before any data arrives.

11 of the 77 configured Focus tables are absent from `dagster_kippmiami_dlt_focus` today because Focus has no rows for them yet: `attendance_day`, `attendance_notes`, `attendance_period`, `discipline_incidents`, `discipline_incidents_join_referrals`, `gradebook_grades`, `referral_code_offenses`, `student_groups`, `student_standard_grades`, `students_join_groups`, `students_join_students`. All 11 are already declared in `src/dbt/focus/models/staging/sources-bigquery.yml`, but none has a staging model — you cannot build one against a table that does not exist. Cause: dlt's `Extract._handle_empty_tables` writes an empty file only for a `replace` table that has previously seen data, so a never-loaded table produces no load package at all and the asset succeeds with `jobs: []`.

Design: `docs/superpowers/specs/2026-08-05-focus-empty-table-materialization-design.md`. Plan: `docs/superpowers/plans/2026-08-05-focus-empty-table-materialization.md`. Both are on this branch.

### What changed

1. **The Focus factory drives `table_rows` directly** instead of calling `sql_database`, so the resource can append `dlt.mark.materialize_table_schema()` when no data came through. Same pattern `libraries/dlt/powerschool/` already uses. The generator body is a plain module-level function (`_focus_table_items`) that `@dlt.resource` wraps, which is what makes the item stream testable.
2. **Both dlt row-id knobs are enabled** in the op body via a module-level `from dlt import config as dlt_config`. This is load-bearing, not tidying: `materialize_table_schema()` travels dlt's object path, which injects `_dlt_id` / `_dlt_load_id` as REQUIRED, so the arrow data path must supply them too. Without them the first real load into an empty-created table fails with `Field _dlt_load_id is missing in new schema`.
3. **`FocusDltConfig.refresh`** lets the one-time migration run as a run-config launch rather than a temporary code change that has to be deployed and reverted. Unset on every scheduled run, and validated against dlt's own `TRefreshMode` — dlt treats any unrecognized value as `drop_resources`, and Dagster's Pythonic config cannot resolve a `Literal` to catch it at launch.
4. The asset key now derives from `data.resource.name` — `explicit_args` exists only on `sql_database`-built resources.

### Required post-merge step

**Merging this without promptly running the migration takes all 66 populated Focus tables down.** The row-id knobs are pipeline-wide: the arrow normalizer stamps `_dlt_id` / `_dlt_load_id` non-nullable into every load file, and dlt's BigQuery load job sets `ALLOW_FIELD_ADDITION` without `ALLOW_FIELD_RELAXATION`, so BigQuery rejects each existing table with `Cannot add required fields to an existing schema` — row 1 of the verification table below. This is a breaking change gated on the migration, not an inert one. An earlier draft of this description said the opposite; the final review caught it.

So: BigQuery refuses to add REQUIRED columns in place, and the 66 already-populated tables must be recreated once by launching the Focus asset job with run config `refresh: drop_resources`. The 11 empty tables are created in the same run. **Merge immediately before that window, not ahead of it.**

Timing is not arbitrary. Focus dlt runs at 04:00, 12:00 and 14:00 ET, and the 12:45 delivery's import-once anti-join reads the dlt snapshot — a snapshot reading empty mid-migration makes that delivery re-send already-imported records and duplicate them in Focus once ops runs the import by hand. That delivery is a plain cron with nothing gating it on the upstreams. **Run after the 14:00 ET pull finishes and well before 04:00; never inside 11:00-15:00 ET.** The full runbook is at the end of the plan document.

### Verification

BigQuery probes in a scratch dataset (dlt 1.29.1), which is what pinned the design:

| Sequence | Knobs off | Knobs on |
| --- | --- | --- |
| Add row-id columns to an existing table | rejected: cannot add required fields | n/a |
| Create empty, then load first real data | rejected: `_dlt_load_id` is missing | passes |
| Recreated table: load, reload, go empty | passes | passes |
| Created empty: data, empty, data again | fails at first data | passes |

Offline tests added (sqlite stands in for Focus, which is IP-allowlisted):

- `test_dlt_focus_materialize_empty.py` — 0 rows ends with the materialize marker; a populated table has none; hints precede the marker.
- `test_dlt_focus_op_config.py` — both knobs get set, `refresh` is omitted when unset and forwarded when set, and an unrecognized value raises rather than silently meaning `drop_resources`.
- `test_dlt_focus_empty_load_package.py` — the emitted parquet for a 0-row table carries the reflected columns, not just `_dlt_*`. This closes the gap the design flagged in its own probe.

22 tests pass across the five affected test files. `uv run pyright` is clean on every file touched. `trunk check --force` over all changed files reports no issues.

Each new test was verified to actually fail against a deliberately broken implementation before being accepted.

### Two corrections the implementation forced on the plan

Recording these because the plan text on this branch is now less accurate than the code:

- The plan's Task 1 test bodies were **unwritable**. `list(decorated_resource())` returns `[]` — `DltResource.__iter__` unwraps the hints and materialize markers before a caller sees them. Hence the plain-generator seam.
- The spec's column-order claim was wrong: both paths emit the row-id columns last.
- Hints-before-marker ordering is **defensive, not load-bearing**. dlt absorbs hints that arrive after the marker too; the reflected columns are lost only if `table_rows` is never consumed at all. The docs and code comments say this; the plan's stronger claim does not.

### AI Assistance

Claude Code did the investigation, the BigQuery probes, the design, the plan, and the implementation across four reviewed subagent tasks. Human-directed: the choice of dlt's own row-id knobs over hand-patching its column hints, the one-time migration framing, deferring Illuminate and PowerSchool, and splitting the staging models into a follow-up.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [ ] `uv run dagster definitions validate` — **not runnable in the Codespace**: `kippmiami` resolves its Focus dlt credentials eagerly at module load, so validate and `tests/test_dagster_definitions.py` fail on unset credentials regardless of this change (documented in `src/teamster/CLAUDE.md`). Verified instead with the offline test suite above, `uv run pyright`, and a direct module import; the Dagster Cloud branch deployment is the real check.
- [x] No new integration — two existing library factories and their tests.
- [x] Asset keys unchanged: the translator now reads `data.resource.name`, which is the table name, so `kippmiami/dlt/focus/<table>` is preserved.

### dbt

- [x] No dbt changes. The 11 staging models are a deliberate follow-up: their contracts need types from tables that do not exist until this ships, and pre-creating them from a branch deployment would write REQUIRED row-id columns into the prod dataset that prod's current code cannot satisfy.

### Docs

- [x] Rewrote the `Empty source tables` section of `libraries/dlt/focus/CLAUDE.md`, which described the now-obsolete behavior.
- [x] Cross-referenced the mechanism from the shared `replace` write-disposition section of `libraries/dlt/CLAUDE.md`, including why Illuminate is not getting this treatment.
- [x] No schedule or sensor change, so no automations-catalog regeneration.

## CI checks

- [ ] **Trunk** — `trunk check --force` on all changed files reports no issues locally.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — `libraries/dlt/` is shared, so all five code locations redeploy.

## Out of scope

- **Illuminate** — exactly one configured table is absent (`dna_repositories.repository_463`), already absorbed by the `illuminate_repository_unpivot` macro's empty fallback, so its asset is healthy. Applying this design there would let that fallback be deleted; that is a follow-up.
- **PowerSchool** — omits `autodetect_schema=True`, so its loads carry a dlt-managed schema and an empty file loads without BigQuery inference. It never had this failure mode.

Separately noted while working here, not fixed in this PR: `libraries/dlt/powerschool/assets.py:306` calls `dlt.config["extract.workers"] = workers` inside an op whose resource parameter is named `dlt`, which shadows the module. `DagsterDltResource` has no `.config`, so that line raises `AttributeError`. It is dormant — no code location passes `max_extract_workers`, so it only fires when someone sets the `dlt_extract_workers` run tag, and then that diagnostic run crashes.

Refs #4740
