### PR TITLE
refactor(dbt): repoint location crosswalk consumers to int_people__location_crosswalk

### DIFF
--- a/docs/guides/adp-location-renames.md
+++ b/docs/guides/adp-location-renames.md
@@ -11,9 +11,11 @@ ADP occasionally renames a location in its system without any real-world change
 to the school or office. When that happens:
 
 1. Open the `src_people__location_crosswalk` Google Sheet.
-2. Add a **new alias row**: set `name` to the new ADP value, set `clean_name` to
-   the unchanged existing clean name, and copy all other columns (region, school
-   level, etc.) from the existing row for that location.
+2. Add a **new alias row**: set `name` to the new ADP value and `clean_name` to
+   the unchanged existing clean name. Those are the only two columns on the
+   sheet — region, school level, school ids, and every other attribute resolve
+   from the `src_google_sheets__people__locations_v3` tab in the same
+   spreadsheet, matched on `clean_name`.
 3. No downstream action is needed — `int_people__location_crosswalk` absorbs the
    rename via alias resolution. All models that join on `clean_name` are
    unaffected.

--- a/docs/guides/adp-location-renames.md
+++ b/docs/guides/adp-location-renames.md
@@ -12,8 +12,9 @@ to the school or office. When that happens:
 
 1. Open the `src_people__location_crosswalk` Google Sheet.
 2. Add a **new alias row**: set `name` to the new ADP value and `clean_name` to
-   the unchanged existing clean name. Those are the only two columns on the
-   sheet — region, school level, school ids, and every other attribute resolve
+   the unchanged existing clean name. Leave the remaining columns alone — dbt
+   reads only those two, via the `src_people__location_crosswalk_v2` named
+   range. Region, school level, school ids, and every other attribute resolve
    from the `src_google_sheets__people__locations_v3` tab in the same
    spreadsheet, matched on `clean_name`.
 3. No downstream action is needed — `int_people__location_crosswalk` absorbs the

--- a/src/dbt/kipptaf/models/amplify/mclass/sftp/staging/properties/stg_amplify__mclass__sftp__pm_student_summary_aimline.yml
+++ b/src/dbt/kipptaf/models/amplify/mclass/sftp/staging/properties/stg_amplify__mclass__sftp__pm_student_summary_aimline.yml
@@ -20,8 +20,8 @@ models:
         data_tests:
           - relationships:
               arguments:
-                to: ref("stg_google_sheets__people__location_crosswalk")
-                field: name
+                to: ref("int_people__location_crosswalk")
+                field: location_name
       - name: _dbt_source_relation
         data_type: string
         description: >-

--- a/src/dbt/kipptaf/models/amplify/mclass/sftp/staging/stg_amplify__mclass__sftp__pm_student_summary_aimline.sql
+++ b/src/dbt/kipptaf/models/amplify/mclass/sftp/staging/stg_amplify__mclass__sftp__pm_student_summary_aimline.sql
@@ -26,18 +26,20 @@ with
         select
             t.* except (_dbt_source_relation),
 
-            lc.region,
-            lc.abbreviation as school,
-            lc.powerschool_school_id as schoolid,
+            lc.location_region as region,
+            lc.location_abbreviation as school,
+            lc.location_powerschool_school_id as schoolid,
 
             regexp_replace(
-                t._dbt_source_relation, r'kipp[a-z]+_', lc.dagster_code_location || '_'
+                t._dbt_source_relation,
+                r'kipp[a-z]+_',
+                lc.location_dagster_code_location || '_'
             ) as _dbt_source_relation,
 
         from transformations as t
         left join
-            {{ ref("stg_google_sheets__people__location_crosswalk") }} as lc
-            on t.school_name = lc.name
+            {{ ref("int_people__location_crosswalk") }} as lc
+            on t.school_name = lc.location_name
     )
 
 select

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__comm_log.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__comm_log.yml
@@ -7,5 +7,5 @@ models:
         data_tests:
           - relationships:
               arguments:
-                to: ref("stg_google_sheets__people__location_crosswalk")
-                field: deanslist_school_id
+                to: ref("int_people__location_crosswalk")
+                field: location_deanslist_school_id

--- a/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
+++ b/src/dbt/kipptaf/models/deanslist/api/intermediate/properties/int_deanslist__incidents__penalties.yml
@@ -21,5 +21,5 @@ models:
         data_tests:
           - relationships:
               arguments:
-                to: ref("stg_google_sheets__people__location_crosswalk")
-                field: deanslist_school_id
+                to: ref("int_people__location_crosswalk")
+                field: location_deanslist_school_id

--- a/src/dbt/kipptaf/models/google/sheets/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources-external.yml
@@ -1204,6 +1204,11 @@ sources:
                 - sheets
                 - people
                 - location_crosswalk
+        columns:
+          - name: Name
+            data_type: STRING
+          - name: Clean_Name
+            data_type: STRING
       - name: src_google_sheets__people__locations
         external:
           options:

--- a/src/dbt/kipptaf/models/google/sheets/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources-external.yml
@@ -1193,7 +1193,7 @@ sources:
             format: GOOGLE_SHEETS
             uris:
               - https://docs.google.com/spreadsheets/d/1FCc28XWxFj3gSfItGGJ2tVU0C1fYD1JxKRxuSFqisMo
-            sheet_range: src_people__location_crosswalk
+            sheet_range: src_people__location_crosswalk_v2
             skip_leading_rows: 1
         config:
           meta:

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__location_crosswalk.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__location_crosswalk.yml
@@ -9,23 +9,3 @@ models:
                 severity: error
       - name: Clean_Name
         data_type: string
-      - name: Abbreviation
-        data_type: string
-      - name: Grade_Band
-        data_type: string
-      - name: Region
-        data_type: string
-      - name: PowerSchool_School_ID
-        data_type: int64
-      - name: Deanslist_School_ID
-        data_type: int64
-      - name: Reporting_School_ID
-        data_type: int64
-      - name: Is_Campus
-        data_type: boolean
-      - name: Is_Pathways
-        data_type: boolean
-      - name: Dagster_Code_Location
-        data_type: string
-      - name: Head_of_Schools_Employee_Number
-        data_type: int64

--- a/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__schools.yml
+++ b/src/dbt/kipptaf/models/powerschool/staging/properties/stg_powerschool__schools.yml
@@ -28,8 +28,8 @@ models:
         data_tests:
           - relationships:
               arguments:
-                to: ref("stg_google_sheets__people__location_crosswalk")
-                field: powerschool_school_id
+                to: ref("int_people__location_crosswalk")
+                field: location_powerschool_school_id
               config:
                 where: state_excludefromreporting = 0
           - unique:


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will narrow the `src_people__location_crosswalk` external to the two columns it is actually for — `name` and `clean_name` — and route every attribute lookup through `int_people__location_crosswalk`.

`int_people__location_crosswalk` already resolves every attribute (region, abbreviation, school ids, dagster code location, etc.) from `stg_google_sheets__people__locations`, joining the crosswalk sheet only for its alias-to-clean-name mapping. The crosswalk sheet's own attribute columns were a parallel, hand-maintained copy of that data with four consumers left.

### Part 1 — repoint the remaining consumers

- `stg_amplify__mclass__sftp__pm_student_summary_aimline` — `region`, `abbreviation`, `powerschool_school_id`, `dagster_code_location`, plus the join key
- `stg_powerschool__schools` — `powerschool_school_id` relationships test
- `int_deanslist__comm_log` — `deanslist_school_id` relationships test
- `int_deanslist__incidents__penalties` — `deanslist_school_id` relationships test

Value-neutral, verified against prod. Across all 251 crosswalk aliases the intermediate's values match the sheet's exactly, with three exceptions where the sheet is blank and the intermediate resolves a value: `KIPP Paterson Prep Middle`, `KIPP Paterson Prep Elementary`, and `Poinciana Campus`. No alias loses a value.

The aimline model's own output columns are unchanged, so no contracted column is renamed or removed and no downstream consumer is affected.

### Part 2 — narrow the source to the v2 named range

Ops added a `src_people__location_crosswalk_v2` named range covering `'Location Crosswalk'!A1:B1193` — the same 251 alias rows, columns A and B only.

- `sources-external.yml` — `sheet_range` moves to `src_people__location_crosswalk_v2`, plus an explicit `columns:` block pinning `Name` and `Clean_Name` (see the autodetect note below). The source `name:` and the Dagster asset key are unchanged, matching the existing `src_google_sheets__people__locations_v3` precedent of versioning only the range.
- `stg_google_sheets__people__location_crosswalk.yml` — drop the 10 attribute columns from the contract, keeping `Name` (with its uniqueness test) and `Clean_Name`.
- `docs/guides/adp-location-renames.md` — Scenario 1 told Ops to copy region, school level, and the rest onto each new alias row. It now says to leave those columns alone and explains where the attributes actually resolve from.

Nothing is deleted from the spreadsheet, so the Seat Tracker AppSheet app — which depends on `stg_google_sheets__people__location_crosswalk` directly, separate from `rpt_appsheet__seat_tracker_roster` — keeps whatever columns it reads off the sheet.

### Why the source needs an explicit `columns:` block

BigQuery's Google Sheets header autodetect only infers column names when the header row differs in type from the data below it. The old A:L range contained int64 columns, so row 1 was recognized as a header and the external came back with real names. The v2 range is all-string, so autodetect could not distinguish the header, and the first re-stage produced `string_field_0` / `string_field_1` — which would have failed the contract. Declaring `columns:` at the source level pins the names. `skip_leading_rows: 1` still drops the header row, so the row set is unchanged.

## Pre-merge state

The staging external has already been re-staged against the v2 range, so dbt Cloud CI should build against the correct 2-column schema:

```sh
uv run dbt run-operation stage_external_sources \
  --args "select: google_sheets.src_google_sheets__people__location_crosswalk" \
  --vars '{ext_full_refresh: true}' \
  --target staging --project-dir src/dbt/kipptaf
```

`zz_stg_kipptaf_google_sheets.src_google_sheets__people__location_crosswalk` now reports exactly `Name` and `Clean_Name`, both STRING.

**After merge**, re-stage the prod external with the same command and `--target prod`. Doing it before merge would break the deployed 12-column contract in prod.

## AI Assistance

Claude Code authored the change. Human-directed: the decision to repoint everything to `int_people__location_crosswalk`, to narrow the source in the same PR, the v2 named range itself, and authorizing the staging re-stage. AI-assisted: locating the consumers, the edits, diagnosing the autodetect failure, and the verification below.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] No new models, so no new properties file is needed.
- [x] No exposure change. The `seat_tracker_app` exposure still depends on `stg_google_sheets__people__location_crosswalk`, which still exists with two columns.
- [x] **Breaking change to a contracted model.** `stg_google_sheets__people__location_crosswalk` loses 10 columns. Nothing in dbt reads them after Part 1, and the spreadsheet itself is untouched, so AppSheet is unaffected. Rollback is to revert `sheet_range` to `src_people__location_crosswalk`, drop the `columns:` block, restore the yml columns, and re-stage.
- [x] **The external source is modified**, so `stage_external_sources --target staging` was run with `ext_full_refresh: true`. See above.

Local verification from the feature branch:

- `dbt parse --target prod` — clean on every commit, no ref cycles from staging and intermediate models referencing an intermediate.
- `dbt build --select stg_amplify__mclass__sftp__pm_student_summary_aimline --target dev --defer` — PASS=4 (model plus its 3 tests, including the repointed relationships test).
- `dbt test --select stg_powerschool__schools int_deanslist__comm_log int_deanslist__incidents__penalties --target dev --defer` — the `stg_powerschool__schools` test passes. **The two deanslist tests passed vacuously and should not be read as verification**: the run resolved both child models to stale copies in a personal dev schema instead of falling through to prod. CI reports the real numbers, 8,135 and 552 orphan rows, and they are pre-existing rather than caused by the repoint — holding the child side fixed, the old parent (sheet `Deanslist_School_ID`) and the new parent (`location_deanslist_school_id`) both yield exactly 8,135 and 552, which follows from their value sets being identical. Both tests are warn-severity, so CI stays green. Detail in the review reply comment.
- `dbt build --select stg_google_sheets__people__location_crosswalk+1 --target dev --defer` against a personally-staged v2 external — PASS=25, contract satisfied. The single WARN is the known free-text `adp_location` orphan issue tracked by #3728, and it is not caused by this PR: holding the seats side at prod gives 7 orphans against either the old or the new crosswalk, so swapping the crosswalk changes nothing. The 7-versus-5 difference comes from a stale dev copy of `stg_google_appsheet__seat_tracker__seats`.
- Row-level parity of the v2 range against the current prod table: 251 rows on both sides, zero `Name` values present in one and not the other, zero `Clean_Name` mismatches.
- Both named ranges read directly through the Sheets API: the old resolves to `'Location Crosswalk'!A1:L1193`, the new to `'Location Crosswalk'!A1:B1193`, both 252 rows including the header.
- `trunk check --force` over all 10 changed files, run from inside the worktree — no issues.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes. 25 warn-severity test warnings, all pre-existing; the 3 crosswalk-related ones are analyzed in the review reply comment.
- [x] **Dagster Cloud** — not triggered (no Dagster paths changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
