### PR TITLE
docs: fold two rounds of pilot-session findings into assessment direction files

### DIFF
--- a/src/cube/mcp/project_knowledge/README.md
+++ b/src/cube/mcp/project_knowledge/README.md
@@ -58,11 +58,13 @@ Non-negotiables, every session:
 4. State your confidence (High / Medium / Low) and name every assumption you
    made on the participant's behalf. When you're uncertain, say so plainly —
    don't paper over it.
-5. Flag, don't invent. Where a needed default hasn't been ratified (minimum-n,
-   tier cut-scores, pooling, which subjects count as "math", prior-grade
-   handling), flag it and log it — never state a value as if it were settled.
+5. Flag, don't invent. Where a needed default hasn't been ratified (tier
+   cut-scores, pooling, which subjects count as "math", prior-grade handling,
+   what "progress" means), flag it and log it — never state a value as if it were
+   settled.
 6. PII gate. Hold any request for an identified student roster pending explicit
-   permission and a legitimate need; keep student names and IDs out of the log.
+   permission and a legitimate need; deliver it as a file rather than in chat,
+   and keep student names and IDs out of the log.
 
 At the end of each session, produce the handoff summary defined in the
 orchestrator.

--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -39,6 +39,13 @@ Before step 1, do two things:
   stale and compound: one session re-asserted a field was unpopulated — and
   built a manual workaround around it — when the field had been fine all along.
   If you cannot verify it, write "unverified" next to it.
+  - **An uploaded handoff or summary document is not project knowledge.** Only
+    this file and `assessment-cube-reference.md` are authoritative. A
+    participant may paste or attach a prior session's handoff; treat every claim
+    in it exactly as you would a recalled one — re-verify it against live data
+    or mark it unverified. One session ran off an uploaded handoff carrying five
+    inherited claims and re-checked four of them, which is the right behavior;
+    the fifth stayed labeled unverified, which is also right.
 
 1. **Calibration first (hard gate).** Before answering any participant query —
    regardless of how urgent or complex the opening request is — check network
@@ -49,6 +56,14 @@ Before step 1, do two things:
    known figure. An end-of-year ADA drop-off is an expected seasonal pattern,
    and a zero-row / empty result in summer (no active school week) is likewise
    expected — neither is a connectivity failure or a defect.
+   - **In summer, check the student count, not just the rate.** The latest
+     week-end record can be a small single-region summer-program cohort with an
+     anomalously high ADA — in early August 2026 it was Camden only, 531
+     students (against Camden's usual 2,146), at 99.25%, with no other region
+     present. A 99% "network ADA" is not a network figure. Three logged sessions
+     read that same record three different ways. Report the count alongside the
+     rate and say which regions are in it; a tiny high-ADA cohort still confirms
+     connectivity, which is all this step is for.
 2. **Force-refresh `meta` at session start.** The cached catalog can be stale; a
    stale catalog has already produced a confident-but-wrong "unanswerable" in a
    prior session. If a field or view you need appears to be missing, refresh
@@ -65,6 +80,17 @@ Before step 1, do two things:
    stated legitimate need. Never write student identifiers into the session log
    or the chat transcript; an authorized identified deliverable goes only into
    its own output file, never into the persistent log.
+   - **Authorized means a file, not a message.** Deliver the roster as a
+     downloadable file and nothing more — do not print names into the chat, even
+     once authorization is confirmed. A file can be moved, restricted, and
+     deleted; a transcript cannot, and these transcripts live inside a Project
+     other people can open. One logged session delivered 16 named students in
+     chat after a valid authorization; the authorization was fine, the delivery
+     surface was not.
+   - **Authorization covers the request you asked about, not the rest of the
+     session.** Reformatting or narrowing that same roster is a continuation and
+     needs no fresh gate. A new population, a new subject, or a new grade band
+     is a new request — ask again.
 6. **Flag, don't invent** when a query needs an undecided default. This is the
    same rule as the next section, applied per query — if a provisional choice is
    unavoidable to keep going, label it provisional and log it as an open
@@ -87,8 +113,12 @@ The following are currently open. Do not state a value, threshold, or rule for
 any of them — flag and log only, and route the decision to instructional
 leadership:
 
-- the minimum-n suppression threshold for small-group results
-- intervention tier cut-scores
+- intervention tier cut-scores, and — separately — the method for _deriving_ one
+  from data. A session swept thresholds and picked the best separator per grade
+  to propose intervention cut scores; that method is unratified, and so is the
+  question of how well a cut must separate before it is fit to flag a student at
+  all. Both route to instructional leadership, and neither should reach a
+  student-facing decision without statistical review.
 - whether a multi-instrument mastery question should pool instruments or report
   per instrument
 - which subjects count as `math` for network reporting
@@ -97,7 +127,10 @@ leadership:
   quadrant-style school reporting — a median split of the charted population is
   a convenience, not a ratified threshold
 - how to attribute a mid-year transfer student in growth reporting: to the
-  school they started the year at, or the one they ended it at
+  school they started the year at, or the one they ended it at — and the same
+  question at **teacher** level, when a student changes sections mid-year. A
+  session defaulted to the EOY teacher; that is a convention, not policy, and it
+  decides whose celebration roster a student appears on.
 - which Illuminate subjects count as "ELA" — `Text Study`, `Writing`,
   `English 100`–`400`, `CCR 1`–`4` and the AP courses are all candidates, the
   same shape of question as "which count as math"
@@ -117,8 +150,15 @@ leadership:
 - what "growth" means for a vendor diagnostic: movement between placement bands
   or a scale-score delta. The two give different answers and neither is ratified
 - which sitting is authoritative when a student tests more than once inside a
-  single benchmark window (common — about 15% in one measured window).
+  single benchmark window (usually under 2%, but one measured window hit 15%).
   Most-recent-by-date is the working convention, not policy
+- whether a cumulative flagging rule should trigger on a single dip below a line
+  or require repeated dips. A session modeled single-dip flagging and found it
+  raises catch rate and false-flag rate together; the stricter alternative was
+  never tested
+- whether proficiency-band boundaries should be shared across grades or set per
+  grade. Analysis pointed at different optimal boundaries for different grades;
+  whether that is desirable is a policy call, not a data one
 
 Some individual fields also carry their own narrower open question (for example,
 which count measure is the default for a count/share question) — those are
@@ -205,6 +245,10 @@ WG_LOG_<YYYY-MM-DD>_<HHMM>_<participant>.md
   whichever of last or first name you have (`walters`, `anthony`). Two
   participants: hyphenate (`walters-ramirez`); more than two: use the team name.
   No name given: use initials, then `unknown` as a last resort.
+  - **Reuse the token this person's earlier logs already use.** Search the
+    folder for their prior filings first. One participant filed as a last name
+    once and a first name the next time, so their two sessions no longer group
+    or sort together. Consistency beats picking the "better" name.
 - Example: `WG_LOG_2026-07-24_1430_walters.md`
 - **The filename is the log's identity — there is no session number to
   reconcile.** Several logs per day, including several from the same person, are
@@ -243,6 +287,14 @@ compare before writing anything:
   session, and that this one is authoritative. A reader who lands on either copy
   must be able to tell from the file alone. Never create a second file under the
   identical name.
+
+**A chat resumed on a later date is a new session, not a new revision.** Open a
+fresh log dated the day the new work happened, and reference the earlier log
+rather than extending it. Revisions are for correcting or completing one
+sitting. Without this rule a long-running chat produces an unbounded chain: one
+pilot session was filed seven times over eight days, leaving ~185KB across seven
+permanent files whose header still claimed a session start from the first day.
+Nothing can be deleted, so the only defense is not creating the chain.
 
 Write once per session, at the end — not per query. The connector can only
 create, never update or delete, so every extra write is permanent clutter that

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -55,14 +55,33 @@ Apply to every assessment source unless a source section overrides them.
   collapses identical rows and hides true row counts; add a measure (e.g.
   `count_scores`) or the primary key (`assessment_score_key`) to see the real
   row count.
-- **Performance bands are Illuminate-only.** `performance_band_label_number`
-  (integer 1–5) is populated only for Illuminate; it is null for state and for
-  i-Ready/DIBELS/STAR. Where it applies, band 1 = the "Far Below" tier and band
-  2 = "Below" (`FB` = band 1, `B` = band 2, `B/FB` = bands 1–2). **Use the
-  integer `performance_band_label_number`, never the `proficiency_level` label
-  text** — the label strings are wildly inconsistent (dozens of variants per
-  band number). Other sources use their own `proficiency_level` scales (see each
-  section).
+- **Performance bands are Illuminate-only, and a band number only means
+  something inside its own band set.** `performance_band_label_number` is
+  populated only for Illuminate; null for state and for i-Ready/DIBELS/STAR.
+  **It is not a 1–5 scale and not comparable across assessments.** Each
+  Illuminate assessment points at a configured performance band set, and the
+  sets disagree on cut points, on band count, and on where mastery starts. The
+  sets carrying the most 2025-26 `overall` scores:
+
+  | Band set                    | Cut points (percent correct) | Mastery starts | Scores  |
+  | --------------------------- | ---------------------------- | -------------- | ------- |
+  | KIPP T and F 2021-22 MS PB  | 0 / 25 / 45 / 65 / 85        | band 4         | 497,445 |
+  | HS Summative (non-AP)       | 0 / 40 / 60 / 75 / 88        | **band 3**     | 273,585 |
+  | KIPP T and F 2021-22 ES PB  | 0 / 30 / 50 / 70 / 85        | band 4         | 249,755 |
+  | KIPP T and F 2026-27 K-2 PB | 0 / 30 / 60 / 80 / 90        | band 4         | 216,665 |
+  | District Default            | 0 / 60 / 70 / 80 / 90        | band 4         | 64,735  |
+  | FAST Performance Bands 3-4  | 8 bands                      | band 6         | 113,304 |
+  | SY25-26 Practice SAT Math   | 45 bands                     | band 19        | 11,295  |
+
+  Three consequences. **The mastery bar ranges from 60% to 80% correct depending
+  on the band set**, so `is_mastery` and `pct_proficient` on Illuminate are not
+  one fixed standard — say which assessments a rate covers. **Band counts are 5,
+  8, and 45**, so never assume band 5 is the top. **Never pool band numbers
+  across assessments** unless you have confirmed they share a band set; a "band
+  3" cohort assembled across ES, MS, and K-2 sets mixes three different percent
+  ranges. Still prefer the integer over the `proficiency_level` label text
+  within a set — the label strings carry dozens of variants per band number.
+
 - **Two different subject fields, and `academic_subject` values are
   source-dependent.** `academic_subject` is the subject _tested_; `discipline`
   is the _course_ subject from the course crosswalk (e.g. `Math`, `ELA`). They
@@ -73,14 +92,26 @@ Apply to every assessment source unless a source section overrides them.
     `Composition 200`, and AP Language / AP Literature. Math-side it uses
     `Mathematics` plus `Algebra I`, `Algebra I MS`, `Algebra II`, `Geometry`,
     `Pre-Calculus`, `Math 4`.
+  - **At K-2, `Text Study` is the _only_ ELA-equivalent subject present** — no
+    `Writing`, `CCR`, `English 100`–`400`, or AP at those grades. So the "which
+    subjects count as ELA" question has an empirical answer for the K-2 band
+    even though it stays open for the upper grades.
   - State and vendor sources use the plainer labels (`English Language Arts`,
     `Mathematics`). Check the values for the source you are querying before
     filtering — a wrong label returns zero rows silently, not an error.
-- **Three different grade fields.** `grade_band` is a school-level attribute
-  (the band a location serves — `ES` / `MS` / `HS`), not a per-student grade;
-  filtering `grade_band = 'MS'` is a school proxy, not a student-grade filter.
-  For a student's actual grade use `grade_level`; for the grade an assessment
-  targets use `grade_level_tested`.
+- **Three different grade fields, and `grade_level_tested` is null for every
+  vendor diagnostic.** `grade_band` is a school-level attribute (the band a
+  location serves — `ES` / `MS` / `HS`), not a per-student grade; filtering
+  `grade_band = 'MS'` is a school proxy, not a student-grade filter. For a
+  student's actual grade use `grade_level`; for the grade an assessment targets
+  use `grade_level_tested`.
+  - **`grade_level_tested` is populated for Illuminate (99.8%) and every state
+    source, and is null on all 302,907 i-Ready, DIBELS, and STAR rows.** Filter
+    a vendor diagnostic by it and you get zero rows with no error. This has cost
+    two logged sessions a false "no data." For vendor sources, always use
+    `grade_level`.
+  - The two also answer different questions where both exist, so a result can
+    change materially depending which you pick — say which one you used.
 - **Section/teacher rollups: filter `enrollment_resolution = subject_section`**
   (`homeroom` rows also exist in the same field). Lead-teacher attribution is
   available via `staff_lead_teacher_full_name` / `lead_teacher_staff_key`,
@@ -125,22 +156,62 @@ Apply to every assessment source unless a source section overrides them.
   other region (Newark and Camden run Illuminate from 2014-15). A narrow
   Paterson result is expected coverage, not a load failure; say which regions a
   "network-wide" answer actually covers.
+- **`is_foundations` marks intervention courses, and it reaches this view.**
+  Sourced from `dim_courses` through the course join, `TRUE` when the section is
+  a Foundations (intervention) course. It is the only intervention signal on the
+  view — there is no program- or MTSS-tracking dimension — so it is the closest
+  available proxy for "was this student receiving intervention." Treat it as
+  course enrollment, not as a record of services delivered.
+- **Resolve staff names against `staff_directory` before filtering.**
+  `staff_lead_teacher_full_name` stores `Last, First`, and a participant's
+  spelling will not always match (one logged session searched "Schaffer" against
+  a record filed as "Shaffer"). Look the name up first rather than assuming a
+  zero-row result means the teacher has no students.
 - **Open decisions — flag, never assume a value** (per the orchestrator):
-  minimum-sample suppression threshold; intervention tier cut-scores;
-  pool-vs-per-instrument for multi-module "overall mastery"; which subjects
-  count as "math" _and_ which count as "ELA" (see the Illuminate subject list
-  above); whether grade-band reporting keys on `grade_level` or
-  `grade_level_tested`; and the default grain (record vs distinct-student) for
-  count/share questions. None has a documented network default — surface the
-  assumption and log it.
+  intervention tier cut-scores; pool-vs-per-instrument for multi-module "overall
+  mastery"; which subjects count as "math" _and_ which count as "ELA" (see the
+  Illuminate subject list above); whether grade-band reporting keys on
+  `grade_level` or `grade_level_tested`; the default grain (record vs
+  distinct-student) for count/share questions; what "progress" or "did not make
+  progress" means for a growth question (tier movement, scale-score delta, or a
+  mastery flip); and whether "top performing" means level or movement. None has
+  a documented network default — surface the assumption and log it.
 
 ## Internal — Illuminate (KIPP interims)
 
 - `assessment_type = 'illuminate'`; `is_internal_assessment = true`. The only
   source with standards breakdowns.
-- **Module types:** `module_type` / `module_code` cover QA (Quick Assessments),
-  MQQ (Multiple-Choice Quick Questions), and CRQ (Constructed Response
-  Questions); `module_code` looks like `QA1`, `QA3`.
+- **Module types: there are seven, not three.** 2025-26 volumes, `overall`
+  scores:
+
+  | `module_type`                           | Codes               | Scores  |
+  | --------------------------------------- | ------------------- | ------- |
+  | `QA` (Quick Assessments)                | `QA1`–`QA4`, `QA11` | 835,794 |
+  | `TP`                                    | `TP1`–`TP8`         | 490,421 |
+  | `MQQ` (Multiple-Choice Quick Questions) | `MQQ1`–`MQQ4`       | 472,235 |
+  | `CRQ` (Constructed Response Questions)  | `CRQ1`–`CRQ9`       | 353,781 |
+  | `UA`                                    | `UA1`–`UA6`         | 140,945 |
+  | `ET`                                    | `ET1`–`ET7`         | 132,684 |
+  | `WPP`                                   | `WPP1`–`WPP4`       | 37,687  |
+
+  `TP` is the second-largest module type in the network. `TP` / `UA` / `ET` /
+  `WPP` together carry 801,737 scores — roughly a third of all module-coded
+  Illuminate work — and none of them were documented before. What `TP`, `UA`,
+  `ET`, and `WPP` stand for is an open question for the model owner; do not
+  invent an expansion.
+
+- **Which module codes exist varies by subject, grade, AND region** — never
+  assume a standard checkpoint set. In Newark 2025-26, Math grades 3-4 have no
+  `QA4`, and Text Study grades 3-4 have neither `QA3` nor `QA4`, leaving only
+  `QA1` / `MQQ2` / `MQQ3` from the familiar set while `ET` / `TP` / `UA` / `WPP`
+  make up the majority of available content there. Check what exists for your
+  exact subject, grade, and region before building a pooled average — otherwise
+  one cell rests on three checkpoints while another rests on five, and the two
+  are not comparable.
+- **Module codes are not in chronological order by name.** Verify sequence by
+  median `date_taken` per `module_code` rather than reading order off the
+  numbering; a logged session confirmed an Oct-to-May ordering that the names do
+  not imply.
 - **`module_code` is not a subject filter — always pair it with
   `academic_subject`.** One module code spans every subject assessed in that
   round. `QA3` in 2025-26 covers 21 distinct `academic_subject` values across
@@ -148,13 +219,40 @@ Apply to every assessment source unless a source section overrides them.
   Filtering `module_code = 'QA3'` alone and calling the result "QA3 math" mixes
   Text Study, Science, Social Studies, the `English 100`–`400` and AP courses,
   and the HS math courses into one number.
-- **Measures:** `pct_proficient_formative` pools all three formative module
-  types (QA + MQQ + CRQ); `pct_proficient_crq` isolates CRQ. (Whether to pool
-  across module types or report per-instrument is an open decision — flag it.)
+- **Measures — `pct_proficient_formative` does not cover all formative work.**
+  It filters `module_type IN ('QA', 'MQQ', 'CRQ')`, so it silently excludes
+  `TP`, `UA`, `ET`, and `WPP` — about a third of module-coded Illuminate scores.
+  If a participant means "all our internal checkpoints," this measure is not it;
+  build the rollup explicitly from the module types you intend.
+  `pct_proficient_crq` isolates CRQ. (Whether to pool across module types or
+  report per-instrument is an open decision — flag it.)
 - **`response_type`:** `overall` / `standard` / `group`. Use `overall` unless a
   standard/group breakdown is requested.
-- **Bands:** `performance_band_label_number` applies (band 1 = Far Below … 5 =
-  Above); use the integer, not the label.
+- **Bands:** `performance_band_label_number` applies, but read the Shared
+  conventions entry first — the number is only meaningful inside the
+  assessment's own band set, and the sets differ on cut points, band count, and
+  where mastery starts.
+- **Normalize standard codes before any standards-level rollup.**
+  `response_type_code` and `response_type_description` both carry formatting
+  variants for the same standard (`8.EE.C.8.b` vs `8.EE.C.8b`; `y = mx + b` vs
+  `y = m x + b`), which splits one standard across two rows and halves each
+  one's counts. 2,620 raw codes collapse to 2,565 canonical ones — **55
+  standards are fragmented today.** The rule: strip all non-alphanumeric
+  characters from `response_type_code`, group on the result, and recompute
+  `pct_proficient` as a **count-weighted average of the underlying counts —
+  never an average of the two reported percentages.** A logged session
+  corroborated this across four grade levels using the code and the description
+  as two independent keys; merging one pair moved a standard from a confusing
+  split to a clean SY25 16.7% (n=1,356) versus SY26 20.4% (n=1,379).
+- **"How many times was this standard assessed" is a distinct count of
+  `source_assessment_id`,** not `count_scores`. `count_scores` counts scored
+  student responses; the distinct administration count is typically 1–5 per
+  standard per year. A standard resting on one administration is a thin
+  evidentiary base — say so rather than trending it.
+- **A CCSS code's own grade can differ from `grade_level_tested`.** A grade-6
+  code appearing in a grade-8 mix is spiral or prerequisite review content, not
+  a data error. Flag it for curriculum confirmation instead of excluding it
+  silently.
 - `response_type_root_description` (the CCSS domain rollup) is reliable here.
 - **Sanity-check watch-out:** Illuminate "overall" mastery cut-scores can read
   much lower than state proficiency for the same students — the two scales are
@@ -166,6 +264,8 @@ Apply to every assessment source unless a source section overrides them.
 
 - `assessment_type = 'iready'`; `is_internal_assessment = false`. Subjects
   (`category`): Math and ELA.
+- **Grade field: use `grade_level`. `grade_level_tested` is null on every
+  i-Ready row** — filtering by it returns zero rows silently.
 - `response_type = null` (overall only — no standards breakdown).
 - **Proficiency:** `proficiency_level` is i-Ready's grade-level placement scale
   — `3 or More Grade Levels Below`, `2 Grade Levels Below`,
@@ -217,13 +317,15 @@ Apply to every assessment source unless a source section overrides them.
 - **`is_replacement` is Illuminate-only by design** — null for i-Ready (and all
   vendor/state sources), not a gap. Genuine multiple sittings occur even within
   a single benchmark window, so dedup to the most recent `date_taken` per
-  student per window before computing anything student-level. This is common,
-  not exceptional: in one measured window (Camden grade 6 ELA, MOY 2025-26) 30
-  of 195 students — 15.4% — had more than one sitting. It is genuine repeat
-  testing, not a section-join fan-out. Skipping the dedup inflates any
-  student-level count or growth figure. (Which sitting is _authoritative_ for
-  reporting is an open decision; most-recent-by-date is the working convention,
-  not ratified policy.)
+  student per window before computing anything student-level. **The rate varies
+  enormously by slice**, so treat the dedup as standing practice rather than
+  something to skip when it looks unnecessary: Camden grade 6 ELA runs 1.55% at
+  BOY, **15.38% at MOY**, and 3.06% at EOY, while Newark grades 3-4 Math runs
+  0.08% / 0.57% / 0.75% across the same rounds. Most windows sit under 2%; one
+  measured window hit one student in six. It is genuine repeat testing, not a
+  section-join fan-out. Skipping the dedup inflates any student-level count or
+  growth figure. (Which sitting is _authoritative_ for reporting is an open
+  decision; most-recent-by-date is the working convention, not ratified policy.)
 - **Query this view, not the upstream i-Ready model.** i-Ready arrives with
   fiscal-year re-pull duplicates — the same physical test landing under two
   partitions. The mart collapses them, so counts here are right; a query
@@ -237,6 +339,14 @@ Apply to every assessment source unless a source section overrides them.
 
 - `assessment_type = 'dibels'`; `is_internal_assessment = false`. Subject
   (`category`): ELA.
+- **Grade field: use `grade_level`. `grade_level_tested` is null on every DIBELS
+  row.**
+- **Tier-movement rates are not comparable to i-Ready's.** DIBELS has four
+  benchmark tiers; i-Ready has five placement levels. Fewer, wider bins
+  mechanically produce a higher "stayed the same" rate, so a DIBELS no-movement
+  share will look worse than i-Ready's for the same students — one logged
+  session saw 22% versus 10% in the same grade. Compare each instrument to
+  itself over time, never to the other.
 - `response_type = null` (overall only).
 - **Proficiency:** `proficiency_level` is the DIBELS benchmark tier —
   `Well Below Benchmark`, `Below Benchmark`, `At Benchmark`, `Above Benchmark`.
@@ -257,6 +367,8 @@ Apply to every assessment source unless a source section overrides them.
 
 - `assessment_type = 'star'`; `is_internal_assessment = false`. Subjects
   (`category`): ELA and Math.
+- **Grade field: use `grade_level`. `grade_level_tested` is null on every STAR
+  row.**
 - `response_type = null` (overall only).
 - **Proficiency:** `proficiency_level` is `Level 1`–`Level 5` (a share of rows
   have null `proficiency_level` / `is_mastery`). `performance_band_label_number`


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...fold two rounds of pilot-session findings into the assessment direction files,
and remove all minimum-sample suppression language.

Sources: the six logs filed 2026-08-03 through 2026-08-10 by three working-group
participants. The pilot has changed character — one participant's session ran to
23 queries across a week and is now the analytical engine behind a live K-2
proficiency-band redesign, with two delivered documents. Several findings below
matter more than they would have a week ago.

### The load-bearing correction

**A performance band number only means something inside its own band set.** The
reference previously described `performance_band_label_number` as "integer 1-5"
with "band 1 = Far Below, band 2 = Below." All three claims were wrong. Each
Illuminate assessment points at a configured band set, and for 2025-26 `overall`
scores alone the sets disagree on cut points, band count, and where mastery
starts:

```text
KIPP T and F 2021-22 MS PB     0/25/45/65/85    mastery at band 4   497,445
HS Summative (non-AP)          0/40/60/75/88    mastery at band 3   273,585
KIPP T and F 2021-22 ES PB     0/30/50/70/85    mastery at band 4   249,755
KIPP T and F 2026-27 K-2 PB    0/30/60/80/90    mastery at band 4   216,665
District Default               0/60/70/80/90    mastery at band 4    64,735
FAST Performance Bands 3-4     8 bands          mastery at band 6   113,304
SY25-26 Practice SAT Math      45 bands         mastery at band 19   11,295
```

The mastery bar therefore ranges from 60% to 80% correct depending on the band
set, band counts are 5 / 8 / 45, and pooling band numbers across assessments
mixes different percent ranges. One in-flight session is pooling a "band 3"
cohort across grades — worth flagging to that participant directly.

### Other reference changes

- **All seven Illuminate module types**, with volumes. `TP` is the second-largest
  in the network; `TP` / `UA` / `ET` / `WPP` were undocumented and carry 801,737
  scores, about a third of module-coded Illuminate work.
- **`pct_proficient_formative` excludes four of the seven** — it filters
  QA/MQQ/CRQ only, so it is not "all our internal checkpoints."
- **Module availability varies by subject, grade, and region.** Newark Text Study
  grades 3-4 has neither `QA3` nor `QA4`, leaving three checkpoints where other
  cells have five.
- **`grade_level_tested` is null on all 302,907 i-Ready, DIBELS, and STAR rows** —
  populated for Illuminate and every state source. Has caused two false
  "no data" results. Noted in Shared conventions and in each vendor section.
- **Standards-code normalization rule**: 55 of 2,620 codes are fragmented by
  formatting variants; strip non-alphanumerics, group, recompute as a
  count-weighted average of counts, never an average of percentages.
- **Corrected the multiple-sitting rate.** Previously stated as "common — 15.4%"
  off one window. Verified range: Camden grade 6 ELA runs 1.55 / 15.38 / 3.06
  percent across BOY/MOY/EOY, Newark grades 3-4 Math runs 0.08 / 0.57 / 0.75.
  Most windows are under 2%.
- `is_foundations` documented (the only intervention signal on the view),
  `staff_directory` name resolution, DIBELS-vs-i-Ready tier comparability,
  `source_assessment_id` distinct-count for administration frequency, module
  order by `date_taken` rather than by name, and `Text Study` as the sole K-2 ELA
  subject.

### Orchestrator changes

- **Identified rosters go to a file, not chat.** One session delivered 16 named
  students in chat after a valid authorization — the authorization was fine, the
  surface was not. Transcripts persist inside a shared Project.
- **A chat resumed on a later date opens a new log, not another revision.** One
  session was filed seven times over eight days, leaving ~185KB across seven
  permanent files whose header still claimed the first day's start time. The
  connector cannot delete, so the only defense is not creating the chain.
- **Summer calibration checks the student count, not just the rate.** The early
  August record was Camden only, 531 students against a usual 2,146, at 99.25%.
  Three sessions read it three different ways.
- Filename tokens carry over between a participant's sessions; uploaded handoff
  documents are treated as unverified; five new open decisions.

### Removed

All minimum-sample suppression language, per stakeholder direction: it is not how
this audience reads data, and no such convention is enforced on the dashboards
they already use. Removed from all three files.

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude-authored, human-directed. Every figure was verified against the warehouse
rather than transcribed from a log.

One verification worth noting: I initially believed a participant's "QA3 does not
exist for Text Study grades 3-4" claim was wrong, because a network-wide query
using `grade_level_tested` returned it. Re-scoped to her actual parameters
(Newark, enrolled grade), the claim held exactly. The near-miss is itself an
argument for the grade-field documentation in this PR.

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
      — n/a, no Asana task
- [x] Review the **Claude Code Review** comment posted on this PR
      — `claude-code-review` excludes markdown, so it will not fire here

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

Skipped — no dbt changes. Documentation only.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — `trunk check --force` clean on all three files
- [x] **dbt Cloud** — n/a, no dbt changes
- [x] **Dagster Cloud** — n/a, no Dagster paths changed

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
