### PR TITLE
feat(finalsite): rank parent contacts densely and guard against student contacts

### DIFF
--- a/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
+++ b/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
@@ -597,9 +597,11 @@ Create
 -- stays SIS-agnostic and emits rows for every student record including
 -- prospects and applicants, who legitimately have no parent on file yet -- so
 -- the enrolled scope lives here, in the test, rather than in the model.
--- Every row is a Finalsite data-entry gap: a missing `primary`/`financial`
--- flag, or a parent whose own contact record is miskeyed with a student status
--- and therefore fails the adult guard.
+-- Every row is a Finalsite data-entry gap: no relationship on the record
+-- carries a `primary` or `financial` flag. A parent miskeyed with a student
+-- status does NOT surface here -- dense ranking backfills the slot from the
+-- next candidate -- so that case is reported by
+-- stg_finalsite__contact_relationships__caregiver_is_adult instead.
 select
     s.finalsite_enrollment_id,
     s.grade_name,
@@ -609,7 +611,7 @@ where
     s.status = 'enrolled'
     and s.school_year_start = {{ var("current_academic_year") }}
     and not exists (
-        select 1
+        select 1,
         from {{ ref("int_finalsite__student_contacts") }} as c
         where
             c.finalsite_enrollment_id = s.finalsite_enrollment_id

--- a/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
+++ b/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
@@ -52,16 +52,16 @@ prettier via trunk, dbt unit tests and singular tests.
 
 ## File Structure
 
-| Path                                                                                  | Responsibility                                     |
-| ------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `src/dbt/finalsite/dbt_project.yml`                                                   | Declare `current_academic_year` var (default `0`)  |
-| `src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql`              | Warn: `enrolled` record stamped with a prior year  |
-| `src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql`    | Warn: a student holds more than one `primary`      |
-| `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`       | Parent candidate set, dense ranking, adult guard   |
-| `.../properties/int_finalsite__student_contacts.yml`                                  | `accepted_values`, description, unit-test fixtures |
-| `src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql` | Warn: current enrolled student with no `contact_1` |
-| `src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`      | Warn: any slot past `contact_2`                    |
-| `src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql`             | Stop misfiling an unknown parent slot as emergency |
+| Path                                                                                  | Responsibility                                      |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `src/dbt/finalsite/dbt_project.yml`                                                   | Declare `current_academic_year` var (default `0`)   |
+| `src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql`              | Warn: `enrolled` record stamped with a prior year   |
+| `src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql`    | Warn: a student holds more than one `primary`       |
+| `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`       | Parent candidate set, dense ranking, adult guard    |
+| `.../properties/int_finalsite__student_contacts.yml`                                  | Slot-pattern test, descriptions, unit-test fixtures |
+| `src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql` | Warn: current enrolled student with no `contact_1`  |
+| `src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`      | Warn: any slot past `contact_2`                     |
+| `src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql`             | Stop misfiling an unknown parent slot as emergency  |
 
 ---
 
@@ -485,19 +485,36 @@ uv run dbt test \
 
 Expected: PASS for both unit tests.
 
-- [ ] **Step 6: Update `accepted_values` and the model description**
+- [ ] **Step 6: Replace `accepted_values` and update the descriptions**
 
-In `int_finalsite__student_contacts.yml`, add `- contact_3` to the
-`accepted_values` list for `contact_slot`, immediately after `- contact_2`.
+Corrected mid-execution. The original plan said to add `- contact_3` to the
+`accepted_values` list. That was wrong: it was based on a maximum of three
+measured against currently enrolled students, but this model emits every student
+record. 8 students across Camden and Newark have four parent slots, and dense
+ranking has no upper bound at all.
+
+In `int_finalsite__student_contacts.yml`, DELETE the whole `accepted_values`
+data test on `contact_slot` and replace it with a `dbt_utils.expression_is_true`
+test at `severity: error` asserting:
+
+```text
+regexp_contains(contact_slot, r'^(contact_[0-9]+|emergency_[1-4])$')
+```
+
+Parent slots stay unbounded; emergency slots stay bounded at four because they
+are a positional passthrough of four fixed `emrg_N` custom-field sets. Follow
+the argument syntax already used at
+`src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contacts__households.yml:22-30`.
 
 Replace the `contact_slot` column description with:
 
 ```yaml
 description:
-  Which contact this row represents — `contact_1` through `contact_3`, or
-  `emergency_1` through `emergency_4`. Parent slots are numbered densely by
-  rank, so `contact_1` is the top-ranked parent rather than strictly the
-  `primary` relationship.
+  Which contact this row represents. Parent slots are numbered densely from
+  `contact_1` with no fixed upper bound — as many as the student has qualifying
+  adults — so `contact_1` is the top-ranked parent rather than strictly the
+  `primary` relationship. `emergency_1` through `emergency_4` are the positional
+  `emrg_N` custom-field sets.
 ```
 
 Replace the model-level description's first sentence about `contact_1` and
@@ -535,9 +552,9 @@ uv run dbt build \
 ```
 
 Expected: build succeeds; the `unique_combination_of_columns` and
-`accepted_values` tests pass. If `accepted_values` fails on a `contact_4`, stop
-— the observed maximum is three and a fourth slot means the guard or the
-candidate filter is wrong.
+`expression_is_true` tests pass, including for the 8 students who have four
+parent slots. If `expression_is_true` fails, the slot label is malformed —
+inspect the failing values rather than widening the pattern.
 
 - [ ] **Step 8: Commit**
 
@@ -798,8 +815,8 @@ enrolled scope appears only inside the Task 3 test. Section 2 → Task 1 Step 2.
 Section 3 → Task 2 Step 4. Section 4 → the
 `inner join ... and rc.status = 'not_in_workflow'` in Task 2 Step 4, with the
 no-carve-out consequence asserted in Task 3 Step 3. Section 5 → Tasks 1 and 3,
-plus the `accepted_values` change in Task 2 Step 6. Section 6 → Task 4. Section
-7 → Task 2 Steps 1 and 2.
+plus the slot-pattern test in Task 2 Step 6. Section 6 → Task 4. Section 7 →
+Task 2 Steps 1 and 2.
 
 **One deviation from the spec, deliberate.** Section 4 says the guard "folds
 into the join the model already performs in `parents_typed`". It cannot: the

--- a/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
+++ b/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
@@ -1,0 +1,822 @@
+# Finalsite Parent Definition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redefine how `int_finalsite__student_contacts` selects a student's
+parents — drop the Parent-1-household filter, guard both slots against picking
+another student, rank candidates densely instead of capping at two — and add
+warn tests that surface students with no parent or with more than two.
+
+**Architecture:** The model currently picks `contact_1` from the relationship
+flagged `primary`, then picks `contact_2` only from candidates co-resident with
+`contact_1`. That coupling means a missing `primary` flag suppresses both slots.
+The rewrite builds one `parent_candidates` set (flagged `primary` or
+`financial`, related contact is an adult), ranks it, and numbers slots densely.
+Household co-membership with the **student** becomes a sort key rather than a
+gate.
+
+**Tech Stack:** dbt (BigQuery), `uv` for all Python/dbt invocation, sqlfluff +
+prettier via trunk, dbt unit tests and singular tests.
+
+## Global Constraints
+
+- Worktree is
+  `/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition`.
+  Every `git` call uses `git -C "$wt"`. Every dbt call uses
+  `--project-dir "$wt/src/dbt/<project>"`. Set
+  `wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition`
+  once per shell.
+- **Keep that shell variable lowercase.** `check-sensitive.sh` Rule 7 denies any
+  Bash command that expands a non-allowlisted `$UPPER_CASE` variable — including
+  one defined in the same command — and reports it as the misleading
+  `Cannot access sensitive path`. `wt` works; `WT` gets the whole command
+  blocked.
+- Never run bare `python`/`dbt`. Always `uv run dbt ...`.
+- The `finalsite` project is a **package**, not a standalone project. Build and
+  test its models through a district project — use `kippnewark` throughout.
+- Do not run `trunk fmt` or `trunk check` manually; the pre-commit hook formats
+  and the pre-push hook blocks. Exception: after editing SQL, run
+  `/workspaces/teamster/.trunk/tools/trunk check --force --no-fix <files> </dev/null`
+  with cwd set to the worktree before the final push, because sqlfluff fires
+  only at pre-push and in CI.
+- Commit messages use conventional commits and end with `Refs #4768`.
+- No student, parent, or contact names in any committed file, commit message, PR
+  body, or issue comment. Counts and column names only.
+- Design spec is
+  `docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md`.
+
+---
+
+## File Structure
+
+| Path                                                                                  | Responsibility                                     |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `src/dbt/finalsite/dbt_project.yml`                                                   | Declare `current_academic_year` var (default `0`)  |
+| `src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql`              | Warn: `enrolled` record stamped with a prior year  |
+| `src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql`    | Warn: a student holds more than one `primary`      |
+| `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`       | Parent candidate set, dense ranking, adult guard   |
+| `.../properties/int_finalsite__student_contacts.yml`                                  | `accepted_values`, description, unit-test fixtures |
+| `src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql` | Warn: current enrolled student with no `contact_1` |
+| `src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`      | Warn: any slot past `contact_2`                    |
+| `src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql`             | Stop misfiling an unknown parent slot as emergency |
+
+---
+
+## Task 1: Source-data warn tests
+
+Independent of the model rewrite; lands first so the rewrite starts from a clean
+build. Adds the `current_academic_year` var the first test needs.
+
+**Files:**
+
+- Modify: `src/dbt/finalsite/dbt_project.yml` (vars block, lines 33-36)
+- Create:
+  `src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql`
+- Create:
+  `src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `var("current_academic_year")` available inside the `finalsite`
+  package. Task 3 reads it.
+
+- [ ] **Step 1: Declare the year var in the finalsite package**
+
+The package has no `current_academic_year`, so
+`{{ var("current_academic_year") }}` would fail to compile. `focus` and
+`powerschool` declare it as `0` and let each district override; follow that.
+
+Replace the `vars:` block at the end of `src/dbt/finalsite/dbt_project.yml`:
+
+```yaml
+vars:
+  cloud_storage_uri_base: null
+  bigquery_external_connection_name: null
+  local_timezone: null
+  current_academic_year: 0
+```
+
+All four district projects already set `current_academic_year: 2026`, so no
+district change is needed.
+
+- [ ] **Step 2: Write the stale-enrolled test**
+
+Create `src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql`:
+
+```sql
+{{ config(severity="warn") }}
+
+-- Finalsite never rolls a graduated cohort off `enrolled` -- last year's
+-- seniors keep that status indefinitely -- and separately, some students who
+-- are still enrolled never get a current-year record created. Both surface as
+-- an `enrolled` contact stamped with a prior school year. Warn, not error:
+-- this is a standing Ops worklist inside Finalsite, and the count only falls
+-- when someone corrects records at the source.
+select
+    finalsite_enrollment_id,
+    status,
+    school_year_start,
+    grade_name,
+from {{ ref("stg_finalsite__contacts") }}
+where
+    status = 'enrolled'
+    and school_year_start < {{ var("current_academic_year") }}
+```
+
+- [ ] **Step 3: Write the single-primary test**
+
+Create
+`src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql`:
+
+```sql
+{{ config(severity="warn") }}
+
+-- `primary` is a per-student singleton in Finalsite. The old model surfaced a
+-- violation as a duplicate contact_1 failing the uniqueness test; dense ranking
+-- absorbs a second primary into contact_2 instead, so the condition is tested
+-- at the source where it can be acted on. No student trips this today -- it
+-- guards against regression rather than reporting a backlog.
+select
+    finalsite_enrollment_id,
+    count(*) as primary_relationships,
+from {{ ref("stg_finalsite__contact_relationships") }}
+where is_primary
+group by finalsite_enrollment_id
+having count(*) > 1
+```
+
+- [ ] **Step 4: Run both tests against Newark**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt test \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select stg_finalsite__contacts__no_stale_enrolled \
+           stg_finalsite__contact_relationships__single_primary
+```
+
+Expected: `stg_finalsite__contacts__no_stale_enrolled` **WARN** with 303 rows.
+`stg_finalsite__contact_relationships__single_primary` **PASS** with 0 rows.
+Neither may ERROR — an error means the var did not resolve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+git -C "$wt" add src/dbt/finalsite/dbt_project.yml src/dbt/finalsite/tests
+git -C "$wt" commit -m "test(finalsite): warn on stale enrolled records and duplicate primaries
+
+Refs #4768"
+```
+
+---
+
+## Task 2: Rewrite parent selection
+
+The core change. TDD: the existing unit test asserts the behaviour being
+removed, so it is rewritten first and must fail before the model changes.
+
+**Files:**
+
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql`
+- Modify:
+  `src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml`
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: `contact_slot` values `contact_1`, `contact_2`, `contact_3`. Task 3
+  tests these; Task 4 defends against them.
+
+- [ ] **Step 1: Rewrite the `test_student_contacts_parent_2` unit test**
+
+In `int_finalsite__student_contacts.yml`, replace the whole
+`test_student_contacts_parent_2` unit test with the version below.
+
+Three fixture changes matter. The model now reads `status` from
+`stg_finalsite__contacts` for the adult guard, so every contact fixture needs
+it. The model now refs `int_finalsite__contacts__households`, so that becomes a
+`given` input. The model no longer reads `household_ids`, so it is dropped.
+
+```yaml
+- name: test_student_contacts_parent_2
+  description:
+    Dense slot assignment. stu1 has a primary parent (con1), a financial
+    stepparent sharing stu1's household (con2), and a financial parent in a
+    different household (con3) -- yielding contact_1, contact_2, contact_3, with
+    con3 ranked last because it shares no household with the student rather than
+    being excluded. stu2 has no primary and two financial relationships --
+    yielding contact_1 and contact_2, where the old rule yielded nothing. con6
+    is a financial relationship to another STUDENT record and is excluded from
+    stu2 entirely by the adult guard.
+  model: int_finalsite__student_contacts
+  given:
+    - input: ref('stg_finalsite__contact_relationships')
+      format: sql
+      rows: |
+        select
+          'stu1' as finalsite_enrollment_id,
+          'rel1' as relationship_id,
+          'con1' as rel_id,
+          'Jane Doe' as rel_name,
+          'parent' as rel_type,
+          true as is_primary,
+          true as is_financial,
+          false as is_parent2
+        union all
+        select
+          'stu1', 'rel2', 'con2', 'John Doe', 'stepparent',
+          cast(null as boolean), true, false
+        union all
+        select
+          'stu1', 'rel3', 'con3', 'Jim Poe', 'parent',
+          cast(null as boolean), true, false
+        union all
+        select
+          'stu2', 'rel4', 'con4', 'Fay Ray', 'parent',
+          cast(null as boolean), true, false
+        union all
+        select
+          'stu2', 'rel5', 'con5', 'Gus Ray', 'parent',
+          cast(null as boolean), true, false
+        union all
+        select
+          'stu2', 'rel6', 'con6', 'Kid Ray', 'sibling',
+          cast(null as boolean), true, false
+    - input: ref('stg_finalsite__contacts')
+      format: sql
+      rows: |
+        select
+          'stu1' as finalsite_enrollment_id,
+          'enrolled' as status,
+          cast(null as string) as email,
+          'Stu' as first_name,
+          'One' as last_name,
+          cast(null as string) as phone_1_number,
+          cast(null as string) as phone_1_type,
+          cast(null as string) as phone_2_number,
+          cast(null as string) as phone_2_type,
+          cast(null as string) as phone_3_number,
+          cast(null as string) as phone_3_type,
+          cast(null as string) as address_1,
+          cast(null as string) as address_2,
+          cast(null as string) as city,
+          cast(null as string) as state,
+          cast(null as string) as zip
+        union all
+        select
+          'stu2', 'enrolled', cast(null as string), 'Stu', 'Two',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con1', 'not_in_workflow', 'jane@example.com', 'Jane', 'Doe',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con2', 'not_in_workflow', 'john@example.com', 'John', 'Doe',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con3', 'not_in_workflow', 'jim@example.com', 'Jim', 'Poe',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con4', 'not_in_workflow', 'fay@example.com', 'Fay', 'Ray',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con5', 'not_in_workflow', 'gus@example.com', 'Gus', 'Ray',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+        union all
+        select
+          'con6', 'enrolled', 'kid@example.com', 'Kid', 'Ray',
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string),
+          cast(null as string), cast(null as string), cast(null as string)
+    - input: ref('int_finalsite__contacts__households')
+      format: sql
+      rows: |
+        select 'stu1' as finalsite_enrollment_id, 'hh1' as household_id
+        union all
+        select 'con1', 'hh1'
+        union all
+        select 'con2', 'hh1'
+        union all
+        select 'con3', 'hh2'
+        union all
+        select 'stu2', 'hh3'
+        union all
+        select 'con4', 'hh3'
+        union all
+        select 'con5', 'hh3'
+        union all
+        select 'con6', 'hh3'
+    - input: ref('int_finalsite__contact_custom_attributes')
+      rows: []
+  expect:
+    format: sql
+    rows: |
+      select
+        'stu1' as finalsite_enrollment_id,
+        'contact_1' as contact_slot,
+        'con1' as finalsite_contact_id,
+        'Jane Doe' as contact_name,
+        'Jane' as contact_first_name,
+        'Doe' as contact_last_name,
+        'parent' as relationship
+      union all
+      select 'stu1', 'contact_2', 'con2', 'John Doe', 'John', 'Doe', 'stepparent'
+      union all
+      select 'stu1', 'contact_3', 'con3', 'Jim Poe', 'Jim', 'Poe', 'parent'
+      union all
+      select 'stu2', 'contact_1', 'con4', 'Fay Ray', 'Fay', 'Ray', 'parent'
+      union all
+      select 'stu2', 'contact_2', 'con5', 'Gus Ray', 'Gus', 'Ray', 'parent'
+```
+
+Note the `expect` block lists only the seven columns under test. dbt unit tests
+compare only the columns named in `expect`.
+
+- [ ] **Step 2: Add `status` to the other unit test's fixture**
+
+`test_student_contacts_phone_typed_slots` also mocks `stg_finalsite__contacts`
+and will fail to compile once the model reads `status`. In that test's
+`stg_finalsite__contacts` input, add `'not_in_workflow' as status,` immediately
+after the `finalsite_enrollment_id` line, delete the
+`array<string>[] as household_ids` line, and add a
+`ref('int_finalsite__contacts__households')` input with `rows: []`.
+
+- [ ] **Step 3: Run the unit tests to verify they fail**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt test \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select int_finalsite__student_contacts
+```
+
+Expected: FAIL. `test_student_contacts_parent_2` fails because the current model
+excludes `con3` and emits nothing for `stu2`. Compilation errors referencing
+`status` or `int_finalsite__contacts__households` are also expected at this
+point.
+
+- [ ] **Step 4: Replace the parent CTEs in the model**
+
+In `int_finalsite__student_contacts.sql`, delete the five CTEs
+`contact_1_picked`, `primary_household_ids`, `contact_household_ids`,
+`contact_2_candidates`, and `contact_2_ranked`, and replace `parent_picks` with
+the block below. Everything from `parents_typed` onward is unchanged.
+
+```sql
+with
+    parent_candidates as (
+        -- A parent candidate is any relationship flagged `primary` or
+        -- `financial` whose related contact is an ADULT. Finalsite marks adults
+        -- with status `not_in_workflow`; every other status (enrolled, inquiry,
+        -- waitlisted, ...) belongs to a student record, and a student is never
+        -- a parent. This guard -- not `rel_type` -- is what keeps a co-resident
+        -- sibling out of a parent slot, which matters because an adult sibling
+        -- CAN legitimately be a guardian and must still qualify.
+        select
+            r.finalsite_enrollment_id,
+            r.relationship_id,
+            r.rel_id,
+            r.rel_name,
+            r.rel_type,
+
+            coalesce(r.is_primary, false) as is_primary,
+        from {{ ref("stg_finalsite__contact_relationships") }} as r
+        inner join
+            {{ ref("stg_finalsite__contacts") }} as rc
+            on r.rel_id = rc.finalsite_enrollment_id
+            and rc.status = 'not_in_workflow'
+        where coalesce(r.is_primary, false) or coalesce(r.is_financial, false)
+    ),
+
+    candidates_sharing_student_household as (
+        -- One row per (student, candidate) that co-belong to any household.
+        -- grain projection: a pair sharing several households would otherwise
+        -- repeat and fan out the rank below. Not a mask for upstream duplicates.
+        select distinct
+            c.finalsite_enrollment_id,
+            c.rel_id,
+        from parent_candidates as c
+        inner join
+            {{ ref("int_finalsite__contacts__households") }} as sh
+            on c.finalsite_enrollment_id = sh.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contacts__households") }} as ch
+            on c.rel_id = ch.finalsite_enrollment_id
+            and sh.household_id = ch.household_id
+    ),
+
+    parent_picks as (
+        -- Dense slot numbering: the `primary` relationship sorts first when one
+        -- exists, then co-residents with the student, then an arbitrary but
+        -- stable relationship_id. Household co-membership ORDERS candidates; it
+        -- does not exclude them, so a non-resident parent still fills a slot.
+        -- Numbering has no gaps, so a student with no `primary` still gets a
+        -- populated contact_1 rather than starting at contact_2.
+        select
+            c.finalsite_enrollment_id,
+            c.rel_id,
+            c.rel_name,
+            c.rel_type,
+
+            concat(
+                'contact_',
+                cast(
+                    row_number() over (
+                        partition by c.finalsite_enrollment_id
+                        order by
+                            c.is_primary desc,
+                            (s.rel_id is not null) desc,
+                            c.relationship_id asc
+                    ) as string
+                )
+            ) as contact_slot,
+        from parent_candidates as c
+        left join
+            candidates_sharing_student_household as s
+            on c.finalsite_enrollment_id = s.finalsite_enrollment_id
+            and c.rel_id = s.rel_id
+    ),
+```
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt test \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select int_finalsite__student_contacts
+```
+
+Expected: PASS for both unit tests.
+
+- [ ] **Step 6: Update `accepted_values` and the model description**
+
+In `int_finalsite__student_contacts.yml`, add `- contact_3` to the
+`accepted_values` list for `contact_slot`, immediately after `- contact_2`.
+
+Replace the `contact_slot` column description with:
+
+```yaml
+description:
+  Which contact this row represents — `contact_1` through `contact_3`, or
+  `emergency_1` through `emergency_4`. Parent slots are numbered densely by
+  rank, so `contact_1` is the top-ranked parent rather than strictly the
+  `primary` relationship.
+```
+
+Replace the model-level description's first sentence about `contact_1` and
+`contact_2` with:
+
+```yaml
+description:
+  SIS-agnostic long-format contact list for Finalsite student records — one row
+  per (student, contact slot), grain `(finalsite_enrollment_id, contact_slot)`.
+  Parent slots (`contact_1`, `contact_2`, `contact_3`) come from every
+  relationship flagged `primary` or `financial` whose related contact is an
+  adult (Finalsite status `not_in_workflow`), ranked by the `primary` flag, then
+  by sharing a household with the student, then by `relationship_id`, and
+  numbered densely. Household co-membership orders candidates rather than
+  excluding them, so a non-resident parent still fills a slot. `emergency_1`
+  through `emergency_4` are the `custom_attributes` `emrg_N` sets mapped
+  positionally — `emergency_N` is `emrg_N` as-is, with no priority re-sort and
+  no gap-filling. Sparse — a slot row is emitted only when that slot has data,
+  so emergency slots may have gaps. Feeds the downstream PowerSchool/Focus
+  contact receivers built on top of this model.
+```
+
+Also update the `is_household_member` column description, which currently claims
+`contact_2` requires co-membership by construction. Replace its final
+parenthetical with:
+`(household co-membership now orders parent slots rather than gating them, so a parent slot implies nothing about co-residence)`.
+
+- [ ] **Step 7: Build the model against Newark and check the distribution**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt build \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select int_finalsite__student_contacts+
+```
+
+Expected: build succeeds; the `unique_combination_of_columns` and
+`accepted_values` tests pass. If `accepted_values` fails on a `contact_4`, stop
+— the observed maximum is three and a fourth slot means the guard or the
+candidate filter is wrong.
+
+- [ ] **Step 8: Commit**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+git -C "$wt" add src/dbt/finalsite/models/api/intermediate
+git -C "$wt" commit -m "feat(finalsite): rank parent contacts densely and guard against student contacts
+
+Refs #4768"
+```
+
+---
+
+## Task 3: Slot-count warn tests
+
+**Files:**
+
+- Create:
+  `src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql`
+- Create:
+  `src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`
+
+**Interfaces:**
+
+- Consumes: `var("current_academic_year")` from Task 1; `contact_slot` values
+  `contact_1`..`contact_3` from Task 2.
+- Produces: nothing later tasks rely on.
+
+- [ ] **Step 1: Write the zero-contact test**
+
+Create
+`src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql`:
+
+```sql
+{{ config(severity="warn") }}
+
+-- A currently enrolled student with no parent slot at all. The model itself
+-- stays SIS-agnostic and emits rows for every student record including
+-- prospects and applicants, who legitimately have no parent on file yet -- so
+-- the enrolled scope lives here, in the test, rather than in the model.
+-- Every row is a Finalsite data-entry gap: a missing `primary`/`financial`
+-- flag, or a parent whose own contact record is miskeyed with a student status
+-- and therefore fails the adult guard.
+select
+    s.finalsite_enrollment_id,
+    s.grade_name,
+    s.school_year_start,
+from {{ ref("stg_finalsite__contacts") }} as s
+where
+    s.status = 'enrolled'
+    and s.school_year_start = {{ var("current_academic_year") }}
+    and not exists (
+        select 1
+        from {{ ref("int_finalsite__student_contacts") }} as c
+        where
+            c.finalsite_enrollment_id = s.finalsite_enrollment_id
+            and c.contact_slot = 'contact_1'
+    )
+```
+
+- [ ] **Step 2: Write the extra-contacts test**
+
+Create
+`src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`:
+
+```sql
+{{ config(severity="warn") }}
+
+-- A student with more parents than the two conventional slots. The wide
+-- downstream receivers (contacts pivot, ParentSquare, DeansList, the contacts
+-- bridge) all carry two parent columns, so anything past contact_2 is emitted
+-- here but dropped before it reaches an extract. Warn so the count stays
+-- visible; matching `contact_%` rather than a literal catches a fourth slot too.
+select
+    finalsite_enrollment_id,
+    contact_slot,
+from {{ ref("int_finalsite__student_contacts") }}
+where
+    contact_slot like 'contact\\_%'
+    and contact_slot not in ('contact_1', 'contact_2')
+```
+
+- [ ] **Step 3: Run both tests against Newark**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt test \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select int_finalsite__student_contacts__enrolled_has_contact_1 \
+           int_finalsite__student_contacts__no_extra_contacts
+```
+
+Expected: `enrolled_has_contact_1` **WARN** with 1 row — the single student
+whose parent's contact record carries `status = 'inquiry'` and therefore fails
+the adult guard. This is the deliberate no-carve-out case from the spec.
+`no_extra_contacts` **WARN** with 25 rows for Newark.
+
+If `enrolled_has_contact_1` returns 0 rows, the guard is not being applied. If
+it returns hundreds, the dense ranking is not working and slots are still
+anchored on `primary`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+git -C "$wt" add src/dbt/finalsite/tests
+git -C "$wt" commit -m "test(finalsite): warn on students with no parent slot or more than two
+
+Refs #4768"
+```
+
+---
+
+## Task 4: Downstream misclassification guard
+
+`dim_student_contact_persons` splits rows into parents and emergency contacts
+with complementary predicates. A `contact_3` row satisfies
+`not in ('contact_1', 'contact_2')` and would be recorded as an emergency
+contact, keyed by student plus slot instead of by person identity. No existing
+test catches it.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql:57`
+
+**Interfaces:**
+
+- Consumes: `contact_slot` values from Task 2.
+- Produces: nothing.
+
+- [ ] **Step 1: Make the emergency branch explicit**
+
+At line 57, replace:
+
+```sql
+        where contact_slot not in ('contact_1', 'contact_2')
+```
+
+with:
+
+```sql
+        where contact_slot like 'emergency\\_%'
+```
+
+Leave the parent branch at line 38 as `in ('contact_1', 'contact_2')`. A
+`contact_3` row then matches neither branch and is dropped, consistent with the
+other wide receivers — extending them is out of scope per the spec.
+
+Update the CTE comment directly above `emergency_persons` to say the branch is
+matched positively so an unrecognised parent slot is dropped rather than
+misfiled.
+
+- [ ] **Step 2: Build the dimension and verify no parent slot leaked**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt build \
+  --project-dir "$wt/src/dbt/kipptaf" \
+  --select dim_student_contact_persons bridge_student_contacts
+```
+
+Expected: both build and their tests pass.
+
+- [ ] **Step 3: Confirm no `contact_` slot reached the emergency branch**
+
+Run this against the built dimension using the BigQuery MCP:
+
+```sql
+select count(*) as leaked_parent_slots
+from `teamster-332318.<your_dev_schema>_marts.dim_student_contact_persons`
+where contact_slot like 'contact%'
+```
+
+Expected: 0. The parent branch keys on `person_identity` and does not carry
+`contact_slot` into the emergency-shaped output, so any row matching here means
+the predicate change did not take.
+
+- [ ] **Step 4: Commit**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+git -C "$wt" add src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+git -C "$wt" commit -m "fix(kipptaf): match emergency contact slots positively
+
+Refs #4768"
+```
+
+---
+
+## Task 5: Full-region verification and push
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build the model in all three cutover regions**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+for p in kippnewark kippcamden kipppaterson; do
+  echo "=== $p"
+  uv run dbt build --project-dir "$wt/src/dbt/$p" \
+    --select int_finalsite__student_contacts+
+done
+```
+
+Expected: all three succeed. `kippmiami` has the `api` layer enabled but is not
+a contacts-cutover region; it is not built here.
+
+- [ ] **Step 2: Confirm the per-region slot distribution**
+
+Query the built tables and compare against the spec's audit table. Scope to
+`status = 'enrolled'` and `school_year_start = 2026`:
+
+| Region   | Students | 1 slot | 2 slots | 3 slots |
+| -------- | -------- | ------ | ------- | ------- |
+| Newark   | 6,786    | 3,682  | 3,079   | 25      |
+| Camden   | 2,163    | 1,264  | 840     | 7       |
+| Paterson | 879      | 539    | 297     | 0       |
+
+Newark should have 0 students with no slot except the single guard exclusion;
+Camden and Paterson have 52 and 43 respectively, which predate this change.
+
+- [ ] **Step 3: Lint the changed SQL**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+cd "$wt" && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  $(git -C "$wt" diff --name-only origin/main...HEAD | grep -E '\.(sql|yml|md)$') \
+  </dev/null
+```
+
+Run in the background — a `--force` check over this many files takes more than
+two minutes, and its progress output contains no result lines, so a grep of
+partial output reads as a false clean. Only interpret the result after the
+command exits.
+
+Expected: no sqlfluff or markdownlint issues. If the trunk binary is missing,
+fall back to `~/.cache/trunk/launcher/trunk`.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+git -C "$wt" push -u origin cbini/feat/claude-finalsite-parent-definition
+```
+
+Open the PR with `.github/pull_request_template.md` as the body and
+`Closes #4768` in it. Do not name any student or contact in the PR body — cite
+counts and column names only.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Section 1 (no student-scope filter) is satisfied by not
+adding one — Task 2 leaves the model emitting all student records, and the
+enrolled scope appears only inside the Task 3 test. Section 2 → Task 1 Step 2.
+Section 3 → Task 2 Step 4. Section 4 → the
+`inner join ... and rc.status = 'not_in_workflow'` in Task 2 Step 4, with the
+no-carve-out consequence asserted in Task 3 Step 3. Section 5 → Tasks 1 and 3,
+plus the `accepted_values` change in Task 2 Step 6. Section 6 → Task 4. Section
+7 → Task 2 Steps 1 and 2.
+
+**One deviation from the spec, deliberate.** Section 4 says the guard "folds
+into the join the model already performs in `parents_typed`". It cannot: the
+guard has to run before ranking, or a student contact would consume a rank and
+shift every slot below it. The plan applies the guard in `parent_candidates` and
+leaves the `parents_typed` join alone, so the model joins
+`stg_finalsite__contacts` twice. The spec's intent — one condition, no
+`not exists` — is preserved.
+
+**Placeholder scan.** The only placeholder is `<your_dev_schema>` in Task 4 Step
+3, which is the implementer's own dbt target schema and cannot be known in
+advance.
+
+**Type consistency.** `contact_slot` is a string everywhere, produced by
+`concat('contact_', cast(row_number() ... as string))` in Task 2 and matched as
+`contact\_%` / `emergency\_%` in Tasks 3 and 4. The backslash escapes the
+underscore, which is a single-character wildcard in BigQuery `LIKE`; without it
+`contact_1` and a hypothetical `contactX1` both match.
+`int_finalsite__contacts__households` exposes `finalsite_enrollment_id` and
+`household_id`, matching its use in Task 2 Step 4 and in the unit-test fixture.

--- a/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
+++ b/docs/superpowers/plans/2026-08-07-finalsite-parent-definition.md
@@ -576,11 +576,13 @@ Refs #4768"
   `src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql`
 - Create:
   `src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql`
+- Create:
+  `src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql`
 
 **Interfaces:**
 
-- Consumes: `var("current_academic_year")` from Task 1; `contact_slot` values
-  `contact_1`..`contact_3` from Task 2.
+- Consumes: `var("current_academic_year")` from Task 1; densely-numbered
+  `contact_slot` values from Task 2.
 - Produces: nothing later tasks rely on.
 
 - [ ] **Step 1: Write the zero-contact test**
@@ -647,21 +649,80 @@ uv run dbt test \
            int_finalsite__student_contacts__no_extra_contacts
 ```
 
-Expected: `enrolled_has_contact_1` **WARN** with 1 row — the single student
-whose parent's contact record carries `status = 'inquiry'` and therefore fails
-the adult guard. This is the deliberate no-carve-out case from the spec.
-`no_extra_contacts` **WARN** with 25 rows for Newark.
+Expected, corrected mid-execution against the built model: both tests PASS with
+0 rows for `enrolled_has_contact_1` and WARN with 49 rows for
+`no_extra_contacts`.
 
-If `enrolled_has_contact_1` returns 0 rows, the guard is not being applied. If
-it returns hundreds, the dense ranking is not working and slots are still
-anchored on `primary`.
+The original plan predicted 1 row for `enrolled_has_contact_1` — the student
+whose parent's contact record carries `status = 'inquiry'` and so fails the
+adult guard. Dense ranking makes that prediction wrong: that student's other
+`financial` parent backfills `contact_1`, so the zero-contact test cannot see
+the guard exclusion at all. Step 4 below adds a test that surfaces it directly.
 
-- [ ] **Step 4: Commit**
+The original 25 for `no_extra_contacts` counted currently-enrolled students; the
+model is unscoped and the test counts rows, giving 49.
+
+If `enrolled_has_contact_1` returns hundreds, the dense ranking is not working
+and slots are still anchored on `primary`.
+
+- [ ] **Step 4: Write the guard-exclusion test**
+
+Added mid-execution. The adult guard drops any relationship whose related
+contact carries a student status — normally correct, since a student is never a
+parent. But a parent record miskeyed with a student status is dropped too, and
+dense ranking then backfills the slot from another candidate, so the exclusion
+is invisible. This test surfaces the miskeyed record directly instead of relying
+on the zero-contact test as a proxy.
+
+Create
+`src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql`:
+
+```sql
+{{ config(severity="warn") }}
+
+-- A relationship flagged as a caregiver whose related contact does NOT carry
+-- Finalsite's adult status. Almost always this is correct and the related
+-- person really is a student -- a sibling flagged `financial`, say -- and the
+-- model's adult guard drops it as intended. The rows worth acting on are the
+-- inverse: an adult whose own contact record was miskeyed with a student
+-- status, whose relationship the guard then discards silently, because dense
+-- ranking backfills the slot from another candidate and nothing else reports
+-- the loss. Warn: each row is a Finalsite record to inspect, not a build
+-- failure.
+select
+    r.finalsite_enrollment_id,
+    r.rel_id,
+    r.rel_type,
+    c.status as related_contact_status,
+    c.grade_name as related_contact_grade,
+from {{ ref("stg_finalsite__contact_relationships") }} as r
+inner join
+    {{ ref("stg_finalsite__contacts") }} as c
+    on r.rel_id = c.finalsite_enrollment_id
+where
+    (coalesce(r.is_primary, false) or coalesce(r.is_financial, false))
+    and c.status != 'not_in_workflow'
+```
+
+Run it:
+
+```bash
+wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
+uv run dbt test \
+  --project-dir "$wt/src/dbt/kippnewark" \
+  --select stg_finalsite__contact_relationships__caregiver_is_adult
+```
+
+Expected: **WARN** with a small number of rows — 1 for Newark on the current
+load. A large count means the guard is excluding far more than intended and the
+`not_in_workflow` assumption needs re-examining before merge.
+
+- [ ] **Step 5: Commit**
 
 ```bash
 wt=/workspaces/teamster/.worktrees/cbini/feat/claude-finalsite-parent-definition
 git -C "$wt" add src/dbt/finalsite/tests
-git -C "$wt" commit -m "test(finalsite): warn on students with no parent slot or more than two
+git -C "$wt" commit -m "test(finalsite): warn on missing, excess, and discarded parent contacts
 
 Refs #4768"
 ```

--- a/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
+++ b/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
@@ -147,13 +147,25 @@ inner join to `stg_finalsite__contacts` already drops them.
 The guard currently excludes exactly one real parent network-wide — a contact
 whose own record carries `status = 'inquiry'` and a grade, i.e. an adult
 miskeyed as a student — out of 6,771 Newark primary relationships. This is
-deliberately **not** carved out. The affected student then has no `contact_1`,
-the 0-contact test fires, and Ops corrects the miskeyed record at source. A
-carve-out would trade that signal for a permanent exception to reason about.
+deliberately **not** carved out: a carve-out would be a permanent exception to
+reason about, and the guard's whole value is that it has no exceptions.
+
+The exclusion is **silent**, and an earlier draft of this spec was wrong about
+why that is acceptable. It claimed the affected student would be left with no
+`contact_1`, firing the zero-contact test. Dense ranking makes that false — the
+student's other `financial` parent backfills `contact_1`, so no downstream
+symptom appears at all. The student keeps a reachable parent, but the miskeyed
+record goes unreported and their listed first contact is not their designated
+primary.
+
+Because the symptom is invisible, the condition is tested at the source instead
+— see the fifth test in section 5, which reports any caregiver-flagged
+relationship whose related contact lacks the adult status. That surfaces the
+miskeyed record directly rather than hoping a downstream slot goes empty.
 
 ### 5. Tests
 
-Four additions, all `warn` severity:
+Five additions, all `warn` severity:
 
 1. **Zero contacts** — a singular test listing students with
    `status = 'enrolled'` and `school_year_start = var('current_academic_year')`
@@ -165,6 +177,11 @@ Four additions, all `warn` severity:
 1. **Stale enrolled** — section 2 above, on `stg_finalsite__contacts`.
 1. **Multiple primary relationships** — asserts no student record holds more
    than one relationship flagged `is_primary`.
+1. **Caregiver is an adult** — reports any relationship flagged `primary` or
+   `financial` whose related contact does not carry `not_in_workflow`. Most rows
+   are correct exclusions (a sibling flagged `financial`); the actionable ones
+   are adults miskeyed with a student status, whose relationship the guard
+   discards with no downstream symptom. 1 row for Newark on the current load.
 
 The `accepted_values` enumeration on `contact_slot` is **removed**, not
 extended. Dense ranking produces as many parent slots as a student has

--- a/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
+++ b/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
@@ -230,11 +230,17 @@ fixture omits, since co-membership is now computed against the student.
 
 ## Out of scope
 
-- **Extending the wide receivers.** `int_students__contacts_pivot`,
-  `rpt_parentsquare__parents`, `rpt_deanslist__family_contacts`, and
-  `bridge_student_contacts` all hardcode a two-slot surface and will drop
-  `contact_3`. No receiver needs a third contact today and it affects 32
-  students; extending them is a separate change.
+- **Extending the wide receivers.** `int_students__contacts` has six real
+  consumers. `int_students__contacts_pivot` and `rpt_parentsquare__parents` drop
+  `contact_3` and later by construction (a fixed `PIVOT ... in (...)` list; an
+  explicit `contact_slot in ('contact_1', 'contact_2')` filter).
+  `rpt_deanslist__family_contacts`, `bridge_student_contacts`, and
+  `dim_student_contact_persons` now exclude those slots explicitly, added in
+  this branch. `rpt_clever__students` is a per-contact feed rather than a
+  two-slot one, and carries a third parent through as a primary contact — a
+  deliberate, accepted behaviour change affecting about 32 students. No receiver
+  needs a third contact column added today; extending one to expose it is a
+  separate change.
 - **Emergency-slot duplication.** The `emrg_N` custom fields are a positional
   passthrough with no dedup against the parent slots or against each other. At
   least one student emits four contact rows for two people, with the primary

--- a/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
+++ b/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
@@ -33,8 +33,13 @@ Qualifying parents per student under the proposed definition:
 | Camden   | 2,163    | 52  | 1,264 | 840   | 7   | 3   |
 | Paterson | 879      | 43  | 539   | 297   | 0   | 2   |
 
-No student anywhere has more than three. 32 students network-wide have three,
-and today the third is discarded.
+32 of these students have three, and today the third is discarded.
+
+That table is scoped to currently enrolled students. **The model is not** — it
+stays SIS-agnostic and emits a row for every student record, including withdrawn
+students and prospects. Across that full population the cutover regions hold 72
+students with three parent slots and 8 with four. Dense ranking has no upper
+bound, so no fixed maximum can be asserted about `contact_slot`; see section 5.
 
 Two failure modes the household filter causes, both observed:
 
@@ -100,12 +105,11 @@ Slot assignment is **dense** — candidates are ranked, then numbered `contact_1
 1. `relationship_id` ascending
 
 Dense numbering matters. If `contact_1` were reserved for the `primary`
-relationship and left empty when none exists, a student with three
-`financial`-only candidates would emit `contact_2` through `contact_4` — which
-contradicts both the observed maximum of three and the `accepted_values` list.
-It would also make the zero-contact test misreport: a student holding
-`contact_2` and `contact_3` but no `contact_1` would be counted as having no
-contacts.
+relationship and left empty when none exists, the zero-contact test would
+misreport: a student holding `contact_2` and `contact_3` but no `contact_1`
+would be counted as having no contacts at all. Every slot number would also
+shift by one for exactly the students whose data is already weakest, making the
+`contact_2` column mean different things for different students.
 
 The cost is that `contact_1` no longer means "the `primary` relationship"; it
 means "the top-ranked parent". Of the 9,733 current students across the cutover
@@ -162,7 +166,18 @@ Four additions, all `warn` severity:
 1. **Multiple primary relationships** — asserts no student record holds more
    than one relationship flagged `is_primary`.
 
-The `accepted_values` test on `contact_slot` is extended to include `contact_3`.
+The `accepted_values` enumeration on `contact_slot` is **removed**, not
+extended. Dense ranking produces as many parent slots as a student has
+qualifying adults — 8 students already have four — so an enumerated list is the
+wrong shape and would fail again at five. It is replaced by a
+`dbt_utils.expression_is_true` assertion at `severity: error`:
+
+```text
+regexp_contains(contact_slot, r'^(contact_[0-9]+|emergency_[1-4])$')
+```
+
+Parent slots stay unbounded; emergency slots stay bounded at four, because they
+are a positional passthrough of four fixed `emrg_N` custom-field sets.
 
 The fourth test replaces a signal the redesign removes. Today a second `primary`
 on one student produces two `contact_1` rows and fails the model's

--- a/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
+++ b/docs/superpowers/specs/2026-08-07-finalsite-parent-definition-design.md
@@ -1,0 +1,223 @@
+# Finalsite parent definition — design
+
+Refs #4768
+
+## Problem
+
+`int_finalsite__student_contacts` fills two parent slots, `contact_1` and
+`contact_2`, from `stg_finalsite__contact_relationships`. Three properties of
+the current pick are wrong or unstated:
+
+1. `contact_2` is defined relative to **Parent 1's household** — a candidate
+   qualifies only if they co-belong to a household with the contact chosen as
+   `contact_1`. This is an undocumented addition. The package CLAUDE.md states
+   the intended rule as "`primary` = Parent 1, an additional
+   `financial`-without-`primary` relationship = Parent 2" and notes that
+   "`households` carry only id + address — membership has no roles."
+1. Because `contact_2` is anchored on Parent 1, a missing `primary` flag
+   suppresses **both** slots, not just the first.
+1. Nothing checks that a selected contact is not themselves a student, and a
+   third qualifying parent is silently discarded by a `relationship_id`
+   tie-break.
+
+### Audit evidence
+
+Measured across the three cutover NJ regions (Newark, Camden, Paterson) on the
+2026-08-07 load, scoped to `status = 'enrolled'` and `school_year_start = 2026`.
+
+Qualifying parents per student under the proposed definition:
+
+| Region   | Students | 0   | 1     | 2     | 3   | Max |
+| -------- | -------- | --- | ----- | ----- | --- | --- |
+| Newark   | 6,786    | 0   | 3,682 | 3,079 | 25  | 3   |
+| Camden   | 2,163    | 52  | 1,264 | 840   | 7   | 3   |
+| Paterson | 879      | 43  | 539   | 297   | 0   | 2   |
+
+No student anywhere has more than three. 32 students network-wide have three,
+and today the third is discarded.
+
+Two failure modes the household filter causes, both observed:
+
+- A parent with a **duplicate contact record** splits the household link. The
+  flagged `primary` relationship points at one record while the student's
+  household contains the other, so the co-membership test fails and the student
+  gets no contacts despite having a correctly flagged parent.
+- Legitimately **non-resident** parents are excluded. In the pre-refresh Newark
+  snapshot, 369 relationship rows were flagged `financial`, typed as a
+  caregiver, and dropped solely for living elsewhere.
+
+## Decisions
+
+### 1. Student scope — no filter
+
+`int_finalsite__student_contacts` stays SIS-agnostic and continues to emit rows
+for every student record, including prospects and applicants. This preserves the
+package convention: "Filtering `where is_primary` yields ALL Finalsite student
+records — scope to enrolled students downstream."
+
+Verified that downstream receivers already scope correctly. Of 303 Newark
+student records still carrying `status = 'enrolled'` for `school_year_start`
+2025, 257 reach `int_students__contacts`, but only 15 reach
+`rpt_parentsquare__parents` and `rpt_deanslist__family_contacts` — the
+receivers' PowerSchool enrollment joins drop the rest.
+
+Those 15 are **not** a leak. PowerSchool has all 15 at `academic_year = 2026`,
+`grade_level = 12`, `enroll_status = 0` — actively enrolled retained seniors.
+Finalsite is the stale side; it never created a current-year record for them. A
+`school_year_start` filter applied on the Finalsite side would wrongly remove 15
+current students' contacts from both receivers.
+
+`is_alumni` is rejected as a scope signal. It marks two unrelated populations:
+302 prior-year graduating seniors, and 104 adults who are current contacts and
+themselves alumni of the school. Applied contact-side it would drop 104
+legitimate parents. It is not added to staging.
+
+### 2. Stale-enrolled warning
+
+New `warn`-severity test on `stg_finalsite__contacts`, asserting no row has
+`status = 'enrolled'` and `school_year_start < var('current_academic_year')`.
+
+The test lives in the finalsite package so all four regions inherit it. It will
+sit yellow as a standing population — accepted deliberately, because the count
+is a live Ops worklist rather than a transient anomaly. It catches two distinct
+Finalsite failures with the same predicate: graduates never rolled off
+`enrolled`, and current students never rolled forward to the new year.
+
+### 3. Parent selection
+
+Replace the `contact_1` / `contact_2` CTEs with a single candidate set.
+
+A **parent candidate** is a relationship on a student record where:
+
+- `is_primary` or `is_financial` is true, and
+- the related contact's `status` is `not_in_workflow`.
+
+Slot assignment is **dense** — candidates are ranked, then numbered `contact_1`,
+`contact_2`, `contact_3` with no gaps. The rank is:
+
+1. `is_primary` descending (the flagged Parent 1 sorts first when present)
+1. household co-membership with the **student** descending
+1. `relationship_id` ascending
+
+Dense numbering matters. If `contact_1` were reserved for the `primary`
+relationship and left empty when none exists, a student with three
+`financial`-only candidates would emit `contact_2` through `contact_4` — which
+contradicts both the observed maximum of three and the `accepted_values` list.
+It would also make the zero-contact test misreport: a student holding
+`contact_2` and `contact_3` but no `contact_1` would be counted as having no
+contacts.
+
+The cost is that `contact_1` no longer means "the `primary` relationship"; it
+means "the top-ranked parent". Of the 9,733 current students across the cutover
+regions who have at least one candidate, 9,691 (99.6%) have a `primary` among
+them, and for those the two readings select the same contact. The remaining 42
+have candidates but no `primary`; a populated `contact_1` is what lets the wide
+receivers show them a parent at all.
+
+The Parent-1-household join, the `primary_household_ids` and
+`contact_household_ids` CTEs, and the `rn_contact_2 = 1` cap are all deleted.
+Household co-membership becomes a sort key computed against the student's own
+`household_ids`, reusing the existing `int_finalsite__contacts__households`
+model rather than re-flattening the array.
+
+Two consequences worth stating explicitly:
+
+- `contact_2` no longer depends on `contact_1`. A student with no `primary` flag
+  but with `financial` relationships now gets contacts, where previously they
+  got none.
+- Ordering by household co-membership before `relationship_id` fixes observed
+  cases where a non-resident candidate won the arbitrary tie-break over a
+  co-resident one.
+
+### 4. Guard shape — no carve-out
+
+The guard is a single condition on the related contact:
+`status = 'not_in_workflow'`. It folds into the join the model already performs
+in `parents_typed` to fetch the contact's name, email, and phone.
+
+No `not exists` form and no allowance for unresolvable `rel_id`s. Of 21,783
+flagged relationship rows across the cutover regions, **zero** point at a
+contact with no record; all 461 unresolvable rows are unflagged. The existing
+inner join to `stg_finalsite__contacts` already drops them.
+
+The guard currently excludes exactly one real parent network-wide — a contact
+whose own record carries `status = 'inquiry'` and a grade, i.e. an adult
+miskeyed as a student — out of 6,771 Newark primary relationships. This is
+deliberately **not** carved out. The affected student then has no `contact_1`,
+the 0-contact test fires, and Ops corrects the miskeyed record at source. A
+carve-out would trade that signal for a permanent exception to reason about.
+
+### 5. Tests
+
+Four additions, all `warn` severity:
+
+1. **Zero contacts** — a singular test listing students with
+   `status = 'enrolled'` and `school_year_start = var('current_academic_year')`
+   that have no `contact_1` row. The test applies the enrolled scope even though
+   the model does not; scoping the denominator here avoids firing on prospects
+   and applicants, who legitimately have no parent on file yet.
+1. **Three or more contacts** — asserts no `contact_3` row exists. Fires when
+   the two conventional slots are insufficient, which today is 32 students.
+1. **Stale enrolled** — section 2 above, on `stg_finalsite__contacts`.
+1. **Multiple primary relationships** — asserts no student record holds more
+   than one relationship flagged `is_primary`.
+
+The `accepted_values` test on `contact_slot` is extended to include `contact_3`.
+
+The fourth test replaces a signal the redesign removes. Today a second `primary`
+on one student produces two `contact_1` rows and fails the model's
+`(finalsite_enrollment_id, contact_slot)` uniqueness test — an intentional loud
+failure, documented in the current model comments. Under dense ranking the
+second `primary` silently becomes `contact_2` instead. Testing the source
+condition directly preserves the signal and reports it against the record that
+needs fixing. No current student holds more than one `primary`, so this test
+starts green and guards against regression rather than reporting a backlog.
+
+### 6. Downstream defensive fix
+
+`dim_student_contact_persons` partitions rows with
+`where contact_slot not in ('contact_1', 'contact_2')` into `emergency_persons`,
+keyed by student plus slot rather than by person identity. A `contact_3` row
+would fall into that branch and be recorded as an emergency contact. No test
+would fail.
+
+Change that predicate to an explicit `like 'emergency%'` so unknown parent slots
+are excluded rather than misclassified.
+
+### 7. Existing unit test
+
+`test_student_contacts_parent_2` asserts the behaviour being removed: its `con3`
+fixture is a `financial` relationship in a different household from Parent 1,
+expected to be excluded. Rewrite it so `con3` becomes `contact_3`, ordered after
+`con2` because `con2` shares the student's household. The fixture's `stu2` case
+— no `primary`, two `financial` relationships, expecting no rows — must also
+change: under dense ranking `stu2` yields `contact_1` and `contact_2`.
+
+Fixtures need a `households` value on the student records, which the current
+fixture omits, since co-membership is now computed against the student.
+
+## Out of scope
+
+- **Extending the wide receivers.** `int_students__contacts_pivot`,
+  `rpt_parentsquare__parents`, `rpt_deanslist__family_contacts`, and
+  `bridge_student_contacts` all hardcode a two-slot surface and will drop
+  `contact_3`. No receiver needs a third contact today and it affects 32
+  students; extending them is a separate change.
+- **Emergency-slot duplication.** The `emrg_N` custom fields are a positional
+  passthrough with no dedup against the parent slots or against each other. At
+  least one student emits four contact rows for two people, with the primary
+  parent's only reachable phone number sitting in a duplicated emergency slot
+  under a misspelled name. Fixing this is a merge problem, not a filter, and is
+  tracked separately.
+- **Ops data corrections.** Miskeyed contact records surfaced by the new tests
+  are fixed in Finalsite, not in dbt.
+
+## Verification
+
+- `uv run dbt build --select int_finalsite__student_contacts+` in each cutover
+  region, plus the unit tests.
+- Confirm the per-region distribution matches the audit table above.
+- Confirm no student loses a contact relative to the current model, other than
+  the single guard exclusion described in section 4.
+- Confirm `dim_student_contact_persons` emits no `contact_3` row in its
+  `emergency_persons` branch.

--- a/src/dbt/finalsite/CLAUDE.md
+++ b/src/dbt/finalsite/CLAUDE.md
@@ -84,10 +84,12 @@ is login-gated.
   fields (`is_parent2/3/4`, `p1_*`–`p4_*`, `emrg_*`) live ONLY on student
   records — `is_parent2` means "this student has a Parent 2" and is never set on
   the parent's own record (0 in tenant data), so never gate on it via `rel_id`.
-  Parent identity comes from `relationships`: `primary` = Parent 1 (a verified
-  per-student singleton), an additional `financial`-without-`primary`
-  relationship = Parent 2. `households` carry only id + address — membership has
-  no roles.
+  Parent identity comes from `relationships`: candidates are relationships
+  flagged `primary` or `financial` whose related contact is an adult
+  (`status = 'not_in_workflow'`), ranked by the `primary` flag, then by sharing
+  a household with the student, then by `relationship_id`, and numbered densely
+  from `contact_1` with no fixed ceiling. `households` carry only id + address —
+  membership has no roles.
 
 ## Cross-Project Usage
 

--- a/src/dbt/finalsite/dbt_project.yml
+++ b/src/dbt/finalsite/dbt_project.yml
@@ -34,3 +34,4 @@ vars:
   cloud_storage_uri_base: null
   bigquery_external_connection_name: null
   local_timezone: null
+  current_academic_year: 0

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -38,36 +38,39 @@ with
             and sh.household_id = ch.household_id
     ),
 
-    parent_picks as (
-        -- Dense slot numbering: the `primary` relationship sorts first when one
-        -- exists, then co-residents with the student, then an arbitrary but
-        -- stable relationship_id. Household co-membership ORDERS candidates; it
-        -- does not exclude them, so a non-resident parent still fills a slot.
-        -- Numbering has no gaps, so a student with no `primary` still gets a
-        -- populated contact_1 rather than starting at contact_2.
+    parent_ranked as (
+        -- The `primary` relationship sorts first when one exists, then
+        -- co-residents with the student, then an arbitrary but stable
+        -- relationship_id. Household co-membership ORDERS candidates; it does
+        -- not exclude them, so a non-resident parent still fills a slot.
         select
             c.finalsite_enrollment_id,
             c.rel_id,
             c.rel_name,
             c.rel_type,
 
-            concat(
-                'contact_',
-                cast(
-                    row_number() over (
-                        partition by c.finalsite_enrollment_id
-                        order by
-                            c.is_primary desc,
-                            (s.rel_id is not null) desc,
-                            c.relationship_id asc
-                    ) as string
-                )
-            ) as contact_slot,
+            row_number() over (
+                partition by c.finalsite_enrollment_id
+                order by
+                    c.is_primary desc,
+                    (s.rel_id is not null) desc,
+                    c.relationship_id asc
+            ) as contact_rank,
         from parent_candidates as c
         left join
             candidates_sharing_student_household as s
             on c.finalsite_enrollment_id = s.finalsite_enrollment_id
             and c.rel_id = s.rel_id
+    ),
+
+    parent_picks as (
+        -- Dense slot numbering has no gaps, so a student with no `primary`
+        -- still gets a populated contact_1 rather than starting at contact_2.
+        select
+            * except (contact_rank),
+
+            concat('contact_', cast(contact_rank as string)) as contact_slot,
+        from parent_ranked
     ),
 
     parents_typed as (

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -1,116 +1,73 @@
 with
-    contact_1_picked as (
-        -- contact_1 is the student's Parent 1: the relationship Finalsite flags
-        -- `primary`. That flag is a per-student singleton and is never `false`
-        -- — it is true or NULL — so a bare `where is_primary` selects exactly
-        -- the Parent 1 row. A student with no primary relationship gets no
-        -- contact_1, and therefore no contact_2: per Ops, a missing primary
-        -- flag is a Finalsite data-entry gap to fix at the source rather than
-        -- something to infer from `financial`. A second primary on one student
-        -- would surface as a duplicate contact_1 and fail this model's
-        -- uniqueness test, which is the intended loud failure. No SIS scoping —
-        -- downstream receivers filter to enrolled students by joining on the
-        -- student id.
-        select finalsite_enrollment_id, rel_id, rel_name, rel_type,
-        from {{ ref("stg_finalsite__contact_relationships") }}
-        where is_primary
-    ),
-
-    primary_household_ids as (
-        -- The student's primary household is the household their Parent 1
-        -- belongs to. Finalsite's own household-1 designation is per-student and
-        -- set in the UI, but it is absent from every field the API exposes (the
-        -- Household object is id plus address only), and array position does not
-        -- reproduce it — `households[safe_offset(0)]` is the UI's Household 2
-        -- for confirmed students. Parent 1's membership is therefore what
-        -- defines the household both parent slots must share. Exploded to one
-        -- row per household so the contact_2 match below is a plain join.
-        select p.finalsite_enrollment_id, p.rel_id as contact_1_rel_id, household_id,
-        from contact_1_picked as p
-        inner join
-            {{ ref("stg_finalsite__contacts") }} as cp
-            on p.rel_id = cp.finalsite_enrollment_id
-        cross join unnest(cp.household_ids) as household_id
-    ),
-
-    contact_household_ids as (
-        -- One row per (contact, household) so household co-membership is a join
-        -- rather than an array containment check.
-        select finalsite_enrollment_id, household_id,
-        from {{ ref("stg_finalsite__contacts") }}
-        cross join unnest(household_ids) as household_id
-    ),
-
-    contact_2_candidates as (
-        -- contact_2 is any OTHER contact flagged `primary` or `financial` that
-        -- belongs to the primary household. `primary` is a singleton already
-        -- taken by contact_1, so in practice these are financial-only rows; the
-        -- disjunction states the rule as Ops expressed it and guards a
-        -- hypothetical second primary. The rel_id inequality skips every
-        -- relationship row pointing at the PERSON already chosen as contact_1,
-        -- so contact_2 can never duplicate contact_1. The student's own
-        -- `is_parent2` custom field is deliberately NOT part of this gate — it
-        -- is false for students who do have a co-resident second parent and true
-        -- for students who have none, so it removed real rows without excluding
-        -- any wrong ones.
-        -- grain projection: every selected column is functionally determined
-        -- by the partition key; not a mask for upstream duplicates. A candidate
-        -- sharing several households with Parent 1 would otherwise repeat.
-        select distinct
+    parent_candidates as (
+        -- A parent candidate is any relationship flagged `primary` or
+        -- `financial` whose related contact is an ADULT. Finalsite marks adults
+        -- with status `not_in_workflow`; every other status (enrolled, inquiry,
+        -- waitlisted, ...) belongs to a student record, and a student is never
+        -- a parent. This guard -- not `rel_type` -- is what keeps a co-resident
+        -- sibling out of a parent slot, which matters because an adult sibling
+        -- CAN legitimately be a guardian and must still qualify.
+        select
             r.finalsite_enrollment_id,
             r.relationship_id,
             r.rel_id,
             r.rel_name,
             r.rel_type,
+
+            coalesce(r.is_primary, false) as is_primary,
         from {{ ref("stg_finalsite__contact_relationships") }} as r
         inner join
-            primary_household_ids as h
-            on r.finalsite_enrollment_id = h.finalsite_enrollment_id
-            and r.rel_id != h.contact_1_rel_id
-        inner join
-            contact_household_ids as ch
-            on r.rel_id = ch.finalsite_enrollment_id
-            and h.household_id = ch.household_id
-        where r.is_primary or r.is_financial
+            {{ ref("stg_finalsite__contacts") }} as rc
+            on r.rel_id = rc.finalsite_enrollment_id
+            and rc.status = 'not_in_workflow'
+        where coalesce(r.is_primary, false) or coalesce(r.is_financial, false)
     ),
 
-    contact_2_ranked as (
-        -- Multiple qualifying second parents tie-break on relationship_id — an
-        -- arbitrary but stable pick, as Finalsite exposes no caregiver ordering
-        -- among them. Only the first fills the single contact_2 slot.
-        select
-            finalsite_enrollment_id,
-            rel_id,
-            rel_name,
-            rel_type,
-
-            row_number() over (
-                partition by finalsite_enrollment_id order by relationship_id asc
-            ) as rn_contact_2,
-        from contact_2_candidates
+    candidates_sharing_student_household as (
+        -- One row per (student, candidate) that co-belong to any household.
+        -- grain projection: a pair sharing several households would otherwise
+        -- repeat and fan out the rank below. Not a mask for upstream duplicates.
+        select distinct c.finalsite_enrollment_id, c.rel_id,
+        from parent_candidates as c
+        inner join
+            {{ ref("int_finalsite__contacts__households") }} as sh
+            on c.finalsite_enrollment_id = sh.finalsite_enrollment_id
+        inner join
+            {{ ref("int_finalsite__contacts__households") }} as ch
+            on c.rel_id = ch.finalsite_enrollment_id
+            and sh.household_id = ch.household_id
     ),
 
     parent_picks as (
+        -- Dense slot numbering: the `primary` relationship sorts first when one
+        -- exists, then co-residents with the student, then an arbitrary but
+        -- stable relationship_id. Household co-membership ORDERS candidates; it
+        -- does not exclude them, so a non-resident parent still fills a slot.
+        -- Numbering has no gaps, so a student with no `primary` still gets a
+        -- populated contact_1 rather than starting at contact_2.
         select
-            finalsite_enrollment_id,
-            rel_id,
-            rel_name,
-            rel_type,
+            c.finalsite_enrollment_id,
+            c.rel_id,
+            c.rel_name,
+            c.rel_type,
 
-            'contact_1' as contact_slot,
-        from contact_1_picked
-
-        union all
-
-        select
-            finalsite_enrollment_id,
-            rel_id,
-            rel_name,
-            rel_type,
-
-            'contact_2' as contact_slot,
-        from contact_2_ranked
-        where rn_contact_2 = 1
+            concat(
+                'contact_',
+                cast(
+                    row_number() over (
+                        partition by c.finalsite_enrollment_id
+                        order by
+                            c.is_primary desc,
+                            (s.rel_id is not null) desc,
+                            c.relationship_id asc
+                    ) as string
+                )
+            ) as contact_slot,
+        from parent_candidates as c
+        left join
+            candidates_sharing_student_household as s
+            on c.finalsite_enrollment_id = s.finalsite_enrollment_id
+            and c.rel_id = s.rel_id
     ),
 
     parents_typed as (

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,25 +3,31 @@ models:
     description:
       SIS-agnostic long-format contact list for Finalsite student records — one
       row per (student, contact slot), grain `(finalsite_enrollment_id,
-      contact_slot)`. `contact_slot` is `contact_1` (the student's Parent 1 —
-      the relationship flagged `primary` in Finalsite, resolved to that person's
-      own Finalsite contact record; absent when the student has no primary
-      relationship, which Ops treats as a Finalsite data-entry gap to fix at the
-      source), `contact_2` (the student's Parent 2 — any other relationship
-      flagged `primary` or `financial` whose contact shares a household with
-      Parent 1, that shared household being the student's primary household;
-      absent otherwise), or `emergency_1` through `emergency_4` (the
-      `custom_attributes` `emrg_N` sets mapped positionally — `emergency_N` is
-      `emrg_N` as-is, with no priority re-sort and no gap-filling). Sparse — a
-      slot row is emitted only when that slot has data, so emergency slots may
-      have gaps. Feeds the downstream PowerSchool/Focus contact receivers built
-      on top of this model.
+      contact_slot)`. Parent slots (`contact_1`, `contact_2`, ...) come from
+      every relationship flagged `primary` or `financial` whose related contact
+      is an adult (Finalsite status `not_in_workflow`), ranked by the `primary`
+      flag, then by sharing a household with the student, then by
+      `relationship_id`, and numbered densely with no fixed upper bound —
+      families with more recorded parent-type relationships get more slots.
+      Household co-membership orders candidates rather than excluding them, so a
+      non-resident parent still fills a slot. `emergency_1` through
+      `emergency_4` are the `custom_attributes` `emrg_N` sets mapped
+      positionally — `emergency_N` is `emrg_N` as-is, with no priority re-sort
+      and no gap-filling. Sparse — a slot row is emitted only when that slot has
+      data, so emergency slots may have gaps. Feeds the downstream
+      PowerSchool/Focus contact receivers built on top of this model.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - finalsite_enrollment_id
               - contact_slot
+          config:
+            severity: error
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              regexp_contains(contact_slot, r'^(contact_[0-9]+|emergency_[1-4])$')
           config:
             severity: error
     columns:
@@ -39,20 +45,11 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1`, `contact_2`, or
-          `emergency_1` through `emergency_4`.
-        data_tests:
-          - accepted_values:
-              arguments:
-                values:
-                  - contact_1
-                  - contact_2
-                  - emergency_1
-                  - emergency_2
-                  - emergency_3
-                  - emergency_4
-              config:
-                severity: error
+          Which contact this row represents. Parent slots are numbered densely
+          from `contact_1` by rank with no fixed upper bound — `contact_1` is
+          the top-ranked parent rather than strictly the `primary` relationship.
+          `emergency_1` through `emergency_4` are the four fixed
+          `custom_attributes` `emrg_N` sets mapped positionally.
       - name: finalsite_contact_id
         data_type: string
         description:
@@ -171,10 +168,10 @@ models:
       - name: is_household_member
         data_type: boolean
         description:
-          Whether the contact lives with the student. Always null for
-          `contact_1` and `contact_2` (note the `contact_2` pick already
-          requires co-membership of Parent 1's household by construction);
-          `emrg_N_lives_with_yn` for an emergency slot.
+          Whether the contact lives with the student. Always null for every
+          parent slot (household co-membership now orders parent slots rather
+          than gating them, so a parent slot implies nothing about
+          co-residence); `emrg_N_lives_with_yn` for an emergency slot.
       - name: is_emergency
         data_type: boolean
         description:
@@ -208,6 +205,7 @@ unit_tests:
         rows: |
           select
             'con1' as finalsite_enrollment_id,
+            'not_in_workflow' as status,
             'jane@example.com' as email,
             'Jane' as first_name,
             'Doe' as last_name,
@@ -221,8 +219,9 @@ unit_tests:
             cast(null as string) as address_2,
             cast(null as string) as city,
             cast(null as string) as state,
-            cast(null as string) as zip,
-            array<string>[] as household_ids
+            cast(null as string) as zip
+      - input: ref('int_finalsite__contacts__households')
+        rows: []
       - input: ref('int_finalsite__contact_custom_attributes')
         rows: []
     expect:
@@ -250,14 +249,14 @@ unit_tests:
 
   - name: test_student_contacts_parent_2
     description:
-      Two students. stu1 has a primary relationship (Parent 1), a second
-      financial relationship to a contact sharing Parent 1's household, and a
-      third financial relationship in a different household — yields contact_1
-      plus contact_2 with the outsider excluded. Every fixture row carries
-      `is_parent2` false, so a contact_2 on stu1 also proves that flag no longer
-      gates the pick. stu2 has no primary relationship and two financial ones —
-      yields no rows at all, since Parent 1 is the primary contact and there is
-      no financial fallback.
+      Dense slot assignment. stu1 has a primary parent (con1), a financial
+      stepparent sharing stu1's household (con2), and a financial parent in a
+      different household (con3) -- yielding contact_1, contact_2, contact_3,
+      with con3 ranked last because it shares no household with the student
+      rather than being excluded. stu2 has no primary and two financial
+      relationships -- yielding contact_1 and contact_2, where the old rule
+      yielded nothing. con6 is a financial relationship to another STUDENT
+      record and is excluded from stu2 entirely by the adult guard.
     model: int_finalsite__student_contacts
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -274,52 +273,33 @@ unit_tests:
             false as is_parent2
           union all
           select
-            'stu1' as finalsite_enrollment_id,
-            'rel2' as relationship_id,
-            'con2' as rel_id,
-            'John Doe' as rel_name,
-            'stepparent' as rel_type,
-            cast(null as boolean) as is_primary,
-            true as is_financial,
-            false as is_parent2
+            'stu1', 'rel2', 'con2', 'John Doe', 'stepparent',
+            cast(null as boolean), true, false
           union all
           select
-            'stu1' as finalsite_enrollment_id,
-            'rel3' as relationship_id,
-            'con3' as rel_id,
-            'Jim Poe' as rel_name,
-            'parent' as rel_type,
-            cast(null as boolean) as is_primary,
-            true as is_financial,
-            false as is_parent2
+            'stu1', 'rel3', 'con3', 'Jim Poe', 'parent',
+            cast(null as boolean), true, false
           union all
           select
-            'stu2' as finalsite_enrollment_id,
-            'rel4' as relationship_id,
-            'con4' as rel_id,
-            'Fay Ray' as rel_name,
-            'parent' as rel_type,
-            cast(null as boolean) as is_primary,
-            true as is_financial,
-            false as is_parent2
+            'stu2', 'rel4', 'con4', 'Fay Ray', 'parent',
+            cast(null as boolean), true, false
           union all
           select
-            'stu2' as finalsite_enrollment_id,
-            'rel5' as relationship_id,
-            'con5' as rel_id,
-            'Gus Ray' as rel_name,
-            'parent' as rel_type,
-            cast(null as boolean) as is_primary,
-            true as is_financial,
-            false as is_parent2
+            'stu2', 'rel5', 'con5', 'Gus Ray', 'parent',
+            cast(null as boolean), true, false
+          union all
+          select
+            'stu2', 'rel6', 'con6', 'Kid Ray', 'sibling',
+            cast(null as boolean), true, false
       - input: ref('stg_finalsite__contacts')
         format: sql
         rows: |
           select
-            'con1' as finalsite_enrollment_id,
-            'jane@example.com' as email,
-            'Jane' as first_name,
-            'Doe' as last_name,
+            'stu1' as finalsite_enrollment_id,
+            'enrolled' as status,
+            cast(null as string) as email,
+            'Stu' as first_name,
+            'One' as last_name,
             cast(null as string) as phone_1_number,
             cast(null as string) as phone_1_type,
             cast(null as string) as phone_2_number,
@@ -330,121 +310,117 @@ unit_tests:
             cast(null as string) as address_2,
             cast(null as string) as city,
             cast(null as string) as state,
-            cast(null as string) as zip,
-            ['hh1'] as household_ids
+            cast(null as string) as zip
           union all
           select
-            'con2' as finalsite_enrollment_id,
-            'john@example.com' as email,
-            'John' as first_name,
-            'Doe' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            ['hh1', 'hh2'] as household_ids
+            'stu2', 'enrolled', cast(null as string), 'Stu', 'Two',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'con3' as finalsite_enrollment_id,
-            'jim@example.com' as email,
-            'Jim' as first_name,
-            'Poe' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            ['hh2'] as household_ids
+            'con1', 'not_in_workflow', 'jane@example.com', 'Jane', 'Doe',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'con4' as finalsite_enrollment_id,
-            'fay@example.com' as email,
-            'Fay' as first_name,
-            'Ray' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            ['hh3'] as household_ids
+            'con2', 'not_in_workflow', 'john@example.com', 'John', 'Doe',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'con5' as finalsite_enrollment_id,
-            'gus@example.com' as email,
-            'Gus' as first_name,
-            'Ray' as last_name,
-            cast(null as string) as phone_1_number,
-            cast(null as string) as phone_1_type,
-            cast(null as string) as phone_2_number,
-            cast(null as string) as phone_2_type,
-            cast(null as string) as phone_3_number,
-            cast(null as string) as phone_3_type,
-            cast(null as string) as address_1,
-            cast(null as string) as address_2,
-            cast(null as string) as city,
-            cast(null as string) as state,
-            cast(null as string) as zip,
-            ['hh3'] as household_ids
+            'con3', 'not_in_workflow', 'jim@example.com', 'Jim', 'Poe',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+          union all
+          select
+            'con4', 'not_in_workflow', 'fay@example.com', 'Fay', 'Ray',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+          union all
+          select
+            'con5', 'not_in_workflow', 'gus@example.com', 'Gus', 'Ray',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+          union all
+          select
+            'con6', 'enrolled', 'kid@example.com', 'Kid', 'Ray',
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contacts__households')
+        format: sql
+        rows: |
+          select 'stu1' as finalsite_enrollment_id, 'hh1' as household_id
+          union all
+          select 'con1', 'hh1'
+          union all
+          select 'con2', 'hh1'
+          union all
+          select 'con3', 'hh2'
+          union all
+          select 'stu2', 'hh3'
+          union all
+          select 'con4', 'hh3'
+          union all
+          select 'con5', 'hh3'
+          union all
+          select 'con6', 'hh3'
       - input: ref('int_finalsite__contact_custom_attributes')
         rows: []
     expect:
-      format: sql
-      rows: |
-        select
-          'stu1' as finalsite_enrollment_id,
-          'contact_1' as contact_slot,
-          'con1' as finalsite_contact_id,
-          'Jane Doe' as contact_name,
-          'Jane' as contact_first_name,
-          'Doe' as contact_last_name,
-          'parent' as relationship,
-          'jane@example.com' as email,
-          cast(null as string) as phone_daytime,
-          cast(null as string) as home_address,
-          cast(null as boolean) as is_pickup,
-          cast(null as boolean) as is_custodial,
-          cast(null as boolean) as is_household_member,
-          false as is_emergency,
-          cast(null as string) as phone_mobile,
-          cast(null as string) as phone_home,
-          cast(null as string) as phone_work,
-          cast(null as string) as phone_primary
-        union all
-        select
-          'stu1' as finalsite_enrollment_id,
-          'contact_2' as contact_slot,
-          'con2' as finalsite_contact_id,
-          'John Doe' as contact_name,
-          'John' as contact_first_name,
-          'Doe' as contact_last_name,
-          'stepparent' as relationship,
-          'john@example.com' as email,
-          cast(null as string) as phone_daytime,
-          cast(null as string) as home_address,
-          cast(null as boolean) as is_pickup,
-          cast(null as boolean) as is_custodial,
-          cast(null as boolean) as is_household_member,
-          false as is_emergency,
-          cast(null as string) as phone_mobile,
-          cast(null as string) as phone_home,
-          cast(null as string) as phone_work,
-          cast(null as string) as phone_primary
+      rows:
+        - finalsite_enrollment_id: stu1
+          contact_slot: contact_1
+          finalsite_contact_id: con1
+          contact_name: Jane Doe
+          contact_first_name: Jane
+          contact_last_name: Doe
+          relationship: parent
+        - finalsite_enrollment_id: stu1
+          contact_slot: contact_2
+          finalsite_contact_id: con2
+          contact_name: John Doe
+          contact_first_name: John
+          contact_last_name: Doe
+          relationship: stepparent
+        - finalsite_enrollment_id: stu1
+          contact_slot: contact_3
+          finalsite_contact_id: con3
+          contact_name: Jim Poe
+          contact_first_name: Jim
+          contact_last_name: Poe
+          relationship: parent
+        - finalsite_enrollment_id: stu2
+          contact_slot: contact_1
+          finalsite_contact_id: con4
+          contact_name: Fay Ray
+          contact_first_name: Fay
+          contact_last_name: Ray
+          relationship: parent
+        - finalsite_enrollment_id: stu2
+          contact_slot: contact_2
+          finalsite_contact_id: con5
+          contact_name: Gus Ray
+          contact_first_name: Gus
+          contact_last_name: Ray
+          relationship: parent

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -277,7 +277,7 @@ unit_tests:
             cast(null as boolean), true, false
           union all
           select
-            'stu1', 'rel3', 'con3', 'Jim Poe', 'parent',
+            'stu1', 'rel0', 'con3', 'Jim Poe', 'parent',
             cast(null as boolean), true, false
           union all
           select

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
@@ -6,8 +6,9 @@
 -- the enrolled scope lives here, in the test, rather than in the model.
 -- Every row is a Finalsite data-entry gap: no relationship on the record
 -- carries a `primary` or `financial` flag. A parent miskeyed with a student
--- status does NOT surface here -- dense ranking backfills the slot from the
--- next candidate -- so that case is reported by
+-- status does not surface here when another eligible candidate exists --
+-- dense ranking backfills the slot from the next candidate -- so that case
+-- is reported by
 -- stg_finalsite__contact_relationships__caregiver_is_adult instead.
 select s.finalsite_enrollment_id, s.grade_name, s.school_year_start,
 from {{ ref("stg_finalsite__contacts") }} as s

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
@@ -4,16 +4,18 @@
 -- stays SIS-agnostic and emits rows for every student record including
 -- prospects and applicants, who legitimately have no parent on file yet -- so
 -- the enrolled scope lives here, in the test, rather than in the model.
--- Every row is a Finalsite data-entry gap: a missing `primary`/`financial`
--- flag, or a parent whose own contact record is miskeyed with a student status
--- and therefore fails the adult guard.
+-- Every row is a Finalsite data-entry gap: no relationship on the record
+-- carries a `primary` or `financial` flag. A parent miskeyed with a student
+-- status does NOT surface here -- dense ranking backfills the slot from the
+-- next candidate -- so that case is reported by
+-- stg_finalsite__contact_relationships__caregiver_is_adult instead.
 select s.finalsite_enrollment_id, s.grade_name, s.school_year_start,
 from {{ ref("stg_finalsite__contacts") }} as s
 where
     s.status = 'enrolled'
     and s.school_year_start = {{ var("current_academic_year") }}
     and not exists (
-        select 1
+        select 1,
         from {{ ref("int_finalsite__student_contacts") }} as c
         where
             c.finalsite_enrollment_id = s.finalsite_enrollment_id

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
@@ -1,0 +1,21 @@
+{{ config(severity="warn") }}
+
+-- A currently enrolled student with no parent slot at all. The model itself
+-- stays SIS-agnostic and emits rows for every student record including
+-- prospects and applicants, who legitimately have no parent on file yet -- so
+-- the enrolled scope lives here, in the test, rather than in the model.
+-- Every row is a Finalsite data-entry gap: a missing `primary`/`financial`
+-- flag, or a parent whose own contact record is miskeyed with a student status
+-- and therefore fails the adult guard.
+select s.finalsite_enrollment_id, s.grade_name, s.school_year_start,
+from {{ ref("stg_finalsite__contacts") }} as s
+where
+    s.status = 'enrolled'
+    and s.school_year_start = {{ var("current_academic_year") }}
+    and not exists (
+        select 1
+        from {{ ref("int_finalsite__student_contacts") }} as c
+        where
+            c.finalsite_enrollment_id = s.finalsite_enrollment_id
+            and c.contact_slot = 'contact_1'
+    )

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__enrolled_has_contact_1.sql
@@ -1,5 +1,3 @@
-{{ config(severity="warn") }}
-
 -- A currently enrolled student with no parent slot at all. The model itself
 -- stays SIS-agnostic and emits rows for every student record including
 -- prospects and applicants, who legitimately have no parent on file yet -- so

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
@@ -1,0 +1,10 @@
+{{ config(severity="warn") }}
+
+-- A student with more parents than the two conventional slots. The wide
+-- downstream receivers (contacts pivot, ParentSquare, DeansList, the contacts
+-- bridge) all carry two parent columns, so anything past contact_2 is emitted
+-- here but dropped before it reaches an extract. Warn so the count stays
+-- visible; matching `contact_%` rather than a literal catches a fourth slot too.
+select finalsite_enrollment_id, contact_slot,
+from {{ ref("int_finalsite__student_contacts") }}
+where contact_slot like 'contact\\_%' and contact_slot not in ('contact_1', 'contact_2')

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
@@ -1,5 +1,3 @@
-{{ config(severity="warn") }}
-
 -- A student with more parents than the two conventional slots. Anything past
 -- contact_2 is emitted here; the receivers exclude those slots themselves
 -- (the contacts pivot and ParentSquare by construction, DeansList and the

--- a/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
+++ b/src/dbt/finalsite/tests/int_finalsite__student_contacts__no_extra_contacts.sql
@@ -1,10 +1,11 @@
 {{ config(severity="warn") }}
 
--- A student with more parents than the two conventional slots. The wide
--- downstream receivers (contacts pivot, ParentSquare, DeansList, the contacts
--- bridge) all carry two parent columns, so anything past contact_2 is emitted
--- here but dropped before it reaches an extract. Warn so the count stays
--- visible; matching `contact_%` rather than a literal catches a fourth slot too.
+-- A student with more parents than the two conventional slots. Anything past
+-- contact_2 is emitted here; the receivers exclude those slots themselves
+-- (the contacts pivot and ParentSquare by construction, DeansList and the
+-- contacts bridge via an explicit slot filter) rather than the row being
+-- dropped upstream of this model. Warn so the count stays visible; matching
+-- `contact_%` rather than a literal catches a fourth slot too.
 select finalsite_enrollment_id, contact_slot,
 from {{ ref("int_finalsite__student_contacts") }}
 where contact_slot like 'contact\\_%' and contact_slot not in ('contact_1', 'contact_2')

--- a/src/dbt/finalsite/tests/properties.yml
+++ b/src/dbt/finalsite/tests/properties.yml
@@ -1,0 +1,81 @@
+data_tests:
+  - name: stg_finalsite__contacts__no_stale_enrolled
+    description: >-
+      Finalsite never rolls a graduated cohort off `enrolled` -- last year's
+      seniors keep that status indefinitely -- and separately, some students who
+      are still enrolled never get a current-year record created. Both surface
+      as an `enrolled` contact stamped with a prior school year. Warn, not
+      error: this is a standing Ops worklist inside Finalsite, and the count
+      only falls when someone corrects records at the source.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: stg_finalsite__contacts
+            package: finalsite
+
+  - name: stg_finalsite__contact_relationships__single_primary
+    description: >-
+      `primary` is a per-student singleton in Finalsite. The old model surfaced
+      a violation as a duplicate contact_1 failing the uniqueness test; dense
+      ranking absorbs a second primary into contact_2 instead, so the condition
+      is tested at the source where it can be acted on. No student trips this
+      today -- it guards against regression rather than reporting a backlog.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: stg_finalsite__contact_relationships
+            package: finalsite
+
+  - name: stg_finalsite__contact_relationships__caregiver_is_adult
+    description: >-
+      A relationship flagged as a caregiver whose related contact does NOT carry
+      Finalsite's adult status. Almost always this is correct and the related
+      person really is a student -- a sibling flagged `financial`, say -- and
+      the model's adult guard drops it as intended. The rows worth acting on are
+      the inverse: an adult whose own contact record was miskeyed with a student
+      status, whose relationship the guard then discards silently, because dense
+      ranking backfills the slot from another candidate and nothing else reports
+      the loss. Warn: each row is a Finalsite record to inspect, not a build
+      failure.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: stg_finalsite__contact_relationships
+            package: finalsite
+
+  - name: int_finalsite__student_contacts__enrolled_has_contact_1
+    description: >-
+      A currently enrolled student with no parent slot at all. The model itself
+      stays SIS-agnostic and emits rows for every student record including
+      prospects and applicants, who legitimately have no parent on file yet --
+      so the enrolled scope lives here, in the test, rather than in the model.
+      Every row is a Finalsite data-entry gap: no relationship on the record
+      carries a `primary` or `financial` flag. A parent miskeyed with a student
+      status does not surface here when another eligible candidate exists --
+      dense ranking backfills the slot from the next candidate -- so that case
+      is reported by stg_finalsite__contact_relationships__caregiver_is_adult
+      instead.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: int_finalsite__student_contacts
+            package: finalsite
+
+  - name: int_finalsite__student_contacts__no_extra_contacts
+    description: >-
+      A student with more parents than the two conventional slots. Anything past
+      contact_2 is emitted here; the receivers exclude those slots themselves
+      (the contacts pivot and ParentSquare by construction, DeansList and the
+      contacts bridge via an explicit slot filter) rather than the row being
+      dropped upstream of this model. Warn so the count stays visible; matching
+      `contact_%` rather than a literal catches a fourth slot too.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: int_finalsite__student_contacts
+            package: finalsite

--- a/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql
@@ -1,5 +1,3 @@
-{{ config(severity="warn") }}
-
 -- A relationship flagged as a caregiver whose related contact does NOT carry
 -- Finalsite's adult status. Almost always this is correct and the related
 -- person really is a student -- a sibling flagged `financial`, say -- and the

--- a/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__caregiver_is_adult.sql
@@ -1,0 +1,23 @@
+{{ config(severity="warn") }}
+
+-- A relationship flagged as a caregiver whose related contact does NOT carry
+-- Finalsite's adult status. Almost always this is correct and the related
+-- person really is a student -- a sibling flagged `financial`, say -- and the
+-- model's adult guard drops it as intended. The rows worth acting on are the
+-- inverse: an adult whose own contact record was miskeyed with a student
+-- status, whose relationship the guard then discards silently, because dense
+-- ranking backfills the slot from another candidate and nothing else reports
+-- the loss. Warn: each row is a Finalsite record to inspect, not a build
+-- failure.
+select
+    r.finalsite_enrollment_id,
+    r.rel_id,
+    r.rel_type,
+    c.status as related_contact_status,
+    c.grade_name as related_contact_grade,
+from {{ ref("stg_finalsite__contact_relationships") }} as r
+inner join
+    {{ ref("stg_finalsite__contacts") }} as c on r.rel_id = c.finalsite_enrollment_id
+where
+    (coalesce(r.is_primary, false) or coalesce(r.is_financial, false))
+    and c.status != 'not_in_workflow'

--- a/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql
@@ -1,0 +1,12 @@
+{{ config(severity="warn") }}
+
+-- `primary` is a per-student singleton in Finalsite. The old model surfaced a
+-- violation as a duplicate contact_1 failing the uniqueness test; dense ranking
+-- absorbs a second primary into contact_2 instead, so the condition is tested
+-- at the source where it can be acted on. No student trips this today -- it
+-- guards against regression rather than reporting a backlog.
+select finalsite_enrollment_id, count(*) as primary_relationships,
+from {{ ref("stg_finalsite__contact_relationships") }}
+where is_primary
+group by finalsite_enrollment_id
+having count(*) > 1

--- a/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contact_relationships__single_primary.sql
@@ -1,5 +1,3 @@
-{{ config(severity="warn") }}
-
 -- `primary` is a per-student singleton in Finalsite. The old model surfaced a
 -- violation as a duplicate contact_1 failing the uniqueness test; dense ranking
 -- absorbs a second primary into contact_2 instead, so the condition is tested

--- a/src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql
@@ -1,0 +1,11 @@
+{{ config(severity="warn") }}
+
+-- Finalsite never rolls a graduated cohort off `enrolled` -- last year's
+-- seniors keep that status indefinitely -- and separately, some students who
+-- are still enrolled never get a current-year record created. Both surface as
+-- an `enrolled` contact stamped with a prior school year. Warn, not error:
+-- this is a standing Ops worklist inside Finalsite, and the count only falls
+-- when someone corrects records at the source.
+select finalsite_enrollment_id, status, school_year_start, grade_name,
+from {{ ref("stg_finalsite__contacts") }}
+where status = 'enrolled' and school_year_start < {{ var("current_academic_year") }}

--- a/src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql
+++ b/src/dbt/finalsite/tests/stg_finalsite__contacts__no_stale_enrolled.sql
@@ -1,5 +1,3 @@
-{{ config(severity="warn") }}
-
 -- Finalsite never rolls a graduated cohort off `enrolled` -- last year's
 -- seniors keep that status indefinitely -- and separately, some students who
 -- are still enrolled never get a current-year record created. Both surface as

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -324,3 +324,97 @@ unit_tests:
             ContactType: Parent1,
             Language: null,
           }
+
+  - name: test_family_contacts_excludes_third_parent_slot
+    description:
+      Locks the exclusion of parent slots past contact_2. Before the slot filter
+      was added, a contact_3 row fell into the `else` branch of the ContactType
+      case and was mislabeled Emergency -- a real parent exported to DeansList
+      under a label that routes guardian-only automated messaging. Feeds one
+      contact_1, one contact_2, one contact_3, and one emergency_1 row for the
+      same student; asserts contact_3 produces no output row at all (not even as
+      a mislabeled Emergency row) while contact_1, contact_2, and emergency_1
+      all still appear under their correct ContactType.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-301' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Jane' as contact_first_name,
+            'One' as contact_last_name,
+            'jane1@example.com' as email,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_work,
+            cast(null as string) as phone_mobile
+          union all
+          select
+            'enr-301', 'kippnewark', 'contact_2', 'parent',
+            'Jane', 'Two', 'jane2@example.com', cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-301', 'kippnewark', 'contact_3', 'parent',
+            'Jane', 'Three', 'jane3@example.com', cast(null as string),
+            cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-301', 'kippnewark', 'emergency_1', 'neighbor',
+            'Jane', 'Four', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-301' as finalsite_enrollment_id,
+            'kippnewark' as _dbt_source_project,
+            '300001' as powerschool_student_number
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            300001 as student_number,
+            0 as enroll_status,
+            'kippnewark' as _dbt_source_project
+    expect:
+      rows:
+        - {
+            StudentID: 300001,
+            ParentFirstName: Jane,
+            ParentLastName: One,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: jane1@example.com,
+            Relationship: parent,
+            ContactType: Parent1,
+            Language: null,
+          }
+        - {
+            StudentID: 300001,
+            ParentFirstName: Jane,
+            ParentLastName: Two,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: jane2@example.com,
+            Relationship: parent,
+            ContactType: Parent2,
+            Language: null,
+          }
+        - {
+            StudentID: 300001,
+            ParentFirstName: Jane,
+            ParentLastName: Four,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: neighbor,
+            ContactType: Emergency,
+            Language: null,
+          }

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -22,7 +22,10 @@ with
             -- included. Overwriting it with a literal `Emergency N` (the prior
             -- behavior) discarded a label Finalsite populates on essentially
             -- every emergency row and left school staff unable to tell a parent
-            -- from a neighbor.
+            -- from a neighbor. Parent slots past contact_2 are excluded by the
+            -- `where` below, upstream of this `case`, so they can never fall
+            -- into the `else` branch and be mislabelled `Emergency`. Carrying a
+            -- third parent into DeansList is deliberately out of scope for now.
             case
                 sc.contact_slot
                 when 'contact_1'
@@ -39,6 +42,10 @@ with
         where
             sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
             and xw.powerschool_student_number is not null
+            and (
+                sc.contact_slot in ('contact_1', 'contact_2')
+                or sc.contact_slot like 'emergency\\_%'
+            )
     )
 
 select

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
@@ -15,6 +15,13 @@ models:
             combination_of_columns:
               - finalsite_enrollment_id
               - contact_slot
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression:
+              "regexp_contains(contact_slot,
+              r'^(contact_[0-9]+|emergency_[1-4])$')"
+          config:
+            severity: error
     columns:
       - name: finalsite_enrollment_id
         data_type: string
@@ -25,17 +32,8 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1`, `contact_2`, or
-          `emergency_1` through `emergency_4`.
-        data_tests:
-          - accepted_values:
-              arguments:
-                values:
-                  - contact_1
-                  - contact_2
-                  - emergency_1
-                  - emergency_2
-                  - emergency_3
-                  - emergency_4
-              config:
-                severity: error
+          Which contact this row represents. Parent slots are numbered densely
+          from `contact_1` with no fixed upper bound — families with more
+          recorded parent-type relationships get more slots. `emergency_1`
+          through `emergency_4` are the four fixed `custom_attributes` `emrg_N`
+          sets mapped positionally.

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__student_contacts.yml
@@ -3,12 +3,13 @@ models:
     description:
       Network-wide union of the per-region Finalsite
       `int_finalsite__student_contacts` models — the SIS-agnostic long-format
-      contact list (one row per student per contact slot, `contact_1` and
-      `contact_2` plus `emergency_1` through `emergency_4`). Unions the NJ
-      cutover regions (Newark, Camden, Paterson) only — Miami has the API wired
-      but is excluded to avoid double-counting against the PowerSchool branch of
-      `int_students__contacts`. Carries `_dbt_source_relation` and the derived
-      `_dbt_source_project`.
+      contact list (one row per student per contact slot). Parent slots
+      (`contact_1`, `contact_2`, ...) are densely numbered with no fixed
+      maximum, plus the fixed `emergency_1` through `emergency_4` sets. Unions
+      the NJ cutover regions (Newark, Camden, Paterson) only — Miami has the API
+      wired but is excluded to avoid double-counting against the PowerSchool
+      branch of `int_students__contacts`. Carries `_dbt_source_relation` and the
+      derived `_dbt_source_project`.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -17,9 +18,8 @@ models:
               - contact_slot
       - dbt_utils.expression_is_true:
           arguments:
-            expression:
-              "regexp_contains(contact_slot,
-              r'^(contact_[0-9]+|emergency_[1-4])$')"
+            expression: |
+              regexp_contains(contact_slot, r'^(contact_[0-9]+|emergency_[1-4])$')
           config:
             severity: error
     columns:

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
@@ -12,6 +12,9 @@ with
 
             coalesce(finalsite_contact_id, personid) as person_identity,
         from {{ ref("int_students__contacts") }}
+        where
+            contact_slot in ('contact_1', 'contact_2')
+            or contact_slot like 'emergency\\_%'
     ),
 
     keyed as (
@@ -28,7 +31,10 @@ with
 
             -- keyed identically to dim_student_contact_persons: parent slots
             -- (contact_1/contact_2) by the person's real identity, emergency by
-            -- student + contact slot
+            -- student + contact slot. Slots outside those two shapes (parent
+            -- slots past contact_2) are excluded in the `contacts` CTE above
+            -- for the same reason the dimension excludes them, so this key
+            -- can never orphan against dim_student_contact_persons.
             if(
                 contact_slot in ('contact_1', 'contact_2'),
                 {{

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -93,3 +93,53 @@ models:
         description: >-
           Whether the student lives with the contact. Null for Finalsite
           contact_1 and contact_2 rows.
+
+unit_tests:
+  - name: test_bridge_student_contacts_excludes_third_parent_slot
+    description:
+      Locks the exclusion of parent slots past contact_2. Before the slot filter
+      was added, a contact_3 row fell into the emergency branch and was exported
+      with is_emergency true instead of being a parent. Feeds one contact_1, one
+      contact_2, one contact_3, and one emergency_1 row for the same student;
+      asserts contact_3 produces no bridge row while contact_1, contact_2, and
+      emergency_1 all still appear -- emergency_1 still carrying is_emergency
+      true rather than being dropped by the new filter.
+    model: bridge_student_contacts
+    given:
+      - input: ref('int_students__contacts')
+        format: sql
+        rows: |
+          select
+            500001 as student_number,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'con1' as finalsite_contact_id,
+            cast(null as string) as personid,
+            'parent' as relationship,
+            false as is_emergency,
+            cast(null as bool) as is_pickup,
+            cast(null as bool) as is_custodial,
+            cast(null as bool) as is_household_member
+          union all
+          select
+            500001, 'kippnewark', 'contact_2', 'con2', cast(null as string),
+            'parent', false, cast(null as bool), cast(null as bool),
+            cast(null as bool)
+          union all
+          select
+            500001, 'kippnewark', 'contact_3', 'con3', cast(null as string),
+            'parent', false, cast(null as bool), cast(null as bool),
+            cast(null as bool)
+          union all
+          select
+            500001, 'kippnewark', 'emergency_1', cast(null as string),
+            cast(null as string), 'neighbor', true, true, false, false
+    expect:
+      rows:
+        - { contact_slot: contact_1, relationship: parent, is_emergency: false }
+        - { contact_slot: contact_2, relationship: parent, is_emergency: false }
+        - {
+            contact_slot: emergency_1,
+            relationship: neighbor,
+            is_emergency: true,
+          }

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
@@ -39,7 +39,9 @@ with
     ),
 
     /* emergency contacts have no stable person record under the Finalsite 2+4
-       shape, so each (student, slot) is its own person keyed by student + slot. */
+       shape, so each (student, slot) is its own person keyed by student + slot.
+       Matched positively on 'emergency_' slots so unrecognised parent slots are
+       dropped rather than misfiled as emergency contacts. */
     emergency_persons as (
         select
             student_number,
@@ -54,7 +56,7 @@ with
             address_home,
             _dbt_source_project,
         from contacts
-        where contact_slot not in ('contact_1', 'contact_2')
+        where contact_slot like 'emergency\\_%'
     )
 
 select

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -104,3 +104,56 @@ models:
           meta:
             source_column: address_home
             contains_pii: true
+
+unit_tests:
+  - name: test_dim_student_contact_persons_excludes_third_parent_slot
+    description:
+      Locks the exclusion of parent slots past contact_2. Before the slot filter
+      was added, a contact_3 row fell into the emergency branch and was treated
+      as an emergency contact rather than a parent. Feeds one contact_1, one
+      contact_2, one contact_3, and one emergency_1 row for the same student;
+      asserts contact_3 produces no person row while contact_1, contact_2, and
+      emergency_1 all still appear -- the emergency row keyed by student and
+      slot rather than dropped by the new filter.
+    model: dim_student_contact_persons
+    given:
+      - input: ref('int_students__contacts')
+        format: sql
+        rows: |
+          select
+            500001 as student_number,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'con1' as finalsite_contact_id,
+            cast(null as string) as personid,
+            'Jane Doe1' as contact_name,
+            'jane1@example.com' as email_current,
+            cast(null as string) as phone_mobile,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_daytime,
+            cast(null as string) as phone_work,
+            '+19170000001' as phone_primary,
+            '1 Main St' as address_home
+          union all
+          select
+            500001, 'kippnewark', 'contact_2', 'con2', cast(null as string),
+            'Jane Doe2', 'jane2@example.com', cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string),
+            '+19170000002', '1 Main St'
+          union all
+          select
+            500001, 'kippnewark', 'contact_3', 'con3', cast(null as string),
+            'Jane Doe3', 'jane3@example.com', cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string),
+            '+19170000003', '1 Main St'
+          union all
+          select
+            500001, 'kippnewark', 'emergency_1', cast(null as string),
+            cast(null as string), 'Jane Doe4', cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string),
+            cast(null as string), '+19170000004', cast(null as string)
+    expect:
+      rows:
+        - { full_name: Jane Doe1, email: jane1@example.com }
+        - { full_name: Jane Doe2, email: jane2@example.com }
+        - { full_name: Jane Doe4, email: null }

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -26,6 +26,13 @@ models:
               - contact_slot
           config:
             severity: error
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression:
+              "regexp_contains(contact_slot,
+              r'^(contact_[0-9]+|emergency_[1-4])$')"
+          config:
+            severity: error
     columns:
       - name: student_number
         data_type: integer
@@ -37,21 +44,13 @@ models:
       - name: contact_slot
         data_type: string
         description:
-          Which contact this row represents — `contact_1`, `contact_2`, or
-          `emergency_1` through `emergency_4`.
+          Which contact this row represents. Parent slots are numbered densely
+          from `contact_1` with no fixed upper bound — families with more
+          recorded parent-type relationships get more slots. `emergency_1`
+          through `emergency_4` are the four fixed `custom_attributes` `emrg_N`
+          sets mapped positionally.
         data_tests:
           - not_null:
-              config:
-                severity: error
-          - accepted_values:
-              arguments:
-                values:
-                  - contact_1
-                  - contact_2
-                  - emergency_1
-                  - emergency_2
-                  - emergency_3
-                  - emergency_4
               config:
                 severity: error
       - name: _dbt_source_project

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -28,9 +28,8 @@ models:
             severity: error
       - dbt_utils.expression_is_true:
           arguments:
-            expression:
-              "regexp_contains(contact_slot,
-              r'^(contact_[0-9]+|emergency_[1-4])$')"
+            expression: |
+              regexp_contains(contact_slot, r'^(contact_[0-9]+|emergency_[1-4])$')
           config:
             severity: error
     columns:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

Redefine which people become a student's parent contacts in
`int_finalsite__student_contacts`, and stop four downstream models from
mishandling the result.

Previously `contact_1` was the relationship flagged `primary`, and `contact_2`
had to co-reside in a household with `contact_1`. That coupling meant a missing
`primary` flag suppressed **both** slots, and a third qualifying parent was
silently discarded by an arbitrary `relationship_id` tie-break. The household
join was also undocumented — the package CLAUDE.md already described the
intended rule as "`primary` = Parent 1, an additional `financial`-without-
`primary` relationship = Parent 2" and noted that "households carry only id plus
address — membership has no roles."

After this change:

- A **parent candidate** is any relationship flagged `primary` or `financial`
  whose related contact is an adult (Finalsite `status = 'not_in_workflow'`).
  That guard is what keeps a co-resident sibling out of a parent slot, and it
  works even though an adult sibling can legitimately be a guardian — which a
  `rel_type` filter could not.
- Candidates are ranked by the `primary` flag, then by sharing a household with
  the **student**, then by `relationship_id`, and numbered **densely** from
  `contact_1` with no ceiling. Household co-membership orders candidates instead
  of excluding them.
- Five warn-severity tests surface the Finalsite data gaps this exposes.

Measured across the three cutover NJ regions on the 2026-08-07 load, scoped to
currently enrolled students:

| Region   | Students | 0 slots | 1     | 2     | 3   |
| -------- | -------- | ------- | ----- | ----- | --- |
| Newark   | 6,786    | 0       | 3,682 | 3,079 | 25  |
| Camden   | 2,163    | 52      | 1,264 | 840   | 7   |
| Paterson | 879      | 43      | 539   | 297   | 0   |

Newark goes from 344 students with no contact at all to zero. Camden and
Paterson still have 52 and 43, which predate this change and are Finalsite
data-entry gaps, not rule failures.

### Downstream corrections

Dense numbering emits slots past `contact_2`, which four models mishandled. All
four assumed exactly two parent slots via a stale complementary predicate:

- `rpt_deanslist__family_contacts` labelled a third parent `Emergency` and
  exported it to DeansList. DeansList routes guardian-only automated messaging
  by `ContactType`, so those parents silently lost guardian messaging. 48 rows
  reach that extract today. **This was the highest-impact defect in the branch
  and no test caught it.**
- `dim_student_contact_persons` recorded a third parent as an emergency contact,
  keyed as if it had no person record.
- `bridge_student_contacts` kept the old key shape, which would have produced
  foreign-key orphans once the dimension stopped emitting those rows.
- Two `accepted_values` enumerations on `contact_slot` in kipptaf would have
  failed CI. Both are replaced by a pattern assertion, because dense ranking has
  no upper bound and an enumerated list keeps breaking.

`rpt_clever__students` is a deliberate exception: it is a per-contact feed
rather than a two-slot one, so a third parent flows through as a primary
contact. About 32 students gain a legitimate parent in the Clever sync.

Extending the wide receivers — the contacts pivot, ParentSquare, DeansList — to
carry a third parent is **out of scope** and tracked separately.

### What is deliberately not here

No student-scope filter. The model stays SIS-agnostic and emits a row for every
student record. Verified that receivers already scope correctly: of 303 Newark
records still marked `enrolled` for the prior school year, only 15 reach the
extracts, and PowerSchool confirms all 15 are actively enrolled retained
seniors. Filtering on the Finalsite side would have removed 15 current students'
contacts.

### Known follow-ups

- The DeansList fix has no regression test — its two existing unit tests have no
  third-parent fixture. This is the class of bug that regresses.
- The comment in `int_finalsite__student_contacts__no_extra_contacts.sql` names
  four of the six consumers. The spec is accurate and complete; the comment is a
  pointer.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude-authored under human direction throughout. The human made every design
call: replacing the slot enumeration with a pattern assertion, adding the
guard-exclusion test, keeping the Clever behaviour, and rejecting a
`rel_type`-based filter on the grounds that an adult sibling can be a legal
guardian. Claude ran the audit, wrote the spec and plan, and executed via
subagents with a review gate per task plus a whole-branch review.

Four defects in Claude's own spec surfaced during execution and are corrected in
the branch history — all from measuring against currently-enrolled students
while the model deliberately emits every student record.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; the five new singular tests get a `tests/properties.yml` carrying
      `meta.dagster.ref` with `package: finalsite`, so they report as asset
      checks rather than logging observations across all parents.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      — no new dashboard consumers.
- [x] **Breaking change?** No column renames or removals. `contact_slot` gains
      values past `contact_2`; every consumer is handled above.
- [x] External sources — none added or modified.

## CI checks

- [ ] **Trunk** — `trunk check --force` run locally over all 14 changed files:
      no issues.
- [ ] **dbt Cloud** — the kipptaf chain cannot be exercised locally, because in
      a dev target its finalsite sources resolve to prod schemas holding the
      pre-change two-slot output. CI is the first real end-to-end run.
- [ ] **Dagster Cloud** — passes or not triggered.

Closes #4768
