### PR TITLE
docs(launch): design spec for the catalog build and CI gate

### DIFF
--- a/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
@@ -1,0 +1,313 @@
+# Launch page: build, validation, and CI gate
+
+Design for productionizing the launch page generator and building the CI gate
+that must exist before it can publish. Companion to
+[the launch page design](2026-08-06-launch-page-design.md), which settles what
+the page is; this settles how it gets built and what stops it shipping broken.
+
+## Context
+
+`src/launch/links.yml` holds 46 tool entries scraped from the Google Site and
+merged in #4763. Verification is in progress on #4767. Only `status: verified`
+entries publish, and **zero of 46 are verified on `main` today**.
+
+That makes now the safest moment to stand up the pipeline: it cannot publish
+anything wrong, because it has nothing to publish. When #4767 merges, nine
+entries flip to verified at once, and that merge becomes the first live publish.
+The MkDocs deploy workflow also fires on `docs/**`, so a catalog that fails
+validation on `main` freezes **all** documentation publishing. The gate has to
+exist before that merge, not after.
+
+## What this delivers
+
+- `src/launch/build.py` — a four-function module, unit-testable without git,
+  temp files, or subprocesses
+- Two-tier validation, so in-progress entries never block a commit but nothing
+  reaches staff malformed
+- A minimum-verified threshold below which no page is generated at all
+- Generation through an MkDocs `on_files` hook
+- `tests/launch/` and a pytest PR workflow scoped to it
+- A downloadable preview of the rendered page on every catalog PR
+
+## Architecture
+
+```text
+  src/launch/links.yml      catalog, 46 entries, each with status:
+  src/launch/groups.yml     group defs, families, promos, publish threshold
+  src/launch/template.html  page shell, __CATALOG__ placeholder
+            |
+            v
+  src/launch/build.py
+      load()      read the three files from the working tree
+      select()    keep only status: verified
+      validate()  tier 1 over all entries, tier 2 over selected
+      render()    inject JSON, RETURN an HTML string
+            |
+            +--> errors        -> raise CatalogError, listing every problem
+            +--> below minimum -> return None, log the count
+            |
+            v
+  docs/hooks.py :: on_files
+      File.generated(config, "launch/index.html", content=html)
+            |
+            v
+  site/launch/index.html -> gh-pages -> /teamster/launch/
+```
+
+One entry point, three callers: `mkdocs serve` locally, `mkdocs build` in the PR
+gate, `mkdocs gh-deploy` on merge. There is no second code path to drift.
+
+### Why `on_files` and not `on_pre_build`
+
+The obvious design — write `docs/launch/index.html` during `on_pre_build` and
+let MkDocs collect it — **causes an infinite rebuild loop under
+`mkdocs serve`**. Measured on a minimal project: one edit to a source file
+produced 61 builds in 30 seconds, roughly two per second, indefinitely.
+
+`serve.py` watches `docs_dir` recursively, and livereload clears its
+`_want_rebuild` flag _before_ running the build, so the hook's own write is
+re-detected as a user change mid-build. Identical content does not help; writing
+the file bumps its mtime.
+
+`File.generated(config, src_uri, content=...)` — present in mkdocs 1.6.1, which
+is what resolves here — registers a virtual file that never touches `docs_dir`.
+Verified against a minimal project: the page lands at `site/launch/index.html`,
+`docs_dir` stays clean, the file is absent from `sitemap.xml`, and a single edit
+produces two builds rather than 61.
+
+This also removes the need for a `.gitignore` entry and eliminates a class of
+bug where a stale generated file lingers in a local checkout.
+
+### `render()` returns a string
+
+Nothing in `build.py` writes to the filesystem. The hook decides where output
+goes. This is what makes every test run on in-memory data, and it is a
+structural guarantee that the serve loop cannot return.
+
+## Validation rules
+
+Selection runs **before** validation, so tier 2 knows which entries it is
+judging. Getting this backwards would force every rule into tier 1.
+
+### Tier 1 — every entry, regardless of status
+
+| Rule                                                             | Why                                                            |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| `links.yml` parses as a list of mappings                         | Everything else depends on it                                  |
+| `id` present, unique, matching `^[a-z0-9_]+$`                    | Duplicates surface at the worst possible moment                |
+| `name` present and non-empty                                     | Nothing can reference an unnamed entry                         |
+| `url` present, scheme is `https`                                 | A staff-facing link must not be plaintext                      |
+| `system` in the nine-value enum documented in `README.md`        | The prototype hard-codes four; the other five degrade silently |
+| `status` in `{needs-review, verified}`                           | A typo would silently unpublish an entry                       |
+| `access`, if present, is exactly `limited`                       | Prototype treats any truthy value as limited                   |
+| `regions` values all in `{newark, camden, miami, paterson, all}` | Unknown regions render blank                                   |
+| Every family member in `groups.yml` names a real entry           | A rename silently drops a tool                                 |
+| Every family names a real group id                               | An unknown group throws before anything renders                |
+
+### Tier 2 — `status: verified` entries only
+
+| Rule                                                  | Why                                                 |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| `description` present and non-empty                   | An unlabelled tile is useless                       |
+| `audiences` non-empty, all values known               | Four entries have none today                        |
+| A family member carries exactly one region, not `all` | Three GPA Rosters render blank buttons without this |
+| `guide`, if present, is `https`                       | Same reason as `url`                                |
+
+A half-finished `needs-review` entry never fails CI. Flipping one to `verified`
+while it is still missing a description does, and the error names the entry and
+the field.
+
+### Deferred
+
+`group` present on every entry and resolving to a known group id. The
+[launch page design](2026-08-06-launch-page-design.md) records `group` as a
+required per-entry field, and that is the right shape — a side table in
+`groups.yml` has to stay exhaustive, which is precisely the coupling that lets
+two individually-green PRs break `main` together.
+
+Adding it means touching all 46 entries while 37 are in flight on #4767.
+Sequenced into a follow-up PR after that merges. Nothing is lost by waiting:
+with zero verified entries there is no grouped rendering to do yet.
+
+## Publication threshold
+
+Below a configured number of verified entries the hook generates **no page at
+all**, logs the count, and lets the docs build succeed. `/teamster/launch/`
+returns 404 until the catalog is genuinely ready.
+
+This exists because the zero-verified page is not merely empty — it is broken.
+With no tools the template falls through to its search-miss branch and renders
+"No tool matches that", above a masthead reading `0 tools` and a footer
+disclaiming `0 of 0 entries are still being verified`. Four of the five promo
+cards in `groups.yml` point at `#`. The first live version would be five cards,
+four of them dead, under an error message.
+
+Gating on a count is cheaper than designing an empty state that should never be
+seen, and it makes a broken intermediate page impossible rather than merely
+unlikely.
+
+The threshold lives in `groups.yml`, not in code. Seeded at **25** — over half
+the catalog. Changing it is a one-line edit and the number belongs to the
+catalog owner, not this design.
+
+`groups.yml` content has no `status` field and therefore no publish gate of its
+own. Promo cards with an empty or `#` URL are rejected by tier 1 rather than
+rendered.
+
+## CI surfaces
+
+### The PR gate
+
+A new `.github/workflows/pytest.yaml`, triggered on pull requests touching:
+
+```yaml
+paths:
+  - src/launch/**
+  - tests/launch/**
+  - docs/hooks.py
+  - mkdocs.yml
+  - .github/workflows/pytest.yaml
+```
+
+`docs/hooks.py` and `mkdocs.yml` are in that list because once generation lives
+in the hook, either can break the page without `src/launch/` changing at all.
+
+Two steps: `uv run pytest tests/launch`, then `uv run --group docs mkdocs build`
+followed by an upload of `site/launch/index.html` as a workflow artifact. A
+reviewer downloads it and opens the real page before approving. The template
+inlines all CSS and JS, so a single file opens standalone.
+
+**No `--strict`.** `mkdocs build --strict` fails on `main` today with exactly 80
+warnings, every one an unresolvable relative link inside `docs/superpowers/**`
+pointing out of `docs/` into `src/`. The live deploy passes only because
+`mkdocs-gh-deploy.yaml` does not pass `--strict`. Fixing those 80 warnings is
+unrelated work, and `--strict` buys nothing here: `build.py` raises
+`CatalogError` on a validation failure, which fails the build strict or not.
+
+### The deploy workflow
+
+`src/launch/**` joins the `paths` filter in `mkdocs-gh-deploy.yaml`. Today that
+workflow watches `docs/**` and `mkdocs.yml` only, so **merging a catalog change
+currently triggers no deploy at all** — the launch page design's claim that
+"merging a catalog change publishes it" is false until this lands.
+
+Appending after the existing `"!docs/superpowers/**"` negation is safe: GitHub's
+documented rule is that a matching _positive_ pattern after a negative match
+re-includes the path, and `src/launch/**` cannot match `docs/superpowers/**`.
+
+A catalog merge will trigger a full docs deploy rather than a partial one. That
+takes about a minute and is acceptable.
+
+### Prerequisite outside this work
+
+The new check has no force until an admin adds it to ruleset `816683`, which
+currently requires only `dbt Cloud` and `Trunk Check Runner`.
+
+`strict_required_status_checks_policy` is `false` on that ruleset, meaning
+branches need not be current with `main` before merging. The catalog has
+cross-file exhaustiveness rules, so two PRs each green in isolation can produce
+a broken `main`. Worth enabling alongside, or adding a merge queue for
+`src/launch/**`.
+
+## Testing
+
+Four files under `tests/launch/`, following the pattern already established by
+`tests/cube/test_cube_schema.py`: pure Python, no Dagster import, no secrets.
+
+| File               | Covers                                                              |
+| ------------------ | ------------------------------------------------------------------- |
+| `test_validate.py` | One test per rule, both tiers, on constructed dicts                 |
+| `test_select.py`   | Status filtering, threshold behaviour above and below               |
+| `test_render.py`   | Script-tag escaping regression, family collapse, the `access` badge |
+| `test_catalog.py`  | Runs the real `src/launch/*.yml` through tier 1                     |
+
+`test_catalog.py` is the one that actually protects `main`. The others protect
+the rules themselves.
+
+The escaping regression is worth naming: `json.dumps` does not escape `<`, so a
+catalog value containing a closing script tag terminates the block early and
+blanks the page with an exit-zero build. The prototype escapes `<`, `>`, and `&`
+at the Unicode level; the test pins that behaviour.
+
+## Failure handling
+
+| Failure                               | Detected by      | Behaviour                                          |
+| ------------------------------------- | ---------------- | -------------------------------------------------- |
+| `links.yml` unparseable               | tier 1           | `CatalogError`, docs build fails                   |
+| Duplicate or malformed `id`           | tier 1           | Same                                               |
+| Unknown `system`, non-https `url`     | tier 1           | Same                                               |
+| Family names a missing entry          | tier 1           | Same                                               |
+| Verified entry missing a description  | tier 2           | Same                                               |
+| Fewer verified entries than threshold | `select()`       | No page emitted, docs build succeeds, count logged |
+| Catalog valid, rendered page wrong    | **Not detected** | Known gap — the preview artifact is the mitigation |
+
+Errors accumulate rather than short-circuit: one build reports every problem, so
+a contributor fixes them in one pass instead of one per push.
+
+## Fixes carried from the prototype
+
+The prototype at `.claude/scratch/launch-prototype/` is the starting point.
+Carried across as-is: family validation, the script-tag escaping, the region
+accent mapping. Fixed on the way:
+
+- Reads `git show origin/main:src/launch/links.yml`. Fails outright under a
+  shallow CI checkout, and reads the wrong tree in any case.
+- Shells out to `git log` for a "last updated" stamp. Under `actions/checkout`
+  the path-filtered form returns empty. `GITHUB_SHA` is not a substitute — it is
+  a commit id where a human-readable date belongs. Either set `fetch-depth: 0`
+  or use the unfiltered tip-commit date, which does resolve at depth 1. This
+  design takes the tip-commit date and omits the stamp when it cannot be
+  resolved; a missing date is not worth failing a build over.
+- `assignments` keyed on the display `name`, a string that changes when someone
+  edits a title. Superseded by per-entry `group` in the follow-up PR.
+- `"limited": bool(e.get("access"))` — truthy for any value, so `access: open`
+  would render a "Limited access" badge. Tier 1 now constrains the value and the
+  test is `== "limited"`.
+- The description substring sniff for `limited access` goes away with it.
+- Hard-coded four-value `SYSTEMS`; the README documents nine.
+- `regions: [all]` is documented as legal but unhandled — yields a blank label
+  on a normal entry and an error on a family member.
+- Loads webfonts from `fonts.googleapis.com`. A staff-facing page should not
+  reach a third party for a typeface; falls back to a system stack.
+
+Two housekeeping items in the same change: declare `pyyaml` in the `docs`
+dependency group — it currently resolves only transitively through mkdocs — and
+add `exclude_docs: hooks.py` to `mkdocs.yml`, since `docs/hooks.py` is inside
+`docs_dir` and is currently served at `/teamster/hooks.py`.
+
+## Out of scope
+
+Recorded so the omissions are deliberate rather than forgotten.
+
+- Wiring the build into the deploy job beyond the `paths` filter
+- The per-entry `group` field and grouped rendering — follow-up PR after #4767
+- `tests/cube` remains unprotected by CI, as does the rest of `tests/`
+- The 80 pre-existing `docs/superpowers` link warnings
+- The `pythonpath` config that would let the full test tree collect
+- The Drive sharing check and its admin identity
+- Retiring the Google Site
+
+## Open questions
+
+- **The threshold number.** Seeded at 25; belongs to the catalog owner.
+- **Whether to enable `strict_required_status_checks_policy`** on ruleset
+  `816683`, or add a merge queue for `src/launch/**`.
+- **Whether `views.yml` is retired.** It still exists on `main` with per-view
+  titles and intro copy. The launch page design says that copy moves into the
+  template, but the prototype template contains none of it.
+
+## Decisions log
+
+| Decision                                  | Rationale                                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Generate at build, do not commit the page | No generated artifact in git; the preview artifact covers reviewability                         |
+| `on_files` with `File.generated`          | `on_pre_build` writing into `docs_dir` loops `mkdocs serve` at two builds per second            |
+| `render()` returns a string               | Makes the loop structurally impossible and every test in-memory                                 |
+| Select before validate                    | Tier 2 cannot exist otherwise                                                                   |
+| Two-tier validation                       | In-progress entries must not block commits; published entries must not be malformed             |
+| Threshold gate instead of an empty state  | The zero-verified page renders an error message, not an empty page; gating makes it unreachable |
+| pytest scoped to `tests/launch`           | The full tree does not collect; a blanket job turns this into a test-infrastructure project     |
+| No `--strict`                             | Fails on `main` today for unrelated reasons, and buys nothing over `CatalogError`               |
+| Defer per-entry `group`                   | 37 entries in flight on #4767; the field is right, the timing is not                            |
+
+Refs #4818, #4761

--- a/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
@@ -101,8 +101,10 @@ judging. Getting this backwards would force every rule into tier 1.
 | `status` in `{needs-review, verified}`                           | A typo would silently unpublish an entry                       |
 | `access`, if present, is exactly `limited`                       | Prototype treats any truthy value as limited                   |
 | `regions` values all in `{newark, camden, miami, paterson, all}` | Unknown regions render blank                                   |
+| `groups.yml` parses, with `groups`, `families`, `promos` present | Same                                                           |
 | Every family member in `groups.yml` names a real entry           | A rename silently drops a tool                                 |
 | Every family names a real group id                               | An unknown group throws before anything renders                |
+| Every promo card has a non-empty `url` that is not `#`           | Four of five point at `#` today and would render as dead links |
 
 ### Tier 2 — `status: verified` entries only
 
@@ -126,8 +128,19 @@ required per-entry field, and that is the right shape — a side table in
 two individually-green PRs break `main` together.
 
 Adding it means touching all 46 entries while 37 are in flight on #4767.
-Sequenced into a follow-up PR after that merges. Nothing is lost by waiting:
-with zero verified entries there is no grouped rendering to do yet.
+Sequenced into a follow-up PR after that merges.
+
+**What this PR renders in the meantime.** `render()` emits a flat, alphabetical
+list of verified entries — families still collapse into one row with per-region
+sub-links, since that is driven by `groups.yml` and not by `group`. The grouped
+layout arrives with the field. Nothing is lost by waiting: the threshold below
+means no page is generated at all until well after the follow-up lands, so the
+flat layout is never what staff see. It exists so `render()` is complete and
+testable now rather than half-written.
+
+Accordingly `groups.yml` in this PR carries group definitions, families, promos
+and the threshold — but no entry-to-group map. The prototype's `assignments`
+block is dropped rather than re-keyed.
 
 ## Publication threshold
 
@@ -176,6 +189,12 @@ Two steps: `uv run pytest tests/launch`, then `uv run --group docs mkdocs build`
 followed by an upload of `site/launch/index.html` as a workflow artifact. A
 reviewer downloads it and opens the real page before approving. The template
 inlines all CSS and JS, so a single file opens standalone.
+
+Below the threshold no page is generated, so there is nothing to upload. The
+upload step sets `if-no-files-found: ignore` — the default is `warn`, which
+would print a confusing warning on every PR until the catalog crosses the
+threshold. The build still runs and the validation still gates; only the preview
+is absent, which is correct, because there is nothing to preview.
 
 **No `--strict`.** `mkdocs build --strict` fails on `main` today with exactly 80
 warnings, every one an unresolvable relative link inside `docs/superpowers/**`

--- a/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
@@ -1,9 +1,14 @@
 # Launch page: build, validation, and CI gate
 
 Design for productionizing the launch page generator and building the CI gate
-that must exist before it can publish. Companion to
-[the launch page design](2026-08-06-launch-page-design.md), which settles what
-the page is; this settles how it gets built and what stops it shipping broken.
+that must exist before it can publish. Companion to the launch page design,
+which settles what the page is; this settles how it gets built and what stops it
+shipping broken.
+
+That companion is **not on `main` yet** — it lives on PR #4762 at
+`docs/superpowers/specs/2026-08-06-launch-page-design.md`. Every reference to it
+below is by PR number rather than by relative link, because a relative link
+would resolve to nothing for anyone reading from `main` until #4762 merges.
 
 ## Context
 
@@ -26,7 +31,8 @@ exist before that merge, not after.
   reaches staff malformed
 - A minimum-verified threshold below which no page is generated at all
 - Generation through an MkDocs `on_files` hook
-- `tests/launch/` and a pytest PR workflow scoped to it
+- `tests/launch/`, a `conftest.py` that makes the module importable, and a
+  pytest PR workflow scoped to it
 - A downloadable preview of the rendered page on every catalog PR
 
 ## Architecture
@@ -39,12 +45,12 @@ exist before that merge, not after.
             v
   src/launch/build.py
       load()      read the three files from the working tree
-      select()    keep only status: verified
+      select()    keep only status: verified          -- partitions, never exits
       validate()  tier 1 over all entries, tier 2 over selected
-      render()    inject JSON, RETURN an HTML string
-            |
-            +--> errors        -> raise CatalogError, listing every problem
-            +--> below minimum -> return None, log the count
+                    |
+                    +--> errors -> raise CatalogError, listing every problem
+      render()    below minimum -> return None, log the count
+                  otherwise     -> inject JSON, RETURN an HTML string
             |
             v
   docs/hooks.py :: on_files
@@ -89,6 +95,13 @@ structural guarantee that the serve loop cannot return.
 Selection runs **before** validation, so tier 2 knows which entries it is
 judging. Getting this backwards would force every rule into tier 1.
 
+`select()` only partitions — it never short-circuits. **Validation always runs
+in full, including below the publication threshold.** The threshold is checked
+in `render()`, after every rule has been applied, so it suppresses output
+without ever suppressing a check. Putting the short-circuit in `select()` would
+mean the entire pre-threshold window — today, and for a long stretch after #4767
+lands nine of 46 — ran with no structural validation on the build path at all.
+
 ### Tier 1 — every entry, regardless of status
 
 | Rule                                                             | Why                                                            |
@@ -121,11 +134,12 @@ the field.
 
 ### Deferred
 
-`group` present on every entry and resolving to a known group id. The
-[launch page design](2026-08-06-launch-page-design.md) records `group` as a
-required per-entry field, and that is the right shape — a side table in
-`groups.yml` has to stay exhaustive, which is precisely the coupling that lets
-two individually-green PRs break `main` together.
+`group` present on every entry and resolving to a known group id. The launch
+page design on #4762 records `group` as a required per-entry field with a logged
+rationale ("role tags and topical domains are different axes"), and that is the
+right shape — a side table in `groups.yml` has to stay exhaustive, which is
+precisely the coupling that lets two individually-green PRs break `main`
+together.
 
 Adding it means touching all 46 entries while 37 are in flight on #4767.
 Sequenced into a follow-up PR after that merges.
@@ -210,9 +224,9 @@ workflow watches `docs/**` and `mkdocs.yml` only, so **merging a catalog change
 currently triggers no deploy at all** — the launch page design's claim that
 "merging a catalog change publishes it" is false until this lands.
 
-Appending after the existing `"!docs/superpowers/**"` negation is safe: GitHub's
-documented rule is that a matching _positive_ pattern after a negative match
-re-includes the path, and `src/launch/**` cannot match `docs/superpowers/**`.
+Position in the list does not matter. `src/launch/**` and `docs/superpowers/**`
+are disjoint prefixes, so no path can match both and the existing negation is
+unaffected wherever the new pattern goes.
 
 A catalog merge will trigger a full docs deploy rather than a partial one. That
 takes about a minute and is acceptable.
@@ -230,15 +244,44 @@ a broken `main`. Worth enabling alongside, or adding a merge queue for
 
 ## Testing
 
-Four files under `tests/launch/`, following the pattern already established by
-`tests/cube/test_cube_schema.py`: pure Python, no Dagster import, no secrets.
+Four files under `tests/launch/`: pure Python, no Dagster import, no secrets.
 
-| File               | Covers                                                              |
-| ------------------ | ------------------------------------------------------------------- |
-| `test_validate.py` | One test per rule, both tiers, on constructed dicts                 |
-| `test_select.py`   | Status filtering, threshold behaviour above and below               |
-| `test_render.py`   | Script-tag escaping regression, family collapse, the `access` badge |
-| `test_catalog.py`  | Runs the real `src/launch/*.yml` through tier 1                     |
+### Making `src/launch/build.py` importable
+
+There is no path by which a test can import it today. `pyproject.toml` packages
+only `src/teamster`; there is no `[tool.pytest.ini_options] pythonpath`, no
+`pytest.ini`, and `tests/conftest.py` does no path manipulation. `tests/` has no
+root `__init__.py`, so pytest inserts only `tests/launch/` itself.
+
+`tests/cube/test_cube_schema.py` is not the precedent for this — it never
+imports `src/cube` code, it only reads YAML through `pathlib.rglob`. The nearest
+real precedent is `tests/cube/test_mcp_server.py`, which reaches
+`src/cube/mcp/server.py` through `importlib.util.spec_from_file_location`
+precisely because no import path exists.
+
+This design uses a **`tests/launch/conftest.py` that inserts `src` on
+`sys.path`**, anchored on `Path(__file__).resolve().parents[2]`. Verified
+empirically: `src/launch` imports as a PEP 420 namespace package with no
+`__init__.py`, and a test importing `launch.build` passes.
+
+Chosen over the alternatives because it is scoped to this one directory and has
+no effect on the other 749 collected tests.
+`[tool.pytest.ini_options] pythonpath` is global config on a tree that already
+fails to collect. Adding `src/launch` to the hatch `packages` list would ship it
+in the `teamster` wheel, which it is not part of. `spec_from_file_location`
+works but is a heavier idiom than a module we control needs.
+
+It also matches what `docs/hooks.py` does, so there is one mechanism to
+understand rather than two.
+
+### The files
+
+| File               | Covers                                                               |
+| ------------------ | -------------------------------------------------------------------- |
+| `test_validate.py` | One test per rule, both tiers, on constructed dicts                  |
+| `test_select.py`   | Status filtering, and that validation still runs below threshold     |
+| `test_render.py`   | Threshold suppression, script-tag escaping, families, `access` badge |
+| `test_catalog.py`  | Runs the real `src/launch/*.yml` through tier 1                      |
 
 `test_catalog.py` is the one that actually protects `main`. The others protect
 the rules themselves.
@@ -250,24 +293,34 @@ at the Unicode level; the test pins that behaviour.
 
 ## Failure handling
 
-| Failure                               | Detected by      | Behaviour                                          |
-| ------------------------------------- | ---------------- | -------------------------------------------------- |
-| `links.yml` unparseable               | tier 1           | `CatalogError`, docs build fails                   |
-| Duplicate or malformed `id`           | tier 1           | Same                                               |
-| Unknown `system`, non-https `url`     | tier 1           | Same                                               |
-| Family names a missing entry          | tier 1           | Same                                               |
-| Verified entry missing a description  | tier 2           | Same                                               |
-| Fewer verified entries than threshold | `select()`       | No page emitted, docs build succeeds, count logged |
-| Catalog valid, rendered page wrong    | **Not detected** | Known gap — the preview artifact is the mitigation |
+| Failure                               | Detected by                       | Behaviour                                          |
+| ------------------------------------- | --------------------------------- | -------------------------------------------------- |
+| `links.yml` unparseable               | tier 1                            | `CatalogError`, docs build fails                   |
+| Duplicate or malformed `id`           | tier 1                            | Same                                               |
+| Unknown `system`, non-https `url`     | tier 1                            | Same                                               |
+| Family names a missing entry          | tier 1                            | Same                                               |
+| Verified entry missing a description  | tier 2                            | Same                                               |
+| Fewer verified entries than threshold | `render()`, after full validation | No page emitted, docs build succeeds, count logged |
+| Catalog valid, rendered page wrong    | **Not detected**                  | Known gap — the preview artifact is the mitigation |
 
 Errors accumulate rather than short-circuit: one build reports every problem, so
 a contributor fixes them in one pass instead of one per push.
 
 ## Fixes carried from the prototype
 
-The prototype at `.claude/scratch/launch-prototype/` is the starting point.
-Carried across as-is: family validation, the script-tag escaping, the region
-accent mapping. Fixed on the way:
+The prototype at `.claude/scratch/launch-prototype/` is the starting point. It
+is gitignored and therefore **not checkable by a reviewer**, so the claims below
+about its behaviour have to be taken on trust until the implementation PR brings
+the code into the repo, where each becomes a diff.
+
+Two of the data claims that motivate the rules do not depend on the prototype
+and can be checked against `main` now: `links.yml` contains three GPA Roster
+entries (`gpa_roster_camden`, `gpa_roster_miami`, `gpa_roster_newark`) and
+exactly four `regions:` keys in the whole file, all four on the Contact Info
+Feeds — so the three Rosters carry none. The promo-card claim is prototype-only,
+since `groups.yml` does not exist in the repo yet. Carried across as-is: family
+validation, the script-tag escaping, the region accent mapping. Fixed on the
+way:
 
 - Reads `git show origin/main:src/launch/links.yml`. Fails outright under a
   shallow CI checkout, and reads the wrong tree in any case.
@@ -302,7 +355,12 @@ Recorded so the omissions are deliberate rather than forgotten.
 - The per-entry `group` field and grouped rendering — follow-up PR after #4767
 - `tests/cube` remains unprotected by CI, as does the rest of `tests/`
 - The 80 pre-existing `docs/superpowers` link warnings
-- The `pythonpath` config that would let the full test tree collect
+- The `pythonpath` config that would let the full test tree collect. This is a
+  separate, pre-existing problem:
+  `tests/sensors/sftp/test_sensors_sftp_renlearn.py` does
+  `from tests.utils import ...` and dies at collection, taking 749 tests with
+  it. The `tests/launch/conftest.py` shim above does not touch it and is not
+  blocked by it.
 - The Drive sharing check and its admin identity
 - Retiring the Google Site
 
@@ -317,16 +375,18 @@ Recorded so the omissions are deliberate rather than forgotten.
 
 ## Decisions log
 
-| Decision                                  | Rationale                                                                                       |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Generate at build, do not commit the page | No generated artifact in git; the preview artifact covers reviewability                         |
-| `on_files` with `File.generated`          | `on_pre_build` writing into `docs_dir` loops `mkdocs serve` at two builds per second            |
-| `render()` returns a string               | Makes the loop structurally impossible and every test in-memory                                 |
-| Select before validate                    | Tier 2 cannot exist otherwise                                                                   |
-| Two-tier validation                       | In-progress entries must not block commits; published entries must not be malformed             |
-| Threshold gate instead of an empty state  | The zero-verified page renders an error message, not an empty page; gating makes it unreachable |
-| pytest scoped to `tests/launch`           | The full tree does not collect; a blanket job turns this into a test-infrastructure project     |
-| No `--strict`                             | Fails on `main` today for unrelated reasons, and buys nothing over `CatalogError`               |
-| Defer per-entry `group`                   | 37 entries in flight on #4767; the field is right, the timing is not                            |
+| Decision                                        | Rationale                                                                                       |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Generate at build, do not commit the page       | No generated artifact in git; the preview artifact covers reviewability                         |
+| `on_files` with `File.generated`                | `on_pre_build` writing into `docs_dir` loops `mkdocs serve` at two builds per second            |
+| `render()` returns a string                     | Makes the loop structurally impossible and every test in-memory                                 |
+| Select before validate                          | Tier 2 cannot exist otherwise                                                                   |
+| Threshold checked in `render()`, not `select()` | Validation must run in full below the threshold, or the pre-launch window has no gate at all    |
+| `tests/launch/conftest.py` path shim            | Scoped to one directory; global pytest config would touch a tree that already fails to collect  |
+| Two-tier validation                             | In-progress entries must not block commits; published entries must not be malformed             |
+| Threshold gate instead of an empty state        | The zero-verified page renders an error message, not an empty page; gating makes it unreachable |
+| pytest scoped to `tests/launch`                 | The full tree does not collect; a blanket job turns this into a test-infrastructure project     |
+| No `--strict`                                   | Fails on `main` today for unrelated reasons, and buys nothing over `CatalogError`               |
+| Defer per-entry `group`                         | 37 entries in flight on #4767; the field is right, the timing is not                            |
 
 Refs #4818, #4761

--- a/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
+++ b/docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md
@@ -30,7 +30,8 @@ exist before that merge, not after.
 - Two-tier validation, so in-progress entries never block a commit but nothing
   reaches staff malformed
 - A minimum-verified threshold below which no page is generated at all
-- Generation through an MkDocs `on_files` hook
+- Generation through an MkDocs `on_files` hook, plus the `watch:` entry and
+  module reload that make local `mkdocs serve` show current output
 - `tests/launch/`, a `conftest.py` that makes the module importable, and a
   pytest PR workflow scoped to it
 - A downloadable preview of the rendered page on every catalog PR
@@ -90,6 +91,43 @@ Nothing in `build.py` writes to the filesystem. The hook decides where output
 goes. This is what makes every test run on in-memory data, and it is a
 structural guarantee that the serve loop cannot return.
 
+### How the hook reaches the module
+
+`docs/hooks.py` today is four lines that set `page.meta["hide"]` on the
+homepage. It imports nothing and touches no paths. The `on_files` hook this
+design adds needs `launch.build`, and the production-side import is as much a
+design decision as the test-side one.
+
+It uses the same shim: `sys.path.insert` anchored on
+`Path(__file__).resolve().parent.parent / "src"`. **Anchored on `__file__`, not
+on cwd** — `mkdocs` is normally invoked from the repo root but nothing
+guarantees it, and `mkdocs build -f <path>` is explicitly supported.
+
+Two importers, one idiom. That is a deliberate choice over
+`importlib.util.spec_from_file_location`, which this design rejects for the
+tests and should not silently adopt here.
+
+### `mkdocs serve` needs `watch:` and a module reload
+
+Two gaps follow from the hook living outside `docs_dir`, both real and both
+specific to local preview.
+
+**The catalog is not watched.** The dev server watches `docs_dir` and the config
+file. `mkdocs.yml` has no `watch:` key today, and `src/launch/` is not under
+`docs_dir` — so editing `links.yml` while `mkdocs serve` runs triggers no
+rebuild at all. Not the round-one infinite-loop bug; its mirror image. Fixed by
+adding `watch: [src/launch]` to `mkdocs.yml`.
+
+**The module is cached.** `import launch.build` lands in `sys.modules` on the
+first hook invocation, so edits to `build.py` itself are not picked up on
+subsequent rebuilds. `load()` re-reads YAML from disk every build, so catalog
+edits are fine once watching is on; only generator-code edits are affected. The
+hook calls `importlib.reload()` when the module is already imported.
+
+Without both, "one entry point, three callers" holds for the deploy and the gate
+but quietly fails for the local-preview caller, which is the one a contributor
+uses most.
+
 ## Validation rules
 
 Selection runs **before** validation, so tier 2 knows which entries it is
@@ -102,22 +140,25 @@ without ever suppressing a check. Putting the short-circuit in `select()` would
 mean the entire pre-threshold window — today, and for a long stretch after #4767
 lands nine of 46 — ran with no structural validation on the build path at all.
 
-### Tier 1 — every entry, regardless of status
+### Tier 1 — structural, regardless of status
 
-| Rule                                                             | Why                                                            |
-| ---------------------------------------------------------------- | -------------------------------------------------------------- |
-| `links.yml` parses as a list of mappings                         | Everything else depends on it                                  |
-| `id` present, unique, matching `^[a-z0-9_]+$`                    | Duplicates surface at the worst possible moment                |
-| `name` present and non-empty                                     | Nothing can reference an unnamed entry                         |
-| `url` present, scheme is `https`                                 | A staff-facing link must not be plaintext                      |
-| `system` in the nine-value enum documented in `README.md`        | The prototype hard-codes four; the other five degrade silently |
-| `status` in `{needs-review, verified}`                           | A typo would silently unpublish an entry                       |
-| `access`, if present, is exactly `limited`                       | Prototype treats any truthy value as limited                   |
-| `regions` values all in `{newark, camden, miami, paterson, all}` | Unknown regions render blank                                   |
-| `groups.yml` parses, with `groups`, `families`, `promos` present | Same                                                           |
-| Every family member in `groups.yml` names a real entry           | A rename silently drops a tool                                 |
-| Every family names a real group id                               | An unknown group throws before anything renders                |
-| Every promo card has a non-empty `url` that is not `#`           | Four of five point at `#` today and would render as dead links |
+Most rows check a catalog entry. The last four check `groups.yml` structures,
+which have no `status` field of their own and so are always in tier 1.
+
+| Rule                                                             | Why                                                              |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `links.yml` parses as a list of mappings                         | Everything else depends on it                                    |
+| `id` present, unique, matching `^[a-z0-9_]+$`                    | Duplicates surface at the worst possible moment                  |
+| `name` present and non-empty                                     | Nothing can reference an unnamed entry                           |
+| `url` present, scheme is `https`                                 | A staff-facing link must not be plaintext                        |
+| `system` in the nine-value enum documented in `README.md`        | The prototype hard-codes four; the other five degrade silently   |
+| `status` in `{needs-review, verified}`                           | A typo would silently unpublish an entry                         |
+| `access`, if present, is exactly `limited`                       | Prototype treats any truthy value as limited                     |
+| `regions` values all in `{newark, camden, miami, paterson, all}` | Unknown regions render blank                                     |
+| `groups.yml` parses, with `groups`, `families`, `promos` present | A missing key raises deep in `render()`, not at validation       |
+| Every family member in `groups.yml` names a real entry           | A rename silently drops a tool                                   |
+| Every family names a real group id                               | An unknown group throws before anything renders                  |
+| Every promo card has a non-empty `url` that is not `#`           | Four of five are `#` in the prototype; dead links on a live page |
 
 ### Tier 2 — `status: verified` entries only
 
@@ -165,9 +206,11 @@ returns 404 until the catalog is genuinely ready.
 This exists because the zero-verified page is not merely empty — it is broken.
 With no tools the template falls through to its search-miss branch and renders
 "No tool matches that", above a masthead reading `0 tools` and a footer
-disclaiming `0 of 0 entries are still being verified`. Four of the five promo
-cards in `groups.yml` point at `#`. The first live version would be five cards,
-four of them dead, under an error message.
+disclaiming `0 of 0 entries are still being verified`. In the prototype's
+`groups.yml`, four of the five promo cards point at `#` — so on that seed data
+the first live version would be five cards, four of them dead, under an error
+message. (`groups.yml` does not exist in the repo yet; that count is
+prototype-only, per _Fixes carried from the prototype_ below.)
 
 Gating on a count is cheaper than designing an empty state that should never be
 seen, and it makes a broken intermediate page impossible rather than merely
@@ -271,17 +314,23 @@ fails to collect. Adding `src/launch` to the hatch `packages` list would ship it
 in the `teamster` wheel, which it is not part of. `spec_from_file_location`
 works but is a heavier idiom than a module we control needs.
 
-It also matches what `docs/hooks.py` does, so there is one mechanism to
-understand rather than two.
+It also matches the shim the `on_files` hook uses, so there is one idiom to
+understand rather than two. Note that `docs/hooks.py` does not do this **today**
+— the hook and its `sys.path` insert both arrive with this work.
+
+`tests/cube/__init__.py` is not a collision risk. A regular package with a
+loader always wins over a same-named namespace portion, and `src/cube/` has no
+`__init__.py`, so `import cube` keeps resolving to `tests/cube` even after `src`
+joins `sys.path`. No dependency in `uv.lock` is named `launch` either.
 
 ### The files
 
 | File               | Covers                                                               |
 | ------------------ | -------------------------------------------------------------------- |
 | `test_validate.py` | One test per rule, both tiers, on constructed dicts                  |
-| `test_select.py`   | Status filtering, and that validation still runs below threshold     |
+| `test_select.py`   | Status filtering only — `select()` has no threshold awareness        |
 | `test_render.py`   | Threshold suppression, script-tag escaping, families, `access` badge |
-| `test_catalog.py`  | Runs the real `src/launch/*.yml` through tier 1                      |
+| `test_catalog.py`  | Runs the real `src/launch/*.yml` through tier 1, at any entry count  |
 
 `test_catalog.py` is the one that actually protects `main`. The others protect
 the rules themselves.
@@ -322,6 +371,12 @@ since `groups.yml` does not exist in the repo yet. Carried across as-is: family
 validation, the script-tag escaping, the region accent mapping. Fixed on the
 way:
 
+- **Four of its five promo cards point at `#`.** The new tier-1 rule rejects
+  those, so the seed `groups.yml` cannot simply be lifted across: the
+  implementation either sources real URLs for About us, The Data Feed, Case
+  studies and the "need something we don't have" card, or ships without them.
+  Dropping them is the default — a promo card pointing at a page that does not
+  exist is worse than no card.
 - Reads `git show origin/main:src/launch/links.yml`. Fails outright under a
   shallow CI checkout, and reads the wrong tree in any case.
 - Shells out to `git log` for a "last updated" stamp. Under `actions/checkout`
@@ -383,6 +438,9 @@ Recorded so the omissions are deliberate rather than forgotten.
 | Select before validate                          | Tier 2 cannot exist otherwise                                                                   |
 | Threshold checked in `render()`, not `select()` | Validation must run in full below the threshold, or the pre-launch window has no gate at all    |
 | `tests/launch/conftest.py` path shim            | Scoped to one directory; global pytest config would touch a tree that already fails to collect  |
+| Same `sys.path` shim in the `on_files` hook     | One idiom for both importers, anchored on `__file__` so `mkdocs build -f` works from any cwd    |
+| `watch: [src/launch]` plus `importlib.reload()` | Without both, local `mkdocs serve` silently serves a stale page — the caller used most often    |
+| Drop the prototype's `#` promo cards            | The new tier-1 rule rejects them; a card pointing nowhere is worse than no card                 |
 | Two-tier validation                             | In-progress entries must not block commits; published entries must not be malformed             |
 | Threshold gate instead of an empty state        | The zero-verified page renders an error message, not an empty page; gating makes it unreachable |
 | pytest scoped to `tests/launch`                 | The full tree does not collect; a blanket job turns this into a test-infrastructure project     |

--- a/src/launch/PROJECT.md
+++ b/src/launch/PROJECT.md
@@ -1,0 +1,141 @@
+# Data launch page — project overview
+
+Orientation for anyone picking up this work. [README.md](README.md) is the field
+reference and [RUNBOOK.md](RUNBOOK.md) is the task sequence; this is the why,
+the scope, and where it stands.
+
+Last updated 2026-08-11.
+
+## The problem
+
+The data team's launch page — the thing staff open to find a dashboard — lives
+on a Google Site. It is edited by hand, has no version history worth the name,
+and the same tool list is maintained separately on five different role pages,
+which have drifted apart. Nobody can review a change before it goes live.
+
+It has to reach roughly **1,800 staff** across Newark, Camden, Miami and
+Paterson: classroom teachers through assistant superintendents.
+
+## The shape of the solution
+
+**Split the content by how sensitive it is.**
+
+| Content                                          | Lives in | Why                                                                                        |
+| ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------ |
+| The tool catalog — names, descriptions, URLs     | git      | Already public on the Google Site. A list of nouns and links that only open behind sign-in |
+| Prose — Our Team, support runbook, Topline, blog | Zendesk  | Authored by humans who are not going to write YAML, and gated by Okta                      |
+
+**The catalog becomes a static page with no authentication.** It carries nothing
+worth gating, and every destination gates itself: Tableau by SSO, Google Sheets
+by Workspace group, Zendesk guides by Okta. That removes the whole problem that
+made "put it on GitHub Pages behind auth" hard — the auth was never needed.
+
+**Only `status: verified` entries publish.** Verification is a release gate, not
+a quality note. Nothing reaches 1,800 people on the strength of a scrape.
+
+```text
+  src/launch/links.yml     46 tools, each with a status
+  src/launch/groups.yml    topical groups, families, promo cards, threshold
+  src/launch/template.html the page shell
+           |
+           v
+  src/launch/build.py      load -> select -> validate -> render
+           |
+           v
+  MkDocs hook -> teamschools.github.io/teamster/launch/
+```
+
+## Where it stands
+
+| Item                                                               | State                                                                 |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Issue [#4761](https://github.com/TEAMSchools/teamster/issues/4761) | Open. The parent. Reopened after a linked-branch merge auto-closed it |
+| PR [#4763](https://github.com/TEAMSchools/teamster/pull/4763)      | **Merged.** Catalog, README and RUNBOOK are on `main`                 |
+| PR [#4767](https://github.com/TEAMSchools/teamster/pull/4767)      | Open. Catalog verification in progress — **10 of 46 verified**        |
+| PR [#4762](https://github.com/TEAMSchools/teamster/pull/4762)      | Open. Design spec for the page itself                                 |
+| Issue [#4818](https://github.com/TEAMSchools/teamster/issues/4818) | Open. The build pipeline and CI gate                                  |
+| PR [#4819](https://github.com/TEAMSchools/teamster/pull/4819)      | Open. Design spec for the build and gate                              |
+| PR [#4816](https://github.com/TEAMSchools/teamster/pull/4816)      | **Merged.** `analytics-engineers` own `/src/launch/`                  |
+| Google Site                                                        | Still live. Retirement is gated on a cutover threshold, not yet set   |
+
+The catalog on `main` is 46 entries — 35 Tableau, 7 Google Sheets, 3 AppSheet, 1
+Zendesk — and **zero are verified**, so the page would currently render empty.
+That is deliberate: it makes this the safe window to build the pipeline, because
+it cannot publish anything wrong yet.
+
+## Who owns what
+
+| Work                                                    | Owner                                                                  |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Verifying the 46 catalog entries                        | Intern, tracked on #4767                                               |
+| Triaging which Google Sheets exposures are staff-facing | Anthony — needs judgement about which reports real people actually use |
+| The build pipeline, validation and CI gate              | Data team, specced on #4819                                            |
+| Prose content in Zendesk                                | Not started; no owner yet                                              |
+
+## Decided — please don't relitigate
+
+Each of these was argued and settled. The reasoning is in the specs if you want
+it.
+
+1. **The tool catalog is public.** It is already public today on the Google
+   Site.
+1. **Prose stays in Zendesk**, authored there rather than migrated into git.
+1. **No Zendesk publishing pipeline.** An earlier design generated Guide
+   articles through the API. It existed to gate a list that needs no gate.
+1. **Only verified entries publish.**
+1. **Don't scrape the dbt exposures into the catalog.** There are 63 Google
+   Sheets exposures and staff-facing ones appear in every naming category, so no
+   heuristic sorts them.
+1. **Don't move the catalog into the exposure YAMLs.** Measured: zero of 46
+   entries have a matching exposure URL. Exposures record lineage, not
+   destinations.
+
+## Open — needs a decision
+
+1. **The cutover threshold.** How much of the catalog has to be verified before
+   the Google Site is retired. A related number, the minimum verified count
+   before the page publishes at all, is seeded at 25 in the build spec.
+1. **An admin identity for the Drive sharing check.** Without one the check
+   fails open: `permissions.list` returns only the owner to a caller that does
+   not administer the file, so a naive assertion passes on a file it knows
+   nothing about.
+1. **Required status checks.** Ruleset `816683` requires only dbt Cloud and
+   Trunk, and `strict_required_status_checks_policy` is `false`. Until the new
+   check is added the gate is advisory, and without strict mode two PRs green in
+   isolation can still break `main`.
+1. **Whether the page should discourage search indexing.** Currently specced
+   with a `noindex` meta tag.
+
+## Sequence
+
+Roughly, and the first two run in parallel:
+
+1. Verification continues on #4767 until the catalog is trustworthy.
+1. The build pipeline and gate land, per #4819. **This has to merge before #4767
+   does** — that merge flips ten entries to verified at once and becomes the
+   first live publish.
+1. The per-entry `group` field and grouped rendering follow, sequenced after
+   #4767 so it does not conflict with in-flight verification.
+1. Prose moves into Zendesk.
+1. Once the catalog crosses the cutover threshold, the Google Site is retired
+   and redirected.
+
+## One thing that will bite you
+
+The MkDocs deploy workflow fires on `docs/**`. Once the build is wired in, **a
+catalog that fails validation on `main` freezes all documentation publishing**,
+not just the launch page. That coupling is deliberate — it is the cost of having
+one code path — and the PR gate is the thing that keeps it from happening. Do
+not wire the build into the deploy before the gate exists.
+
+## Where things live
+
+| Path                                                                 | What                                         |
+| -------------------------------------------------------------------- | -------------------------------------------- |
+| `src/launch/links.yml`                                               | The catalog. Source of truth                 |
+| `src/launch/README.md`                                               | Field reference and what "verified" requires |
+| `src/launch/RUNBOOK.md`                                              | The verification task sequence               |
+| `docs/superpowers/specs/2026-08-06-launch-page-design.md`            | What the page is (on #4762)                  |
+| `docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md` | How it gets built (on #4819)                 |
+
+Both specs are working documents, not published reference pages.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...add the design spec for the launch page build pipeline and the CI gate that
has to exist before it can publish, plus a project overview for the team.
**Docs-only — two files, no code.**

`src/launch/PROJECT.md` is the orientation doc: the problem, the content split,
live state of every issue and PR in this project, who owns what, the decisions
that are settled, what still needs a human, and the sequence. It sits alongside
`README.md` (field reference) and `RUNBOOK.md` (task sequence) so the three read
as a set — why, what, how. Start there if you are picking this up cold.

### Why this is urgent rather than routine

Zero of 46 catalog entries are `verified` on `main` today, so the generated page
is empty. That makes now the safest possible moment to stand up the pipeline: it
cannot publish anything wrong, because it has nothing to publish.

When #4767 merges, nine entries flip to verified at once and that merge becomes
the first live publish. Because the MkDocs deploy workflow also fires on
`docs/**`, a catalog that fails validation on `main` freezes **all**
documentation publishing, not just the launch page. The gate needs to exist
before that merge.

### The design

Four functions in `src/launch/build.py` — load, select, validate, render —
called from an MkDocs `on_files` hook. One code path serves `mkdocs serve`
locally, the PR gate, and the deploy. `render()` returns a string; nothing in
the module writes to disk.

**Two-tier validation.** Structural rules apply to every entry: unique `id`,
known `system`, HTTPS `url`, family members that resolve. Publish-readiness
rules apply only to `status: verified` entries: non-empty description, at least
one audience, a region if the entry is in a family. A half-finished entry never
blocks a commit; nothing reaches staff malformed.

**A minimum-verified threshold**, configured in `groups.yml` and seeded at 25.
Below it the hook generates no page at all and the URL 404s.

### Three findings from adversarial review changed the design

Each reproduced before being applied.

- **`mkdocs build --strict` cannot be the gate.** It fails on `main` right now —
  exit 1, exactly 80 warnings, every one an unresolvable relative link inside
  `docs/superpowers/**`. The live deploy passes only because it does not pass
  `--strict`. Dropped; `CatalogError` fails the build on its own.
- **Writing into `docs_dir` from `on_pre_build` loops `mkdocs serve`.** Measured
  on a minimal project: one edit produced 61 builds in 30 seconds. `serve.py`
  watches `docs_dir` recursively and livereload clears its rebuild flag before
  running the build, so the hook's own write is re-detected mid-build. Moved to
  `on_files` with `File.generated`, which never touches `docs_dir` — and which
  also removes the gitignore entry and the stale-artifact problem.
- **Selection has to run before validation.** Otherwise the two tiers collapse
  into one, and the collapsed version fails on `main` today.

### Two things the review found that are not mine to fix

The **deploy workflow does not watch `src/launch/` at all**. It fires on
`docs/**` and `mkdocs.yml` only, so merging a catalog change currently triggers
nothing. The earlier launch page spec claims otherwise; that claim is false
until this lands. One line, included in the implementation.

**Required checks do not cover this, and are not up-to-date-gated.** Ruleset
`816683` requires only dbt Cloud and Trunk, and
`strict_required_status_checks_policy` is `false`. Until an admin adds the new
check the gate is advisory, and without strict mode two PRs green in isolation
can still break `main`.

Refs #4818, #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude drafted the spec. Every architectural decision was human-directed: the
preview-artifact approach over committing the rendered page, generation via a
hook rather than a workflow step, scoping the pytest job to `tests/launch` only,
two-tier validation, the threshold gate over an empty-state design, and
deferring the per-entry `group` field so it does not conflict with the 37
entries in flight on #4767.

An adversarial reviewer was dispatched against the architecture before the spec
was written. It returned three blockers with reproductions, all of which held
under independent verification and all of which changed the design. A spec
self-review then caught four more gaps — an undefined rendering behaviour during
the deferral window, a validation rule asserted in prose but absent from the
rule table, an unstated disposition for the prototype's `assignments` block, and
an unhandled artifact upload below the threshold.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

N/A — docs only.

### dbt _(skip if no dbt changes)_

N/A — docs only.

### Docs _(skip if no schedule, sensor, or integration changes)_

N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — verified locally with `trunk check --force` before pushing; no
      issues.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — not triggered; no watched paths change.

## Reviewer notes

Two decisions in the spec are open and belong to the catalog owner rather than
to this design:

1. **The threshold number**, seeded at 25 of 46. One line in `groups.yml`.
1. **Whether to enable `strict_required_status_checks_policy`** on ruleset
   `816683`, or add a merge queue for `src/launch/**`.

A third is a loose end from the earlier design: `views.yml` still exists on
`main` with per-view titles and intro copy, and the launch page spec says that
copy moves into the template — but the prototype template contains none of it.

**Note on merging.** This branch is linked to #4818, and a linked branch closes
its issue on PR merge regardless of body keywords. #4818 covers the
implementation, not just the spec, so it will need reopening after this merges —
the same thing happened to #4761 when #4763 landed.
