### PR TITLE
perf(dbt): materialize the assessment star by recording its FKs as metadata

### DIFF
--- a/docs/reference/marts-data-models.md
+++ b/docs/reference/marts-data-models.md
@@ -386,8 +386,8 @@ erDiagram
 
 ```mermaid
 erDiagram
-  fct_survey_responses }o--|| fct_survey_submissions : "survey_submission_key"
   fct_survey_responses }o--|| dim_survey_questions : "survey_question_key"
+  fct_survey_responses }o--|| fct_survey_submissions : "survey_submission_key"
   fct_survey_submissions }o--|| dim_survey_administrations : "survey_administration_key"
   fct_survey_submissions }o--|| dim_staff : "staff_key"
   fct_survey_submissions }o--|| dim_student_enrollments : "student_enrollment_key"

--- a/scripts/generate_marts_reference.py
+++ b/scripts/generate_marts_reference.py
@@ -101,10 +101,14 @@ def parse_fk_edges(yaml_path: Path) -> list[FkEdge]:
     model-level edges (in constraint order, then column order within each
     constraint).  Non-foreign-key constraints are ignored in both locations.
 
-    FK edges come only from literal ``foreign_key`` constraints — never inferred
-    from ``relationships`` data tests.  Every mart (views and table-materialized
-    alike) declares its FKs as constraints, so the constraint blocks are the
-    single source of truth for the diagram.
+    Table-materialized marts cannot carry ``foreign_key`` constraints (they
+    render into the CTAS DDL — see #4587), so they declare the same edge under
+    ``columns[].config.meta.foreign_key`` in the same ``to:`` / ``to_columns:``
+    shape.  Those are read too, immediately after each column's constraints.
+
+    FK edges come only from literal ``foreign_key`` constraints and their
+    ``config.meta.foreign_key`` equivalent — never inferred from
+    ``relationships`` data tests.
     """
     doc = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
     edges: list[FkEdge] = []
@@ -121,6 +125,22 @@ def parse_fk_edges(yaml_path: Path) -> list[FkEdge]:
                     _warn_if_legacy_expression(constraint, source)
                     continue
                 edges.append(FkEdge(source, column["name"], target))
+
+            # Column-level FK metadata, for table-materialized marts.
+            #
+            # A table mart cannot declare a foreign_key CONSTRAINT: it renders
+            # into the CTAS DDL, and no FK edge under marts/ is also a ref()
+            # edge, so nothing serializes the parent build ahead of the child
+            # (#4587). Those marts record the edge under config.meta.foreign_key
+            # instead, in the same to: / to_columns: shape, so it still reaches
+            # the diagram.
+            meta_fk = (column.get("config") or {}).get("meta", {}).get("foreign_key")
+            if isinstance(meta_fk, Mapping):
+                target = _constraint_target(meta_fk)
+                if target is None:
+                    _warn_if_legacy_expression(meta_fk, source)
+                else:
+                    edges.append(FkEdge(source, column["name"], target))
 
         # Model-level FK constraints.
         for constraint in model.get("constraints", []):

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -56,47 +56,49 @@ with
     ),
 
     -- Illuminate `date_taken` is unreliable for a small share of rows, in BOTH
-    -- directions: the raw column spans 0001-01-01 to 4024-12-04. Two guards,
-    -- because neither covers the other's cases.
+    -- directions: the raw column spans 0001-01-01 to 4024-12-04. Every row is
+    -- judged against a date it should sit near, never against a calendar
+    -- constant — an absolute floor is arbitrary, and being one-sided it can
+    -- never reject a future date.
     --
-    -- 1. Relative window. Judge a sitting against its OWN administration, which
-    -- catches a 2001 date attached to a 2020 administration and any absurd
-    -- future date. +/-365 days keeps 99.78% of dated rows; 7,508 fail it.
-    -- An absolute floor alone cannot do this — it is arbitrary and one-sided,
-    -- and can never reject a future date.
+    -- Preferred anchor is the row's own administration (+/-365 days). ~296k
+    -- rows have none, so those fall back to their `academic_year`, which is
+    -- always populated; the +/-1 year window is wide enough to absorb the
+    -- academic-year tagging drift of #3801. Together they null 11,455 rows
+    -- (0.34% of dated rows) and bring the range to 2013-06-03 .. 2026-12-27.
     --
-    -- 2. Absolute floor, for rows with NO administration date to anchor to
-    -- (~296k rows). The window cannot judge them, so without a floor that
-    -- path is unbounded — it is how 1969-12-31 survived an earlier version of
-    -- this guard. Only 1 row needs it today; it is here for the class, not
-    -- the row.
+    -- The fallback is what earns its keep: an earlier version of this guard
+    -- used a 2000-01-01 floor for unanchored rows, which caught exactly 1 row
+    -- and let a ~1,300-row cluster of 2001-01-01 sittings through, because
+    -- they cleared the constant while sitting a decade from their academic
+    -- year.
     --
-    -- Anchored rows inside the window pass through untouched, so a legitimately
-    -- future-dated sitting within its administration window is preserved.
+    -- Rows inside their window pass through untouched, so a legitimately
+    -- future-dated sitting within its administration window is preserved, and
+    -- `assessment_date_key` (`coalesce(administration, date_taken)`) keeps a
+    -- real administration date where one exists — the invariant #4546 rests on.
     --
     -- This matters more than the row counts suggest: the final select takes
     -- `min(date_taken)` per canonical group, so one junk row poisons its whole
     -- group's date. Nulling before the aggregate is what actually fixes it.
-    --
-    -- Unanchored rows that clear the floor are left as-is rather than guessed
-    -- at, which also keeps `assessment_date_key`
-    -- (`coalesce(administration, date_taken)`) non-null downstream — the
-    -- invariant #4546 rests on.
     sanitized_responses as (
         select
             * except (date_taken),
 
-            if(
-                date_taken < date '2000-01-01'
-                or (
+            case
+                when date_taken is null
+                then null
+                when
                     canonical_administered_at is not null
                     and date_diff(date_taken, canonical_administered_at, day)
-                    not between -365
-                    and 365
-                ),
-                null,
-                date_taken
-            ) as date_taken,
+                    between -365 and 365
+                then date_taken
+                when
+                    canonical_administered_at is null
+                    and extract(year from date_taken)
+                    between academic_year - 1 and academic_year + 1
+                then date_taken
+            end as date_taken,
         from scaffold_responses
     ),
 

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -40,7 +40,9 @@ with
                 s.is_internal_assessment, c.grade_level_id, s.grade_level_id
             ) as canonical_grade_level_id,
 
-            if(s.date_taken < date '2000-01-01', null, s.date_taken) as date_taken,
+            -- <= not <: the sentinel IS the floor date (41 rows, 6 students),
+            -- so a strict < left it indistinguishable from a real sitting date.
+            if(s.date_taken <= date '2000-01-01', null, s.date_taken) as date_taken,
         from {{ ref("int_assessments__scaffold") }} as s
         left join
             {{ ref("int_illuminate__agg_student_responses") }} as asr

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -20,6 +20,7 @@ with
             s.is_replacement,
             s.student_assessment_id,
             s.canonical_assessment_id,
+            s.date_taken,
 
             asr.response_type,
             asr.response_type_id,
@@ -40,9 +41,6 @@ with
                 s.is_internal_assessment, c.grade_level_id, s.grade_level_id
             ) as canonical_grade_level_id,
 
-            -- <= not <: the sentinel IS the floor date (41 rows, 6 students),
-            -- so a strict < left it indistinguishable from a real sitting date.
-            if(s.date_taken <= date '2000-01-01', null, s.date_taken) as date_taken,
         from {{ ref("int_assessments__scaffold") }} as s
         left join
             {{ ref("int_illuminate__agg_student_responses") }} as asr
@@ -65,13 +63,58 @@ with
     -- first_value on a deterministic ordering picks both columns from the
     -- same row so independent min() drift can't split them. Once #3801 is
     -- resolved, the partition becomes pure and this CTE can be removed.
+    -- Illuminate `date_taken` is unreliable for a small share of rows, in BOTH
+    -- directions: the raw column spans 0001-01-01 to 4024-12-04. Two guards,
+    -- because neither covers the other's cases.
+    --
+    -- 1. Relative window. Judge a sitting against its OWN administration, which
+    -- catches a 2001 date attached to a 2020 administration and any absurd
+    -- future date. +/-365 days keeps 99.93% of anchored rows; 7,507 fail it.
+    -- An absolute floor alone cannot do this — it is arbitrary and one-sided,
+    -- and can never reject a future date.
+    --
+    -- 2. Absolute floor, for rows with NO administration date to anchor to
+    -- (~296k rows). The window cannot judge them, so without a floor that
+    -- path is unbounded — it is how 1969-12-31 survived an earlier version of
+    -- this guard. Only 1 row needs it today; it is here for the class, not
+    -- the row.
+    --
+    -- Anchored rows inside the window pass through untouched, so a legitimately
+    -- future-dated sitting within its administration window is preserved.
+    --
+    -- This matters more than the row counts suggest: the final select takes
+    -- `min(date_taken)` per canonical group, so one junk row poisons its whole
+    -- group's date. Nulling before the aggregate is what actually fixes it.
+    --
+    -- Unanchored rows that clear the floor are left as-is rather than guessed
+    -- at, which also keeps `assessment_date_key`
+    -- (`coalesce(administration, date_taken)`) non-null downstream — the
+    -- invariant #4546 rests on.
+    sanitized_responses as (
+        select
+            * except (date_taken),
+
+            if(
+                date_taken < date '2000-01-01'
+                or (
+                    canonical_administered_at is not null
+                    and date_diff(date_taken, canonical_administered_at, day)
+                    not between -365
+                    and 365
+                ),
+                null,
+                date_taken
+            ) as date_taken,
+        from scaffold_responses
+    ),
+
     tiebroken_attrs as (
         select
             *,
             first_value(powerschool_school_id) over (w) as selected_school_id,
             first_value(region) over (w) as selected_region,
             first_value(_dbt_source_project) over (w) as selected_dbt_source_project,
-        from scaffold_responses
+        from sanitized_responses
         window
             w as (
                 partition by

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -270,7 +270,10 @@ with
             canonical_performance_band_set_id as performance_band_set_id,
 
             false as is_multipart_assessment,
-        from scaffold_responses
+        -- sanitized_responses, not scaffold_responses: both union branches must
+        -- read the cleaned date_taken. Reading the raw CTE here leaves the
+        -- non-internal branch unsanitized.
+        from sanitized_responses
         where not is_internal_assessment
     )
 

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__response_rollup.sql
@@ -55,21 +55,13 @@ with
             on s.canonical_assessment_id = c.canonical_assessment_id
     ),
 
-    -- Per-partition tiebreak for location columns. NOT a canonical attribute —
-    -- school / _dbt_source_project are per-response location data that vary
-    -- across rows in the same (student, canonical_assessment, is_replacement)
-    -- partition because of upstream Illuminate canonicalization defects
-    -- (#3801) carrying wrong academic_year tags onto duplicated assessments.
-    -- first_value on a deterministic ordering picks both columns from the
-    -- same row so independent min() drift can't split them. Once #3801 is
-    -- resolved, the partition becomes pure and this CTE can be removed.
     -- Illuminate `date_taken` is unreliable for a small share of rows, in BOTH
     -- directions: the raw column spans 0001-01-01 to 4024-12-04. Two guards,
     -- because neither covers the other's cases.
     --
     -- 1. Relative window. Judge a sitting against its OWN administration, which
     -- catches a 2001 date attached to a 2020 administration and any absurd
-    -- future date. +/-365 days keeps 99.93% of anchored rows; 7,507 fail it.
+    -- future date. +/-365 days keeps 99.78% of dated rows; 7,508 fail it.
     -- An absolute floor alone cannot do this — it is arbitrary and one-sided,
     -- and can never reject a future date.
     --
@@ -108,6 +100,14 @@ with
         from scaffold_responses
     ),
 
+    -- Per-partition tiebreak for location columns. NOT a canonical attribute —
+    -- school / _dbt_source_project are per-response location data that vary
+    -- across rows in the same (student, canonical_assessment, is_replacement)
+    -- partition because of upstream Illuminate canonicalization defects
+    -- (#3801) carrying wrong academic_year tags onto duplicated assessments.
+    -- first_value on a deterministic ordering picks both columns from the
+    -- same row so independent min() drift can't split them. Once #3801 is
+    -- resolved, the partition becomes pure and this CTE can be removed.
     tiebroken_attrs as (
         select
             *,

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -30,10 +30,20 @@ models:
               - response_type
               - response_type_id
               - is_replacement
+      # Asserts the relative invariant the model now enforces: a sitting date is
+      # judged against its own administration, not an absolute calendar floor.
+      # Kept at warn so a source regression surfaces without blocking CI.
       - dbt_utils.expression_is_true:
           arguments:
             expression: |-
-              date_taken is null or date_taken > '2000-01-01'
+              date_taken is null
+              or (
+                date_taken >= '2000-01-01'
+                and (
+                  administered_at is null
+                  or abs(date_diff(date_taken, administered_at, day)) <= 365
+                )
+              )
           config:
             severity: warn
     columns:

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -33,7 +33,7 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: |-
-              date_taken is null or date_taken >= '2000-01-01'
+              date_taken is null or date_taken > '2000-01-01'
           config:
             severity: warn
     columns:

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__response_rollup.yml
@@ -38,11 +38,13 @@ models:
             expression: |-
               date_taken is null
               or (
-                date_taken >= '2000-01-01'
-                and (
-                  administered_at is null
-                  or abs(date_diff(date_taken, administered_at, day)) <= 365
-                )
+                administered_at is not null
+                and abs(date_diff(date_taken, administered_at, day)) <= 365
+              )
+              or (
+                administered_at is null
+                and extract(year from date_taken)
+                  between academic_year - 1 and academic_year + 1
               )
           config:
             severity: warn

--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -252,25 +252,38 @@ explicit uniqueness test on its PK (`unique` on a single column, or
 `dbt_utils.unique_combination_of_columns` for composite).
 
 Exception: `dim_assessments`, `dim_courses`, `dim_dates`, `dim_regions`,
-`dim_staff`, `dim_students`, and the four assessment intermediates are
-`materialized: table`. `dim_assessments` also carries a nightly
-`automation_condition.cron_schedule` — Cube is its only consumer and Cube's
-pre-aggregation refreshes daily, so intraday rebuilds are invisible
-([#4559](https://github.com/TEAMSchools/teamster/issues/4559)).
+`dim_staff`, `dim_students`, the six assessment-star marts, and the four
+assessment intermediates are `materialized: table`. All seven assessment marts
+share `int_assessments__response_rollup`'s `0 0,10,13,15,17 * * *` tick — Cube
+is their only consumer and its `proficiency_rollup` pre-aggregation refreshes
+daily, so intraday rebuilds are invisible
+([#4559](https://github.com/TEAMSchools/teamster/issues/4559),
+[#4821](https://github.com/TEAMSchools/teamster/issues/4821)).
 
-**Never materialize an FK-carrying mart as a table.** A table child emits a
-`references` clause into its CTAS DDL, and BigQuery aborts the build when a
-concurrent `create or replace table` on the FK parent changes the parent's PK
-identity ("Referenced primary key in table ... has been updated"). The
-automation condition's `~any_deps_in_progress` guard is upward-facing only, so
-nothing serializes a parent against an in-flight child.
-[#4464](https://github.com/TEAMSchools/teamster/issues/4464) moved the whole
-assessment-scores star to tables for Cube query performance;
-[#4587](https://github.com/TEAMSchools/teamster/issues/4587) reverted the seven
-FK-carrying models to views eight days later, after four such build failures in
-30 days. Per-read recomputation was accepted deliberately to remove the failure
-class — restoring the performance means solving the collision, not re-flipping
-the config.
+**A table mart carries NO outgoing `foreign_key` constraints.** A table child
+renders its declared FKs into the CTAS DDL, and BigQuery aborts when the parent
+isn't a table with a PK, or when a concurrent `create or replace table` on the
+parent changes its PK identity ("Referenced primary key in table ... has been
+updated"). [#4464](https://github.com/TEAMSchools/teamster/issues/4464)
+materialized the assessment star;
+[#4587](https://github.com/TEAMSchools/teamster/issues/4587) reverted it eight
+days later after four such failures in 30 days.
+
+**A cron automation condition does NOT fix this** — the tempting inference, and
+it is wrong. No FK edge under `marts/` is also a `ref()` edge: these models
+re-hash the parent's surrogate key instead of joining the parent, so every
+closure edge is invisible to dbt's topological sort. Parent and child land in
+the same dependency tier and run concurrently across 40 prod threads. The cron
+controls when the run starts, not ordering within it, and
+`~any_deps_in_progress` guards `ref()` deps only. (#4464 set only
+`materialized: table` with no automation condition, so eager was the only
+configuration ever tried — but cron would not have saved it.)
+
+The resolution ([#4821](https://github.com/TEAMSchools/teamster/issues/4821)):
+when materializing a mart, drop its `foreign_key` constraints, keep
+`primary_key`, and record each edge under `config.meta.foreign_key` (below). A
+view mart carries no constraints in BigQuery at all, so a table with a PK and no
+FK is strictly better than the view it replaces.
 
 Drop model-level `dbt_utils.unique_combination_of_columns` when its column set
 equals the surrogate-key hash inputs — `unique` on the PK detects the same
@@ -279,21 +292,35 @@ violations.
 ## FK constraints declared on every mart
 
 `generate_marts_reference.py` derives FK edges **only** from literal
-`foreign_key` constraints — never inferred from `relationships` data tests. So
-every mart (view-materialized and `config.materialized: table` alike) must
-declare its outgoing FKs as column- or model-level `foreign_key` constraints, or
-they vanish from the generated reference diagram. A `relationships` data test is
-still good to keep for orphan detection, but it does not feed the diagram.
+declarations — never inferred from `relationships` data tests. Every mart must
+declare its outgoing FKs one of two ways, or they vanish from the generated
+reference diagram. A `relationships` data test is still good to keep for orphan
+detection, but it does not feed the diagram.
+
+- **View marts** — column- or model-level `foreign_key` constraints, inert in
+  BigQuery because views hold no constraints.
+- **Table marts** — `columns[].config.meta.foreign_key`, same `to:` /
+  `to_columns:` shape, because a real constraint would render into the CTAS DDL
+  (see the prohibition above):
+
+  ```yaml
+  config:
+    meta:
+      foreign_key:
+        to: ref('dim_assessment_administrations')
+        to_columns: [assessment_administration_key]
+  ```
 
 A `config.materialized: table` mart renders `constraints:` into CREATE TABLE DDL
 (inert on the default view marts). On a table mart, add `warn_unenforced: false`
-(not just `warn_unsupported: false`) on EVERY constraint — primary_key AND
-foreign_key both render into DDL and warn otherwise.
+(not just `warn_unsupported: false`) on its `primary_key` constraint — it
+renders into DDL and warns otherwise.
 
 ## Converting a view mart to a table
 
-Only a mart with NO outgoing `foreign_key` constraints is eligible — see the
-FK-carrying prohibition above.
+Move the model's `foreign_key` constraints to `config.meta.foreign_key` first —
+see the FK-carrying prohibition above. That also removes any need to convert the
+FK closure: with no FK DDL rendered, the parents can stay views.
 
 - BigQuery FK DDL requires every referenced relation to be a TABLE with a PK
   constraint. Convert the full FK closure (walk `to: ref(...)` edges) in one PR

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
@@ -20,6 +20,14 @@ models:
 
       Single-member canonical groups produce one bridge row per
       `(canonical_assessment_id, region)`.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view — rationale and tick choice
+          # in fct_assessment_scores_enrollment_scoped. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
@@ -41,11 +41,11 @@ models:
           FK to `dim_assessment_administrations`. Hashed from canonical inputs
           to match the canonical-grain dim row at the same `(canonical, region,
           canonical_administered_date)` coordinate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessment_administrations')
-            to_columns: [assessment_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
         data_tests:
           - relationships:
               arguments:
@@ -58,11 +58,11 @@ models:
           `assessment_id`, not canonical). Each bridge row resolves to the
           member's row in the member-grain `dim_assessments` for full
           definitional detail (member title, module_type, etc.).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessments')
-            to_columns: [assessment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessments')
+              to_columns: [assessment_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_administration_members.yml
@@ -21,19 +21,29 @@ models:
       Single-member canonical groups produce one bridge row per
       `(canonical_assessment_id, region)`.
     config:
-      materialized: table
-      meta:
-        dagster:
-          # 5x/day table instead of an eager view — rationale and tick choice
-          # in fct_assessment_scores_enrollment_scoped. Refs #4821
-          automation_condition:
-            cron_schedule: 0 0,10,13,15,17 * * *
+      # Disabled: nothing consumes this model. No `ref()` to it anywhere under
+      # `src/`, no entry in any exposure, and no reference under
+      # `src/cube/model/`. 180 days of BigQuery history shows only its own build
+      # and its own three tests — 171 GiB (~1.04 USD) per 11 days for a relation
+      # no one reads. `dim_assessments` names it in a comment describing the
+      # canonical-to-member mapping, but does not select from it.
+      #
+      # Kept rather than deleted so the definition survives if the
+      # member-grain bridge is ever needed. Refs #4821
+      enabled: false
+    # Each test carries its own `enabled: false`. dbt does NOT disable a
+    # model's tests when the model itself is disabled in properties yml
+    # (verified with `dbt parse --no-partial-parse`) — left implicit they would
+    # keep running against the stale prod relation, which is the cost this
+    # disable exists to remove.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - assessment_administration_key
               - assessment_key
+          config:
+            enabled: false
     columns:
       - name: assessment_administration_key
         data_type: string
@@ -51,6 +61,8 @@ models:
               arguments:
                 to: ref('dim_assessment_administrations')
                 field: assessment_administration_key
+              config:
+                enabled: false
       - name: assessment_key
         data_type: string
         description: >-
@@ -68,3 +80,5 @@ models:
               arguments:
                 to: ref('dim_assessments')
                 field: assessment_key
+              config:
+                enabled: false

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
@@ -22,6 +22,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
@@ -7,6 +7,14 @@ models:
       administration. Expectations without a resolvable section enrollment
       — replacement assessments and ES Writing in grades K-4 Newark/Camden
       — live in `bridge_assessment_expectations_student_scoped`.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view — rationale and tick choice
+          # in fct_assessment_scores_enrollment_scoped. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_expectation_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_enrollment_scoped.yml
@@ -29,11 +29,11 @@ models:
         data_type: string
         description: >-
           FK to dim_student_section_enrollments.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_section_enrollments')
-            to_columns: [student_section_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_section_enrollments')
+              to_columns: [student_section_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -44,11 +44,11 @@ models:
         data_type: string
         description: >-
           FK to dim_assessment_administrations.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessment_administrations')
-            to_columns: [assessment_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
@@ -29,11 +29,11 @@ models:
       - name: student_key
         data_type: string
         description: FK to dim_students.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
       - name: assessment_administration_key
         data_type: string
         description: FK to dim_assessment_administrations.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessment_administrations')
-            to_columns: [assessment_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
         data_tests:
           - relationships:
               arguments:
@@ -59,11 +59,11 @@ models:
         description: >-
           FK to dim_terms. Resolves via (region x administered_date x school)
           against the reporting terms sheet.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
@@ -8,6 +8,14 @@ models:
       Newark/Camden (where no PowerSchool course-enrollment row exists for
       the writing program). Rows whose expectations can be attributed to a
       section enrollment live in `bridge_assessment_expectations_enrollment_scoped`.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view — rationale and tick choice
+          # in fct_assessment_scores_enrollment_scoped. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_expectation_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_assessment_expectations_student_scoped.yml
@@ -23,6 +23,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -17,11 +17,11 @@ models:
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_project. FK
           to dim_course_sections.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_course_sections')
-            to_columns: [course_section_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_course_sections')
+              to_columns: [course_section_key]
         data_tests:
           - relationships:
               arguments:
@@ -31,11 +31,11 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from employee_number. FK to dim_staff.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_terms.yml
@@ -16,11 +16,11 @@ models:
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_project. FK
           to dim_course_sections.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_course_sections')
-            to_columns: [course_section_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_course_sections')
+              to_columns: [course_section_key]
         data_tests:
           - relationships:
               arguments:
@@ -31,11 +31,11 @@ models:
         description: >-
           Surrogate key derived from type, code, name, start_date, region, and
           school_id of the matching reporting term. FK to dim_terms.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -28,11 +28,11 @@ models:
         description: >-
           Surrogate key for the student. Foreign key to dim_students. Derived
           from the student number.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -44,11 +44,11 @@ models:
         description: >-
           Surrogate key for the contact person. Foreign key to
           dim_student_contact_persons.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_contact_persons')
-            to_columns: [student_contact_person_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_contact_persons')
+              to_columns: [student_contact_person_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           FK to dim_survey_administrations. Identifies which survey
           administration this expectation belongs to.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_survey_administrations')
-            to_columns: [survey_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_survey_administrations')
+              to_columns: [survey_administration_key]
         data_tests:
           - not_null
 
@@ -56,11 +56,11 @@ models:
           FK to dim_staff. Populated when respondent_type is staff. Null for
           student and family respondents.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -72,11 +72,11 @@ models:
           FK to dim_student_enrollments. Populated when respondent_type is
           student. Null for staff and family respondents.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -87,11 +87,11 @@ models:
         description: >-
           FK to dim_student_contact_persons. Populated when respondent_type is
           family. Null for staff and student respondents.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_contact_persons')
-            to_columns: [student_contact_person_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_contact_persons')
+              to_columns: [student_contact_person_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_questions.yml
@@ -22,11 +22,11 @@ models:
         data_type: string
         description: >-
           FK to dim_surveys. Surrogate key derived from survey_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_surveys')
-            to_columns: [survey_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_surveys')
+              to_columns: [survey_key]
         data_tests:
           - relationships:
               arguments:
@@ -37,11 +37,11 @@ models:
         description: >-
           FK to dim_survey_questions. Surrogate key derived from
           question_shortname.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_survey_questions')
-            to_columns: [survey_question_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_survey_questions')
+              to_columns: [survey_question_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -12,6 +12,14 @@ models:
       scheduling column carry a typed NULL for that column (e.g. Illuminate and
       AP carry NULL administration_period; state branches carry NULL
       source_assessment_id).
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view — rationale and tick choice
+          # in fct_assessment_scores_enrollment_scoped. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_administration_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -63,21 +63,20 @@ models:
           sources that don't capture an exact date (state, AP) -- the
           administration is identified by academic_year and
           administration_period instead.
+
+          A few upstream rows carry sentinel dates (1900-01-01, 1982-02-27)
+          below dim_dates' 2000-01-01 floor and so have no FK match -- 2 such
+          rows as of 2026-08-11. The `relationships` test that used to guard
+          this column was dropped in #4821: its `where: administered_date_key >=
+          '2000-01-01'` excluded exactly those rows, leaving a test that could
+          not fail. The foreign_key constraint below still documents the
+          relationship.
         constraints:
           - type: foreign_key
             to: ref('dim_dates')
             to_columns: [date_key]
             warn_unsupported: false
             warn_unenforced: false
-        data_tests:
-          - relationships:
-              arguments:
-                to: ref('dim_dates')
-                field: date_key
-              # Three upstream rows carry sentinel dates (1900-01-01,
-              # 1982-02-27) outside dim_dates' 2000-01-01 floor.
-              config:
-                where: administered_date_key >= '2000-01-01'
 
       - name: _dbt_source_project
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_administrations.yml
@@ -44,12 +44,11 @@ models:
           canonical descriptors (title, academic_subject, type,
           grade_level_tested, module_type) without denormalizing them onto this
           dim.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessments')
-            to_columns: [assessment_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessments')
+              to_columns: [assessment_key]
         data_tests:
           - relationships:
               arguments:
@@ -71,12 +70,11 @@ models:
           '2000-01-01'` excluded exactly those rows, leaving a test that could
           not fail. The foreign_key constraint below still documents the
           relationship.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
 
       - name: _dbt_source_project
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_comparisons.yml
@@ -24,11 +24,11 @@ models:
           FK to dim_regions. Derived from region using
           generate_surrogate_key(["region"]).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_regions')
-            to_columns: [region_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_regions')
+              to_columns: [region_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessment_goals.yml
@@ -27,11 +27,11 @@ models:
           FK to dim_locations. Derived from location_clean_name. Null when the
           school does not appear in the location crosswalk.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_assessments.yml
@@ -22,10 +22,14 @@ models:
       materialized: table
       meta:
         dagster:
-          # nightly instead of eager: Cube-only consumer, daily refresh_key —
-          # see fct_assessment_scores_enrollment_scoped. Refs #4559
+          # 5x/day, raised from nightly (#4559) so the whole assessment star
+          # shares one tick — dim_assessment_administrations has an FK test to
+          # this model, and a nightly dim under 5x/day administrations leaves a
+          # window where a new Illuminate assessment is in administrations but
+          # not yet here. Rationale in fct_assessment_scores_enrollment_scoped.
+          # Refs #4821
           automation_condition:
-            cron_schedule: 0 0 * * *
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
@@ -23,11 +23,11 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from student_number. FK to dim_students.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -37,11 +37,11 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from college_code_branch. FK to dim_colleges.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_colleges')
-            to_columns: [college_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_colleges')
+              to_columns: [college_key]
         data_tests:
           - relationships:
               arguments:
@@ -54,11 +54,11 @@ models:
           x college combination. FK to dim_dates (role-playing as enrollment
           start date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -71,11 +71,11 @@ models:
           college combination. FK to dim_dates (role-playing as enrollment end
           date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_course_sections.yml
@@ -23,12 +23,11 @@ models:
         description: >-
           Surrogate key derived from courses_course_number and
           _dbt_source_project. FK to dim_courses.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_courses')
-            to_columns: [course_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_courses')
+              to_columns: [course_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,12 +40,11 @@ models:
           Null when the section's school ID does not match any location in the
           crosswalk.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_locations.yml
@@ -32,12 +32,11 @@ models:
           `business_unit_code` so this column hashes exactly the keys produced
           by `dim_regions.region_key`. Network-level locations (e.g., KIPP NJ)
           map to KIPP_TAF.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_regions')
-            to_columns: [region_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_regions')
+              to_columns: [region_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_school_calendars.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_school_calendars.yml
@@ -25,11 +25,6 @@ models:
           default `not_null` severity) — junk pre-2000 source dates sanitized to
           NULL upstream by PR #3809; the 3 rows themselves should be filtered
           out of this dim. See follow-up note in #3719 thread.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
         data_tests:
           - not_null
 
@@ -42,15 +37,18 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__calendar_day
             source_column: date_value
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
       - name: location_key
         data_type: string
         description: >-
           Surrogate key for the school. FK to dim_locations.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - not_null
 

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_expectations.yml
@@ -25,11 +25,11 @@ models:
         data_type: string
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,11 +41,11 @@ models:
         description: >-
           Foreign key to dim_terms. Surrogate key derived from term type, code,
           name, start_date, region, and school_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:
@@ -63,11 +63,11 @@ models:
           tags; the not_null test below fails loudly if that invariant ever
           breaks (e.g., if Grow archives one of the matching tags or renames an
           abbreviation without a coordinated update).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_types')
-            to_columns: [staff_observation_type_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_types')
+              to_columns: [staff_observation_type_key]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_observation_rubric_measurements.yml
@@ -33,11 +33,11 @@ models:
         description: >-
           Foreign key to dim_staff_observation_rubrics. Surrogate key derived
           from rubric_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_rubrics')
-            to_columns: [staff_observation_rubric_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_rubrics')
+              to_columns: [staff_observation_rubric_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml
@@ -26,11 +26,11 @@ models:
           Foreign key to dim_staff — a staff member at or above the reportee in
           the reporting tree. Equals reportee_staff_key on the depth-0
           self-pair.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - not_null
           - relationships:
@@ -42,11 +42,11 @@ models:
         data_type: string
         description: >-
           Foreign key to dim_staff — the direct or indirect report.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_periods.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_periods.yml
@@ -23,11 +23,11 @@ models:
       - name: staff_key
         data_type: string
         description: Foreign key to `dim_staff.staff_key` — the reportee.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - not_null
           - relationships:
@@ -39,11 +39,11 @@ models:
         description: >-
           Foreign key to `dim_staff.staff_key` — the manager for this period.
           Nullable: a primary reporting-relationship row may carry no manager.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_status.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_assignments.yml
@@ -33,11 +33,11 @@ models:
           with generate_surrogate_key(["employee_number"]). Null when the
           associate_oid has no active number mapping in
           stg_people__employee_numbers.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -52,11 +52,11 @@ models:
           approves this assignment's time records (distinct from the org-chart
           manager on dim_work_assignment_reporting_relationships). Null when the
           approver's associate_oid has no active number mapping.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
@@ -24,11 +24,11 @@ models:
         data_type: string
         description:
           Foreign key to `dim_staff_work_assignments.work_assignment_key`.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - not_null
           - relationships:
@@ -38,11 +38,11 @@ models:
       - name: staff_key
         data_type: string
         description: Foreign key to `dim_staff.staff_key`.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - not_null
           - relationships:
@@ -54,11 +54,11 @@ models:
         description: >-
           Foreign key to `dim_staff.staff_key` — point-in-time manager for the
           period. Nullable for manager-less staff.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -69,11 +69,11 @@ models:
         description: >-
           Foreign key to `dim_locations.location_key`. Nullable when the ADP
           location has no canonical mapping.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staffing_positions.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           Foreign key to dim_locations. Surrogate key derived from the home work
           location name.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           # TODO: #3686 — adp_location vs dim_locations.location_name coverage
           # gap (same class as #3672). Promote to error once crosswalk is clean.
@@ -43,11 +43,11 @@ models:
           Foreign key to dim_staff for the incumbent (staff member filling the
           position). Surrogate key derived from the teammate employee number.
           Nullable — open positions have no incumbent.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           # TODO: #3710 — Seat Tracker retains historical incumbents outside
           # dim_staff's active-primary scope. Promote to error once resolved.
@@ -62,11 +62,11 @@ models:
           Foreign key to dim_staff for the assigned recruiter. Surrogate key
           derived from the recruiter employee number. Nullable — positions may
           have no assigned recruiter.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           # TODO: #3710 — Seat Tracker recruiter values include staff outside
           # dim_staff's active-primary scope. Promote to error once resolved.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_attendance_intervention_types.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           FK to dim_regions. Surrogate key derived from business_unit_code
           (mapped from _dbt_source_project).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_regions')
-            to_columns: [region_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_regions')
+              to_columns: [region_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_ell_status.yml
@@ -29,11 +29,11 @@ models:
       - name: student_key
         data_type: string
         description: Foreign key to `dim_students.student_key`.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -46,11 +46,11 @@ models:
           status row is bound to exactly one enrollment stint (clipped to its
           entry/exit window at build time). Consumers join here directly rather
           than re-deriving the stint via date-range overlap.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -75,11 +75,11 @@ models:
           First date this span is valid for the student in this district.
           Clipped to the later of the LEP record's begin date and the student's
           PowerSchool enrollment_start in the district.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:
@@ -93,11 +93,11 @@ models:
           the LEP record's end date and the student's PowerSchool enrollment_end
           in the district. `'9999-12-31'` only when the student is currently
           active in the district AND the LEP record is open-ended.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_enrollments.yml
@@ -24,12 +24,11 @@ models:
         data_type: string
         description: >-
           Surrogate key derived from student_number. FK to dim_students.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -42,12 +41,11 @@ models:
           Null when schoolid does not match any location in the crosswalk (e.g.,
           grade_level 99 placeholder schools).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:
@@ -64,12 +62,9 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: entrydate
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
-            warn_unenforced: false
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -88,12 +83,9 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__students
             source_column: exitdate
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
-            warn_unenforced: false
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_iep_status.yml
@@ -31,11 +31,11 @@ models:
       - name: student_key
         data_type: string
         description: Foreign key to `dim_students.student_key`.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -49,11 +49,11 @@ models:
           status row is bound to exactly one enrollment stint (clipped to its
           entry/exit window at build time). Consumers join here directly rather
           than re-deriving the stint via date-range overlap.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -80,11 +80,11 @@ models:
           First date this span is valid for the student in this district.
           Clipped to the later of the IEP record's effective_date and the
           student's PowerSchool enrollment_start in the district.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:
@@ -99,11 +99,11 @@ models:
           the IEP record's effective_end_date and the student's PowerSchool
           enrollment_end in the district. `'9999-12-31'` only when the student
           is currently active in the district AND the IEP record is open-ended.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_meal_eligibility_status.yml
@@ -29,11 +29,11 @@ models:
       - name: student_key
         data_type: string
         description: Foreign key to `dim_students.student_key`.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -47,11 +47,11 @@ models:
           status row is bound to exactly one enrollment stint (clipped to its
           entry/exit window at build time). Consumers join here directly rather
           than re-deriving the stint via date-range overlap.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -78,11 +78,11 @@ models:
           First date this span is valid for the student in this district.
           Clipped to the later of the source eligibility record's start date and
           the student's PowerSchool enrollment_start in the district.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:
@@ -98,11 +98,11 @@ models:
           enrollment_end in the district. `'9999-12-31'` only when the student
           is currently active in the district AND the source record is
           open-ended.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_section_enrollments.yml
@@ -18,12 +18,11 @@ models:
           record, resolved to a staff member via the staff roster. FK to
           dim_staff. Null when the section's teacher does not resolve to a staff
           record.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -53,12 +52,11 @@ models:
           stint covering cc_dateenrolled when one exists, else the earliest
           overlapping stint). Null only when no enrollment stint overlaps the
           section enrollment.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -69,12 +67,11 @@ models:
         description: >-
           Surrogate key derived from sections_dcid and _dbt_source_project. FK
           to dim_course_sections.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_course_sections')
-            to_columns: [course_section_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_course_sections')
+              to_columns: [course_section_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
@@ -22,11 +22,11 @@ models:
         data_type: string
         description: >-
           FK to dim_surveys. Surrogate key derived from survey_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_surveys')
-            to_columns: [survey_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_surveys')
+              to_columns: [survey_key]
         data_tests:
           - relationships:
               arguments:
@@ -37,11 +37,11 @@ models:
         description: >-
           FK to dim_terms. Surrogate key derived from term composite fields
           (type, code, name, start_date, region, school_id).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_terms.yml
@@ -28,12 +28,11 @@ models:
           Foreign key to dim_locations. Surrogate key derived from the location
           name. Nullable when the period is region-wide or when the school is
           not present in dim_locations.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_jobs.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_locations.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
           int_adp_workforce_now__workers__work_assignments via the canonical
           master on adp_location_code. NULL when the ADP location has no
           canonical mapping.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           # TODO: #3686 — adp_location vs dim_locations.location_name coverage
           # gap (same class as #3672). Promote to error once crosswalk is clean.

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_organizational_units.yml
@@ -26,11 +26,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:
@@ -48,11 +48,11 @@ models:
         description: >-
           ADP business-unit code (KCNA, KIPP_MIAMI, KIPP_TAF, KPAT, TEAM). FK to
           dim_regions.business_unit_code.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_regions')
-            to_columns: [business_unit_code]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_regions')
+              to_columns: [business_unit_code]
         data_tests:
           - not_null
           - relationships:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_primary.yml
@@ -30,11 +30,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_reporting_relationships.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:
@@ -42,11 +42,11 @@ models:
           to dim_staff identifying the manager this work assignment reports to.
           Null when the manager's associate_oid has no active number mapping in
           stg_people__employee_numbers.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_status.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_work_assignment_types.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/fct_student_attendance_streaks.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_student_attendance_streaks.sql
@@ -1,5 +1,6 @@
 with
-    enrollments as (
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    enrollments_raw as (
         select
             studentid,
             student_number,
@@ -9,6 +10,25 @@ with
             _dbt_source_relation,
             _dbt_source_project,
         from {{ ref("int_students__student_enrollment_union") }}
+    ),
+
+    -- TODO(#4835): two kippcamden students carry a short AY2026 stint and a
+    -- full-year stint sharing an entrydate, so the half-open date-range join
+    -- below matches both and fans the streak out. Both matches hash to the
+    -- SAME student_enrollment_key (entrydate is its only enrollment input), so
+    -- collapsing them is information-preserving, not duplicate-masking. A
+    -- genuine overlap -- two stints with DIFFERENT entrydates covering one
+    -- streak -- still fans out and still fails the PK test, which is correct.
+    -- Deduped here rather than in the union: the union should faithfully
+    -- represent its source rows, which other consumers may legitimately need.
+    enrollments as (
+        {{
+            dbt_utils.deduplicate(
+                relation="enrollments_raw",
+                partition_by="studentid, yearid, entrydate, _dbt_source_project",
+                order_by="exitdate desc",
+            )
+        }}
     )
 
 select

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -8,6 +8,27 @@ models:
       assessment administration (via assessment_administration_key) and to the
       student's resolved section enrollment (via student_section_enrollment_key
       and enrollment_resolution).
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view. Every reader of this model
+          # recomputed its 27-base-table view chain: each of its 10 dbt tests
+          # per CI build, every Cube query missing the proficiency_rollup, and
+          # every pre-agg partition build. That was 85% of CI's BigQuery spend
+          # (0.486 GiB per test run against a deep view chain vs 0.016 GiB
+          # against a table).
+          #
+          # Tick matches int_assessments__response_rollup, the heaviest
+          # upstream, so ~any_deps_in_progress serializes the pass and
+          # response_rollup builds first. Eager is not an option: the other
+          # upstreams are eager and would drive 125+ rebuilds/day (#4559).
+          # Accepted trade-off: Cube queries that miss the rollup read live
+          # today and become 5x/day fresh. Cube's rollup refresh_key is
+          # already 1 day, so the view bought no freshness Cube consumed.
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_score_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_enrollment_scoped.yml
@@ -47,12 +47,11 @@ models:
           FK to dim_assessment_administrations. Identifies the scheduled
           administration (assessment definition + occurrence context: academic
           year, region, season/window) that this score belongs to.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessment_administrations')
-            to_columns: [assessment_administration_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
         data_tests:
           - relationships:
               arguments:
@@ -80,12 +79,11 @@ models:
           no subject section resolves (see enrollment_resolution). Populated for
           every row; homeroom-resolved rows are coarser-grained than
           subject_section rows.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_section_enrollments')
-            to_columns: [student_section_enrollment_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_section_enrollments')
+              to_columns: [student_section_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -101,12 +99,11 @@ models:
           date rather than through the section enrollment itself, whose term id
           is not quarter-specific. Null when no reporting quarter is defined for
           that school and date.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:
@@ -122,12 +119,11 @@ models:
           assessment_date_key for every state and vendor row (those have no
           administration date); the two differ only for internal and college
           rows, where assessment_date_key uses the administration date.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -144,12 +140,11 @@ models:
           Populated for every row, so academic year resolves for all sources —
           unlike the administration date alone, which is null for state and
           vendor rows.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
-            warn_unenforced: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           # not_null guards the invariant the #4546 fix rests on: the FK
           # relationships test skips nulls and the constraint is not enforced,

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -22,6 +22,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -34,11 +34,11 @@ models:
           scores arrive keyed by ap_number_ap_id via ap_id_crosswalk). Unmatched
           rows carry NULL student_number.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_students')
-            to_columns: [student_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_students')
+              to_columns: [student_key]
         data_tests:
           - relationships:
               arguments:
@@ -51,11 +51,11 @@ models:
           administration (assessment definition + occurrence context: academic
           year, test date, administration round) that this score belongs to.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_assessment_administrations')
-            to_columns: [assessment_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
         data_tests:
           - relationships:
               arguments:
@@ -67,11 +67,11 @@ models:
           FK to dim_dates. The date the assessment was taken. Null for AP exams
           where only the academic year is recorded.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_assessment_scores_student_scoped.yml
@@ -6,6 +6,14 @@ models:
       assessments (SAT, ACT, PSAT) and AP exams. These assessments follow the
       student directly without enrollment context. FK to dim_students via
       student_key, not to dim_student_section_enrollments.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day table instead of an eager view — rationale and tick choice
+          # in fct_assessment_scores_enrollment_scoped. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: assessment_score_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_consequences.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           FK to fct_behavioral_incidents. Surrogate key derived from incident_id
           and _dbt_source_project.
-        constraints:
-          - type: foreign_key
-            to: ref('fct_behavioral_incidents')
-            to_columns: [behavioral_incident_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('fct_behavioral_incidents')
+              to_columns: [behavioral_incident_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,9 @@ models:
             source_system: DeansList
             source_model: int_deanslist__incidents__penalties
             source_column: start_date
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -63,11 +61,9 @@ models:
             source_system: DeansList
             source_model: int_deanslist__incidents__penalties
             source_column: end_date
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_behavioral_incidents.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
           Nullable when the DeansList user cannot be matched to a staff record
           (approximately 4.8% of rows — typically departed staff absent from the
           current roster snapshot).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -63,11 +63,11 @@ models:
           `int_deanslist__incidents` via the canonical master on
           `deanslist_school_id`. NULL for rows where the DeansList school_id
           has no canonical mapping.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:
@@ -82,11 +82,11 @@ models:
           FK to dim_dates for the date the incident was created. Matches
           dim_dates.date_key.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -154,11 +154,11 @@ models:
           FK to dim_dates for the date the incident was closed. Matches
           dim_dates.date_key. Nullable — open incidents have no close date.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -170,11 +170,11 @@ models:
           FK to dim_dates for the date the student is expected to return.
           Matches dim_dates.date_key. Nullable — not all incidents have a return
           date.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_family_communications.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -40,11 +40,11 @@ models:
           Derived from the DeansList user's email resolved to an employee_number
           via int_people__staff_roster, then hashed with generate_surrogate_key.
           Nullable when the DeansList user cannot be matched to a staff record.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -56,11 +56,11 @@ models:
         description: >-
           Date the communication occurred. FK to dim_dates.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -31,11 +31,11 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_project.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_section_enrollments')
-            to_columns: [student_section_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_section_enrollments')
+              to_columns: [student_section_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -48,11 +48,11 @@ models:
           start_date, region, and school_id. Null when due_date does not fall
           within any reporting term for the school and region.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:
@@ -69,11 +69,9 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__assignmentsection
             source_column: duedate
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_project.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_section_enrollments')
-            to_columns: [student_section_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_section_enrollments')
+              to_columns: [student_section_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,11 +41,11 @@ models:
           start_date, region, and school_id. Null when storecode does not map to
           a reporting term for the school and region.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_gpa.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -42,11 +42,11 @@ models:
           start_date, region, and school_id of the matching reporting term. Null
           when the PowerSchool term / year / school does not map to a
           reporting-term record.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_term.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           FK to dim_student_section_enrollments. Surrogate key derived from
           cc_dcid and _dbt_source_project.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_section_enrollments')
-            to_columns: [student_section_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_section_enrollments')
+              to_columns: [student_section_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -42,11 +42,11 @@ models:
           start_date, region, and school_id. Null when storecode does not map to
           a reporting term for the school and region.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:
@@ -58,11 +58,11 @@ models:
           Start date of the term bin. FK to dim_dates (role-playing as term
           start date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -74,11 +74,11 @@ models:
           End date of the term bin. FK to dim_dates (role-playing as term end
           date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_job_candidate_applications.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           Foreign key to dim_job_candidates. Surrogate key derived from
           candidate_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_job_candidates')
-            to_columns: [job_candidate_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_job_candidates')
+              to_columns: [job_candidate_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
           crosswalk; text variants like `KIPP High School` → `KIPP Cooper
           Norcross High` are alias rows on the crosswalk). Nullable when the
           application has no shared location.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:
@@ -59,11 +59,11 @@ models:
           Foreign key to dim_job_postings. Surrogate key derived from job_title,
           department_internal, and job_city.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_job_postings')
-            to_columns: [job_posting_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_job_postings')
+              to_columns: [job_posting_key]
         data_tests:
           - relationships:
               arguments:
@@ -75,11 +75,11 @@ models:
           Foreign key to dim_dates for the date the application entered the New
           stage. Matches dim_dates.date_key.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_attrition.yml
@@ -35,11 +35,11 @@ models:
           retained staff (9/1 for foundation/recruitment, 7/1 for
           nj_compliance), termination effective date for attritors. Null when no
           matching status version exists.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_status')
-            to_columns: [staff_status_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_status')
+              to_columns: [staff_status_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_benefits_enrollments.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_membership_enrollments.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff. Surrogate key derived from employee_number.
           Generated with generate_surrogate_key(["employee_number"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_goals.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           Foreign key to dim_staff for the teacher receiving the goal. Surrogate
           key derived from employee_number.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -40,11 +40,11 @@ models:
         description: >-
           Foreign key to dim_staff_observation_goal_types. Surrogate key derived
           from the goal tag_id.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_goal_types')
-            to_columns: [staff_observation_goal_type_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_goal_types')
+              to_columns: [staff_observation_goal_type_key]
         data_tests:
           - relationships:
               arguments:
@@ -58,11 +58,11 @@ models:
           Surrogate key derived from creator employee_number. May be null if the
           creator cannot be matched to the staff roster.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observation_scores.yml
@@ -23,11 +23,11 @@ models:
         description: >-
           Foreign key to fct_staff_observations. Surrogate key derived from
           observation_id.
-        constraints:
-          - type: foreign_key
-            to: ref('fct_staff_observations')
-            to_columns: [staff_observation_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('fct_staff_observations')
+              to_columns: [staff_observation_key]
         data_tests:
           - relationships:
               arguments:
@@ -40,11 +40,11 @@ models:
           Foreign key to dim_staff_observation_rubric_measurements. Surrogate
           key derived from rubric_id and measurement_id.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_rubric_measurements')
-            to_columns: [staff_observation_rubric_measurement_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_rubric_measurements')
+              to_columns: [staff_observation_rubric_measurement_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_staff_observations.yml
@@ -27,11 +27,11 @@ models:
           has no employee_number (or carries the SchoolMint Grow test sentinel
           999999) flow through with a NULL key per the standard null-wrap
           pattern.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -44,11 +44,11 @@ models:
           the SchoolMint Grow generic tag_id for the observation type. Null when
           the observation type abbreviation does not resolve to an active
           observationtypes tag.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_types')
-            to_columns: [staff_observation_type_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_types')
+              to_columns: [staff_observation_type_key]
         data_tests:
           - relationships:
               arguments:
@@ -62,11 +62,11 @@ models:
           from rubric_id in int_schoolmint_grow__observations. Non-nullable —
           rubric_id is structurally non-null for all published observations and
           enforced by a not_null test on the upstream intermediate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_observation_rubrics')
-            to_columns: [staff_observation_rubric_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_observation_rubrics')
+              to_columns: [staff_observation_rubric_key]
         data_tests:
           - not_null
           - relationships:
@@ -82,11 +82,11 @@ models:
           Foreign key to dim_staff for the observer. Surrogate key derived from
           observer_employee_number.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -98,11 +98,11 @@ models:
           Foreign key to dim_locations. Surrogate key derived from the school's
           location_clean_name.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:
@@ -114,11 +114,11 @@ models:
           Foreign key to dim_terms. Surrogate key derived from term composite
           fields.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:
@@ -129,11 +129,11 @@ models:
         data_type: date
         description: >-
           Local date the observation was conducted. Foreign key to dim_dates.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -39,11 +39,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -53,11 +53,11 @@ models:
         data_type: date
         description: >-
           Calendar date of the attendance record. FK to dim_dates.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -71,11 +71,11 @@ models:
           stg_google_sheets__reporting__terms on (schoolid, term,
           academic_year). Null when the attendance row's term does not appear in
           the terms sheet for that school-year.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_terms')
-            to_columns: [term_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_terms')
+              to_columns: [term_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_interventions.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -40,11 +40,11 @@ models:
         description: >-
           FK to dim_student_attendance_intervention_types. Surrogate key derived
           from _dbt_source_project and family_communication_reason.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_attendance_intervention_types')
-            to_columns: [intervention_type_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_attendance_intervention_types')
+              to_columns: [intervention_type_key]
         data_tests:
           - relationships:
               arguments:
@@ -57,11 +57,11 @@ models:
           FK to fct_family_communications. Surrogate key derived from the
           DeansList comm log record_id and _dbt_source_project. Nullable when no
           matching communication was logged (intervention is not complete).
-        constraints:
-          - type: foreign_key
-            to: ref('fct_family_communications')
-            to_columns: [family_communication_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('fct_family_communications')
+              to_columns: [family_communication_key]
         data_tests:
           - relationships:
               arguments:
@@ -74,11 +74,11 @@ models:
           Date the communication was logged. FK to dim_dates. Null when the
           intervention is missing (not yet completed).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_streaks.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           FK to dim_student_enrollments. Surrogate key derived from
           student_number, _dbt_source_project, academic_year, and entrydate.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,11 +41,11 @@ models:
           First date of the streak. FK to dim_dates (role-playing as streak
           start date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -57,11 +57,11 @@ models:
           Last date of the streak. FK to dim_dates (role-playing as streak end
           date).
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
@@ -26,11 +26,11 @@ models:
         description: >-
           Foreign key to dim_staff for the ticket submitter. Surrogate key
           derived from submitter employee_number.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
           key derived from assignee employee_number. Nullable — unassigned
           tickets have no assignee.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -60,11 +60,11 @@ models:
           Surrogate key derived from original assignee employee_number. Nullable
           — not all tickets have a creation-time assignee.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -77,11 +77,11 @@ models:
           custom field value on the ticket. Currently fails 100% relationships
           against dim_locations pending Zendesk-slug → canonical-location
           crosswalk (#3709).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_locations')
-            to_columns: [location_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_locations')
+              to_columns: [location_key]
         data_tests:
           - relationships:
               arguments:
@@ -92,11 +92,11 @@ models:
         description: >-
           Foreign key to dim_dates for the date the ticket was created. Matches
           dim_dates.date_key.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - not_null
 
@@ -111,11 +111,11 @@ models:
           dim_dates.date_key. Nullable — open or pending tickets have no solved
           date.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -25,11 +25,11 @@ models:
         description: >-
           FK to dim_survey_questions. Identifies which question this response
           answers.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_survey_questions')
-            to_columns: [survey_question_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_survey_questions')
+              to_columns: [survey_question_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,11 +41,11 @@ models:
         description: >-
           FK to fct_survey_submissions. Links this response to its parent
           submission record.
-        constraints:
-          - type: foreign_key
-            to: ref('fct_survey_submissions')
-            to_columns: [survey_submission_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('fct_survey_submissions')
+              to_columns: [survey_submission_key]
       - name: response_value
         data_type: numeric
         description: >-

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -32,11 +32,11 @@ models:
         description: >-
           FK to dim_survey_administrations. Identifies which survey
           administration this submission belongs to.
-        constraints:
-          - type: foreign_key
-            to: ref('dim_survey_administrations')
-            to_columns: [survey_administration_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_survey_administrations')
+              to_columns: [survey_administration_key]
         data_tests:
           - relationships:
               arguments:
@@ -48,11 +48,11 @@ models:
           FK to dim_dates (role-playing as submission date). The local date the
           survey was submitted.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -80,11 +80,11 @@ models:
           student / family respondents AND for staff respondents whose identity
           cannot be resolved upstream.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:
@@ -101,11 +101,11 @@ models:
           not present in int_extracts__student_enrollments or has no enrollment
           row covering date_submitted.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_enrollments')
-            to_columns: [student_enrollment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_enrollments')
+              to_columns: [student_enrollment_key]
         data_tests:
           - relationships:
               arguments:
@@ -117,11 +117,11 @@ models:
           FK to dim_student_contact_persons for the respondent. Populated when
           respondent_type is family. Null for staff and student.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_student_contact_persons')
-            to_columns: [student_contact_person_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_student_contact_persons')
+              to_columns: [student_contact_person_key]
         data_tests:
           - relationships:
               arguments:
@@ -135,11 +135,11 @@ models:
           (direct report) evaluates their manager (subject). Null for all other
           survey types.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff')
-            to_columns: [staff_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff')
+              to_columns: [staff_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_additional_earnings.yml
@@ -26,11 +26,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:
@@ -43,11 +43,11 @@ models:
           Role-playing FK to dim_dates. The date this earnings version became
           effective, from additionalRemunerations.effectiveDate.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -61,11 +61,11 @@ models:
           effective_start_date_key (within the same assignment and earning
           type), or 9999-12-31 for the current version.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_work_assignment_compensation.yml
@@ -24,11 +24,11 @@ models:
         description: >-
           Foreign key to dim_staff_work_assignments. Surrogate key derived from
           item_id. Generated with generate_surrogate_key(["item_id"]).
-        constraints:
-          - type: foreign_key
-            to: ref('dim_staff_work_assignments')
-            to_columns: [work_assignment_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_staff_work_assignments')
+              to_columns: [work_assignment_key]
         data_tests:
           - relationships:
               arguments:
@@ -41,11 +41,11 @@ models:
           Role-playing FK to dim_dates. The date this compensation version
           became effective, from ADP baseRemuneration.effectiveDate.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:
@@ -58,11 +58,11 @@ models:
           effective. Computed as one day before the next version's
           effective_start_date_key, or 9999-12-31 for the current version.
 
-        constraints:
-          - type: foreign_key
-            to: ref('dim_dates')
-            to_columns: [date_key]
-            warn_unsupported: false
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_dates')
+              to_columns: [date_key]
         data_tests:
           - relationships:
               arguments:

--- a/tests/scripts/fixtures/sample_fct_meta_fk.yml
+++ b/tests/scripts/fixtures/sample_fct_meta_fk.yml
@@ -1,0 +1,49 @@
+models:
+  - name: fct_meta_sample
+    description: >-
+      Table-materialized fact that records its FK edges as
+      config.meta.foreign_key, since a table mart cannot carry foreign_key
+      constraints (they render into the CTAS DDL).
+    config:
+      materialized: table
+    columns:
+      # primary_key stays a real constraint on a table mart — ignored here.
+      - name: sample_key
+        data_type: string
+        constraints:
+          - type: primary_key
+            warn_unsupported: false
+            warn_unenforced: false
+
+      # the meta form yields an edge, and its relationships test is not
+      # double-counted alongside it.
+      - name: assessment_administration_key
+        data_type: string
+        config:
+          meta:
+            foreign_key:
+              to: ref('dim_assessment_administrations')
+              to_columns: [assessment_administration_key]
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_assessment_administrations')
+                field: assessment_administration_key
+
+      # a literal constraint still yields an edge — both forms coexist.
+      - name: still_constrained_key
+        data_type: string
+        constraints:
+          - type: foreign_key
+            to: ref('dim_other')
+            to_columns: [other_key]
+            warn_unsupported: false
+
+      # relationships test with neither form yields nothing.
+      - name: relationships_only_key
+        data_type: string
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('dim_ignored')
+                field: ignored_key

--- a/tests/scripts/test_generate_marts_reference.py
+++ b/tests/scripts/test_generate_marts_reference.py
@@ -65,6 +65,22 @@ def test_parse_fk_edges_ignores_relationships_tests_on_table_marts() -> None:
     ]
 
 
+def test_parse_fk_edges_reads_config_meta_foreign_key() -> None:
+    edges = gen.parse_fk_edges(FIXTURE_DIR / "sample_fct_meta_fk.yml")
+
+    # A table mart records FKs under config.meta.foreign_key instead of as
+    # constraints (#4587 / #4821). Both forms yield edges, in column order;
+    # primary_key and relationships-only columns still yield nothing.
+    assert edges == [
+        gen.FkEdge(
+            "fct_meta_sample",
+            "assessment_administration_key",
+            "dim_assessment_administrations",
+        ),
+        gen.FkEdge("fct_meta_sample", "still_constrained_key", "dim_other"),
+    ]
+
+
 def test_parse_fk_edges_warns_and_skips_legacy_expression(capsys) -> None:
     # An FK constraint using the legacy free-text expression: form (no to:) is
     # skipped, and a warning is emitted so the dropped FK is not silent.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will materialize the assessment-star marts as tables on a shared 5x-per-day cron, by moving their `foreign_key` constraints into `config.meta.foreign_key` so no FK DDL is rendered. It then applies the same move to **every** remaining mart (146 constraints, 56 files) so the failure class cannot recur anywhere, and disables one bridge model nothing consumes.

**This re-attempts [#4464](https://github.com/TEAMSchools/teamster/issues/4464), which [#4587](https://github.com/TEAMSchools/teamster/issues/4587) reverted.** That is deliberate, and the mechanism that broke it is addressed rather than re-risked. Please read the "Why this is not #4464 again" section before reviewing the rest.

### The cost problem

BigQuery spend hit 5.02 TiB on 2026-08-10 against a 1.8-2.7 TiB baseline. Measured over 2026-08-01 to 2026-08-11:

- **85% of dbt Cloud's BigQuery spend is tests**, not model builds (7.79 TiB vs 1.34 TiB). All of it is PR CI -- 100% ran against the `staging` target.
- Test cost tracks materialization of the test target and nothing else: **0.016 GiB per run against a table vs 0.486 GiB against a deep view chain, a 30x spread.** 96.8% of test spend goes to tests whose target is not materialized.
- `fct_assessment_scores_enrollment_scoped` expands to 27 base tables and carries 10 tests, so CI recomputes the entire fact 10 times per build to check 10 assertions on one result set.
- Cube pays the same tax: 1,416 of its 1,450 GiB (98%) is assessment-mart queries averaging 21.4 base tables each.

Attributable: **28.50 USD** in CI test scans plus **8.65 USD** in Cube, per 11 days, at on-demand 6.25 USD per TiB.

### Why this is not #4464 again

#4587 reverted the materialization after four `Referenced primary key in table ... has been updated` failures in 30 days. The recorded explanation blamed concurrent rebuilds under the eager automation condition, which implies a cron would fix it. Checking the actual history and graph shows something sharper:

- **#4464 set only `materialized: table`** across 11 models, with no `automation_condition` at all. Eager was the only configuration ever tried, so the cron hypothesis was never tested.
- **But a cron would not have helped.** No FK edge under `marts/` is also a `ref()` edge -- all 26 closure edges are declared-only, because these models re-hash the parent's surrogate key rather than joining the parent. dbt's topological sort therefore has no edge to order parent before child; they land in the same dependency tier and build concurrently across `threads: 40`. A cron controls when a run starts, not ordering inside it, and `any_deps_in_progress` guards `ref()` deps only.

So the failure class is not "eager" and not "cron" -- it is **rendering FK constraints into CTAS DDL at all**. This PR removes that, which removes the failure class:

- The 17 `foreign_key` constraints on the six marts move to `columns[].config.meta.foreign_key`, same `to:` / `to_columns:` shape. `primary_key` constraints stay.
- A view mart carries **no** constraints in BigQuery, so a table with a PK and no FK is strictly better than the view it replaces on every axis.
- With no FK DDL rendered, the parents can stay views -- no need to convert the 11-model FK closure, which would have pulled in core dims (`dim_student_enrollments`, `dim_locations`, `dim_course_sections`) well outside this PR.

The invariant every existing table mart already satisfies is preserved and now stated explicitly in `marts/CLAUDE.md`: **a table mart carries no outgoing FK constraints.** All 6 pre-existing table marts have zero; this change takes the set from 6 to 12.

### The reference diagram is unaffected

`generate_marts_reference.py` derives edges only from literal `foreign_key` constraints, so moving them would have silently emptied the diagram. It now reads the `meta` form alongside constraints.

Verified rather than assumed: regenerating the page and normalizing away padding leaves **all 80 FK rows identical**. The one remaining line difference is a Mermaid reorder that reproduces on unmodified `main` -- pre-existing drift the regeneration absorbs. A new fixture and test case cover the meta form; all 13 generator tests pass.

### Why the 5x-per-day tick

Matches `int_assessments__response_rollup`, the heaviest upstream, moved off eager for the same reason in [#4559](https://github.com/TEAMSchools/teamster/issues/4559). `dim_assessments` is raised from nightly to the same tick so the whole star shares one cadence -- otherwise a new Illuminate assessment could land in `dim_assessment_administrations` at 10:00 and not appear in `dim_assessments` until midnight.

### Consumer cadence check

`cube_semantic_layer` is the only exposure touching these marts -- no Tableau workbook, Sheets extract, or AppSheet app (checked all five files in `models/exposures/`). It lists 6 of the 7; `bridge_assessment_administration_members` has no exposure anywhere, a pre-existing gap noted in the self-review. Cube's `proficiency_rollup` pre-aggregation declares `refresh_key: every: 1 day`, so a 5x-per-day table is **fresher** than what Cube serves on its hot path.

**Accepted trade-off:** Cube queries that miss the rollup read the fact view live today and become 5x-per-day fresh.

### Every other mart follows the same pattern

`0` `foreign_key` constraints remain anywhere under `marts/`: 146 more move to `config.meta.foreign_key` across 56 files. A view mart's constraints are inert in BigQuery, so this is behavior-neutral today. What it buys is that materializing **any** mart is now safe by default, and a future view-to-table flip no longer drags its FK closure along.

Six columns already carried a `config` block (`meta.source_system` / `source_model` / `source_column`). Those are merged into, not replaced -- a duplicate `config` key would have silently dropped the existing mapping. All six verified to retain their `source_*` keys alongside the new `foreign_key`.

Sizing what this unlocks: 169 tests on other marts' deep view chains cost **16.37 USD per 11 days**, and every one of those models is now a candidate for the same treatment.

### Disabled: bridge_assessment_administration_members

Nothing reads it -- no `ref()` under `src/`, no exposure, no reference under `src/cube/model/`. 180 days of BigQuery history shows only its own build and its own three tests: **171 GiB (~1.04 USD) per 11 days** for a relation with no consumer. `dim_assessments` names it in a comment but does not select from it.

Each test carries its own `enabled: false`, because **dbt does not disable a model's tests when the model is disabled in properties yml** -- verified with `dbt parse --no-partial-parse`, where the model moved to `disabled` while all three tests stayed in `nodes`. Left implicit they would keep scanning the stale prod relation, which is the cost the disable exists to remove.

### A latent defect the refactor surfaced

Touching every mart pulled models into CI's `state:modified+` selection that CI had **never built before**, and one of them failed at `severity: error`: `fct_student_attendance_streaks` had 5 duplicate primary keys. Prod carries the identical 5.

Root cause is source data. Two kippcamden students each hold two active AY2026 enrollment stints sharing `entrydate: 2026-07-01` -- a 2-3 day stint and a full-year one. The fact joins the enrollment union by half-open date range, so both stints match one streak and it fans out. Because `entrydate` is the only enrollment input to `student_enrollment_key`, both matches hash identically and the duplicate rows are byte-identical.

Filed as #4835 (`ops-tracked`, no student identifiers -- those are PII). Interim mitigation here collapses the fan-out with `dbt_utils.deduplicate` and a `TODO(#4835)`. This is not duplicate-masking: both matches yield the same key, so the collapse is information-preserving, and a **genuine** overlap (two stints with different entrydates covering one streak) still fans out and still fails the PK test.

Verified by running the compiled SQL against prod: `duplicated_keys` 0 (was 5), total rows 6,164,285 equal to distinct keys exactly -- removing precisely those 5 rows and nothing else.

The PK test is left at `severity: error`. #3923 deliberately restored it to error after an earlier warn period; downgrading it would quietly reverse that decision.

### Two data-quality fixes riding along

- **Dropped one unfailable test.** `relationships` on `dim_assessment_administrations.administered_date_key` carried `where: administered_date_key >= '2000-01-01'`, which excluded the only 2 rows in the codebase that could fail it. Auditing all 37 `relationships`-to-`dim_dates` tests found 1 structurally vacuous, 36 dormant (zero rows in their failure domain, but they would fire on an upstream regression), 0 currently catching anything. Only the vacuous one is removed; its sentinel-row note moves into the column description.
- **Closed a floor-sentinel gap.** `int_assessments__response_rollup` nulled `date_taken < date '2000-01-01'` -- strictly less-than, so the sentinel that IS the floor passed through, surfacing as a minimum `test_date_key` of exactly `2000-01-01` (41 rows, 6 students). Widened to `<=`, and the paired `expression_is_true` guard tightened to `> '2000-01-01'`, still `severity: warn`. Verified no fan-out: all 32 affected fact rows keep a real `administered_date`, so `assessment_date_key` and the #4546 `not_null` invariant are untouched, and nulling a date can only remove LEFT JOIN matches.

This does **not** address the broader `date_taken` corruption (1,327,443 rows, 5.66%, predating any real administration), which is already documented in `student_assessment_scores.yml` and worked around by anchoring calendar rollups on `assessment_date_key`.

## AI Assistance

Claude Code authored this PR. The cost triage, exposure/cadence analysis, the pre-2000 audit, the FK-vs-ref graph analysis, and all edits were AI-executed; scope, the one-PR decision, the 5x-per-day tick, and the decision to drop FK constraints rather than convert the closure were human-directed. Claude initially proposed deleting 37 tests on a wrong premise and dropped it after the audit contradicted it, and initially missed that #4587 had already reverted this change.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
      -- not done, needs a human
- [ ] Review the **Claude Code Review** comment posted on this PR

### Dagster

- [x] `dagster definitions validate` -- `kipptaf` passes, which also proves the cron
      expression parses (cron typos surface only at Dagster load, per
      `automation-conditions.md`)
- [x] `uv run pytest tests/test_dagster_definitions.py` -- 4 passed, 2 failed.
      Both failures are `kippmiami` on an unresolvable local `FOCUS_DB`
      credential, reproduced identically on `main`; pre-existing and unrelated
- [x] New integrations follow the Library + Config pattern -- N/A

### dbt

- [x] Properties file for all new models -- N/A, no new models
- [x] Exposure for models consumed by an external tool -- N/A, `cube_semantic_layer`
      covers 6 of the 7 and is unchanged. `bridge_assessment_administration_members`
      is absent from it, but Cube references that model nowhere in
      `src/cube/model/`, so adding a `depends_on` edge would declare a dependency
      that does not exist. Pre-existing gap, flagged for follow-up
- [x] **Breaking change?** No column or contract changes. The FK constraints are
      removed from the DDL but preserved as metadata and in the diagram, and the
      `relationships` tests that actually detect orphans are untouched.
      **Rollback:** revert; the models return to views on the next deploy. Note
      the reverse conversion needs a drop -- per `src/dbt/CLAUDE.md`,
      `create or replace view` does not replace an existing table, so a revert
      needs `DROP TABLE IF EXISTS` on the six relations or one
      `dbt build --select <model> --full-refresh` each
- [x] `stage_external_sources` -- N/A

### Docs

- [x] `marts/CLAUDE.md` updated: the FK-carrying prohibition now states the
      FK-vs-`ref()` mechanism, records that cron does not fix it, and documents
      the `config.meta.foreign_key` form as the sanctioned path
- [x] `docs/reference/marts-data-models.md` regenerated
- [x] Automations catalog -- **not needed.** It covers schedules and sensors;
      `gen-automations-doc.py` filters out `__automation_condition_sensor`, and
      `docs/CLAUDE.md` warns it silently drops code locations when run in a
      codespace

## CI checks

- [ ] **Trunk** -- `trunk check --force` clean locally on all 11 changed files
      (2 markdown files needed prettier padding, applied by the pre-commit hook)
- [ ] **dbt Cloud** -- the previous run failed on exactly the FK DDL this commit
      removes; awaiting the re-run
- [ ] **Dagster Cloud** -- awaiting CI

## Post-merge verification

A properties-yml-only flip does not fire `code_version_changed`, so each relation stays a view until its first cron tick. After that tick:

1. Confirm the 5 remaining flipped relations report `type = 1` in `kipptaf_marts.__TABLES__`
1. Drop the now-orphaned `kipptaf_marts.bridge_assessment_administration_members` view (dbt no longer manages it; needs a human, BQ MCP is SELECT-only)
2. Confirm none carries a FOREIGN KEY in `INFORMATION_SCHEMA.TABLE_CONSTRAINTS`, and each carries its PRIMARY KEY
3. Re-run the `JOBS_BY_PROJECT` test-cost query and confirm the assessment tests move into the 1-2 base-table bucket

Refs #4821
