### PR TITLE
chore(github): give analytics-engineers ownership of src/launch/

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -126,7 +126,7 @@ principal itself.
 | `admins`              | admin     | Global fallback (`*`)                                                         |
 | `platform`            | maintain  | `.github/`, `.devcontainer/`, `.claude/`, `.trunk/`, Dockerfile, scripts, MCP |
 | `data-engineers`      | write     | `src/teamster/`, tests                                                        |
-| `analytics-engineers` | maintain  | All `src/dbt/`                                                                |
+| `analytics-engineers` | maintain  | `src/dbt/`, `src/cube/`, `src/launch/`                                        |
 | `analysts`            | write     | kipptaf folders without staging models (see CODEOWNERS)                       |
 | `data-team`           | write     | docs                                                                          |
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,9 +14,10 @@
 /src/teamster/ @TEAMSchools/admins @TEAMSchools/data-engineers
 /tests/ @TEAMSchools/admins @TEAMSchools/data-engineers
 
-# analytics engineers — all dbt projects
+# analytics engineers — dbt projects, semantic layer, launch catalog
 /src/dbt/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
 /src/cube/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
+/src/launch/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
 
 # analysts — kipptaf folders without staging models
 /src/dbt/kipptaf/models/assessments/ @TEAMSchools/admins @TEAMSchools/analytics-engineers @TEAMSchools/analysts


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...give `@TEAMSchools/analytics-engineers` ownership of `/src/launch/`, so
launch-page catalog PRs can be approved by the team that maintains the data the
catalog describes.

`/src/launch/` landed in #4763 with no CODEOWNERS entry, so it fell through to
the global `* @TEAMSchools/admins` fallback. Every catalog PR — including the
in-flight verification pass on #4767 — currently needs an admins approval to
merge, which is a bottleneck on work that is otherwise self-contained.

`analytics-engineers` is the right owner rather than `data-team`: they hold
`maintain` on the repo, and `/src/launch/` sits alongside `/src/dbt/` and
`/src/cube/`, which they already own. Added to that same block.

```text
# analytics engineers — dbt projects, semantic layer, launch catalog
/src/dbt/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
/src/cube/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
/src/launch/ @TEAMSchools/admins @TEAMSchools/analytics-engineers
```

Also corrects the team table in `.github/CLAUDE.md`, which described the
analytics-engineers scope as "All `src/dbt/`" and omitted `src/cube/`.

Refs #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Human-directed. Claude proposed `data-team`; the author corrected it to
`analytics-engineers`, which is also the better fit on repo role.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

N/A — no Dagster changes.

### dbt _(skip if no dbt changes)_

N/A — no dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — verified locally with `trunk check --force` on both changed
      files before pushing; no issues.
- [ ] **Dagster Cloud** — not triggered; no watched paths change.

## Reviewer notes

This needs a `@TEAMSchools/platform` approval, since `.github/` is theirs.

Ownership only — no change to branch protection or required-approval counts.
`admins` remains an owner on the new path, so nothing that could approve a
launch PR before can approve fewer of them now.
