### PR TITLE
fix(google): validate groupKey before sending student group memberships

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -50,6 +50,14 @@
   filter matches the pushed delta (which includes the merge commit), NOT the net
   three-dot PR diff (where the merged-in files, now equal to main, don't
   appear).
+- **A markdown-only commit still re-triggered the `kipptaf` deploy** on
+  `pull_request`, despite `"!**/CLAUDE.md"` in BOTH trigger blocks of
+  `deploy-prod-kipptaf.yaml` (verified: the commit touched 3 files, all `.md`,
+  and a `kipptaf` run appeared for that headSha). This contradicts the
+  pushed-delta model above, which predicts no run — one of the two is
+  incomplete, and no mechanism is established here. Plan for the cost: a
+  docs-only push to a PR is NOT free, so batch doc changes into the code commit
+  rather than splitting them off to "avoid CI".
 - **Each `deploy-prod-<location>.yaml` push-`paths` must list every dbt package
   in that district's `src/dbt/<district>/packages.yml`** (`src/dbt/pearson/**`,
   etc.). Drift silently skips that district's prod deploy on a shared

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   findings are advisory, and `git grep` settles it faster than complying.
   **Always invoke `superpowers:receiving-code-review` BEFORE processing
   `claude-review` findings** — verify each claim (including its file:line
-  citations) against the code before relaying or replying, not after.
+  citations) against the code before relaying or replying, not after. Fixing a
+  finding in code is not a reply — post a per-finding verdict as a PR comment
+  (declines included, with reasons). A silent fix reads to a human reviewer as
+  an unaddressed review.
 
 - **A dispatched code-review subagent's "confirmed non-issue" dismissals aren't
   authoritative** — one over-read the `unnest` scalar-aggregate carve-out to
@@ -331,6 +334,13 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **IDE selection arrives only via `<ide_selection>` tags**, not
   `<ide_opened_file>` (which only names the open path). When the user references
   "this" without an `<ide_selection>`, ask for the snippet — don't guess.
+
+- **Before claiming a harness artifact (rewritten output, phantom rendering,
+  truncated literal), verify with a DERIVED value** — line length, `grep -c`, a
+  checksum. A misread is far likelier than a rewriting pipeline, and a plausible
+  substitute string survives eyeballing where a length does not. This session an
+  asserted "tool output renders X as Y" artifact was a plain misread, and it
+  produced a false correction to the user before it was tested.
 
 - **Built-in tools over Bash**: Use dedicated tools for file I/O (Read, Grep,
   Glob, Edit, Write). Bash is only for commands with no dedicated tool (`git`,

--- a/docs/superpowers/plans/2026-08-10-google-directory-groupkey-guard.md
+++ b/docs/superpowers/plans/2026-08-10-google-directory-groupkey-guard.md
@@ -1,0 +1,1003 @@
+# Google Directory `groupKey` Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop sending group-membership adds for a Google Workspace group that
+does not exist, without blocking student account provisioning, and surface the
+missing group once per run instead of once per student.
+
+**Architecture:** Re-enable the dormant `groups` asset in the kipptaf Google
+Directory code location so a `stg_google_directory__groups` model exists, then
+left join it in `rpt_google_directory__users_import` so an unresolvable group
+address becomes a null `groupKey` — the same shape `orgUnitPath` already uses.
+The membership-payload builder skips null-`groupKey` users and returns one
+aggregated error, which the `user_create` asset folds into its `zero_api_errors`
+check.
+
+**Tech Stack:** Dagster (`dagster`, `dagster-gcp`), Google Admin SDK Directory
+API via `googleapiclient`, Pydantic + `py_avro_schema`, dbt on BigQuery, pytest,
+uv.
+
+Spec:
+`docs/superpowers/specs/2026-08-10-google-directory-groupkey-guard-design.md`
+
+Refs [#4766](https://github.com/TEAMSchools/teamster/issues/4766)
+
+## Global Constraints
+
+- **Worktree:** every command and every file edit targets
+  `/workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard`.
+  Use `git -C <worktree>` for git and `uv --directory <worktree> run ...`
+  (prefixed with `VIRTUAL_ENV=`) for Python. Editing
+  `/workspaces/teamster/<path>` instead silently dirties `main`.
+- **Python:** always `uv run`, never bare `python` / `python3` / `pytest`.
+- **`requires-python = ">=3.13"`.** Built-in generics (`list[dict]`,
+  `tuple[list[dict], list[dict]]`), `X | None` for nullable.
+- **Docstrings:** Google Python Style Guide. Multi-line is expected here.
+- **Do not run `trunk fmt`.** The pre-commit hook formats. Run
+  `.trunk/tools/trunk check --force --no-fix <paths> </dev/null` from inside the
+  worktree only where a step says to; the binary lives only in the main repo, so
+  invoke it by absolute path with cwd set to the worktree.
+- **SQL conventions:** BigQuery dialect, trailing comma after the last select
+  column (CV03), ST06 select-column ordering (plain refs grouped by source table
+  in join order, then constants, then simple functions, then logicals), no
+  one-sided calculations in join predicates, no `ORDER BY`, no `QUALIFY`, max
+  one level of function nesting.
+- **dbt staging layer:** `staging/` under `google/directory/` inherits
+  `+materialized: table` and `+contract: enforced: true` from
+  `src/dbt/kipptaf/dbt_project.yml` — do not repeat either in properties yml.
+  Every staging test sets `config: severity: error` explicitly, because the
+  project default is `warn`.
+- **PII:** group addresses and org unit paths are not student PII. Do not put
+  any student email, name, or number in a commit message, PR body, or issue
+  comment.
+- **The `members` asset and `MEMBERS_SCHEMA` stay commented out.** They belong
+  to the deferred reconciliation work in #4766. Re-enabling them is out of
+  scope.
+- **Do not add a dbt test on null `groupKey`.** The extract is a view, and the
+  data-change automation condition only re-materializes tables, so such a test
+  would almost never re-run. The Python-side aggregated error is the alert.
+
+---
+
+## File Structure
+
+| File                                                                                      | Responsibility                                    |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/teamster/libraries/google/directory/resources.py`                                    | Membership-payload builder; skip and report guard |
+| `tests/resources/test_resource_google_directory.py`                                       | Unit tests for that builder                       |
+| `src/teamster/code_locations/kipptaf/google/directory/schema.py`                          | Avro schema for the `groups` asset                |
+| `src/teamster/code_locations/kipptaf/google/directory/assets.py`                          | `groups` asset; `user_create` caller wiring       |
+| `src/teamster/code_locations/kipptaf/google/directory/schedules.py`                       | Daily pull of `groups`                            |
+| `src/dbt/kipptaf/models/google/directory/sources-external.yml`                            | External Avro source over the new GCS prefix      |
+| `src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql`        | Flat staging select                               |
+| `.../staging/properties/stg_google_directory__groups.yml`                                 | Contract columns, uniqueness test, descriptions   |
+| `src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql` | The guard join                                    |
+| `.../extracts/google/directory/properties/rpt_google_directory__users_import.yml`         | `groupKey` description; stale Paterson sentence   |
+
+Task order is Python first, then Dagster wiring, then dbt. Task 1 is inert until
+Task 4 lands, because `groupKey` cannot be null before the join exists — so each
+task is independently safe to merge.
+
+---
+
+### Task 1: Skip and report unresolvable group addresses
+
+**Files:**
+
+- Modify: `src/teamster/libraries/google/directory/resources.py:696-726`
+- Modify:
+  `src/teamster/code_locations/kipptaf/google/directory/assets.py:208-218`
+- Test: `tests/resources/test_resource_google_directory.py:469-497`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces:
+  `members_for_created_users(users: list[dict], create_errors: list[dict]) -> tuple[list[dict], list[dict]]`.
+  First element is `batch_insert_members` payloads (`groupKey` / `email` /
+  `delivery_settings`). Second element holds at most one dict with keys `error`
+  (str), `count` (int), `orgUnitPaths` (list[str]).
+
+- [ ] **Step 1: Update the shared test fixtures**
+
+The three existing tests call `_created_user`, which has no `orgUnitPath` and no
+way to express a null `groupKey`. Replace both helpers at
+`tests/resources/test_resource_google_directory.py:472-478`:
+
+```python
+def _created_user(
+    email: str,
+    group_key: str | None = "g@x.org",
+    org_unit_path: str = "/Students/School A",
+) -> dict:
+    return {
+        "primaryEmail": email,
+        "groupKey": group_key,
+        "orgUnitPath": org_unit_path,
+    }
+
+
+def _member(email: str) -> dict:
+    return {"groupKey": "g@x.org", "email": email, "delivery_settings": "DISABLED"}
+```
+
+- [ ] **Step 2: Update the three existing tests for the tuple return**
+
+Each currently asserts against a bare list. Replace the three assertions:
+
+```python
+def test_members_for_created_users_all_succeeded():
+    users = [_created_user("a@x.org"), _created_user("b@x.org")]
+    assert members_for_created_users(users, []) == (
+        [_member("a@x.org"), _member("b@x.org")],
+        [],
+    )
+
+
+def test_members_for_created_users_skips_failed_create():
+    users = [_created_user("a@x.org"), _created_user("b@x.org")]
+    create_errors = [{"primaryEmail": "b@x.org", "error": "boom"}]
+    assert members_for_created_users(users, create_errors) == (
+        [_member("a@x.org")],
+        [],
+    )
+
+
+def test_members_for_created_users_all_failed_returns_empty():
+    users = [_created_user("a@x.org")]
+    create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]
+    assert members_for_created_users(users, create_errors) == ([], [])
+```
+
+- [ ] **Step 3: Write the three new failing tests**
+
+Append after `test_members_for_created_users_all_failed_returns_empty`:
+
+```python
+def test_members_for_created_users_skips_null_group_key():
+    users = [_created_user("a@x.org"), _created_user("b@x.org", group_key=None)]
+
+    members, _ = members_for_created_users(users, [])
+
+    assert members == [_member("a@x.org")]
+
+
+def test_members_for_created_users_reports_null_group_key_once():
+    users = [
+        _created_user("a@x.org", group_key=None, org_unit_path="/Students/School B"),
+        _created_user("b@x.org", group_key=None, org_unit_path="/Students/School A"),
+    ]
+
+    _, unresolved = members_for_created_users(users, [])
+
+    assert unresolved == [
+        {
+            "error": (
+                "2 created users have no resolvable students group; membership"
+                " skipped"
+            ),
+            "count": 2,
+            "orgUnitPaths": ["/Students/School A", "/Students/School B"],
+        }
+    ]
+
+
+def test_members_for_created_users_does_not_report_null_group_key_for_failed_create():
+    users = [_created_user("a@x.org", group_key=None)]
+    create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]
+
+    assert members_for_created_users(users, create_errors) == ([], [])
+```
+
+The third test is the one that matters for alert hygiene: a user whose account
+creation failed is already reported by `batch_insert_users`, so reporting it
+again as an unresolved group would double-count the same student.
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  run pytest tests/resources/test_resource_google_directory.py -k members_for_created_users -v
+```
+
+Expected: the three updated tests fail comparing a `list` to a `tuple`; the
+three new tests fail unpacking a `list` into two names
+(`ValueError: too many values to unpack`) or on the missing second element.
+
+- [ ] **Step 5: Rewrite the helper**
+
+Replace the whole function at
+`src/teamster/libraries/google/directory/resources.py:696-726`:
+
+```python
+def members_for_created_users(
+    users: list[dict], create_errors: list[dict]
+) -> tuple[list[dict], list[dict]]:
+    """Build group-membership payloads for users whose creation did not fail.
+
+    A user's group membership can only be added once the account exists, so a
+    user whose ``batch_insert_users`` call failed must be excluded — otherwise
+    the membership insert is guaranteed to fail with "resource not found".
+
+    A user whose ``groupKey`` is null is excluded for a different reason: the
+    extract resolves ``groupKey`` against the groups Google actually has, so
+    null means the students group for that region does not exist. Attempting the
+    add would fail with "404 Resource Not Found: groupKey" once per user, so the
+    membership is skipped and reported once for the whole run instead.
+
+    Args:
+        users: The users passed to
+            :meth:`GoogleDirectoryResource.batch_insert_users`.
+        create_errors: The ``{"primaryEmail", "error"}`` dicts it returned for
+            users whose creation ultimately failed.
+
+    Returns:
+        A two-tuple. The first element holds
+        :meth:`GoogleDirectoryResource.batch_insert_members` payloads
+        (``groupKey`` / ``email`` / ``delivery_settings``) for created users
+        whose ``groupKey`` resolved. The second holds at most one aggregated
+        ``{"error", "count", "orgUnitPaths"}`` dict describing the created users
+        whose group could not be resolved, and is empty when every group
+        resolved.
+    """
+    failed_emails = {e["primaryEmail"] for e in create_errors}
+
+    created = [u for u in users if u["primaryEmail"] not in failed_emails]
+
+    members = [
+        {
+            "groupKey": u["groupKey"],
+            "email": u["primaryEmail"],
+            "delivery_settings": "DISABLED",
+        }
+        for u in created
+        if u["groupKey"] is not None
+    ]
+
+    unresolved = [u for u in created if u["groupKey"] is None]
+
+    if not unresolved:
+        return members, []
+
+    return members, [
+        {
+            "error": (
+                f"{len(unresolved)} created users have no resolvable students"
+                " group; membership skipped"
+            ),
+            "count": len(unresolved),
+            "orgUnitPaths": sorted({u["orgUnitPath"] for u in unresolved}),
+        }
+    ]
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  run pytest tests/resources/test_resource_google_directory.py -k members_for_created_users -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 7: Update the caller**
+
+In `src/teamster/code_locations/kipptaf/google/directory/assets.py`, replace the
+comment and call at lines 208-218:
+
+```python
+            # Only add users whose creation succeeded — a failed create leaves
+            # no account, so its member insert would fail with "resource not
+            # found" and double-count the same student in the error check.
+            # Users whose groupKey did not resolve are skipped and reported
+            # once, rather than once per user.
+            members_data, unresolved_group_errors = members_for_created_users(
+                valid_users, create_errors
+            )
+
+            errors.extend(unresolved_group_errors)
+
+            if members_data:
+                members_errors = google_directory.batch_insert_members(members_data)
+
+                for me in members_errors:
+                    context.log.error(msg=me)
+                    errors.append(me)
+```
+
+- [ ] **Step 8: Verify the whole resource test module still passes**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  run pytest tests/resources/test_resource_google_directory.py -v \
+  --deselect tests/resources/test_resource_google_directory.py::test_list_orgunits \
+  --deselect tests/resources/test_resource_google_directory.py::test_get_orgunit \
+  --deselect tests/resources/test_resource_google_directory.py::test_list_roles \
+  --deselect tests/resources/test_resource_google_directory.py::test_list_role_assignments \
+  --deselect tests/resources/test_resource_google_directory.py::test_list_members
+```
+
+Expected: no failures. Those five deselected tests are credential-backed
+developer probes that call the live Directory API and dump JSON into `env/`;
+they error without Google credentials. Every other test in the module, including
+the mocked `test_list_*` pagination and retry tests, must pass — do not widen
+the deselect list to `-k "not list_"`, which would silently skip those.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+git add src/teamster/libraries/google/directory/resources.py \
+  src/teamster/code_locations/kipptaf/google/directory/assets.py \
+  tests/resources/test_resource_google_directory.py
+git commit -m "fix(dagster): skip membership adds for an unresolved students group
+
+Refs #4766"
+```
+
+---
+
+### Task 2: Re-enable the `groups` asset
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kipptaf/google/directory/schema.py:1-25`
+- Modify:
+  `src/teamster/code_locations/kipptaf/google/directory/assets.py:13-18,31,279-303`
+- Modify:
+  `src/teamster/code_locations/kipptaf/google/directory/schedules.py:4-12,23`
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: Dagster asset key `kipptaf/google/directory/groups`, writing Avro to
+  `<bucket>/dagster/kipptaf/google/directory/groups/`. Task 3's dbt source reads
+  that prefix.
+
+- [ ] **Step 1: Add the Avro schema**
+
+In `schema.py`, add `Group` to the existing import and uncomment the schema. The
+import block and the new constant:
+
+```python
+from teamster.libraries.google.directory.schema import (
+    Group,
+    OrgUnits,
+    Role,
+    RoleAssignment,
+    User,
+)
+
+GROUPS_SCHEMA = json.loads(py_avro_schema.generate(py_type=Group, namespace="group"))
+```
+
+Place `GROUPS_SCHEMA` above `ORGUNITS_SCHEMA` to keep the constants
+alphabetical, and delete only the commented `GROUPS_SCHEMA` line at the bottom.
+Leave the commented `MEMBERS_SCHEMA` line exactly as it is.
+
+- [ ] **Step 2: Verify the schema generates**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  run python -c "from teamster.code_locations.kipptaf.google.directory.schema import GROUPS_SCHEMA; print(sorted(f['name'] for f in GROUPS_SCHEMA['fields']))"
+```
+
+Expected:
+`['adminCreated', 'aliases', 'description', 'directMembersCount', 'email', 'etag', 'id', 'kind', 'name', 'nonEditableAliases']`.
+
+If this fails with a missing `manifest.json`, the code location's `__init__`
+needs the dbt manifest — build it once in the worktree, then re-run:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  run dagster-dbt project prepare-and-package \
+  --file src/teamster/code_locations/kipptaf/__init__.py
+```
+
+- [ ] **Step 3: Define the asset**
+
+In `assets.py`, add `GROUPS_SCHEMA` to the schema import (alphabetically first),
+then insert this asset immediately above the existing `orgunits` asset at
+line 31. It must be defined above the `assets` list at the bottom of the file,
+or the list raises `NameError`:
+
+```python
+@asset(
+    key=[*key_prefix, "groups"],
+    check_specs=[build_check_spec_avro_schema_valid([*key_prefix, "groups"])],
+    io_manager_key="io_manager_gcs_avro",
+    group_name="google_directory",
+    kinds={"python"},
+)
+def groups(context: AssetExecutionContext, google_directory: GoogleDirectoryResource):
+    data = google_directory.list_groups()
+
+    yield Output(value=(data, GROUPS_SCHEMA), metadata={"record_count": len(data)})
+
+    yield check_avro_schema_valid(
+        asset_key=context.asset_key, records=data, schema=GROUPS_SCHEMA
+    )
+```
+
+Then add `groups` to the `assets` list, before `orgunits`:
+
+```python
+assets = [
+    google_directory_role_assignments_create,
+    google_directory_user_create,
+    google_directory_user_update,
+    groups,
+    orgunits,
+    role_assignments,
+    roles,
+    users,
+]
+```
+
+Delete the now-duplicated commented `groups` asset block at the bottom of the
+file. Leave the commented `members` asset and
+`google_directory_partitioned_assets` block untouched.
+
+`GoogleDirectoryResource.list_groups()` already exists and takes no required
+arguments — do not add or change resource methods.
+
+- [ ] **Step 4: Schedule the daily pull**
+
+In `schedules.py`, add `groups` to the asset import (alphabetically, after the
+three `google_directory_*` names) and to the nonpartitioned schedule target:
+
+```python
+google_directory_nonpartitioned_asset_schedule = ScheduleDefinition(
+    name=f"{CODE_LOCATION}__google__directory__nonpartitioned_asset_job_schedule",
+    target=[groups, orgunits, role_assignments, roles, users],
+    cron_schedule="30 1 * * *",
+    execution_timezone=str(LOCAL_TIMEZONE),
+)
+```
+
+This is the same 1:30am schedule `orgunits` uses. Do not add a separate schedule
+and do not change any cron.
+
+- [ ] **Step 5: Verify the modules compile and the wiring is present**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+VIRTUAL_ENV= uv --directory . run python -m py_compile \
+  src/teamster/code_locations/kipptaf/google/directory/assets.py \
+  src/teamster/code_locations/kipptaf/google/directory/schedules.py \
+  src/teamster/code_locations/kipptaf/google/directory/schema.py
+grep -n "groups," src/teamster/code_locations/kipptaf/google/directory/assets.py \
+  src/teamster/code_locations/kipptaf/google/directory/schedules.py
+```
+
+Expected: `py_compile` silent, and `grep` shows `groups,` in both the `assets`
+list and the schedule `target`.
+
+`dagster definitions validate -m teamster.code_locations.kipptaf.definitions` is
+NOT the gate here — it fails in this codespace on unrelated Illuminate and
+Zendesk dlt credential resolution. The real runtime gate is the branch
+deployment in Task 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+git add src/teamster/code_locations/kipptaf/google/directory/assets.py \
+  src/teamster/code_locations/kipptaf/google/directory/schedules.py \
+  src/teamster/code_locations/kipptaf/google/directory/schema.py
+git commit -m "feat(dagster): pull Google Workspace groups daily
+
+Refs #4766"
+```
+
+---
+
+### Task 3: Stage groups as a dbt source and staging model
+
+**Files:**
+
+- Modify: `src/dbt/kipptaf/models/google/directory/sources-external.yml:26`
+- Create:
+  `src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql`
+- Create:
+  `src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml`
+
+**Interfaces:**
+
+- Consumes: the GCS prefix written by Task 2's asset.
+- Produces: `ref("stg_google_directory__groups")` with columns `email`, `id`,
+  `name`, `description`, `direct_members_count`, `admin_created`, `etag`,
+  `kind`, `aliases`, `non_editable_aliases`. Task 4 joins on `email`.
+
+- [ ] **Step 1: Install dbt packages in the worktree**
+
+A fresh worktree has no `dbt_packages/`, and every later dbt command fails
+without it.
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster run dbt deps \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard/src/dbt/kipptaf
+```
+
+- [ ] **Step 2: Declare the external source**
+
+In `sources-external.yml`, insert this block immediately after the
+`src_google_directory__users` block and before `src_google_directory__orgunits`.
+Indentation must match its siblings exactly — the block starts at 6 spaces:
+
+```yaml
+- name: src_google_directory__groups
+  external:
+    location: "{{ var('cloud_storage_uri_base') }}/google/directory/groups/*"
+    options:
+      connection_name: "{{ var('bigquery_external_connection_name') }}"
+      metadata_cache_mode: MANUAL
+      max_staleness: INTERVAL 7 DAY
+      format: AVRO
+      enable_logical_types: true
+  config:
+    meta:
+      dagster:
+        asset_key:
+          - kipptaf
+          - google
+          - directory
+          - groups
+```
+
+Do not touch the source-level `schema:` block — the existing dev/staging/prod
+prefix conditional already covers every table in this source.
+
+- [ ] **Step 3: Write the staging model**
+
+Create `stg_google_directory__groups.sql`. BigQuery column references are
+case-insensitive, so the lowercased Avro field names are the repo convention
+here (matching `stg_google_directory__users.sql`). The trailing comma after the
+last column is required by sqlfluff CV03:
+
+```sql
+select
+    id,
+    email,
+    name,
+    description,
+    directmemberscount as direct_members_count,
+    admincreated as admin_created,
+    etag,
+    kind,
+
+    /* repeated */
+    aliases,
+    noneditablealiases as non_editable_aliases,
+from {{ source("google_directory", "src_google_directory__groups") }}
+```
+
+If `trunk check` in Step 6 flags `name` under sqlfluff RF04 (reserved keyword as
+identifier), change that line to ``name as `name`,`` — the backticked form is
+the precedent in `stg_google_directory__orgunits.sql` and is not an AL09
+self-alias violation. Make no other change in response to RF04.
+
+- [ ] **Step 4: Write the properties yml**
+
+Create `properties/stg_google_directory__groups.yml`. `email` sorts to the top
+because it carries the column-level tests. Do not add `materialized` or
+`contract` — both are inherited from `dbt_project.yml`:
+
+```yaml
+models:
+  - name: stg_google_directory__groups
+    description: >
+      Google Workspace groups as returned by the Directory API groups list
+      endpoint. Consumed by rpt_google_directory__users_import to confirm that a
+      region's student group exists before a membership add is attempted against
+      it.
+    columns:
+      - name: email
+        data_type: string
+        description: >
+          Primary address of the group. Join key for validating a constructed
+          student group address against the groups Google actually has.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: id
+        data_type: string
+        description: Immutable Google-assigned identifier for the group.
+      - name: name
+        data_type: string
+        description: Display name of the group, as set in the admin console.
+      - name: description
+        data_type: string
+        description: >
+          Free-text purpose of the group, as set in the admin console. Often
+          empty.
+      - name: direct_members_count
+        data_type: string
+        description: >
+          Number of members that belong to the group directly rather than
+          through a nested group. Carried as a string by the Directory API.
+      - name: admin_created
+        data_type: boolean
+        description: >
+          True when an administrator created the group, false when it was
+          created by a user.
+      - name: etag
+        data_type: string
+        description: Entity tag of the resource, reported by the API.
+      - name: kind
+        data_type: string
+        description: >
+          Resource type reported by the API, always admin#directory#group.
+      - name: aliases
+        data_type: array<string>
+        description: Alternate addresses that deliver to this group.
+      - name: non_editable_aliases
+        data_type: array<string>
+        description: >
+          Domain-derived alternate addresses for the group that cannot be
+          edited.
+```
+
+- [ ] **Step 5: Verify the model parses and compiles**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster run dbt compile \
+  --select stg_google_directory__groups --target prod \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard/src/dbt/kipptaf
+```
+
+Expected: compiles, and `target/compiled/.../stg_google_directory__groups.sql`
+resolves the source to `kipptaf_google_directory.src_google_directory__groups`.
+`compile` performs no warehouse write. A `dbt build` cannot work yet — the
+external table does not exist until Task 5 materializes the asset and stages it.
+
+- [ ] **Step 6: Lint the new files**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/google/directory/sources-external.yml \
+  src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql \
+  src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml \
+  </dev/null
+```
+
+If `.trunk/tools/trunk` does not exist, use `~/.cache/trunk/launcher/trunk`
+instead — the symlink is created lazily on first run. Formatting-only findings
+(`prettier`, MD060) are fixed by the pre-commit hook; act only on sqlfluff and
+yamllint findings that name a rule and a line.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+git add src/dbt/kipptaf/models/google/directory/sources-external.yml \
+  src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql \
+  src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml
+git commit -m "feat(dbt): stage Google Workspace groups
+
+Refs #4766"
+```
+
+---
+
+### Task 4: Resolve `groupKey` against the staged groups
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql:186-260`
+- Modify:
+  `src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml:3-11,45-46`
+
+**Interfaces:**
+
+- Consumes: `ref("stg_google_directory__groups")` from Task 3, joined on
+  `email`.
+- Produces: the `groupKey` column of
+  `kipptaf_extracts.rpt_google_directory__users_import`, now null when the
+  region's students group is absent from Google. Task 1's helper reads it.
+
+- [ ] **Step 1: Derive the target address in `with_google`**
+
+Add one column to the `with_google` select, between `u.surrogate_key_target` and
+the first `if(...)`. ST06 puts an operator expression before the logicals:
+
+```sql
+            u.surrogate_key_target,
+
+            'group-students-' || s.region || '@teamstudents.org'
+            as group_key_target,
+
+            if(u.primary_email is not null, true, false) as is_matched,
+```
+
+The address is built here, one CTE upstream of the join, for two reasons: the
+SQL guide forbids one-sided calculations in join predicates, and BigQuery
+rejects a select-list alias referenced from its own select's `ON` clause.
+
+- [ ] **Step 2: Join the groups model in `final`**
+
+Replace the whole `final` CTE. It gains a table alias because it now reads from
+two relations, so every column reference is prefixed:
+
+```sql
+    final as (
+        select
+            w.*,
+
+            g.email as group_key,
+
+            if(not w.is_matched and not w.suspended, true, false) as is_create,
+
+            if(
+                w.is_matched
+                and {{
+                    dbt_utils.generate_surrogate_key(
+                        ["first_name", "last_name", "suspended", "org_unit_path"]
+                    )
+                }} != w.surrogate_key_target,
+                true,
+                false
+            ) as is_update,
+        from with_google as w
+        /* A null group_key means the region's students group does not exist in
+        Google. Unlike a null org_unit_path, it does NOT drop the student: the
+        account is still provisioned, and the user_create asset skips the
+        membership add and reports the missing group once. */
+        left join
+            {{ ref("stg_google_directory__groups") }} as g
+            on w.group_key_target = g.email
+    )
+```
+
+Leave the `generate_surrogate_key` arguments unqualified. They are column-name
+strings, and `g` contributes none of those four names, so they stay unambiguous.
+
+- [ ] **Step 3: Project the resolved address in the outer select**
+
+Replace the outer select's column list. `groupKey` is now a plain column
+reference, so ST06 moves it up into the enumeration group and out of the
+constants group where the concatenation used to sit:
+
+```sql
+select
+    student_email_google as `primaryEmail`,
+    org_unit_path as `orgUnitPath`,
+    group_key as `groupKey`,
+    suspended,
+    is_create,
+    is_update,
+    student_number,
+
+    'SHA-1' as `hashFunction`,
+
+    struct(first_name as `givenName`, last_name as `familyName`) as `name`,
+    to_hex(sha1(student_web_password)) as `password`,
+
+    if(grade_level >= 3, true, false) as `changePasswordAtNextLogin`,
+from final
+```
+
+Do NOT change the trailing `where` clause or its comment. The student must stay
+in the extract when the group is missing. `group_key_target` reaches `final` via
+`w.*` but is deliberately not projected here — the extract's columns become the
+Google `users.insert` payload, so an unused extra field would ride along.
+
+- [ ] **Step 4: Update the properties yml**
+
+Two edits. First, the model description's last sentence claims Paterson is
+excluded, untrue since 079381c63 — replace the description:
+
+```yaml
+description: >
+  Google Workspace student accounts to create or update, consumed by the
+  google_directory user_create and user_update assets. Rows are the union of two
+  enrollment sources — PowerSchool for the NJ regions, and Focus for Miami,
+  whose PowerSchool instance is a frozen archive. A row appears only when the
+  account is missing (is_create) or when its name, suspension state, or org unit
+  has drifted from the source of record (is_update).
+```
+
+Second, give `groupKey` a description recording the null semantics:
+
+```yaml
+- name: groupKey
+  data_type: string
+  description: >
+    Address of the region's student group, resolved against
+    stg_google_directory__groups. Null when that group does not exist in Google
+    Workspace, in which case the account is still created and the membership add
+    is skipped.
+```
+
+Add no data test on this column — see Global Constraints.
+
+- [ ] **Step 5: Verify the extract compiles**
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster run dbt compile \
+  --select rpt_google_directory__users_import --target prod \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard/src/dbt/kipptaf
+```
+
+Expected: compiles. Read
+`target/compiled/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql`
+and confirm three things: the `left join` resolves to
+`kipptaf_google_directory.stg_google_directory__groups`, the outer select
+projects `group_key as groupKey`, and `group_key_target` appears nowhere in the
+outer select.
+
+- [ ] **Step 6: Lint the changed SQL**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql \
+  src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml \
+  </dev/null
+```
+
+Expected: no sqlfluff findings. ST06 (column ordering) and ST09 (join-predicate
+order) are the two rules this change is most likely to trip; both fire only at
+pre-push and CI, so this step is not optional.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard
+git add src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql \
+  src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
+git commit -m "fix(dbt): resolve groupKey against the staged Google groups
+
+Refs #4766"
+```
+
+---
+
+### Task 5: Validate on the branch deployment and open the PR
+
+**Files:** none. This task is operational.
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1-4.
+- Produces: a staged
+  `zz_stg_kipptaf_google_directory.src_google_directory__groups` external table,
+  a green dbt Cloud CI run, and an open PR.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard \
+  push -u origin cbini/fix/claude-google-directory-groupkey-guard
+```
+
+The pre-push hook runs `trunk check` git-diff-scoped. It can miss findings on
+already-committed lines, which is why Tasks 3 and 4 ran `--force` explicitly.
+
+- [ ] **Step 2: Open the PR**
+
+Use `.github/pull_request_template.md` as the body and include `Refs #4766` so
+the PR lands on the project board. Do not `gh project item-add` the PR.
+
+Because the diff touches `src/teamster/**`, this PR gets a Dagster branch
+deployment. Recover its name from the `dagster-cloud-deploy / deploy` job log
+line `Deploying to branch deployment <hash>`; there are ~5 same-named check
+runs, one per code location, and all must reach a terminal conclusion before the
+deploy counts as green.
+
+- [ ] **Step 3: Materialize `groups` in the branch deployment**
+
+Preview first, then confirm:
+
+```text
+mcp__dagster__launch_run(
+    asset_keys=["kipptaf/google/directory/groups"],
+    deployment="<branch-deployment-hash>",
+    confirm=False,
+)
+```
+
+A dormant branch deployment throws `DagsterUserCodeUnreachableError` on the
+first call — retry after about 90 seconds to let the code location warm.
+
+Confirm the Avro landed via `mcp__dagster__get_asset_materializations` and check
+`record_count` is greater than zero. Branch deployments redirect the bucket, so
+the file is at `gs://teamster-test/dagster/kipptaf/google/directory/groups/`.
+
+Also confirm the asset's `avro_schema_valid` check passed. A warning there means
+the Directory API returns a field the `Group` Pydantic model does not declare;
+the fix is to add the field to
+`src/teamster/libraries/google/directory/schema.py`, not to suppress the check.
+
+- [ ] **Step 4: Stage the staging-target external (user runs this)**
+
+dbt Cloud CI runs `target=staging`, which resolves `cloud_storage_uri_base` to
+the prod bucket — not the test bucket the branch deployment just wrote to. So
+the location must be overridden for this one staging run:
+
+```text
+uv run dbt run-operation stage_external_sources
+  --args "select: google_directory.src_google_directory__groups"
+  --vars '{cloud_storage_uri_base: gs://teamster-test/dagster/kipptaf, ext_full_refresh: true}'
+  --target staging
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard/src/dbt/kipptaf
+```
+
+This drops and recreates a shared `zz_stg` table, so the auto-classifier blocks
+it. Hand it to the user's terminal rather than retrying it.
+
+- [ ] **Step 5: Build the staging model to exercise the contract**
+
+Contract enforcement (`assert_columns_equivalent`) runs only inside a real
+`dbt build`, never in `compile` and never in a SELECT against the external. This
+is the first point at which it can run, because the external table now exists:
+
+```bash
+VIRTUAL_ENV= uv --directory /workspaces/teamster run dbt build \
+  --select stg_google_directory__groups --target staging \
+  --project-dir /workspaces/teamster/.worktrees/cbini/fix/claude-google-directory-groupkey-guard/src/dbt/kipptaf
+```
+
+Expected: the model builds and both `email` tests pass. A contract failure here
+names the offending column and type — reconcile the properties yml `data_type`
+against `INFORMATION_SCHEMA.COLUMNS` on the staged table rather than guessing;
+`numeric` and `float64` are distinct types, and BigQuery's legacy spellings
+(`bool` / `boolean`, `int64` / `integer`) may differ between the yml and
+`INFORMATION_SCHEMA` without being real drift.
+
+- [ ] **Step 6: Confirm CI is green on both surfaces**
+
+dbt Cloud is a commit status; Trunk, CodeQL, and `claude` are check runs. Check
+both:
+
+```bash
+gh pr checks <pr-number> --json name,bucket,state
+```
+
+Trunk's check runs are re-created on every push, so a poll that samples the gap
+between them can report done prematurely — re-check after a delay. After dbt
+Cloud passes, fetch warnings with
+`mcp__dbt__get_job_run_error(run_id=<ci_run>, warning_only=true)` before calling
+the PR done.
+
+Process `claude-review` findings through `superpowers:receiving-code-review` —
+verify each claim against the code before replying. It runs only on `opened` /
+`ready_for_review`, never on a push, so do not wait for a re-review after
+pushing a fix.
+
+- [ ] **Step 7: Record the two post-merge actions in the PR body**
+
+Neither is a code change, and both need an owner:
+
+1. Ops creates `group-students-paterson@teamstudents.org` in the admin console.
+   Until then the guard fires one warning per run and Paterson accounts are
+   created without membership.
+1. Launch `kipptaf/google/directory/groups` in prod as soon as the post-merge
+   deploy lands. The prod external table does not exist until a prod
+   materialization drops a file, and `build_dbt_assets` runs
+   `stage_external_sources` on every dbt asset run — which fails creating an
+   AVRO external over an empty prefix. The dbt automation fires within minutes
+   of the deploy, well before the 1:30am schedule. Worst case it fails once and
+   self-heals after the manual materialization.
+
+---
+
+## Out of scope
+
+Tracked on #4766, deliberately not in this plan:
+
+- Backfilling group membership for the 884 existing Paterson accounts.
+- Recurring membership reconciliation. Membership is attempted only under
+  `is_create`, so no region has drift correction, and a student whose membership
+  was skipped is never retried. That work needs the `members` asset, which
+  re-enabling `groups` makes possible as a follow-up.

--- a/docs/superpowers/plans/2026-08-10-google-directory-groupkey-guard.md
+++ b/docs/superpowers/plans/2026-08-10-google-directory-groupkey-guard.md
@@ -955,7 +955,35 @@ against `INFORMATION_SCHEMA.COLUMNS` on the staged table rather than guessing;
 (`bool` / `boolean`, `int64` / `integer`) may differ between the yml and
 `INFORMATION_SCHEMA` without being real drift.
 
-- [ ] **Step 6: Confirm CI is green on both surfaces**
+- [ ] **Step 6: Verify the three working regions resolve — added by the final
+      review**
+
+The join compares the constructed address to
+`stg_google_directory__groups.email` only. The code it replaces passed that
+address to `members.insert`, which also resolves aliases and unique ids. So if
+`newark`, `camden`, or `miami`'s address is an **alias** of a group whose
+primary address differs, this change turns a working region's `groupKey` null
+and silently stops its membership adds — the regression class this branch exists
+to prevent, inverted.
+
+This is the first point where it can be checked, because the staged table now
+holds real group data:
+
+```sql
+select email
+from `teamster-332318.zz_stg_kipptaf_google_directory.stg_google_directory__groups`
+where email like 'group-students-%'
+```
+
+Expect `camden`, `miami`, and `newark` — and NOT `paterson`, whose absence is
+the bug this branch guards. If any of the three is missing, its address is an
+alias: add `or w.group_key_target in unnest(g.aliases)` to the join in
+`rpt_google_directory__users_import.sql`. The staging model already carries
+`aliases`, so no schema change is needed. Do not add that arm speculatively —
+verify first, because an unnecessary alias arm widens the match and can resolve
+a group address that Google would have rejected.
+
+- [ ] **Step 7: Confirm CI is green on both surfaces**
 
 dbt Cloud is a commit status; Trunk, CodeQL, and `claude` are check runs. Check
 both:
@@ -975,7 +1003,7 @@ verify each claim against the code before replying. It runs only on `opened` /
 `ready_for_review`, never on a push, so do not wait for a re-review after
 pushing a fix.
 
-- [ ] **Step 7: Record the two post-merge actions in the PR body**
+- [ ] **Step 8: Record the two post-merge actions in the PR body**
 
 Neither is a code change, and both need an owner:
 

--- a/docs/superpowers/specs/2026-08-10-google-directory-groupkey-guard-design.md
+++ b/docs/superpowers/specs/2026-08-10-google-directory-groupkey-guard-design.md
@@ -1,0 +1,237 @@
+# Guard `groupKey` in the Google Directory student user import
+
+Refs [#4766](https://github.com/TEAMSchools/teamster/issues/4766)
+
+## Problem
+
+`rpt_google_directory__users_import` builds the student group address by string
+concatenation with nothing to validate it against:
+
+```sql
+'group-students-' || region || '@teamstudents.org' as `groupKey`,
+```
+
+`orgUnitPath`, three lines up in the same select, **is** validated: it joins
+`stg_google_directory__orgunits` on the path, so a path missing from Google
+resolves to null and the student drops out of the extract.
+[#4513](https://github.com/TEAMSchools/teamster/issues/4513) added that guard
+for org units and left the group address unguarded. There is nothing to join
+against for groups — the `groups` asset is commented out in
+`src/teamster/code_locations/kipptaf/google/directory/assets.py`, so no
+`stg_google_directory__groups` model exists.
+
+Paterson entered this extract on 2026-08-03 when 079381c63 removed it from the
+exclusion list. `group-students-paterson@teamstudents.org` has never existed, so
+Dagster run `bc28dc20-ae50-4af7-b45a-b3a0bd05d440` logged 429 identical
+`404 Resource Not Found: groupKey` errors — one per created student — on the
+`zero_api_errors` check for `kipptaf/google/directory/user_create`.
+
+## Verified state
+
+Checked against the current working tree and prod before designing:
+
+| Claim                                                 | Status                                                        |
+| ----------------------------------------------------- | ------------------------------------------------------------- |
+| `groupKey` built by concatenation, no join            | Confirmed, `rpt_google_directory__users_import.sql` line 250  |
+| `orgUnitPath` guarded by a join plus a `where` filter | Confirmed, same file, lines 216-218 and 260                   |
+| `groups` asset commented out, nothing to join against | Confirmed, `assets.py` lines 289-303; no staging model exists |
+| Group membership attempted only under `is_create`     | Confirmed, `assets.py` lines 201-218                          |
+| Paterson student accounts exist with no group         | 884 accounts, 0 disabled (issue said 883; one added since)    |
+
+The deployed BigQuery view definition confirms the concatenated literal is
+`group-students-`, matching the issue.
+
+## Decisions
+
+- **Scope is the guard only.** The 884 stranded Paterson memberships and
+  recurring membership reconciliation (issue scope items 1 and 3) stay open on
+  #4766.
+- **Validate against Google, not a spreadsheet.** Re-enabling the `groups` asset
+  and joining it mirrors the `orgUnitPath` guard exactly, self-heals the moment
+  Ops creates the group, and needs no per-school sheet coordination for a
+  per-region value. The alternative — naming the group in the
+  `people__locations` sheet and resolving it through
+  `int_people__location_crosswalk` — validates the sheet rather than Google.
+- **A missing group must not block provisioning.** Mirroring the `orgUnitPath`
+  guard literally would drop the student from the extract, so no Paterson
+  student would get an account until Ops creates the group. Today those accounts
+  are created correctly and only the membership fails. The guard therefore skips
+  the membership and keeps the account.
+- **The missing group stays visible.** Skipping silently would leave students
+  created group-less indefinitely with no alert, which is worse than the noisy
+  status quo. One aggregated error keeps `zero_api_errors` firing.
+
+## Prerequisite
+
+Ops creates `group-students-paterson@teamstudents.org` in the Google admin
+console. This is not a code change. Until it exists, Paterson accounts are
+created without group membership and the run reports one warning.
+
+## Design
+
+### Re-enable the `groups` asset
+
+- `src/teamster/code_locations/kipptaf/google/directory/schema.py` — uncomment
+  `GROUPS_SCHEMA` and add `Group` to the import from
+  `teamster.libraries.google.directory.schema`. `MEMBERS_SCHEMA` stays
+  commented.
+- `src/teamster/code_locations/kipptaf/google/directory/assets.py` — uncomment
+  the `groups` asset and add it to the `assets` list. The `members` asset stays
+  commented; it belongs to the deferred reconciliation work.
+- `src/teamster/code_locations/kipptaf/google/directory/schedules.py` — add
+  `groups` to `google_directory_nonpartitioned_asset_schedule`, where `orgunits`
+  already sits.
+
+`GoogleDirectoryResource.list_groups()` already exists and needs no change.
+
+The groups snapshot runs at 1:30am and `user_sync` at 1:00am, so the guard reads
+a snapshot up to a day old. `orgunits` already carries the identical lag, and
+regional student groups change roughly once a year, so no re-ordering is
+warranted.
+
+### Expose it to dbt
+
+- `src/dbt/kipptaf/models/google/directory/sources-external.yml` — add
+  `src_google_directory__groups`, copied from the
+  `src_google_directory__orgunits` block with the `google/directory/groups/*`
+  location and the matching `dagster.asset_key` meta.
+- `src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql`
+  — a flat select over the source, following the column-renaming style of
+  `stg_google_directory__users.sql` (`directmemberscount` becomes
+  `direct_members_count`, `admincreated` becomes `admin_created`,
+  `noneditablealiases` becomes `non_editable_aliases`; `email`, `id`, `name`,
+  `description`, and `aliases` keep their names).
+- Its properties yml declares every column with `data_type`, since the
+  `staging/` directory default enforces contracts, plus `unique` and `not_null`
+  on `email` at `severity: error` as the staging layer requires.
+
+### Guard the join
+
+In `rpt_google_directory__users_import.sql`, `with_google` derives the
+constructed address as a named column and the existing `final` CTE joins on it:
+
+```sql
+with_google as (
+    select
+        ...
+        'group-students-' || s.region || '@teamstudents.org' as group_key_target,
+    ...
+),
+
+final as (
+    select
+        w.*,
+        g.email as group_key,
+        ...
+    from with_google as w
+    left join {{ ref("stg_google_directory__groups") }} as g
+        on w.group_key_target = g.email
+)
+```
+
+The address is derived one CTE upstream of the join rather than inline in the
+`ON` clause for two reasons: the SQL guide forbids one-sided calculations in
+join predicates, and BigQuery rejects a select-list alias referenced from the
+same select's `ON` clause. Joining in `final` avoids adding a CTE, since
+`with_google` already computes derived columns and `final` already reads from
+it.
+
+The outer select projects the resolved address as `groupKey`, null when the
+group does not exist in Google — the same shape as `o.org_unit_path`.
+`group_key_target` is not projected; it is join plumbing, and an unrecognized
+extra field would ride along into the Google `users.insert` payload.
+
+The final `where` clause does **not** change: the student stays in the extract
+and still gets an account. The contract does not change either, since
+nullability is not part of it. The projected `groupKey` moves into the
+column-enumeration group of the select to satisfy ST06 ordering.
+
+The model description also loses its stale "Paterson is excluded" sentence,
+untrue since 079381c63.
+
+### Skip the membership and report it once
+
+`members_for_created_users` in
+`src/teamster/libraries/google/directory/resources.py` is the single place
+membership payloads are built, so the guard belongs there rather than in the
+asset — every caller routes through it.
+
+It returns a 2-tuple: the payloads for users whose `groupKey` resolved, and a
+list holding at most one aggregated error dict that carries the count of skipped
+users and the distinct `orgUnitPath` values affected. `orgUnitPath` names the
+region precisely and is already on the payload, so no extra extract column is
+needed to make the alert actionable.
+
+`google_directory_user_create` extends its `errors` list with that second
+element, so `zero_api_errors` still warns — once per run, naming the affected
+schools, instead of once per student.
+
+Unit tests go in the existing
+`tests/resources/test_resource_google_directory.py`: a null `groupKey` is
+excluded from the payloads and reported once, and a populated `groupKey` is
+unaffected.
+
+## Ship sequence
+
+One PR. Pre-merge, on the branch deployment:
+
+1. Push. The `src/teamster/**` changes give this PR a Dagster branch deployment;
+   a dbt-only PR would not get one.
+1. Materialize `kipptaf/google/directory/groups` in that branch deployment. The
+   bucket redirect writes to
+   `gs://teamster-test/dagster/kipptaf/google/directory/groups/`.
+1. Stage the staging-target external at that location, because dbt Cloud CI runs
+   `target=staging`, which resolves `cloud_storage_uri_base` to the prod bucket
+   rather than the test one:
+
+   ```text
+   dbt run-operation stage_external_sources
+     --args "select: google_directory.src_google_directory__groups"
+     --vars '{cloud_storage_uri_base: gs://teamster-test/dagster/kipptaf, ext_full_refresh: true}'
+     --target staging
+   ```
+
+   This drops and recreates a shared `zz_stg` table, so it is classifier-blocked
+   and runs from the user's terminal or under explicitly-named authorization.
+
+1. Confirm dbt Cloud CI passes on the new source and staging model.
+
+## Verification
+
+- `uv run python -c "import teamster.code_locations.kipptaf.google.directory.assets"`
+  plus `py_compile` on the edited files. `dagster definitions validate` on
+  `kipptaf.definitions` fails in the codespace on unrelated dlt credential
+  resolution, so it is not the gate.
+- `uv run pytest tests/resources/test_resource_google_directory.py` for the
+  `members_for_created_users` guard.
+- `uv run dbt compile --select stg_google_directory__groups rpt_google_directory__users_import --target prod`
+  to resolve refs and SQL without a warehouse write.
+- `uv run dbt build --select stg_google_directory__groups --target staging` once
+  the external is staged, which is what exercises the contract.
+- `trunk check --force` on the changed SQL, YAML, Python, and this document, run
+  from inside the worktree.
+
+## Risks
+
+The prod external table does not exist until a prod `groups` materialization
+drops a file in GCS, and `build_dbt_assets` runs `stage_external_sources` itself
+with `ext_full_refresh` on every dbt asset run. The post-merge code deploy fires
+the dbt automation within minutes, most likely before the 1:30am `groups`
+schedule, and `stage_external_sources` fails creating an AVRO external over an
+empty prefix.
+
+Mitigation: launch `kipptaf/google/directory/groups` in prod as soon as the
+post-merge deploy lands. Worst case the dbt staging step fails once and
+self-heals on the next run after that materialization. This is a one-time
+ordering problem at first deploy, so it gets an operator action rather than
+machinery in the codebase.
+
+## Out of scope
+
+Tracked on #4766, not addressed here:
+
+- Backfilling group membership for the 884 existing Paterson accounts.
+- Recurring membership reconciliation. Membership is attempted only under
+  `is_create`, so no region has drift correction today, and a student whose
+  membership was skipped is never retried. Reconciliation needs the `members`
+  asset, which re-enabling `groups` makes possible as a follow-up.

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -63,6 +63,16 @@ Consuming district projects override these in their own `dbt_project.yml`.
 When a PR adds or modifies an external source, flag that the developer must
 stage it with `--target staging` before the dbt Cloud CI job will pass.
 
+**A brand-new external source cannot be staged until its asset has materialized
+once** — Avro autodetect needs >=1 file. Pre-merge, open the PR non-draft so the
+branch deployment builds, materialize the asset there, then stage with the
+`gs://teamster-test/...` `--vars` override below. Post-merge, launch that asset
+in prod IMMEDIATELY: external sources are excluded from the deps gate
+(`any_deps_missing().ignore(_EXTERNAL_SOURCE_SELECTION)` in
+`core/automation_conditions.py`), so the first post-deploy tick requests the new
+staging model and its `stage_external_sources` fails on the still-empty prod
+prefix.
+
 **AVRO external tables autodetect schema from the LAST ALPHABETICAL file.** To
 evolve an Avro source's schema, the new-schema file must sort last — materialize
 the MAX partition (latest hive `_dagster_partition_date=`). Mixed old/new files

--- a/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
+++ b/src/dbt/kipptaf/models/extracts/google/directory/properties/rpt_google_directory__users_import.yml
@@ -4,10 +4,9 @@ models:
       Google Workspace student accounts to create or update, consumed by the
       google_directory user_create and user_update assets. Rows are the union of
       two enrollment sources — PowerSchool for the NJ regions, and Focus for
-      Miami, whose PowerSchool instance is a frozen archive. Paterson is
-      excluded. A row appears only when the account is missing (is_create) or
-      when its name, suspension state, or org unit has drifted from the source
-      of record (is_update).
+      Miami, whose PowerSchool instance is a frozen archive. A row appears only
+      when the account is missing (is_create) or when its name, suspension
+      state, or org unit has drifted from the source of record (is_update).
     config:
       meta:
         contains_pii: true
@@ -43,6 +42,11 @@ models:
         data_type: string
       - name: groupKey
         data_type: string
+        description: >
+          Address of the region's student group, resolved against
+          stg_google_directory__groups. Null when that group does not exist in
+          Google Workspace, in which case the account is still created and the
+          membership add is skipped.
       - name: name
         data_type: record
       - name: name.givenName

--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__users_import.sql
@@ -199,6 +199,8 @@ with
 
             u.surrogate_key_target,
 
+            'group-students-' || s.region || '@teamstudents.org' as group_key_target,
+
             if(u.primary_email is not null, true, false) as is_matched,
 
             if(
@@ -220,34 +222,42 @@ with
 
     final as (
         select
-            *,
+            w.*,
 
-            if(not is_matched and not suspended, true, false) as is_create,
+            g.email as group_key,
+
+            if(not w.is_matched and not w.suspended, true, false) as is_create,
 
             if(
-                is_matched
+                w.is_matched
                 and {{
                     dbt_utils.generate_surrogate_key(
                         ["first_name", "last_name", "suspended", "org_unit_path"]
                     )
-                }} != surrogate_key_target,
+                }} != w.surrogate_key_target,
                 true,
                 false
             ) as is_update,
-        from with_google
+        from with_google as w
+        /* A null group_key means the region's students group does not exist in
+        Google. Unlike a null org_unit_path, it does NOT drop the student: the
+        account is still provisioned, and the user_create asset skips the
+        membership add and reports the missing group once. */
+        left join
+            {{ ref("stg_google_directory__groups") }} as g
+            on w.group_key_target = g.email
     )
 
 select
     student_email_google as `primaryEmail`,
     org_unit_path as `orgUnitPath`,
+    group_key as `groupKey`,
     suspended,
     is_create,
     is_update,
     student_number,
 
     'SHA-1' as `hashFunction`,
-
-    'group-students-' || region || '@teamstudents.org' as `groupKey`,
 
     struct(first_name as `givenName`, last_name as `familyName`) as `name`,
     to_hex(sha1(student_web_password)) as `password`,

--- a/src/dbt/kipptaf/models/google/directory/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/directory/sources-external.yml
@@ -23,6 +23,24 @@ sources:
                 - google
                 - directory
                 - users
+      - name: src_google_directory__groups
+        external:
+          location:
+            "{{ var('cloud_storage_uri_base') }}/google/directory/groups/*"
+          options:
+            connection_name: "{{ var('bigquery_external_connection_name') }}"
+            metadata_cache_mode: MANUAL
+            max_staleness: INTERVAL 7 DAY
+            format: AVRO
+            enable_logical_types: true
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - kipptaf
+                - google
+                - directory
+                - groups
       - name: src_google_directory__orgunits
         external:
           location:

--- a/src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml
+++ b/src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml
@@ -1,0 +1,56 @@
+models:
+  - name: stg_google_directory__groups
+    description: >
+      Google Workspace groups as returned by the Directory API groups list
+      endpoint. Consumed by rpt_google_directory__users_import to confirm that a
+      region's student group exists before a membership add is attempted against
+      it.
+    columns:
+      - name: email
+        data_type: string
+        description: >
+          Primary address of the group. Join key for validating a constructed
+          student group address against the groups Google actually has.
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: id
+        data_type: string
+        description: Immutable Google-assigned identifier for the group.
+      - name: name
+        data_type: string
+        description: Display name of the group, as set in the admin console.
+      - name: description
+        data_type: string
+        description: >
+          Free-text purpose of the group, as set in the admin console. Often
+          empty.
+      - name: direct_members_count
+        data_type: string
+        description: >
+          Number of members that belong to the group directly rather than
+          through a nested group. Carried as a string by the Directory API.
+      - name: admin_created
+        data_type: boolean
+        description: >
+          True when an administrator created the group, false when it was
+          created by a user.
+      - name: etag
+        data_type: string
+        description: Entity tag of the resource, reported by the API.
+      - name: kind
+        data_type: string
+        description: >
+          Resource type reported by the API, always admin#directory#group.
+      - name: aliases
+        data_type: array<string>
+        description: Alternate addresses that deliver to this group.
+      - name: non_editable_aliases
+        data_type: array<string>
+        description: >
+          Domain-derived alternate addresses for the group that cannot be
+          edited.

--- a/src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml
+++ b/src/dbt/kipptaf/models/google/directory/staging/properties/stg_google_directory__groups.yml
@@ -9,8 +9,10 @@ models:
       - name: email
         data_type: string
         description: >
-          Primary address of the group. Join key for validating a constructed
-          student group address against the groups Google actually has.
+          Primary address of the group, lowercased. Join key for validating a
+          constructed student group address against the groups Google actually
+          has. Google preserves the case supplied at creation, so it is
+          normalized here because an address is a case-insensitive identifier.
         data_tests:
           - unique:
               config:

--- a/src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql
+++ b/src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql
@@ -1,0 +1,14 @@
+select
+    id,
+    email,
+    name,
+    description,
+    directmemberscount as direct_members_count,
+    admincreated as admin_created,
+    etag,
+    kind,
+
+    /* repeated */
+    aliases,
+    noneditablealiases as non_editable_aliases,
+from {{ source("google_directory", "src_google_directory__groups") }}

--- a/src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql
+++ b/src/dbt/kipptaf/models/google/directory/staging/stg_google_directory__groups.sql
@@ -1,6 +1,5 @@
 select
     id,
-    email,
     name,
     description,
     directmemberscount as direct_members_count,
@@ -11,4 +10,9 @@ select
     /* repeated */
     aliases,
     noneditablealiases as non_editable_aliases,
+
+    /* Google preserves the case it was given when a group is created, but an
+    address is a case-insensitive identifier and the extract joins on a
+    lowercase constructed value. Normalizing here keeps that join honest. */
+    lower(email) as email,
 from {{ source("google_directory", "src_google_directory__groups") }}

--- a/src/teamster/code_locations/kipptaf/google/directory/assets.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/assets.py
@@ -11,6 +11,7 @@ from dagster_gcp import BigQueryResource
 
 from teamster.code_locations.kipptaf import CODE_LOCATION
 from teamster.code_locations.kipptaf.google.directory.schema import (
+    GROUPS_SCHEMA,
     ORGUNITS_SCHEMA,
     ROLE_ASSIGNMENTS_SCHEMA,
     ROLES_SCHEMA,
@@ -26,6 +27,23 @@ from teamster.libraries.google.directory.resources import (
 )
 
 key_prefix = [CODE_LOCATION, "google", "directory"]
+
+
+@asset(
+    key=[*key_prefix, "groups"],
+    check_specs=[build_check_spec_avro_schema_valid([*key_prefix, "groups"])],
+    io_manager_key="io_manager_gcs_avro",
+    group_name="google_directory",
+    kinds={"python"},
+)
+def groups(context: AssetExecutionContext, google_directory: GoogleDirectoryResource):
+    data = google_directory.list_groups()
+
+    yield Output(value=(data, GROUPS_SCHEMA), metadata={"record_count": len(data)})
+
+    yield check_avro_schema_valid(
+        asset_key=context.asset_key, records=data, schema=GROUPS_SCHEMA
+    )
 
 
 @asset(
@@ -286,28 +304,12 @@ assets = [
     google_directory_role_assignments_create,
     google_directory_user_create,
     google_directory_user_update,
+    groups,
     orgunits,
     role_assignments,
     roles,
     users,
 ]
-
-# @asset(
-#     key=[*key_prefix, "groups"],
-#     check_specs=[build_check_spec_avro_schema_valid([*key_prefix, "groups"])],
-#     io_manager_key="io_manager_gcs_avro",
-#     group_name="google_directory",
-#     kinds={"python"},
-# )
-# def groups(context: AssetExecutionContext, google_directory: GoogleDirectoryResource):
-#     data = google_directory.list_groups()
-
-#     yield Output(value=(data, GROUPS_SCHEMA), metadata={"record_count": len(data)})
-
-#     yield check_avro_schema_valid(
-#         asset_key=context.asset_key, records=data, schema=GROUPS_SCHEMA
-#     )
-
 
 # @asset(
 #     key=[*key_prefix, "members"],

--- a/src/teamster/code_locations/kipptaf/google/directory/assets.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/assets.py
@@ -208,7 +208,13 @@ def google_directory_user_create(
             # Only add users whose creation succeeded — a failed create leaves
             # no account, so its member insert would fail with "resource not
             # found" and double-count the same student in the error check.
-            members_data = members_for_created_users(valid_users, create_errors)
+            # Users whose groupKey did not resolve are skipped and reported
+            # once, rather than once per user.
+            members_data, unresolved_group_errors = members_for_created_users(
+                valid_users, create_errors
+            )
+
+            errors.extend(unresolved_group_errors)
 
             if members_data:
                 members_errors = google_directory.batch_insert_members(members_data)

--- a/src/teamster/code_locations/kipptaf/google/directory/assets.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/assets.py
@@ -232,7 +232,9 @@ def google_directory_user_create(
                 valid_users, create_errors
             )
 
-            errors.extend(unresolved_group_errors)
+            for ue in unresolved_group_errors:
+                context.log.error(msg=ue)
+                errors.append(ue)
 
             if members_data:
                 members_errors = google_directory.batch_insert_members(members_data)

--- a/src/teamster/code_locations/kipptaf/google/directory/schedules.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/schedules.py
@@ -5,6 +5,7 @@ from teamster.code_locations.kipptaf.google.directory.assets import (
     google_directory_role_assignments_create,
     google_directory_user_create,
     google_directory_user_update,
+    groups,
     orgunits,
     role_assignments,
     roles,
@@ -20,7 +21,7 @@ google_directory_users_schedule = ScheduleDefinition(
 
 google_directory_nonpartitioned_asset_schedule = ScheduleDefinition(
     name=f"{CODE_LOCATION}__google__directory__nonpartitioned_asset_job_schedule",
-    target=[orgunits, role_assignments, roles, users],
+    target=[groups, orgunits, role_assignments, roles, users],
     cron_schedule="30 1 * * *",
     execution_timezone=str(LOCAL_TIMEZONE),
 )

--- a/src/teamster/code_locations/kipptaf/google/directory/schema.py
+++ b/src/teamster/code_locations/kipptaf/google/directory/schema.py
@@ -3,11 +3,14 @@ import json
 import py_avro_schema
 
 from teamster.libraries.google.directory.schema import (
+    Group,
     OrgUnits,
     Role,
     RoleAssignment,
     User,
 )
+
+GROUPS_SCHEMA = json.loads(py_avro_schema.generate(py_type=Group, namespace="group"))
 
 ORGUNITS_SCHEMA = json.loads(
     py_avro_schema.generate(py_type=OrgUnits, namespace="orgunits")
@@ -21,5 +24,4 @@ ROLES_SCHEMA = json.loads(py_avro_schema.generate(py_type=Role, namespace="role"
 
 USERS_SCHEMA = json.loads(py_avro_schema.generate(py_type=User, namespace="user"))
 
-# GROUPS_SCHEMA = json.loads(py_avro_schema.generate(py_type=Group, namespace="group"))
 # MEMBERS_SCHEMA = json.loads(py_avro_schema.generate(py_type=Member, namespace="member"))

--- a/src/teamster/libraries/google/CLAUDE.md
+++ b/src/teamster/libraries/google/CLAUDE.md
@@ -63,6 +63,19 @@ path) to suppress inter-batch delays.
 `{"users": []}` for pages with no items. Use `response.get(key, [])`, not
 `response[key]`.
 
+**`groups.list` and `members.list` cap `maxResults` at 200, but their discovery
+entries carry no `maximum` key** — `googleapiclient` does not validate, so the
+resource-wide default of 500 reaches the server. Both need an explicit
+`max_results` pop (`roles`=100 and `roleAssignments`=200 already have one).
+`list_groups` is now capped; `list_members` is NOT — cap it when the `members`
+asset is revived.
+
+**Directory resolves a `groupKey` by alias and case-insensitively.** Validating
+a constructed address against a staged mirror instead (the `groupKey` guard in
+`rpt_google_directory__users_import`) narrows that, so the staging model
+lowercases `email`; an alias-only address still resolves to null. Verified once:
+camden/miami/newark are primary addresses with no aliases.
+
 **`schema.py`**: Pydantic models (`User`, `OrgUnits`, `Role`, `RoleAssignment`,
 `Group`, `Member`) mirroring the Google Directory API response shapes. Code
 locations consume these via `py_avro_schema.generate()` to produce Avro schemas

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -299,7 +299,7 @@ class GoogleDirectoryResource(ConfigurableResource):
 
         Args:
             **kwargs: Forwarded to ``_list``. ``customer`` defaults to
-                ``self.customer_id``.
+                ``self.customer_id``. Page size defaults to 200 (API maximum).
 
         Returns:
             List of group resource dicts.
@@ -308,7 +308,13 @@ class GoogleDirectoryResource(ConfigurableResource):
             HttpError: If all retry attempts are exhausted.
         """
         customer = kwargs.pop("customer", self.customer_id)
-        return self._list(api_name="groups", customer=customer, **kwargs)
+        max_results = kwargs.pop("max_results", 200)
+        return self._list(
+            api_name="groups",
+            customer=customer,
+            max_results=max_results,
+            **kwargs,
+        )
 
     def list_members(self, group_key: str, **kwargs) -> list[dict]:
         """Retrieves a paginated list of all members in a group.
@@ -742,13 +748,15 @@ def members_for_created_users(
     if not unresolved:
         return members, []
 
+    count = len(unresolved)
     return members, [
         {
             "error": (
-                f"{len(unresolved)} created users have no resolvable students"
+                f"{count} created {'user' if count == 1 else 'users'} "
+                f"{'has' if count == 1 else 'have'} no resolvable students"
                 " group; membership skipped"
             ),
-            "count": len(unresolved),
+            "count": count,
             "orgUnitPaths": sorted({u["orgUnitPath"] for u in unresolved}),
         }
     ]

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -695,12 +695,18 @@ class GoogleDirectoryResource(ConfigurableResource):
 
 def members_for_created_users(
     users: list[dict], create_errors: list[dict]
-) -> list[dict]:
+) -> tuple[list[dict], list[dict]]:
     """Build group-membership payloads for users whose creation did not fail.
 
     A user's group membership can only be added once the account exists, so a
     user whose ``batch_insert_users`` call failed must be excluded — otherwise
     the membership insert is guaranteed to fail with "resource not found".
+
+    A user whose ``groupKey`` is null is excluded for a different reason: the
+    extract resolves ``groupKey`` against the groups Google actually has, so
+    null means the students group for that region does not exist. Attempting the
+    add would fail with "404 Resource Not Found: groupKey" once per user, so the
+    membership is skipped and reported once for the whole run instead.
 
     Args:
         users: The users passed to
@@ -709,18 +715,40 @@ def members_for_created_users(
             users whose creation ultimately failed.
 
     Returns:
+        A two-tuple. The first element holds
         :meth:`GoogleDirectoryResource.batch_insert_members` payloads
-        (``groupKey`` / ``email`` / ``delivery_settings``) for the users NOT
-        present in ``create_errors``.
+        (``groupKey`` / ``email`` / ``delivery_settings``) for created users
+        whose ``groupKey`` resolved. The second holds at most one aggregated
+        ``{"error", "count", "orgUnitPaths"}`` dict describing the created users
+        whose group could not be resolved, and is empty when every group
+        resolved.
     """
     failed_emails = {e["primaryEmail"] for e in create_errors}
 
-    return [
+    created = [u for u in users if u["primaryEmail"] not in failed_emails]
+
+    members = [
         {
             "groupKey": u["groupKey"],
             "email": u["primaryEmail"],
             "delivery_settings": "DISABLED",
         }
-        for u in users
-        if u["primaryEmail"] not in failed_emails
+        for u in created
+        if u["groupKey"] is not None
+    ]
+
+    unresolved = [u for u in created if u["groupKey"] is None]
+
+    if not unresolved:
+        return members, []
+
+    return members, [
+        {
+            "error": (
+                f"{len(unresolved)} created users have no resolvable students"
+                " group; membership skipped"
+            ),
+            "count": len(unresolved),
+            "orgUnitPaths": sorted({u["orgUnitPath"] for u in unresolved}),
+        }
     ]

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -466,6 +466,17 @@ def test_list_role_assignments_uses_max_results_200_and_items_key():
     assert call_kwargs["maxResults"] == 200
 
 
+def test_list_groups_uses_max_results_200():
+    resource, mock_api = _make_resource()
+    mock_api.groups.return_value.list.return_value.execute.return_value = {
+        "groups": [{"email": "g@x.org"}]
+    }
+    data = resource.list_groups()
+    assert data == [{"email": "g@x.org"}]
+    _, call_kwargs = mock_api.groups.return_value.list.call_args
+    assert call_kwargs["maxResults"] == 200
+
+
 # ── members_for_created_users ─────────────────────────────────────────────────
 
 

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -535,6 +535,24 @@ def test_members_for_created_users_reports_null_group_key_once():
     ]
 
 
+def test_members_for_created_users_reports_null_group_key_singular():
+    users = [
+        _created_user("a@x.org", group_key=None, org_unit_path="/Students/School A")
+    ]
+
+    _, unresolved = members_for_created_users(users, [])
+
+    assert unresolved == [
+        {
+            "error": (
+                "1 created user has no resolvable students group; membership skipped"
+            ),
+            "count": 1,
+            "orgUnitPaths": ["/Students/School A"],
+        }
+    ]
+
+
 def test_members_for_created_users_does_not_report_null_group_key_for_failed_create():
     users = [_created_user("a@x.org", group_key=None)]
     create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -469,8 +469,16 @@ def test_list_role_assignments_uses_max_results_200_and_items_key():
 # ── members_for_created_users ─────────────────────────────────────────────────
 
 
-def _created_user(email: str) -> dict:
-    return {"primaryEmail": email, "groupKey": "g@x.org"}
+def _created_user(
+    email: str,
+    group_key: str | None = "g@x.org",
+    org_unit_path: str = "/Students/School A",
+) -> dict:
+    return {
+        "primaryEmail": email,
+        "groupKey": group_key,
+        "orgUnitPath": org_unit_path,
+    }
 
 
 def _member(email: str) -> dict:
@@ -479,22 +487,59 @@ def _member(email: str) -> dict:
 
 def test_members_for_created_users_all_succeeded():
     users = [_created_user("a@x.org"), _created_user("b@x.org")]
-    assert members_for_created_users(users, []) == [
-        _member("a@x.org"),
-        _member("b@x.org"),
-    ]
+    assert members_for_created_users(users, []) == (
+        [_member("a@x.org"), _member("b@x.org")],
+        [],
+    )
 
 
 def test_members_for_created_users_skips_failed_create():
     users = [_created_user("a@x.org"), _created_user("b@x.org")]
     create_errors = [{"primaryEmail": "b@x.org", "error": "boom"}]
-    assert members_for_created_users(users, create_errors) == [_member("a@x.org")]
+    assert members_for_created_users(users, create_errors) == (
+        [_member("a@x.org")],
+        [],
+    )
 
 
 def test_members_for_created_users_all_failed_returns_empty():
     users = [_created_user("a@x.org")]
     create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]
-    assert members_for_created_users(users, create_errors) == []
+    assert members_for_created_users(users, create_errors) == ([], [])
+
+
+def test_members_for_created_users_skips_null_group_key():
+    users = [_created_user("a@x.org"), _created_user("b@x.org", group_key=None)]
+
+    members, _ = members_for_created_users(users, [])
+
+    assert members == [_member("a@x.org")]
+
+
+def test_members_for_created_users_reports_null_group_key_once():
+    users = [
+        _created_user("a@x.org", group_key=None, org_unit_path="/Students/School B"),
+        _created_user("b@x.org", group_key=None, org_unit_path="/Students/School A"),
+    ]
+
+    _, unresolved = members_for_created_users(users, [])
+
+    assert unresolved == [
+        {
+            "error": (
+                "2 created users have no resolvable students group; membership skipped"
+            ),
+            "count": 2,
+            "orgUnitPaths": ["/Students/School A", "/Students/School B"],
+        }
+    ]
+
+
+def test_members_for_created_users_does_not_report_null_group_key_for_failed_create():
+    users = [_created_user("a@x.org", group_key=None)]
+    create_errors = [{"primaryEmail": "a@x.org", "error": "boom"}]
+
+    assert members_for_created_users(users, create_errors) == ([], [])
 
 
 def get_google_directory_resource() -> GoogleDirectoryResource:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop `rpt_google_directory__users_import` from sending group-membership adds
for a Google group that does not exist, without blocking student account
provisioning.

The extract built the student group address by string concatenation —
`'group-students-' || region || '@teamstudents.org'` — with nothing validating
that the group exists. `orgUnitPath`, three lines above in the same select, **is**
validated: it joins `stg_google_directory__orgunits`, so a missing path resolves
to null and the student drops out. #4513 added that guard for org units and left
the group address unguarded. When Paterson entered this extract on 2026-08-03,
its students group had never been created, so run
`bc28dc20-ae50-4af7-b45a-b3a0bd05d440` logged 429 identical
`404 Resource Not Found: groupKey` errors — one per created student.

`groupKey` now gets the same treatment, with one deliberate difference: **a null
`groupKey` does not drop the student.** The account is still created and only the
membership is skipped. Mirroring the `orgUnitPath` guard literally would mean no
Paterson student gets an account at all until Ops creates the group — a
provisioning regression traded for a cosmetic fix.

What changed, in four parts:

1. The dormant `groups` asset in the kipptaf Google Directory location is
   re-enabled and added to the existing 1:30am nonpartitioned schedule, so group
   data reaches GCS as Avro.
1. A `src_google_directory__groups` external source and a
   `stg_google_directory__groups` staging model expose it to dbt.
1. `rpt_google_directory__users_import` derives the constructed address as
   `group_key_target` in `with_google` and left joins the staged groups on
   `email` in `final`, projecting the resolved value as `groupKey`. The trailing
   `where` clause is unchanged.
1. `members_for_created_users` skips users whose `groupKey` is null and returns
   one aggregated error naming the count and the affected `orgUnitPath` values,
   which `user_create` folds into its `zero_api_errors` check. So the alert fires
   once per run instead of once per student.

Also fixes two things found along the way: `list_groups` was passing
`maxResults=500` to an endpoint documented at a 200 maximum (latent until this PR
made the method live — its discovery entry carries no `maximum` key, so
`googleapiclient` never validated it), and the extract's model description still
claimed Paterson was excluded, untrue since 079381c63.

### Prerequisite and post-merge actions

Neither is a code change, and both need an owner:

- [ ] **Ops:** create `group-students-paterson@teamstudents.org` in the admin
      console. Until it exists, Paterson accounts are created without membership
      and each run reports one warning.
- [ ] **On merge:** launch `kipptaf/google/directory/groups` in prod as soon as
      the deploy lands. The prod external table does not exist until a prod
      materialization drops a file, and `build_dbt_assets` runs
      `stage_external_sources` on every dbt asset run. External sources are
      excluded from the `any_deps_missing` gate, so the first post-deploy tick
      **will** request the new staging model — ahead of the 1:30am schedule.
      Losing that race costs one failed dbt run: `create or replace external
      table` leaves nothing dropped, the prod extract is a view that keeps its
      old definition, provisioning is unaffected, and it self-heals after the
      manual materialization. Accepted deliberately rather than splitting this
      into two PRs.

### Out of scope

Still open on #4766: backfilling group membership for the ~884 existing Paterson
accounts, and recurring membership reconciliation. Membership is attempted only
under `is_create`, so no region has drift correction today and a student whose
membership was skipped is never retried. That work needs the `members` asset,
which re-enabling `groups` now makes possible — `members` and `MEMBERS_SCHEMA`
are deliberately left commented out here.

Two smaller deferrals worth recording: `libraries/google/directory/ops.py` holds
an unguarded duplicate of the membership-payload builder (dead — its only
importer is an underscore-prefixed archived test pytest never collects; the right
fix is deleting it, not porting the guard), and `list_members` has the same
uncapped `max_results` that `list_groups` had, still dormant.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude Code authored the design, the plan, and the implementation, working from
issue #4766 and the existing `orgUnitPath` guard as the pattern. Human-directed:
the decision to validate against Google rather than the `people__locations`
sheet, the decision to keep the account and skip only the membership, and the
decision to ship as one PR and accept the post-deploy race. Design spec and
implementation plan are in `docs/superpowers/`.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code
      location
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

The two unchecked boxes cannot run in a Codespace: `kipptaf.definitions` fails at
module load on the Illuminate and Zendesk dlt credential resolvers, which are
unset locally and unrelated to this change. Verified instead by `py_compile` on
the three edited modules, a runtime import confirming `GROUPS_SCHEMA` generates
the expected 10 Avro fields, and the branch deployment. `uv run pytest tests/resources/test_resource_google_directory.py`
passes 7/7 on the `members_for_created_users` guard.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table. See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

No columns were renamed or removed. `groupKey` keeps its name and type and only
becomes nullable, which the contract does not constrain. The consumer is the
`user_create` / `user_update` asset pair, not a dashboard, so no exposure applies.

The staging run needs a location override, because CI's `target=staging` resolves
`cloud_storage_uri_base` to the prod bucket while the branch deployment writes to
the test one:

```text
uv run dbt run-operation stage_external_sources
  --args "select: google_directory.src_google_directory__groups"
  --vars '{cloud_storage_uri_base: gs://teamster-test/dagster/kipptaf, ext_full_refresh: true}'
  --target staging
  --project-dir src/dbt/kipptaf
```

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

The `groups` asset joins an existing schedule rather than adding one, so the
automations catalog is unchanged in substance. Regenerating it here would drop
every code location that fails to import in a Codespace, so it is left alone —
per `docs/CLAUDE.md`, that script must run in a full environment.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt` locally,
      fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

`trunk check --force --no-fix` was run on all 12 changed files from inside the
worktree: no issues.

## Open verification gate

The join compares the constructed address to `stg_google_directory__groups.email`
only, while the code it replaces passed that address to `members.insert`, which
also resolves aliases and unique ids. If `newark`, `camden`, or `miami`'s address
is an **alias** of a group whose primary address differs, this change would turn a
working region's `groupKey` null and silently stop its membership adds. Checked
once the staged table holds data:

```sql
select email
from `teamster-332318.zz_stg_kipptaf_google_directory.stg_google_directory__groups`
where email like 'group-students-%'
```

Expect `camden`, `miami`, `newark` — and not `paterson`. If one of the three is
missing, its address is an alias and the join needs
`or w.group_key_target in unnest(g.aliases)`; the staging model already carries
`aliases`.

Refs #4766
