### PR TITLE
perf(dbt): remove 59 vacuous data tests that cannot fail

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -759,9 +759,25 @@ legitimately-superseded inactive rows that repeat the key.
 - Unscoped `+config` applies to tests from all installed packages, not just the
   current project
 - **`accepted_values` passes NULLs** — it compiles to
-  `where value not in (...)`, which NULL never satisfies. Pair it with
-  `not_null` on any enum column that must be non-null, including one a
-  `coalesce` makes non-null by construction.
+  `where value not in (...)`, which NULL never satisfies. Every enum column that
+  must be non-null carries `not_null` too, including one a `coalesce` makes
+  non-null by construction. **Never delete a `not_null` from a column that
+  carries `accepted_values`.** It is not vacuous, whatever the SQL looks like —
+  the pairing is the only thing making the enum test reject NULL.
+- **Never add `not_null` to a column that cannot be NULL by construction.** It
+  can never fail, and it still costs a full BigQuery scan per CI run — on a view
+  mart that scan re-expands the entire upstream chain. Non-nullable by
+  construction means every definition site is one of: an unwrapped
+  `generate_surrogate_key`, a `coalesce` / `ifnull` with a non-null default, a
+  literal in every UNION branch, or `count(...)`. The `accepted_values` pairing
+  above overrides this rule; nothing else does.
+
+### Verifying a test-removal PR
+
+Never report a count from the YAML diff — it does not say which dbt nodes
+actually disappeared. `dbt parse` on main and on the branch, then diff the
+`resource_type == 'test'` node names. That fixes the delta and proves nothing
+unintended was dropped.
 
 ### An FK check belongs on the pre-join model, as a column `relationships` test
 
@@ -892,8 +908,8 @@ if(
 Without this, relationship tests check the placeholder hash against the parent
 dimension and fail.
 
-Corollary: never add `not_null` tests on `generate_surrogate_key` output — it
-never returns NULL.
+**Never add a `not_null` test to `generate_surrogate_key` output** — it never
+returns NULL, so the test cannot fail. This holds for FK columns as much as PKs.
 
 #### Nullable PK inputs need a fallback, not a null-wrap
 
@@ -1152,8 +1168,11 @@ alias.
 - All new or modified models require `description:` on the model and every
   column. Profile staging data via BigQuery MCP; infer downstream from parents.
   Describe calculated fields by logic. Use qualitative language — no stats.
-- Columns with **per-column** `data_tests:` should be sorted to the top of the
-  `columns:` list for visibility. Model-level composite tests
+- Columns with **per-column** `data_tests:` must be sorted to the top of the
+  `columns:` list for visibility — including after a change that strips a
+  column's last test. Reorder freely under `contract: enforced`: BigQuery
+  matches contract columns by name, not position (`fct_survey_responses` already
+  differs from its `select` order and builds clean). Model-level composite tests
   (`dbt_utils.unique_combination_of_columns`, etc.) do not trigger this rule —
   they go in the model-level `data_tests:` block ABOVE `columns:`, and their
   referenced columns can stay in their natural / contract order.

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__contact_address_of_record.yml
@@ -77,10 +77,6 @@ models:
           Number of distinct addresses on this contact's household linkage. One
           resolves outright; zero means no household carries a street; more than
           one means the emitted address was picked from among them.
-        data_tests:
-          - not_null:
-              config:
-                severity: error
       - name: address_1
         data_type: string
         description:

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
@@ -57,6 +57,9 @@ models:
                   - unresolved
               config:
                 severity: error
+          - not_null:
+              config:
+                severity: error
       - name: address_source
         data_type: string
         description:

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_address_of_record.yml
@@ -57,9 +57,6 @@ models:
                   - unresolved
               config:
                 severity: error
-          - not_null:
-              config:
-                severity: error
       - name: address_source
         data_type: string
         description:

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
@@ -16,9 +16,6 @@ models:
           - unique:
               config:
                 severity: error
-          - not_null:
-              config:
-                severity: error
       - name: location_name
         data_type: string
         description: |

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -23,8 +23,6 @@ models:
             to_columns: [course_section_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_course_sections')
@@ -39,8 +37,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
@@ -22,8 +22,6 @@ models:
             to_columns: [course_section_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_course_sections')
@@ -39,8 +37,6 @@ models:
             to_columns: [term_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_terms')

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -34,8 +34,6 @@ models:
             to_columns: [student_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_students')
@@ -52,8 +50,6 @@ models:
             to_columns: [student_contact_person_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_contact_persons')

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
@@ -42,7 +42,6 @@ models:
           Discriminator for respondent type: staff, student, or family.
           Determines which respondent FK is populated.
         data_tests:
-          - not_null
           - accepted_values:
               arguments:
                 values:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
@@ -42,6 +42,7 @@ models:
           Discriminator for respondent type: staff, student, or family.
           Determines which respondent FK is populated.
         data_tests:
+          - not_null
           - accepted_values:
               arguments:
                 values:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
@@ -28,8 +28,6 @@ models:
             to_columns: [survey_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_surveys')
@@ -45,8 +43,6 @@ models:
             to_columns: [survey_question_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_survey_questions')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
@@ -29,8 +29,6 @@ models:
             to_columns: [student_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_students')
@@ -45,8 +43,6 @@ models:
             to_columns: [college_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_colleges')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -30,8 +30,6 @@ models:
             warn_unsupported: false
             warn_unenforced: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_courses')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
@@ -42,10 +42,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - relationships:
-              arguments:
-                to: ref('dim_staff')
-                field: staff_key
 
       - name: google_email
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -31,7 +31,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff')
@@ -48,7 +47,6 @@ models:
             to_columns: [term_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_terms')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -39,7 +39,6 @@ models:
             to_columns: [staff_observation_rubric_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_observation_rubrics')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
@@ -29,7 +29,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
@@ -35,7 +35,6 @@ models:
             to_columns: [student_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_students')
@@ -53,7 +52,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollment_status.yml
@@ -21,10 +21,6 @@ models:
             warn_unsupported: false
         data_tests:
           - unique
-          - relationships:
-              arguments:
-                to: ref('dim_student_enrollments')
-                field: student_enrollment_key
 
       - name: iep_classification
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -31,8 +31,6 @@ models:
             warn_unsupported: false
             warn_unenforced: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_students')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
@@ -37,7 +37,6 @@ models:
             to_columns: [student_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_students')
@@ -56,7 +55,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
@@ -35,7 +35,6 @@ models:
             to_columns: [student_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_students')
@@ -54,7 +53,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -74,8 +74,6 @@ models:
             warn_unsupported: false
             warn_unenforced: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_course_sections')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
@@ -28,8 +28,6 @@ models:
             to_columns: [survey_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_surveys')
@@ -45,8 +43,6 @@ models:
             to_columns: [term_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_terms')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
@@ -21,9 +21,6 @@ models:
           - unique:
               config:
                 severity: error
-          - not_null:
-              config:
-                severity: error
 
       - name: location_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
@@ -29,7 +29,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
@@ -31,7 +31,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
@@ -32,7 +32,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
@@ -36,7 +36,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
@@ -30,7 +30,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
@@ -30,7 +30,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
@@ -29,7 +29,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
@@ -29,8 +29,6 @@ models:
             to_columns: [behavioral_incident_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('fct_behavioral_incidents')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
@@ -30,8 +30,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
@@ -29,8 +29,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -37,8 +37,6 @@ models:
             to_columns: [student_section_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -30,8 +30,6 @@ models:
             to_columns: [student_section_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [student_section_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_section_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
@@ -29,8 +29,6 @@ models:
             to_columns: [job_candidate_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_job_candidates')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
@@ -30,7 +30,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
@@ -30,7 +30,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_staff')
@@ -48,7 +46,6 @@ models:
             to_columns: [staff_observation_goal_type_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_observation_goal_types')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
@@ -29,7 +29,6 @@ models:
             to_columns: [staff_observation_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('fct_staff_observations')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -45,8 +45,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
@@ -31,8 +31,6 @@ models:
             to_columns: [student_enrollment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_student_enrollments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
@@ -32,8 +32,6 @@ models:
             to_columns: [staff_key]
             warn_unsupported: false
         data_tests:
-          - not_null
-
           - relationships:
               arguments:
                 to: ref('dim_staff')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -30,13 +30,6 @@ models:
             to: ref('fct_survey_submissions')
             to_columns: [survey_submission_key]
             warn_unsupported: false
-        data_tests:
-          - relationships:
-              arguments:
-                to: ref('fct_survey_submissions')
-                field: survey_submission_key
-              config:
-                severity: error
       - name: survey_question_key
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -20,16 +20,6 @@ models:
         data_tests:
           - unique
 
-      - name: survey_submission_key
-        data_type: string
-        description: >-
-          FK to fct_survey_submissions. Links this response to its parent
-          submission record.
-        constraints:
-          - type: foreign_key
-            to: ref('fct_survey_submissions')
-            to_columns: [survey_submission_key]
-            warn_unsupported: false
       - name: survey_question_key
         data_type: string
         description: >-
@@ -45,6 +35,17 @@ models:
               arguments:
                 to: ref('dim_survey_questions')
                 field: survey_question_key
+
+      - name: survey_submission_key
+        data_type: string
+        description: >-
+          FK to fct_survey_submissions. Links this response to its parent
+          submission record.
+        constraints:
+          - type: foreign_key
+            to: ref('fct_survey_submissions')
+            to_columns: [survey_submission_key]
+            warn_unsupported: false
       - name: response_value
         data_type: numeric
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -64,6 +64,7 @@ models:
           Discriminator for respondent type: staff, student, or family.
           Determines which respondent FK is populated.
         data_tests:
+          - not_null
           - accepted_values:
               arguments:
                 values:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -64,7 +64,6 @@ models:
           Discriminator for respondent type: staff, student, or family.
           Determines which respondent FK is populated.
         data_tests:
-          - not_null
           - accepted_values:
               arguments:
                 values:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
@@ -32,7 +32,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
@@ -30,7 +30,6 @@ models:
             to_columns: [work_assignment_key]
             warn_unsupported: false
         data_tests:
-          - not_null
           - relationships:
               arguments:
                 to: ref('dim_staff_work_assignments')

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
@@ -14,8 +14,6 @@ models:
           generate_surrogate_key(["tag_id"]). Uniqueness is enforced via the
           unique test on tag_id below — the hash is a deterministic function of
           tag_id.
-        data_tests:
-          - not_null
       - name: tag_id
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observation_types.yml
@@ -7,13 +7,6 @@ models:
       dim_staff_observation_types, int_schoolmint_grow__observations, and
       dim_staff_observation_expectations.
     columns:
-      - name: staff_observation_type_key
-        data_type: string
-        description: >-
-          Surrogate key derived from tag_id. Generated with
-          generate_surrogate_key(["tag_id"]). Uniqueness is enforced via the
-          unique test on tag_id below — the hash is a deterministic function of
-          tag_id.
       - name: tag_id
         data_type: string
         description: >-
@@ -29,6 +22,14 @@ models:
         data_tests:
           - unique
           - not_null
+
+      - name: staff_observation_type_key
+        data_type: string
+        description: >-
+          Surrogate key derived from tag_id. Generated with
+          generate_surrogate_key(["tag_id"]). Uniqueness is enforced via the
+          unique test on tag_id above — the hash is a deterministic function of
+          tag_id.
       - name: name
         quote: true
         data_type: string

--- a/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
+++ b/src/dbt/kipptaf/models/schoolmint/grow/intermediate/properties/int_schoolmint_grow__observations.yml
@@ -29,8 +29,6 @@ models:
           Pre-hashed surrogate key derived from rubric_id. Generated with
           generate_surrogate_key(["rubric_id"]). Consumed by
           fct_staff_observations as its rubric FK.
-        data_tests:
-          - not_null
       - name: staff_observation_type_key
         data_type: string
         description: >-


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

When merged, this pull request will remove 59 dbt data tests that cannot fail by
construction. Each one still costs a full BigQuery scan per CI run, and because
most of the host models are views, that scan re-expands the whole upstream chain
rather than reading one column.

[#4773](https://github.com/TEAMSchools/teamster/issues/4773) removed 69 such
tests from marts **primary key** columns. This PR covers the rest of the sweep:
mostly the **foreign key** columns it did not touch, plus two other vacuous
classes. One correction to that framing, from review: `dim_terms.term_key` is a
single-column **primary key** that #4773's pass never reached — `dim_terms.yml`
was untouched by it. So Class A is not purely FK columns. Of the 59 removals, 9
sit on a PK-constrained column: 6 are composite-PK members in bridges (which are
FKs at the same time), and 3 are single-column PKs.

**Class A — 55 `not_null` tests on unwrapped surrogate keys.**
`dbt_utils.generate_surrogate_key` coalesces every input to a null sentinel
before hashing, so it never returns NULL. `src/dbt/CLAUDE.md` already states the
rule. 52 are marts columns, 2 are `int_schoolmint_grow__*` intermediates, and 1
is `stg_google_sheets__people__locations.location_key`.

Every removal was verified against the model SQL, not just the YAML: each
definition site is an unwrapped macro call, and none sits behind an outer join
that could null it. Conditional keys are excluded — a wrapped key such as
`if(sr.employee_number is not null, {{ generate_surrogate_key([...]) }}, cast(null as string)) as lead_teacher_staff_key`
keeps its `not_null`, because that test is real.

**Class B — 1 `not_null` test on a non-nullable expression.**
`int_finalsite__contact_address_of_record.candidate_count` is
`coalesce(cc.candidate_count, 0)`, and the column carries no `accepted_values`
test.

Three further Class B candidates were removed and then **restored** after
review. `src/dbt/CLAUDE.md` states that `accepted_values` compiles to
`where value not in (...)`, which NULL never satisfies, so it must be paired
with `not_null` on any enum column that must be non-null — explicitly including
one a `coalesce` makes non-null by construction. That is exactly the reasoning
those three were removed under, and
`int_finalsite__contact_address_of_record.resolution_status` sets the precedent
in the same project. Restored:
`bridge_survey_expectations.respondent_type`,
`fct_survey_submissions.respondent_type`, and
`int_finalsite__student_address_of_record.resolution_status`.

**Class C — 3 `relationships` tests on an inner-joined parent.** The join has
already dropped every unmatched row, which `src/dbt/CLAUDE.md` documents:
`dim_staff_cube_access.staff_key`, `fct_survey_responses.survey_submission_key`,
and `dim_student_enrollment_status.student_enrollment_key` — the last of which
selects directly `from dim_student_enrollments`.

### Held out for review

The 7 `dim_staff_cube_access` scope columns are `coalesce(ovr.x, rp.x, 'none')`
and so are equally vacuous, but they feed Cube's row-level access policies and
the test doubles as a tripwire if that `coalesce` is ever dropped. They are left
in place pending a call on this PR, the way #4773 kept `assessment_date_key`.

### Checked and deliberately kept

`dim_student_iep_status.is_current` and
`dim_student_meal_eligibility_status.is_current` are **not** vacuous —
`max(effective_end_date)` returns NULL when every value is NULL, and `least()`
propagates that. `dim_student_ell_status.is_current` is vacuous, but only
through a two-hop in-model chain, which is too fragile to justify removing.

The sweep also found no duplicate generics anywhere in the repo, and no
single-column `dbt_utils.unique_combination_of_columns` shadowing a `unique`.
Eleven of sixteen projects are clean.

### Verification

Checked against the parsed manifests rather than the YAML alone:

- `dbt parse --no-partial-parse` clean on `kipptaf` and `finalsite`
- `kipptaf` 808 tests to 750; `finalsite` 39 to 38 — delta exactly 59
- every removed node name begins with `not_null_` or `relationships_`; nothing
  added
- `trunk check --force` on all changed files: no issues

Two YAML files also had their tested-columns-first ordering restored
(`fct_survey_responses`, `int_schoolmint_grow__observation_types`). Removing a
column's only test had left an untested column above tested ones. Column order
in a properties file does not affect contract enforcement — `fct_survey_responses`
already differs from its select order and builds clean.

### Not a breaking change

No model SQL, column, or contract changes. One visible side effect: 59 dbt tests
are 59 Dagster asset checks, so that many checks disappear from the Dagster UI.

Refs #4784

## AI Assistance

Claude Code ran the sweep across all 16 dbt projects, verified each candidate
against the model SQL, applied the removals, and confirmed the result against
the parsed manifests. Human-directed: the decision to open an issue and work in
a worktree, and the scope call to hold the seven `dim_staff_cube_access` scope
tests pending review.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; existing properties files edited only
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      model changes, so no exposure changes
- [x] **Breaking change?** No. No columns renamed or removed, no contract
      changes. Rollback is a straight revert of the single commit.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      no external source changes

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).
