### PR TITLE
docs(claude): record seven learnings from the assessment-star session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -160,6 +160,10 @@ mutate ProjectV2 items/fields fail with "Resource not accessible by integration"
 — prefix with `GITHUB_TOKEN=` to fall back to the user's OAuth token (`gho_*`)
 which has full scopes.
 
+`gh run rerun` fails the same way as the below: the `ghu_*` token lacks
+`workflow` scope, and the `GITHUB_TOKEN=` fallback returns "cannot be retried".
+Hand reruns to the user or push a commit to re-trigger.
+
 `gh workflow run` (`workflow_dispatch`) can't be done from the Codespace: the
 `ghu_*` token lacks the `workflow` scope (403 "Resource not accessible by
 integration"), and emptying it via `GITHUB_TOKEN=` leaves `gh` API calls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **Git resuming**: Before resuming work on an existing branch, merge `main`:
   `git fetch origin main && git merge origin/main`.
 
+- **A CI failure in a file your branch never touched usually means `main`
+  moved** — run `git log <merge-base>..origin/main` before diagnosing. A merged
+  PR that narrowed a contract read as a live production incident this session;
+  merging `main` was the entire fix.
+
 - **A mid-session Codespace restart can delete `.worktrees/` and desync local
   git refs** (stale `main`, `git ls-remote <branch>` empty for a live branch, a
   HEAD that reads as the pre-session commit yet holds merged content). Trust

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -250,6 +250,12 @@ config blocks before the move, and rename the model's singular tests and their
 
 ## View→table flips for BigQuery plan depth
 
+**Before re-attempting a materialization or automation-condition change, check
+whether it was already reverted**:
+`git log -S '<config key>' -- <properties yml>`. A reverted perf change reads as
+an obvious win and CI passes for a while — that is how #4464 got re-done here,
+eight days after #4587 reverted it.
+
 A table model with a plan of hundreds of stages (straggler-fragile, e.g.
 [#4153](https://github.com/TEAMSchools/teamster/issues/4153)) usually inherits
 the depth from view upstreams: BigQuery inlines each view's full SQL per
@@ -797,6 +803,10 @@ legitimately-superseded inactive rows that repeat the key.
   `generate_surrogate_key`, a `coalesce` / `ifnull` with a non-null default, a
   literal in every UNION branch, or `count(...)`. The `accepted_values` pairing
   above overrides this rule; nothing else does.
+- **Disabling a model does NOT disable its tests.** `config: enabled: false` in
+  properties yml moves the model to `disabled` but leaves every test in `nodes`
+  (verified with `--no-partial-parse`), still scanning the stale prod relation.
+  Add `config: enabled: false` to each test as well.
 
 ### Verifying a test-removal PR
 
@@ -804,6 +814,11 @@ Never report a count from the YAML diff — it does not say which dbt nodes
 actually disappeared. `dbt parse` on main and on the branch, then diff the
 `resource_type == 'test'` node names. That fixes the delta and proves nothing
 unintended was dropped.
+
+Parse BOTH sides with `--no-partial-parse` — partial parse caches node
+enable/disable state and under-reports (767 vs 772 tests this session). Re-parse
+main fresh too: the main checkout's manifest is a stale artifact that reports
+since-deleted models as REMOVED and since-added ones as ADDED.
 
 ### An FK check belongs on the pre-join model, as a column `relationships` test
 

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -407,6 +407,12 @@ dbt Cloud project ID: `211862`.
 CI job: `dbt build --select state:modified+ --full-refresh`, target `staging`,
 defers to Staging environment.
 
+A refactor touching many models pulls them into `state:modified+`, so CI builds
+models it has never built — expect latent `severity: error` failures unrelated
+to your change (a 56-file sweep surfaced 5 duplicate PKs sitting in prod). Query
+prod for the same count before assuming you caused it, and budget for triage
+when scoping a wide sweep.
+
 CI is scoped to the kipptaf project only. PRs touching only a district project
 (kipppaterson, kippnewark, kippcamden, kippmiami) get a no-op kipptaf CI run
 that selects no models — kipptaf CI green is not evidence the district-side

--- a/src/dbt/kipptaf/models/marts/CLAUDE.md
+++ b/src/dbt/kipptaf/models/marts/CLAUDE.md
@@ -145,6 +145,12 @@ guarantees the parent row exists, use INNER JOIN. LEFT JOIN silently produces
 null hash inputs that surrogate-key into placeholder hashes — orphans surface
 only at `relationships` test runtime, not at compile.
 
+A dedupe on such a join is information-preserving — not dup-masking — when every
+matched parent yields the SAME hash (e.g. duplicate stints sharing the key's
+only input). Confirm the duplicate output rows are identical across every
+column; a genuine ambiguity produces differing rows and must still fail the PK
+test.
+
 ## BigQuery reserved identifiers
 
 Columns named `name`, `type`, `text`, `order`, `role`, `rank`, `timestamp`, etc.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add seven lines to CLAUDE.md capturing learnings from the #4821 / #4822 session. Each one is tied to a specific wrong turn taken during that work and names the decision a future session should make differently — per the necessity test in the root CLAUDE.md editing rules.

Docs only. No dbt nodes change, so the dbt Cloud check is a no-op run rather than validation.

| File | Learning | What went wrong without it |
| --- | --- | --- |
| `CLAUDE.md` | A CI failure in a file the branch never touched usually means `main` moved | #4823 merging mid-session was diagnosed as a live production incident; merging `main` was the entire fix |
| `src/dbt/CLAUDE.md` | Diff node sets with `--no-partial-parse`, and re-parse main | Partial parse under-reported 767 vs 772 tests; a stale main manifest produced 66 phantom removals |
| `src/dbt/CLAUDE.md` | Disabling a model does NOT disable its tests | A disable that saved nothing -- all 3 tests kept scanning the stale prod relation |
| `src/dbt/CLAUDE.md` | Check for a prior revert before re-attempting a materialization change | #4464 was rebuilt eight days after #4587 reverted it, and got two commits deep before the revert was found |
| `src/dbt/kipptaf/CLAUDE.md` | A wide refactor pulls never-built models into CI | A 56-file sweep surfaced 5 duplicate PKs sitting in prod, invisible because CI only builds `state:modified+` |
| `marts/CLAUDE.md` | When a hash-input-join dedupe is information-preserving | The repo bans dup-masking dedupes; naming the legitimate case is what unblocked the streaks fix |
| `.claude/CLAUDE.md` | `gh run rerun` is unavailable from the Codespace | Two wasted calls discovering neither token can retry a workflow |

The `marts/CLAUDE.md` line lands in the "Hash-input joins" section and complements the FK-vs-`ref()` rules added in #4822; the two do not conflict and can merge in either order.

## AI Assistance

Claude Code authored this PR, via `/claude-md-management:revise-claude-md`. Claude proposed the seven additions and the human approved all seven. Every claim is drawn from a failure observed in the session rather than from general practice.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
      -- not done, needs a human
- [ ] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file / exposures / contracts -- N/A, no model changes
- [x] **Breaking change?** No. Documentation only; purely additive (36 insertions,
      0 deletions)

### Docs

- [x] `trunk check --force` on all 5 changed files -- no rule violations; 2 files
      needed prettier prose reflow, applied by the pre-commit hook

## CI checks

- [ ] **Trunk** -- awaiting CI
- [ ] **dbt Cloud** -- expected to be a trivial no-op; a docs-only PR selects no
      models, so a green check here is not validation of anything
- [ ] **Dagster Cloud** -- not triggered, no relevant paths changed

Closes #4840
