### PR TITLE
fix(cube): exclude null-attendance days from ADA and tardy rates

### DIFF
--- a/src/cube/model/cubes/student_attendance/student_attendance.yml
+++ b/src/cube/model/cubes/student_attendance/student_attendance.yml
@@ -218,31 +218,52 @@ cubes:
         filters:
           - sql: "{CUBE}.membership_value > 0"
 
+      # Numerator and denominator must span the SAME set of days, or days
+      # present in one and absent from the other silently become absences.
+      # attendance_value IS NULL means attendance was never recorded, not that
+      # the student was absent — those days carry membership_value = 1, so
+      # leaving them in the denominator alone counted them as absences (#4744).
+      # membership_value = 1 matches rpt_tableau__attendance_dashboard and drops
+      # the pre-AY2021 membership_value = 0 rows that carry a real
+      # attendance_value and would otherwise inflate the numerator only.
       - name: _sum_attendance_value
         sql: attendance_value
         type: sum
         public: false
+        filters:
+          - sql: "{CUBE}.membership_value = 1"
 
       - name: _sum_membership_value
         sql: membership_value
         type: sum
         public: false
+        filters:
+          - sql: "{CUBE}.membership_value = 1"
+          - sql: "{CUBE}.attendance_value IS NOT NULL"
 
       - name: avg_daily_attendance
-        description:
-          Average Daily Attendance (ADA) — SUM(attendance_value) /
-          SUM(membership_value)
+        description: >-
+          Average Daily Attendance (ADA) — attendance value summed over full
+          membership days, divided by the count of those days. Days with no
+          recorded attendance value are excluded from both numerator and
+          denominator, matching the attendance dashboard; counting them in the
+          denominator alone would report them as absences.
         sql: "{_sum_attendance_value} / NULLIF({_sum_membership_value}, 0)"
         type: number
         format: percent
         public: true
 
+      # Same numerator/denominator symmetry as ADA: a tardy code recorded on a
+      # day with no attendance value is excluded here, because
+      # _count_present_days already excludes it (is_absent is NULL whenever
+      # attendance_value is, so `is_absent = 0` never matches).
       - name: _sum_tardy
         sql: is_tardy
         type: sum
         public: false
         filters:
           - sql: "{CUBE}.membership_value = 1"
+          - sql: "{CUBE}.attendance_value IS NOT NULL"
 
       - name: _count_present_days
         sql: "1"
@@ -255,8 +276,8 @@ cubes:
       - name: pct_tardy
         description: >-
           Percentage of present days where the student was tardy (tardy days /
-          present days). Absent days are excluded from both numerator and
-          denominator.
+          present days). Absent days and days with no recorded attendance value
+          are excluded from both numerator and denominator.
 
           Date filter behavior: filtering to a single date returns that day's
           tardy rate only. For a cumulative YTD rate as of a given date, use a
@@ -270,8 +291,9 @@ cubes:
       - name: pct_ontime
         description: >-
           Percentage of present days where the student arrived on time (on-time
-          days / present days). Complement of pct_tardy. Absent days are
-          excluded from both numerator and denominator.
+          days / present days). Complement of pct_tardy. Absent days and days
+          with no recorded attendance value are excluded from both numerator and
+          denominator.
 
           Date filter behavior: filtering to a single date returns that day's
           on-time rate only. For a cumulative YTD rate as of a given date, use a

--- a/src/cube/model/cubes/student_attendance/student_attendance.yml
+++ b/src/cube/model/cubes/student_attendance/student_attendance.yml
@@ -225,7 +225,11 @@ cubes:
       # leaving them in the denominator alone counted them as absences (#4744).
       # membership_value = 1 matches rpt_tableau__attendance_dashboard and drops
       # the pre-AY2021 membership_value = 0 rows that carry a real
-      # attendance_value and would otherwise inflate the numerator only.
+      # attendance_value and would otherwise inflate the numerator only. It
+      # would also drop fractional dual-enrollment days, which count_absent_days
+      # keeps via membership_value > 0 — no such row exists today (zero rows
+      # outside {0, 1} across all 12.8M), but if dual enrollment ever produces
+      # one, ADA and count_absent_days will span different day sets.
       - name: _sum_attendance_value
         sql: attendance_value
         type: sum

--- a/src/cube/model/views/student_attendance/student_attendance_view.yml
+++ b/src/cube/model/views/student_attendance/student_attendance_view.yml
@@ -2,17 +2,21 @@ views:
   - name: student_attendance_view
     description: >-
       Student attendance — row-level (one row per student × school day with
-      attendance recorded) and aggregate breakdowns in a single view. ADA is
-      always SUM(attendance_value) / SUM(membership_value); never average a
-      per-row ratio. attendance_value (0.0–1.0) is the fractional attendance
-      contribution; membership_value (0.0–1.0) is the school's claim on the
-      student that day (split across schools if dual-enrolled); present_weight
-      equals attendance_value but tardies count 0.67. attendance_category is the
-      coarse rollup (Present, Absent, Tardy, In-School Suspension, Out-of-School
-      Suspension); attendance_code is the raw SIS code for specific drill-down.
-      is_in_session and is_membership_day come from school_calendars and are
-      joined on (date_key, student_school_enrollments.location_key). Contains
-      direct student identifiers — see access_policy for PII gating.
+      attendance recorded) and aggregate breakdowns in a single view. For ADA,
+      use the avg_daily_attendance measure rather than rebuilding the ratio from
+      the raw dimensions — it scopes both sides to full membership days with a
+      recorded attendance value, and a hand-rolled SUM(attendance_value) /
+      SUM(membership_value) counts days that were never recorded as absences.
+      Never average a per-row ratio either way. attendance_value (0.0–1.0) is
+      the fractional attendance contribution; membership_value (0.0–1.0) is the
+      school's claim on the student that day (split across schools if
+      dual-enrolled); present_weight equals attendance_value but tardies count
+      0.67. attendance_category is the coarse rollup (Present, Absent, Tardy,
+      In-School Suspension, Out-of-School Suspension); attendance_code is the
+      raw SIS code for specific drill-down. is_in_session and is_membership_day
+      come from school_calendars and are joined on (date_key,
+      student_school_enrollments.location_key). Contains direct student
+      identifiers — see access_policy for PII gating.
 
       CA, tier, and truancy base measures default to year-end snapshots when
       queried without an anchor — no filter required for year-over-year


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Make Cube's `avg_daily_attendance` agree with the attendance dashboard, by
excluding days that have no recorded attendance value from both sides of the
ratio instead of counting them as absences.

`avg_daily_attendance` divided `SUM(attendance_value)` by
`SUM(membership_value)` with no filter on either measure. A day where attendance
was never recorded carries `attendance_value` NULL and `membership_value` 1 —
`SUM` skips it in the numerator but counts it in the denominator, so Cube
reported it as an absence. `rpt_tableau__attendance_dashboard` filters
`attendancevalue is not null` alongside `membershipvalue = 1`, so the two
surfaces reported different ADA for the same population.

Changes to `src/cube/model/cubes/student_attendance/student_attendance.yml`:

- `_sum_attendance_value` (ADA numerator) filters `membership_value = 1`
- `_sum_membership_value` (ADA denominator) filters `membership_value = 1` and
  `attendance_value IS NOT NULL`
- `_sum_tardy` gains the same null filter, for symmetry with
  `_count_present_days` — that denominator already excluded those days, since
  `is_absent` is NULL whenever `attendance_value` is, so `is_absent = 0` never
  matched them
- Descriptions on `avg_daily_attendance`, `pct_tardy`, `pct_ontime` updated

### Impact

Network ADA by academic year, before and after:

| AY   | null attendance | before | after | delta (pp) |
| ---- | --------------- | ------ | ----- | ---------- |
| 2026 | 0.76%           | 99.24  | 100.00 | +0.76     |
| 2025 | 0.03%           | 92.29  | 92.32 | +0.03      |
| 2024 | 0.22%           | 91.79  | 91.98 | +0.19      |
| 2023 | 1.36%           | 88.70  | 89.92 | +1.22      |
| 2022 | 0.72%           | 86.68  | 87.31 | +0.63      |
| 2021 | 2.24%           | 83.20  | 85.12 | +1.92      |
| 2020 | 0.79%           | 89.68  | 90.36 | +0.68      |
| 2019 | 1.28%           | 91.51  | 92.59 | +1.08      |
| 2018 | 0.86%           | 93.07  | 93.88 | +0.81      |
| 2017 | 0.34%           | 93.39  | 93.71 | +0.32      |
| 2016 | 0.72%           | 93.65  | 94.33 | +0.68      |
| 2010 | 0.00%           | 93.45  | 92.92 | -0.53      |
| 2007 | 1.30%           | 95.82  | 95.49 | -0.33      |

AY2008/2009/2011 are unchanged. School-level damage is much larger than the
network figure, because null-attendance days cluster by school — KIPP Miami,
Royalty, AY2023-24 moves 83.71 to 90.88 (+7.17pp), and the Miami region moves
86.38 to 90.91 (+4.53pp).

AY2007 and AY2010 move DOWN. Those are the only years with `membership_value = 0`
rows carrying a real `attendance_value`, which previously inflated the numerator
with nothing in the denominator; the new `membership_value = 1` filter on
`_sum_attendance_value` removes them.

The `_sum_tardy` change is not a no-op — 16,773 rows network-wide carry a tardy
code with a null `attendance_value` on a full membership day, so `pct_tardy` was
overstated (and `pct_ontime` understated) by the same amount:

| AY   | pct_tardy before | after  | delta (pp) |
| ---- | ---------------- | ------ | ---------- |
| 2025 | 16.269           | 16.266 | -0.003     |
| 2024 | 21.224           | 21.169 | -0.055     |
| 2023 | 23.537           | 23.195 | -0.342     |
| 2022 | 20.505           | 20.331 | -0.174     |
| 2021 | 15.524           | 15.181 | -0.343     |
| 2020 | 15.331           | 15.201 | -0.130     |
| 2019 | 12.841           | 12.689 | -0.152     |

Smaller than the ADA movement, but real.

### Scope checks the issue asked for

Both checked against the warehouse and found NOT exposed, so nothing changes for
them:

- `count_absent_days` — `is_absent` is `abs(attendance_value - 1)`, so it is
  NULL exactly when `attendance_value` is, and `SUM` skips it. Verified zero
  rows where one is null and the other is not, across all 12.8M rows.
- `is_chronically_absent` / `ada_tier` — `fct_student_attendance_daily` computes
  `_running_ada` as `avg(if(membership_value = 1, attendance_value, null))`, and
  `AVG` already excludes NULLs from both the sum and the count.

Also worth recording: `membership_value` is only ever 0 or 1 across all 12.8M
rows, all-time. There are no partial-membership days, so the `= 1` versus `> 0`
distinction has no effect on the numbers above.

The remaining item from the issue — why Royalty carried ~8% missing attendance
records in AY2023-24 while Courage carried near zero — is a data-capture
question, not a Cube one, and is not addressed here.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude verified the issue's claims against the warehouse, checked the three
"also worth checking" items, and wrote the change. The scope decision (full
dashboard parity rather than the narrower fix the issue proposed) was
human-directed.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

Review findings, all three addressed in `a0a0792`:

1. **Stale view description** (Important) — valid, fixed.
   `student_attendance_view`'s description told analysts ADA is always
   `SUM(attendance_value) / SUM(membership_value)`, and the view exposes both raw
   dimensions, so following it literally reproduced this exact bug. Now points at
   the `avg_daily_attendance` measure and states what it scopes.
2. **Comment undersells the `membership_value = 1` blast radius** (Minor) —
   valid as a comment gap, but its premise is wrong: there are no
   currently-occurring fractional-membership days. `membership_value` is only ever
   0 or 1 across all 12.8M rows, all-time. The dimension description says
   fractions are expected; the data has none. Added the note anyway, since
   `count_absent_days` keeps `> 0` and the two would diverge if dual enrollment
   ever produced one.
3. **Quantify whether `_sum_tardy` moves anything** (Minor, data-dependent) — ran
   the suggested query: 16,773 rows, not zero. Per-year `pct_tardy` deltas added
   to the Impact section above.

### Verification

- [x] Cube dev server compiles the model with no errors; the generated SQL for
      `avg_daily_attendance` and `pct_tardy` matches the expression reconciled
      against the dashboard in BigQuery.
- [x] `trunk check --force` on the changed YAML — no issues.
- [ ] Validate on a Cube Cloud branch staging deployment before merge (manual —
      Data Model, Dev Mode, add the branch by name).

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. No dbt models changed, so this run selects nothing.
- [ ] **Dagster Cloud** — not triggered (no Dagster paths changed).

Closes #4744
