### PR TITLE
perf(dbt): drop vacuous marts PK not_null tests and materialize a survey intermediate

### DIFF
--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -251,11 +251,26 @@ Marts inherit `contract: enforced: true` and `materialized: view` from
 explicit uniqueness test on its PK (`unique` on a single column, or
 `dbt_utils.unique_combination_of_columns` for composite).
 
-Exception: the assessment-scores star (`fct_assessment_scores_enrollment_scoped`
-plus its FK-closure dims) and the three assessment intermediates are
-`materialized: table` for Cube query performance
-([#4464](https://github.com/TEAMSchools/teamster/issues/4464)) — don't revert to
-view without re-profiling Cube's BigQuery spend.
+Exception: `dim_assessments`, `dim_courses`, `dim_dates`, `dim_regions`,
+`dim_staff`, `dim_students`, and the four assessment intermediates are
+`materialized: table`. `dim_assessments` also carries a nightly
+`automation_condition.cron_schedule` — Cube is its only consumer and Cube's
+pre-aggregation refreshes daily, so intraday rebuilds are invisible
+([#4559](https://github.com/TEAMSchools/teamster/issues/4559)).
+
+**Never materialize an FK-carrying mart as a table.** A table child emits a
+`references` clause into its CTAS DDL, and BigQuery aborts the build when a
+concurrent `create or replace table` on the FK parent changes the parent's PK
+identity ("Referenced primary key in table ... has been updated"). The
+automation condition's `~any_deps_in_progress` guard is upward-facing only, so
+nothing serializes a parent against an in-flight child.
+[#4464](https://github.com/TEAMSchools/teamster/issues/4464) moved the whole
+assessment-scores star to tables for Cube query performance;
+[#4587](https://github.com/TEAMSchools/teamster/issues/4587) reverted the seven
+FK-carrying models to views eight days later, after four such build failures in
+30 days. Per-read recomputation was accepted deliberately to remove the failure
+class — restoring the performance means solving the collision, not re-flipping
+the config.
 
 Drop model-level `dbt_utils.unique_combination_of_columns` when its column set
 equals the surrogate-key hash inputs — `unique` on the PK detects the same
@@ -276,6 +291,9 @@ A `config.materialized: table` mart renders `constraints:` into CREATE TABLE DDL
 foreign_key both render into DDL and warn otherwise.
 
 ## Converting a view mart to a table
+
+Only a mart with NO outgoing `foreign_key` constraints is eligible — see the
+FK-carrying prohibition above.
 
 - BigQuery FK DDL requires every referenced relation to be a TABLE with a PK
   constraint. Convert the full FK closure (walk `to: ref(...)` edges) in one PR

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_section_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: survey_administration_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: survey_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -26,7 +26,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: assessment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: region_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: location_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
@@ -42,7 +42,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: type
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_colleges.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_colleges.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: college_code_branch
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -17,7 +17,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: course_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_courses.yml
@@ -20,7 +20,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: course_code
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_candidates.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_candidates.yml
@@ -15,7 +15,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: first_name
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_postings.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_job_postings.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: position_title
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -24,7 +24,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: region_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_regions.yml
@@ -26,7 +26,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: name
         quote: true

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff.yml
@@ -22,7 +22,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_unique_id
         data_type: int64

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
@@ -42,7 +42,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_goal_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_goal_types.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: goal_name
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -27,7 +27,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_observation_rubric_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubrics.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubrics.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: name
         quote: true

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_types.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: name
         quote: true

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_periods.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_periods.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
       - name: staff_key
         data_type: string
         description: Foreign key to `dim_staff.staff_key` — the reportee.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
@@ -25,7 +25,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
       - name: work_assignment_key
         data_type: string
         description:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: location_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: region_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -23,7 +23,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
         config:
           meta:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
@@ -26,7 +26,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
       - name: student_key
         data_type: string
         description: Foreign key to `dim_students.student_key`.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollment_status.yml
@@ -21,7 +21,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -19,7 +19,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
@@ -27,7 +27,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
@@ -25,7 +25,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -41,7 +41,6 @@ models:
           - unique:
               config:
                 severity: error
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_students.yml
@@ -18,7 +18,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: lea_student_identifier
         data_type: int64

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: survey_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_questions.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: shortname
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_surveys.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_surveys.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: name
         quote: true

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
@@ -24,7 +24,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -19,7 +19,6 @@ models:
             warn_unenforced: false
         data_tests:
           - unique
-          - not_null
 
       - name: assessment_administration_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -16,7 +16,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: behavioral_incident_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -25,7 +25,6 @@ models:
           - unique:
               config:
                 severity: warn
-          - not_null
 
       - name: student_section_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_section_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_section_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: job_candidate_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
@@ -26,7 +26,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_status_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: teacher_staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
@@ -17,7 +17,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: staff_observation_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: teacher_staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -33,7 +33,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
@@ -19,7 +19,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
@@ -19,7 +19,6 @@ models:
           - unique:
               config:
                 severity: error
-          - not_null
 
       - name: student_enrollment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: submitter_staff_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
@@ -20,7 +20,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
@@ -18,7 +18,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - not_null
 
       - name: work_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_survey_details.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_survey_details.yml
@@ -1,5 +1,17 @@
 models:
   - name: int_surveys__manager_survey_details
+    config:
+      materialized: table
+      # 175k rows re-derived from 7 base tables on each read — 0.35 GiB per
+      # expansion vs 0.03 GiB stored, the worst recompute-to-size ratio in the
+      # survey chain.
+      meta:
+        dagster:
+          # nightly instead of eager: the only consumers are the survey marts
+          # (read by Cube, whose pre-aggregation refreshes daily) and two
+          # Tableau exposures with no Dagster-managed cron. Refs #4559
+          automation_condition:
+            cron_schedule: 0 0 * * *
     columns:
       - name: effective_survey_response_id
         data_type: string

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_survey_details.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_survey_details.yml
@@ -7,11 +7,23 @@ models:
       # survey chain.
       meta:
         dagster:
-          # nightly instead of eager: the only consumers are the survey marts
-          # (read by Cube, whose pre-aggregation refreshes daily) and two
-          # Tableau exposures with no Dagster-managed cron. Refs #4559
+          # nightly instead of eager: no consumer needs sub-daily freshness.
+          # The survey marts are its only dbt consumers, and its two Tableau
+          # exposures (manager_survey_reports, manager_survey_rollup) carry no
+          # Dagster-managed cron. Refs #4559
           automation_condition:
             cron_schedule: 0 0 * * *
+    data_tests:
+      # grain matches the hash inputs fct_survey_responses uses for its PK. It
+      # never re-ran under automation while this model was a view — the
+      # data-change condition only re-materializes tables — so the nightly tick
+      # above is what turns it into a recurring check.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - survey_id
+              - effective_survey_response_id
+              - survey_question_id
     columns:
       - name: effective_survey_response_id
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will remove 69 dbt tests that cannot fail,
materialize one survey intermediate as a table, and correct marts guidance that
currently points readers at a change known to break prod builds.

Three commits, in order:

**1. Remove 69 vacuous `not_null` tests from marts primary keys.** Every marts
PK is `dbt_utils.generate_surrogate_key` output, which never returns NULL —
`src/dbt/CLAUDE.md` already states the rule. Each of these tests still costs a
full BigQuery scan per CI run, and because most marts are views that scan
re-expands the whole upstream chain rather than reading one column. A single
`not_null` on `fct_assessment_scores_enrollment_scoped` dry-runs at 1.71 GiB
across 24 base tables.

Every deletion was verified against the model SQL, not just the YAML: each PK
traces to an unwrapped `generate_surrogate_key`, either directly or through a
non-nulling pass-through. Prod confirms zero nulls. Measured over 30 days, the
68 of them that ran cost 13,230 executions and 9.18 USD.

Two `not_null` tests were deliberately kept: `dim_dates.date_key` is a raw DATE,
and `fct_assessment_scores_enrollment_scoped.assessment_date_key` guards the
invariant the #4546 fix rests on.

**2. Correct the marts materialization guidance.** The exception paragraph in
`models/marts/CLAUDE.md` still described the eight-day window between #4464 and
#4587. It claimed the assessment-scores star and its FK-closure dims are
materialized as tables and warned against reverting them to views — but #4587
reverted the seven FK-carrying models to views on 2026-07-28, so the paragraph
named the current, correct setup as something to avoid. Replaced with the six
marts that are actually tables, why `dim_assessments` carries a nightly cron,
and the prohibition on materializing any FK-carrying mart.

**3. Materialize `int_surveys__manager_survey_details` as a table.** 175k rows
re-derived from 7 base tables on every read: 0.35 GiB per expansion against 0.03
GiB stored, the worst recompute-to-size ratio in the survey chain, and 32 survey
tests expand it. The survey marts cannot be materialized instead — they carry FK
constraints and #4587 covers exactly that — but this intermediate carries none.
Nightly rather than eager, because its only consumers are the survey marts (read
by Cube on a daily pre-aggregation refresh) and two Tableau exposures with no
Dagster-managed cron.

`int_surveys__survey_responses` was implemented and then backed out. Its hourly
consumers would force an hourly tick, and 24 rebuilds/day of 2.4 GiB plus
per-tick tests costs roughly 0.42 USD/day against roughly 0.9 USD/day of total
survey test spend measured over 30 days — net negative on quiet days. A nightly
tick would pay for itself but adds up to 24h of staleness to `survey_dashboard`
and `personalized_survey_links`.

### Not a breaking change

No model SQL, column, or contract changes. Test removals only drop checks that
are vacuous by construction, and the materialization change alters storage, not
output. One visible side effect: 69 dbt tests are 69 Dagster asset checks, so
that many checks disappear from the Dagster UI.

### Deploy note

A properties-yml-only materialization flip does not bump the dagster-dbt code
version (it is a SHA1 of raw SQL), so `int_surveys__manager_survey_details`
stays a view until the first midnight cron tick. Do not read BigQuery object
types right after merge and conclude it failed.

## AI Assistance

Claude Code did the investigation, measurement, and implementation; direction,
scope decisions, and the call to back out `int_surveys__survey_responses` were
human. The cost analysis that motivated this work is Claude's, and one of its
intermediate figures was wrong before correction — an early query mislabeled its
UTC window as America/New_York and inflated a day's CI cost by roughly 2.8x. All
figures quoted above are from corrected, calendar-day-aligned queries.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; edits are to existing properties files
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no new
      or changed consumers
- [x] **Breaking change?** No. No renamed or removed columns in any contracted
      model; see "Not a breaking change" above
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external sources touched

### Docs

- [x] No schedule, sensor, or integration changes. The `models/marts/CLAUDE.md`
      edit is a correction to existing guidance, not a new integration

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

## Verification performed

- `dbt parse --no-partial-parse --target prod` clean; manifest `not_null` count
  drops 291 to 222, exactly 69
- `dbt build` is not run locally here — dbt Cloud CI builds
  `int_surveys__manager_survey_details` as a table on the PR schema, which is
  the real gate for the materialization change
- Diff shape checked: 69 files at exactly -1/+0, all 69 removed lines identical
- `trunk check --force` clean on all changed files
