### PR TITLE
fix(marts,cube): resolve assessment reporting term by date, drop it from the section dim

### DIFF
--- a/docs/reference/marts-data-models.md
+++ b/docs/reference/marts-data-models.md
@@ -29,6 +29,7 @@ erDiagram
   fct_assessment_scores_enrollment_scoped }o--|| dim_assessment_administrations : "assessment_administration_key"
   fct_assessment_scores_enrollment_scoped }o--|| dim_student_section_enrollments : "student_section_enrollment_key"
   dim_assessment_administrations }o--|| dim_assessments : "assessment_key"
+  dim_student_section_enrollments }o--|| dim_staff : "lead_teacher_staff_key"
   dim_student_section_enrollments }o--|| dim_student_enrollments : "student_enrollment_key"
   dim_student_section_enrollments }o--|| dim_course_sections : "course_section_key"
   dim_student_enrollments }o--|| dim_students : "student_key"
@@ -40,7 +41,9 @@ erDiagram
 | FK column                        | References                        |
 | -------------------------------- | --------------------------------- |
 | `assessment_administration_key`  | `dim_assessment_administrations`  |
+| `assessment_date_key`            | `dim_dates`                       |
 | `student_section_enrollment_key` | `dim_student_section_enrollments` |
+| `term_key`                       | `dim_terms`                       |
 | `test_date_key`                  | `dim_dates`                       |
 
 ## fct_assessment_scores_student_scoped
@@ -120,6 +123,7 @@ erDiagram
 ```mermaid
 erDiagram
   fct_grades_assignments }o--|| dim_student_section_enrollments : "student_section_enrollment_key"
+  dim_student_section_enrollments }o--|| dim_staff : "lead_teacher_staff_key"
   dim_student_section_enrollments }o--|| dim_student_enrollments : "student_enrollment_key"
   dim_student_section_enrollments }o--|| dim_course_sections : "course_section_key"
   dim_student_enrollments }o--|| dim_students : "student_key"
@@ -139,6 +143,7 @@ erDiagram
 ```mermaid
 erDiagram
   fct_grades_category }o--|| dim_student_section_enrollments : "student_section_enrollment_key"
+  dim_student_section_enrollments }o--|| dim_staff : "lead_teacher_staff_key"
   dim_student_section_enrollments }o--|| dim_student_enrollments : "student_enrollment_key"
   dim_student_section_enrollments }o--|| dim_course_sections : "course_section_key"
   dim_student_enrollments }o--|| dim_students : "student_key"
@@ -172,6 +177,7 @@ erDiagram
 ```mermaid
 erDiagram
   fct_grades_term }o--|| dim_student_section_enrollments : "student_section_enrollment_key"
+  dim_student_section_enrollments }o--|| dim_staff : "lead_teacher_staff_key"
   dim_student_section_enrollments }o--|| dim_student_enrollments : "student_enrollment_key"
   dim_student_section_enrollments }o--|| dim_course_sections : "course_section_key"
   dim_student_enrollments }o--|| dim_students : "student_key"

--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -28,6 +28,14 @@ cubes:
           {CUBE}.student_section_enrollment_key
         relationship: many_to_one
 
+      # Reporting quarter of the score, keyed on the fact's own term_key (the
+      # quarter containing the administration/test date at the section's school).
+      # Reached only through this path: the section dim no longer carries a term
+      # FK, so there is no diamond back to terms (#4484).
+      - name: terms
+        sql: "{terms.term_key} = {CUBE}.term_key"
+        relationship: many_to_one
+
     dimensions:
       - name: assessment_score_key
         description: Surrogate key. Primary key for this fact.
@@ -48,6 +56,11 @@ cubes:
         sql: CAST(test_date_key AS TIMESTAMP)
         type: time
         public: true
+
+      - name: term_key
+        description: FK to terms — the reporting quarter containing the score.
+        sql: term_key
+        type: string
 
       - name: enrollment_resolution
         description: >-

--- a/src/cube/model/cubes/students/student_section_enrollments.yml
+++ b/src/cube/model/cubes/students/student_section_enrollments.yml
@@ -14,10 +14,6 @@ cubes:
         sql: "{course_sections.course_section_key} = {CUBE}.course_section_key"
         relationship: many_to_one
 
-      - name: terms
-        sql: "{terms.term_key} = {CUBE}.term_key"
-        relationship: many_to_one
-
       # Lead teacher name/attributes. many_to_one — one lead per enrollment
       # after dbt resolution — so no fan-out. Joins the staff_lead_teacher
       # role-play cube (extends staff) so the lead-teacher members can't collide
@@ -47,11 +43,6 @@ cubes:
       - name: course_section_key
         description: FK to course_sections.
         sql: course_section_key
-        type: string
-
-      - name: term_key
-        description: FK to terms.
-        sql: term_key
         type: string
 
       - name: academic_year

--- a/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
+++ b/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
@@ -146,7 +146,7 @@ views:
           - region_name
           - state
 
-      - join_path: student_assessment_scores.student_section_enrollments.terms
+      - join_path: student_assessment_scores.terms
         includes:
           - semester
           - term_name

--- a/src/cube/model/views/students/student_section_enrollments_view.yml
+++ b/src/cube/model/views/students/student_section_enrollments_view.yml
@@ -44,13 +44,6 @@ views:
           - identifier
           - period
 
-      - join_path: student_section_enrollments.terms
-        includes:
-          - semester
-          - term_name
-          - term_code
-          - term_type
-
       - join_path: student_section_enrollments.student_school_enrollments
         prefix: false
         includes:
@@ -105,12 +98,6 @@ views:
             - is_foundations
             - identifier
             - period
-        - name: Term
-          members:
-            - semester
-            - term_name
-            - term_code
-            - term_type
         - name: Location
           members:
             - locations_location_name

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -278,10 +278,13 @@ with
             s._dbt_source_project,
             s.source_type,
             s.score_grain_key,
+            s.anchor_date,
 
             ce.cc_dcid,
             ce._dbt_source_project as cc_source_project,
             ce.cc_dateleft,
+            ce.powerschool_school_id,
+            ce.region,
 
             1 as tier,
 
@@ -323,10 +326,13 @@ with
             s._dbt_source_project,
             s.source_type,
             s.score_grain_key,
+            s.anchor_date,
 
             ce.cc_dcid,
             ce._dbt_source_project as cc_source_project,
             ce.cc_dateleft,
+            ce.powerschool_school_id,
+            ce.region,
 
             2 as tier,
 
@@ -375,6 +381,13 @@ select
     cc_source_project,
     source_type,
     resolution_type,
+
+    -- the resolved section's school and region. Carried so consumers can resolve
+    -- a score's reporting quarter from the score's OWN date (#4484); this model
+    -- is one row per score GRAIN, so its anchor_date cannot stand in for the
+    -- date of every score row sharing that grain.
+    powerschool_school_id,
+    region,
 
     {{ dbt_utils.generate_surrogate_key(["cc_dcid", "cc_source_project"]) }}
     as student_section_enrollment_key,

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -13,7 +13,8 @@ models:
       client date for iReady, STAR, and DIBELS); tier 2 falls back to the
       homeroom section active on the same anchor date. Scores with no matching
       section in either tier are dropped. The resolution_type column identifies
-      which tier resolved the row.
+      which tier resolved the row. Also carries the resolved section's school
+      and region so consumers can resolve a score's reporting quarter by date.
     config:
       materialized: table
     columns:
@@ -111,6 +112,25 @@ models:
           Surrogate key derived from (cc_dcid, cc_source_project) of the
           resolved course enrollment, matching
           dim_student_section_enrollments.student_section_enrollment_key.
+      - name: powerschool_school_id
+        data_type: int64
+        description: >-
+          School of the resolved section enrollment. Carried so consumers can
+          resolve a score's reporting quarter for the right school; this model
+          is one row per score grain, so it cannot resolve the quarter itself —
+          scores sharing a grain can carry different dates.
+        config:
+          meta:
+            source_column: int_assessments__course_enrollments.powerschool_school_id
+      - name: region
+        data_type: string
+        description: >-
+          Short region name (Newark, Camden, Miami, Paterson) of the resolved
+          section enrollment. Pairs with powerschool_school_id when matching the
+          reporting-terms sheet, which keys quarters by school and region.
+        config:
+          meta:
+            source_column: int_assessments__course_enrollments.region
 
 unit_tests:
   - name: test_subject_section_in_window_wins
@@ -145,6 +165,8 @@ unit_tests:
               cc_dateenrolled: 2024-01-01,
               cc_dateleft: 2025-06-15,
               cc_dcid: 111,
+              powerschool_school_id: 73252,
+              region: Newark,
             }
           - {
               powerschool_student_number: 1,
@@ -154,6 +176,8 @@ unit_tests:
               cc_dateenrolled: 2025-09-01,
               cc_dateleft: 2026-06-15,
               cc_dcid: 222,
+              powerschool_school_id: 73252,
+              region: Newark,
             }
       - input: ref('int_pearson__all_assessments')
         rows: []
@@ -205,6 +229,8 @@ unit_tests:
               cc_dateenrolled: 2024-09-01,
               cc_dateleft: 2025-06-15,
               cc_dcid: 333,
+              powerschool_school_id: 179902,
+              region: Camden,
             }
       - input: ref('int_pearson__all_assessments')
         rows: []
@@ -279,6 +305,8 @@ unit_tests:
               cc_dateenrolled: 2024-09-01,
               cc_dateleft: 2025-06-15,
               cc_dcid: 444,
+              powerschool_school_id: 73252,
+              region: Newark,
             }
       - input: ref('int_pearson__all_assessments')
         rows:
@@ -334,6 +362,8 @@ unit_tests:
               cc_dateenrolled: 2024-09-01,
               cc_dateleft: 2025-06-15,
               cc_dcid: 555,
+              powerschool_school_id: 73252,
+              region: Newark,
             }
       - input: ref('int_pearson__all_assessments')
         rows: []

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -21,9 +21,6 @@ with
             cc.cc_academic_year,
             cc.cc_dateenrolled,
             cc.cc_dateleft,
-            cc.cc_abs_termid,
-            cc.sections_schoolid,
-            cc.region,
             cc.is_dropped_section,
             cc.is_dropped_course,
             cc.cc_course_number,
@@ -61,39 +58,6 @@ with
         }}
     ),
 
-    course_enrollments_joined as (
-        select
-            er.cc_dcid,
-            er._dbt_source_project,
-            er.sections_dcid,
-            er.cc_academic_year,
-            er.cc_dateenrolled,
-            er.cc_dateleft,
-            er.is_dropped_section,
-            er.is_dropped_course,
-            er.cc_course_number,
-            er.teachernumber,
-            er.enr_source_project,
-            er.enr_student_number,
-            er.enr_academic_year,
-            er.enr_entrydate,
-
-            rt.`type` as rt_type,
-            rt.code as rt_code,
-            rt.`name` as rt_name,
-            rt.start_date as rt_start_date,
-            rt.region as rt_region,
-            rt.school_id as rt_school_id,
-        from enrollment_resolved as er
-        left join
-            {{ ref("stg_google_sheets__reporting__terms") }} as rt
-            on er.cc_abs_termid = rt.powerschool_term_id
-            and er.sections_schoolid = rt.school_id
-            and er.region = rt.region
-            and rt.`type` = 'RT'
-    ),
-
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     section_enrollments as (
         select
             cc_academic_year as academic_year,
@@ -131,39 +95,7 @@ with
                 }},
                 cast(null as string)
             ) as student_enrollment_key,
-
-            if(
-                rt_code is not null,
-                {{
-                    dbt_utils.generate_surrogate_key(
-                        [
-                            "rt_type",
-                            "rt_code",
-                            "rt_name",
-                            "rt_start_date",
-                            "rt_region",
-                            "rt_school_id",
-                        ]
-                    )
-                }},
-                cast(null as string)
-            ) as term_key,
-        from course_enrollments_joined
-    ),
-
-    -- Reporting terms are not unique on (powerschool_term_id, school, region) —
-    -- one term id maps to several reporting quarters — so the term join fans a
-    -- section enrollment across quarters. Collapse to one row per PK (the model
-    -- grain); term_key resolves to a single deterministic quarter, as before.
-    -- TODO(#4484): resolve term_key to the enrollment's actual quarter by date.
-    section_enrollments_deduped as (
-        {{
-            dbt_utils.deduplicate(
-                relation="section_enrollments",
-                partition_by="student_section_enrollment_key",
-                order_by="term_key asc",
-            )
-        }}
+        from enrollment_resolved
     ),
 
     section_enrollments_resolved as (
@@ -177,7 +109,6 @@ with
             se.student_section_enrollment_key,
             se.course_section_key,
             se.student_enrollment_key,
-            se.term_key,
 
             if(
                 sr.employee_number is not null,
@@ -210,7 +141,7 @@ with
                     se.entry_date desc,
                     se.student_section_enrollment_key asc
             ) as homeroom_rank,
-        from section_enrollments_deduped as se
+        from section_enrollments as se
         left join
             {{ ref("int_people__staff_roster") }} as sr
             on se.teachernumber = sr.powerschool_teacher_number
@@ -226,7 +157,6 @@ select
     student_section_enrollment_key,
     course_section_key,
     student_enrollment_key,
-    term_key,
     lead_teacher_staff_key,
 
     (course_enrollment_rank = 1) as is_current_section_enrollment,

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -5,9 +5,11 @@ models:
       enrollment of a student into a section. Multiple rows per student x
       section are possible when a student drops and re-enrolls in the same
       section within a year. FK to dim_student_enrollments via
-      student_enrollment_key, dim_course_sections via course_section_key,
-      dim_terms via term_key (nullable when CC term does not map to a reporting
-      term), and dim_staff via lead_teacher_staff_key.
+      student_enrollment_key, dim_course_sections via course_section_key, and
+      dim_staff via lead_teacher_staff_key. Carries no term FK — a section
+      enrollment spans several reporting quarters, so
+      bridge_course_section_terms is the grain-correct link from a section to
+      its quarters.
     columns:
       - name: lead_teacher_staff_key
         data_type: string
@@ -80,25 +82,6 @@ models:
               arguments:
                 to: ref('dim_course_sections')
                 field: course_section_key
-      - name: term_key
-        data_type: string
-        description: >-
-          Surrogate key derived from type, code, name, start_date, region, and
-          school_id of the matching reporting term. FK to dim_terms. Null when
-          the course-enrollment's term ID does not match any reporting term for
-          the section's school and region.
-
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
-            warn_unenforced: false
-        data_tests:
-          - relationships:
-              arguments:
-                to: ref('dim_terms')
-                field: term_key
       - name: academic_year
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_assessment_scores_enrollment_scoped.sql
@@ -355,6 +355,19 @@ with
             national_percentile,
             is_mastery,
         from dibels_scores
+    ),
+
+    -- Reporting quarters. A score's quarter comes from the date it was
+    -- administered or taken, NOT from its section enrollment: a section spans
+    -- several quarters, so "the quarter for a section enrollment" is not well
+    -- defined (#4484). Resolved per score row rather than in
+    -- int_assessments__resolved_section_enrollments, which is one row per score
+    -- GRAIN — scores sharing a grain can carry different dates. RT rows abut but
+    -- never overlap within a (school_id, region), so BETWEEN matches one row.
+    reporting_terms as (
+        select `type`, code, `name`, `start_date`, end_date, region, school_id,
+        from {{ ref("stg_google_sheets__reporting__terms") }}
+        where `type` = 'RT'
     )
 
 /* internal assessments */
@@ -387,6 +400,23 @@ select
         )
     }} as assessment_administration_key,
 
+    if(
+        rt.code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "rt.type",
+                    "rt.code",
+                    "rt.name",
+                    "rt.start_date",
+                    "rt.region",
+                    "rt.school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
+
     sr.student_section_enrollment_key,
 
     ia.test_date as test_date_key,
@@ -418,6 +448,11 @@ inner join
     and ia.assessment_id = sr.canonical_assessment_id
     and ia._dbt_source_project = sr._dbt_source_project
     and sr.source_type = 'internal'
+left join
+    reporting_terms as rt
+    on sr.powerschool_school_id = rt.school_id
+    and sr.region = rt.region
+    and ia.assessment_date_key between rt.`start_date` and rt.end_date
 
 union all
 
@@ -449,6 +484,23 @@ select
             ]
         )
     }} as assessment_administration_key,
+
+    if(
+        rt.code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "rt.type",
+                    "rt.code",
+                    "rt.name",
+                    "rt.start_date",
+                    "rt.region",
+                    "rt.school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
 
     sr.student_section_enrollment_key,
 
@@ -486,6 +538,11 @@ inner join
     and su.illuminate_subject = sr.subject_area
     and su._dbt_source_project = sr._dbt_source_project
     and sr.source_type in ('state_nj', 'state_fl')
+left join
+    reporting_terms as rt
+    on sr.powerschool_school_id = rt.school_id
+    and sr.region = rt.region
+    and su.test_date between rt.`start_date` and rt.end_date
 
 union all
 
@@ -519,6 +576,23 @@ select
             ]
         )
     }} as assessment_administration_key,
+
+    if(
+        rt.code is not null,
+        {{
+            dbt_utils.generate_surrogate_key(
+                [
+                    "rt.type",
+                    "rt.code",
+                    "rt.name",
+                    "rt.start_date",
+                    "rt.region",
+                    "rt.school_id",
+                ]
+            )
+        }},
+        cast(null as string)
+    ) as term_key,
 
     sr.student_section_enrollment_key,
 
@@ -555,3 +629,8 @@ inner join
     and va.illuminate_subject = sr.subject_area
     and va._dbt_source_project = sr._dbt_source_project
     and va.score_source = sr.source_type
+left join
+    reporting_terms as rt
+    on sr.powerschool_school_id = rt.school_id
+    and sr.region = rt.region
+    and va.test_date between rt.`start_date` and rt.end_date

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -75,11 +75,11 @@ models:
         data_type: string
         description: >-
           FK to dim_terms. The reporting quarter containing the date this score
-          was administered or taken, resolved at the section's school by
-          int_assessments__resolved_section_enrollments. Resolved by date rather
-          than through the section enrollment, whose term id is not
-          quarter-specific. Null when no reporting quarter is defined for that
-          school and date.
+          was administered or taken, at the school of the section enrollment
+          int_assessments__resolved_section_enrollments resolved. Matched by
+          date rather than through the section enrollment itself, whose term id
+          is not quarter-specific. Null when no reporting quarter is defined for
+          that school and date.
         constraints:
           - type: foreign_key
             to: ref('dim_terms')

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -71,6 +71,27 @@ models:
                 to: ref('dim_student_section_enrollments')
                 field: student_section_enrollment_key
 
+      - name: term_key
+        data_type: string
+        description: >-
+          FK to dim_terms. The reporting quarter containing the date this score
+          was administered or taken, resolved at the section's school by
+          int_assessments__resolved_section_enrollments. Resolved by date rather
+          than through the section enrollment, whose term id is not
+          quarter-specific. Null when no reporting quarter is defined for that
+          school and date.
+        constraints:
+          - type: foreign_key
+            to: ref('dim_terms')
+            to_columns: [term_key]
+            warn_unsupported: false
+            warn_unenforced: false
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_terms')
+                field: term_key
+
       - name: test_date_key
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/tests/fct_assessment_scores_enrollment_scoped__term_covers_assessment_date.sql
+++ b/src/dbt/kipptaf/tests/fct_assessment_scores_enrollment_scoped__term_covers_assessment_date.sql
@@ -6,6 +6,7 @@
 select
     f.assessment_score_key,
     f.assessment_date_key,
+
     t.term_name,
     t.`start_date`,
     t.end_date,

--- a/src/dbt/kipptaf/tests/fct_assessment_scores_enrollment_scoped__term_covers_assessment_date.sql
+++ b/src/dbt/kipptaf/tests/fct_assessment_scores_enrollment_scoped__term_covers_assessment_date.sql
@@ -1,0 +1,14 @@
+-- Asserts that a score's resolved reporting quarter actually contains the date
+-- the score was administered or taken. Guards the #4484 regression: term_key
+-- resolved at any grain coarser than the score row (via the section enrollment,
+-- or via int_assessments__resolved_section_enrollments' per-score-GRAIN anchor
+-- date) assigns quarters that do not cover the row's own date.
+select
+    f.assessment_score_key,
+    f.assessment_date_key,
+    t.term_name,
+    t.`start_date`,
+    t.end_date,
+from {{ ref("fct_assessment_scores_enrollment_scoped") }} as f
+inner join {{ ref("dim_terms") }} as t on f.term_key = t.term_key
+where f.assessment_date_key < t.`start_date` or f.assessment_date_key > t.end_date

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -225,6 +225,20 @@ data_tests:
           ref:
             name: int_assessments__resolved_section_enrollments
 
+  - name: fct_assessment_scores_enrollment_scoped__term_covers_assessment_date
+    description: >-
+      Asserts that each score's resolved reporting quarter contains the date the
+      score was administered or taken. Any resolution grain coarser than the
+      score row — through the section enrollment, or through the per-score-grain
+      anchor date in int_assessments__resolved_section_enrollments — assigns
+      quarters that do not cover the row's own date, which is the #4484 defect.
+      Failure rows name the score, its date, and the quarter it landed in.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: fct_assessment_scores_enrollment_scoped
+
   - name: int_collegeboard__ap_unpivot__crosswalk_resolves
     description: >-
       Returns one row per `stg_collegeboard__ap.ap_number_ap_id` that has no


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...fix reporting-term resolution for assessment scores, and remove the broken
term FK from the section-enrollment dim.

**What was actually wrong.** `dim_student_section_enrollments.term_key` joined
the reporting-terms sheet on `cc_abs_termid`, which for every current section is
the **full-year** PowerSchool term (`3500` for AY2025) while the sheet carries
quarter ids (`3503`-`3506`). Nothing matches. The column is 100% NULL for AY2024
and 0.5% populated for AY2025, so the Term folders in **both** Cube views
(`student_section_enrollments_view`, `student_assessment_scores_view`) return
NULL today.

| academic_year | rows | non-null `term_key` |
| ------------- | ------ | ------------------- |
| 2024          | 85,886 | 0                   |
| 2025          | 91,901 | 444 (0.5%)          |
| 2026          | 53,060 | 16                  |

The 8,109-row fan-out described in the issue is a separate, historical cause:
the join omits `academic_year`, and the sheet duplicates a term id across two
academic years for some AY2018-2023 rows (e.g. `2801` filed under both 2017 and
2018).

**Section dim.** A section enrollment spans several quarters, so a single term FK
does not belong at that grain. Dropped `term_key` from
`dim_student_section_enrollments` — and with it the reporting-terms join and the
`dbt_utils.deduplicate` that was masking the fan-out — plus the `terms` join on
the section cube and the Term folder on the roster view.
`bridge_course_section_terms` already models section-to-quarter correctly (by
date, ~3.9 quarters per section); it is the path to use if a Term-filtered roster
is ever wanted. Not wired into Cube here — nobody asked for it.

**Assessment scores.** The quarter is now resolved in the fact, from each row's
own `assessment_date_key`, at the resolved section's school and region. RT rows
never overlap within a `(school_id, region)` (verified), so `BETWEEN` matches at
most one.

Resolving it one layer up in `int_assessments__resolved_section_enrollments` was
tried and **rejected**: that model is one row per score _grain_, and scores
sharing a grain carry different dates, which put 925 rows on a quarter that did
not contain their date. The resolver now just carries `powerschool_school_id` and
`region` through. A new singular test asserts the resolved quarter contains the
score's date.

### Result

| metric                                            | before      | after       |
| ------------------------------------------------- | ----------- | ----------- |
| `term_key` populated on the assessment-scores fact | 0.4%        | 100% - 441 rows |
| rows whose quarter excludes their own date         | 925         | 0           |
| fact row count / distinct PK                       | 14,508,002  | 14,508,002  |
| section dim row count / distinct PK                | 837,722     | 837,722     |

The 441 remaining nulls are scores whose date falls outside any RT quarter for
their school (Paterson has no AY2024 RT rows). Row counts and PKs are identical
to prod on both models, so neither change fans out or drops rows.

## AI Assistance

Claude-authored, human-directed. The user pointed at the issue and chose to
delete the section dim's `term_key` rather than re-resolve it by entry date.
Claude did the diagnosis (the full-year-term-id finding, which reframed the fix),
the implementation, and the validation.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties files updated for every touched model, plus a properties entry
      for the new singular test.
- [x] Cube is the only consumer; its exposure (`cube.yml`) already covers both
      models, and the Cube YAML changes ship in this PR.
- [x] **Breaking change** — `dim_student_section_enrollments.term_key` is
      removed. Consumers: Cube only, updated here. The four Term members
      (`semester`, `term_name`, `term_code`, `term_type`) disappear from
      `student_section_enrollments_view` and keep working, unchanged in name, on
      `student_assessment_scores_view`. Rollback: revert the commit; nothing
      outside Cube reads the column.
- [ ] No external sources added or modified.

### Validation

Local `dbt build` against the branch, dev target, `--defer --favor-state`:
`PASS=29 WARN=0 ERROR=0` — including all 6 resolver unit tests, the fact PK
`unique`, every `relationships` test (the new `term_key` to `dim_terms` among
them), and the new
`fct_assessment_scores_enrollment_scoped__term_covers_assessment_date`.

`trunk check --force` clean after the commit-time `fmt`.

**Cube model changes are not validated by CI** — per `src/cube/CLAUDE.md`, branch
schema validation is manual, and the cubes read `kipptaf_marts`, which lacks
`term_key` until this merges. The added join mirrors the shape
`student_attendance` already uses (fact to `terms` on `term_key`, view
`join_path: <fact>.terms`), and the view's Term member names are unchanged.

`docs/reference/marts-data-models.md` was regenerated
(`uv run scripts/generate_marts_reference.py`). Five of its six added lines are
pre-existing drift the regeneration corrected — the four `dim_staff` FK edges and
the `assessment_date_key` FK row, all of whose constraints predate this PR. Only
`term_key` to `dim_terms` is new.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — not triggered (`src/dbt/**` and `src/cube/**` are
      excluded from the deploy workflows' `pull_request` paths).

Closes #4484
