### PR TITLE
fix(extracts): send real relationship labels and emergency contacts to the NJ contact feeds

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -7,20 +7,26 @@ models:
       primary, falling back to financial; `contact_2`, the second parent from
       the student's household 1) plus emergency contacts (`emergency_1` through
       `emergency_4`). `ContactType` distinguishes `Parent1` / `Parent2` /
-      `Emergency` so DeansList can scope automated guardian messaging; emergency
-      contacts additionally carry a numbered `Emergency N` relationship, while
-      parents keep their real Finalsite relationship. Column names match the
-      DeansList import template headers exactly. Delivered by the Dagster asset
-      `kipptaf/extracts/deanslist/contacts_txt`.
+      `Emergency` so DeansList can scope automated guardian messaging, and every
+      contact carries its real Finalsite relationship to the student. Column
+      names match the DeansList import template headers exactly. Delivered by
+      the Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
     data_tests:
+      # The source grain is (student, contact_slot), but the DeansList template
+      # fixes the header set so the slot cannot be projected — name plus
+      # relationship is the closest key the output can carry. warn, not error:
+      # two emergency slots can legitimately hold the same person for one
+      # student, a Finalsite data-entry gap rather than an extract defect.
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - StudentID
               - ContactType
+              - ParentFirstName
+              - ParentLastName
               - Relationship
           config:
-            severity: error
+            severity: warn
     columns:
       - name: StudentID
         data_type: int64
@@ -50,11 +56,13 @@ models:
       - name: Relationship
         data_type: string
         description:
-          Relationship of the contact to the student. For parents (`contact_1`
-          and `contact_2`) this is the Finalsite `rel_type` (`parent`,
-          `stepparent`, `guardian`, `grandparent`, etc.). For emergency contacts
-          this is `Emergency N`, numbered by the Finalsite emergency slot
-          (`emergency_1` through `emergency_4`).
+          Relationship of the contact to the student, for every slot. Parents
+          (`contact_1` and `contact_2`) carry the Finalsite `rel_type`
+          (`parent`, `stepparent`, `guardian`, `grandparent`, etc.); emergency
+          contacts carry the relationship recorded on their emergency
+          custom-field set (`Mother`, `Grandmother`, `Aunt`, `Neighbor`, etc.),
+          which is populated on nearly every emergency row. Null where Finalsite
+          holds an emergency contact with no relationship recorded.
         data_tests:
           - not_null
       - name: ContactType
@@ -104,13 +112,13 @@ models:
           send.
 
 unit_tests:
-  - name: test_family_contacts_emergency_numbering
+  - name: test_family_contacts_slot_contact_types
     description:
       One enrolled student with two parents plus all four emergency slots.
-      Asserts the parents keep their Finalsite relationship and get
-      Parent1/Parent2 contact types, and each emergency slot is relabeled
-      Emergency N by slot number with an Emergency contact type (exercising
-      every case branch).
+      Asserts contact_1 and contact_2 map to Parent1/Parent2 and every emergency
+      slot maps to Emergency (exercising each case branch), and that all six
+      rows pass their Finalsite relationship through unchanged rather than
+      having the emergency ones overwritten with a slot ordinal.
     model: rpt_deanslist__family_contacts
     given:
       - input: ref('int_finalsite__student_contacts')
@@ -200,7 +208,7 @@ unit_tests:
             WorkPhone: null,
             CellPhone: "13055550200",
             Email: null,
-            Relationship: Emergency 1,
+            Relationship: grandparent,
             ContactType: Emergency,
             Language: null,
           }
@@ -212,7 +220,7 @@ unit_tests:
             WorkPhone: null,
             CellPhone: null,
             Email: null,
-            Relationship: Emergency 2,
+            Relationship: aunt,
             ContactType: Emergency,
             Language: null,
           }
@@ -224,7 +232,7 @@ unit_tests:
             WorkPhone: null,
             CellPhone: null,
             Email: null,
-            Relationship: Emergency 3,
+            Relationship: uncle,
             ContactType: Emergency,
             Language: null,
           }
@@ -236,7 +244,7 @@ unit_tests:
             WorkPhone: null,
             CellPhone: null,
             Email: null,
-            Relationship: Emergency 4,
+            Relationship: neighbor,
             ContactType: Emergency,
             Language: null,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -4,6 +4,7 @@ with
             sc.contact_first_name,
             sc.contact_last_name,
             sc.email,
+            sc.relationship,
             sc._dbt_source_project,
 
             safe_cast(xw.powerschool_student_number as int64) as student_number,
@@ -14,21 +15,14 @@ with
             regexp_replace(lower(sc.phone_work), r'[^0-9x]', '') as phone_work,
             regexp_replace(lower(sc.phone_mobile), r'[^0-9x]', '') as phone_mobile,
 
-            case
-                sc.contact_slot
-                when 'emergency_1'
-                then 'Emergency 1'
-                when 'emergency_2'
-                then 'Emergency 2'
-                when 'emergency_3'
-                then 'Emergency 3'
-                when 'emergency_4'
-                then 'Emergency 4'
-                else sc.relationship
-            end as relationship,
-
             -- DeansList routes guardian-only automated messaging (reports,
-            -- texts, emails) by ContactType; Relationship stays informational.
+            -- texts, emails) by ContactType, so the slot ordinal need not be
+            -- encoded anywhere else; Relationship carries the contact's actual
+            -- relationship to the student for every slot, emergency contacts
+            -- included. Overwriting it with a literal `Emergency N` (the prior
+            -- behavior) discarded a label Finalsite populates on essentially
+            -- every emergency row and left school staff unable to tell a parent
+            -- from a neighbor.
             case
                 sc.contact_slot
                 when 'contact_1'

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__student_contact_info.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__student_contact_info.yml
@@ -50,7 +50,7 @@ models:
       - name: release_3
         data_type: string
       - name: release_4
-        data_type: int64
+        data_type: string
       - name: release_5
         data_type: int64
       - name: guardianemail

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__student_contact_info.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__student_contact_info.sql
@@ -39,11 +39,41 @@ select
     contact_1_name as mother,
     contact_2_name as father,
 
-    concat(pickup_1_name, ' | ', pickup_1_phone_mobile) as release_1,
-    concat(pickup_2_name, ' | ', pickup_2_phone_mobile) as release_2,
-    concat(pickup_3_name, ' | ', pickup_3_phone_mobile) as release_3,
+    -- The release columns hold the student's emergency contacts. They read the
+    -- pickup_* slots until #4751; no model has emitted a pickup_* contact slot
+    -- since the Finalsite cutover, so every release column was empty for every
+    -- NJ student. array_to_string rather than concat: concat returns NULL if
+    -- either argument is NULL, which would drop the contact's name entirely for
+    -- the minority with no phone on file.
+    array_to_string(
+        [
+            emergency_1_name,
+            coalesce(emergency_1_phone_mobile, emergency_1_phone_primary)
+        ],
+        ' | '
+    ) as release_1,
+    array_to_string(
+        [
+            emergency_2_name,
+            coalesce(emergency_2_phone_mobile, emergency_2_phone_primary)
+        ],
+        ' | '
+    ) as release_2,
+    array_to_string(
+        [
+            emergency_3_name,
+            coalesce(emergency_3_phone_mobile, emergency_3_phone_primary)
+        ],
+        ' | '
+    ) as release_3,
+    array_to_string(
+        [
+            emergency_4_name,
+            coalesce(emergency_4_phone_mobile, emergency_4_phone_primary)
+        ],
+        ' | '
+    ) as release_4,
 
-    null as release_4,
     null as release_5,
 
     coalesce(contact_1_email_current, contact_2_email_current) as guardianemail,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make the NJ DeansList and Google Sheets
contact feeds carry the contact information they were already receiving from
Finalsite but discarding. Two defects, both in the extract layer, surfaced by
Zendesk 474545 (Newark DSOs, during Welcome Calls and BTSN RSVPs).

**1. `rpt_deanslist__family_contacts` discarded the real relationship label.**
The `case` on `contact_slot` replaced `Relationship` with the literal strings
`Emergency 1`..`Emergency 4` for every emergency-slot row. Finalsite populates a
real label on essentially all of them, so a student's mother sitting in an
emergency slot reached DeansList as `Emergency 1` and staff calling families
could not tell a parent from a neighbor. The fix passes `relationship` through
unchanged; `ContactType` already carries `Emergency` for DeansList message
routing, so the slot ordinal was redundant as well as harmful.

Newark rows in `int_finalsite__student_contacts`, showing the labels that were
being thrown away:

| Slot        | Rows   | Carry a relationship label | Distinct labels |
| ----------- | ------ | -------------------------- | --------------- |
| contact_1   | 10,747 | 10,747                     | 7               |
| contact_2   | 3,485  | 3,485                      | 4               |
| emergency_1 | 6,970  | 6,969                      | 13              |
| emergency_2 | 6,798  | 6,796                      | 13              |
| emergency_3 | 1,790  | 1,790                      | 13              |
| emergency_4 | 671    | 671                        | 13              |

Across NJ that recovers real labels on ~21,500 emergency rows, including 1,129
`Mother` and 3,369 `Father` — exactly the complaint in the ticket.

**2. `rpt_gsheets__student_contact_info` release columns were empty by
construction.** `release_1`..`release_3` were built from the `pickup_1`..
`pickup_3` slots and `release_4` was hardcoded null. No model has emitted a
`pickup_*` contact slot since the Finalsite cutover — `int_finalsite__student_contacts`
produces only `contact_1`, `contact_2`, and `emergency_1`..`emergency_4`, and the
Focus branch produces the same set — so every release column was empty for every
student in all four regions. Now built from `emergency_1`..`emergency_4`.

Verified against prod `int_extracts__student_enrollments`, current-vs-new:

| Region   | Students | release_1 before | release_1 after | release_2 | release_3 | release_4 |
| -------- | -------- | ---------------- | --------------- | --------- | --------- | --------- |
| Camden   | 2,148    | 0                | 1,585           | 1,441     | 164       | 53        |
| Miami    | 1,114    | 0                | 1,012           | 802       | 52        | 8         |
| Newark   | 6,795    | 0                | 6,641           | 6,489     | 1,731     | 647       |
| Paterson | 881      | 0                | 866             | 852       | 201       | 73        |

`array_to_string` rather than `concat`, because `concat` returns NULL if either
argument is NULL — that would drop the contact's name entirely for the ~6% of
emergency contacts with no mobile number on file. The phone falls back to
`phone_primary` for the same reason. `release_5` stays null; there is no fifth
emergency slot to source it from.

### Test change that needs a look

The DeansList model's uniqueness key was
`(StudentID, ContactType, Relationship)` at `severity: error`. That only held
because `Emergency N` doubled as a slot discriminator; with honest labels it
fails on 1,922 key groups. The source grain is `(student, contact_slot)`, but
the DeansList import template fixes the header set so the slot cannot be
projected. The key is now name plus relationship at `severity: warn` — two
emergency slots can legitimately hold the same person for one student (174 rows
NJ-wide), which is a Finalsite data-entry gap rather than an extract defect, and
papering over it with a dedupe would hide it from Ops.

Two other warns, for the record:

- `not_null` on `Relationship` now returns 6 rows. New, and intended: these are
  Finalsite emergency contacts with a name but no relationship recorded. Prod
  returns 0 today only because the literal `Emergency N` masked them.
- `not_null` on `ParentLastName` returns 9 rows. Pre-existing and unchanged —
  prod returns the same 9.

### Out of scope

512 active NJ students (Newark 292, Camden 154, Paterson 66) have no Parent 1
row because Finalsite carries no `primary` relationship flag for them. Of
Newark's 298, 265 have a `financial` relationship with no `primary`, 30 have
relationships that are neither, and 3 have no relationship rows at all. That is
a source data-entry gap plus a possible rule change (relaxing the Parent 1 pick
to `primary or financial` would fill 265 of the 298 today), being worked with
SRE and the Finalsite rep. Not touched here.

The header comment on `int_students__contacts_pivot` still claims `contact_2`
has no source rows, which is stale — Newark has 3,485. Left alone deliberately:
an inline SQL comment on that hub model marks it `state:modified` and fans a CI
rebuild across its whole descendant graph, for a comment fix.

`rpt_gsheets__student_contact_info.yml` carries no column descriptions. That is
pre-existing across all ~40 columns and backfilling them is a separate change.

## AI Assistance

Claude Code investigated the ticket, diagnosed both defects, quantified them
against prod, and wrote the changes and the test adjustment. Human-directed:
the decision to open this as a fix PR and the scoping of the Parent 1 population
problem out of it.

## Self-review

### General

- [x] Reviewed the diff
- [ ] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties files updated for both changed models
- [x] No new or changed exposures — both models already have them
- [x] **Not a breaking change** — no columns renamed or removed. `release_4`
      changes type from `int64` (it was hardcoded null) to `string`, matching
      its sibling release columns; the Google Sheet consumer reads text.
- [x] No external source changes, so no `stage_external_sources` run needed

## Validation

Run from the worktree against the `kipptaf` project:

- `dbt build --select rpt_deanslist__family_contacts rpt_gsheets__student_contact_info --target dev --favor-state --defer` — PASS=8 WARN=3 ERROR=0. Contracts enforced on both models, including the `release_4` type change.
- `dbt test --select "test_type:unit,extracts.deanslist"` — 2 unit tests pass. `test_family_contacts_emergency_numbering` is renamed to `test_family_contacts_slot_contact_types` and now asserts relationships pass through instead of being renumbered.
- `trunk check --force` on all 4 changed files — no issues.

Refs #4751
