### PR TITLE
fix(dbt): exclude Miami from the Illuminate SFTP feeds

### DIFF
--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__courses.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__courses.sql
@@ -27,4 +27,4 @@ select distinct
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__courses") }}
 -- Miami left Illuminate ahead of AY2026-27
-where _dbt_source_project is distinct from 'kippmiami'
+where _dbt_source_project != 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__courses.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__courses.sql
@@ -26,3 +26,5 @@ select distinct
     null as `24 Tech Prep`,
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__courses") }}
+-- Miami left Illuminate ahead of AY2026-27
+where _dbt_source_project is distinct from 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
@@ -17,7 +17,11 @@ select
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("int_people__staff_roster") }} as sr
 inner join
-    {{ ref("stg_powerschool__schools") }} as sch on sch.state_excludefromreporting = 0
+    {{ ref("stg_powerschool__schools") }} as sch
+    on sch.state_excludefromreporting = 0
+    -- Miami left Illuminate ahead of AY2026-27. Filter the SITE side only: CMO
+    -- staff are network-wide, so they keep roles at every remaining site.
+    and sch._dbt_source_project is distinct from 'kippmiami'
 where
     sr.worker_status_code != 'Terminated'
     and sr.home_department_name in ('Teaching and Learning', 'Data', 'Executive')
@@ -51,6 +55,8 @@ where
     sr.worker_status_code != 'Terminated'
     and sr.home_department_name not in ('Teaching and Learning', 'Data', 'Executive')
     and sr.home_work_location_is_campus
+    -- Miami left Illuminate ahead of AY2026-27
+    and sr.home_work_location_dagster_code_location is distinct from 'kippmiami'
 
 union all
 
@@ -75,6 +81,8 @@ where
     worker_status_code != 'Terminated'
     and home_department_name not in ('Teaching and Learning', 'Data', 'Executive')
     and not home_work_location_is_campus
+    -- Miami left Illuminate ahead of AY2026-27
+    and home_work_location_dagster_code_location is distinct from 'kippmiami'
 
 union all
 
@@ -95,3 +103,5 @@ select
     1 as `05 Session Type ID`,
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("int_people__temp_staff") }}
+-- Miami left Illuminate ahead of AY2026-27
+where dagster_code_location is distinct from 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
@@ -21,7 +21,7 @@ inner join
     on sch.state_excludefromreporting = 0
     -- Miami left Illuminate ahead of AY2026-27. Filter the SITE side only: CMO
     -- staff are network-wide, so they keep roles at every remaining site.
-    and sch._dbt_source_project is distinct from 'kippmiami'
+    and sch._dbt_source_project != 'kippmiami'
 where
     sr.worker_status_code != 'Terminated'
     and sr.home_department_name in ('Teaching and Learning', 'Data', 'Executive')
@@ -56,7 +56,7 @@ where
     and sr.home_department_name not in ('Teaching and Learning', 'Data', 'Executive')
     and sr.home_work_location_is_campus
     -- Miami left Illuminate ahead of AY2026-27
-    and sr.home_work_location_dagster_code_location is distinct from 'kippmiami'
+    and sr.home_work_location_dagster_code_location != 'kippmiami'
 
 union all
 
@@ -82,7 +82,7 @@ where
     and home_department_name not in ('Teaching and Learning', 'Data', 'Executive')
     and not home_work_location_is_campus
     -- Miami left Illuminate ahead of AY2026-27
-    and home_work_location_dagster_code_location is distinct from 'kippmiami'
+    and home_work_location_dagster_code_location != 'kippmiami'
 
 union all
 
@@ -104,4 +104,4 @@ select
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("int_people__temp_staff") }}
 -- Miami left Illuminate ahead of AY2026-27
-where dagster_code_location is distinct from 'kippmiami'
+where dagster_code_location != 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__sites.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__sites.sql
@@ -39,5 +39,4 @@ select
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__schools") }}
 -- Miami left Illuminate ahead of AY2026-27
-where
-    state_excludefromreporting = 0 and _dbt_source_project is distinct from 'kippmiami'
+where state_excludefromreporting = 0 and _dbt_source_project != 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__sites.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__sites.sql
@@ -38,4 +38,6 @@ select
     null as `15 Parent Site ID`,
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__schools") }}
-where state_excludefromreporting = 0
+-- Miami left Illuminate ahead of AY2026-27
+where
+    state_excludefromreporting = 0 and _dbt_source_project is distinct from 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__student_portal_accounts.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__student_portal_accounts.sql
@@ -11,4 +11,4 @@ select
 from {{ ref("int_extracts__student_enrollments") }}
 -- Miami left Illuminate ahead of AY2026-27; its PowerSchool records still read
 -- enroll_status = 0 post-Focus-cutover, so the region filter is load-bearing
-where rn_all = 1 and enroll_status = 0 and region is distinct from 'Miami'
+where rn_all = 1 and enroll_status = 0 and region != 'Miami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__student_portal_accounts.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__student_portal_accounts.sql
@@ -9,4 +9,6 @@ select
     student_web_password as `05 Temporary Password`,
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("int_extracts__student_enrollments") }}
-where rn_all = 1 and enroll_status = 0
+-- Miami left Illuminate ahead of AY2026-27; its PowerSchool records still read
+-- enroll_status = 0 post-Focus-cutover, so the region filter is load-bearing
+where rn_all = 1 and enroll_status = 0 and region is distinct from 'Miami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__terms.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__terms.sql
@@ -15,3 +15,5 @@ select
     dcid as `09 Local Term ID`,
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__terms") }}
+-- Miami left Illuminate ahead of AY2026-27
+where _dbt_source_project is distinct from 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__terms.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__terms.sql
@@ -16,4 +16,4 @@ select
 -- trunk-ignore-end(sqlfluff/RF05)
 from {{ ref("stg_powerschool__terms") }}
 -- Miami left Illuminate ahead of AY2026-27
-where _dbt_source_project is distinct from 'kippmiami'
+where _dbt_source_project != 'kippmiami'

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__users.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__users.sql
@@ -11,6 +11,8 @@ with
             home_business_unit_name,
             job_title,
         from {{ ref("int_people__staff_roster") }}
+        -- Miami left Illuminate ahead of AY2026-27
+        where home_work_location_dagster_code_location is distinct from 'kippmiami'
 
         union all
 
@@ -28,6 +30,8 @@ with
             company as home_business_unit_name,
             title as job_title,
         from {{ ref("int_people__temp_staff") }}
+        -- Miami left Illuminate ahead of AY2026-27
+        where dagster_code_location is distinct from 'kippmiami'
     )
 
 -- trunk-ignore(sqlfluff/ST06)

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__users.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__users.sql
@@ -11,8 +11,11 @@ with
             home_business_unit_name,
             job_title,
         from {{ ref("int_people__staff_roster") }}
-        -- Miami left Illuminate ahead of AY2026-27
-        where home_work_location_dagster_code_location is distinct from 'kippmiami'
+        -- Miami left Illuminate ahead of AY2026-27. The inequality also excludes
+        -- rows with a NULL code location, which is intended, not an oversight: a
+        -- staff row with no work location does not belong in the feed. Do not
+        -- "fix" this to is distinct from.
+        where home_work_location_dagster_code_location != 'kippmiami'
 
         union all
 
@@ -31,7 +34,7 @@ with
             title as job_title,
         from {{ ref("int_people__temp_staff") }}
         -- Miami left Illuminate ahead of AY2026-27
-        where dagster_code_location is distinct from 'kippmiami'
+        where dagster_code_location != 'kippmiami'
     )
 
 -- trunk-ignore(sqlfluff/ST06)


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will drop every Miami student, staff member, site, term, and course from the 11-file Illuminate SFTP feed, so the feed can be restarted for 2026-27 without leaking a region that has left the platform.

`kipptaf__extracts__illuminate__asset_job_schedule` (cron `0 3 * * *` ET) is currently STOPPED. **Merge this and let prod rematerialize BEFORE restarting it** — otherwise the first 3am run pushes 1,114 Miami students and 477 Miami staff rows into Illuminate.

Six of the 11 feed models carried Miami rows: the five with no academic-year filter, plus the two staff feeds, which read the network-wide roster.

### Verified deltas

Prod view vs a dev build of this branch, both reading prod upstreams in the same query:

| Feed | prod | this branch | removed | reconciles to |
| --- | --- | --- | --- | --- |
| `student_portal_accounts` | 10,963 | 9,849 | 1,114 | Miami students still reading `enroll_status = 0` |
| `users` | 4,780 | 4,303 | 477 | 469 Miami roster rows (all statuses) plus 5 Miami temps plus 3 NULL-location records |
| `roles` | 2,219 | 1,964 | 255 | 41 campus-based plus 129 school-based plus 5 temps plus 80 (40 CMO staff at 2 Miami sites) |
| `terms` | 2,139 | 1,925 | 214 | every Miami term row |
| `courses` | 1,537 | 1,443 | 94 | 94 of 149 Miami course tuples are Miami-only; 55 are shared with NJ and correctly survive `select distinct` |
| `sites` | 21 | 19 | 2 | the 2 Miami schools that pass `state_excludefromreporting = 0` |

Every number reconciles exactly against an independent count of the Miami population. `dbt build --target dev --defer --favor-state` passes on all 6 models, including both contract enforcements and both uniqueness tests.

### The NULL-location rows in `users` are excluded on purpose

Three roster rows carry a NULL `home_work_location_dagster_code_location`. A plain `!=` excludes them along with Miami, because `NULL != 'kippmiami'` evaluates to NULL rather than true — and that exclusion is **desired**: a staff row with no work location does not belong in the feed.

That behavior is a consequence of three-valued logic rather than something the SQL states outright, which makes it easy to misread as an oversight. An earlier revision of this PR did exactly that and "fixed" it to `is distinct from`, which wrongly re-admitted all three. The `users` model now carries a comment saying the exclusion is deliberate, so the next reader does not repeat it. Every predicate here uses the same `!=` idiom as the roughly 45 other region-exclusion sites across the project.

For the record, all three are ADP data-entry gaps rather than anything this feed should carry: probed against the ADP API, all three return HTTP 200 (not deleted), and all three show `homeOrganizationalUnits: []` with `homeWorkLocation: null` — including at `asOfDate` values mid-tenure while their assignments were still Active. One is a 3-day test record from 2021; the other two never had a location set at any point. Worth a People Operations follow-up on its own, not here.

In `roles`, the CMO branch filters the **site** side only. Those staff are network-wide, so they keep roles at every remaining site; filtering the roster side would have stripped Miami-seated central staff from all 19 sites.

### Models deliberately NOT changed

`roster`, `enrollment`, `studemo`, `programs`, and `mastschd` all filter `current_school_year` with no region restriction, and prod confirms zero Miami rows for 2026-27 — the Focus cutover emptied Miami's PowerSchool data for the year. Adding a dead predicate to a year-scoped feed is noise, so they are untouched.

The same absence of a region filter is why **Paterson 2026-27 needs no code at all**: 889 students, 3,934 non-dropped course enrollments, 140 sections, 4 sites, and 135 courses already flow through.

### Out of scope

The 1,114 Miami students still read `enroll_status = 0` in PowerSchool roughly a year after the Focus cutover — nobody withdrew them. This PR stops them reaching Illuminate; it does not fix the stale PowerSchool records. Worth a separate Ops ticket.

## AI Assistance

Claude Code investigated and authored this change end to end, human-directed. Two course corrections came from the human review during the session: the scoping decision to filter only the 6 feeds that actually carry Miami rather than all 11, and the correction that NULL-location exclusion is intended behavior rather than a bug to fix.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] No new models, so no new properties files needed; no column changes, so no contract or exposure impact.
- [x] **Breaking change?** No. Filters only, no renames or removals — every contracted column set is unchanged.
- [x] No external sources added or modified.

## CI checks

- [x] **Trunk** — clean on all 6 files.
- [x] **dbt Cloud** — passed with zero warnings on the first commit; re-running for the second.
- [x] **Dagster Cloud** — not triggered (dbt-only change).

Refs #4777
