### PR TITLE
fix(dagster): cursor powerschool users, schoolstaff, sectionteacher on transaction_date

### DIFF
--- a/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
+++ b/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
@@ -1,0 +1,585 @@
+# PowerSchool dlt Intraday Cursor Switch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change the intraday change-detection cursor from `whenmodified` to
+`transaction_date` for the three PowerSchool tables that carry both columns, so
+in-place updates that do not bump `whenmodified` stop being invisible to the
+sensor.
+
+**Architecture:** Pure configuration change. The sensor already reads
+`cursor_column` per table from each district's `assets.yaml` and interpolates it
+into `SELECT COUNT(*), MAX({cursor_column}) FROM {table_name}`. Changing the
+configured value changes the probe with no code change. Ten sibling tables in
+the same files already use `transaction_date`.
+
+**Tech Stack:** YAML config consumed by `yaml.safe_load`, Dagster sensors, dlt,
+BigQuery, `uv` for Python execution.
+
+## Global Constraints
+
+- Spec:
+  `docs/superpowers/specs/2026-08-06-powerschool-dlt-cursor-transaction-date-design.md`
+- Issue: [#4754](https://github.com/TEAMSchools/teamster/issues/4754)
+- Worktree:
+  `/workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date`
+- Branch: `cbini/fix/claude-powerschool-cursor-transaction-date`
+- Every git command uses
+  `git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date`.
+  A bare `git` from the main repo commits to `main`.
+- Every Read, Edit, and Write targets the worktree path, not
+  `/workspaces/teamster/<path>`. Editing the main checkout silently leaves the
+  worktree unchanged.
+- Exactly three tables change: `users`, `schoolstaff`, `sectionteacher`. Do not
+  touch any other table entry.
+- Only `cursor_column` changes. Do not touch `intraday` or `nightly` on any
+  entry.
+- No Python changes. No new test files.
+- The `trunk` binary lives only in the main repo. Invoke it by absolute path
+  `/workspaces/teamster/.trunk/tools/trunk` with cwd set to the worktree. If
+  that path does not exist, use `~/.cache/trunk/launcher/trunk`.
+- `cursor_column: whenmodified` appears 13 times in the Paterson file and 17
+  times in each of the Newark and Camden files. Every edit must anchor on the
+  preceding `- table_name: <name>` line so it cannot match the wrong table.
+
+---
+
+## File Structure
+
+Three files are modified. No files are created.
+
+| File                                                                              | Change                                                         |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml` | 3 lines: `schoolstaff` L48, `sectionteacher` L56, `users` L88  |
+| `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml`   | 3 lines: `schoolstaff` L48, `sectionteacher` L56, `users` L104 |
+| `src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml`   | 3 lines: `schoolstaff` L48, `sectionteacher` L56, `users` L104 |
+
+Line numbers are as of branch point `6d58d4607`. Anchor edits on the
+`table_name` line rather than trusting the number.
+
+---
+
+### Task 1: Switch the cursor for the three tables across all three districts
+
+**Files:**
+
+- Modify:
+  `src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml:48,56,88`
+- Modify:
+  `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml:48,56,104`
+- Modify:
+  `src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml:48,56,104`
+- Test: none. Verified by the inline assertion script in Step 1, which is run
+  from the shell and never committed.
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks. This is the first task.
+- Produces: the three config files in their final state. Task 2 pushes them;
+  Task 3 verifies their runtime effect. No Python symbols are added or changed.
+
+- [ ] **Step 1: Write the verification script and watch it fail**
+
+This replaces a unit test. It parses each config exactly as `sensors.py` does
+and asserts the three tables cursor on `transaction_date`. Write it to the
+scratch directory so it is never committed.
+
+Write `/workspaces/teamster/.claude/scratch/verify_cursors.py`:
+
+```python
+import pathlib
+import sys
+
+import yaml
+
+TARGET = {"users", "schoolstaff", "sectionteacher"}
+WORKTREE = pathlib.Path(
+    "/workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date"
+)
+
+failures = []
+
+for loc in ["kipppaterson", "kippnewark", "kippcamden"]:
+    path = (
+        WORKTREE
+        / "src/teamster/code_locations"
+        / loc
+        / "powerschool/sis/dlt/config/assets.yaml"
+    )
+    assets = yaml.safe_load(path.read_text())["assets"]
+
+    seen = set()
+    for entry in assets:
+        name = entry["table_name"]
+        if name not in TARGET:
+            continue
+        seen.add(name)
+
+        if entry["cursor_column"] != "transaction_date":
+            failures.append(f"{loc}.{name}: cursor is {entry['cursor_column']!r}")
+        if entry["intraday"] is not True:
+            failures.append(f"{loc}.{name}: intraday changed to {entry['intraday']!r}")
+        if entry["nightly"] is not False:
+            failures.append(f"{loc}.{name}: nightly changed to {entry['nightly']!r}")
+
+    missing = TARGET - seen
+    if missing:
+        failures.append(f"{loc}: missing table entries {sorted(missing)}")
+
+    # Guard against a stray edit: count how many entries still cursor on
+    # whenmodified across the whole file. Paterson has 24 before the change and
+    # 21 after; Newark and Camden have 29 before and 26 after.
+    remaining = sum(1 for e in assets if e["cursor_column"] == "whenmodified")
+    expected = 21 if loc == "kipppaterson" else 26
+    if remaining != expected:
+        failures.append(
+            f"{loc}: {remaining} tables still cursor on whenmodified, expected {expected}"
+        )
+
+if failures:
+    print("FAIL")
+    for f in failures:
+        print(f"  {f}")
+    sys.exit(1)
+
+print("PASS: all three tables cursor on transaction_date in all three districts")
+```
+
+- [ ] **Step 2: Run it to confirm it fails before any edit**
+
+```bash
+uv run --active python /workspaces/teamster/.claude/scratch/verify_cursors.py
+```
+
+Expected: exit 1, and nine `cursor is 'whenmodified'` lines — three per
+district. If you see fewer than nine, stop: the branch is not at the expected
+baseline.
+
+- [ ] **Step 3: Edit the three Paterson entries**
+
+In
+`/workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml`,
+make three separate edits. Each `old_string` includes the `table_name` line so
+the match is unique.
+
+Edit 1:
+
+```yaml
+- table_name: schoolstaff
+  cursor_column: whenmodified
+```
+
+becomes:
+
+```yaml
+- table_name: schoolstaff
+  cursor_column: transaction_date
+```
+
+Edit 2:
+
+```yaml
+- table_name: sectionteacher
+  cursor_column: whenmodified
+```
+
+becomes:
+
+```yaml
+- table_name: sectionteacher
+  cursor_column: transaction_date
+```
+
+Edit 3:
+
+```yaml
+- table_name: users
+  cursor_column: whenmodified
+```
+
+becomes:
+
+```yaml
+- table_name: users
+  cursor_column: transaction_date
+```
+
+- [ ] **Step 4: Repeat the same three edits in the Newark config**
+
+Same three edits, in
+`/workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml`.
+The `table_name` anchors are identical; only the file path differs.
+
+- [ ] **Step 5: Repeat the same three edits in the Camden config**
+
+Same three edits, in
+`/workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml`.
+
+- [ ] **Step 6: Run the verification script to confirm it passes**
+
+```bash
+uv run --active python /workspaces/teamster/.claude/scratch/verify_cursors.py
+```
+
+Expected:
+`PASS: all three tables cursor on transaction_date in all three districts`
+
+If the `still cursor on whenmodified` guard fires, an edit hit the wrong table.
+Inspect the diff before continuing.
+
+- [ ] **Step 7: Confirm the diff is exactly nine lines**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date diff --stat
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date diff
+```
+
+Expected: `3 files changed, 9 insertions(+), 9 deletions(-)`. Every changed line
+is a `cursor_column:` line. If any other line appears in the diff, revert it.
+
+- [ ] **Step 8: Confirm the sensor builds its table list from the new config**
+
+This exercises the real code path in `sensors.py` without needing a dbt
+manifest.
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date && \
+uv run --active python -c "
+import pathlib, yaml
+from teamster.libraries.dlt.powerschool.assets import PowerSchoolTable
+p = pathlib.Path('src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml')
+tables = [PowerSchoolTable(name=a['table_name'], cursor_column=a['cursor_column'])
+          for a in yaml.safe_load(p.read_text())['assets'] if a['intraday']]
+print(f'{len(tables)} intraday tables')
+print([t for t in tables if t.name in ('users','schoolstaff','sectionteacher')])
+"
+```
+
+Expected: `37 intraday tables`, and all three printed tables show
+`cursor_column='transaction_date'`.
+
+- [ ] **Step 9: Optionally run the PR template's Dagster checks**
+
+The PR template asks for `dagster definitions validate` and
+`pytest tests/test_dagster_definitions.py` on modified code locations. Both need
+a dbt manifest per location, which a fresh worktree does not have. If you want
+them, generate the manifests first:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date && \
+uv run dagster-dbt project prepare-and-package \
+  --file src/teamster/code_locations/kipppaterson/__init__.py
+```
+
+Then:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date && \
+uv run dagster definitions validate \
+  -m teamster.code_locations.kipppaterson.definitions
+```
+
+This is optional. Step 8 already exercises the exact code path this change
+affects, and `definitions validate` is prone to environment-related false
+failures in the codespace. If you skip it, say so in the PR rather than ticking
+the box.
+
+- [ ] **Step 10: Lint the three changed files**
+
+yamllint runs at pre-push and in CI, not in the pre-commit format hook, so check
+it explicitly.
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml \
+  src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml \
+  src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml </dev/null
+```
+
+Expected: `No issues`. A `✖ N unformatted files` result is fine — the pre-commit
+format hook fixes it at commit time.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date \
+  add src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml \
+      src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml \
+      src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml
+
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date \
+  commit -m "fix(dagster): cursor powerschool users, schoolstaff, sectionteacher on transaction_date
+
+The intraday sensor signature is COUNT(*) plus MAX(cursor_column), so an
+in-place UPDATE that does not advance the cursor is invisible. Confirmed live
+on Paterson users: 10 rows changed homeschoolid, 0 changed whenmodified, and
+the probe signature matched the stored baseline exactly.
+
+These three tables carry both whenmodified and transaction_date. The ten other
+intraday tables in the same configs already cursor on transaction_date.
+
+Closes #4754
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+If the commit hook rejects the message, write it to
+`.claude/scratch/commit-msg.txt` with the Write tool and use
+`git -C <worktree> commit -F .claude/scratch/commit-msg.txt`.
+
+---
+
+### Task 2: Open the pull request
+
+**Files:**
+
+- Modify: none. This task only pushes and opens the PR.
+
+**Interfaces:**
+
+- Consumes: the commit produced by Task 1.
+- Produces: a PR number, used by Task 3 to confirm the merge landed.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date push
+```
+
+The branch already tracks its remote, so a bare `push` is correct here. The
+pre-push hook runs `trunk check`; if it fails, fix and re-push before opening
+the PR.
+
+- [ ] **Step 2: Confirm the pushed diff against main is only the config and the
+      spec**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date \
+  diff --stat origin/main...HEAD
+```
+
+Expected: four files — the three `assets.yaml` plus the spec markdown from the
+brainstorming commit. Nothing else.
+
+- [ ] **Step 3: Open the PR**
+
+Use `mcp__github__create_pull_request` with base `main`, head
+`cbini/fix/claude-powerschool-cursor-transaction-date`, and title:
+
+```text
+fix(dagster): cursor powerschool users, schoolstaff, sectionteacher on transaction_date
+```
+
+Open it ready-for-review, not draft — `deploy-prod-<location>.yaml` gates the
+branch deploy on a non-draft PR.
+
+Body:
+
+```markdown
+# Pull Request
+
+## Summary & Motivation
+
+> "When merged, this pull request will..."
+
+Change the intraday change-detection cursor from `whenmodified` to
+`transaction_date` for `users`, `schoolstaff`, and `sectionteacher` in all three
+PowerSchool districts.
+
+The intraday sensor detects change with `COUNT(*)` plus `MAX(cursor_column)`, so
+an in-place UPDATE that does not advance the cursor is invisible. These three
+tables are `intraday: true` with `nightly: false`, so there is no full-refresh
+backstop and the staleness persists indefinitely.
+
+Confirmed live against PowerSchool Paterson: 10 staff rows had `homeschoolid`
+corrected in PowerSchool, 0 of them advanced `whenmodified`, and the probe
+signature was byte-identical to the stored baseline. `transaction_date` moved on
+all 10. Across all three districts, every `users` row modified in 2026 carries a
+`transaction_date` at or after its `whenmodified` — 284 of 284.
+
+These three tables are the only exposed tables carrying both columns. The other
+ten intraday tables in the same configs, including the four largest, already
+cursor on `transaction_date`. Tables with only `whenmodified` are deliberately
+untouched: no defect has been demonstrated for them.
+
+This self-remediates. The stored baseline holds a `whenmodified` value, so the
+first probe after deploy returns a differing signature and each table reloads
+once, clearing the accumulated drift with no manual run.
+
+Design:
+`docs/superpowers/specs/2026-08-06-powerschool-dlt-cursor-transaction-date-design.md`
+
+Closes #4754
+
+## AI Assistance
+
+Claude investigated the root cause, ran the live read-only comparison against
+PowerSchool, and authored the spec, plan, and config change. Scope was
+human-directed: limiting the fix to tables with a demonstrated defect and a
+better cursor already available, and dropping a config parity test from scope.
+
+## Self-review
+
+### General
+
+- [x] Review the **Claude Code Review** comment posted on this PR
+
+### Dagster
+
+- [x] Config-only change consumed by `yaml.safe_load`; no Python modified
+- [x] Verified the sensor builds `PowerSchoolTable` with the new cursor for all
+      three tables
+
+## CI checks
+
+- [ ] **Trunk** — passes
+- [ ] **dbt Cloud** — passes. Note this passes trivially: no dbt models are
+      touched, so `state:modified+` selects nothing. Not validation.
+- [ ] **Dagster Cloud** — passes for all three affected locations
+```
+
+Avoid `&`, `"`, and angle-bracket tokens in the title and in code spans — the
+GitHub MCP write tools sanitize them even inside backticks.
+
+- [ ] **Step 4: Read the stored PR body back and confirm it is intact**
+
+```bash
+gh api repos/TEAMSchools/teamster/pulls/<PR_NUMBER> --jq .body
+```
+
+The MCP read tools also sanitize on output, so verify with raw `gh api`, not
+`pull_request_read`.
+
+- [ ] **Step 5: Wait for CI and confirm both surfaces are green**
+
+```bash
+gh pr checks <PR_NUMBER> --json name,bucket,state
+```
+
+CI lives on two disjoint surfaces: dbt Cloud is a commit status, while Trunk,
+CodeQL, and `claude` are check runs. `gh pr checks` covers both. The
+`dagster-cloud-deploy / deploy` check emits one same-named run per code location
+— wait for all of them to reach a terminal conclusion.
+
+Note that dbt Cloud CI will pass trivially: this PR touches no dbt models, so
+`state:modified+` selects nothing. That is not validation.
+
+---
+
+### Task 3: Verify the fix in production after merge
+
+Do not start this task until the PR is merged and the Dagster code locations
+have redeployed. The three tables reload on the first sensor tick after deploy;
+ticks run every 15 minutes.
+
+**Files:**
+
+- Modify: none. This task is verification only.
+
+**Interfaces:**
+
+- Consumes: the merged change from Task 2.
+- Produces: confirmation for the issue thread. No code artifacts.
+
+- [ ] **Step 1: Confirm the code locations reloaded with the merge commit**
+
+Use `mcp__dagster__get_location_load_history` for `kipppaterson`, and confirm
+the new commit shows `LOADED`.
+
+- [ ] **Step 2: Confirm the sensor selected the three tables instead of
+      skipping**
+
+```text
+mcp__dagster__get_tick_history(
+  name="kipppaterson__powerschool__dlt__intraday_sensor",
+  repository_location_name="kipppaterson",
+  limit=5,
+)
+```
+
+Expected: a `SUCCESS` tick whose `requestedAssetKeys` include
+`kipppaterson/powerschool/sis/users`,
+`kipppaterson/powerschool/sis/schoolstaff`, and
+`kipppaterson/powerschool/sis/sectionteacher`. This is the self-remediation
+described in the spec: the stored baseline holds a `whenmodified` value, the new
+probe returns a `transaction_date` value, so the signatures differ and all three
+tables are selected once.
+
+If ticks still report `no change across 37 probed tables`, the deploy has not
+landed yet. Wait for the next tick rather than launching a run.
+
+- [ ] **Step 3: Confirm the drift cleared in BigQuery**
+
+```sql
+select count(*) as still_drifted
+from `teamster-332318.dagster_kipppaterson_dlt_powerschool.users`
+where dcid in (205, 555, 652, 901, 905, 1751, 1764, 1951, 2051, 2257)
+  and homeschoolid = 0
+```
+
+Expected: a low count. Eight of the ten rows read `homeschoolid = 0` before the
+fix and should now carry a real school id. Two rows (dcid 555 and 2257) were
+already non-zero but wrong, so confirm those individually against the live
+values recorded in the spec's evidence section.
+
+- [ ] **Step 4: Confirm the affected staff returned to the extract**
+
+Wait for the dbt automation to rebuild `stg_powerschool__users`, then:
+
+```sql
+select count(*) as paterson_teachers
+from `teamster-332318.kipppaterson_extracts.rpt_powerschool__autocomm_teachers`
+```
+
+Compare against the pre-fix count. Expected: up to 10 more rows for Paterson.
+
+- [ ] **Step 5: Re-measure the network-wide mismatch and update the issue**
+
+The 122 figure in #4754 was measured against the stale warehouse copy and is an
+upper bound. Re-run it now that all three districts have reloaded:
+
+```sql
+with sr as (
+  select
+    powerschool_teacher_number,
+    home_work_location_powerschool_school_id as adp_school,
+    home_work_location_dagster_code_location as loc
+  from `teamster-332318.kipptaf_people.int_people__staff_roster`
+  where assignment_status = 'Active'
+    and (home_department_name != 'Data' or home_department_name is null)
+)
+select
+  sr.loc,
+  countif(u.teachernumber is not null and u.homeschoolid != sr.adp_school) as mismatched
+from sr
+left join `teamster-332318.kipptaf_powerschool.stg_powerschool__users` as u
+  on sr.powerschool_teacher_number = u.teachernumber
+  and sr.loc = u._dbt_source_project
+group by sr.loc
+order by sr.loc
+```
+
+Post the before and after counts as a comment on #4754. Report counts only —
+never `teachernumber` or `dcid` values, which are employee identifiers.
+
+- [ ] **Step 6: Clean up the throwaway artifacts**
+
+```bash
+rm -f /workspaces/teamster/tests/assets/test_zz_ps_users_probe.py \
+      /workspaces/teamster/tests/assets/test_zz_ps_users_drift.py \
+      /workspaces/teamster/.claude/scratch/verify_cursors.py
+```
+
+These are untracked in the main checkout and were only diagnostic. Confirm with
+`git -C /workspaces/teamster status --short` that nothing remains.
+
+- [ ] **Step 7: Remove the worktree**
+
+```bash
+git -C /workspaces/teamster worktree remove \
+  /workspaces/teamster/.worktrees/cbini/fix/claude-powerschool-cursor-transaction-date
+```

--- a/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
+++ b/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
@@ -167,44 +167,44 @@ the match is unique.
 
 Edit 1:
 
-```yaml
-- table_name: schoolstaff
-  cursor_column: whenmodified
+```text
+  - table_name: schoolstaff
+    cursor_column: whenmodified
 ```
 
 becomes:
 
-```yaml
-- table_name: schoolstaff
-  cursor_column: transaction_date
+```text
+  - table_name: schoolstaff
+    cursor_column: transaction_date
 ```
 
 Edit 2:
 
-```yaml
-- table_name: sectionteacher
-  cursor_column: whenmodified
+```text
+  - table_name: sectionteacher
+    cursor_column: whenmodified
 ```
 
 becomes:
 
-```yaml
-- table_name: sectionteacher
-  cursor_column: transaction_date
+```text
+  - table_name: sectionteacher
+    cursor_column: transaction_date
 ```
 
 Edit 3:
 
-```yaml
-- table_name: users
-  cursor_column: whenmodified
+```text
+  - table_name: users
+    cursor_column: whenmodified
 ```
 
 becomes:
 
-```yaml
-- table_name: users
-  cursor_column: transaction_date
+```text
+  - table_name: users
+    cursor_column: transaction_date
 ```
 
 - [ ] **Step 4: Repeat the same three edits in the Newark config**

--- a/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
+++ b/docs/superpowers/plans/2026-08-06-powerschool-dlt-cursor-transaction-date.md
@@ -514,17 +514,35 @@ landed yet. Wait for the next tick rather than launching a run.
 
 - [ ] **Step 3: Confirm the drift cleared in BigQuery**
 
+Check the invariant rather than a hardcoded row list: no active Paterson staff
+member should have a warehouse `homeschoolid` that disagrees with their ADP home
+school.
+
 ```sql
-select count(*) as still_drifted
-from `teamster-332318.dagster_kipppaterson_dlt_powerschool.users`
-where dcid in (205, 555, 652, 901, 905, 1751, 1764, 1951, 2051, 2257)
-  and homeschoolid = 0
+with sr as (
+  select
+    powerschool_teacher_number,
+    home_work_location_powerschool_school_id as adp_school
+  from `teamster-332318.kipptaf_people.int_people__staff_roster`
+  where assignment_status = 'Active'
+    and home_work_location_dagster_code_location = 'kipppaterson'
+    and (home_department_name != 'Data' or home_department_name is null)
+)
+select count(*) as still_mismatched
+from sr
+inner join `teamster-332318.kipptaf_powerschool.stg_powerschool__users` as u
+  on sr.powerschool_teacher_number = u.teachernumber
+  and u._dbt_source_project = 'kipppaterson'
+where u.homeschoolid != sr.adp_school
 ```
 
-Expected: a low count. Eight of the ten rows read `homeschoolid = 0` before the
-fix and should now carry a real school id. Two rows (dcid 555 and 2257) were
-already non-zero but wrong, so confirm those individually against the live
-values recorded in the spec's evidence section.
+Before the fix this returned 10. Expected after: 0, or 1 if the one ADP-side
+case has not been corrected in Workday — that row's ADP school is itself wrong,
+so it is a People Ops fix, not a pipeline one.
+
+This query names no individual identifiers. The ten specific rows are recorded
+in the investigation artifacts under `.claude/scratch/` and the SDD workspace,
+both git-ignored; do not copy them into this file, the issue, or the PR.
 
 - [ ] **Step 4: Confirm the affected staff returned to the extract**
 
@@ -566,7 +584,35 @@ order by sr.loc
 Post the before and after counts as a comment on #4754. Report counts only —
 never `teachernumber` or `dcid` values, which are employee identifiers.
 
-- [ ] **Step 6: Clean up the throwaway artifacts**
+- [ ] **Step 6: Confirm the steady-state reload cadence is sane**
+
+Raised in review on PR #4757. `transaction_date` moved on 105 of 219 Paterson
+`users` rows between the stored baseline and the live probe, which would be a
+problem if it advanced on most 15-minute ticks: these tables load
+`write_disposition="replace"` behind a per-district pool at limit 1, so constant
+reloading would compete with the large `transaction_date` tables.
+
+Measurement during the investigation says it does not. Live
+`MAX(transaction_date)` read `2026-08-06T07:17:33` at both 16:12Z and 17:11Z —
+unchanged across roughly 40 consecutive ticks. The column advances in discrete
+batches, not continuously, so the signature is stable between batches.
+
+Confirm that holds in production over a longer window than the first tick:
+
+```text
+mcp__dagster__get_tick_history(
+  name="kipppaterson__powerschool__dlt__intraday_sensor",
+  repository_location_name="kipppaterson",
+  limit=100,
+)
+```
+
+Count how many ticks selected any of the three tables. Expected: a small
+fraction, clustered around the batch stamping. If instead they are selected on
+most ticks, that is a real regression — open a follow-up issue rather than
+reverting, since the correctness fix still stands.
+
+- [ ] **Step 7: Clean up the throwaway artifacts**
 
 ```bash
 rm -f /workspaces/teamster/tests/assets/test_zz_ps_users_probe.py \
@@ -577,7 +623,7 @@ rm -f /workspaces/teamster/tests/assets/test_zz_ps_users_probe.py \
 These are untracked in the main checkout and were only diagnostic. Confirm with
 `git -C /workspaces/teamster status --short` that nothing remains.
 
-- [ ] **Step 7: Remove the worktree**
+- [ ] **Step 8: Remove the worktree**
 
 ```bash
 git -C /workspaces/teamster worktree remove \

--- a/docs/superpowers/specs/2026-08-06-powerschool-dlt-cursor-transaction-date-design.md
+++ b/docs/superpowers/specs/2026-08-06-powerschool-dlt-cursor-transaction-date-design.md
@@ -1,0 +1,148 @@
+# PowerSchool dlt intraday cursor: `whenmodified` to `transaction_date`
+
+Date: 2026-08-06 Issue:
+[#4754](https://github.com/TEAMSchools/teamster/issues/4754)
+
+## Problem
+
+The PowerSchool dlt intraday sensor detects change with a signature of
+`COUNT(*)` plus `MAX(cursor_column)`. An in-place UPDATE that changes row
+content without advancing the cursor produces an identical signature, so the
+sensor skips and the warehouse copy stays stale. Tables configured
+`intraday: true` with `nightly: false` have no full-refresh backstop, so the
+staleness persists indefinitely.
+
+This is not a defect in the sensor. `probe_signature` and `_compute_changed`
+behave exactly as written. The cursor is the wrong signal for the tables in
+scope.
+
+## Evidence
+
+Ops corrected `homeschoolid` for 10 Paterson staff. A live read-only probe over
+the SSH tunnel compared all 219 rows of PowerSchool `users` against the
+warehouse copy:
+
+```text
+rows live / warehouse    : 219 / 219   (no inserts, no deletes)
+homeschoolid changed     : 10 rows
+whenmodified changed     : 0 rows
+transaction_date changed : 105 rows
+
+live   COUNT(*)          : 219                   stored baseline: 219
+live   MAX(whenmodified) : 2026-08-05T00:01:03   stored baseline: 2026-08-05T00:01:03
+live   MAX(transaction_date): 2026-08-06T07:17:33  stored baseline: 2026-08-05T00:01:04
+```
+
+The probe signature was byte-identical to the stored baseline, so the sensor
+correctly reported no change. `transaction_date` moved on all 10 drifted rows
+and its max advanced past the baseline, so the sensor would have fired on that
+cursor.
+
+`transaction_date` tracks updates reliably in every district. Of the rows
+modified in 2026 across all three districts, every one carries a
+`transaction_date` at or after its `whenmodified`:
+
+| district     | rows modified in 2026 | transaction_date null | stale | tracks |
+| ------------ | --------------------- | --------------------- | ----- | ------ |
+| kipppaterson | 55                    | 0                     | 0     | 55     |
+| kippnewark   | 179                   | 0                     | 0     | 179    |
+| kippcamden   | 50                    | 0                     | 0     | 50     |
+
+`transaction_date` is 26 to 45 percent NULL overall in Newark and Camden, but
+those are rows untouched since the column was introduced. `MAX()` ignores NULLs,
+so the signature is unaffected.
+
+## Scope
+
+Three tables have both `whenmodified` and `transaction_date` and currently use
+`whenmodified` as their cursor. The set is identical in all three districts:
+
+- `users`
+- `schoolstaff`
+- `sectionteacher`
+
+Every other exposed table has only `whenmodified` and no better cursor
+available. Those are excluded: there is no evidence their updates fail to bump
+the cursor, and a fix without a demonstrated defect is speculative.
+
+Ten sibling tables in the same config already use `transaction_date`, including
+the four largest (`attendance`, `pgfinalgrades`, `storedgrades`, `cc`). The
+three tables in scope are the outliers, not the precedent.
+
+## Decision
+
+Change `cursor_column` from `whenmodified` to `transaction_date` for the three
+tables, in each of the three district configs. Nine lines across three files. No
+Python changes.
+
+Files:
+
+- `src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml`
+- `src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml`
+- `src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml`
+
+## Behavior on deploy
+
+The change remediates the existing drift without a manual run:
+
+1. Merge triggers the code location redeploy; the sensor rebuilds its
+   `PowerSchoolTable` list with the new cursors.
+2. The next 15-minute tick probes `MAX(transaction_date)` rather than
+   `MAX(whenmodified)`.
+3. The stored dlt baseline still holds the old `whenmodified` value, so the
+   signatures differ and `_compute_changed` selects all three tables.
+4. Each table full-replaces, and the new baseline persists carrying the
+   `transaction_date` signature.
+5. dbt automation rebuilds `stg_powerschool__users`; the
+   `rpt_powerschool__autocomm_teachers` join matches on the corrected
+   `homeschoolid`, and affected staff return to the nightly 3am extract.
+
+The three tables total 219 to 52k rows per district. The one-time reload is well
+inside the `dlt_powerschool_*` pool limit of 1.
+
+## Verification
+
+After the deploy lands:
+
+1. Confirm the sensor tick selected the three tables rather than skipping.
+2. Re-run the live drift comparison for Paterson `users`. Expect `homeschoolid`
+   drift of 0 rows.
+3. Confirm the affected staff appear in `rpt_powerschool__autocomm_teachers`.
+
+Existing sensor unit tests are unaffected because no Python changes.
+
+## Rollback
+
+Revert the nine lines. The next tick observes a signature differing from the
+stored `transaction_date` baseline, reloads once, and re-baselines on
+`whenmodified`. One extra reload in either direction, on small tables, with no
+destructive step.
+
+## Alternatives considered
+
+**Probe both columns and take the max of the two.** Strictly cannot regress,
+being a superset of both signals. Rejected: it requires changing `cursor_column`
+to a list and reshaping the signature, which invalidates the stored baseline for
+every table in every district config, not just the three in scope. Given that
+`transaction_date` tracked every 2026 modification in all three districts, the
+additional surface area buys almost nothing.
+
+**Set `nightly: true` on the three tables.** Simple and a guaranteed backstop.
+Rejected: it leaves the intraday tick blind and corrects once a night, accepting
+up to 24 hours of staleness while a working intraday signal goes unused. It
+treats the symptom rather than the wrong cursor.
+
+**A config parity test across the three district files.** The three configs are
+copies of one PowerSchool schema and drifted into disagreement, which is how
+this defect arose. Considered and deliberately excluded from this change to keep
+it minimal; it remains available as separate work.
+
+## Out of scope
+
+- The 10 exposed tables with only `whenmodified`. No demonstrated defect.
+- Nightly backstop policy for the large `transaction_date` tables.
+- The circular join in `rpt_powerschool__autocomm_teachers`, which requires a
+  staff member's `homeschoolid` to already be correct in order to include them
+  in the extract that sets it. Recorded in
+  [#4754](https://github.com/TEAMSchools/teamster/issues/4754); it needs its own
+  design.

--- a/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kippcamden/powerschool/sis/dlt/config/assets.yaml
@@ -45,7 +45,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: schoolstaff
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: sections
@@ -53,7 +53,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: sectionteacher
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: storedgrades
@@ -101,7 +101,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: users
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: userscorefields

--- a/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kippnewark/powerschool/sis/dlt/config/assets.yaml
@@ -45,7 +45,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: schoolstaff
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: sections
@@ -53,7 +53,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: sectionteacher
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: storedgrades
@@ -101,7 +101,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: users
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: userscorefields

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
@@ -45,7 +45,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: schoolstaff
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: sections
@@ -53,7 +53,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: sectionteacher
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: storedgrades
@@ -85,7 +85,7 @@ assets:
     intraday: true
     nightly: false
   - table_name: users
-    cursor_column: whenmodified
+    cursor_column: transaction_date
     intraday: true
     nightly: false
   - table_name: userscorefields


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Change the intraday change-detection cursor from `whenmodified` to
`transaction_date` for `users`, `schoolstaff`, and `sectionteacher` in all three
PowerSchool districts.

The intraday sensor detects change with `COUNT(*)` plus `MAX(cursor_column)`, so
an in-place UPDATE that does not advance the cursor is invisible. These three
tables are `intraday: true` with `nightly: false`, so there is no full-refresh
backstop and the staleness persists indefinitely.

Confirmed live against PowerSchool Paterson: 10 staff rows had `homeschoolid`
corrected in PowerSchool, 0 of them advanced `whenmodified`, and the probe
signature was byte-identical to the stored baseline. `transaction_date` moved on
all 10. Across all three districts, every `users` row modified in 2026 carries a
`transaction_date` at or after its `whenmodified` — 284 of 284.

These three tables are the only exposed tables carrying both columns. The other
ten intraday tables in the same configs, including the four largest, already
cursor on `transaction_date`. Tables with only `whenmodified` are deliberately
untouched: no defect has been demonstrated for them.

This self-remediates. The stored baseline holds a `whenmodified` value, so the
first probe after deploy returns a differing signature and each table reloads
once, clearing the accumulated drift with no manual run.

Design:
`docs/superpowers/specs/2026-08-06-powerschool-dlt-cursor-transaction-date-design.md`

Closes #4754

## AI Assistance

Claude investigated the root cause, ran the live read-only comparison against
PowerSchool, and authored the spec, plan, and config change. Scope was
human-directed: limiting the fix to tables with a demonstrated defect and a
better cursor already available, and dropping a config parity test from scope.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR

### Dagster

- [x] Config-only change consumed by `yaml.safe_load`; no Python modified
- [x] Verified the sensor builds `PowerSchoolTable` with the new cursor for all
      three tables

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes. Note this passes trivially: no dbt models are
      touched, so `state:modified+` selects nothing. Not validation.
- [ ] **Dagster Cloud** — passes for all three affected locations
