### PR TITLE
feat(extracts): add state_test_proficiency to rpt_tableau__assessment_dashboard

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__assessment_dashboard.yml
@@ -105,3 +105,10 @@ models:
         data_type: boolean
       - name: dibels_most_recent_composite
         data_type: string
+      - name: state_test_proficiency
+        data_type: string
+        description: >-
+          Prior-year state test proficiency for this student and subject — NJSLA
+          aggregated proficiency in New Jersey, FAST PM3 administration in
+          Florida. Populated only where the subject resolves to ELA or Math, and
+          set to the literal No Test when the student has no prior-year result.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assessment_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__assessment_dashboard.sql
@@ -193,6 +193,7 @@ select
     sf.is_sipps,
     sf.is_low_25_fl,
     sf.dibels_most_recent_composite,
+    sf.state_test_proficiency,
 
     /* retired fields kept for tableau compatibility */
     null as power_standard_goal,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...add `state_test_proficiency` to `rpt_tableau__assessment_dashboard`, so the
DDI Suite workbook can filter on prior-year state test proficiency directly from
the assessment data source instead of blending against the DDI data source.

The extract already left joins `int_extracts__student_enrollments_subjects` (as
`sf`) and projects six columns from it, so this is a one-line projection add plus
the contract entry. No join change, no filter change, no row-count change.

The value is **prior-year** despite the column name — NJSLA aggregated
proficiency in New Jersey, FAST PM3 in Miami, defaulting to the literal `No Test`
when there is no prior-year result. The name deliberately matches
`rpt_tableau__ddi_dashboard`: both models feed the same `ddi_suite` exposure, so a
second name for the same value inside one workbook would cost more confusion than
the vague name does.

Coverage is unchanged from the six `sf` columns already on this extract —
populated only where the subject join key resolves to ELA or Math, null
elsewhere.

**Verified against prod.** Dev build with `--favor-state`; the compiled SQL was
confirmed to carry zero dev-schema refs, so this is a true prod-data comparison
rather than a stale-dev artifact.

| Check                             | Prod      | Dev       |
| --------------------------------- | --------- | --------- |
| Row count                         | 3,190,635 | 3,190,635 |
| Distinct students                 | 11,056    | 11,056    |
| `nj_student_tier` non-null        | 1,907,930 | 1,907,930 |
| `state_test_proficiency` non-null | n/a       | 1,907,930 |

Values agree with `rpt_tableau__ddi_dashboard` on every shared student / academic
year / subject area key — **zero disagreements** across AY2025 and AY2026. In all
51 keys where this extract is null and DDI is not, `nj_student_tier` is null too,
meaning the `sf` join missed on the assessment side. Zero rows have
`state_test_proficiency` null while `nj_student_tier` is present, so the column
adds no nullness of its own.

**Follow-up outside this PR:** the field still has to be added to the assessment
data source in the DDI Suite workbook. Landing the column in dbt does not put it
on a sheet.

Refs #4804

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Human-directed: the request, the scope decision (this column only, not the
sibling exemption and proficiency fields), and the call to include a column
description. Claude-authored: the two edits, the verification queries, and this
description.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
      — no new models; the existing properties file gains the contract entry plus
      a description for the new column.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the
      `ddi_suite` exposure already depends on this model; a column add does not
      change `depends_on`.
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above. — Not breaking: purely additive. Rollback is reverting the
      commit, which drops a column no Tableau sheet references yet.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table. —
      N/A, no external source touched.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
