### PR TITLE
fix(google): declare archivalTime on the directory User model

### DIFF
--- a/src/teamster/libraries/google/directory/schema.py
+++ b/src/teamster/libraries/google/directory/schema.py
@@ -147,6 +147,7 @@ class User(DirectoryBaseModel):
     suspensionReason: str | None = None
     suspensionTime: str | None = None
     archived: bool | None = None
+    archivalTime: str | None = None
     changePasswordAtNextLogin: bool | None = None
     ipWhitelisted: bool | None = None
     customerId: str | None = None


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the `avro_schema_valid` asset-check
alert on `kipptaf/google/directory/users` and start capturing the new
`archivalTime` field.

Google added a read-only `archivalTime` string field to the Admin SDK Directory
`User` resource on 2026-08-05. Every scheduled run since has tripped the
`avro_schema_valid` check with `extras: archivalTime`, firing an alert on an
otherwise-successful run and silently dropping the field from the Avro output.

- Last passing check: 2026-08-05 12:00 UTC
- First failing check: 2026-08-05 16:00 UTC, then 5 consecutive runs
- Confirmed against the `admin.googleapis.com` `directory_v1` discovery
  document: `archivalTime`, `type: string`, `readOnly: true`, described as
  "User's account archival time"

The fix declares the field on the shared Pydantic model in
`libraries/google/directory/schema.py`, which is what every code location
generates its Avro schema from.

Not in scope: `stg_google_directory__users` selects explicit columns, so nothing
downstream breaks and no dbt change is required. Surfacing `archival_time` in
staging is a separate decision.

## AI Assistance

Claude Code diagnosed the run and authored the one-line change; the branch
strategy and the decision to skip a regression test were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

Verified locally in the worktree:

- The generated Avro schema for `User` now contains `archivalTime` as
  `["null", "string"]`
- `check_avro_schema_valid` passes on a record carrying `archivalTime`
  (`extras` is empty)

`uv run dagster definitions validate -m teamster.code_locations.kipptaf.definitions`
was not run: it requires `src/dbt/kipptaf/target/manifest.json`, which a fresh
worktree does not have. Adding a nullable field to a Pydantic model cannot
change whether the module imports, and the Dagster Cloud branch-deploy check
validates the definitions in CI.

## CI checks

- [ ] **Trunk** — `trunk check` reported no issues on the modified file
- [ ] **dbt Cloud** — no dbt changes
- [ ] **Dagster Cloud** — pending
