### PR TITLE
feat(kipptaf): add rpt_gsheets__kfwd_student_salesforce_ids lookup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,15 +47,16 @@ urgent, unplanned need of a single student.
 
 _Avoid_: emergency aid, hardship grant, micro-grant
 
-**Disbursement**: One payment of Maher Fund money made to or on behalf of one
-student.
+**Cohort**: The year-group a student enters 9th grade with. Fixed at entry, so a
+retention or a skipped grade does not change it.
 
-_Avoid_: award, grant, aid payment
+_Avoid_: class, graduating class, graduation year
 
-**Cohort**: The year-group a student is associated with for KIPP high school
-graduation.
+**Graduation year**: The calendar year a student graduates high school, or is
+projected to. Reflects retentions and skipped grades, so it can differ from the
+student's cohort.
 
-_Avoid_: class, graduating class, grad year
+_Avoid_: cohort, grad year
 
 **Region**: One of the four cities whose schools the network operates — Newark,
 Camden, Miami, and Paterson.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,63 @@
+# KIPP TEAM and Family data platform
+
+The shared vocabulary for the network's data models. Terms are added as they get
+pinned down in design work, so this file grows in clusters rather than arriving
+complete.
+
+## Language
+
+### KIPP Forward and postsecondary aid
+
+**KIPP Forward**: The network's postsecondary program, supporting students from
+middle school through college and career. Its legacy name survives inside
+identifiers such as `ktc_status`.
+
+_Avoid_: KTC, KIPP Through College
+
+**Student**: A person holding a Salesforce contact record whose record type is
+one of the student lifecycle stages. Parents, staff, and other contacts on the
+same object are not students.
+
+_Avoid_: alum, alumni, contact
+
+**Salesforce contact ID**: The eighteen-character Salesforce identifier for a
+contact record, and the network's canonical identifier for a student outside the
+student information system. The SIS holds no identifier of its own for a
+Salesforce record.
+
+_Avoid_: SF ID, contact ID, `salesforce_id`
+
+**KTC status**: Where a student sits relative to KIPP secondary enrollment —
+enrolled at a given grade level, graduated from a KIPP high school, or a KIPP
+middle school graduate who has not graduated from a KIPP high school.
+
+_Avoid_: postsecondary status, record type, lifecycle stage
+
+**Record type**: The lifecycle stage a Salesforce contact record was last set
+to. It describes the state of the record, not the state of the student, and lags
+real transitions in both directions.
+
+_Avoid_: status, KTC status
+
+**Maher Fund**: The fund from which the network pays discretionary awards to
+KIPP Forward students, divided into emergency and enrichment purposes.
+
+**Emergency funding request**: A request to pay Maher Fund money toward an
+urgent, unplanned need of a single student.
+
+_Avoid_: emergency aid, hardship grant, micro-grant
+
+**Disbursement**: One payment of Maher Fund money made to or on behalf of one
+student.
+
+_Avoid_: award, grant, aid payment
+
+**Cohort**: The year-group a student is associated with for KIPP high school
+graduation.
+
+_Avoid_: class, graduating class, grad year
+
+**Region**: One of the four cities whose schools the network operates — Newark,
+Camden, Miami, and Paterson.
+
+_Avoid_: district, market, area

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -504,3 +504,7 @@ snapshot — before removing it.
   `models/marts/`. Actively being developed; see
   `src/dbt/kipptaf/models/marts/CLAUDE.md` for column-naming rubric, hash-change
   discipline, and strict-chain rules.
+
+New KIPP Forward Google Sheets extracts take the `rpt_gsheets__kfwd_` prefix.
+Existing models use both `kfwd_` and `kippfwd_`; `kfwd_` is the going-forward
+choice, and the older ones are not being renamed.

--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -77,6 +77,19 @@ exposures:
         dagster:
           kinds:
             - googlesheets
+  - name: kfwd_student_salesforce_ids
+    label: KIPP Forward Student Salesforce IDs
+    type: application
+    owner:
+      name: Data Team
+    url: https://docs.google.com/spreadsheets/d/1AAiEQ46OeMbgLjRawoFayfW-4WavtkNPwCvxMOkdSLo
+    depends_on:
+      - ref("rpt_gsheets__kfwd_student_salesforce_ids")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - googlesheets
   - name: camden_sar_accommodations_errors20241031
     label: "[Camden] SAR Accommodations Errors - 20241031"
     type: application

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_student_salesforce_ids.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_student_salesforce_ids.yml
@@ -9,8 +9,9 @@ models:
       int_kippadb__roster because no aid request originates from one; the roster
       itself only covers students with a KIPP secondary enrollment, so a
       Salesforce contact without one does not appear here. The remaining columns
-      exist to tell same-name students apart — graduation cohort separates most
-      pairs, region and birth date separate the rest.
+      exist to tell same-name students apart — cohort separates most pairs,
+      region and birth date separate the rest, which is why all three carry a
+      null check.
     config:
       meta:
         contains_pii: true
@@ -27,6 +28,34 @@ models:
         config:
           meta:
             contains_pii: true
+      - name: birthdate
+        data_type: date
+        data_tests:
+          - not_null
+        description:
+          Student date of birth from Salesforce. Carried only as the final
+          tiebreaker for students who share a name, a cohort, and a region.
+        config:
+          meta:
+            contains_pii: true
+      - name: cohort
+        data_type: int64
+        data_tests:
+          - not_null
+        description:
+          Year-group the student entered 9th grade with, taken from the
+          Salesforce KIPP high school class and falling back to the PowerSchool
+          cohort. Fixed at entry, so it does not move for a retention or a
+          skipped grade and can differ from the year the student is projected to
+          graduate. The strongest single disambiguator between students who
+          share a name.
+      - name: region
+        data_type: string
+        data_tests:
+          - not_null
+        description:
+          Region whose schools the student attended — Newark, Camden, Miami, or
+          Paterson.
       - name: student_name
         data_type: string
         description:
@@ -52,26 +81,6 @@ models:
         config:
           meta:
             contains_pii: true
-      - name: birthdate
-        data_type: date
-        description:
-          Student date of birth from Salesforce. Included only as the final
-          tiebreaker for students who share a name, a graduation cohort, and a
-          region.
-        config:
-          meta:
-            contains_pii: true
-      - name: hs_class
-        data_type: int64
-        description:
-          Graduation cohort the student belongs to, taken from the Salesforce
-          KIPP high school class and falling back to the PowerSchool cohort. The
-          strongest single disambiguator between students who share a name.
-      - name: region
-        data_type: string
-        description:
-          Region whose schools the student attended — Newark, Camden, Miami, or
-          Paterson.
       - name: student_number
         data_type: int64
         description:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_student_salesforce_ids.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_student_salesforce_ids.yml
@@ -1,0 +1,99 @@
+models:
+  - name: rpt_gsheets__kfwd_student_salesforce_ids
+    description:
+      Google Sheets lookup pairing each KIPP Forward student with their
+      Salesforce contact id, so whoever records an emergency postsecondary aid
+      disbursement in Coupa can attach the id to that transaction instead of
+      leaving the student to be matched by name after the fact. One row per
+      Salesforce contact. Currently enrolled 8th graders are dropped from
+      int_kippadb__roster because no aid request originates from one; the roster
+      itself only covers students with a KIPP secondary enrollment, so a
+      Salesforce contact without one does not appear here. The remaining columns
+      exist to tell same-name students apart — graduation cohort separates most
+      pairs, region and birth date separate the rest.
+    config:
+      meta:
+        contains_pii: true
+    columns:
+      - name: salesforce_contact_id
+        data_type: string
+        data_tests:
+          - unique
+        description:
+          Salesforce contact id in its 18-character form, which is
+          case-insensitive and self-checksumming. This is the value copied into
+          Coupa on an aid disbursement and the key that ties the resulting KIPP
+          Aid record to the right student.
+        config:
+          meta:
+            contains_pii: true
+      - name: student_name
+        data_type: string
+        description:
+          Student name as last name, comma, first name — the field to scan when
+          looking a student up. Sourced from Salesforce, falling back to the
+          PowerSchool name when Salesforce carries none.
+        config:
+          meta:
+            contains_pii: true
+      - name: last_name
+        data_type: string
+        description:
+          Student last name, exposed separately from the combined name so the
+          sheet can be sorted and filtered on it.
+        config:
+          meta:
+            contains_pii: true
+      - name: first_name
+        data_type: string
+        description:
+          Student first name, exposed separately from the combined name so the
+          sheet can be sorted and filtered on it.
+        config:
+          meta:
+            contains_pii: true
+      - name: birthdate
+        data_type: date
+        description:
+          Student date of birth from Salesforce. Included only as the final
+          tiebreaker for students who share a name, a graduation cohort, and a
+          region.
+        config:
+          meta:
+            contains_pii: true
+      - name: hs_class
+        data_type: int64
+        description:
+          Graduation cohort the student belongs to, taken from the Salesforce
+          KIPP high school class and falling back to the PowerSchool cohort. The
+          strongest single disambiguator between students who share a name.
+      - name: region
+        data_type: string
+        description:
+          Region whose schools the student attended — Newark, Camden, Miami, or
+          Paterson.
+      - name: student_number
+        data_type: int64
+        description:
+          Student number assigned by the school, carried so an id can be
+          cross-checked against paperwork that cites the SIS identifier rather
+          than a name.
+        config:
+          meta:
+            contains_pii: true
+      - name: record_type
+        data_type: string
+        description:
+          Salesforce record type on the contact, describing the lifecycle stage
+          the record was last set to. Present for context only. It is not a
+          reliable indicator of where a student actually is, because the value
+          lags real transitions in both directions, so it must not be used to
+          decide whether a student is eligible for postsecondary aid.
+      - name: ktc_status
+        data_type: string
+        description:
+          KIPP Through College status describing where the student sits relative
+          to KIPP secondary enrollment — a grade-level code while enrolled in a
+          KIPP high school, HSG once they graduate one, and TAF or TAFHS for a
+          KIPP middle school graduate who has not graduated from a KIPP high
+          school. Useful for orientation rather than for lookup.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kfwd_student_salesforce_ids.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kfwd_student_salesforce_ids.sql
@@ -3,7 +3,7 @@ select
     last_name,
     first_name,
     contact_birthdate as birthdate,
-    ktc_cohort as hs_class,
+    ktc_cohort as cohort,
     region,
     contact_id as salesforce_contact_id,
     student_number,

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kfwd_student_salesforce_ids.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kfwd_student_salesforce_ids.sql
@@ -1,0 +1,17 @@
+select
+    lastfirst as student_name,
+    last_name,
+    first_name,
+    contact_birthdate as birthdate,
+    ktc_cohort as hs_class,
+    region,
+    contact_id as salesforce_contact_id,
+    student_number,
+    record_type_name as record_type,
+    ktc_status,
+from {{ ref("int_kippadb__roster") }}
+/* MS8 is excluded rather than enumerating the statuses to keep (as
+   rpt_tableau__kfwd_dashboard does) so any newly introduced ktc_status appears
+   here by default: a student missing from the lookup causes the mis-attribution
+   this feed exists to prevent, while an extra middle schooler is inert. */
+where contact_id is not null and ktc_status != 'MS8'


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will publish `rpt_gsheets__kfwd_student_salesforce_ids` to a Google Sheet, exposing the Salesforce contact id for every KIPP Forward student so the person entering an emergency postsecondary aid transaction in Coupa can attach the id to it.

Today Coupa transactions carry no student identifier, so disbursements get matched to Salesforce contacts by name when the `KIPP_Aid__c` records are loaded. Across all 10,132 Salesforce student contacts — the set that name-matching runs against today — name alone is ambiguous for 102 contacts in 50 colliding name groups. Capturing the id at Coupa entry time means it rides along in the CSV export and no name matching is needed downstream.

One row per Salesforce contact, sourced from `int_kippadb__roster` filtered to `contact_id is not null and ktc_status != 'MS8'`, giving 7,930 rows.

### Population reasoning

- `int_kippadb__roster` is the limiter, so Salesforce contacts without a KIPP secondary enrollment do not appear.
- `ktc_status != 'MS8'` drops currently enrolled 8th graders. Validated against the full award history: **every Maher award ever made goes to a student this population keeps**; the residual is 6 non-Maher awards across 4 students.
- Salesforce `record_type` is deliberately **not** a filter. It lags real transitions in both directions — 1,093 `TAF` students and 445 currently enrolled 9th graders are still tagged `MS Student`, and 14 `HSG` are still tagged `HS Student`. It is carried as context only, and its column description says so.
- The filter is an exclusion rather than the inclusion list `rpt_tableau__kfwd_dashboard` uses. The two are identical today and diverge only if a new `ktc_status` value is introduced. Exclusion fails safe: a student missing from the lookup causes the mis-attribution this feed exists to prevent, while an extra middle schooler is inert.

### Disambiguation

Measured **on the 7,930 rows this model actually publishes**: name alone leaves 65 rows ambiguous, adding `cohort` leaves 8, adding `region` leaves 6, and `birthdate` closes the remainder. All three are fully populated, and each now carries a `not_null` check so that stays true.

`cohort` is the 9th-grade entry year — a distinct concept from graduation year, which reflects retentions and skipped grades. The two differ for 324 of these rows. They are equally effective as disambiguators (either one takes 65 down to 8), so the column carries cohort on the grounds that it is the stable identifier, not because it discriminates better.

### Convention

`kfwd_` is now recorded in `src/dbt/kipptaf/CLAUDE.md` as the going-forward prefix for KIPP Forward Google Sheets extracts. Existing `kippfwd_` models are not being renamed.

`CONTEXT.md` is new at the repo root — a glossary of the terms pinned down while designing this (student, Salesforce contact ID, KTC status vs record type, Maher Fund, cohort vs graduation year, region). It is a working vocabulary file for developers and agents, deliberately outside the MkDocs nav.

## AI Assistance

Claude Code co-authored this PR.

**Human-directed:** every design decision — population scope, that the roster is the limiter, filtering on `ktc_status` rather than record type, the column set, snake_case headers, the `kfwd_` naming convention, PII tagging scope, the decision to accept the excluded grade-8-withdrawal population without a tracking issue, and the cohort-versus-graduation-year correction.

**AI-assisted:** fact-finding against the warehouse (name-collision counts, record-type lag, null profiling, award-history validation of the population choice), then writing the model, properties YAML, exposure, and `CONTEXT.md`, and running the local build and lint.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Two findings
      implemented, two answered with reasoning in a reply below.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No. Additive only — no existing model, column, or
      exposure is modified, so reverting these commits is a complete rollback.
- [x] External sources — not applicable, none added or modified.

## Local validation

- `dbt build --select rpt_gsheets__kfwd_student_salesforce_ids --target dev --defer --favor-state` — view created, all 4 data tests PASS (`unique` on the contact id, `not_null` on `birthdate` / `cohort` / `region`).
- Contract confirmed independently via `INFORMATION_SCHEMA.COLUMNS`: all 10 columns present with the declared types.
- Dev view returns 7,930 rows, and its stored SQL resolves upstream to prod `kipptaf_kippadb.int_kippadb__roster` — so the count is not a stale-dev-copy artifact.
- `trunk check --force` over all changed files — no issues.

## Post-merge, owner action

The destination sheet needs a named range `rpt_gsheets__kfwd_student_salesforce_ids` pointed at `kipptaf_extracts.rpt_gsheets__kfwd_student_salesforce_ids`, plus CMO-only sharing. This cannot be done before merge, because the prod view does not exist until Dagster materializes the new asset.

## CI checks

- [x] **Trunk** — passed on `ea1246bbe`.
- [x] **dbt Cloud** — passed on `ea1246bbe`.
- [x] **Dagster Cloud** — not triggered, no Dagster paths changed.

Refs #4798
