### PR TITLE
feat(dbt): add decoded homeless fields to OKRTS extracts

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_behavior.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_behavior.yml
@@ -59,6 +59,16 @@ models:
         data_type: string
       - name: self_contained_status
         data_type: string
+      - name: homeless_status
+        data_type: string
+        description:
+          Decoded homelessness status for the enrollment year. Null for Miami,
+          which does not populate the underlying PowerSchool field.
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+        description:
+          Decoded primary nighttime residence for the enrollment year. Collected
+          in New Jersey only, so null elsewhere.
       - name: behavior_month
         data_type: int64
       - name: school_enrollment_by_week

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
@@ -113,6 +113,16 @@ models:
         data_type: string
       - name: self_contained_status
         data_type: string
+      - name: homeless_status
+        data_type: string
+        description:
+          Decoded homelessness status for the enrollment year. Null for Miami,
+          which does not populate the underlying PowerSchool field.
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+        description:
+          Decoded primary nighttime residence for the enrollment year. Collected
+          in New Jersey only, so null elsewhere.
       - name: entry_staff
         data_type: string
       - name: last_update_staff

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_behavior.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_behavior.sql
@@ -139,6 +139,8 @@ select
     co.ml_status,
     co.status_504,
     co.self_contained_status,
+    co.homeless_status,
+    co.homeless_primary_nighttime_residence,
     co.quarter as term,
     co.week_start_monday,
     co.week_end_sunday,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -239,6 +239,8 @@ select
     co.ml_status,
     co.status_504,
     co.self_contained_status,
+    co.homeless_status,
+    co.homeless_primary_nighttime_residence,
     co.week_start_monday,
     co.week_end_sunday,
     co.week_number_academic_year,

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -43,7 +43,7 @@ with
     )
 
 select
-    ar.* except (lep_status, lunchstatus, spedlep, prevstudentid),
+    ar.* except (lep_status, lunchstatus, spedlep, prevstudentid, homeless_code),
 
     -- same value as _dbt_source_project, named for the Dagster code location;
     -- projected here rather than re-derived from _dbt_source_relation (#3142)
@@ -148,7 +148,7 @@ select
     both the live value and the history accurate (#4814). */
     if(
         ar.academic_year = {{ var("current_academic_year") }},
-        scf.homeless_code,
+        ar.homeless_code,
         njr.homeless_code
     ) as homeless_code,
 
@@ -245,10 +245,6 @@ left join
     {{ ref("stg_powerschool__s_nj_ren_x") }} as njr
     on ar.reenrollments_dcid = njr.reenrollmentsdcid
     and ar._dbt_source_project = njr._dbt_source_project
-left join
-    {{ ref("stg_powerschool__studentcorefields") }} as scf
-    on ar.students_dcid = scf.studentsdcid
-    and ar._dbt_source_project = scf._dbt_source_project
 left join
     {{ ref("stg_people__student_logins") }} as sl
     on ar.student_number = sl.student_number

--- a/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/powerschool/base/base_powerschool__student_enrollments.sql
@@ -140,6 +140,24 @@ select
 
     if(adb.latest_fafsa_date is null, 'No', 'Yes') as salesforce_contact_df_has_fafsa,
 
+    /* The NJ re-enrollment extension records homelessness per enrollment stint,
+    but is not written until well after year end -- it is empty for the current
+    year. The student-level tables are maintained live yet overwritten in place,
+    so they describe only current status. Reading the current year from the
+    student-level tables and closed years from the re-enrollment extension keeps
+    both the live value and the history accurate (#4814). */
+    if(
+        ar.academic_year = {{ var("current_academic_year") }},
+        scf.homeless_code,
+        njr.homeless_code
+    ) as homeless_code,
+
+    if(
+        ar.academic_year = {{ var("current_academic_year") }},
+        njs.homelessprimarynighttimeres,
+        njr.homelessprimarynighttimeres
+    ) as homeless_primary_nighttime_residence_code,
+
     coalesce(
         if(ar.region in ('Miami', 'Paterson'), ar.spedlep, sped.spedlep), 'No IEP'
     ) as spedlep,
@@ -227,6 +245,10 @@ left join
     {{ ref("stg_powerschool__s_nj_ren_x") }} as njr
     on ar.reenrollments_dcid = njr.reenrollmentsdcid
     and ar._dbt_source_project = njr._dbt_source_project
+left join
+    {{ ref("stg_powerschool__studentcorefields") }} as scf
+    on ar.students_dcid = scf.studentsdcid
+    and ar._dbt_source_project = scf._dbt_source_project
 left join
     {{ ref("stg_people__student_logins") }} as sl
     on ar.student_number = sl.student_number

--- a/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/powerschool/base/properties/base_powerschool__student_enrollments.yml
@@ -13,6 +13,36 @@ models:
       Current enrollment records come from `stg_powerschool__students` and previous
       enrollments come from `stg_powerschool__reenrollments`.
     columns:
+      - name: homeless_code
+        data_type: string
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - N
+                  - Y1
+                  - Y2
+        description:
+          Raw PowerSchool homelessness code for the enrollment year — N for not
+          homeless, Y1 for homeless while in the physical custody of a parent or
+          legal guardian, Y2 for homeless and unaccompanied. Read from
+          `stg_powerschool__studentcorefields` for the current academic year and
+          from `stg_powerschool__s_nj_ren_x` for closed years. Null for Miami,
+          which does not populate the field.
+      - name: homeless_primary_nighttime_residence_code
+        data_type: int64
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1, 2, 3, 4]
+                quote: false
+        description:
+          Raw NJ primary nighttime residence code for the enrollment year — 1
+          for shelters or transitional housing, 2 for doubled-up, 3 for
+          unsheltered, 4 for hotels or motels. Zero means no selection was made.
+          Read from `stg_powerschool__s_nj_stu_x` for the current academic year
+          and from `stg_powerschool__s_nj_ren_x` for closed years. Null outside
+          New Jersey.
       - name: student_number
         data_type: int64
         description: |-

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -115,7 +115,9 @@ select
         salesforce_contact_college_match_gpa_band,
         salesforce_contact_owner_name,
         state_studentnumber,
-        `state`
+        `state`,
+        homeless_code,
+        homeless_primary_nighttime_residence_code
     ),
 
     sc.contact_1_name,
@@ -378,6 +380,32 @@ select
     case
         e.ethnicity when 'T' then 'T' when 'H' then 'H' else e.ethnicity
     end as race_ethnicity,
+
+    /* Labels come from the PowerSchool dropdown definitions; the two Y labels are
+    shortened. Codes outside the mapped set decode to null rather than being
+    guessed at -- a small number of dirty values exist upstream, and the
+    accepted_values tests on the raw codes surface anything new (#4814). */
+    case
+        e.homeless_code
+        when 'N'
+        then 'Not Homeless'
+        when 'Y1'
+        then 'Homeless - With Guardian'
+        when 'Y2'
+        then 'Homeless - Unaccompanied'
+    end as homeless_status,
+
+    case
+        e.homeless_primary_nighttime_residence_code
+        when 1
+        then 'Shelters, transitional housing'
+        when 2
+        then 'Doubled-up'
+        when 3
+        then 'Unsheltered'
+        when 4
+        then 'Hotels or Motels'
+    end as homeless_primary_nighttime_residence,
 
     -- TODO: figure out a better way to track these
     case

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
@@ -829,6 +829,23 @@ models:
       - name: self_contained_status
         data_type: string
         description: Conditional on is_self_contained.
+      - name: homeless_status
+        data_type: string
+        description:
+          Decoded homelessness status for the enrollment year — Not Homeless,
+          Homeless - With Guardian, or Homeless - Unaccompanied. Conditional on
+          homeless_code. Null where the code is unset or unrecognized, and for
+          Miami, which does not populate the field. May disagree with
+          is_homeless on closed years, which reads current status for every
+          year.
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+        description:
+          Decoded primary nighttime residence for the enrollment year —
+          Shelters, transitional housing / Doubled-up / Unsheltered / Hotels or
+          Motels. Conditional on homeless_primary_nighttime_residence_code. Null
+          where no selection was made and outside New Jersey, which is the only
+          state that collects it.
       - name: state_studentnumber
         data_type: string
         description:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_weeks.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_weeks.yml
@@ -272,6 +272,21 @@ models:
         data_type: boolean
       - name: is_homeless
         data_type: boolean
+      - name: homeless_status
+        data_type: string
+        description:
+          Decoded homelessness status for the enrollment year — Not Homeless,
+          Homeless - With Guardian, or Homeless - Unaccompanied. Null where the
+          code is unset or unrecognized, and for Miami, which does not populate
+          the field. May disagree with is_homeless on closed years, which reads
+          current status for every year.
+      - name: homeless_primary_nighttime_residence
+        data_type: string
+        description:
+          Decoded primary nighttime residence for the enrollment year —
+          Shelters, transitional housing / Doubled-up / Unsheltered / Hotels or
+          Motels. Null where no selection was made and outside New Jersey, which
+          is the only state that collects it.
       - name: is_out_of_district
         data_type: boolean
       - name: is_self_contained

--- a/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
@@ -132,6 +132,7 @@ select
 
     scf.spedlep,
     scf.lep_status,
+    scf.homeless_code,
     scf.is_homeless,
     scf.prevstudentid,
 

--- a/src/dbt/powerschool/models/sis/base/properties/base_powerschool__student_enrollments.yml
+++ b/src/dbt/powerschool/models/sis/base/properties/base_powerschool__student_enrollments.yml
@@ -125,6 +125,13 @@ models:
         data_type: string
       - name: lep_status
         data_type: boolean
+      - name: homeless_code
+        data_type: string
+        description:
+          Raw PowerSchool homelessness code — N for not homeless, Y1 for
+          homeless while in the physical custody of a parent or legal guardian,
+          Y2 for homeless and unaccompanied. Student-level and overwritten in
+          place, so it reflects current status rather than the enrollment year.
       - name: is_homeless
         data_type: boolean
       - name: advisory_name


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add two decoded columns —
`homeless_status` and `homeless_primary_nighttime_residence` — to
`rpt_tableau__okrts_behavior` and `rpt_tableau__okrts_referrals`, surfacing
PowerSchool's `Homeless_Code` and `HomelessPrimaryNighttimeRes` on the OKRTS
dashboard as readable labels rather than raw codes.

Refs #4814
Refs #4813

### Decode

Labels come from the PowerSchool dropdown definitions. The two `Y` labels are
shortened; the residence labels are used as they appear.

| Column                                 | Values                                                                            |
| -------------------------------------- | --------------------------------------------------------------------------------- |
| `homeless_status`                      | Not Homeless / Homeless - With Guardian / Homeless - Unaccompanied                |
| `homeless_primary_nighttime_residence` | Shelters, transitional housing / Doubled-up / Unsheltered / Hotels or Motels      |

Residence code `0` maps to null — the dropdown's first entry is blank, so `0`
reads as no selection. Codes outside the mapped set decode to null rather than
being guessed at; the `accepted_values` tests on the raw codes surface anything
new instead of letting it silently disappear.

### Source resolution

Both fields are read per academic year:

- current academic year: `stg_powerschool__studentcorefields` and
  `stg_powerschool__s_nj_stu_x`
- prior academic years: `stg_powerschool__s_nj_ren_x`

The NJ re-enrollment extension records the value that was true for each
enrollment stint, but is not written until well after year end and is empty for
the current year. The student-level tables are maintained live yet overwritten
in place, so they describe only current status. Splitting by year gives an
accurate current year and accurate history.

Populated non-Miami enrollment rows, by source, showing why neither source
works alone:

| Academic year | `homeless_code` (ren_x) | `homeless_code` (SCF) | residence (ren_x) | residence (stu_x) |
| ------------- | ----------------------- | --------------------- | ----------------- | ----------------- |
| 2022          | 7,208                   | 5,196                 | 260               | 288               |
| 2023          | 7,611                   | 4,985                 | 310               | 377               |
| 2024          | 7,581                   | 4,027                 | 636               | 403               |
| 2025          | 8,157                   | 2,914                 | 726               | 365               |
| 2026          | 0                       | 361                   | 0                 | 269               |

### Implementation

1. `base_powerschool__student_enrollments` — adds a 1:1 join to
   `stg_powerschool__studentcorefields` (the `s_nj_stu_x` and `s_nj_ren_x`
   joins already existed) and emits the two year-resolved raw code columns.
   Resolving the source here keeps the decode downstream to a single flat
   `CASE`.
1. `int_extracts__student_enrollments` — decodes each raw code to its label.
   The raw codes are added to the `except` list so only labels flow downstream.
1. `int_extracts__student_enrollments_weeks` — carried through by the existing
   star projection; properties YAML entries only.
1. Both `rpt_tableau__okrts_*` models project the two labels and declare them
   in their contract YAML.

Not a breaking change: both models gain columns, and nothing is renamed or
removed.

### Known gaps, out of scope

- **Miami is blank.** `Homeless_Code` is null for all 3,943 Miami rows, and
  Miami has no `s_nj_stu_x` or `s_nj_ren_x` source, so both columns are null
  for every Miami row in every year. Miami's homeless flag lives in Focus as
  `homeless_student_pk_12`.
- **`is_homeless` disagrees with `homeless_status` on historical rows** — 903
  rows across AY2022 to AY2025. Re-deriving it would silently shift counts on
  the DIBELS dashboard, grad plan tracking, student contact info, and the
  subjects-weeks extract, so it deserves its own reconciliation. Tracked in
  #4813.
- **AY2026 is thinly populated** in both sources (361 and 269 rows
  network-wide, non-Miami). A data-entry gap for Ops.
- **The two PowerSchool fields disagree with each other at source** — 74 Newark
  students in AY2025 are marked not homeless yet carry a doubled-up residence
  code, with smaller counts across the other residence values. Both fields are
  reported faithfully; reconciling them is an Ops question.

### Local validation

`dbt build` against `dev` with `--defer --favor-state`, selecting every changed
model: `PASS=11 WARN=1 ERROR=0 SKIP=0`. The single warning is the pre-existing
`test_incorrect_student_number_pearson` (WARN 8), unrelated to these columns.

Verified in the built relations rather than from the build alone, since a view
build creates the relation without evaluating any rows: all seven labels render
as specified, Miami is null in both years, AY2025 shows 8,077 of 11,251
students populated (reading the re-enrollment extension) and AY2026 shows 346
(reading the live field).

Note for reviewers: three personal `zz_` district source copies had to be
re-cloned from prod before the build succeeded. They predated the powerschool
package dropping its contact columns, which made `base` 209 columns instead of
prod's 135 and collided with `int_extracts`. `source()` does not honor
`--favor-state`, so this is environment staleness, not a change in this PR.

## AI Assistance

Claude Code co-authored this PR. Human-directed: the decision to surface these
two fields, the choice of decoded labels over raw codes, the authoritative
PowerSchool dropdown definitions, the instruction to shorten the `Y` labels and
keep the residence labels as-is, and the current-year-versus-history source
split. AI-assisted: lineage tracing, the source coverage and divergence
profiling, model and YAML edits, local validation, and this description.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; every new column is documented in the existing properties files.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the
      `okrts_dashboard` exposure already depends on both models; no change
      needed.
- [x] **Breaking change?** No — additive columns only, nothing renamed or
      removed.
- [x] External sources — none added or modified.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.
