### PR TITLE
fix(dbt): gate ddi dashboard assessments on enrollment dates

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
@@ -6,9 +6,10 @@ models:
       assessment response appears for a student when that student was enrolled
       as of the end of the week the assessment was administered, determined from
       enrollment dates rather than from whether the student is enrolled today,
-      so students who have since withdrawn or graduated keep their history.
-      Students with an inactive or pre-registered enrollment status, and
-      students in an out-of-district placement, are excluded.
+      so students who have since withdrawn or graduated keep their history for
+      as long as the extract's two-year window still covers it. Rows are
+      restricted to students holding a valid enrollment status, and students in
+      an out-of-district placement are excluded.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
@@ -1,5 +1,14 @@
 models:
   - name: rpt_tableau__ddi_dashboard
+    description: >-
+      Weekly extract behind the DDI Suite dashboard, unioning ES/MS assessment
+      responses, HS assessment responses, and staff walkthrough observations. An
+      assessment response appears for a student when that student was enrolled
+      as of the end of the week the assessment was administered, determined from
+      enrollment dates rather than from whether the student is enrolled today,
+      so students who have since withdrawn or graduated keep their history.
+      Students with an inactive or pre-registered enrollment status, and
+      students in an out-of-district placement, are excluded.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ddi_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__ddi_dashboard.sql
@@ -153,8 +153,14 @@ with
             and cc.courses_credittype = sf.powerschool_credittype
             and sf.rn_year = 1
         where
-            co.enroll_status = 0
-            and co.is_enrolled_week_end
+            /* Eligibility is enrollment as of the week end, not current
+               enroll_status: that column is student-level and current-only, so
+               pinning it to 0 retroactively erased the assessment history of every
+               student who had since withdrawn, transferred, or graduated (#4807).
+               Withdrawn (2) and graduated (3) are in scope; inactive (1) and
+               pre-registered (-1) stay out -- never report against either. */
+            co.is_enrolled_week_end
+            and co.enroll_status in (0, 2, 3)
             and not co.is_out_of_district
             and co.academic_year >= {{ var("current_academic_year") - 1 }}
             {# TODO: Remove SY26 #}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make an assessment appear on the DDI Suite dashboard based on whether the student was enrolled when it was administered, rather than on whether they are enrolled today.

`rpt_tableau__ddi_dashboard` pinned `co.enroll_status = 0` in its `identifiers` CTE. That column is student-level and current-only — it reflects a student's status now, not their status on the administered-at date — so every student who has since withdrawn, transferred, or graduated lost their entire assessment history retroactively. The loss lands on transition grades:

| Grade (Newark, AY2025) | Enrolled during SY25-26 | Kept by the old filter | Retained |
| --- | --- | --- | --- |
| K-7 | 515-669 each | - | 85-91% |
| 8 | 618 | 348 | 56% |
| 9-11 | 321-419 each | - | 86-91% |
| 12 | 310 | 14 | 4.5% |

95.5% of the Newark senior class was absent from the dashboard for the year they were seniors.

Eligibility now rests on `is_enrolled_week_end`, which is already a point-in-time enrollment test, bounded to valid statuses `(0, 2, 3)` so inactive (1) and pre-registered (-1) students stay out per the `enroll_status` rule in `src/dbt/kipptaf/CLAUDE.md`. `not co.is_out_of_district` is retained deliberately. No contract change — `enroll_status` is still projected in every UNION branch and no column type moved.

**Validation.** CRQ2 / Mathematics / Newark / AY2025, measured against `rpt_tableau__assessment_dashboard`:

- Students 4,357 to 5,091, against 5,110 on the assessment dashboard — 734 of the 753-student gap closed (97.5%)
- Mastery rate 58.43% to 58.45%, against 58.39% on the assessment dashboard

So this is a completeness fix, not a metric shift. Of the 19 residual students, 6 are deliberately excluded as out-of-district, 8 withdrew mid-week after sitting the assessment (deferred), and 5 were enrolled neither at week end nor on the administered-at date — correctly excluded here, and present on the assessment dashboard only because that model applies no date gate at all.

**Retroactive to AY2025, cleared with the stakeholder.** SY25-26 figures on the DDI Suite will move, most visibly for grades 8 and 12. Rollback is a one-line revert of the predicate.

The DDI Suite workbook references `enroll_status` in no worksheet, so the change surfaces on the dashboard rather than being filtered out downstream.

**Deliberately out of scope**, each examined and consciously left alone:

- `and r.module_type != 'WPP'` sits in the WHERE against a left-joined table, so the LEFT JOIN behaves as an INNER JOIN and zero-assessment student-weeks drop out. Known and stakeholder-accepted.
- The iReady measures are keyed to the assessment row's `subject_area` and undercount as a result. Filed separately as #4808.
- The properties yml's 72 columns carry no `description:`, and the model has no uniqueness test. Pre-existing convention gaps; a 72-column docs backfill would bury a one-predicate fix, and the uniqueness test needs its own look at the existing fan-out.
- Gating on the administered-at date instead of week end, worth 8 students in the validated slice.

Primary antecedent: https://teamschools.zendesk.com/agent/tickets/434923

Closes #4807

## AI Assistance

AI-assisted throughout, human-directed on every decision. Claude Code did the investigation (reading both models, quantifying the gap against prod, unpacking the packaged Tableau workbook to confirm no worksheet filters `enroll_status`), wrote the change, and validated it. The scope calls — Option B over the alternatives, keeping `not is_out_of_district`, deferring the administered-at gate, retroactive application, and keeping the PR minimal rather than backfilling docs — were all made by the requester. The `enroll_status in (0, 2, 3)` bound was raised by Claude after querying the value domain and accepted.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file present — `properties/rpt_tableau__ddi_dashboard.yml` exists and gains a model-level `description:` stating the new eligibility rule.
- [x] Exposure present — the `ddi_suite` exposure in `models/exposures/tableau.yml` already covers this model. No change needed.
- [x] Not a breaking change — no column renamed or removed, no type changed. `enroll_status` keeps its position and type; it simply stops being constant `0`.
- [x] No external source added or modified, so no `stage_external_sources` run is required.

## CI checks

- [ ] **Trunk** — passes. Locally, `trunk check --force` on both changed files returned no issues after the commit-time `fmt`.
- [ ] **dbt Cloud** — passes. This is a kipptaf-only change, so `state:modified+` genuinely selects and builds the model.
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the deploy workflow `pull_request` paths.

## Local verification

- `uv run dbt compile --select rpt_tableau__ddi_dashboard --target prod` succeeds; the compiled artifact contains zero occurrences of `enroll_status = 0` and one of the new bound, with `co.enroll_status` still projected in all three UNION branches.
- No `dbt build` was run. The model is a view, and a view build does not evaluate data, so validation is the prod-query comparison above.
