### PR TITLE
refactor(finalsite): make the contacts pull incremental and land it before its consumers

### DIFF
--- a/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
+++ b/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
@@ -1,0 +1,148 @@
+# Finalsite incremental contacts: cutover runbook
+
+Refs #4715. Run these in order. Steps marked **manual** need a human — they
+touch production GCS or the Dagster+ UI.
+
+The external glob `contacts/*` matches recursively, so while both the legacy
+root object and partition files exist the table unions them and every `id`
+appears twice at the storage layer. That window is steps 3 to 5.
+
+## Before you merge
+
+dbt Cloud CI will be **red** on this PR, by design:
+
+- CI runs `dbt build` only — it never runs `stage_external_sources` — so it
+  reads the pre-cutover production `finalsite.contacts` external table, which
+  has no `_dagster_partition_*` columns. `stg_finalsite__contacts` therefore
+  fails in CI and cannot pass until the cutover in step 6 runs.
+- Merging requires overriding that required check.
+- Every prod dbt model downstream of contacts is broken from merge until step 6
+  completes. Schedule the merge and the cutover together — do not merge and walk
+  away.
+
+## 1. Record the pre-cutover baseline (manual)
+
+```sql
+select count(*) as contacts, count(distinct id) as ids
+from `teamster-332318.kippnewark_finalsite.contacts`
+```
+
+Repeat for `kippcamden`, `kippmiami`, `kipppaterson`. Expected around 25,052
+(kippnewark) and 7,688 (kippmiami). Keep these numbers for step 6.
+
+## 2. Pause the schedules (manual, Dagster+ UI)
+
+Stop all four `<location>__finalsite__contacts__daily_asset_job_schedule`
+schedules. Do not rename them.
+
+## 3. Merge the PR and let the deploy land
+
+Confirm every `dagster-cloud-deploy / deploy` check-run reaches a terminal
+conclusion — a shared-library change redeploys every consuming location, so
+expect one same-named check per location.
+
+## 4. Seed one full partition per district (manual, Dagster+ UI)
+
+For each location, materialize `<location>/finalsite/contacts` for partition
+`2026-08-11` with run config:
+
+```yaml
+ops:
+  <location>__finalsite__contacts:
+    config:
+      full_pull: true
+```
+
+Override the run's `dagster/max_runtime` tag to `3600` for these four runs only
+— a full pull is ~20 minutes for kippnewark, well past the new 900s default.
+They serialize through the `finalsite_api` pool, so budget ~35 minutes total.
+
+Verify each run's `record_count` metadata matches step 1's baseline, and that
+its `since` metadata reads `FULL PULL`.
+
+## 5. Delete the legacy root object (manual, destructive)
+
+One per bucket. Check before deleting:
+
+```bash
+gsutil ls -l gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+gsutil rm gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+```
+
+Repeat for `teamster-kippcamden`, `teamster-kippmiami`, `teamster-kipppaterson`.
+
+Confirm only partition directories remain:
+
+```bash
+gsutil ls gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/
+```
+
+Expected: only `_dagster_partition_fiscal_year=.../` entries, no bare `data`.
+
+## 6. Re-stage the external source and rebuild staging
+
+```bash
+uv run dbt run-operation stage_external_sources \
+  --project-dir src/dbt/kippnewark --args "select: finalsite.contacts"
+uv run dbt build --project-dir src/dbt/kippnewark --select stg_finalsite__contacts
+```
+
+Repeat the `stage_external_sources` call for `kippcamden`, `kippmiami`, and
+`kipppaterson` before their `dbt build`.
+
+From the moment this PR merges (step 3) until this step finishes, expect
+`stg_finalsite__contacts` to fail to **build**, not to fail a test. The
+production `finalsite.contacts` external table currently has zero
+`_dagster_partition_*` columns (confirmed via `INFORMATION_SCHEMA`:
+`status_report` has one, `contacts` has none), and `stg_finalsite__contacts` now
+orders by `_dagster_partition_date`. Until `stage_external_sources` recreates
+the table over the Hive-partitioned files, any query against
+`stg_finalsite__contacts` — and everything downstream of it — errors with
+`Unrecognized name: _dagster_partition_date`. The window to minimize is merge →
+re-stage, not seed → delete; that's why "Before you merge" above says to
+schedule the merge and this step together.
+
+Then confirm the grain and the count, with `--nouse_cache` so the results cache
+cannot mask a stale read:
+
+```sql
+select count(*) as rows, count(distinct finalsite_enrollment_id) as ids
+from `teamster-332318.kippnewark_finalsite.stg_finalsite__contacts`
+```
+
+`rows` must equal `ids`, and both must match step 1's baseline within a day of
+churn. The `unique` test on `finalsite_enrollment_id` is the automated form of
+this check.
+
+## 7. Verify downstream consumers
+
+`stg_finalsite__contacts` dedupes to one row per contact, but nothing that
+assumes that grain could be build-verified before now — the partition column
+didn't exist until step 6. Build and test the real consumers:
+
+```bash
+uv run dbt build --project-dir src/dbt/kippnewark --select stg_finalsite__contacts+
+```
+
+Repeat with `--project-dir src/dbt/<location>` for `kippcamden`, `kippmiami`,
+and `kipppaterson`. A pass proves the deduped one-row-per-contact grain holds
+through every model built on it, specifically:
+
+- `int_finalsite__student_contacts`
+- `int_finalsite__student_address_of_record`
+- the singular tests `stg_finalsite__contact_relationships__caregiver_is_adult`
+  and `stg_finalsite__contact_relationships__single_primary`
+
+If any of these fail, the cutover has not actually restored one row per contact
+— do not resume schedules until they pass.
+
+## 8. Resume the schedules (manual, Dagster+ UI)
+
+Start all four schedules. The next tick is 00:15 or 12:00 ET.
+
+## 9. Confirm the first incremental tick
+
+After the first 00:15 run, check its metadata: `since` should read the previous
+day's date, and `record_count` should be in the low thousands, not the tens of
+thousands. Then confirm the 01:00 Google Directory sync and 01:25 DeansList ship
+read same-day contacts.

--- a/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
+++ b/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
@@ -77,14 +77,27 @@ would then ship empty files to DeansList, ParentSquare and Focus instead of
 failing loudly. That is the reason for the step 4 → step 5 order; do not reorder
 these under time pressure.
 
-One per bucket. Check before deleting:
+One per bucket, and every delete is preceded by its own inspection — the paths
+are written out rather than left as "repeat" because this is an irreversible
+delete across four production buckets:
 
 ```bash
 gsutil ls -l gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
-gsutil rm gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+gsutil rm    gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+
+gsutil ls -l gs://teamster-kippcamden/dagster/kippcamden/finalsite/contacts/data
+gsutil rm    gs://teamster-kippcamden/dagster/kippcamden/finalsite/contacts/data
+
+gsutil ls -l gs://teamster-kippmiami/dagster/kippmiami/finalsite/contacts/data
+gsutil rm    gs://teamster-kippmiami/dagster/kippmiami/finalsite/contacts/data
+
+gsutil ls -l gs://teamster-kipppaterson/dagster/kipppaterson/finalsite/contacts/data
+gsutil rm    gs://teamster-kipppaterson/dagster/kipppaterson/finalsite/contacts/data
 ```
 
-Repeat for `teamster-kippcamden`, `teamster-kippmiami`, `teamster-kipppaterson`.
+If an `ls` reports the object missing, STOP rather than moving on — either the
+delete already ran or the path is wrong, and the next `rm` would be operating
+blind.
 
 Confirm only partition directories remain:
 
@@ -161,3 +174,15 @@ After the first 00:15 run, check its metadata: `since` should read the previous
 day's date, and `record_count` should be in the low thousands, not the tens of
 thousands. Then confirm the 01:00 Google Directory sync and 01:25 DeansList ship
 read same-day contacts.
+
+## Ongoing: watch for missing partitions
+
+`since` is derived from the partition key, so partition `D+1` asks for
+`since = D` and never re-requests changes made on `D-1`. One failed tick is
+harmless — the other tick that day covers the same window. **A day where both
+ticks fail does not self-heal**, and nothing currently alerts on it.
+
+Check the `contacts` asset for gaps in the Dagster UI's partition view. Backfill
+any missing partition before the next tick; a backfilled partition requests its
+own `D-1` window, which closes the gap. The longer a gap sits, the more contacts
+hold stale values with no error raised anywhere.

--- a/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
+++ b/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md
@@ -60,7 +60,22 @@ They serialize through the `finalsite_api` pool, so budget ~35 minutes total.
 Verify each run's `record_count` metadata matches step 1's baseline, and that
 its `since` metadata reads `FULL PULL`.
 
+The partition key `2026-08-11` must equal the asset's configured
+`DailyPartitionsDefinition(start_date=...)` in all four code locations'
+`finalsite/assets.py` — seeding the wrong partition key puts the base data on a
+partition the schedule will never revisit. If the cutover happens later than
+`2026-08-11`, bump `start_date` in all four `finalsite/assets.py` files and this
+runbook's partition key together, in the same change.
+
 ## 5. Delete the legacy root object (manual, destructive)
+
+Do not run this step until step 4's seed runs are verified to have landed
+(`record_count` matched step 1's baseline for all four locations). Deleting the
+root object before the seed is confirmed would leave the external table empty,
+and `stg_finalsite__contacts` would build to zero rows — the downstream feeds
+would then ship empty files to DeansList, ParentSquare and Focus instead of
+failing loudly. That is the reason for the step 4 → step 5 order; do not reorder
+these under time pressure.
 
 One per bucket. Check before deleting:
 

--- a/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts.md
+++ b/docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts.md
@@ -1,0 +1,1289 @@
+# Finalsite Incremental Contacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pull only Finalsite contacts changed since the previous day,
+accumulate them as Hive-partitioned Avro, and dedupe to one row per contact in
+staging, so the pull runs twice daily instead of once and lands before the
+consumers that read it.
+
+**Architecture:** The contacts asset gains a `DailyPartitionsDefinition` and
+derives the API's `since` parameter from its own partition key
+(`partition_date - 1`), so the partition key IS the watermark and no cursor is
+stored. Each pull writes its own Hive partition instead of replacing one object;
+`stg_finalsite__contacts` picks the newest partition per contact `id` with
+`dbt_utils.deduplicate`, and `stg_finalsite__contact_relationships` reads that
+deduped model rather than the raw source.
+
+**Tech Stack:** Dagster (assets, `DailyPartitionsDefinition`, `@schedule`), dbt
+on BigQuery (external Avro source, `dbt_utils.deduplicate`, unit tests), `uv`
+for all Python execution.
+
+**Design spec:**
+`docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md`
+
+## Global Constraints
+
+- **Worktree:** all work happens in
+  `/workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts`.
+  Use `git -C <worktree>` on every git call and
+  `--project-dir <worktree>/src/dbt/<project>` on every dbt call. Editing
+  `/workspaces/teamster/<path>` silently dirties `main`.
+- **The asset key must not change:** `[{code_location}, finalsite, contacts]`.
+- **The dbt source name must not change:** `source('finalsite', 'contacts')`.
+- **Schedule names must stay byte-identical** to today's
+  (`{code_location}__finalsite__contacts__daily_asset_job_schedule`). Renaming
+  mints a new Dagster+ schedule object and abandons its status and tick history.
+- **No `QUALIFY`, no dup-masking `SELECT DISTINCT`.** Use
+  `dbt_utils.deduplicate`. Its `order_by` must use bare `desc` — BigQuery
+  rejects explicit null-ordering inside the `array_agg` the macro compiles to.
+- **The `finalsite_api` pool stays at limit 1.** #4408 is out of scope.
+- **Python:** always `uv run`, never bare `python`. Return type annotations on
+  all library functions. Built-in generics (`list[str]`, `dict[str, int]`),
+  `X | None` for nullable.
+- **Never run `trunk fmt` or `trunk check` manually** except the explicit
+  `--force` verification steps in this plan, which run from inside the worktree
+  using the absolute binary `/workspaces/teamster/.trunk/tools/trunk`.
+- **Markdown:** every fenced block needs a language (MD040).
+- **`CUTOVER_START_DATE` is `2026-08-11`.** If the merge slips past that date,
+  bump it before merging. A `start_date` in the past only shows extra missing
+  partitions, which is harmless, so erring early is safe.
+
+---
+
+### Task 1: Derive `since` from the partition key in the asset factory
+
+**Files:**
+
+- Modify: `src/teamster/libraries/finalsite/api/assets.py`
+- Test: `tests/libraries/test_finalsite_contacts_since.py` (create)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `get_finalsite_since(partition_key: str) -> str` — returns the ISO date one
+    day before `partition_key`.
+  - `FinalsiteContactsConfig` — a `dagster.Config` subclass with one field,
+    `full_pull: bool = False`.
+  - `build_finalsite_asset(code_location: str, asset_name: str, schema, params: dict | None = None, partitions_def=None)`
+    — the existing factory plus a trailing optional `partitions_def`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/libraries/test_finalsite_contacts_since.py`:
+
+```python
+from teamster.libraries.finalsite.api.assets import get_finalsite_since
+
+
+def test_since_subtracts_the_safety_day():
+    assert get_finalsite_since("2026-08-11") == "2026-08-10"
+
+
+def test_since_crosses_a_month_boundary():
+    assert get_finalsite_since("2026-08-01") == "2026-07-31"
+
+
+def test_since_crosses_a_year_boundary():
+    assert get_finalsite_since("2026-01-01") == "2025-12-31"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run pytest tests/libraries/test_finalsite_contacts_since.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'get_finalsite_since'`.
+
+- [ ] **Step 3: Add the helper and the config class**
+
+In `src/teamster/libraries/finalsite/api/assets.py`, replace the import block
+and add the two new definitions above `build_finalsite_asset`:
+
+```python
+from datetime import date, timedelta
+
+from dagster import AssetExecutionContext, Config, Output, asset
+
+from teamster.core.asset_checks import (
+    build_check_spec_avro_schema_valid,
+    check_avro_schema_valid,
+)
+from teamster.libraries.finalsite.api.resources import FinalsiteResource
+
+
+def get_finalsite_since(partition_key: str) -> str:
+    """Return the `since` date for a pull, one day before the partition date.
+
+    The API's `since` is date-grained, so the finest possible increment is one
+    day. Subtracting a safety day means a run that straddles midnight or hits a
+    vendor clock skew cannot drop records, and it makes every pull on a given
+    date a superset of any earlier pull on that date — which is what lets the
+    midday run overwrite the overnight run's partition safely. Measured cost on
+    kippmiami: 43 extra records, 2 extra pages.
+    """
+    return (date.fromisoformat(partition_key) - timedelta(days=1)).isoformat()
+
+
+class FinalsiteContactsConfig(Config):
+    """Run config for a contacts pull.
+
+    `full_pull` omits `since` entirely, pulling every contact. Used once per
+    district to seed the first partition; a `since` pull alone would leave
+    staging holding only contacts that changed after go-live.
+    """
+
+    full_pull: bool = False
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run pytest tests/libraries/test_finalsite_contacts_since.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Wire the factory to use them**
+
+Replace the body of `build_finalsite_asset` in the same file:
+
+```python
+def build_finalsite_asset(
+    code_location: str,
+    asset_name: str,
+    schema,
+    params: dict | None = None,
+    partitions_def=None,
+):
+    key = [code_location, "finalsite", asset_name]
+
+    @asset(
+        key=key,
+        io_manager_key="io_manager_gcs_avro",
+        partitions_def=partitions_def,
+        check_specs=[build_check_spec_avro_schema_valid(key)],
+        group_name="finalsite",
+        # One shared pool across ALL districts (not per-location): the Finalsite
+        # gateway throttles by source IP, so simultaneous pulls from the shared
+        # egress IP return 403 even with separate subdomains and credentials.
+        # Set this pool's limit to 1 in Dagster+ to serialize them. See #4408.
+        pool="finalsite_api",
+        kinds={"python"},
+    )
+    def _asset(
+        context: AssetExecutionContext,
+        finalsite: FinalsiteResource,
+        config: FinalsiteContactsConfig,
+    ):
+        request_params = {**(params or {})}
+
+        # A partitioned asset pulls incrementally: the partition key IS the
+        # watermark, so a failed run writes no partition and advances nothing.
+        # `full_pull` is the seed escape hatch.
+        if partitions_def is not None and not config.full_pull:
+            request_params["since"] = get_finalsite_since(context.partition_key)
+
+        data = finalsite.list(path=asset_name, params=request_params)
+
+        yield Output(
+            value=(data, schema),
+            metadata={
+                "record_count": len(data),
+                "since": request_params.get("since", "FULL PULL"),
+            },
+        )
+        yield check_avro_schema_valid(
+            asset_key=context.asset_key, records=data, schema=schema
+        )
+
+    return _asset
+```
+
+`partitions_def=None` keeps the factory usable for a future non-partitioned
+asset, and the `since` derivation is gated on it rather than assumed.
+
+- [ ] **Step 6: Verify the module still imports**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run python -c "from teamster.libraries.finalsite.api.assets import build_finalsite_asset, get_finalsite_since, FinalsiteContactsConfig; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/teamster/libraries/finalsite/api/assets.py \
+  tests/libraries/test_finalsite_contacts_since.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): derive an incremental since date from the partition key
+
+Refs #4715"
+```
+
+---
+
+### Task 2: Pass `partitions_def` at the four code-location call sites
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippnewark/finalsite/assets.py:25-30`
+- Modify: `src/teamster/code_locations/kippcamden/finalsite/assets.py:27-32`
+- Modify: `src/teamster/code_locations/kippmiami/finalsite/assets.py:27-32`
+- Modify: `src/teamster/code_locations/kipppaterson/finalsite/assets.py:27-32`
+
+**Interfaces:**
+
+- Consumes: `build_finalsite_asset(..., partitions_def=...)` from Task 1.
+- Produces: four partitioned `contacts` assets, still keyed
+  `[{code_location}, finalsite, contacts]`.
+
+- [ ] **Step 1: Edit all four call sites**
+
+In each of the four files, add the two imports and the `partitions_def`
+argument. The `contacts` block becomes identical in all four (only
+`CODE_LOCATION` and the already-imported `LOCAL_TIMEZONE` differ by module):
+
+```python
+from dagster import DailyPartitionsDefinition
+
+from teamster.code_locations.<location> import CODE_LOCATION, LOCAL_TIMEZONE
+
+contacts = build_finalsite_asset(
+    code_location=CODE_LOCATION,
+    asset_name="contacts",
+    schema=CONTACTS_SCHEMA,
+    params={"includes": "contacts.relationships"},
+    # One partition per pull date. The partition key is the incremental
+    # watermark (see get_finalsite_since); start_date is the cutover date, so
+    # Dagster shows no backlog of partitions that predate the migration.
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+    ),
+)
+```
+
+Note on each file: `kippnewark` already imports `CURRENT_FISCAL_YEAR` and
+`LOCAL_TIMEZONE` may not be imported yet — add it to the existing
+`from teamster.code_locations.<location> import ...` line rather than adding a
+second import statement.
+
+`params` keeps only `includes`. Do **not** add `since_includes_expanded`: it
+measured as a no-op (identical id sets with it on and off), and the relationship
+edits it would catch arrive anyway.
+
+- [ ] **Step 2: Verify each module imports and the asset is partitioned**
+
+`kippnewark` and `kippcamden` import cleanly. `kippmiami` and `kipptaf`
+`definitions` modules fail at module load in a codespace on unrelated dlt
+credential specs, so import the `finalsite` submodule alone for those.
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run python -c "
+from dagster import DailyPartitionsDefinition
+for loc in ['kippnewark', 'kippcamden', 'kippmiami', 'kipppaterson']:
+    mod = __import__(f'teamster.code_locations.{loc}.finalsite.assets', fromlist=['contacts'])
+    pd = mod.contacts.partitions_def
+    assert isinstance(pd, DailyPartitionsDefinition), (loc, pd)
+    assert mod.contacts.key.to_user_string() == f'{loc}/finalsite/contacts', mod.contacts.key
+    print(loc, 'ok', pd)
+"
+```
+
+Expected: four `ok` lines, each naming a `DailyPartitionsDefinition`.
+
+Use `key.to_user_string()` for the slash form — `str(AssetKey([...]))` returns
+the repr, not `code_location/integration/name`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/teamster/code_locations/kippnewark/finalsite/assets.py \
+  src/teamster/code_locations/kippcamden/finalsite/assets.py \
+  src/teamster/code_locations/kippmiami/finalsite/assets.py \
+  src/teamster/code_locations/kipppaterson/finalsite/assets.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): partition the contacts asset by pull date
+
+Refs #4715"
+```
+
+---
+
+### Task 3: Schedule factory at 00:15 and 12:00 for all four districts
+
+**Files:**
+
+- Create: `src/teamster/libraries/finalsite/api/schedules.py`
+- Modify: `src/teamster/code_locations/kippnewark/finalsite/schedules.py`
+- Modify: `src/teamster/code_locations/kippcamden/finalsite/schedules.py`
+- Modify: `src/teamster/code_locations/kippmiami/finalsite/schedules.py`
+- Modify: `src/teamster/code_locations/kipppaterson/finalsite/schedules.py`
+- Test: `tests/libraries/test_finalsite_contacts_schedule.py` (create)
+
+**Interfaces:**
+
+- Consumes: the partitioned `contacts` assets from Task 2.
+- Produces:
+  `build_finalsite_contacts_schedule(code_location: str, execution_timezone: str, asset_selection: list[AssetsDefinition], cron_schedule: Sequence[str] = ("15 0 * * *", "0 12 * * *"), max_runtime_seconds: int = 900) -> ScheduleDefinition`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/libraries/test_finalsite_contacts_schedule.py`. It builds its own
+fixture asset rather than importing a code location, so it needs no dbt
+manifest:
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from dagster import (
+    DailyPartitionsDefinition,
+    DagsterInstance,
+    asset,
+    build_schedule_context,
+)
+
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
+
+TIMEZONE = "America/New_York"
+
+
+@asset(
+    key=["test", "finalsite", "contacts"],
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-01", timezone=TIMEZONE
+    ),
+)
+def _contacts() -> None: ...
+
+
+def _run_requests_at(hour: int, minute: int):
+    schedule = build_finalsite_contacts_schedule(
+        code_location="test",
+        execution_timezone=TIMEZONE,
+        asset_selection=[_contacts],
+    )
+
+    context = build_schedule_context(
+        instance=DagsterInstance.ephemeral(),
+        scheduled_execution_time=datetime(
+            2026, 8, 11, hour, minute, tzinfo=ZoneInfo(TIMEZONE)
+        ),
+    )
+
+    return list(schedule.evaluate_tick(context).run_requests or [])
+
+
+def test_overnight_tick_targets_todays_partition():
+    run_requests = _run_requests_at(hour=0, minute=15)
+
+    assert len(run_requests) == 1
+    assert run_requests[0].partition_key == "2026-08-11"
+
+
+def test_midday_tick_targets_the_same_partition():
+    run_requests = _run_requests_at(hour=12, minute=0)
+
+    assert len(run_requests) == 1
+    assert run_requests[0].partition_key == "2026-08-11"
+
+
+def test_run_key_is_none_so_the_second_daily_tick_is_not_deduplicated():
+    # Both ticks target the same partition key. A run_key equal to the partition
+    # key would make Dagster's idempotency silently swallow the 12:00 run.
+    assert _run_requests_at(hour=0, minute=15)[0].run_key is None
+
+
+def test_max_runtime_tag_is_bounded_for_an_incremental_pull():
+    tags = _run_requests_at(hour=0, minute=15)[0].tags
+
+    assert tags["dagster/max_runtime"] == "900"
+
+
+def test_schedule_name_matches_the_existing_dagster_plus_object():
+    schedule = build_finalsite_contacts_schedule(
+        code_location="test",
+        execution_timezone=TIMEZONE,
+        asset_selection=[_contacts],
+    )
+
+    assert schedule.name == "test__finalsite__contacts__daily_asset_job_schedule"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run pytest tests/libraries/test_finalsite_contacts_schedule.py -v
+```
+
+Expected: FAIL with
+`ModuleNotFoundError: No module named 'teamster.libraries.finalsite.api.schedules'`.
+
+- [ ] **Step 3: Write the schedule factory**
+
+Create `src/teamster/libraries/finalsite/api/schedules.py`:
+
+```python
+from collections.abc import Sequence
+
+from dagster import (
+    MAX_RUNTIME_SECONDS_TAG,
+    AssetsDefinition,
+    RunRequest,
+    ScheduleDefinition,
+    ScheduleEvaluationContext,
+    schedule,
+)
+
+
+def build_finalsite_contacts_schedule(
+    code_location: str,
+    execution_timezone: str,
+    asset_selection: list[AssetsDefinition],
+    cron_schedule: Sequence[str] = ("15 0 * * *", "0 12 * * *"),
+    max_runtime_seconds: int = 900,
+) -> ScheduleDefinition:
+    """Build the twice-daily incremental contacts schedule for one district.
+
+    Both ticks target the SAME daily partition: 00:15 lands before the 01:00
+    Google Directory account sync and the 01:25 DeansList ship, and 12:00 feeds
+    the midday Focus import cycle. Neither is top-of-hour, where GKE Autopilot
+    fan-out adds 3-9 minutes of step-pod scheduling wait.
+
+    The name is deliberately unchanged from the pre-incremental schedule --
+    renaming mints a NEW Dagster+ schedule object and abandons this one's status
+    and tick history -- so "daily" now means twice a day.
+    """
+
+    @schedule(
+        name=f"{code_location}__finalsite__contacts__daily_asset_job_schedule",
+        cron_schedule=list(cron_schedule),
+        execution_timezone=execution_timezone,
+        target=asset_selection,
+    )
+    def _schedule(context: ScheduleEvaluationContext):
+        # run_key stays None: both daily ticks share a partition key, and a
+        # run_key equal to it would dedupe the second run away.
+        yield RunRequest(
+            partition_key=context.scheduled_execution_time.date().isoformat(),
+            tags={MAX_RUNTIME_SECONDS_TAG: str(max_runtime_seconds)},
+        )
+
+    return _schedule
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run pytest tests/libraries/test_finalsite_contacts_schedule.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Replace each district's schedule module**
+
+`src/teamster/code_locations/kippnewark/finalsite/schedules.py` becomes (and the
+other three are identical apart from the import path):
+
+```python
+from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kippnewark.finalsite.assets import contacts
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
+
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=[contacts],
+)
+
+schedules = [
+    finalsite_contacts_daily_asset_job_schedule,
+]
+```
+
+For `kippmiami`, this replaces the `["0 4 * * *", "0 12 * * *"]` cron. Preserve
+the substance of its existing comment by moving the midday-chain rationale into
+the call site:
+
+```python
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=[contacts],
+    # 12:00 feeds the midday Focus import cycle, firing alongside the Focus dlt
+    # pull rather than staggered behind it: they share no pool and neither gates
+    # the other. The 12:45 delivery is a plain cron with a 45-minute time
+    # budget, not a dependency -- an incremental pull uses ~1-2 min of it where
+    # the full snapshot used ~5. 00:15 replaces the old 04:00: FRESH's 05:00
+    # Tableau extract still reads a same-day pull, and the NJ consumers at 01:00
+    # and 01:25 stop reading yesterday's. See #4715.
+)
+```
+
+- [ ] **Step 6: Verify the schedules resolve**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && uv run python -c "
+for loc in ['kippnewark', 'kippcamden', 'kippmiami', 'kipppaterson']:
+    mod = __import__(f'teamster.code_locations.{loc}.finalsite.schedules', fromlist=['schedules'])
+    s = mod.schedules[0]
+    assert s.name == f'{loc}__finalsite__contacts__daily_asset_job_schedule', s.name
+    print(s.name, s.cron_schedule)
+"
+```
+
+Expected: four lines, each with the unchanged name and
+`['15 0 * * *', '0 12 * * *']`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/teamster/libraries/finalsite/api/schedules.py \
+  tests/libraries/test_finalsite_contacts_schedule.py \
+  src/teamster/code_locations/kippnewark/finalsite/schedules.py \
+  src/teamster/code_locations/kippcamden/finalsite/schedules.py \
+  src/teamster/code_locations/kippmiami/finalsite/schedules.py \
+  src/teamster/code_locations/kipppaterson/finalsite/schedules.py
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): pull contacts at 00:15 and 12:00 on a shared schedule factory
+
+The NJ consumers of stg_finalsite__contacts run at 01:00 (Google Directory
+user sync), 01:25 (DeansList) and 18:00 (ParentSquare), all ahead of the
+04:00 pull that fed them, so they shipped day-old contacts. 00:15 puts the
+pull in front of them. Drops max_runtime from 3600s to 900s.
+
+Refs #4715"
+```
+
+---
+
+### Task 4: Hive-partition the dbt external source
+
+**Files:**
+
+- Modify: `src/dbt/finalsite/models/sources-external.yml:28-40`
+
+**Interfaces:**
+
+- Consumes: the partitioned GCS layout written by Task 2's asset.
+- Produces: `source('finalsite', 'contacts')` exposing `_dagster_partition_date`
+  as a column, which Task 5 orders on.
+
+- [ ] **Step 1: Add `hive_partition_uri_prefix` to the contacts source**
+
+The `contacts` entry becomes (mirroring `status_report` twelve lines above it,
+which already uses this pattern):
+
+```yaml
+- name: contacts
+  external:
+    location: "{{ var('cloud_storage_uri_base') }}/finalsite/contacts/*"
+    options:
+      connection_name: "{{ var('bigquery_external_connection_name') }}"
+      metadata_cache_mode: MANUAL
+      max_staleness: INTERVAL 7 DAY
+      hive_partition_uri_prefix:
+        "{{ var('cloud_storage_uri_base',
+        env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/finalsite/contacts/"
+      format: AVRO
+      enable_logical_types: true
+  config:
+    meta:
+      dagster:
+        asset_key:
+          - "{{ project_name }}"
+          - finalsite
+          - contacts
+```
+
+`location` is unchanged. Only `hive_partition_uri_prefix` is added.
+
+- [ ] **Step 2: Verify the project still parses**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt parse --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark
+```
+
+Expected: parse succeeds with no error mentioning `sources-external.yml`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/dbt/finalsite/models/sources-external.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): hive-partition the contacts external source
+
+Refs #4715"
+```
+
+---
+
+### Task 5: Dedupe to one row per contact in `stg_finalsite__contacts`
+
+**Files:**
+
+- Modify: `src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql`
+- Modify:
+  `src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml`
+
+**Interfaces:**
+
+- Consumes: `_dagster_partition_date` from Task 4.
+- Produces: `stg_finalsite__contacts` at one row per `finalsite_enrollment_id`,
+  now also carrying a `relationships` column of type
+  `array<struct<id string, rel_id string, rel_name string, rel_type string, primary bool, financial bool, portal_access bool>>`,
+  which Task 6 unnests.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to `unit_tests:` in
+`src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml`.
+Two partitions of the same contact go in; the newer one wins and one row
+survives:
+
+```yaml
+- name: test_contacts_dedupe_newest_partition_wins
+  description: Accumulated partitions hold the same contact more than once. The
+    newest `_dagster_partition_date` wins and exactly one row survives per
+    contact, so the singleton grain every downstream model assumes still holds.
+    Guards the `is_primary` and address-of-record picks in #4616 / #4617 / #4680.
+  model: stg_finalsite__contacts
+  given:
+    - input: source('finalsite', 'contacts')
+      format: sql
+      rows: |
+        select
+          'con1' as id,
+          'Stale' as first_name,
+          cast(null as string) as middle_name,
+          'Doe' as last_name,
+          'Stale Doe' as full_name,
+          cast(null as string) as preferred_name,
+          'stale@example.com' as email,
+          'F' as gender,
+          'Female' as gender_display,
+          'Female' as gender_full_text,
+          'applicant' as status,
+          'new' as enrollment_type,
+          cast(null as string) as inquiry_submit_date,
+          cast(null as string) as application_submit_date,
+          cast(null as string) as contract_submit_date,
+          struct('5' as canonical_name, 'Grade 5' as name, 'ES' as school_level)
+            as grade,
+          struct('6' as canonical_name) as prospect_entry_grade,
+          struct(2025 as start_year) as school_year,
+          struct(2026 as start_year) as prospect_entry_year,
+          struct('Cell' as phone_type, '8623007240' as number) as phone_1,
+          struct(cast(null as string) as phone_type, cast(null as string) as number)
+            as phone_2,
+          struct(cast(null as string) as phone_type, cast(null as string) as number)
+            as phone_3,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as custom_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as id_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as track_attributes,
+          '2015-04-05' as birth_date,
+          [
+            struct(
+              'hh1' as id,
+              '1 Old St' as address_1,
+              cast(null as string) as address_2,
+              'Newark' as city,
+              'NJ' as state,
+              '07102' as zip,
+              'US' as country
+            )
+          ] as households,
+          array<
+            struct<
+              id string,
+              rel_id string,
+              rel_name string,
+              rel_type string,
+              `primary` bool,
+              financial bool,
+              portal_access bool
+            >
+          >[] as relationships,
+          '2026-08-10' as _dagster_partition_date
+        union all
+        select
+          'con1' as id,
+          'Fresh' as first_name,
+          cast(null as string) as middle_name,
+          'Doe' as last_name,
+          'Fresh Doe' as full_name,
+          cast(null as string) as preferred_name,
+          'fresh@example.com' as email,
+          'F' as gender,
+          'Female' as gender_display,
+          'Female' as gender_full_text,
+          'enrolled' as status,
+          'returning' as enrollment_type,
+          cast(null as string) as inquiry_submit_date,
+          cast(null as string) as application_submit_date,
+          cast(null as string) as contract_submit_date,
+          struct('6' as canonical_name, 'Grade 6' as name, 'MS' as school_level)
+            as grade,
+          struct('6' as canonical_name) as prospect_entry_grade,
+          struct(2026 as start_year) as school_year,
+          struct(2026 as start_year) as prospect_entry_year,
+          struct('Cell' as phone_type, '8623007240' as number) as phone_1,
+          struct(cast(null as string) as phone_type, cast(null as string) as number)
+            as phone_2,
+          struct(cast(null as string) as phone_type, cast(null as string) as number)
+            as phone_3,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as custom_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as id_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as track_attributes,
+          '2015-04-05' as birth_date,
+          [
+            struct(
+              'hh1' as id,
+              '2 New Ave' as address_1,
+              cast(null as string) as address_2,
+              'Newark' as city,
+              'NJ' as state,
+              '07103' as zip,
+              'US' as country
+            )
+          ] as households,
+          array<
+            struct<
+              id string,
+              rel_id string,
+              rel_name string,
+              rel_type string,
+              `primary` bool,
+              financial bool,
+              portal_access bool
+            >
+          >[] as relationships,
+          '2026-08-11' as _dagster_partition_date
+  expect:
+    format: sql
+    rows: |
+      select
+        'con1' as finalsite_enrollment_id,
+        'Fresh' as first_name,
+        'enrolled' as status,
+        'returning' as enrollment_type,
+        '2 New Ave' as address_1,
+        '07103' as zip
+```
+
+- [ ] **Step 2: Add `_dagster_partition_date` to the existing unit test
+      fixture**
+
+`test_contacts_phone_normalization` supplies an explicit column list, and the
+model is about to reference `_dagster_partition_date` in its `order_by`. Add one
+line to that fixture's `rows` block (after `] as households`, line 273):
+
+```sql
+,
+'2026-08-11' as _dagster_partition_date
+```
+
+Without this, the existing test fails to compile once Step 3 lands.
+
+- [ ] **Step 3: Run the unit tests to verify the new one fails**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt test --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark \
+       --select stg_finalsite__contacts
+```
+
+Expected: `test_contacts_dedupe_newest_partition_wins` FAILS with 2 rows
+returned where 1 was expected (the model does not dedupe yet).
+
+- [ ] **Step 4: Add the dedupe and the `relationships` passthrough**
+
+`src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql` gains a CTE
+wrapper. The existing projection is unchanged except for the added
+`relationships` column and the new `from` clause:
+
+```sql
+with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    source as (select * from {{ source("finalsite", "contacts") }}),
+
+    -- Pulls accumulate one Hive partition per pull date, and a `since` window
+    -- re-delivers a contact on every pull that covers it, so the same `id`
+    -- appears in many partitions. Keep the newest. `desc` alone is deliberate:
+    -- the macro compiles to array_agg(... limit 1) and BigQuery rejects
+    -- explicit null-ordering inside an aggregate. See #4715.
+    deduplicated as (
+        {{
+            dbt_utils.deduplicate(
+                relation="source",
+                partition_by="id",
+                order_by="_dagster_partition_date desc",
+            )
+        }}
+    )
+
+select
+    id as finalsite_enrollment_id,
+    -- ... every existing column expression, unchanged ...
+
+    -- passed through whole so stg_finalsite__contact_relationships can unnest
+    -- one deduped copy rather than re-reading the accumulated source. Same
+    -- contract-widening move `households` already carries for
+    -- int_finalsite__contacts__households.
+    relationships,
+from deduplicated
+```
+
+Change only three things in that file: wrap with the two CTEs, add
+`relationships,` to the select list, and change the final line from
+`from {{ source("finalsite", "contacts") }}` to `from deduplicated`.
+
+- [ ] **Step 5: Declare `relationships` in the enforced contract**
+
+`api/staging` is `+contract: enforced: true`, so the new column must be
+declared. Add to the `columns:` list in
+`properties/stg_finalsite__contacts.yml`, after the `households` entry:
+
+```yaml
+- name: relationships
+  data_type:
+    array<struct<id string, rel_id string, rel_name string, rel_type string,
+    `primary` bool, financial bool, portal_access bool>>
+  description:
+    Raw bidirectional relationship links for this contact, passed through whole
+    so `stg_finalsite__contact_relationships` unnests a deduped copy instead of
+    re-reading the accumulated source. `primary` is a per-record singleton and
+    is NULL, not false, when unset.
+```
+
+- [ ] **Step 6: Run the unit tests to verify both pass**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt test --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark \
+       --select stg_finalsite__contacts
+```
+
+Expected: `test_contacts_dedupe_newest_partition_wins` PASSES and
+`test_contacts_phone_normalization` still PASSES.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql \
+  src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): dedupe accumulated contacts partitions to one row per contact
+
+Refs #4715"
+```
+
+---
+
+### Task 6: Read the deduped model in `stg_finalsite__contact_relationships`
+
+**Files:**
+
+- Modify:
+  `src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql`
+- Modify:
+  `src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml`
+
+**Interfaces:**
+
+- Consumes: `stg_finalsite__contacts.relationships` and
+  `stg_finalsite__contacts.household_1_id` from Task 5.
+- Produces: `stg_finalsite__contact_relationships` at one row per (contact,
+  relationship), unchanged column set.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add a `unit_tests:` entry to
+`properties/stg_finalsite__contact_relationships.yml`. Because this model now
+reads `stg_finalsite__contacts`, the fixture mocks that ref rather than the
+source — which is exactly what proves the fan-out is gone: one contact with two
+relationships yields two rows, not two per partition.
+
+```yaml
+unit_tests:
+  - name: test_relationships_do_not_fan_out_across_partitions
+    description: One deduped contact with two relationships yields exactly two
+      rows. Reading the deduped model instead of the accumulated source is what
+      prevents the cross join multiplying each relationship by the number of
+      partitions the contact appears in. See #4715.
+    model: stg_finalsite__contact_relationships
+    given:
+      - input: ref('stg_finalsite__contacts')
+        format: sql
+        rows: |
+          select
+            'con1' as finalsite_enrollment_id,
+            'hh1' as household_1_id,
+            array<struct<field_name string, value struct<boolean_value bool>>>[]
+              as custom_attributes,
+            [
+              struct(
+                'rel1' as id,
+                'adult1' as rel_id,
+                'Ann Doe' as rel_name,
+                'mother' as rel_type,
+                true as `primary`,
+                true as financial,
+                true as portal_access
+              ),
+              struct(
+                'rel2' as id,
+                'adult2' as rel_id,
+                'Bob Doe' as rel_name,
+                'father' as rel_type,
+                cast(null as bool) as `primary`,
+                false as financial,
+                false as portal_access
+              )
+            ] as relationships
+    expect:
+      format: sql
+      rows: |
+        select
+          'con1' as finalsite_enrollment_id,
+          'rel1' as relationship_id,
+          'adult1' as rel_id,
+          'mother' as rel_type,
+          true as is_primary,
+          'hh1' as household_1_id
+        union all
+        select
+          'con1' as finalsite_enrollment_id,
+          'rel2' as relationship_id,
+          'adult2' as rel_id,
+          'father' as rel_type,
+          cast(null as bool) as is_primary,
+          'hh1' as household_1_id
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt test --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark \
+       --select stg_finalsite__contact_relationships
+```
+
+Expected: FAIL — the model still reads `source('finalsite', 'contacts')`, so the
+mocked `ref` is unused and the fixture columns do not resolve.
+
+- [ ] **Step 3: Repoint the model**
+
+Replace
+`src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql`
+in full:
+
+```sql
+select
+    finalsite_enrollment_id,
+
+    r.id as relationship_id,
+    r.rel_id,
+    r.rel_name,
+    r.rel_type,
+    r.primary as is_primary,
+    r.financial as is_financial,
+    r.portal_access as has_portal_access,
+
+    household_1_id,
+
+    -- record-owner fields carried onto the relationship grain so consumers
+    -- gating on them (e.g. the contact_2 pick) need no extra joins. These
+    -- describe the OWNING contact (`finalsite_enrollment_id`), never the
+    -- related person (`rel_id`).
+    (
+        select logical_or(ca.value.boolean_value),
+        from unnest(custom_attributes) as ca
+        where ca.field_name = 'is_parent2'
+    ) as is_parent2,
+from {{ ref("stg_finalsite__contacts") }}
+cross join unnest(relationships) as r
+```
+
+Two things changed beyond the `from`: `household_1_id` is now read from
+`stg_finalsite__contacts` instead of being re-derived as
+`c.households[safe_offset(0)].id`, and the `c.` alias is gone.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt test --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark \
+       --select stg_finalsite__contact_relationships
+```
+
+Expected: PASS, 2 rows.
+
+- [ ] **Step 5: Verify nothing downstream broke**
+
+Run:
+
+```bash
+cd /workspaces/teamster \
+  && uv run dbt build --project-dir /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts/src/dbt/kippnewark \
+       --select stg_finalsite__contacts+ --empty
+```
+
+Expected: every downstream model compiles and resolves its columns. `--empty`
+proves column resolution only, not values — the value proof is cutover step 6.
+
+- [ ] **Step 6: Lint the changed SQL and YAML**
+
+`sqlfluff` and `yamllint` fire at pre-push and in CI, not in the pre-commit
+`fmt` hook, so check them explicitly. This takes over two minutes — run it in
+the background and read the output only after it exits.
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+       src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql \
+       src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql \
+       src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml \
+       src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml \
+       src/dbt/finalsite/models/sources-external.yml </dev/null
+```
+
+Expected: `No issues`, or only `unformatted file` findings, which the commit
+hook fixes. Fix any `file:line` + rule finding before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql \
+  src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "feat(finalsite): unnest relationships from the deduped contacts model
+
+Refs #4715"
+```
+
+---
+
+### Task 7: Cutover runbook and spec correction
+
+**Files:**
+
+- Create:
+  `docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md`
+- Modify:
+  `docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md`
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: the ordered manual runbook the cutover follows.
+
+- [ ] **Step 1: Correct the spec's `since_includes_expanded` row**
+
+The Decisions table says `Dropped. Measured no-op.` but the parameter was never
+sent — all four code locations passed only `includes`. Change that cell to:
+
+```markdown
+| `since_includes_expanded` | Not adopted. Measured no-op, and it was never sent
+today. |
+```
+
+- [ ] **Step 2: Write the cutover runbook**
+
+Create the file with this content:
+
+````markdown
+# Finalsite incremental contacts: cutover runbook
+
+Refs #4715. Run these in order. Steps marked **manual** need a human — they
+touch production GCS or the Dagster+ UI.
+
+The external glob `contacts/*` matches recursively, so while both the legacy
+root object and partition files exist the table unions them and every `id`
+appears twice. That window is steps 3 to 5.
+
+## 1. Record the pre-cutover baseline (manual)
+
+```sql
+select count(*) as contacts, count(distinct id) as ids
+from `teamster-332318.kippnewark_finalsite.contacts`
+```
+
+Repeat for `kippcamden`, `kippmiami`, `kipppaterson`. Expected around 25,052
+(kippnewark) and 7,688 (kippmiami). Keep these numbers for step 6.
+
+## 2. Pause the schedules (manual, Dagster+ UI)
+
+Stop all four `<location>__finalsite__contacts__daily_asset_job_schedule`
+schedules. Do not rename them.
+
+## 3. Merge the PR and let the deploy land
+
+Confirm every `dagster-cloud-deploy / deploy` check-run reaches a terminal
+conclusion — a shared-library change redeploys every consuming location, so
+expect one same-named check per location.
+
+## 4. Seed one full partition per district (manual, Dagster+ UI)
+
+For each location, materialize `<location>/finalsite/contacts` for partition
+`2026-08-11` with run config:
+
+```yaml
+ops:
+  <location>__finalsite__contacts:
+    config:
+      full_pull: true
+```
+
+Override the run's `dagster/max_runtime` tag to `3600` for these four runs only
+— a full pull is ~20 minutes for kippnewark, well past the new 900s default.
+They serialize through the `finalsite_api` pool, so budget ~35 minutes total.
+
+Verify each run's `record_count` metadata matches step 1's baseline, and that
+its `since` metadata reads `FULL PULL`.
+
+## 5. Delete the legacy root object (manual, destructive)
+
+One per bucket. Check before deleting:
+
+```bash
+gsutil ls -l gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+gsutil rm gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/data
+```
+
+Repeat for `teamster-kippcamden`, `teamster-kippmiami`, `teamster-kipppaterson`.
+
+Confirm only partition directories remain:
+
+```bash
+gsutil ls gs://teamster-kippnewark/dagster/kippnewark/finalsite/contacts/
+```
+
+Expected: only `_dagster_partition_fiscal_year=.../` entries, no bare `data`.
+
+## 6. Rebuild and verify values
+
+Re-stage the external source and rebuild:
+
+```bash
+uv run dbt run-operation stage_external_sources \
+  --project-dir src/dbt/kippnewark --args "select: finalsite.contacts"
+uv run dbt build --project-dir src/dbt/kippnewark --select stg_finalsite__contacts+
+```
+
+Then confirm the grain and the count, with `--nouse_cache` so the results cache
+cannot mask a stale read:
+
+```sql
+select count(*) as rows, count(distinct finalsite_enrollment_id) as ids
+from `teamster-332318.kippnewark_finalsite.stg_finalsite__contacts`
+```
+
+`rows` must equal `ids`, and both must match step 1's baseline within a day of
+churn. The `unique` test on `finalsite_enrollment_id` is the automated form of
+this check.
+
+Between steps 4 and 5 expect that `unique` test to FAIL: the seed bumps the
+source's data version, the automation sensor rebuilds staging while duplicates
+exist. That ordering is deliberate — deleting the root object first would leave
+the table empty and ship empty files to DeansList, ParentSquare and Focus. A
+loud failed test beats a silent empty shipment.
+
+## 7. Resume the schedules (manual, Dagster+ UI)
+
+Start all four schedules. The next tick is 00:15 or 12:00 ET.
+
+## 8. Confirm the first incremental tick
+
+After the first 00:15 run, check its metadata: `since` should read the previous
+day's date, and `record_count` should be in the low thousands, not the tens of
+thousands. Then confirm the 01:00 Google Directory sync and 01:25 DeansList ship
+read same-day contacts.
+````
+
+- [ ] **Step 3: Lint both documents**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts \
+  && /workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+       docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md \
+       docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md </dev/null
+```
+
+Expected: `No issues`, or only `unformatted file`, which the commit hook fixes.
+The nested fences in the runbook are why its outer block is four backticks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts add \
+  docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md \
+  docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
+git -C /workspaces/teamster/.worktrees/cbini/refactor/claude-finalsite-incremental-contacts commit -m "docs(finalsite): add the incremental contacts cutover runbook
+
+Refs #4715"
+```
+
+---
+
+## Out of scope
+
+- `status_report` — SFTP, already school-year partitioned.
+- The `finalsite_api` pool limit and the shared-IP 403 (#4408).
+- Bounded retry in `_request` (#4494).
+- Un-pausing kippnewark's ParentSquare extract schedule.
+- Any full-refresh mechanism. Hard deletes leak by design; see the spec's Known
+  limitations.
+- Renaming `stg_finalsite__contact_relationships` to `int_`. Precedent
+  (`int_finalsite__contacts__households`) says a model reading a
+  contract-widened staging column belongs in `intermediate`, but renaming would
+  ripple into `kipptaf`'s `source()` references for no functional gain.

--- a/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
+++ b/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
@@ -96,7 +96,7 @@ a student entered in Finalsite by 12:00 ET is usable in Focus by 14:00 ET, via a
 | Storage shape             | Option 2a: Hive-partitioned Avro accumulate by pull date, plus dedupe in staging. Keeps the Avro asset factory and `check_avro_schema_valid`. |
 | Watermark                 | The partition key itself. No stored cursor.                                                                                                   |
 | Safety day                | Always. `since = partition_date - 1`.                                                                                                         |
-| `since_includes_expanded` | Dropped. Measured no-op.                                                                                                                      |
+| `since_includes_expanded` | Not adopted. Measured no-op, and it was never sent today — all four code locations only ever pass `includes`.                                 |
 | Full refresh              | None. Hard deletes are accepted as a known limitation, revisited only if they become a problem.                                               |
 | Dedupe location           | `stg_finalsite__contacts`.                                                                                                                    |
 | Relationships             | `stg_finalsite__contacts` carries the `relationships` array; `stg_finalsite__contact_relationships` refs it instead of the source.            |

--- a/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
+++ b/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
@@ -339,18 +339,28 @@ beats a silent empty shipment.
   today against the overwritten single object.
 - **Partition count grows without pruning.** One object per district per day. At
   BigQuery's scale this is years away from mattering, so no pruning is designed.
+- **A day where BOTH ticks fail does not self-heal.** `since` is derived from
+  the partition key, so partition `D+1` asks for `since = D` and never
+  re-requests changes made on `D-1`. One failed tick is harmless — the other
+  tick that day covers the same window — but a fully-missed day leaves that
+  window unasked, and the affected contacts hold stale values until the vendor
+  happens to touch them again. Recovery is to backfill the missing partition,
+  which requests its own `D-1` window. **Nothing currently alerts on a missing
+  partition**, so this depends on someone noticing the gap in the Dagster UI.
+  The old full-snapshot design was completely self-healing here; this is a new
+  operational trap accepted in exchange for the incremental cost saving.
 
 ## Acceptance criteria
 
-| Criterion (#4715)                                                                | How this design meets it                                                                                                             |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| A normal tick requests only changed contacts and issues far fewer requests       | 81 pages vs ~1,002 for kippnewark; 40 vs ~308 for kippmiami                                                                          |
-| A relationship-only change is picked up                                          | Confirmed by the probe: 44 relationship-signature diffs on kippnewark, 2 on kippmiami, all present without `since_includes_expanded` |
-| A changed or new contact lands with the same column values                       | Same Avro schema, same projection; verified by the pre/post row-count and value comparison in cutover step 6                         |
-| A deleted contact stops appearing within one full-refresh cycle                  | **Not met, deliberately.** No full refresh; see Known limitations                                                                    |
-| A failed run does not advance the watermark and the next run recovers            | The watermark is the partition key; a failed run writes no partition                                                                 |
-| Asset keys and dbt source names unchanged; downstream builds with no model edits | Asset key and source name unchanged; edits confined to the two staging models                                                        |
-| kippnewark's `MAX_RUNTIME_SECONDS_TAG` can be dropped or reduced                 | 3600 to 900                                                                                                                          |
+| Criterion (#4715)                                                                | How this design meets it                                                                                                                                                                               |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A normal tick requests only changed contacts and issues far fewer requests       | 81 pages vs ~1,002 for kippnewark; 40 vs ~308 for kippmiami                                                                                                                                            |
+| A relationship-only change is picked up                                          | Confirmed by the probe: 44 relationship-signature diffs on kippnewark, 2 on kippmiami, all present without `since_includes_expanded`                                                                   |
+| A changed or new contact lands with the same column values                       | Same Avro schema, same projection; verified by the pre/post row-count and value comparison in cutover step 6                                                                                           |
+| A deleted contact stops appearing within one full-refresh cycle                  | **Not met, deliberately.** No full refresh; see Known limitations                                                                                                                                      |
+| A failed run does not advance the watermark; a failed TICK recovers              | The watermark is the partition key, so a failed run writes no partition. One failed tick is covered by the other tick that day. A day where BOTH ticks fail does NOT self-heal — see Known limitations |
+| Asset keys and dbt source names unchanged; downstream builds with no model edits | Asset key and source name unchanged; edits confined to the two staging models                                                                                                                          |
+| kippnewark's `MAX_RUNTIME_SECONDS_TAG` can be dropped or reduced                 | 3600 to 900                                                                                                                                                                                            |
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
+++ b/docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md
@@ -1,0 +1,361 @@
+# Finalsite contacts: incremental pull design
+
+Refs #4715.
+
+## Problem
+
+`build_finalsite_asset` calls `finalsite.list(path="contacts")`, which walks the
+cursor to the end and writes every record as one non-partitioned GCS Avro
+object. Every tick is a full snapshot replace. The API caps `count` at 25
+records per page and pagination is sequential cursor-only, so kippnewark (~25k
+contacts) takes roughly 20 minutes and carries `MAX_RUNTIME_SECONDS_TAG: 3600`
+purely to survive its own length. All four districts share the `finalsite_api`
+pool at limit 1 (#4408), so the window is the sum across districts, not the max.
+
+The real cost is not compute. It is that freshness is capped at the pull
+cadence, and at full-snapshot prices a frequent cadence is unaffordable.
+
+## What the live API actually does
+
+Probed against kippmiami and kippnewark on 2026-08-10 with throwaway harnesses
+over the production `FinalsiteResource`. Aggregates only; no student values left
+the local checkout.
+
+| Question                                              | Answer                                                                                                                                                                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Is `since` enforced server-side?                      | Yes. `since=2999-01-01` returns 0 records. A malformed value returns HTTP 400 (`invalid since: must be in YYYY-MM-DD format`), so a bad watermark fails loudly instead of silently degrading to a full pull. |
+| Date or timestamp grain?                              | Date. A timestamp is accepted (HTTP 200) but truncated to the day. For day D, `D` / `DT00:00:00Z` / `DT23:59:59Z` returned 1033 / 1033 / 1034 while `D+1` returned 991.                                      |
+| Inclusive?                                            | Consistent with on-or-after. Not directly testable without a change timestamp on the payload, and moot once a safety day is subtracted.                                                                      |
+| Does `since_includes_expanded=true` widen the result? | No measurable effect. At `since=-1d` on kippmiami the id sets with the flag on and off are identical (1033 each, delta 0).                                                                                   |
+| `count` cap                                           | 25 confirmed. Requests for 100 and 500 both returned 25.                                                                                                                                                     |
+
+### Volume, and the over-broadness that shapes the design
+
+`since=today`, measured 2026-08-10:
+
+|                                   | kippmiami  | kippnewark   |
+| --------------------------------- | ---------- | ------------ |
+| total contacts                    | 7,688      | 25,052       |
+| returned by `since=today`         | 990 (13%)  | 2,013 (8%)   |
+| pages: incremental vs full        | 40 vs ~308 | 81 vs ~1,002 |
+| request reduction                 | ~8x        | ~12x         |
+| identical to landed snapshot      | 984 (99%)  | 1,889 (94%)  |
+| genuinely changed                 | 6          | 122          |
+| new contacts absent from snapshot | 0          | 2            |
+
+Roughly 1,000 (kippmiami) and 2,000 (kippnewark) contacts are touched
+server-side each day without any field we land actually moving. Nightly billing
+recomputation is the likely source. Tightening the window does not help: on
+kippmiami `since=today` and `since=today-1` returned 990 and 1,033 records and
+found the **same 6 changes**.
+
+Two consequences:
+
+- The request win is ~8-12x, not the order of magnitude #4715 implies. Still
+  enough to make an intraday cadence affordable and to retire kippnewark's
+  runtime override.
+- The safety day is nearly free (43 extra records, 2 extra pages on kippmiami),
+  so take it unconditionally.
+
+Caveat on the diff: `custom_attributes` / `id_attributes` / `track_attributes`
+**values** and the billing/financial amounts were excluded, because the landed
+Avro shape (`boolean_value` / `string_value` / `array_string_value`) does not
+line up with raw API json without a mapping layer. `custom_attributes` was
+compared on count only. The changed counts are a floor; the identical
+percentages are an upper bound on waste.
+
+## The freshness problem is partly a scheduling bug
+
+Tracing every NJ consumer of `stg_finalsite__contacts` to its schedule:
+
+| NJ destination                      | model                                  | runs at (ET) | contacts age                                |
+| ----------------------------------- | -------------------------------------- | ------------ | ------------------------------------------- |
+| Google Directory user create/update | `rpt_google_directory__users_import`   | 01:00        | ~21 h, yesterday's pull                     |
+| DeansList family contacts           | `rpt_deanslist__family_contacts`       | 01:25        | ~21.4 h, yesterday's pull                   |
+| ParentSquare emergency contacts     | `rpt_parentsquare__emergency_contacts` | 18:00        | ~14 h (kippnewark's schedule ships STOPPED) |
+| FRESH Dashboard (Tableau)           | `rpt_tableau__fresh_*`                 | 05:00        | ~1 h, correctly sequenced                   |
+| Finalsite contacts pull             | —                                      | 04:00        | —                                           |
+
+Three of four NJ consumers run **before** the pull that feeds them. A student
+entered in Finalsite Monday morning is pulled Tuesday 04:00 and gets a Google
+account Wednesday 01:00 — about 45 hours, of which ~21 are pure mis-ordering.
+
+Moving the pull earlier is unsafe today: four districts serializing full
+snapshots through a limit-1 pool takes up to ~46 minutes, so a 00:30 start
+finishes ~01:16 and misses the 01:00 sync outright. The incremental change is
+what makes the correct ordering fit.
+
+kippmiami additionally has a stakeholder commitment documented in its CLAUDE.md:
+a student entered in Finalsite by 12:00 ET is usable in Focus by 14:00 ET, via a
+12:45 SFTP delivery that is a plain cron with a time budget, not a dependency.
+
+## Decisions
+
+| Decision                  | Choice                                                                                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Storage shape             | Option 2a: Hive-partitioned Avro accumulate by pull date, plus dedupe in staging. Keeps the Avro asset factory and `check_avro_schema_valid`. |
+| Watermark                 | The partition key itself. No stored cursor.                                                                                                   |
+| Safety day                | Always. `since = partition_date - 1`.                                                                                                         |
+| `since_includes_expanded` | Dropped. Measured no-op.                                                                                                                      |
+| Full refresh              | None. Hard deletes are accepted as a known limitation, revisited only if they become a problem.                                               |
+| Dedupe location           | `stg_finalsite__contacts`.                                                                                                                    |
+| Relationships             | `stg_finalsite__contacts` carries the `relationships` array; `stg_finalsite__contact_relationships` refs it instead of the source.            |
+| Cadence                   | 00:15 and 12:00 ET, all four districts. No 04:00.                                                                                             |
+
+## Design
+
+### 1. Ingestion
+
+`build_finalsite_asset` gains a `partitions_def` and derives `since` from the
+partition key. The asset key stays `[{code_location}, finalsite, contacts]`.
+
+```python
+@asset(
+    key=key,
+    io_manager_key="io_manager_gcs_avro",
+    partitions_def=DailyPartitionsDefinition(start_date=CUTOVER_DATE),
+    check_specs=[build_check_spec_avro_schema_valid(key)],
+    group_name="finalsite",
+    pool="finalsite_api",
+    kinds={"python"},
+)
+def _asset(context: AssetExecutionContext, finalsite: FinalsiteResource):
+    partition_date = date.fromisoformat(context.partition_key)
+    since = partition_date - timedelta(days=1)
+
+    data = finalsite.list(
+        path=asset_name,
+        params={**(params or {}), "since": since.isoformat()},
+    )
+```
+
+Properties:
+
+- The watermark is the partition key. A missed day is a visibly missing
+  partition, backfillable with normal partition tooling. No cursor to corrupt.
+- Because the safety day makes each pull a superset of any earlier pull on the
+  same date, the 12:00 run can overwrite the 00:15 run's partition safely.
+- A failed run writes no partition, so nothing advances and nothing is skipped.
+- The seed (below) is the one run with `since` omitted, gated behind a run
+  config flag so it cannot fire accidentally.
+
+### 2. Storage and the dbt source
+
+The IO manager needs no changes. A `DailyPartitionsDefinition` key parses as
+`%Y-%m-%d` and expands to four Hive dimensions:
+
+```text
+gs://teamster-<loc>/dagster/<loc>/finalsite/contacts/
+  _dagster_partition_fiscal_year=2027/
+    _dagster_partition_date=2026-08-10/
+      _dagster_partition_hour=00/
+        _dagster_partition_minute=00/
+          data
+```
+
+`hour` and `minute` are constant `00` for a daily partition.
+
+The source gains `hive_partition_uri_prefix`, mirroring `status_report` in the
+same file:
+
+```yaml
+- name: contacts
+  external:
+    location: "{{ var('cloud_storage_uri_base') }}/finalsite/contacts/*"
+    options:
+      connection_name: "{{ var('bigquery_external_connection_name') }}"
+      metadata_cache_mode: MANUAL
+      max_staleness: INTERVAL 7 DAY
+      hive_partition_uri_prefix:
+        "{{ var('cloud_storage_uri_base',
+        env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', '')) }}/finalsite/contacts/"
+      format: AVRO
+      enable_logical_types: true
+```
+
+That exposes `_dagster_partition_date` as a pseudo-column for the dedupe to
+order on. The `location` glob is unchanged.
+
+### 3. Dedupe and the singleton invariant
+
+`stg_finalsite__contacts` becomes the single dedupe point:
+
+```sql
+with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    source as (select * from {{ source("finalsite", "contacts") }}),
+
+    deduplicated as (
+        {{
+            dbt_utils.deduplicate(
+                relation="source",
+                partition_by="id",
+                order_by="_dagster_partition_date desc",
+            )
+        }}
+    )
+
+select
+    id as finalsite_enrollment_id,
+    -- ... existing projection unchanged ...
+    relationships,
+from deduplicated
+```
+
+Rules this follows rather than invents:
+
+- `dbt_utils.deduplicate`, not `QUALIFY` and not dup-masking `SELECT DISTINCT`
+  (both banned in `src/dbt/CLAUDE.md`).
+- Bare `desc`, never `desc nulls first` — the macro compiles to
+  `array_agg(original order by ... limit 1)` and BigQuery rejects explicit
+  null-ordering inside an aggregate. Plain `desc` is NULLS LAST.
+- `partition_by="id"` matches the downstream join key
+  (`finalsite_enrollment_id`).
+
+`relationships` is added to the projection and to the enforced contract:
+
+```yaml
+- name: relationships
+  data_type:
+    array<struct<id string, rel_id string, rel_name string, rel_type string,
+    `primary` bool, financial bool, portal_access bool>>
+```
+
+`stg_finalsite__contact_relationships` then reads the deduped model:
+
+```sql
+select
+    finalsite_enrollment_id,
+    r.id as relationship_id,
+    r.rel_id,
+    r.rel_name,
+    r.rel_type,
+    r.primary as is_primary,
+    r.financial as is_financial,
+    r.portal_access as has_portal_access,
+    household_1_id,
+    (
+        select logical_or(ca.value.boolean_value),
+        from unnest(custom_attributes) as ca
+        where ca.field_name = 'is_parent2'
+    ) as is_parent2,
+from {{ ref("stg_finalsite__contacts") }}
+cross join unnest(relationships) as r
+```
+
+This also removes a re-derivation: `household_1_id` is already a column on
+`stg_finalsite__contacts`, so the relationships model stops recomputing
+`households[safe_offset(0)].id`.
+
+Without this change the `cross join unnest` would multiply each contact's
+relationships by the number of partitions it appears in.
+
+Downstream of staging nothing changes: the `int_` models, the Focus / DeansList
+/ ParentSquare feeds and FRESH need no edits.
+
+The invariant already has its guard. `stg_finalsite__contacts` carries a
+`unique` test on `finalsite_enrollment_id` and
+`stg_finalsite__contact_relationships` a
+`dbt_utils.unique_combination_of_columns`. Today they pass trivially; under this
+design they are what fails loudly if the dedupe regresses, before
+`int_finalsite__student_address_of_record` or the `is_primary` picks in #4616 /
+#4617 / #4680 see a duplicated row.
+
+### 4. Scheduling
+
+A library factory keeps all four districts on one implementation:
+
+```python
+@schedule(
+    name=f"{code_location}__finalsite__contacts__daily_asset_job_schedule",
+    cron_schedule=["15 0 * * *", "0 12 * * *"],
+    execution_timezone=str(local_timezone),
+    target=[contacts_asset],
+)
+def _schedule(context: ScheduleEvaluationContext):
+    yield RunRequest(
+        partition_key=context.scheduled_execution_time.date().isoformat(),
+        tags={MAX_RUNTIME_SECONDS_TAG: str(900)},
+    )
+```
+
+- `run_key` stays `None`. Both ticks target the same partition key; a `run_key`
+  equal to the partition key would make Dagster's idempotency swallow the 12:00
+  run.
+- The schedule name is byte-identical to today's. Renaming mints a new Dagster+
+  schedule object and abandons its status and tick history, which is why "daily"
+  stays in a name that now means twice daily.
+- `MAX_RUNTIME_SECONDS_TAG` drops 3600 to 900.
+- The `finalsite_api` pool stays at limit 1. #4408 is untouched.
+- 00:15 rather than 00:30 leaves ~30 minutes of margin before the 01:00 account
+  sync, and both avoid top-of-hour, where GKE Autopilot fan-out adds 3-9 minutes
+  of step-pod scheduling wait.
+
+## Cutover
+
+The external glob `contacts/*` matches recursively, so while both the legacy
+root object and partition files exist the table unions them and every `id`
+appears twice.
+
+1. Pause the four contacts schedules in Dagster+ (manual, UI).
+1. Merge the PR; let the deploy land.
+1. Seed each district: one manual materialization with the full-pull flag,
+   roughly 35 minutes serialized through the pool.
+1. Delete the legacy `.../finalsite/contacts/data` object in each of the four
+   buckets (manual, `gsutil`).
+1. Run `stage_external_sources` plus a metadata cache refresh, then rebuild
+   staging and downstream.
+1. Verify row counts against the pre-cutover baseline: kippmiami 7,688,
+   kippnewark 25,052.
+1. Resume the schedules at 00:15 and 12:00.
+
+Expect a transient test failure between steps 3 and 4: the seed bumps the
+source's data version, the automation sensor rebuilds staging while duplicates
+exist, and the `unique` test fails. That ordering is deliberate. Deleting the
+root object first would leave the table empty, and staging would build 0 rows
+and ship empty files to DeansList, ParentSquare and Focus. A loud failed test
+beats a silent empty shipment.
+
+## Known limitations
+
+- **Hard deletes leak.** Latest-per-`id` dedupe never forgets a contact whose
+  record vanishes from Finalsite: its last-seen partition stays newest for that
+  `id`. Scope exits (withdrawn, graduated) are unaffected because they are
+  status updates, not deletions. Observed rate: kippmiami `record_count` ran
+  7,679 to 7,691 to 7,688 across consecutive pulls, so a few a day. Accepted
+  deliberately; revisit only if it becomes a problem.
+- **Schema heterogeneity is now a recurring chore.** When Avro files with
+  different schemas coexist under one external table, a query scanning both
+  resolves a single reader schema and drops the newer field for the whole scan;
+  the column reads NULL everywhere and no cache refresh fixes it. Because
+  staging scans full partition history, every future field added to
+  `CONTACTS_SCHEMA` requires re-encoding the entire history with
+  `scripts/reencode_avro_partitions.py`. Today, with one object replaced whole,
+  a schema addition heals on the next pull.
+- **The #4151 metadata-cache race is inherited, not introduced.**
+  `refresh_external_metadata_cache` returning DONE does not mean queryable-fresh
+  (lag seconds to hours, non-monotonic), so the 00:15 to 01:00 chain carries a
+  tail risk that scheduling margin cannot fully close. The same race exists
+  today against the overwritten single object.
+- **Partition count grows without pruning.** One object per district per day. At
+  BigQuery's scale this is years away from mattering, so no pruning is designed.
+
+## Acceptance criteria
+
+| Criterion (#4715)                                                                | How this design meets it                                                                                                             |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| A normal tick requests only changed contacts and issues far fewer requests       | 81 pages vs ~1,002 for kippnewark; 40 vs ~308 for kippmiami                                                                          |
+| A relationship-only change is picked up                                          | Confirmed by the probe: 44 relationship-signature diffs on kippnewark, 2 on kippmiami, all present without `since_includes_expanded` |
+| A changed or new contact lands with the same column values                       | Same Avro schema, same projection; verified by the pre/post row-count and value comparison in cutover step 6                         |
+| A deleted contact stops appearing within one full-refresh cycle                  | **Not met, deliberately.** No full refresh; see Known limitations                                                                    |
+| A failed run does not advance the watermark and the next run recovers            | The watermark is the partition key; a failed run writes no partition                                                                 |
+| Asset keys and dbt source names unchanged; downstream builds with no model edits | Asset key and source name unchanged; edits confined to the two staging models                                                        |
+| kippnewark's `MAX_RUNTIME_SECONDS_TAG` can be dropped or reduced                 | 3600 to 900                                                                                                                          |
+
+## Out of scope
+
+- `status_report`. It arrives by SFTP and is already school-year partitioned.
+- The `finalsite_api` pool limit and the shared-IP 403 (#4408).
+- Bounded retry in `_request` (#4494).
+- Un-pausing kippnewark's ParentSquare extract schedule, which ships STOPPED for
+  reasons unrelated to contacts freshness.

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contact_relationships.yml
@@ -61,3 +61,66 @@ models:
           student has a Parent 2"); null when the field is unset. A record-owner
           field carried onto the relationship grain — it never describes the
           related person (`rel_id`).
+
+unit_tests:
+  - name: test_relationships_do_not_fan_out_across_partitions
+    description: One deduped contact with two relationships yields exactly two
+      rows. Reading the deduped model instead of the accumulated source is what
+      prevents the cross join multiplying each relationship by the number of
+      partitions the contact appears in. See #4715.
+    model: stg_finalsite__contact_relationships
+    given:
+      - input: ref('stg_finalsite__contacts')
+        format: sql
+        rows: |
+          select
+            'con1' as finalsite_enrollment_id,
+            'hh1' as household_1_id,
+            array<struct<field_name string, value struct<boolean_value bool>>>[]
+              as custom_attributes,
+            [
+              struct(
+                'rel1' as id,
+                'adult1' as rel_id,
+                'Ann Doe' as rel_name,
+                'mother' as rel_type,
+                true as `primary`,
+                true as financial,
+                true as portal_access
+              ),
+              struct(
+                'rel2' as id,
+                'adult2' as rel_id,
+                'Bob Doe' as rel_name,
+                'father' as rel_type,
+                cast(null as bool) as `primary`,
+                false as financial,
+                false as portal_access
+              )
+            ] as relationships
+    expect:
+      format: sql
+      rows: |
+        select
+          'con1' as finalsite_enrollment_id,
+          'rel1' as relationship_id,
+          'adult1' as rel_id,
+          'Ann Doe' as rel_name,
+          'mother' as rel_type,
+          true as is_primary,
+          true as is_financial,
+          true as has_portal_access,
+          'hh1' as household_1_id,
+          cast(null as bool) as is_parent2
+        union all
+        select
+          'con1' as finalsite_enrollment_id,
+          'rel2' as relationship_id,
+          'adult2' as rel_id,
+          'Bob Doe' as rel_name,
+          'father' as rel_type,
+          cast(null as bool) as is_primary,
+          false as is_financial,
+          false as has_portal_access,
+          'hh1' as household_1_id,
+          cast(null as bool) as is_parent2

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -118,7 +118,12 @@ models:
         description:
           Repeated key-value custom fields; `value` is a typed union struct
           (boolean / string / string-array). Passed through whole for downstream
-          pivoting.
+          pivoting. Tagged PII because the field set is open-ended and carries
+          indirect identifiers (housing status, race, program flags) alongside
+          benign values — the array cannot be assumed non-sensitive.
+        config:
+          meta:
+            contains_pii: true
       - name: id_attributes
         data_type:
           array<struct<field_id string, field_name string, field_display_name
@@ -126,7 +131,12 @@ models:
           array_string_value array<string>>>>
         description:
           Repeated identifier fields (e.g. minted student number) in the same
-          key-value shape as `custom_attributes`. Passed through whole.
+          key-value shape as `custom_attributes`. Passed through whole. Tagged
+          PII because it carries student and contact identifiers — direct
+          identifiers under FERPA.
+        config:
+          meta:
+            contains_pii: true
       - name: track_attributes
         data_type:
           array<struct<field_id string, field_name string, field_display_name
@@ -147,7 +157,12 @@ models:
           model's scalar `address_*` columns are this array's first element
           only; `int_finalsite__contacts__households` flattens every element per
           contact, with the same blank-to-null and state-uppercasing
-          normalization applied downstream.
+          normalization applied downstream. Tagged PII because it carries raw
+          street address, city and zip — direct identifiers under FERPA, and the
+          same values this model's scalar `address_*` columns already tag.
+        config:
+          meta:
+            contains_pii: true
       - name: birth_date
         data_type: date
         description: Contact's date of birth, cast from the source string.
@@ -212,7 +227,12 @@ models:
           Raw bidirectional relationship links for this contact, passed through
           whole so `stg_finalsite__contact_relationships` unnests a deduped copy
           instead of re-reading the accumulated source. `primary` is a
-          per-record singleton and is NULL, not false, when unset.
+          per-record singleton and is NULL, not false, when unset. Tagged PII
+          because `rel_name` is a person's name — a direct identifier under
+          FERPA.
+        config:
+          meta:
+            contains_pii: true
 
 unit_tests:
   - name: test_contacts_phone_normalization

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -204,6 +204,15 @@ models:
       - name: country
         data_type: string
         description: Country of the primary household address.
+      - name: relationships
+        data_type:
+          array<struct<id string, rel_id string, rel_name string, rel_type
+          string, `primary` bool, financial bool, portal_access bool>>
+        description:
+          Raw bidirectional relationship links for this contact, passed through
+          whole so `stg_finalsite__contact_relationships` unnests a deduped copy
+          instead of re-reading the accumulated source. `primary` is a
+          per-record singleton and is NULL, not false, when unset.
 
 unit_tests:
   - name: test_contacts_phone_normalization
@@ -270,7 +279,19 @@ unit_tests:
                 '33101' as zip,
                 'US' as country
               )
-            ] as households
+            ] as households,
+            array<
+              struct<
+                id string,
+                rel_id string,
+                rel_name string,
+                rel_type string,
+                `primary` bool,
+                financial bool,
+                portal_access bool
+              >
+            >[] as relationships,
+            '2026-08-11' as _dagster_partition_date
     expect:
       format: sql
       rows: |
@@ -327,4 +348,207 @@ unit_tests:
           ['hh1'] as household_ids,
           '+18623007240' as phone_1_number,
           '+19292255670' as phone_2_number,
-          'no phone' as phone_3_number
+          'no phone' as phone_3_number,
+          array<
+            struct<
+              id string,
+              rel_id string,
+              rel_name string,
+              rel_type string,
+              `primary` bool,
+              financial bool,
+              portal_access bool
+            >
+          >[] as relationships
+
+  - name: test_contacts_dedupe_newest_partition_wins
+    description: Accumulated partitions hold the same contact more than once.
+      The newest `_dagster_partition_date` wins and exactly one row survives per
+      contact, so the singleton grain every downstream model assumes still
+      holds. Guards the `is_primary` and address-of-record picks in #4616 / #4617 / #4680.
+    model: stg_finalsite__contacts
+    given:
+      - input: source('finalsite', 'contacts')
+        format: sql
+        rows: |
+          select
+            'con1' as id,
+            'Stale' as first_name,
+            cast(null as string) as middle_name,
+            'Doe' as last_name,
+            'Stale Doe' as full_name,
+            cast(null as string) as preferred_name,
+            'stale@example.com' as email,
+            'F' as gender,
+            'Female' as gender_display,
+            'Female' as gender_full_text,
+            'applicant' as status,
+            'new' as enrollment_type,
+            cast(null as string) as inquiry_submit_date,
+            cast(null as string) as application_submit_date,
+            cast(null as string) as contract_submit_date,
+            struct('5' as canonical_name, 'Grade 5' as name, 'ES' as school_level)
+              as grade,
+            struct('6' as canonical_name) as prospect_entry_grade,
+            struct(2025 as start_year) as school_year,
+            struct(2026 as start_year) as prospect_entry_year,
+            struct('Cell' as phone_type, '8623007240' as number) as phone_1,
+            struct(cast(null as string) as phone_type, cast(null as string) as number)
+              as phone_2,
+            struct(cast(null as string) as phone_type, cast(null as string) as number)
+              as phone_3,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as custom_attributes,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as id_attributes,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as track_attributes,
+            '2015-04-05' as birth_date,
+            [
+              struct(
+                'hh1' as id,
+                '1 Old St' as address_1,
+                cast(null as string) as address_2,
+                'Newark' as city,
+                'NJ' as state,
+                '07102' as zip,
+                'US' as country
+              )
+            ] as households,
+            array<
+              struct<
+                id string,
+                rel_id string,
+                rel_name string,
+                rel_type string,
+                `primary` bool,
+                financial bool,
+                portal_access bool
+              >
+            >[] as relationships,
+            '2026-08-10' as _dagster_partition_date
+          union all
+          select
+            'con1' as id,
+            'Fresh' as first_name,
+            cast(null as string) as middle_name,
+            'Doe' as last_name,
+            'Fresh Doe' as full_name,
+            cast(null as string) as preferred_name,
+            'fresh@example.com' as email,
+            'F' as gender,
+            'Female' as gender_display,
+            'Female' as gender_full_text,
+            'enrolled' as status,
+            'returning' as enrollment_type,
+            cast(null as string) as inquiry_submit_date,
+            cast(null as string) as application_submit_date,
+            cast(null as string) as contract_submit_date,
+            struct('6' as canonical_name, 'Grade 6' as name, 'MS' as school_level)
+              as grade,
+            struct('6' as canonical_name) as prospect_entry_grade,
+            struct(2026 as start_year) as school_year,
+            struct(2026 as start_year) as prospect_entry_year,
+            struct('Cell' as phone_type, '8623007240' as number) as phone_1,
+            struct(cast(null as string) as phone_type, cast(null as string) as number)
+              as phone_2,
+            struct(cast(null as string) as phone_type, cast(null as string) as number)
+              as phone_3,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as custom_attributes,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as id_attributes,
+            array<struct<field_name string, value struct<string_value string>>>[]
+              as track_attributes,
+            '2015-04-05' as birth_date,
+            [
+              struct(
+                'hh1' as id,
+                '2 New Ave' as address_1,
+                cast(null as string) as address_2,
+                'Newark' as city,
+                'NJ' as state,
+                '07103' as zip,
+                'US' as country
+              )
+            ] as households,
+            array<
+              struct<
+                id string,
+                rel_id string,
+                rel_name string,
+                rel_type string,
+                `primary` bool,
+                financial bool,
+                portal_access bool
+              >
+            >[] as relationships,
+            '2026-08-11' as _dagster_partition_date
+    expect:
+      format: sql
+      rows: |
+        select
+          'con1' as finalsite_enrollment_id,
+          'Fresh' as first_name,
+          cast(null as string) as middle_name,
+          'Doe' as last_name,
+          'Fresh Doe' as full_name,
+          cast(null as string) as preferred_name,
+          'fresh@example.com' as email,
+          'F' as gender,
+          'Female' as gender_display,
+          'Female' as gender_full_text,
+          'enrolled' as status,
+          'returning' as enrollment_type,
+          cast(null as string) as inquiry_submit_date,
+          cast(null as string) as application_submit_date,
+          cast(null as string) as contract_submit_date,
+          '6' as grade_canonical_name,
+          'Grade 6' as grade_name,
+          'MS' as grade_school_level,
+          '6' as prospect_entry_grade_canonical_name,
+          2026 as school_year_start,
+          2026 as prospect_entry_year_start,
+          'Cell' as phone_1_type,
+          cast(null as string) as phone_2_type,
+          cast(null as string) as phone_3_type,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as custom_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as id_attributes,
+          array<struct<field_name string, value struct<string_value string>>>[]
+            as track_attributes,
+          [
+            struct(
+              'hh1' as id,
+              '2 New Ave' as address_1,
+              cast(null as string) as address_2,
+              'Newark' as city,
+              'NJ' as state,
+              '07103' as zip,
+              'US' as country
+            )
+          ] as households,
+          cast('2015-04-05' as date) as birth_date,
+          'hh1' as household_1_id,
+          '2 New Ave' as address_1,
+          cast(null as string) as address_2,
+          'Newark' as city,
+          'NJ' as state,
+          '07103' as zip,
+          'US' as country,
+          ['hh1'] as household_ids,
+          '+18623007240' as phone_1_number,
+          cast(null as string) as phone_2_number,
+          cast(null as string) as phone_3_number,
+          array<
+            struct<
+              id string,
+              rel_id string,
+              rel_name string,
+              rel_type string,
+              `primary` bool,
+              financial bool,
+              portal_access bool
+            >
+          >[] as relationships

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contact_relationships.sql
@@ -1,5 +1,5 @@
 select
-    c.id as finalsite_enrollment_id,
+    finalsite_enrollment_id,
 
     r.id as relationship_id,
     r.rel_id,
@@ -9,7 +9,7 @@ select
     r.financial as is_financial,
     r.portal_access as has_portal_access,
 
-    c.households[safe_offset(0)].id as household_1_id,
+    household_1_id,
 
     -- record-owner fields carried onto the relationship grain so consumers
     -- gating on them (e.g. the contact_2 pick) need no extra joins. These
@@ -17,8 +17,8 @@ select
     -- related person (`rel_id`).
     (
         select logical_or(ca.value.boolean_value),
-        from unnest(c.custom_attributes) as ca
+        from unnest(custom_attributes) as ca
         where ca.field_name = 'is_parent2'
     ) as is_parent2,
-from {{ source("finalsite", "contacts") }} as c
-cross join unnest(c.relationships) as r
+from {{ ref("stg_finalsite__contacts") }}
+cross join unnest(relationships) as r

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -1,7 +1,4 @@
 with
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    source as (select *, from {{ source("finalsite", "contacts") }}),
-
     -- Pulls accumulate one Hive partition per pull date, and a `since` window
     -- re-delivers a contact on every pull that covers it, so the same `id`
     -- appears in many partitions. Keep the newest. `desc` alone is deliberate:
@@ -10,7 +7,7 @@ with
     deduplicated as (
         {{
             dbt_utils.deduplicate(
-                relation="source",
+                relation=source("finalsite", "contacts"),
                 partition_by="id",
                 order_by="_dagster_partition_date desc",
             )
@@ -52,6 +49,12 @@ select
     track_attributes,
     households,
 
+    -- passed through whole so stg_finalsite__contact_relationships can unnest
+    -- one deduped copy rather than re-reading the accumulated source. Same
+    -- contract-widening move `households` already carries for
+    -- int_finalsite__contacts__households.
+    relationships,
+
     safe_cast(birth_date as date) as birth_date,
 
     households[safe_offset(0)].id as household_1_id,
@@ -78,10 +81,4 @@ select
     {{ clean_phone("phone_1.number") }} as phone_1_number,
     {{ clean_phone("phone_2.number") }} as phone_2_number,
     {{ clean_phone("phone_3.number") }} as phone_3_number,
-
-    -- passed through whole so stg_finalsite__contact_relationships can unnest
-    -- one deduped copy rather than re-reading the accumulated source. Same
-    -- contract-widening move `households` already carries for
-    -- int_finalsite__contacts__households.
-    relationships,
 from deduplicated

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -1,3 +1,22 @@
+with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    source as (select * from {{ source("finalsite", "contacts") }}),
+
+    -- Pulls accumulate one Hive partition per pull date, and a `since` window
+    -- re-delivers a contact on every pull that covers it, so the same `id`
+    -- appears in many partitions. Keep the newest. `desc` alone is deliberate:
+    -- the macro compiles to array_agg(... limit 1) and BigQuery rejects
+    -- explicit null-ordering inside an aggregate. See #4715.
+    deduplicated as (
+        {{
+            dbt_utils.deduplicate(
+                relation="source",
+                partition_by="id",
+                order_by="_dagster_partition_date desc",
+            )
+        }}
+    )
+
 select
     id as finalsite_enrollment_id,
     first_name,
@@ -59,4 +78,10 @@ select
     {{ clean_phone("phone_1.number") }} as phone_1_number,
     {{ clean_phone("phone_2.number") }} as phone_2_number,
     {{ clean_phone("phone_3.number") }} as phone_3_number,
-from {{ source("finalsite", "contacts") }}
+
+    -- passed through whole so stg_finalsite__contact_relationships can unnest
+    -- one deduped copy rather than re-reading the accumulated source. Same
+    -- contract-widening move `households` already carries for
+    -- int_finalsite__contacts__households.
+    relationships,
+from deduplicated

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -1,6 +1,6 @@
 with
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    source as (select * from {{ source("finalsite", "contacts") }}),
+    source as (select *, from {{ source("finalsite", "contacts") }}),
 
     -- Pulls accumulate one Hive partition per pull date, and a `since` window
     -- re-delivers a contact on every pull that covers it, so the same `id`

--- a/src/dbt/finalsite/models/sources-external.yml
+++ b/src/dbt/finalsite/models/sources-external.yml
@@ -33,6 +33,10 @@ sources:
             connection_name: "{{ var('bigquery_external_connection_name') }}"
             metadata_cache_mode: MANUAL
             max_staleness: INTERVAL 7 DAY
+            hive_partition_uri_prefix:
+              "{{ var('cloud_storage_uri_base',
+              env_var('DBT_DEV_CLOUD_STORAGE_URI_BASE', ''))
+              }}/finalsite/contacts/"
             format: AVRO
             enable_logical_types: true
         config:

--- a/src/teamster/code_locations/kippcamden/CLAUDE.md
+++ b/src/teamster/code_locations/kippcamden/CLAUDE.md
@@ -17,7 +17,7 @@ GCS bucket: `teamster-kippcamden`
 | `powerschool` | dlt assets        | sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh) |
 | `deanslist`   | API assets        | schedule (nightly)                                                    |
 | `edplan`      | SFTP asset        | sensor (`build_edplan_sftp_sensor`)                                   |
-| `finalsite`   | API + SFTP assets | schedule (`contacts`, 4am) + sensor (`status_report`)                 |
+| `finalsite`   | API + SFTP assets | schedule (`contacts`, 00:15 + 12:00 ET) + sensor (`status_report`)    |
 | `overgrad`    | API assets        | schedule                                                              |
 | `pearson`     | SFTP assets       | `AutomationConditionSensor`                                           |
 | `titan`       | SFTP assets       | sensor (`build_titan_sftp_sensor`)                                    |

--- a/src/teamster/code_locations/kippcamden/finalsite/assets.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/assets.py
@@ -1,4 +1,10 @@
-from teamster.code_locations.kippcamden import CODE_LOCATION, CURRENT_FISCAL_YEAR
+from dagster import DailyPartitionsDefinition
+
+from teamster.code_locations.kippcamden import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
 from teamster.code_locations.kippcamden.finalsite.schema import (
     CONTACTS_SCHEMA,
     STATUS_REPORT_SCHEMA,
@@ -29,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+    ),
 )
 
 assets = [

--- a/src/teamster/code_locations/kippcamden/finalsite/assets.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/assets.py
@@ -35,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    # One partition per pull date. The partition key is the incremental
+    # watermark (see get_finalsite_since); start_date is the cutover date, so
+    # Dagster shows no backlog of partitions that predate the migration.
     partitions_def=DailyPartitionsDefinition(
         start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
     ),

--- a/src/teamster/code_locations/kippcamden/finalsite/assets.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/assets.py
@@ -38,8 +38,11 @@ contacts = build_finalsite_asset(
     # One partition per pull date. The partition key is the incremental
     # watermark (see get_finalsite_since); start_date is the cutover date, so
     # Dagster shows no backlog of partitions that predate the migration.
+    # end_offset=1 is required: without it the current day's partition does
+    # not exist until the following day, so a schedule targeting today's key
+    # fails with DagsterUnknownPartitionError.
     partitions_def=DailyPartitionsDefinition(
-        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE), end_offset=1
     ),
 )
 

--- a/src/teamster/code_locations/kippcamden/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippcamden/finalsite/schedules.py
@@ -1,16 +1,13 @@
-from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition
-
 from teamster.code_locations.kippcamden import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kippcamden.finalsite.assets import contacts
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
 
-finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    cron_schedule="0 4 * * *",
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=[f"{CODE_LOCATION}/finalsite/contacts"],
-    # Covers a full sequential pull plus GKE step-pod scheduling wait. The
-    # finalsite_api pool (limit 1) serializes districts; a waiting run stays
-    # QUEUED, so queue wait does not burn this clock. See #4408.
-    tags={MAX_RUNTIME_SECONDS_TAG: str(3600)},
+    asset_selection=[contacts],
 )
 
 schedules = [

--- a/src/teamster/code_locations/kippmiami/CLAUDE.md
+++ b/src/teamster/code_locations/kippmiami/CLAUDE.md
@@ -15,7 +15,7 @@ GCS bucket: `teamster-kippmiami`
 | ----------- | ------------- | ------------------------------------------------------- |
 | `dbt`       | dbt assets    | `AutomationConditionSensor`                             |
 | `deanslist` | API assets    | schedule (nightly)                                      |
-| `finalsite` | API + SFTP    | schedule (contacts 04:00 + 12:00 ET) + couchdrop sensor |
+| `finalsite` | API + SFTP    | schedule (contacts 00:15 + 12:00 ET) + couchdrop sensor |
 | `fldoe`     | SFTP assets   | `AutomationConditionSensor`                             |
 | `iready`    | SFTP assets   | sensor (`build_iready_sftp_sensor`)                     |
 | `renlearn`  | SFTP assets   | sensor (`build_renlearn_sftp_sensor`)                   |
@@ -64,9 +64,13 @@ Three constraints to preserve when touching any of these times:
   14:00 sits ON the 2pm commitment rather than after it, so a late import lands
   after that snapshot — the safe rule is a dependency ("a sync has run since the
   last import"), never a clock time, and 04:00 is what makes the next day safe.
-- **Keep the 04:00 runs.** Miami is Focus-sourced network-wide, and FRESH's
-  Tableau extract refreshes at 05:00 — moving the only pull to midday leaves
-  every morning dashboard on day-old Miami data.
+- **Keep the dlt Focus 04:00 snapshot.** It is the overnight backstop for the
+  `rpt_focus__*` import-once anti-join described above — the `contacts` API pull
+  moving off 04:00 doesn't change that. The `contacts` pull itself now runs at
+  00:15, not 04:00: that still lands before FRESH's 05:00 Tableau extract, so
+  Miami's morning dashboard reads same-day data, and it additionally puts
+  `contacts` ahead of the NJ consumers of `stg_finalsite__contacts` at 01:00
+  (Google Directory user sync) and 01:25 (DeansList). See #4715.
 
 `kippmiami__extracts__focus__asset_job_schedule` also has to be STARTED in the
 Dagster+ UI; its `defaultStatus` is STOPPED and it had never run in prod as of

--- a/src/teamster/code_locations/kippmiami/finalsite/assets.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/assets.py
@@ -1,4 +1,10 @@
-from teamster.code_locations.kippmiami import CODE_LOCATION, CURRENT_FISCAL_YEAR
+from dagster import DailyPartitionsDefinition
+
+from teamster.code_locations.kippmiami import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
 from teamster.code_locations.kippmiami.finalsite.schema import (
     CONTACTS_SCHEMA,
     STATUS_REPORT_SCHEMA,
@@ -29,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+    ),
 )
 
 assets = [

--- a/src/teamster/code_locations/kippmiami/finalsite/assets.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/assets.py
@@ -35,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    # One partition per pull date. The partition key is the incremental
+    # watermark (see get_finalsite_since); start_date is the cutover date, so
+    # Dagster shows no backlog of partitions that predate the migration.
     partitions_def=DailyPartitionsDefinition(
         start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
     ),

--- a/src/teamster/code_locations/kippmiami/finalsite/assets.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/assets.py
@@ -38,8 +38,11 @@ contacts = build_finalsite_asset(
     # One partition per pull date. The partition key is the incremental
     # watermark (see get_finalsite_since); start_date is the cutover date, so
     # Dagster shows no backlog of partitions that predate the migration.
+    # end_offset=1 is required: without it the current day's partition does
+    # not exist until the following day, so a schedule targeting today's key
+    # fails with DagsterUnknownPartitionError.
     partitions_def=DailyPartitionsDefinition(
-        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE), end_offset=1
     ),
 )
 

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -1,31 +1,20 @@
-from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition
-
 from teamster.code_locations.kippmiami import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kippmiami.finalsite.assets import contacts
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
 
-finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
-    # "daily" is now twice a day. The name is kept as-is on purpose -- renaming
-    # mints a NEW Dagster+ schedule object and abandons this one's status and
-    # tick history.
-    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    # 04:00 stays for the overnight refresh every other Finalsite consumer reads.
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
+    execution_timezone=str(LOCAL_TIMEZONE),
+    asset_selection=[contacts],
     # 12:00 feeds the midday Focus import cycle, firing alongside the Focus dlt
     # pull rather than staggered behind it: they share no pool and neither gates
-    # the other (this API pull and the manually-pushed SFTP drop feed opposite
-    # sides of int_finalsite__enrollment_lifecycle; the dlt pull feeds the
-    # import-once anti-join). Top-of-hour GKE Autopilot fan-out can add 3-9 min of
-    # step-pod scheduling wait, which only queues the run -- against 45 min before
-    # the 12:45 delivery that is noise, and the 3600s max_runtime below absorbs it.
-    #
-    # Miami is the only district on a midday tick, so the finalsite_api pool
-    # (limit 1) is uncontended then -- at 04:00 the four districts serialize and
-    # Miami has waited up to 46 minutes for a slot.
-    cron_schedule=["0 4 * * *", "0 12 * * *"],
-    execution_timezone=str(LOCAL_TIMEZONE),
-    target=[f"{CODE_LOCATION}/finalsite/contacts"],
-    # Covers a full sequential pull plus GKE step-pod scheduling wait. The
-    # finalsite_api pool (limit 1) serializes districts; a waiting run stays
-    # QUEUED, so queue wait does not burn this clock. See #4408.
-    tags={MAX_RUNTIME_SECONDS_TAG: str(3600)},
+    # the other. The 12:45 delivery is a plain cron with a 45-minute time
+    # budget, not a dependency -- an incremental pull uses ~1-2 min of it where
+    # the full snapshot used ~5. 00:15 replaces the old 04:00: FRESH's 05:00
+    # Tableau extract still reads a same-day pull, and the NJ consumers at 01:00
+    # and 01:25 stop reading yesterday's. See #4715.
 )
 
 schedules = [

--- a/src/teamster/code_locations/kippmiami/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippmiami/finalsite/schedules.py
@@ -15,6 +15,12 @@ finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
     # the full snapshot used ~5. 00:15 replaces the old 04:00: FRESH's 05:00
     # Tableau extract still reads a same-day pull, and the NJ consumers at 01:00
     # and 01:25 stop reading yesterday's. See #4715.
+    #
+    # Miami used to be the ONLY district on a midday tick, so the finalsite_api
+    # pool (limit 1) was uncontended at 12:00. All four now share it. That is
+    # still comfortably inside the budget: four INCREMENTAL pulls serialized is
+    # ~6 min against the 45 min before the 12:45 delivery, where four full
+    # snapshots would have been ~46 min and blown it.
 )
 
 schedules = [

--- a/src/teamster/code_locations/kippnewark/CLAUDE.md
+++ b/src/teamster/code_locations/kippnewark/CLAUDE.md
@@ -18,7 +18,7 @@ GCS bucket: `teamster-kippnewark`
 | `amplify` (mclass sftp) | SFTP assets   | sensor (`build_amplify_mclass_sftp_sensor`)                           |
 | `deanslist`             | API assets    | schedule (nightly)                                                    |
 | `edplan`                | SFTP asset    | sensor (`build_edplan_sftp_sensor`)                                   |
-| `finalsite`             | API + SFTP    | schedule (contacts 4am) + couchdrop sensor                            |
+| `finalsite`             | API + SFTP    | schedule (contacts 00:15 + 12:00 ET) + couchdrop sensor               |
 | `iready`                | SFTP assets   | sensor (`build_iready_sftp_sensor`)                                   |
 | `overgrad`              | API assets    | schedule                                                              |
 | `pearson`               | SFTP assets   | `AutomationConditionSensor`                                           |

--- a/src/teamster/code_locations/kippnewark/finalsite/assets.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/assets.py
@@ -36,8 +36,11 @@ contacts = build_finalsite_asset(
     # One partition per pull date. The partition key is the incremental
     # watermark (see get_finalsite_since); start_date is the cutover date, so
     # Dagster shows no backlog of partitions that predate the migration.
+    # end_offset=1 is required: without it the current day's partition does
+    # not exist until the following day, so a schedule targeting today's key
+    # fails with DagsterUnknownPartitionError.
     partitions_def=DailyPartitionsDefinition(
-        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE), end_offset=1
     ),
 )
 

--- a/src/teamster/code_locations/kippnewark/finalsite/assets.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/assets.py
@@ -1,4 +1,10 @@
-from teamster.code_locations.kippnewark import CODE_LOCATION, CURRENT_FISCAL_YEAR
+from dagster import DailyPartitionsDefinition
+
+from teamster.code_locations.kippnewark import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
 from teamster.code_locations.kippnewark.finalsite.schema import (
     CONTACTS_SCHEMA,
     STATUS_REPORT_SCHEMA,
@@ -27,6 +33,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+    ),
 )
 
 assets = [

--- a/src/teamster/code_locations/kippnewark/finalsite/assets.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/assets.py
@@ -33,6 +33,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    # One partition per pull date. The partition key is the incremental
+    # watermark (see get_finalsite_since); start_date is the cutover date, so
+    # Dagster shows no backlog of partitions that predate the migration.
     partitions_def=DailyPartitionsDefinition(
         start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
     ),

--- a/src/teamster/code_locations/kippnewark/finalsite/schedules.py
+++ b/src/teamster/code_locations/kippnewark/finalsite/schedules.py
@@ -1,18 +1,13 @@
-from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition
-
 from teamster.code_locations.kippnewark import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kippnewark.finalsite.assets import contacts
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
 
-finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    cron_schedule="0 4 * * *",
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=[f"{CODE_LOCATION}/finalsite/contacts"],
-    # kippnewark (largest district, ~24k contacts) pulls sequentially at ~1 req/s
-    # for ~20 min; adding GKE step-pod scheduling wait brushes the ~30 min default.
-    # The finalsite_api pool (limit 1) serializes districts, but with run blocking
-    # a waiting run stays QUEUED (not STARTED), so queue wait does not burn this
-    # clock. 1h covers the pull plus scheduling with margin. See #4408.
-    tags={MAX_RUNTIME_SECONDS_TAG: str(3600)},
+    asset_selection=[contacts],
 )
 
 schedules = [

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -17,7 +17,7 @@ GCS bucket: `teamster-kipppaterson`
 | `powerschool` (sis/dlt) | dlt assets (Oracle→BigQuery) | sensor (intraday probe, 15-min) + schedule (nightly 2am full-refresh) |
 | `amplify` (mclass sftp) | SFTP assets                  | sensor (`build_amplify_mclass_sftp_sensor`)                           |
 | `deanslist`             | API assets                   | schedule (nightly)                                                    |
-| `finalsite`             | API + SFTP assets            | schedule (`contacts`, 4am) + sensor (`status_report`)                 |
+| `finalsite`             | API + SFTP assets            | schedule (`contacts`, 00:15 + 12:00 ET) + sensor (`status_report`)    |
 | `pearson`               | SFTP assets                  | `AutomationConditionSensor`                                           |
 | `extracts`              | BigQuery→SFTP                | schedule (3am)                                                        |
 | `couchdrop`             | sensor only                  | sensor (Google Drive watcher, Finalsite only)                         |

--- a/src/teamster/code_locations/kipppaterson/finalsite/assets.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/assets.py
@@ -1,4 +1,10 @@
-from teamster.code_locations.kipppaterson import CODE_LOCATION, CURRENT_FISCAL_YEAR
+from dagster import DailyPartitionsDefinition
+
+from teamster.code_locations.kipppaterson import (
+    CODE_LOCATION,
+    CURRENT_FISCAL_YEAR,
+    LOCAL_TIMEZONE,
+)
 from teamster.code_locations.kipppaterson.finalsite.schema import (
     CONTACTS_SCHEMA,
     STATUS_REPORT_SCHEMA,
@@ -29,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+    ),
 )
 
 assets = [

--- a/src/teamster/code_locations/kipppaterson/finalsite/assets.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/assets.py
@@ -35,6 +35,9 @@ contacts = build_finalsite_asset(
     asset_name="contacts",
     schema=CONTACTS_SCHEMA,
     params={"includes": "contacts.relationships"},
+    # One partition per pull date. The partition key is the incremental
+    # watermark (see get_finalsite_since); start_date is the cutover date, so
+    # Dagster shows no backlog of partitions that predate the migration.
     partitions_def=DailyPartitionsDefinition(
         start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
     ),

--- a/src/teamster/code_locations/kipppaterson/finalsite/assets.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/assets.py
@@ -38,8 +38,11 @@ contacts = build_finalsite_asset(
     # One partition per pull date. The partition key is the incremental
     # watermark (see get_finalsite_since); start_date is the cutover date, so
     # Dagster shows no backlog of partitions that predate the migration.
+    # end_offset=1 is required: without it the current day's partition does
+    # not exist until the following day, so a schedule targeting today's key
+    # fails with DagsterUnknownPartitionError.
     partitions_def=DailyPartitionsDefinition(
-        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE)
+        start_date="2026-08-11", timezone=str(LOCAL_TIMEZONE), end_offset=1
     ),
 )
 

--- a/src/teamster/code_locations/kipppaterson/finalsite/schedules.py
+++ b/src/teamster/code_locations/kipppaterson/finalsite/schedules.py
@@ -1,16 +1,13 @@
-from dagster import MAX_RUNTIME_SECONDS_TAG, ScheduleDefinition
-
 from teamster.code_locations.kipppaterson import CODE_LOCATION, LOCAL_TIMEZONE
+from teamster.code_locations.kipppaterson.finalsite.assets import contacts
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
 
-finalsite_contacts_daily_asset_job_schedule = ScheduleDefinition(
-    name=f"{CODE_LOCATION}__finalsite__contacts__daily_asset_job_schedule",
-    cron_schedule="0 4 * * *",
+finalsite_contacts_daily_asset_job_schedule = build_finalsite_contacts_schedule(
+    code_location=CODE_LOCATION,
     execution_timezone=str(LOCAL_TIMEZONE),
-    target=[f"{CODE_LOCATION}/finalsite/contacts"],
-    # Covers a full sequential pull plus GKE step-pod scheduling wait. The
-    # finalsite_api pool (limit 1) serializes districts; a waiting run stays
-    # QUEUED, so queue wait does not burn this clock. See #4408.
-    tags={MAX_RUNTIME_SECONDS_TAG: str(3600)},
+    asset_selection=[contacts],
 )
 
 schedules = [

--- a/src/teamster/libraries/finalsite/CLAUDE.md
+++ b/src/teamster/libraries/finalsite/CLAUDE.md
@@ -7,18 +7,22 @@ Two ingestion paths for **Finalsite** (school website/communications platform):
 
 ## `api/`
 
-**`assets.py`** (`build_finalsite_asset()`): Non-partitioned GCS Avro asset.
-Calls `finalsite.list(path=asset_name)` to fetch all records.
+**`assets.py`** (`build_finalsite_asset()`): Partitioned GCS Avro asset
+(`DailyPartitionsDefinition`, `start_date="2026-08-11"`) — derives the API
+`since` parameter from the partition key, so each tick pulls only records
+changed since the prior partition rather than the full `finalsite.list`
+response.
 
 **Concurrency (do NOT parallelize).** All districts' `contacts` schedules fire
-at `0 4 * * *` ET simultaneously. The Finalsite gateway throttles by shared
-egress IP and returns a bare nginx `403` (not `429`) under concurrent pulls,
-despite separate subdomains/credentials — so `build_finalsite_asset` puts every
-district's op in one shared `finalsite_api` pool (limit **1**, set in Dagster+
-Deployment then Concurrency; the `pool=` kwarg alone does nothing until the
-limit is configured). `_request` also retries `403` and transient network
-faults. Pagination is sequential cursor-only (~1 req/s, 25/page); kippnewark
-(~24k contacts) is ~20 min.
+at `00:15` and `12:00` ET simultaneously. The Finalsite gateway throttles by
+shared egress IP and returns a bare nginx `403` (not `429`) under concurrent
+pulls, despite separate subdomains/credentials — so `build_finalsite_asset` puts
+every district's op in one shared `finalsite_api` pool (limit **1**, set in
+Dagster+ Deployment then Concurrency; the `pool=` kwarg alone does nothing until
+the limit is configured). `_request` also retries `403` and transient network
+faults. Pagination is sequential cursor-only (~1 req/s, 25/page): a full/seed
+pull for kippnewark (~24k contacts) is ~20 min, but an incremental tick is ~81
+pages (~1-2 min).
 
 **`resources.py`** (`FinalsiteResource`): REST client with pagination support.
 

--- a/src/teamster/libraries/finalsite/api/assets.py
+++ b/src/teamster/libraries/finalsite/api/assets.py
@@ -1,4 +1,6 @@
-from dagster import AssetExecutionContext, Output, asset
+from datetime import date, timedelta
+
+from dagster import AssetExecutionContext, Config, Output, asset
 
 from teamster.core.asset_checks import (
     build_check_spec_avro_schema_valid,
@@ -7,15 +9,43 @@ from teamster.core.asset_checks import (
 from teamster.libraries.finalsite.api.resources import FinalsiteResource
 
 
+def get_finalsite_since(partition_key: str) -> str:
+    """Return the `since` date for a pull, one day before the partition date.
+
+    The API's `since` is date-grained, so the finest possible increment is one
+    day. Subtracting a safety day means a run that straddles midnight or hits a
+    vendor clock skew cannot drop records, and it makes every pull on a given
+    date a superset of any earlier pull on that date — which is what lets the
+    midday run overwrite the overnight run's partition safely. Measured cost on
+    kippmiami: 43 extra records, 2 extra pages.
+    """
+    return (date.fromisoformat(partition_key) - timedelta(days=1)).isoformat()
+
+
+class FinalsiteContactsConfig(Config):
+    """Run config for a contacts pull.
+
+    `full_pull` omits `since` entirely, pulling every contact. Used once per
+    district to seed the first partition; a `since` pull alone would leave
+    staging holding only contacts that changed after go-live.
+    """
+
+    full_pull: bool = False
+
+
 def build_finalsite_asset(
-    code_location: str, asset_name: str, schema, params: dict | None = None
+    code_location: str,
+    asset_name: str,
+    schema,
+    params: dict | None = None,
+    partitions_def=None,
 ):
     key = [code_location, "finalsite", asset_name]
 
     @asset(
         key=key,
         io_manager_key="io_manager_gcs_avro",
-        # partitions_def=partitions_def,
+        partitions_def=partitions_def,
         check_specs=[build_check_spec_avro_schema_valid(key)],
         group_name="finalsite",
         # One shared pool across ALL districts (not per-location): the Finalsite
@@ -25,10 +55,28 @@ def build_finalsite_asset(
         pool="finalsite_api",
         kinds={"python"},
     )
-    def _asset(context: AssetExecutionContext, finalsite: FinalsiteResource):
-        data = finalsite.list(path=asset_name, params=params or {})
+    def _asset(
+        context: AssetExecutionContext,
+        finalsite: FinalsiteResource,
+        config: FinalsiteContactsConfig,
+    ):
+        request_params = {**(params or {})}
 
-        yield Output(value=(data, schema), metadata={"record_count": len(data)})
+        # A partitioned asset pulls incrementally: the partition key IS the
+        # watermark, so a failed run writes no partition and advances nothing.
+        # `full_pull` is the seed escape hatch.
+        if partitions_def is not None and not config.full_pull:
+            request_params["since"] = get_finalsite_since(context.partition_key)
+
+        data = finalsite.list(path=asset_name, params=request_params)
+
+        yield Output(
+            value=(data, schema),
+            metadata={
+                "record_count": len(data),
+                "since": request_params.get("since", "FULL PULL"),
+            },
+        )
         yield check_avro_schema_valid(
             asset_key=context.asset_key, records=data, schema=schema
         )

--- a/src/teamster/libraries/finalsite/api/assets.py
+++ b/src/teamster/libraries/finalsite/api/assets.py
@@ -1,6 +1,12 @@
 from datetime import date, timedelta
 
-from dagster import AssetExecutionContext, Config, Output, asset
+from dagster import (
+    AssetExecutionContext,
+    Config,
+    Output,
+    PartitionsDefinition,
+    asset,
+)
 
 from teamster.core.asset_checks import (
     build_check_spec_avro_schema_valid,
@@ -22,6 +28,31 @@ def get_finalsite_since(partition_key: str) -> str:
     return (date.fromisoformat(partition_key) - timedelta(days=1)).isoformat()
 
 
+def build_contacts_request_params(
+    params: dict | None, partition_key: str | None, full_pull: bool
+) -> dict:
+    """Build the query params for one contacts pull.
+
+    Three cases, in the order they are decided:
+
+    - `full_pull` omits `since` entirely, pulling every contact. This is the seed
+      run each district performs once at cutover.
+    - A partitioned run derives `since` from its own partition key, so the
+      partition key is the watermark.
+    - An unpartitioned asset has no partition key and therefore pulls in full.
+
+    Never mutates `params` — it is captured once at asset-definition time and
+    reused on every invocation, so writing `since` into it would leak the first
+    run's watermark into every later run.
+    """
+    request_params = {**(params or {})}
+
+    if partition_key is not None and not full_pull:
+        request_params["since"] = get_finalsite_since(partition_key)
+
+    return request_params
+
+
 class FinalsiteContactsConfig(Config):
     """Run config for a contacts pull.
 
@@ -38,7 +69,7 @@ def build_finalsite_asset(
     asset_name: str,
     schema,
     params: dict | None = None,
-    partitions_def=None,
+    partitions_def: PartitionsDefinition | None = None,
 ):
     key = [code_location, "finalsite", asset_name]
 
@@ -60,13 +91,17 @@ def build_finalsite_asset(
         finalsite: FinalsiteResource,
         config: FinalsiteContactsConfig,
     ):
-        request_params = {**(params or {})}
-
         # A partitioned asset pulls incrementally: the partition key IS the
         # watermark, so a failed run writes no partition and advances nothing.
-        # `full_pull` is the seed escape hatch.
-        if partitions_def is not None and not config.full_pull:
-            request_params["since"] = get_finalsite_since(context.partition_key)
+        # `full_pull` is the seed escape hatch. `context.partition_key` raises on
+        # an unpartitioned asset, so it is only read when there is a partition.
+        request_params = build_contacts_request_params(
+            params=params,
+            partition_key=(
+                context.partition_key if partitions_def is not None else None
+            ),
+            full_pull=config.full_pull,
+        )
 
         data = finalsite.list(path=asset_name, params=request_params)
 

--- a/src/teamster/libraries/finalsite/api/schedules.py
+++ b/src/teamster/libraries/finalsite/api/schedules.py
@@ -1,0 +1,46 @@
+from collections.abc import Sequence
+
+from dagster import (
+    MAX_RUNTIME_SECONDS_TAG,
+    AssetsDefinition,
+    RunRequest,
+    ScheduleDefinition,
+    ScheduleEvaluationContext,
+    schedule,
+)
+
+
+def build_finalsite_contacts_schedule(
+    code_location: str,
+    execution_timezone: str,
+    asset_selection: list[AssetsDefinition],
+    cron_schedule: Sequence[str] = ("15 0 * * *", "0 12 * * *"),
+    max_runtime_seconds: int = 900,
+) -> ScheduleDefinition:
+    """Build the twice-daily incremental contacts schedule for one district.
+
+    Both ticks target the SAME daily partition: 00:15 lands before the 01:00
+    Google Directory account sync and the 01:25 DeansList ship, and 12:00 feeds
+    the midday Focus import cycle. Neither is top-of-hour, where GKE Autopilot
+    fan-out adds 3-9 minutes of step-pod scheduling wait.
+
+    The name is deliberately unchanged from the pre-incremental schedule --
+    renaming mints a NEW Dagster+ schedule object and abandons this one's status
+    and tick history -- so "daily" now means twice a day.
+    """
+
+    @schedule(
+        name=f"{code_location}__finalsite__contacts__daily_asset_job_schedule",
+        cron_schedule=list(cron_schedule),
+        execution_timezone=execution_timezone,
+        target=asset_selection,
+    )
+    def _schedule(context: ScheduleEvaluationContext):
+        # run_key stays None: both daily ticks share a partition key, and a
+        # run_key equal to it would dedupe the second run away.
+        yield RunRequest(
+            partition_key=context.scheduled_execution_time.date().isoformat(),
+            tags={MAX_RUNTIME_SECONDS_TAG: str(max_runtime_seconds)},
+        )
+
+    return _schedule

--- a/tests/libraries/test_finalsite_contacts_partitions.py
+++ b/tests/libraries/test_finalsite_contacts_partitions.py
@@ -1,0 +1,50 @@
+"""Guards the production partitioning of the Finalsite contacts asset.
+
+`test_finalsite_contacts_schedule.py` proves the schedule yields the right
+`RunRequest` for a correctly-configured asset, but it does so against a local
+fixture asset carrying its own `partitions_def` — so it cannot catch a
+misconfigured PRODUCTION asset. These tests read the real per-district assets.
+
+The regression they exist for: `DailyPartitionsDefinition` defaults to
+`end_offset=0`, which only exposes partitions whose window has CLOSED. The
+schedule targets the CURRENT day's key, so without `end_offset=1` every tick
+fails with `DagsterUnknownPartitionError` in all four districts.
+"""
+
+import pytest
+from dagster import DailyPartitionsDefinition
+from dagster_shared import check
+
+CODE_LOCATIONS = ["kippnewark", "kippcamden", "kippmiami", "kipppaterson"]
+
+
+def _contacts_partitions_def(code_location: str) -> DailyPartitionsDefinition:
+    module = __import__(
+        f"teamster.code_locations.{code_location}.finalsite.assets",
+        fromlist=["contacts"],
+    )
+
+    return check.inst(module.contacts.partitions_def, DailyPartitionsDefinition)
+
+
+@pytest.mark.parametrize("code_location", CODE_LOCATIONS)
+def test_contacts_exposes_the_current_day_partition(code_location: str):
+    """The schedule targets today's key, so today's partition must be valid.
+
+    `end_offset=1` is what makes the in-flight day addressable. This asserts the
+    property the schedule depends on rather than the flag that implements it.
+    """
+    partitions_def = _contacts_partitions_def(code_location)
+
+    assert partitions_def.end_offset == 1
+
+
+@pytest.mark.parametrize("code_location", CODE_LOCATIONS)
+def test_contacts_asset_key_is_unchanged(code_location: str):
+    """The dbt source and every downstream consumer key off this exact path."""
+    module = __import__(
+        f"teamster.code_locations.{code_location}.finalsite.assets",
+        fromlist=["contacts"],
+    )
+
+    assert module.contacts.key.to_user_string() == f"{code_location}/finalsite/contacts"

--- a/tests/libraries/test_finalsite_contacts_schedule.py
+++ b/tests/libraries/test_finalsite_contacts_schedule.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 from dagster import (
     DagsterInstance,
     DailyPartitionsDefinition,
+    Definitions,
     asset,
     build_schedule_context,
 )
@@ -17,8 +18,12 @@ TIMEZONE = "America/New_York"
 
 @asset(
     key=["test", "finalsite", "contacts"],
+    # end_offset=1 mirrors the production partitions_def (see the four
+    # code-location finalsite/assets.py files) -- without it today's partition
+    # doesn't exist until tomorrow, and this fixture would not reproduce the
+    # DagsterUnknownPartitionError the production defect actually raised.
     partitions_def=DailyPartitionsDefinition(
-        start_date="2026-08-01", timezone=TIMEZONE
+        start_date="2026-08-01", timezone=TIMEZONE, end_offset=1
     ),
 )
 def _contacts() -> None: ...
@@ -31,14 +36,17 @@ def _run_requests_at(hour: int, minute: int):
         asset_selection=[_contacts],
     )
 
+    defs = Definitions(assets=[_contacts], schedules=[schedule])
+
     context = build_schedule_context(
         instance=DagsterInstance.ephemeral(),
         scheduled_execution_time=datetime(
             2026, 8, 11, hour, minute, tzinfo=ZoneInfo(TIMEZONE)
         ),
+        repository_def=defs.get_repository_def(),
     )
 
-    return list(schedule(context=context))
+    return list(schedule.evaluate_tick(context).run_requests or [])
 
 
 def test_overnight_tick_targets_todays_partition():

--- a/tests/libraries/test_finalsite_contacts_schedule.py
+++ b/tests/libraries/test_finalsite_contacts_schedule.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from dagster import (
+    DagsterInstance,
+    DailyPartitionsDefinition,
+    asset,
+    build_schedule_context,
+)
+
+from teamster.libraries.finalsite.api.schedules import (
+    build_finalsite_contacts_schedule,
+)
+
+TIMEZONE = "America/New_York"
+
+
+@asset(
+    key=["test", "finalsite", "contacts"],
+    partitions_def=DailyPartitionsDefinition(
+        start_date="2026-08-01", timezone=TIMEZONE
+    ),
+)
+def _contacts() -> None: ...
+
+
+def _run_requests_at(hour: int, minute: int):
+    schedule = build_finalsite_contacts_schedule(
+        code_location="test",
+        execution_timezone=TIMEZONE,
+        asset_selection=[_contacts],
+    )
+
+    context = build_schedule_context(
+        instance=DagsterInstance.ephemeral(),
+        scheduled_execution_time=datetime(
+            2026, 8, 11, hour, minute, tzinfo=ZoneInfo(TIMEZONE)
+        ),
+    )
+
+    return list(schedule(context=context))
+
+
+def test_overnight_tick_targets_todays_partition():
+    run_requests = _run_requests_at(hour=0, minute=15)
+
+    assert len(run_requests) == 1
+    assert run_requests[0].partition_key == "2026-08-11"
+
+
+def test_midday_tick_targets_the_same_partition():
+    run_requests = _run_requests_at(hour=12, minute=0)
+
+    assert len(run_requests) == 1
+    assert run_requests[0].partition_key == "2026-08-11"
+
+
+def test_run_key_is_none_so_the_second_daily_tick_is_not_deduplicated():
+    # Both ticks target the same partition key. A run_key equal to the partition
+    # key would make Dagster's idempotency silently swallow the 12:00 run.
+    assert _run_requests_at(hour=0, minute=15)[0].run_key is None
+
+
+def test_max_runtime_tag_is_bounded_for_an_incremental_pull():
+    tags = _run_requests_at(hour=0, minute=15)[0].tags
+
+    assert tags["dagster/max_runtime"] == "900"
+
+
+def test_schedule_name_matches_the_existing_dagster_plus_object():
+    schedule = build_finalsite_contacts_schedule(
+        code_location="test",
+        execution_timezone=TIMEZONE,
+        asset_selection=[_contacts],
+    )
+
+    assert schedule.name == "test__finalsite__contacts__daily_asset_job_schedule"

--- a/tests/libraries/test_finalsite_contacts_since.py
+++ b/tests/libraries/test_finalsite_contacts_since.py
@@ -1,0 +1,13 @@
+from teamster.libraries.finalsite.api.assets import get_finalsite_since
+
+
+def test_since_subtracts_the_safety_day():
+    assert get_finalsite_since("2026-08-11") == "2026-08-10"
+
+
+def test_since_crosses_a_month_boundary():
+    assert get_finalsite_since("2026-08-01") == "2026-07-31"
+
+
+def test_since_crosses_a_year_boundary():
+    assert get_finalsite_since("2026-01-01") == "2025-12-31"

--- a/tests/libraries/test_finalsite_contacts_since.py
+++ b/tests/libraries/test_finalsite_contacts_since.py
@@ -1,4 +1,9 @@
-from teamster.libraries.finalsite.api.assets import get_finalsite_since
+from teamster.libraries.finalsite.api.assets import (
+    build_contacts_request_params,
+    get_finalsite_since,
+)
+
+INCLUDES = {"includes": "contacts.relationships"}
 
 
 def test_since_subtracts_the_safety_day():
@@ -11,3 +16,48 @@ def test_since_crosses_a_month_boundary():
 
 def test_since_crosses_a_year_boundary():
     assert get_finalsite_since("2026-01-01") == "2025-12-31"
+
+
+def test_incremental_run_sends_the_safety_day_since():
+    assert build_contacts_request_params(
+        params=INCLUDES, partition_key="2026-08-11", full_pull=False
+    ) == {"includes": "contacts.relationships", "since": "2026-08-10"}
+
+
+def test_full_pull_omits_since_entirely():
+    """The seed path each district runs once at cutover.
+
+    Sending `since` here would land only the contacts changed since the previous
+    day, leaving staging without the ~25k-row base every later incremental
+    partition is deduped against.
+    """
+    assert build_contacts_request_params(
+        params=INCLUDES, partition_key="2026-08-11", full_pull=True
+    ) == {"includes": "contacts.relationships"}
+
+
+def test_unpartitioned_asset_pulls_in_full():
+    assert build_contacts_request_params(
+        params=INCLUDES, partition_key=None, full_pull=False
+    ) == {"includes": "contacts.relationships"}
+
+
+def test_caller_params_are_never_mutated():
+    """`params` is captured once at asset-definition time and reused every run.
+
+    Writing `since` into it would leak the first run's watermark into every
+    later run of the same asset.
+    """
+    params = dict(INCLUDES)
+
+    build_contacts_request_params(
+        params=params, partition_key="2026-08-11", full_pull=False
+    )
+
+    assert params == INCLUDES
+
+
+def test_missing_params_is_tolerated():
+    assert build_contacts_request_params(
+        params=None, partition_key="2026-08-11", full_pull=False
+    ) == {"since": "2026-08-10"}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make the Finalsite `contacts` pull
incremental and move it ahead of the consumers that read it.

The asset becomes daily-partitioned and derives the vendor API's `since`
parameter from its own partition key (`partition_date - 1`), so the partition key
IS the watermark — no stored cursor, and a failed run writes no partition and
advances nothing. Each pull writes its own Hive partition instead of replacing
one GCS object, `stg_finalsite__contacts` dedupes to the newest partition per
contact `id`, and `stg_finalsite__contact_relationships` reads that deduped model
instead of the raw source. The schedule moves from 04:00 (kippmiami: 04:00 +
12:00) to **00:15 + 12:00** for all four districts, and
`MAX_RUNTIME_SECONDS_TAG` drops from 3600 to 900.

Two things came out of investigating this that changed the shape of the work:

**1. The freshness problem was partly a scheduling bug.** Three of the four NJ
consumers of `stg_finalsite__contacts` were running *before* the 04:00 pull that
fed them, so they shipped day-old contacts:

| NJ destination                      | model                                  | runs at (ET) |
| ----------------------------------- | -------------------------------------- | ------------ |
| Google Directory user create/update | `rpt_google_directory__users_import`   | 01:00        |
| DeansList family contacts           | `rpt_deanslist__family_contacts`       | 01:25        |
| ParentSquare emergency contacts     | `rpt_parentsquare__emergency_contacts` | 18:00        |
| FRESH Dashboard (Tableau)            | `rpt_tableau__fresh_*`                 | 05:00        |

A student entered in Finalsite Monday morning was pulled Tuesday 04:00 and got a
Google account Wednesday 01:00 — about 45 hours, of which ~21 were pure
mis-ordering. Moving the pull earlier was unsafe at full-snapshot cost (four
districts serialized through the limit-1 `finalsite_api` pool is up to ~46 min,
so a 00:30 start would have missed the 01:00 sync). The incremental change is
what makes the correct ordering fit.

**2. `since` is far more over-broad than the issue assumed.** Probed live against
kippmiami and kippnewark: it is server-enforced and date-grained (a timestamp is
accepted but truncated to the day; a malformed value 400s), `count` is hard-capped
at 25, and `since_includes_expanded` is a measured no-op so it is not adopted.
Volume, measured for `since=today`:

|                                   | kippmiami  | kippnewark   |
| --------------------------------- | ---------- | ------------ |
| total contacts                    | 7,688      | 25,052       |
| returned by `since=today`         | 990 (13%)  | 2,013 (8%)   |
| pages: incremental vs full        | 40 vs ~308 | 81 vs ~1,002 |
| identical to landed snapshot      | 984 (99%)  | 1,889 (94%)  |
| genuinely changed                 | 6          | 122          |

So the request win is roughly **8-12x**, not the order of magnitude #4715
implies. Still enough to make the intraday cadence affordable and to retire
kippnewark's runtime override, but worth having on record.

Design and rollout documents are in this PR:

- `docs/superpowers/specs/2026-08-10-finalsite-incremental-contacts-design.md`
- `docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts.md`
- `docs/superpowers/plans/2026-08-10-finalsite-incremental-contacts-cutover.md`

### Deliberate limitations

- **No full refresh, so hard deletes leak.** Latest-per-`id` dedupe never forgets
  a contact whose record vanishes from Finalsite. Scope exits (withdrawn,
  graduated) are unaffected — they are status updates. Observed rate is a few a
  day. Accepted; revisit if it becomes a problem.
- **A future `CONTACTS_SCHEMA` field addition needs the partition history
  re-encoded** (`scripts/reencode_avro_partitions.py`), because staging now scans
  full partition history and a mixed-schema scan drops the new column.
- **A day where BOTH ticks fail does not self-heal** — partition `D+1` asks for
  `since = D` and never re-requests the `D-1` window. Nothing alerts on a missing
  partition today; the cutover runbook adds an ongoing watch step.

### dbt Cloud CI is red — triaged, and NOT caused by this PR

Corrected after triaging the actual run (70403220458583). An earlier version of
this section predicted CI would fail on `stg_finalsite__contacts` with
`Unrecognized name: _dagster_partition_date`. **That prediction was wrong.**

Two tests fail, both pre-existing and data-driven:

| Failing test                                                | Evidence it is pre-existing                                                                                                                                                                              |
| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `unique_fct_student_attendance_streaks_student_attendance_streak_key` | The PROD table has the same 5 duplicate keys today. Attendance streaks are unrelated to Finalsite.                                                                                               |
| `dbt_utils_unique_combination_of_columns_rpt_parentsquare__parents_student_id__first_name__last_name` | Prod's own `int_students__contacts` has the same 3 duplicate groups today. Prod's `rpt_parentsquare__parents` reads 0 only because that materialization predates the drift — it will fail on its next prod rebuild. |

That second one is worth someone's attention on its own merits, independent of
this PR: it is a latent failure sitting in prod data.

**This CI job also does not build the `finalsite` package models at all.** The
PR's CI datasets contain no `*_finalsite` schema, so `stg_finalsite__contacts`
and `stg_finalsite__contact_relationships` were never built here. dbt Cloud CI
therefore does not validate this PR's dbt changes in either direction — a green
run would not have proven them correct.

What remains true, and is the real constraint on merging:

1. Production's `finalsite.contacts` external table has zero
   `_dagster_partition_*` columns until the cutover re-stages it (verified via
   `INFORMATION_SCHEMA`: `status_report` has 1, `contacts` has 0). After merge,
   PROD's `stg_finalsite__contacts` fails to build with
   `Unrecognized name: _dagster_partition_date`, blocking everything downstream
   until cutover step 6.
1. **Schedule the merge and the cutover together** — do not merge and walk away.
1. The dbt half's real validation is cutover steps 6 and 7, not CI.

Rollback: revert this PR. Nothing is destroyed by the code alone; the only
irreversible step is the legacy-object deletion in cutover step 5, which happens
after merge and is gated on verifying the seed landed.

## AI Assistance

Claude Code authored the implementation, the spec, the plan and the runbook, and
ran the live-API probe. Human-directed: the storage-shape decision (option 2a,
Hive-partitioned Avro accumulate rather than dlt merge), keeping Avro at all, the
no-full-refresh call, putting the dedupe in `stg_finalsite__contacts` and
carrying the `relationships` array to satisfy it, the 00:15 + 12:00 cadence with
04:00 dropped, shipping as one PR with red CI accepted, and keeping the one-day
safety window with a docs-only fix for the both-ticks-fail gap.

Executed via `superpowers:subagent-driven-development`: a fresh implementer per
task with a spec-plus-quality review between each, then a whole-branch review on
Opus and one scoped re-review of its fix wave. That final review caught a
Critical defect — `DailyPartitionsDefinition` defaults to `end_offset=0`, so
today's partition did not exist and every tick in all four districts would have
raised `DagsterUnknownPartitionError`, writing no partition at all. Fixed, and
`tests/libraries/test_finalsite_contacts_partitions.py` now reads the four real
per-district assets so a regression fails a test (verified: removing
`end_offset` from kippnewark fails with `assert 0 == 1` for that district alone).

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster

- [ ] `uv run dagster definitions validate` — **not run.** It needs the dbt
      manifest and full credentials; kippmiami's `definitions` additionally fails
      to load in a codespace on the unrelated Focus dlt credential spec. Verified
      instead: each of the four `finalsite.assets` submodules imports, each
      `contacts` asset resolves to a `DailyPartitionsDefinition` with
      `end_offset=1`, and each asset key is unchanged at
      `{code_location}/finalsite/contacts`. Please run this in a full
      environment before merging.
- [ ] `uv run pytest tests/test_dagster_definitions.py` — **not run**, same
      reason.
- [x] Follows the Library + Config pattern: the new schedule factory lives in
      `src/teamster/libraries/finalsite/api/schedules.py` and each code location
      calls it. Asset keys and the Avro IO manager are unchanged.

### dbt

- [x] No new models, so no new properties file is required. The two changed
      staging models keep their existing properties YAML, and the new
      `relationships` column is declared in the enforced contract.
- [x] No new exposure — no new dashboard, analysis or application consumer.
- [x] **Not a breaking change.** `stg_finalsite__contacts` gains a column
      (`relationships`); nothing is renamed, removed or retyped. Its output
      column set is otherwise identical, and
      `stg_finalsite__contact_relationships` keeps its exact column set, so
      downstream `int_` models and every feed need no edits.
- [ ] `stage_external_sources --target staging` — **not run, deliberately.** The
      GCS data is not Hive-partitioned until the cutover seeds it, so staging the
      source now would point the CI table at a prefix holding only the legacy
      root object. This is the reason for the red-CI callout above; the re-stage
      happens in cutover step 6.

### Docs

- [ ] `uv run scripts/gen-automations-doc.py` — **not run, and must not be run
      from a codespace.** The script silently skips code locations that fail to
      import, which would drop them from the catalog. `docs/reference/automations.md`
      is stale for the four contacts schedules (still shows 04:00) and needs
      regenerating in a full environment.
- [x] Updated the affected `CLAUDE.md` files: `libraries/finalsite/` (the asset
      is now partitioned, schedules fire at 00:15 and 12:00, incremental vs full
      pull timings) and all four code locations' integration tables. kippmiami's
      midday-Focus-chain constraints were rewritten to separate the dlt Focus
      04:00 snapshot, which stays, from the contacts pull, which moved.

## CI checks

- [ ] **Trunk** — `trunk check --force` was clean on every changed file locally,
      and the pre-push hook passed.
- [x] **dbt Cloud** — FAILS on two pre-existing, data-driven test failures
      unrelated to this PR, triaged with evidence in the section above. CI does
      not build the finalsite package models, so it neither validates nor
      invalidates this PR's dbt changes.
- [x] **Dagster Cloud** — kippnewark and kippcamden deployed green. kippmiami's
      first attempt failed with
      `DagsterUserCodeUnreachableError: ... Connection refused` on the code
      server — a transient GKE pod-startup failure, not a definitions error (no
      import traceback, and the identical change deployed fine on the other
      locations). Re-run as attempt 2.

## Verification performed

```text
16/16 pytest   tests/libraries/test_finalsite_contacts_{partitions,schedule,since}.py
 2/2  dbt unit stg_finalsite__contacts (dedupe newest-partition-wins, phone normalization)
 1/1  dbt unit stg_finalsite__contact_relationships (no partition fan-out)
      trunk check --force clean on all changed files
```

Not yet verified, and only verifiable at cutover: that the external table reads
the partitioned Avro at runtime, and that the real downstream consumers
(`int_finalsite__student_contacts`, `int_finalsite__student_address_of_record`,
and the two `stg_finalsite__contact_relationships` singular tests) build against
it. Cutover steps 6 and 7 cover both, and step 7 gates resuming the schedules on
them passing.

Refs #4715
