### PR TITLE
feat(dbt): gate the ops EKG extract on the walked school entity

### DIFF
--- a/docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md
+++ b/docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md
@@ -323,6 +323,18 @@ design doc's earlier estimate.
   **performed**, not the ones **of their school**. `school_clean_name` is the
   walked school, added in PR #4746; it must be merged and materialized before
   this workbook's Tier 5 edit.
+- **Entity-gate variant on `operations_ekg`:** the Tier 5 entity gate reads
+  `[school_business_unit_name]`, not `[home_business_unit_name]`, for the same
+  reason — it is the entity of the walked school. Central-office staff walk
+  schools in every region and would otherwise only ever match the unconditional
+  KTAF branch, and no respondent on this form is based in KIPP Paterson, so the
+  Paterson branch matches zero of the 25 Paterson Prep walkthroughs. **Drop the
+  KTAF branch from this workbook's entity gate** — no school is owned by
+  `KIPP TEAM and Family Schools Inc.`, so that branch can never match; central
+  office reaches this data through Tiers 2 and 4. Column added in PR #4749.
+- **Field the workbook loses:** `[School]` is removed from `operations_ekg` in
+  PR #4749. Swap any use of it to `[school_clean_name]` in the same window, or
+  the sheets referencing it break when the view rematerializes.
 - **Role variant:** omit the AP branch entirely
 - **Note:** `operations_pm` keeps `[respondent_job_title]` and
   `[respondent_name]` — that model has two people per row and the respondent is

--- a/docs/superpowers/specs/2026-07-30-tableau-rls-entra-migration-design.md
+++ b/docs/superpowers/specs/2026-07-30-tableau-rls-entra-migration-design.md
@@ -100,6 +100,21 @@ a property of the location, not the viewer: Room 9's region is
 office. Using `location_region` for entity gating would hand central-office
 staff a region's access.
 
+This governs **person-grain** extracts, where the gated row describes a member
+of staff. On an **event-grain** extract the row describes something that
+happened at a place, and both gates come from that place, not from whoever
+recorded it. `rpt_tableau__operations_ekg` is the case: a row is a walkthrough
+of a school, so it gates on `school_clean_name` and `school_business_unit_name`,
+both resolved from the walked school through `int_people__location_crosswalk`.
+Gating it on the respondent instead shows a school leader the walkthroughs they
+performed rather than the ones of their school, and no respondent on that form
+is based in KIPP Paterson, so a Paterson leader sees nothing at all. The Room 9
+failure above cannot reach an event-grain extract whose place is always a real
+school — the walkthrough form's dropdown lists no Rooms — and the gate still
+requires group membership, so sourcing entity from the place widens nothing.
+Before applying this carve-out to another extract, confirm its place column
+cannot resolve to a Room.
+
 **Location and department stay separate columns.** This is the structural idea
 borrowed from `dim_staff_cube_access` (#4269), and it is what stops Rooms from
 granting location-wide visibility.

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
@@ -27,8 +27,11 @@ models:
       - name: home_business_unit_name
         data_type: string
         description: >-
-          Legal entity. Drives the Tableau entity gate. Never location_region,
-          which is a property of the location rather than the person.
+          The respondent's own legal entity, from the roster join. This does NOT
+          drive the Tableau entity gate on this model — use
+          school_business_unit_name, the entity of the school that was walked.
+          Central-office respondents walk schools in every region, and no
+          respondent on this form is based in KIPP Paterson.
         data_tests:
           - not_null
           - accepted_values:
@@ -46,12 +49,30 @@ models:
           int_people__location_crosswalk, so every alias of one school collapses
           to a single value. This is the column a Tableau location gate scopes
           on. Null when the form label is absent from the crosswalk, which is
-          also when grade_band is null.
+          also when school_business_unit_name and grade_band are null.
         data_tests:
           - not_null:
               config:
                 severity: warn
-                where: school is not null
+      - name: school_business_unit_name
+        data_type: string
+        description: >-
+          Legal entity that owns the walked school, from
+          int_people__location_crosswalk. This is the column a Tableau entity
+          gate scopes on, NOT home_business_unit_name — that one is the
+          respondent's own entity, and central-office staff walk schools in
+          every region. Null when the form label is absent from the crosswalk.
+        data_tests:
+          - not_null:
+              config:
+                severity: warn
+          - accepted_values:
+              arguments:
+                values:
+                  - TEAM Academy Charter School
+                  - KIPP Cooper Norcross Academy
+                  - KIPP Miami
+                  - KIPP Paterson
       - name: respondent
         data_type: string
       - name: google_email
@@ -104,13 +125,6 @@ models:
         data_type: int64
       - name: walkthrough_round
         data_type: string
-      - name: school
-        data_type: string
-        description: >-
-          The school walked, as the form's dropdown recorded it. Raw form text —
-          several values are retired or abbreviated aliases, and the same school
-          can arrive under more than one label across waves, so never gate or
-          group on this column. Use school_clean_name.
       - name: grade_band
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__operations_ekg.yml
@@ -61,7 +61,9 @@ models:
           int_people__location_crosswalk. This is the column a Tableau entity
           gate scopes on, NOT home_business_unit_name — that one is the
           respondent's own entity, and central-office staff walk schools in
-          every region. Null when the form label is absent from the crosswalk.
+          every region. Takes four values, not the five home_business_unit_name
+          takes — KIPP TEAM and Family Schools Inc. owns no school, so it never
+          appears here. Null when the form label is absent from the crosswalk.
         data_tests:
           - not_null:
               config:

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__operations_ekg.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__operations_ekg.sql
@@ -86,12 +86,18 @@ with
     final as (
         select
             roster.*,
-            responses_pivoted.*,
+            -- raw form-dropdown text is join-key-only. it carries retired and
+            -- abbreviated aliases, so consumers get school_clean_name instead
+            responses_pivoted.* except (school),
 
             sc.location_grade_band as grade_band,
             -- the walked school, resolved to its canonical name. distinct from
             -- roster.location_clean_name, which is the respondent's own location
             sc.location_clean_name as school_clean_name,
+            -- entity that owns the WALKED school. distinct from
+            -- roster.home_business_unit_name, which is the respondent's own
+            -- entity, and is never KIPP Paterson on this form
+            sc.location_region as school_business_unit_name,
         from responses_pivoted
         left join
             roster


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

> "When merged, this pull request will..."

...add `school_business_unit_name` to `rpt_tableau__operations_ekg` so a Tableau
entity gate can scope a row to the entity that owns the school that was
**walked**, and drop the raw `school` column from the projection.

### The entity gate on this model reaches the wrong rows

`home_business_unit_name` is the respondent's own entity, resolved through the
roster join. The school walked is a different school, and often a different
entity. Cross-tab from prod:

| Walked school | Respondent entity | Walkthroughs |
| --- | --- | --- |
| Paterson Prep Elementary School | KIPP Cooper Norcross Academy | 6 |
| Paterson Prep Elementary School | KIPP TEAM and Family Schools Inc. | 8 |
| Paterson Prep Middle School | KIPP Cooper Norcross Academy | 5 |
| Paterson Prep Middle School | KIPP TEAM and Family Schools Inc. | 6 |

No respondent on this form is based in KIPP Paterson, so the Tier 5 entity
branch `ISMEMBEROF('...Paterson') AND [home_business_unit_name] = 'KIPP Paterson'`
matches zero of the 25 Paterson Prep walkthroughs. A Paterson school leader sees
nothing even with the location gate pointed at `school_clean_name`.

It is not Paterson-specific. Central-office staff walk schools in every region,
so those rows only ever satisfy the unconditional KTAF branch, never the region
that owns the school. Same defect class as the location gate corrected in #4746,
one layer over.

`school_business_unit_name` comes from `sc.location_region` on the
`int_people__location_crosswalk` join the model already has. All 21 walked
schools resolve to exactly one entity each — Paterson Prep ES/MS to
`KIPP Paterson`, Courage/Royalty to `KIPP Miami`, Hatch / Lanning Square /
Sumner / Cooper Norcross High to `KIPP Cooper Norcross Academy`, the remaining
12 to `TEAM Academy Charter School`.

### Dropping the raw `school` column

`school` stays the join key to the crosswalk but is no longer projected. It is
raw form-dropdown text: 5 of its 23 values are retired or abbreviated aliases,
and two schools arrive under two labels each, so anything grouping on it splits
Hatch and Sumner in half. `school_clean_name` is the column consumers want.

### Breaking change

Yes. `school` is removed from a contract-enforced extract with a live Tableau
exposure. If the Operations Systems workbook references `[School]`, swap it to
`[school_clean_name]` in the same window as the merge. Reverting the commit and
rematerializing restores the column.

`school_business_unit_name` is additive and nullable.

### Tableau rollout — two edits, not one

Merging this changes nothing a viewer sees. The workbook edits are what fix the
bug, and both are now recorded in the Operations Systems section of
`docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md`:

1. **Repoint the Tier 5 entity gate** from `[home_business_unit_name]` to
   `[school_business_unit_name]`, and drop the KTAF branch — no school is owned
   by the parent entity, so that branch can never match on this extract.
   Without this edit the Paterson-leader symptom persists after merge.
1. **Swap `[School]` to `[school_clean_name]`** wherever the workbook uses it,
   since `school` is removed here.

The Tier 5 location gate repoint to `[school_clean_name]` shipped as part of
#4746 and is already in the runbook.

### Relation to the entity-from-the-person rule

The design doc forbids `location_region` for entity gating, and
`school_business_unit_name` is `location_region`. That rule protects
person-grain rows, where the region of the building someone sits in is not
their entity — Room 9 reads `TEAM Academy Charter School` while most of its
occupants are KTAF central office.

This extract is event-grain: the row is a walkthrough of a school, so both
gates come from that school. The Room 9 failure cannot reach it — the form
dropdown lists no Rooms, all 21 values are real schools — and the gate still
requires group membership, so nothing widens. This PR scopes the rule in the
design doc rather than leaving a silent contradiction, and records the
precondition for reusing the carve-out.

## AI Assistance

Claude Code diagnosed the entity gap and wrote the change. Human-directed: the
decision to stop exposing the raw form value, and the choice to fix the entity
gate in dbt rather than dropping the entity branch in the Tableau calculation.

## Self-review

### General

- [x] No Asana due-date change needed — data-layer prerequisite, not a dated
      request
- [ ] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file updated — new column documented and typed, `school`
      removed, `home_business_unit_name` description corrected to say it does
      NOT drive this model's entity gate
- [x] Exposure — `rpt_tableau__operations_ekg` already has one; no exposure edit
      needed
- [x] **Breaking change?** Yes, `school` removed. See above
- [x] No external source added or modified

### Verification done locally

- `dbt build --select rpt_tableau__operations_ekg --target dev --defer --favor-state`
  — PASS=8, contract enforced. The contract is what proves `school` is gone and
  `school_business_unit_name` is present.
- New tests: warn-severity `not_null` on `school_business_unit_name`, plus
  `accepted_values` over the four school-owning entities. Both pass.
- The `not_null` on `school_clean_name` lost its `where: school is not null`
  guard, since `school` is no longer projected. Prod has zero rows with a null
  school, so the plain warn is equivalent today and fires if a row ever arrives
  without one.
- Against the dev view: 21 walked schools, each mapping to exactly one entity,
  0 nulls.
- `trunk check --force` on all changed files — no issues.

### Docs changed alongside

- `docs/superpowers/specs/2026-07-30-tableau-rls-entra-migration-design.md` —
  entity-from-the-person rule scoped to person-grain extracts, with the
  event-grain carve-out and its Rooms precondition.
- `docs/superpowers/plans/2026-07-31-tableau-workbook-remediation.md` —
  entity-gate variant and the dropped `[School]` field added to the Operations
  Systems section.

Refs #4638
