### PR TITLE
feat(dbt): surface the walked school's canonical name on the ops EKG extract

### DIFF
--- a/docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md
+++ b/docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md
@@ -316,6 +316,13 @@ design doc's earlier estimate.
 - **Fields on `operations_ekg`:** `[region]` → `[home_business_unit_name]`,
   `[respondent_location]` → `[location_clean_name]`, `[respondent_job_title]` →
   `[job_title]`
+- **Location-gate variant on `operations_ekg`:** the Tier 5 location gate reads
+  `[school_clean_name]`, not `[location_clean_name]`. Those are two different
+  schools on this extract — `location_clean_name` comes from the roster join on
+  the respondent, so gating on it shows a school leader the walkthroughs they
+  **performed**, not the ones **of their school**. `school_clean_name` is the
+  walked school, added in PR #4746; it must be merged and materialized before
+  this workbook's Tier 5 edit.
 - **Role variant:** omit the AP branch entirely
 - **Note:** `operations_pm` keeps `[respondent_job_title]` and
   `[respondent_name]` — that model has two people per row and the respondent is

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
@@ -39,6 +39,19 @@ models:
                   - KIPP Miami
                   - KIPP Paterson
                   - KIPP TEAM and Family Schools Inc.
+      - name: school_clean_name
+        data_type: string
+        description: >-
+          The walked school resolved to its canonical name via
+          int_people__location_crosswalk, so every alias of one school collapses
+          to a single value. This is the column a Tableau location gate scopes
+          on. Null when the form label is absent from the crosswalk, which is
+          also when grade_band is null.
+        data_tests:
+          - not_null:
+              config:
+                severity: warn
+                where: school is not null
       - name: respondent
         data_type: string
       - name: google_email
@@ -98,14 +111,6 @@ models:
           several values are retired or abbreviated aliases, and the same school
           can arrive under more than one label across waves, so never gate or
           group on this column. Use school_clean_name.
-      - name: school_clean_name
-        data_type: string
-        description: >-
-          The walked school resolved to its canonical name via
-          int_people__location_crosswalk, so every alias of one school collapses
-          to a single value. This is the column a Tableau location gate scopes
-          on. Null when the form label is absent from the crosswalk, which is
-          also when grade_band is null.
       - name: grade_band
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
@@ -16,9 +16,12 @@ models:
       - name: location_clean_name
         data_type: string
         description: >-
-          Canonical location from int_people__location_crosswalk. Drives the
-          Tableau location gate; retired name aliases collapse onto their
-          canonical clean name here.
+          The respondent's own canonical location from
+          int_people__location_crosswalk, resolved through the roster join on
+          respondent_email. This is where the walkthrough's author works, NOT
+          the school they walked — use school_clean_name to scope a row to the
+          observed school. Retired name aliases collapse onto their canonical
+          clean name here.
         data_tests:
           - not_null
       - name: home_business_unit_name
@@ -90,5 +93,21 @@ models:
         data_type: string
       - name: school
         data_type: string
+        description: >-
+          The school walked, as the form's dropdown recorded it. Raw form text —
+          several values are retired or abbreviated aliases, and the same school
+          can arrive under more than one label across waves, so never gate or
+          group on this column. Use school_clean_name.
+      - name: school_clean_name
+        data_type: string
+        description: >-
+          The walked school resolved to its canonical name via
+          int_people__location_crosswalk, so every alias of one school collapses
+          to a single value. This is the column a Tableau location gate scopes
+          on. Null when the form label is absent from the crosswalk, which is
+          also when grade_band is null.
       - name: grade_band
         data_type: string
+        description: >-
+          Grade band of the walked school, from int_people__location_crosswalk.
+          Null when the form's school label is absent from the crosswalk.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__operations_ekg.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__operations_ekg.sql
@@ -84,7 +84,14 @@ with
     ),
 
     final as (
-        select roster.*, responses_pivoted.*, sc.location_grade_band as grade_band,
+        select
+            roster.*,
+            responses_pivoted.*,
+
+            sc.location_grade_band as grade_band,
+            -- the walked school, resolved to its canonical name. distinct from
+            -- roster.location_clean_name, which is the respondent's own location
+            sc.location_clean_name as school_clean_name,
         from responses_pivoted
         left join
             roster


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

> "When merged, this pull request will..."

...add `school_clean_name` to `rpt_tableau__operations_ekg`, so a consumer can
scope a row to the school that was **walked** rather than the school the
walkthrough's author works at.

The model already joins `int_people__location_crosswalk` on the walked school to
get `grade_band`. It just never selected the clean name from that join. This is
one additive line in the `final` CTE.

### Two columns on this model describe a school, and they are not the same school

- `location_clean_name` comes from the roster join on `respondent_email`, so it
  is where the walkthrough's **author** works.
- The school **walked** is the pivoted `school` column, which is raw form-dropdown
  text.

`school` cannot be grouped or gated on. 5 of its 23 values are retired or
abbreviated aliases, and two schools arrive under two labels each:

| Raw `school` label | rows | resolves to |
| --- | --- | --- |
| `KIPP Hatch Middle` | 146 | `KIPP Hatch Middle` |
| `KIPP Hatch Academy` | 9 | `KIPP Hatch Middle` |
| `KIPP Sumner Elementary` | 51 | `KIPP Sumner Elementary` |
| `KIPP Sumner Academy` | 5 | `KIPP Sumner Elementary` |
| `KIPP Cooper Norcross High School` | 103 | `KIPP Cooper Norcross High` |

So anything grouping on `school` splits Hatch and Sumner in half.
`school_clean_name` collapses all 23 labels to 21 canonical schools.

### Why now

This unblocks scoping the Operations Systems workbook's `operations_ekg` gate to
a school leader's own school. That gate is currently a flat list of group
memberships with no location check, because the workbook's embedded extract
predates the access contract and carries none of the columns a gate would need.
An audit of all 11 gated workbooks on 2026-08-05 found it; the remediation
sequence is in
`docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md`.

### Also in here

Corrected `location_clean_name`'s description, which claimed it "Drives the
Tableau location gate." It should not, and that is the mistake this PR exists to
prevent: a gate pointed at it would show school leaders the walkthroughs they
**performed**, not the ones **of their school**.

### Not a breaking change

Additive: one new nullable column, no renames, no removals. Reverting the commit
and rematerializing restores the prior column set.

## AI Assistance

Claude Code found the problem and wrote the change. Human-directed: the decision
that the broad Operations Systems groups stay cross-regional while school leaders
and DSOs get school-scoped, and the crosswalk sheet edit described below.

Claude's own first read of this was wrong in a way worth recording: it initially
proposed gating on `location_clean_name`, which would have scoped school leaders
to walkthroughs they authored rather than walkthroughs of their school. Reading
the model's roster join is what caught it.

## Self-review

### General

- [x] No Asana due-date change needed — this is a data-layer prerequisite, not a
      dated request
- [ ] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated — `description` and `data_type` for the new column,
      plus descriptions added to `school` and `grade_band`, which had none
- [x] Exposure — `rpt_tableau__operations_ekg` already has one; an additive
      column needs no exposure edit
- [x] **Breaking change?** No. One additive nullable column
- [x] No external source added or modified

### Verification done locally

- `dbt build --select rpt_tableau__operations_ekg --target dev --defer --favor-state`
  — contract enforced, view created, all 4 data tests pass.
- Against the dev view: `school_clean_name` non-null on all 3,577 rows, 23 raw
  labels collapsing to 21 canonical schools, both Hatch labels resolving to
  `KIPP Hatch Middle` and both Sumner labels to `KIPP Sumner Elementary`.
- `trunk check --force` on both changed files — no issues.

### A pre-existing defect this surfaced

`grade_band` on this model was null for **602 rows across 25 walkthroughs**. The
form labels `KIPP Paterson Prep ES` and `KIPP Paterson Prep MS` were absent from
the location crosswalk, so the model's existing `grade_band` join missed them.
The crosswalk sheet now carries both aliases, which cleared it — independent of
this change, and verified at 0 nulls afterwards. Worth knowing because the same
gap would have made `school_clean_name` null for those rows.

Refs #4638
