### PR TITLE
feat(launch): add the data tool catalog and intern runbook

### DIFF
--- a/src/launch/README.md
+++ b/src/launch/README.md
@@ -103,49 +103,11 @@ setting, _and_ it reads from a backing Google Sheet with its own separate
 sharing. Both have to require sign-in. There is no API shortcut here — open the
 app, then open the Sheet behind it, and check each.
 
-### Tools that are on the site but not on any role page
+### What order to do it in, and which entries need a decision
 
-Three AppSheet apps (`Leader PM App`, `Seat Tracker`, `Stipend App`) were linked
-only from the Support page, so there is no signal about who they are for. They
-are in `links.yml` with empty `audiences` and a TODO. Assigning those is a real
-decision, not a lookup.
-
-Related question worth raising rather than answering alone: Clever, DeansList,
-Grow, and PowerSchool are named on the Support page, but all four link to the
-same Okta dashboard URL rather than to the apps themselves. Should they be
-catalog entries at all, and if so what should they point at?
-
-### Suggested order
-
-Do the straightforward ones first to build context, then bring the judgment
-calls to a person rather than guessing.
-
-1. **Start with the tools you already know.** Confirm the pattern works before
-   scaling up.
-1. **Work through the rest alphabetically.** Most will be quick.
-1. **Save the `TODO(verify)` entries for last** and discuss them. There are four
-   and each needs a real decision, not a lookup:
-   - `Home Instruction Tracker` points at **two different URLs** depending on
-     which page of the old site you came from, and one of the two descriptions
-     is plainly the wrong tool's. Somebody has to decide which is canonical.
-   - `Literacy Tool (ELIT)` and `Early Literacy Tool (ELIT)` are **different
-     dashboards with nearly identical names**. Both appear live. They probably
-     need renaming so a teacher can tell them apart.
-   - `Testing Accommodations` has two contradictory descriptions on the old site
-     — results versus requests. These are not the same thing.
-
-### Things worth flagging as you go
-
-You are the first person to look at all of these at once, which makes you the
-most likely person to notice:
-
-- A tool that appears twice under different names
-- A tool nobody has used in years
-- A tool that is missing from the list entirely
-- A description that would confuse somebody who did not already know the tool
-
-Open an issue or leave a note. Finding these is genuinely part of the job, not a
-distraction from it.
+See [RUNBOOK.md](RUNBOOK.md). That file owns the sequence, the entries that need
+a judgment call rather than a lookup, and what to flag as you go. This file
+stays the field reference so the two cannot drift apart.
 
 ## Out of scope
 

--- a/src/launch/README.md
+++ b/src/launch/README.md
@@ -1,0 +1,156 @@
+# Data launch page — tool catalog
+
+This directory holds the source of truth for the data team's tool catalog. It
+gets rendered into role-specific articles in the Zendesk Help Center.
+
+Design: `docs/superpowers/specs/2026-08-06-launch-page-zendesk-design.md` (under
+review separately).
+
+| File         | What it is                                                      |
+| ------------ | --------------------------------------------------------------- |
+| `links.yml`  | Every tool: name, URL, description, who it is for               |
+| `views.yml`  | The six views and their intro copy. Presentation only           |
+| `RUNBOOK.md` | The task sequence — start there if you are picking up this work |
+| `README.md`  | This file: what the directory is and what "reviewed" means      |
+
+The renderer and publishing pipeline do not exist yet. This is the data they
+will consume.
+
+## Current state
+
+`links.yml` was **scraped from the existing Google Site** and merged. It is a
+starting point, not a finished catalog. Every entry carries
+`status: needs-review`.
+
+- **46 tools** — 35 Tableau, 7 Google Sheets, 3 AppSheet apps, 1 Zendesk
+- **61 `TODO` lines** flagging specific things a human needs to resolve
+- **9 tools** have a linked user guide; the rest may or may not have one
+- **4 tools** have no `audiences` at all and need roles assigned
+
+The scrape found several kinds of problem, which is a good sign — these are
+exactly the failures that come from maintaining the same list on five separate
+pages by hand.
+
+## The work
+
+Review every entry and change its `status` to `verified`. An entry is verified
+when all five of these are true:
+
+1. **The tool still exists** and the URL loads. You will need Tableau access for
+   most of them; ask if you do not have it.
+1. **The name matches what the tool actually calls itself** when you open it,
+   not what the old site called it.
+1. **The description is accurate and one sentence.** Say what the tool is for,
+   not how it works. Many scraped descriptions are decent; some are stale.
+1. **`audiences` is right.** Who actually needs this in their day-to-day? See
+   `views.yml` for what each role means. A tool can be in several. A tool in
+   none still appears in the All view, so an empty list is a real answer — but
+   it should be a decision, not an accident.
+1. **`system` is right** — `tableau`, `appsheet`, `zendesk`, `google-sheet`,
+   `google-slides`, `google-form`, `google-doc`, `apps-script`, or `other`.
+1. **For anything Google-hosted, the sharing is group-based.** See below. This
+   one is not optional.
+
+Add `guide:` with the Zendesk article URL if the tool has a help article and the
+entry is missing it.
+
+### Google-hosted tools need one extra check
+
+A Tableau link is safe to publish because Tableau requires sign-in — the URL is
+useless to anyone outside. **A Google Drive link is not automatically safe.** If
+a Sheet is shared "anyone with the link," then the URL _is_ the access control,
+and publishing it here — in a public repository — hands it to the internet.
+
+So for every entry with a `google-*` system, open the file, click **Share**, and
+confirm **General access is _not_** "Anyone with the link." It should be
+restricted to named people or Workspace groups.
+
+If you find one that is link-shared: **do not add it to this file.** Flag it
+instead. That is a live exposure to fix at the source, not something to
+document.
+
+The three GPA Rosters currently in `links.yml` were checked and are group-shared
+correctly. Anything you add is on you to check.
+
+**A tooling caveat you will hit.** For a file you do not administer, the Drive
+API returns only the owner — not the groups it is actually shared with. An empty
+group list from a script is therefore inconclusive, not evidence of a problem.
+Check the Share dialog in the UI, which shows the real picture.
+
+The four Student Contact Info Feeds are the case in point: automated reads show
+only an owner, but the data team confirmed each is shared to its region's group
+with CMO staff holding access to all four, and none is link-shared. They carry
+student and guardian contact information, so treat them as the most sensitive
+entries here and re-confirm rather than assume if anything about them changes.
+
+**AppSheet apps need this twice over.** An AppSheet app has its own access
+setting, _and_ it reads from a backing Google Sheet with its own separate
+sharing. Both have to require sign-in. There is no API shortcut here — open the
+app, then open the Sheet behind it, and check each.
+
+### Tools that are on the site but not on any role page
+
+Three AppSheet apps (`Leader PM App`, `Seat Tracker`, `Stipend App`) were linked
+only from the Support page, so there is no signal about who they are for. They
+are in `links.yml` with empty `audiences` and a TODO. Assigning those is a real
+decision, not a lookup.
+
+Related question worth raising rather than answering alone: Clever, DeansList,
+Grow, and PowerSchool are named on the Support page, but all four link to the
+same Okta dashboard URL rather than to the apps themselves. Should they be
+catalog entries at all, and if so what should they point at?
+
+### Suggested order
+
+Do the straightforward ones first to build context, then bring the judgment
+calls to a person rather than guessing.
+
+1. **Start with the tools you already know.** Confirm the pattern works before
+   scaling up.
+1. **Work through the rest alphabetically.** Most will be quick.
+1. **Save the `TODO(verify)` entries for last** and discuss them. There are four
+   and each needs a real decision, not a lookup:
+   - `Home Instruction Tracker` points at **two different URLs** depending on
+     which page of the old site you came from, and one of the two descriptions
+     is plainly the wrong tool's. Somebody has to decide which is canonical.
+   - `Literacy Tool (ELIT)` and `Early Literacy Tool (ELIT)` are **different
+     dashboards with nearly identical names**. Both appear live. They probably
+     need renaming so a teacher can tell them apart.
+   - `Testing Accommodations` has two contradictory descriptions on the old site
+     — results versus requests. These are not the same thing.
+
+### Things worth flagging as you go
+
+You are the first person to look at all of these at once, which makes you the
+most likely person to notice:
+
+- A tool that appears twice under different names
+- A tool nobody has used in years
+- A tool that is missing from the list entirely
+- A description that would confuse somebody who did not already know the tool
+
+Open an issue or leave a note. Finding these is genuinely part of the job, not a
+distraction from it.
+
+## Out of scope
+
+Do not worry about any of this — it is handled elsewhere:
+
+- The rendering or publishing pipeline
+- Zendesk configuration, permissions, or article IDs
+- Rewriting the `views.yml` intro copy (it needs doing, but not by hand here)
+- The Our Team page, the support runbook, or the blog — those live in Zendesk
+  directly and are not part of this catalog
+
+## Conventions
+
+- **Everything in this directory is public.** The repository is public and so is
+  this file. Tool names, descriptions, and URLs are fine — they are already
+  public on the current site, and the URLs require sign-in to be useful. **Do
+  not add** phone numbers, email addresses, individual staff names, or anything
+  explaining how to authenticate to a system.
+- `audiences` controls **relevance, not access**. Tagging a tool for one role
+  does not hide it from anyone; the All view always lists everything, and the
+  destination system enforces who can actually see the data.
+- One sentence per description. If it needs two, the second one probably belongs
+  in a help guide.

--- a/src/launch/README.md
+++ b/src/launch/README.md
@@ -1,15 +1,18 @@
 # Data launch page — tool catalog
 
-This directory holds the source of truth for the data team's tool catalog. It
-gets rendered into role-specific articles in the Zendesk Help Center.
+This directory holds the source of truth for the data team's tool catalog — what
+tools exist, what each is for, and who needs it.
 
-Design: `docs/superpowers/specs/2026-08-06-launch-page-zendesk-design.md` (under
-review separately).
+**Where it gets served is a separate decision.** The catalog renders into
+role-specific staff-facing articles; the current design candidate is the Zendesk
+Help Center (see #4762), and follow-on work may render the same source into Okta
+bookmark tiles or a discovery skill. Nothing in this directory depends on that
+choice being settled.
 
 | File         | What it is                                                      |
 | ------------ | --------------------------------------------------------------- |
 | `links.yml`  | Every tool: name, URL, description, who it is for               |
-| `views.yml`  | The six views and their intro copy. Presentation only           |
+| `views.yml`  | The five views and their intro copy. Presentation only          |
 | `RUNBOOK.md` | The task sequence — start there if you are picking up this work |
 | `README.md`  | This file: what the directory is and what "reviewed" means      |
 
@@ -50,6 +53,18 @@ when all five of these are true:
    `google-slides`, `google-form`, `google-doc`, `apps-script`, or `other`.
 1. **For anything Google-hosted, the sharing is group-based.** See below. This
    one is not optional.
+
+### The other fields
+
+- **`guide:`** — optional. The Zendesk help article for this tool, if one
+  exists.
+- **`access: limited`** — optional badge for tools most staff cannot open.
+- **`regions:`** — optional, and **not the same thing as `audiences`**. This is
+  geography: which of `newark`, `camden`, `miami`, `paterson` a tool covers, or
+  `[all]`. Use it when a tool exists once per region, like the Student Contact
+  Info Feeds. `audiences: [region]` means something entirely different — it is
+  the _Regional and CMO_ role view. A tool can be `audiences: [region]` with no
+  `regions:` at all, or scoped to one region and used by teachers.
 
 Add `guide:` with the Zendesk article URL if the tool has a help article and the
 entry is missing it.

--- a/src/launch/RUNBOOK.md
+++ b/src/launch/RUNBOOK.md
@@ -1,0 +1,212 @@
+# Launch page catalog — runbook
+
+The task sequence for getting `links.yml` from a scraped starting point to a
+catalog we would put in front of staff.
+
+[README.md](README.md) is the reference: what the directory is, what each field
+means, and what "verified" requires. This file is the order to do things in and
+who owns what.
+
+The design behind all of it lives in `docs/superpowers/specs/` as
+`2026-08-06-launch-page-zendesk-design.md`, which is under review separately.
+You do not need to read it to do this work.
+
+## The goal
+
+**All 46 entries in `links.yml` carry `status: verified`.**
+
+That is the deliverable. Steps 0 through 2 get there. Step 3 is a contingent
+stretch that only exists if the exposures triage lands in time, and the week is
+a success without it.
+
+---
+
+## Step 0 — Access, on day one
+
+Nothing else can start until these work. Check all of them the first morning and
+escalate immediately if any is missing; waiting until Wednesday to discover a
+Tableau access gap loses the week.
+
+- [ ] **Tableau** — `tableau.kipp.org`. Needed for 35 of the 46 entries. This is
+      the one that blocks everything.
+- [ ] **Google Drive** — the GPA Rosters, the Student Contact Info Feeds, and
+      the Sheets behind the AppSheet apps.
+- [ ] **AppSheet** — the three apps.
+- [ ] **A Codespace on this repository**, and push access to open a pull
+      request.
+
+You do **not** need Zendesk agent or Guide editing rights. Being able to read
+existing help articles is enough — the only Zendesk work here is confirming that
+a `guide:` link points at a real article.
+
+## Step 1 — Verify the catalog entries
+
+The week's work. For each entry, apply the five checks in
+[README.md](README.md#the-work) and change `status: needs-review` to
+`status: verified`.
+
+Suggested order:
+
+1. **The tools you already know**, to confirm the pattern before scaling up.
+1. **The rest alphabetically.** Most are quick — open it, confirm the name,
+   tighten the description, decide the audiences.
+1. **Anything Google-hosted gets the sharing check** described in README.md.
+   Non-optional, and it is the one check with a real consequence if skipped.
+
+Roughly 46 entries at ten to fifteen minutes each is about a day and a half of
+focused time. The rest of the week is the judgment calls and what you turn up
+along the way.
+
+### Bring these to Anthony rather than guessing
+
+Five entries need a decision, not a lookup. They are marked `TODO(verify)` in
+the file. Batch them into one conversation rather than blocking on each:
+
+- **`Home Instruction Tracker`** — resolves to two different URLs depending on
+  which page of the old site you came from, and one of the two descriptions
+  plainly belongs to a different tool.
+- **`Literacy Tool (ELIT)` and `Early Literacy Tool (ELIT)`** — different
+  dashboards, nearly identical names. Both live. Probably need renaming.
+- **`Testing Accommodations`** — two contradictory descriptions on the old site:
+  assessment _results_ versus accommodation _requests_. Not the same thing.
+- **`Stipend and Bonus Dashboard`** — described as a live dashboard, but the URL
+  points at a help article.
+- **The four entries with empty `audiences`** — `Early Literacy Tool`,
+  `Leader PM App`, `Seat Tracker`, `Stipend App`. Nothing on the old site says
+  who they are for.
+
+### One open question worth raising
+
+Clever, DeansList, Grow, and PowerSchool are named on the old Support page, but
+all four link to the same Okta dashboard URL rather than to the apps themselves.
+Should they be catalog entries at all, and if so, pointing at what?
+
+## Step 2 — Flag what you find
+
+You will be the first person to look at all 46 at once, which makes you the most
+likely person to notice:
+
+- A tool that appears twice under different names
+- A tool that nobody has opened in years
+- A tool missing from the list entirely
+- A description that would confuse someone who did not already know the tool
+
+Open an issue or leave a note. This is part of the job, not a distraction from
+it — the duplicates and contradictions already found came from exactly this kind
+of looking.
+
+## Step 3 — Describe the Google Sheets that survive triage
+
+**Contingent. Only happens if the exposures triage below finishes in time, and
+it is explicitly the last thing.** If it does not happen, the week still
+succeeded — Step 1 is the deliverable.
+
+Anthony decides which of the 63 exposures are canonical for staff access and
+appends them to `links.yml` with an `id`, `name`, `url`, and `system` filled in.
+Everything else is left blank.
+
+Your job is the part you will have spent the week getting good at:
+
+- **Write the description.** One sentence, what it is for rather than how it
+  works. These will mostly arrive with no description at all, or with a raw
+  model name where a human name should be — nine of the exposures are called
+  things like `rpt_gsheets__athletic_eligibility`.
+- **Set `audiences`.** Same judgment as Step 1.
+- **Run the Drive sharing check.** Every one of these is a Google Sheet, so
+  every one needs it. No exceptions.
+- **Flip `status` to `verified`.**
+
+How many entries this is depends entirely on the triage — could be eight, could
+be twenty-five. Do not plan around a number.
+
+If a sheet arrives without enough context to write an honest description, say so
+rather than guessing. A vague description is worse than no entry: it puts
+something in front of 1,800 people that does not tell them whether it is what
+they want.
+
+---
+
+## Working agreement
+
+**Editing.** Work in your Codespace. Branch off `main`, edit `links.yml`,
+commit, push, open a pull request. Branch naming follows the repo convention in
+the root `CLAUDE.md`.
+
+**Commit as you go**, not all at the end. A commit per batch of entries is easy
+to review; one commit with 46 changed entries is not. Open a pull request early
+and keep pushing to it rather than saving everything for Friday.
+
+**Before pushing, check formatting.** `links.yml` is linted in CI, and the rules
+that catch YAML problems fire at push time rather than at commit time. If a push
+is rejected, the error message names the file and rule.
+
+One quoting rule worth knowing up front, because it is the one that bites:
+**quote a string only when YAML needs it.** A value containing `: ` (colon then
+space) needs quotes. Most do not, and adding them anyway fails the linter.
+
+**Ask early.** Every judgment call in this file is one somebody else can answer
+in two minutes. Guessing costs more than asking.
+
+**Do not worry about** the rendering pipeline, Zendesk configuration or article
+IDs, the `views.yml` intro copy, or the Our Team / support / blog content. All
+handled elsewhere.
+
+---
+
+## Not intern work — owned by Anthony
+
+### Triage the Google Sheets exposures
+
+`src/dbt/kipptaf/models/exposures/google-sheets.yml` documents **63 Google
+Sheets** the pipeline writes to, each with a URL and its upstream model. Only 7
+are in `links.yml`.
+
+**The question for each: is this canonical for staff access right now?** Three
+answers, all common — yes and it belongs in the catalog; no, it is machine
+plumbing; or no, it is dead and worth flagging.
+
+This is deliberately not delegated. It needs someone who knows the history of
+each sheet, and that context is slower to transfer than to apply.
+
+**It also cannot be shortcut by sorting.** A first pass grouped the 63 by how
+their names looked — integration feeds, personal one-offs, stale-by-title,
+un-renamed model names, plausible candidates. That grouping was wrong:
+staff-facing tools sit in every one of those buckets, including the ones that
+looked most obviously like plumbing. There is no keyword rule and no scrape that
+gets this right.
+
+Two further reasons not to scrape the file:
+
+- It is **not complete**. The four Student Contact Info Feeds — used from
+  operations associates up to assistant superintendents — are not in it, or
+  anywhere else in this repository.
+- An exposure records _"this model feeds this artifact"_, a lineage fact. The
+  catalog records _"a staff member might need to find this"_, an audience fact.
+  The second is not derivable from the first.
+
+**Sequencing.** Triage output feeds
+[Step 3](#step-3--describe-the-google-sheets-that-survive-triage). Append the
+surviving sheets to `links.yml` with `id`, `name`, `url`, and `system` filled in
+and the rest blank; descriptions, audiences, and the sharing check are then the
+intern's last task.
+
+Doing it in that order matters for a practical reason: it keeps two people from
+editing one YAML file all week. Append after their pass through the existing 46,
+not during it.
+
+If triage does not finish in time, nothing is lost — Step 3 simply does not
+happen, and the surviving sheets get described whenever the triage does land.
+
+### Findings to handle separately
+
+Independent of triage, and independent of the catalog:
+
+- **Nine exposures have no human label**, carrying the raw model name
+  (`gsheets_student_contact_info`, `rpt_gsheets__athletic_eligibility`, and
+  similar). Small dbt hygiene fix.
+- **At least six are stale by their own titles** — named for school years or
+  projects that have passed. If they still materialize nightly, that is compute
+  spent on outputs nobody reads.
+- **The four Student Contact Info Feeds are not tracked in this repository at
+  all.** Worth establishing how they are maintained, since that determines
+  whether an upstream schema change would break them silently.

--- a/src/launch/RUNBOOK.md
+++ b/src/launch/RUNBOOK.md
@@ -7,9 +7,9 @@ catalog we would put in front of staff.
 means, and what "verified" requires. This file is the order to do things in and
 who owns what.
 
-The design behind all of it lives in `docs/superpowers/specs/` as
-`2026-08-06-launch-page-zendesk-design.md`, which is under review separately.
-You do not need to read it to do this work.
+The design for how this catalog eventually gets served is under review
+separately in #4762. You do not need to read it to do this work, and the catalog
+does not depend on it landing.
 
 ## The goal
 

--- a/src/launch/RUNBOOK.md
+++ b/src/launch/RUNBOOK.md
@@ -132,9 +132,26 @@ they want.
 commit, push, open a pull request. Branch naming follows the repo convention in
 the root `CLAUDE.md`.
 
-**Commit as you go**, not all at the end. A commit per batch of entries is easy
-to review; one commit with 46 changed entries is not. Open a pull request early
-and keep pushing to it rather than saving everything for Friday.
+**Work in batches, and merge as you go.** Not one pull request for the whole
+week — a 46-entry diff reviewed on Friday is reviewed badly, and anything still
+open when the week ends is wasted. Not one per entry either. Roughly seven:
+
+| Batch                                    | Notes                                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Warm-up** — 5 tools you already know   | Proves the whole loop while a mistake is still cheap                                                         |
+| **Google Sheets** — 7 entries            | The sharing-check batch. Do it early: a link-shared file is something you want to find on Monday, not Friday |
+| **AppSheet + Zendesk** — 4 entries       | Small. AppSheet needs the check twice — the app and the Sheet behind it                                      |
+| **Tableau** — three chunks of roughly 12 | The homogeneous bulk. Alphabetical is fine                                                                   |
+| **Judgment calls**                       | After the batched conversation. Needs decisions baked in                                                     |
+| **Step 3**, if it happens                | The triaged sheets                                                                                           |
+
+**A blocked entry never blocks its batch.** If something needs a decision, leave
+it `status: needs-review`, note it for the batched conversation, and keep going.
+One open question should not stall twelve tools.
+
+**Findings are issues, not pull requests.** Anything from Step 2 — a duplicate,
+a dead tool, a missing tool — goes in an issue. Do not turn a discovery into a
+code change that needs reviewing.
 
 **Before pushing, check formatting.** `links.yml` is linted in CI, and the rules
 that catch YAML problems fire at push time rather than at commit time. If a push

--- a/src/launch/links.yml
+++ b/src/launch/links.yml
@@ -1,7 +1,8 @@
 # Data launch page — tool catalog
 #
-# Source of truth for the generated Zendesk catalog articles.
-# See docs/superpowers/specs/2026-08-06-launch-page-zendesk-design.md
+# Source of truth for the generated staff-facing catalog articles. Where those
+# get served is a separate decision; the current design candidate is the Zendesk
+# Help Center, tracked in GitHub #4762.
 #
 # THIS FILE IS A STARTING POINT, NOT A FINISHED CATALOG. It was scraped from
 # the existing Google Site, so every entry carries `status: needs-review`

--- a/src/launch/links.yml
+++ b/src/launch/links.yml
@@ -1,0 +1,511 @@
+# Data launch page — tool catalog
+#
+# Source of truth for the generated Zendesk catalog articles.
+# See docs/superpowers/specs/2026-08-06-launch-page-zendesk-design.md
+#
+# THIS FILE IS A STARTING POINT, NOT A FINISHED CATALOG. It was scraped from
+# the existing Google Site, so every entry carries `status: needs-review`
+# until a human has confirmed it against the live tool. See README.md in this
+# directory for what reviewing an entry means.
+#
+# `audiences` controls which role views a tool appears in. It is NOT an
+# access control — the All view always renders every entry, and access is
+# enforced by the destination system.
+
+- id: attendance_dashboard
+  name: Attendance Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/AttendanceDashboard/Trends?:embed=y
+  description:
+    Monitor ADA, Chronic Absenteeism, Suspension and Daily Attendance Calls
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, ops, region]
+  system: tableau
+  status: needs-review
+
+- id: certification_dashboard
+  name: Certification Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/NJCertificationDashboardSchoolsView/CertificationDashboard?:embed=y
+  description:
+    Certification status and individual teacher steps for certification, effort
+    logging, and PRAXIS intensive attendance.
+  audiences: [leaders, region]
+  system: tableau
+  status: needs-review
+
+- id: coaching_conversation_tool
+  name: Coaching Conversation Tool
+  url: https://tableau.kipp.org/t/KIPPNJ/views/CoachingConversationTool/CoachingConversationTool?:embed=y
+  description:
+    View performance management results for yourself and those you coach from
+    2018 to present.
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, teachers]
+  system: tableau
+  status: needs-review
+
+- id: college_admission_readiness_assessment_tracker
+  name: College Admission Readiness Assessment Tracker (CARAT)
+  url: https://tableau.kipp.org/t/KIPPNJ/views/CollegeAdmissionReadinessAssessmentsTrackerCARAT/LandingPage?:embed=y
+  description:
+    "Tracking of any assessment that helps our students go to and through
+    college: ACT, SAT, PSAT10, PSAT NMSQT, PSAT 8/9, and AP."
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: content_team
+  name: Content Team (MIA)
+  url: https://tableau.kipp.org/t/KIPPNJ/views/ContentTeamDashboard/Home?:embed=y
+  description:
+    Information from CTM Rubric and O3s for Instructional Leads in Miami
+  audiences: [leaders]
+  system: tableau
+  status: needs-review
+
+- id: data_quality_dashboard
+  name: Data Quality Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/DataQualityDashboard/Home?:embed=y
+  description: Audits that alert on missing student info and assessment scores.
+  audiences: [ops, teachers]
+  system: tableau
+  status: needs-review
+
+- id: ddi_suite
+  name: DDI Suite
+  url: https://tableau.kipp.org/t/KIPPNJ/views/DDISuite/LandingPage?:embed=y
+  description:
+    Data-Driven Instruction info. Week-over-week assessment, standard, and QBL
+    mastery.
+  audiences: [leaders, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: early_literacy_tool
+  name: Early Literacy Tool (ELIT)
+  url: https://tableau.kipp.org/t/KIPPNJ/views/EarlyLiteracyDashboard_16940305949500/RegionOverview-Benchmark?:embed=y
+  description:
+    Analyze participation rates and measure level achievement distribution for
+    DIBELS.
+  audiences: []
+  # TODO(audiences): appeared only on the All page; assign roles
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/17344531036183
+  # TODO(verify): See note on 'Literacy Tool (ELIT)'. Different URL, near-identical name.
+  status: needs-review
+
+- id: fast_and_iready_data_tool
+  name: FAST & iReady Data Tool (MIA)
+  url: https://tableau.kipp.org/t/KIPPNJ/views/KIPPMiamiFASTi-ReadyAnalysis_16759101332760/LandingPage?:embed=y&:showAppBanner=false&:display_count=n&:showVizHome=n&:origin=viz_share_link
+  description: View Florida Assessment of Student Thinking (FAST) results.
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: finance_and_accounting_tools
+  name: Finance & Accounting Tools
+  url: https://tableau.kipp.org/t/KIPPNJ/views/FinanceAccountingToolsResources/TeacherSalariesbyYearDash?:embed=y
+  description:
+    Staff salary, benefits, and roster counts by year. Limited access.
+  audiences: [region]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/16753644522391#h_01H2QN8AEA0WXWYWJJBTVXF78H
+  # also listed on the source site as: Finance & Accounting Tools & Resources
+  status: needs-review
+
+- id: fresh_dashboard
+  name: FRESH Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/FRESHDashboard/LandingPage?%3Aembed=y#1
+  description: Track SRE's efforts for recruitment and registration.
+  audiences: [ops]
+  system: tableau
+  status: needs-review
+
+- id: gpa_roster_camden
+  name: "GPA Roster: Camden"
+  url: https://docs.google.com/spreadsheets/d/1qM6DQk_mqh4x_rI5YVQyZdYbfDxzOaLGyrqjySlVv2Y/edit?gid=0#gid=0
+  description: ""
+  # TODO(description): no description found on the source site
+  audiences: [region, teachers]
+  system: google-sheet
+  # TODO(verify): Google Sheet, linked as a bare sub-link under the Gradebook dashboard
+  # TODO(verify): with no description of its own. Confirm it is still the live roster and
+  # TODO(verify): write one.
+  status: needs-review
+
+- id: gpa_roster_miami
+  name: "GPA Roster: Miami"
+  url: https://docs.google.com/spreadsheets/d/1HsxearGC74LDySGx0QOZFkkH_HbsxmwzZ57Wi4vaZLg/edit?gid=0#gid=0
+  description: ""
+  # TODO(description): no description found on the source site
+  audiences: [region, teachers]
+  system: google-sheet
+  # TODO(verify): Google Sheet, linked as a bare sub-link under the Gradebook dashboard
+  # TODO(verify): with no description of its own. Confirm it is still the live roster and
+  # TODO(verify): write one.
+  status: needs-review
+
+- id: gpa_roster_newark
+  name: "GPA Roster: Newark"
+  url: https://docs.google.com/spreadsheets/d/12RHEUde41uR91Fp1aNrpImxhg72kOjPAQu7xLJ90evc/edit?gid=0#gid=0
+  description: ""
+  # TODO(description): no description found on the source site
+  audiences: [region, teachers]
+  system: google-sheet
+  # TODO(verify): Google Sheet, linked as a bare sub-link under the Gradebook dashboard
+  # TODO(verify): with no description of its own. Confirm it is still the live roster and
+  # TODO(verify): write one.
+  status: needs-review
+
+- id: gradebook_and_gpa_dashboard
+  name: Gradebook and GPA Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/GradebookandGPADashboard/GradebookGPADashboardLandingPage?%3Aembed=y
+  description: GPA, Gradebook Audit, ES Teacher/Monitor Audit.
+  audiences: [region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: grow_dashboard
+  name: Grow Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/SchoolMintGrowDashboard_17226096936880/Home?:embed=y
+  description:
+    Completion tracking, ratings and comments for teacher performance management
+    (ETR and Self & Others), Grow classroom walkthroughs, O3s, Microgoals and
+    Look fors.
+  audiences: [leaders, region]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/360008681374-Performance-Management-Teacher-Goals-Coaching-Excellent-Teaching-Rubric-ETR-Observations-SchoolMint-Grow
+  status: needs-review
+
+- id: high_school_early_warning
+  name: High School Early Warning
+  url: https://tableau.kipp.org/t/KIPPNJ/views/HighSchoolEarlyWarningDashboard/HSEarlyWarningDashboard-LandingPage?:embed=y
+  description: High school at-risk data & graduation eligibility
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, teachers]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/13464666347031--User-Guide-High-School-Early-Warning-Dashboard
+  # also listed on the source site as: High School Early Warning & Graduation Eligibility
+  status: needs-review
+
+- id: home_instruction_tracker
+  name: Home Instruction Tracker
+  url: https://tableau.kipp.org/t/KIPPNJ/views/NewarkHomeInstructionTracker/KIPPNJMiamiHomeInstructionTracker?:embed=y
+  # TODO(url-conflict): also linked as https://tableau.kipp.org/t/KIPPNJ/views/OKRTSDashboard_17247098359700/HomeInstruction?:embed=y
+  description: Tracking home instruction requests
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [ops]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/360013473594-Home-Instruction-Request-Process
+  # TODO(verify): TWO different URLs on the live site (a dedicated tracker vs an OKRTS
+  # TODO(verify): tab), and the Operations page shows the OKRTS description on this tool.
+  # TODO(verify): Decide which is canonical; the other may be a separate entry or a dead
+  # TODO(verify): link.
+  status: needs-review
+
+- id: i_ready_apm_tool
+  name: i-Ready APM Tool
+  url: https://tableau.kipp.org/t/KIPPNJ/views/APMDashboard/i-Ready?%3Aembed=y&%3AshowAppBanner=false&%3Adisplay_count=n&%3AshowVizHome=n&%3Aorigin=viz_share_link
+  description: ""
+  # TODO(description): no description found on the source site
+  audiences: [leaders, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: kipp_forward_data_suite
+  name: KIPP Forward Data Suite
+  url: https://tableau.kipp.org/t/KIPPNJ/views/KIPPForwardDataSuite_16988639234650/SplashPage?:embed=y
+  description:
+    Metrics on match, persistence, college success, career launch, and
+    re-enrollment
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: leader_pm_dashboard
+  name: Leader PM Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/LeadershipDevelopment_17017220456180/CompletionTracking?:embed=y
+  description:
+    Completion tracking and side-by-side self and manager reflections for those
+    in Leader Performance Management
+  audiences: [leaders, ops, region]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/19465485148183
+  status: needs-review
+
+- id: leader_pm_app
+  name: Leader PM App
+  description: Enter self and manager reflections and goals.
+  url: https://www.appsheet.com/start/861f035c-b076-4d1e-9a68-e36fcafe8184
+  audiences: []
+  # TODO(audiences): listed on the Support page, not on any role page, so there
+  # TODO(audiences): is no signal about who this is for. Assign roles.
+  # TODO(verify): AppSheet app. Confirm its access setting requires sign-in AND
+  # TODO(verify): check the sharing on the Sheet backing it. See README.
+  system: appsheet
+  status: needs-review
+
+- id: literacy_tool
+  name: Literacy Tool (ELIT)
+  url: https://tableau.kipp.org/t/KIPPNJ/views/LiteracyDashboard/LITDashboard-LandingPage?:embed=y
+  description:
+    Analysis of performance, growth and fidelity monitoring for DIBELS 8.
+  audiences: [leaders, teachers]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/17344531036183
+  # also listed on the source site as: LIT Dashboard
+  # TODO(verify): Name collision with 'Early Literacy Tool (ELIT)', which is a DIFFERENT
+  # TODO(verify): dashboard. Confirm both are live and rename one so they are
+  # TODO(verify): distinguishable.
+  status: needs-review
+
+- id: manager_survey_report
+  name: Manager Survey Report
+  url: https://tableau.kipp.org/t/KIPPNJ/views/ManagerSurveyReports/ManagerReport?:embed=y
+  description: View twice yearly feedback from your direct reports.
+  audiences: [leaders, ops, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: okrts_dashboard
+  name: OKRTS Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/OKRTSDashboard_17247098359700/LandingPage?:embed=y
+  description:
+    Our Kids Run To School (OKRTS). Monitor suspensions, referrals, and
+    DeansList behavior entry, as well as Promise Team metrics.
+  audiences: [leaders, ops, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: operations_systems
+  name: Operations Systems
+  url: https://tableau.kipp.org/t/KIPPNJ/views/OperationsSystems/Walkthroughs?:embed=y
+  description:
+    Operations Walkthroughs and Operations Teammate Performance Management
+    results and roll-ups.
+  audiences: [ops]
+  system: tableau
+  status: needs-review
+
+- id: ops_dashboard
+  name: Ops Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/OpsDashboard/EnrollmentDashboard?:embed=y
+  description: Student enrollment, demographics, SPED, and attrition metrics.
+  audiences: [leaders, ops, region]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/360035994714
+  status: needs-review
+
+- id: promotional_status_dashboard
+  name: Promotional Status Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/PromotionalStatusDashboard/Roll-Up?:embed=y
+  description:
+    Roll up and roster of individual student promotional status by quarter.
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: recruitment_dashboard
+  name: Recruitment Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/RecruitmentDashboard_17213358840600/Home?:embed=y
+  description:
+    Seat Tracker reporting view, hiring statuses over time, interview/demo
+    tracking, candidate quality, and sourcing metrics.
+  audiences: [leaders, ops, region]
+  system: tableau
+  guide: https://teamschools.zendesk.com/hc/en-us/articles/19856763832855--User-Guide-Seat-Tracker-App-and-Reporting
+  status: needs-review
+
+- id: seat_tracker
+  name: Seat Tracker
+  description: Work with the recruitment team on staffing.
+  url: https://www.appsheet.com/start/da7c51f8-1985-4c8d-b786-2aaf816ae1d2
+  audiences: []
+  # TODO(audiences): listed on the Support page, not on any role page, so there
+  # TODO(audiences): is no signal about who this is for. Assign roles.
+  # TODO(verify): AppSheet app. Confirm its access setting requires sign-in AND
+  # TODO(verify): check the sharing on the Sheet backing it. See README.
+  system: appsheet
+  status: needs-review
+
+- id: staff_attrition_dashboard
+  name: Staff Attrition Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/AttritionDashboard/AttritionDashboard?:embed=y
+  description:
+    Track retention rates for staff by year, location, job title, and more.
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: staff_demographic_explorer
+  name: Staff Demographic Explorer
+  url: https://tableau.kipp.org/t/KIPPNJ/views/StaffDemographicExplorer/StaffDemographicsExplorer?:embed=y
+  description:
+    View information provided by staff about race, ethnicity, and other
+    identities by job group, titles, and more.
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: staff_recent_job_and_salary_changes
+  name: Staff Recent Job & Salary Changes
+  url: https://tableau.kipp.org/t/KIPPNJ/views/RecentJobSalaryChanges/JobDeptLocFlags?:embed=y
+  description: Audit view for staff changes. Limited access.
+  audiences: [region]
+  system: tableau
+  status: needs-review
+
+- id: staff_roster
+  name: Staff Roster
+  url: https://tableau.kipp.org/t/KIPPNJ/views/StaffRoster/StaffRosterdisabled?:embed=y&:showAppBanner=false&:display_count=n&:showVizHome=n&:origin=viz_share_link
+  description:
+    Access roster of all staff for quick lookup of info, location, job title,
+    and more.
+  audiences: [leaders, ops, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: state_testing_analysis_tool
+  name: State Testing Analysis Tool
+  url: https://tableau.kipp.org/t/KIPPNJ/views/StateTestingAnalysisToolSTAT_17001442186870/StateTestingAnalysisToolSTAT-LandingPage?%3Aembed=y&%3AshowAppBanner=false&%3Adisplay_count=n&%3AshowVizHome=n&%3Aorigin=viz_share_link#4
+  description: ""
+  # TODO(description): no description found on the source site
+  audiences: [leaders, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: stipend_and_bonus_dashboard
+  name: Stipend and Bonus Dashboard
+  url: https://teamschools.zendesk.com/hc/en-us/articles/18404769341463--User-Guide-Stipend-and-Bonus-App
+  description:
+    Live data from the Stipend and Bonus app on stipends entered by quarter and
+    approval status.
+  audiences: [ops, region]
+  system: zendesk
+  # TODO(verify): the description says this is a live dashboard, but the URL
+  # TODO(verify): points at a help article, not the dashboard. Find the real
+  # TODO(verify): dashboard URL and move this one to the `guide` field.
+  status: needs-review
+
+- id: stipend_app
+  name: Stipend App
+  description: Submit stipends and bonuses for staff.
+  url: https://www.appsheet.com/start/f396eae8-7840-4648-b77e-1179506dae89
+  audiences: []
+  # TODO(audiences): listed on the Support page, not on any role page, so there
+  # TODO(audiences): is no signal about who this is for. Assign roles.
+  # TODO(verify): AppSheet app. Confirm its access setting requires sign-in AND
+  # TODO(verify): check the sharing on the Sheet backing it. See README.
+  system: appsheet
+  status: needs-review
+
+# Student Contact Info Feeds — one per region. NOT linked from the Google Site;
+# added directly. These carry student and guardian contact information, making
+# them the most sensitive entries in this catalog.
+#
+# Sharing confirmed by the data team: each feed is shared to its region's
+# group, with CMO staff holding access to all four. No link sharing. Note that
+# an automated permissions read returns only the file owner here — the Drive
+# API does not enumerate full permissions for a caller who does not administer
+# the file, so an empty group list from tooling is inconclusive, not a finding.
+
+- id: student_contact_info_feed_camden
+  name: Student Contact Info Feed - KIPP Camden
+  description: Student and guardian contact information for KIPP Camden.
+  url: https://docs.google.com/spreadsheets/d/1uHO67F5VNQltCTt3J1bB1ze6Hfp1QiE2O5HzJeQI97Y
+  audiences: [region]
+  # TODO(audiences): region is certain (CMO staff hold access to all four).
+  # TODO(audiences): decide whether ops and leaders should see their own region's
+  # TODO(audiences): feed too — the Drive sharing suggests they can already open it.
+  system: google-sheet
+  regions: [camden]
+  status: needs-review
+
+- id: student_contact_info_feed_miami
+  name: Student Contact Info Feed - KIPP Miami
+  description: Student and guardian contact information for KIPP Miami.
+  url: https://docs.google.com/spreadsheets/d/1bhSA4rG1zgg6PBxlBaje0COyU4L5lvozXMvpGjw0Mlw
+  audiences: [region]
+  # TODO(audiences): region is certain (CMO staff hold access to all four).
+  # TODO(audiences): decide whether ops and leaders should see their own region's
+  # TODO(audiences): feed too — the Drive sharing suggests they can already open it.
+  system: google-sheet
+  regions: [miami]
+  status: needs-review
+
+- id: student_contact_info_feed_newark
+  name: Student Contact Info Feed - KIPP Newark
+  description: Student and guardian contact information for KIPP Newark.
+  url: https://docs.google.com/spreadsheets/d/18X4M7nQ25xRy_8ieZryrsaaljsWG3Es1jY8yzzmBPDQ
+  audiences: [region]
+  # TODO(audiences): region is certain (CMO staff hold access to all four).
+  # TODO(audiences): decide whether ops and leaders should see their own region's
+  # TODO(audiences): feed too — the Drive sharing suggests they can already open it.
+  system: google-sheet
+  regions: [newark]
+  status: needs-review
+
+- id: student_contact_info_feed_paterson
+  name: Student Contact Info Feed - KIPP Paterson
+  description: Student and guardian contact information for KIPP Paterson.
+  url: https://docs.google.com/spreadsheets/d/13ld6WVnOoFLxYXN_HQ837j_ha8Hgr14AtWNZmhjCno0
+  audiences: [region]
+  # TODO(audiences): region is certain (CMO staff hold access to all four).
+  # TODO(audiences): decide whether ops and leaders should see their own region's
+  # TODO(audiences): feed too — the Drive sharing suggests they can already open it.
+  system: google-sheet
+  regions: [paterson]
+  status: needs-review
+
+- id: survey_dashboard
+  name: Survey Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/SurveyDashboard_17078426466440/Home?:embed=y
+  description:
+    Completion status (all) and results (ITR and Support) for KTAF-administered
+    surveys.
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, ops, region]
+  system: tableau
+  status: needs-review
+
+- id: survey_hq
+  name: Survey HQ
+  url: https://tableau.kipp.org/t/KIPPNJ/views/PersonalizedSurveyLinks/SurveyHQ?:embed=y
+  description:
+    Your personalized links for the School Community Diagnostic, Staff
+    Demographic Info, Intent to Return, Manager, and Support surveys (does not
+    include Gallup and TNTP Insight)
+  audiences: [leaders, ops, region, teachers]
+  system: tableau
+  status: needs-review
+
+- id: teacher_development_dashboard
+  name: Teacher Development Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/TeacherDevelopmentDashboard_16994705799120/HeatMap?:embed=y
+  description:
+    Information on observations conducted by the Teacher Development Team for
+    TiRs and New Leads in their programs.
+  audiences: [leaders, region]
+  system: tableau
+  status: needs-review
+
+- id: testing_accommodations
+  name: Testing Accommodations
+  url: https://tableau.kipp.org/t/KIPPNJ/views/StateTestingAccommodationsTracker/StateTestingAccommodationsTracker?:embed=y
+  description: Access accommodations requests for state testing.
+  # TODO(description): source site had conflicting wording; verify
+  audiences: [leaders, ops, region, teachers]
+  system: tableau
+  # also listed on the source site as: Accommodations Tracker (NJ)
+  # TODO(verify): Two conflicting descriptions on the live site: 'access state assessment
+  # TODO(verify): results and testing accommodations' vs 'accommodations requests'. Pick
+  # TODO(verify): one.
+  status: needs-review
+
+- id: zendesk_dashboard
+  name: Zendesk Dashboard
+  url: https://tableau.kipp.org/t/KIPPNJ/views/ZendeskReporting/Launch?:embed=y
+  description: Support ticket metrics by department, agent, and category.
+  audiences: [ops, region]
+  system: tableau
+  status: needs-review

--- a/src/launch/views.yml
+++ b/src/launch/views.yml
@@ -1,0 +1,48 @@
+# Catalog views — presentation only.
+#
+# Membership is NOT defined here. A tool appears in a view when that view's id
+# is in the tool's `audiences` list in links.yml. The `all` view is special: it
+# always renders every entry regardless of tags.
+#
+# Intro copy below was carried over from the existing Google Site and should be
+# rewritten before launch — see README.md.
+
+- id: all
+  title: "Data: All Tools"
+  intro: >
+    An alphabetical list of all our data tools, all in one place.
+  renders: everything
+  sort: name
+
+- id: teachers
+  title: "Data: For Teachers"
+  intro: >
+    Teachers have access to data for their classrooms, students, and their own
+    personal information, like performance management ratings. Coaches also have
+    this information for the teachers on their teams.
+  sort: name
+
+- id: leaders
+  title: "Data: For Leaders"
+  intro: >
+    Data tools curated for those in school leadership positions. Assistant
+    School Leaders see data for their schools and the instructors at them.
+    School Leaders also see data for all teammates at their school.
+  sort: name
+
+- id: ops
+  title: "Data: For Operations"
+  intro: >
+    Data tools curated for those in operations departments and leadership roles.
+    DSOs and DCOs see data for their individual schools and campuses.
+  sort: name
+
+- id: region
+  title: "Data: For Regional and CMO"
+  intro: >
+    Data tools curated for those who serve multiple schools in a region, like
+    Heads of Schools and MDSOs, or departments like KIPP Forward, Special
+    Education, and Teaching and Learning. Regional teammates see data for the
+    schools they serve; CMO teammates see data relevant to their domains across
+    all schools.
+  sort: name


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...establish `src/launch/` as the source of truth for the data team's tool
catalog, plus the runbook for finishing it.

**Deliberately independent of where the catalog gets served.** The companion
design spec (#4762) proposes rendering this into Zendesk Help Center articles,
but that spec is waiting on several open questions. The catalog is not: it is
the same source whether it renders to Zendesk, to Okta bookmark tiles, to a
Claude discovery skill, or to a ticket-response agent. Splitting it out means it
can merge and be worked on now rather than inheriting the spec's blockers.

### What is in `links.yml`

**46 tools**, scraped from the five role pages of the existing Google Site and
merged — 35 Tableau, 7 Google Sheets, 3 AppSheet apps, 1 Zendesk. Duplicates
that appeared under different names with identical URLs were merged; navigation
chrome was dropped.

Every entry carries `status: needs-review`, with **61 `TODO` lines** marking
what a human has to resolve. This is a starting point, not a finished catalog.

The scrape surfaced real defects that the five-page duplication had been
hiding:

- A tool that resolves to **two different URLs** depending on which page you
  came from, with one of its two descriptions plainly belonging to a different
  tool
- **Two live dashboards with near-identical names**, indistinguishable to a
  teacher
- **Contradictory descriptions** for the same tool on different pages
- An entry that **points at a help article** rather than the dashboard it
  describes

Those four are exactly the failure mode this change exists to end.

### The four Student Contact Info Feeds

Added directly rather than scraped — they were never linked from the Google
Site, and they do not appear anywhere else in this repository either. Sharing
was confirmed with the data team: each is scoped to its region's group with CMO
staff holding access to all four, none link-shared.

### Google-hosted entries carry an extra rule

A Tableau URL is gated by SSO no matter who holds it. **A Drive URL is gated by
that file's sharing setting** — so if a file is shared "anyone with the link,"
the URL _is_ the access control, and publishing it in a public repository hands
it out. `README.md` makes that check mandatory for every `google-*` entry.

It also documents a trap: for a file you do not administer, the Drive API
returns only the owner, not the groups. An empty group list from a script is
inconclusive, not evidence of a problem. Check the Share dialog.

### The other three files

- `views.yml` — the six views and their intro copy. Presentation only;
  membership is derived from `audiences` tags, so the five-way duplication
  cannot come back.
- `README.md` — the reference: what each field means, what "verified" requires.
- `RUNBOOK.md` — the task sequence and the ownership split.

Refs #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude extracted and merged the catalog from the live site, wrote the runbook
and reference docs, and verified Drive sharing where the API permitted. Scope
and every judgment call were human-directed: which content is public, what
belongs in the catalog versus authored elsewhere, and the decision not to seed
this from the dbt Google Sheets exposures.

That last one is worth recording. Claude proposed scraping the 63 exposures in
`google-sheets.yml` as a catalog source and was overruled with two facts it did
not have: the exposures file does not contain the Student Contact Info Feeds at
all, and staff-facing tools sit in every category the names suggest — including
the ones that look most like machine plumbing. There is no heuristic that sorts
them. That triage is recorded in `RUNBOOK.md` as human work, explicitly not
delegated.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

N/A — no Dagster code. `src/launch/` contains data and documentation only.

### dbt _(skip if no dbt changes)_

N/A — no dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. Verified locally with `trunk check --force` across all
      four files, since yamllint and markdownlint fire at push rather than at
      the commit hook.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not expected to trigger; no watched paths change.

## Reviewer notes

**Worth a look before merge:** `src/launch/` has no `CODEOWNERS` entry, so it
currently matches only the catch-all `* @TEAMSchools/admins`. Every pull request
against this directory will require an admins approval, which will be a
bottleneck once someone is working through the catalog daily. Adding
`/src/launch/ @TEAMSchools/admins @TEAMSchools/data-team` would spread that
load. Not included here since it is a `.github/` change.

**Merging this unblocks the catalog work**, which is independent of every open
question in #4762.
