### PR TITLE
fix(level_data): retry transient 5xx responses in GrowResource

### DIFF
--- a/src/teamster/libraries/level_data/grow/resources.py
+++ b/src/teamster/libraries/level_data/grow/resources.py
@@ -1,11 +1,13 @@
 import copy
+from typing import NoReturn
 
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster_shared import check
 from oauthlib.oauth2 import BackendApplicationClient
 from pydantic import PrivateAttr
 from requests import Response, Session
-from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError, Timeout
 from requests_oauthlib import OAuth2Session
 from tenacity import (
     retry,
@@ -32,11 +34,12 @@ class GrowAPIError(Exception):
 
 
 class GrowServerError(GrowAPIError):
-    """Raised when the Grow API returns a 5xx on an idempotent request.
+    """Raised when a request to the Grow API fails transiently.
 
-    An upstream gateway flake (502/504), not an application bug. Recoverable via
-    retry. POST is excluded: a 5xx on a create may have landed server-side, so
-    retrying it risks a duplicate record.
+    Covers a 5xx response and a connection-level failure (refused, reset, DNS,
+    timeout) on an idempotent request. An upstream flake, not an application
+    bug, so it is recoverable via retry. POST is excluded: the create may have
+    landed server-side, so retrying it risks a duplicate record.
     """
 
 
@@ -89,18 +92,38 @@ class GrowResource(ConfigurableResource):
         reraise=True,
     )
     def _request(self, method: str, url: str, **kwargs) -> Response:
-        response = self._session.request(method=method, url=url, **kwargs)
+        try:
+            response = self._session.request(method=method, url=url, **kwargs)
+        except (RequestsConnectionError, Timeout) as e:
+            self._raise_request_error(
+                message=str(e), cause=e, transient=method != "POST"
+            )
 
         try:
             response.raise_for_status()
             return response
         except HTTPError as e:
-            if response.status_code >= 500 and method != "POST":
-                self._log.warning(msg=response.text)
-                raise GrowServerError(response.text) from e
+            self._raise_request_error(
+                message=response.text,
+                cause=e,
+                transient=response.status_code >= 500 and method != "POST",
+            )
 
-            self._log.error(msg=response.text)
-            raise GrowAPIError(response.text) from e
+    def _raise_request_error(
+        self, message: str, cause: Exception, *, transient: bool
+    ) -> NoReturn:
+        """Raise the retryable or terminal error for a failed request.
+
+        Keeps the severity decision in one place: a transient failure logs at
+        WARNING, since the retry above recovers it and an ERROR would file a
+        false-positive GCP Error Reporting group.
+        """
+        if transient:
+            self._log.warning(msg=message)
+            raise GrowServerError(message) from cause
+
+        self._log.error(msg=message)
+        raise GrowAPIError(message) from cause
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/teamster/libraries/level_data/grow/resources.py
+++ b/src/teamster/libraries/level_data/grow/resources.py
@@ -31,6 +31,15 @@ class GrowAPIError(Exception):
     """
 
 
+class GrowServerError(GrowAPIError):
+    """Raised when the Grow API returns a 5xx on an idempotent request.
+
+    An upstream gateway flake (502/504), not an application bug. Recoverable via
+    retry. POST is excluded: a 5xx on a create may have landed server-side, so
+    retrying it risks a duplicate record.
+    """
+
+
 class GrowResource(ConfigurableResource):
     client_id: str
     client_secret: str
@@ -73,6 +82,12 @@ class GrowResource(ConfigurableResource):
             "/" + "/".join(args) if args else ""
         )
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential_jitter(initial=5, max=30),
+        retry=retry_if_exception_type(GrowServerError),
+        reraise=True,
+    )
     def _request(self, method: str, url: str, **kwargs) -> Response:
         response = self._session.request(method=method, url=url, **kwargs)
 
@@ -80,6 +95,10 @@ class GrowResource(ConfigurableResource):
             response.raise_for_status()
             return response
         except HTTPError as e:
+            if response.status_code >= 500 and method != "POST":
+                self._log.warning(msg=response.text)
+                raise GrowServerError(response.text) from e
+
             self._log.error(msg=response.text)
             raise GrowAPIError(response.text) from e
 

--- a/tests/resources/test_resource_grow_retry.py
+++ b/tests/resources/test_resource_grow_retry.py
@@ -7,6 +7,7 @@ import logging
 import types
 
 import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 from tenacity import wait_none
 
@@ -18,12 +19,13 @@ from teamster.libraries.level_data.grow.resources import (
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, text: str = "") -> None:
+    def __init__(self, status_code: int, text: str = "", json_body: dict | None = None):
         self.status_code = status_code
         self.text = text
+        self._json_body = json_body if json_body is not None else {"ok": True}
 
     def json(self) -> dict:
-        return {"ok": True}
+        return self._json_body
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -36,6 +38,9 @@ def _build_offline_resource(request_fn) -> GrowResource:
 
     object.__setattr__(grow, "_session", types.SimpleNamespace(request=request_fn))
     object.__setattr__(grow, "_log", logging.getLogger("test_grow"))
+    object.__setattr__(
+        grow, "_default_params", {"limit": 100, "district": "x", "skip": 0}
+    )
 
     return grow
 
@@ -64,6 +69,100 @@ def test_put_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
 
     assert grow.put("users", "abc", json={"name": "x"}) == {"ok": True}
     assert calls["n"] == 3
+
+
+def test_get_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx on the single-record GET branch retries.
+
+    ``get`` carries its own retry for ``GrowIncompleteResponseError``, so this
+    covers the inner ``_request`` retry running nested inside that outer loop.
+    """
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        if calls["n"] < 3:
+            return _FakeResponse(502, "502 Server Error")
+
+        return _FakeResponse(200, json_body={"_id": "abc"})
+
+    grow = _build_offline_resource(request_fn)
+    response = grow.get("users", "abc")
+
+    assert response["data"] == [{"_id": "abc"}]
+    assert calls["n"] == 3
+
+
+def test_get_paginated_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx mid-pagination retries that page and the pull still completes."""
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+    monkeypatch.setattr(GrowResource.get.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        if calls["n"] == 1:
+            return _FakeResponse(502, "502 Server Error")
+
+        return _FakeResponse(200, json_body={"count": 1, "data": [{"_id": "abc"}]})
+
+    grow = _build_offline_resource(request_fn)
+    response = grow.get("users")
+
+    assert response["count"] == 1
+    assert response["data"] == [{"_id": "abc"}]
+    assert calls["n"] == 2
+
+
+def test_connection_error_retries_then_surfaces_as_grow_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A connection-level failure retries, then lands as a catchable error.
+
+    Regression: an unwrapped ``requests`` ConnectionError is not a
+    ``GrowAPIError``, so ``grow_user_sync`` would crash instead of recording it
+    in the check's error list.
+    """
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        raise RequestsConnectionError("connection reset by peer")
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError):
+        grow.put("users", "abc", json={"name": "x"})
+
+    assert calls["n"] == 3
+
+
+def test_connection_error_on_post_does_not_retry(monkeypatch: pytest.MonkeyPatch):
+    """POST stays non-idempotent for connection failures too."""
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        raise RequestsConnectionError("connection reset by peer")
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError) as excinfo:
+        grow.post("users", json={"name": "x"})
+
+    assert not isinstance(excinfo.value, GrowServerError)
+    assert calls["n"] == 1
 
 
 def test_post_does_not_retry_on_server_error(monkeypatch: pytest.MonkeyPatch):

--- a/tests/resources/test_resource_grow_retry.py
+++ b/tests/resources/test_resource_grow_retry.py
@@ -1,0 +1,130 @@
+"""Offline retry tests for ``GrowResource``.
+
+Kept separate from ``test_resource_grow.py``, whose tests hit the live Grow API.
+"""
+
+import logging
+import types
+
+import pytest
+from requests.exceptions import HTTPError
+from tenacity import wait_none
+
+from teamster.libraries.level_data.grow.resources import (
+    GrowAPIError,
+    GrowResource,
+    GrowServerError,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> dict:
+        return {"ok": True}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} Server Error", response=self)  # pyright: ignore[reportArgumentType]
+
+
+def _build_offline_resource(request_fn) -> GrowResource:
+    """Instantiate the resource without the network setup_for_execution path."""
+    grow = GrowResource(client_id="x", client_secret="x", district_id="x")
+
+    object.__setattr__(grow, "_session", types.SimpleNamespace(request=request_fn))
+    object.__setattr__(grow, "_log", logging.getLogger("test_grow"))
+
+    return grow
+
+
+def test_put_retries_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx on a PUT is a transient gateway failure and must be retried.
+
+    Regression: a single 502 on a user update failed permanently, recorded an
+    entry in the ``zero_api_errors`` check, and fired a WARN alert for work the
+    next daily sync would have redone anyway.
+    """
+    # make tenacity backoff instant for the test
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        if calls["n"] < 3:
+            return _FakeResponse(502, "502 Server Error")
+
+        return _FakeResponse(200)
+
+    grow = _build_offline_resource(request_fn)
+
+    assert grow.put("users", "abc", json={"name": "x"}) == {"ok": True}
+    assert calls["n"] == 3
+
+
+def test_post_does_not_retry_on_server_error(monkeypatch: pytest.MonkeyPatch):
+    """A 5xx on a POST is not retried: the create may have landed server-side."""
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        return _FakeResponse(502, "502 Server Error")
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError) as excinfo:
+        grow.post("users", json={"name": "x"})
+
+    assert not isinstance(excinfo.value, GrowServerError)
+    assert calls["n"] == 1
+
+
+def test_client_error_does_not_retry(monkeypatch: pytest.MonkeyPatch):
+    """A 4xx is deterministic: surface it to the asset's error list immediately."""
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        return _FakeResponse(400, '{"message":"ValidationError"}')
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError):
+        grow.put("users", "abc", json={"name": "x"})
+
+    assert calls["n"] == 1
+
+
+def test_server_error_exhausts_retries_as_grow_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A persistent 5xx still lands in the asset's error list after retries.
+
+    ``GrowServerError`` subclasses ``GrowAPIError``, so ``grow_user_sync``
+    catches it without a change to the asset.
+    """
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        return _FakeResponse(502, "502 Server Error")
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError):
+        grow.delete("users", "abc")
+
+    assert calls["n"] == 3


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will stop a single transient 5xx from the Grow API turning into a failed asset check and a WARN alert.

Run `b25428e3-4095-4ddf-af49-6f2a230e0446` succeeded, but its `zero_api_errors` check on `kipptaf/schoolmint/grow/user_sync` failed. The one recorded error was a Google frontend 502 on a `PUT` to the Grow users endpoint for a single staff user. `GrowResource._request` converted it to `GrowAPIError` and raised immediately: the only retry in that module was on `get()`, with a `GrowIncompleteResponseError` predicate, so `post` / `put` / `delete` had no retry at all.

This adds `GrowServerError(GrowAPIError)` for 5xx on idempotent requests and retries it in `_request` with the tenacity set already imported there, matching `libraries/adp/workforce_now/api/resources.py`.

- `POST` is excluded: a 5xx on a create may have landed server-side, so retrying risks a duplicate record. That is the exact duplicate-email ValidationError seen in the 2026-06-30 check failure.
- 4xx keeps its fail-fast behavior and still lands in the asset's error list.
- A retryable 5xx logs at WARNING instead of ERROR, so recovered flakes stop filing GCP Error Reporting groups.
- No change to `grow_user_sync`: `GrowServerError` subclasses `GrowAPIError`, which the asset already catches in all three places.

Frequency check over the last 50 daily executions: 2 failures, this 502 and the June ValidationError. Impact of the bug was a false-positive alert rather than stale data, since the sync is idempotent and the next run reapplied the skipped update.

## AI Assistance

Diagnosed and authored by Claude Code under the systematic-debugging skill, human-directed. Root cause was traced from the run logs and check metadata to the resource before any code changed. Fix scope, the POST carve-out, and the branch strategy were confirmed with the author.

## Self-review

### General

- [x] Review the Claude Code Review comment posted on this PR
- [ ] Update due date and assignee on the TEAMster Asana Project

### Dagster

- [x] `uv run pytest tests/resources/test_resource_grow_retry.py` passes, 4 tests, offline with a stubbed session
- [x] `trunk check --force` clean on both changed files
- [x] No new asset, schedule, sensor, or integration, so no docs regeneration needed

## CI checks

- [ ] Trunk
- [ ] dbt Cloud
- [ ] Dagster Cloud

Refs #4764
