### PR TITLE
refactor(dbt): make the campus crosswalk the sole owner of location to campus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,12 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   the edits to subagents (their context absorbs the injection) and verify via
   `git -C <worktree> diff` from the main repo.
 
+- **When subagents aren't available**, edit worktree files by `Write`-ing a
+  Python script to `.claude/scratch/` and running it by ABSOLUTE path from the
+  main repo cwd — `Write` content is injection-exempt and no `cd` occurs, so
+  neither step re-injects. Assert each anchor matches exactly once and abort
+  otherwise; verify with `git -C <worktree> diff`.
+
 - **`git worktree add` with a RELATIVE path resolves against the shell cwd**,
   which drifts after a foreground `cd` into another worktree — pass an ABSOLUTE
   path (`git worktree add /workspaces/teamster/.worktrees/<branch> <branch>`) or
@@ -206,7 +212,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **A CI failure in a file your branch never touched usually means `main`
   moved** — run `git log <merge-base>..origin/main` before diagnosing. A merged
   PR that narrowed a contract read as a live production incident this session;
-  merging `main` was the entire fix.
+  merging `main` was the entire fix. A clean prod baseline does NOT rule this
+  out — CI builds `--full-refresh` against deferred upstreams, so prod passing
+  and CI failing is the expected shape. Check git before the warehouse; it is
+  one command and decisive.
 
 - **A mid-session Codespace restart can delete `.worktrees/` and desync local
   git refs** (stale `main`, `git ls-remote <branch>` empty for a live branch, a
@@ -349,6 +358,11 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
 - **IDE selection arrives only via `<ide_selection>` tags**, not
   `<ide_opened_file>` (which only names the open path). When the user references
   "this" without an `<ide_selection>`, ask for the snippet — don't guess.
+
+- **Never assert remaining context as fact** — there is no token counter, the
+  harness compacts automatically, and a felt sense of a long session is not
+  evidence. Truncating analysis or handing off work on that basis costs more
+  than finishing it.
 
 - **Before claiming a harness artifact (rewritten output, phantom rendering,
   truncated literal), verify with a DERIVED value** — line length, `grep -c`, a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,10 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   `<ide_opened_file>` (which only names the open path). When the user references
   "this" without an `<ide_selection>`, ask for the snippet — don't guess.
 
+- **Arm the Monitor in the same turn you say you'll watch something.** A monitor
+  that has exited is indistinguishable from one still waiting — both are silent.
+  Stating an intention is not a mechanism.
+
 - **Never assert remaining context as fact** — there is no token counter, the
   harness compacts automatically, and a felt sense of a long session is not
   evidence. Truncating analysis or handing off work on that basis costs more

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -531,6 +531,11 @@ dev parent dim produces false-positive `relationships` orphans. Before trusting
 a dev relationships warning on a FK, include the parent in `--select` or
 `dbt clone --select <parent_dim>` from prod.
 
+The inverse also happens: a stale dev CHILD makes a `relationships` test pass
+VACUOUSLY. A `dbt test` that passes locally and warns in CI with thousands of
+orphans is this, not a regression — confirm by holding the child fixed and
+swapping only the parent.
+
 Same trap applies to mart PK `unique` tests — a stale dev parent fans out a
 date-range join. Query prod before filing upstream bugs or adding defensive
 dedupe from a dev mart-test failure.
@@ -641,6 +646,17 @@ text-formatted `00000` in Sheets becomes INT64.
       data_type: STRING
 ```
 
+- **Header autodetect needs type variation.** BigQuery only treats row 1 as a
+  header when it differs in type from the data below. An all-STRING range (e.g.
+  a narrowed name-only crosswalk) autodetects as `string_field_0`,
+  `string_field_1` — which fails a contracted `select *`. Declare `columns:`
+  explicitly for any all-string range; `skip_leading_rows: 1` still drops the
+  header.
+- **To narrow a Sheets source, add a new named range and move `sheet_range`**
+  (`src_x` → `src_x_v2`), don't delete sheet columns — AppSheet and other
+  non-dbt consumers read the same tab. Version only the range; keep the source
+  `name:` and Dagster asset key. Precedent:
+  `src_google_sheets__people__locations_v3`.
 - **Phantom empty rows**: a Sheet's full grid (often ~1000 rows) lands as
   null-key rows in the external table → staging `not_null`/`unique` key tests
   fail with ~N results. Filter them in the staging model:
@@ -797,6 +813,14 @@ legitimately-superseded inactive rows that repeat the key.
   `generate_surrogate_key`, a `coalesce` / `ifnull` with a non-null default, a
   literal in every UNION branch, or `count(...)`. The `accepted_values` pairing
   above overrides this rule; nothing else does.
+
+### Retiring a crosswalk or lookup as redundant
+
+Check the join TYPE per consumer first. An INNER join makes the table a
+membership filter — often gating an outbound feed — not a lookup, and its row
+set may encode no derivable rule. Likewise count the rows any replacement
+`coalesce` fallback actually fires on: one written to preserve a single row
+fired on 251.
 
 ### Verifying a test-removal PR
 

--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -73,6 +73,13 @@ in prod IMMEDIATELY: external sources are excluded from the deps gate
 staging model and its `stage_external_sources` fails on the still-empty prod
 prefix.
 
+**Sheets externals need no manual post-merge prod re-stage.** The
+`build_dbt_assets` stage→refresh→build flow re-stages the prod external and
+rebuilds the `stg_` table on the next tick. The "launch that asset in prod
+IMMEDIATELY" rule above is for NEW Avro/GCS sources only. Verify with
+`INFORMATION_SCHEMA.COLUMNS` on the prod external before filing a manual
+re-stage as outstanding work.
+
 **AVRO external tables autodetect schema from the LAST ALPHABETICAL file.** To
 evolve an Avro source's schema, the new-schema file must sort last — materialize
 the MAX partition (latest hive `_dagster_partition_date=`). Mixed old/new files

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -244,7 +244,11 @@ Canonical-grain consumers (1 row per logical school) should use
 **`stg_google_sheets__people__campus_crosswalk`** uniqueness grain is
 `Location_Name` only. `Name` is the parent campus and repeats across sibling
 schools (e.g., `KIPP Miami - North Campus` rolls up five `Location_Name`
-children).
+children). It is the SOLE owner of location-to-campus — `campus_name` on
+`int_people__location_crosswalk` and `campus` on `dim_locations` resolve from
+here; don't reintroduce a `Campus_Name` scalar on the locations sheet. It
+carries no self-referential rows, so a campus record's `campus_name` is NULL by
+design. It also gates `rpt_illuminate__roles` via an INNER join.
 
 **`stg_powerschool__students` phantom rows**: PowerSchool retains 4 placeholder
 rows (one per district) with

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -417,6 +417,15 @@ to your change (a 56-file sweep surfaced 5 duplicate PKs sitting in prod). Query
 prod for the same count before assuming you caused it, and budget for triage
 when scoping a wide sweep.
 
+`state:modified+` is branch-vs-deferred-environment, NOT commit-vs-commit. A
+docs-only or `.md`-only push to a branch that already modifies dbt models
+re-runs the whole selection — measured at 918 relations and ~4.5 min on a
+13-file PR whose last commit touched only `.md`. Batch doc commits before
+pushing, or land them in a separate PR. Verify what a run actually built with
+`creation_time` in `region-us.INFORMATION_SCHEMA.TABLES` filtered to
+`dbt_cloud_pr_<job>_<pr>%` — step duration and warning counts are both weak
+proxies.
+
 CI is scoped to the kipptaf project only. PRs touching only a district project
 (kipppaterson, kippnewark, kippcamden, kippmiami) get a no-op kipptaf CI run
 that selects no models — kipptaf CI green is not evidence the district-side

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
@@ -3,15 +3,8 @@ with
         select
             sr.powerschool_teacher_number,
             sr.home_work_location_dagster_code_location,
-
-            coalesce(
-                ccw.powerschool_school_id, sr.home_work_location_powerschool_school_id
-            ) as school_id,
+            sr.home_work_location_powerschool_school_id as school_id,
         from {{ ref("int_people__staff_roster") }} as sr
-        left join
-            {{ ref("stg_google_sheets__people__campus_crosswalk") }} as ccw
-            on sr.home_work_location_reporting_name = ccw.location_name
-            and not ccw.is_pathways
         where
             sr.assignment_status != 'Terminated'
             -- Miami rosters into Clever directly from Focus; excluded from all

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -73,23 +73,11 @@ with
             sr.home_department_name,
             sr.sam_account_name,
 
-            cast(
-                coalesce(
-                    ccw.powerschool_school_id,
-                    sr.home_work_location_powerschool_school_id
-                ) as string
-            ) as school_id,
+            cast(sr.home_work_location_powerschool_school_id as string) as school_id,
         from staff_roster as sr
-        left join
-            {{ ref("stg_google_sheets__people__campus_crosswalk") }} as ccw
-            on sr.home_work_location_reporting_name = ccw.location_name
-            and not ccw.is_pathways
         where
             sr.home_department_name not in ('Data', 'Teaching and Learning')
-            and coalesce(
-                ccw.powerschool_school_id, sr.home_work_location_powerschool_school_id
-            )
-            != 0
+            and sr.home_work_location_powerschool_school_id != 0
 
         union all
 

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -62,8 +62,9 @@ with
     ),
 
     assignments as (
-        /* - School staff assigned to primary school only
-           - Campus staff assigned to all schools at campus
+        /* School and campus staff assigned to their primary school only. The
+           campus crosswalk previously overrode the school id here, but it
+           resolved to the same value the roster already carries.
         */
         select
             sr.powerschool_teacher_number,

--- a/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/appsheet/rpt_appsheet__seat_tracker_roster.sql
@@ -91,7 +91,7 @@ select
         lc.location_abbreviation, sr.home_work_location_name
     ) as location_shortname,
 
-    coalesce(cc.name, sr.home_work_location_name) as campus,
+    coalesce(lc.campus_name, sr.home_work_location_name) as campus,
 
     case
         when
@@ -170,9 +170,6 @@ from {{ ref("int_people__staff_roster") }} as sr
 inner join
     {{ ref("int_people__location_crosswalk") }} as lc
     on sr.home_work_location_name = lc.location_name
-left join
-    {{ ref("stg_google_sheets__people__campus_crosswalk") }} as cc
-    on sr.home_work_location_name = cc.location_name
 left join itr_response as ir on sr.employee_number = ir.employee_number
 left join pm_tier as pm on sr.employee_number = pm.employee_number
 

--- a/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
+++ b/src/dbt/kipptaf/models/extracts/illuminate/rpt_illuminate__roles.sql
@@ -34,7 +34,7 @@ select
     -- trunk-ignore-begin(sqlfluff/RF05)
     sr.powerschool_teacher_number as `01 Local User ID`,
 
-    cc.powerschool_school_id as `02 Site ID`,
+    sr.home_work_location_powerschool_school_id as `02 Site ID`,
 
     'School Leadership' as `03 Role Name`,
 
@@ -50,11 +50,11 @@ from {{ ref("int_people__staff_roster") }} as sr
 inner join
     {{ ref("stg_google_sheets__people__campus_crosswalk") }} as cc
     on sr.home_work_location_reporting_name = cc.location_name
-    and not cc.is_pathways
 where
     sr.worker_status_code != 'Terminated'
     and sr.home_department_name not in ('Teaching and Learning', 'Data', 'Executive')
     and sr.home_work_location_is_campus
+    and not sr.home_work_location_is_pathways
     -- Miami left Illuminate ahead of AY2026-27
     and sr.home_work_location_dagster_code_location != 'kippmiami'
 

--- a/src/dbt/kipptaf/models/google/sheets/sources-external.yml
+++ b/src/dbt/kipptaf/models/google/sheets/sources-external.yml
@@ -1271,7 +1271,7 @@ sources:
             format: GOOGLE_SHEETS
             uris:
               - https://docs.google.com/spreadsheets/d/1FCc28XWxFj3gSfItGGJ2tVU0C1fYD1JxKRxuSFqisMo
-            sheet_range: src_people__campus_crosswalk
+            sheet_range: src_people__campus_crosswalk_v2
             skip_leading_rows: 1
         config:
           meta:
@@ -1282,6 +1282,11 @@ sources:
                 - sheets
                 - people
                 - campus_crosswalk
+        columns:
+          - name: Name
+            data_type: STRING
+          - name: Location_Name
+            data_type: STRING
       - name: src_google_sheets__people__powerschool_crosswalk
         external:
           options:

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__campus_crosswalk.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__campus_crosswalk.yml
@@ -1,37 +1,28 @@
 models:
   - name: stg_google_sheets__people__campus_crosswalk
     description: |
-      Campus roll-up crosswalk — maps each campus `Name` to the canonical
-      location it belongs to, along with school-level metadata. Sourced from
-      a Google Sheet maintained by the People team.
+      Maps each school `Location_Name` to the parent campus `Name` it rolls up
+      to. Sole owner of the location-to-campus relationship — `campus_name` on
+      `int_people__location_crosswalk` and `campus` on `dim_locations` both
+      resolve from here. Sourced from a Google Sheet maintained by the People
+      team.
+
+      Also serves as the membership list for `rpt_illuminate__roles`, which
+      inner-joins it to decide which locations receive Illuminate roles.
     columns:
       - name: Location_Name
         description: |
-          Canonical location name from `int_people__location_crosswalk`. Join
-          key to `int_people__staff_roster.home_work_location_reporting_name`.
+          Canonical location name of the child school. Join key to
+          `int_people__staff_roster.home_work_location_reporting_name` and to
+          `int_people__location_crosswalk.location_clean_name`.
         data_type: string
         data_tests:
           - unique:
               config:
                 severity: error
       - name: Name
-        description: Campus name (distinct from Location_Name).
+        description: |
+          Parent campus the location rolls up to. Repeats across sibling
+          schools sharing a campus, and equals `Location_Name` for a location
+          that is itself a campus.
         data_type: string
-      - name: Region
-        description: Region the campus belongs to.
-        data_type: string
-      - name: Grade_Band
-        description: Grade band the campus serves.
-        data_type: string
-      - name: PowerSchool_School_ID
-        description: PowerSchool `school_id` for the campus.
-        data_type: int64
-      - name: Reporting_School_ID
-        description: Stable reporting ID for the campus.
-        data_type: int64
-      - name: Abbreviation
-        description: Short code / abbreviation for the campus.
-        data_type: string
-      - name: Is_Pathways
-        description: Whether the campus is part of the Pathways program.
-        data_type: boolean

--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__people__locations.yml
@@ -97,12 +97,6 @@ models:
         description: |
           Grow (observation platform) location identifier. STRING type for
           downstream FK uniformity.
-      - name: campus_name
-        data_type: string
-        description: |
-          Parent campus name for multi-school campuses (e.g., two schools that
-          share a building). Null when the location is not grouped under a
-          named campus.
       - name: address
         data_type: string
         description: |

--- a/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__people__locations.sql
+++ b/src/dbt/kipptaf/models/google/sheets/staging/stg_google_sheets__people__locations.sql
@@ -14,7 +14,6 @@ select
     `Head_of_Schools_Employee_Number` as head_of_schools_employee_number,
     `ADP_Location_Code` as adp_location_code,
     `Grow_Location_ID` as grow_location_id,
-    `Campus_Name` as campus_name,
     `Address` as address,
     `City` as city,
     `Postal_Code` as postal_code,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
@@ -7,7 +7,7 @@ select
     pl.city,
     pl.postal_code,
 
-    coalesce(cc.name, if(pl.is_campus, pl.location_name, null)) as campus,
+    cc.name as campus,
 
     {{ dbt_utils.generate_surrogate_key(["pl.business_unit_code"]) }} as region_key,
 

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
@@ -7,7 +7,7 @@ select
     pl.city,
     pl.postal_code,
 
-    cc.name as campus,
+    coalesce(cc.name, if(pl.is_campus, pl.location_name, null)) as campus,
 
     {{ dbt_utils.generate_surrogate_key(["pl.business_unit_code"]) }} as region_key,
 

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_locations.sql
@@ -1,16 +1,19 @@
 select
-    location_key,
+    pl.location_key,
+    pl.location_name as `name`,
+    pl.grade_band,
+    pl.is_campus,
+    pl.address,
+    pl.city,
+    pl.postal_code,
 
-    {{ dbt_utils.generate_surrogate_key(["business_unit_code"]) }} as region_key,
+    cc.name as campus,
 
-    location_name as `name`,
-    grade_band,
-    campus_name as campus,
-    is_campus,
-    address,
-    city,
-    postal_code,
+    {{ dbt_utils.generate_surrogate_key(["pl.business_unit_code"]) }} as region_key,
 
-    coalesce(abbreviation, location_name) as abbreviation,
-from {{ ref("stg_google_sheets__people__locations") }}
-where not is_pathways and location_name <> 'KIPP Whittier Elementary'
+    coalesce(pl.abbreviation, pl.location_name) as abbreviation,
+from {{ ref("stg_google_sheets__people__locations") }} as pl
+left join
+    {{ ref("stg_google_sheets__people__campus_crosswalk") }} as cc
+    on pl.location_name = cc.location_name
+where not pl.is_pathways and pl.location_name <> 'KIPP Whittier Elementary'

--- a/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
+++ b/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
@@ -16,7 +16,9 @@ select
     pl.dagster_code_location as location_dagster_code_location,
     pl.head_of_schools_employee_number as location_head_of_schools_employee_number,
 
-    cc.name as campus_name,
+    /* the crosswalk maps child schools to a parent campus and never carries a
+       self-referential row, so a campus record resolves to itself */
+    coalesce(cc.name, if(pl.is_campus, pl.location_name, null)) as campus_name,
 from {{ ref("stg_google_sheets__people__location_crosswalk") }} as lc
 left join
     {{ ref("stg_google_sheets__people__locations") }} as pl

--- a/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
+++ b/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
@@ -15,8 +15,12 @@ select
     pl.is_pathways as location_is_pathways,
     pl.dagster_code_location as location_dagster_code_location,
     pl.head_of_schools_employee_number as location_head_of_schools_employee_number,
-    pl.campus_name,
+
+    cc.name as campus_name,
 from {{ ref("stg_google_sheets__people__location_crosswalk") }} as lc
 left join
     {{ ref("stg_google_sheets__people__locations") }} as pl
     on lc.clean_name = pl.location_name
+left join
+    {{ ref("stg_google_sheets__people__campus_crosswalk") }} as cc
+    on lc.clean_name = cc.location_name

--- a/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
+++ b/src/dbt/kipptaf/models/people/intermediate/int_people__location_crosswalk.sql
@@ -16,9 +16,7 @@ select
     pl.dagster_code_location as location_dagster_code_location,
     pl.head_of_schools_employee_number as location_head_of_schools_employee_number,
 
-    /* the crosswalk maps child schools to a parent campus and never carries a
-       self-referential row, so a campus record resolves to itself */
-    coalesce(cc.name, if(pl.is_campus, pl.location_name, null)) as campus_name,
+    cc.name as campus_name,
 from {{ ref("stg_google_sheets__people__location_crosswalk") }} as lc
 left join
     {{ ref("stg_google_sheets__people__locations") }} as pl


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will make `src_people__campus_crosswalk` the single owner of the location-to-campus relationship, and remove the duplicate copy of that data from the locations sheet.

Closes #4838.

The mapping was maintained in two places that could drift. Six of the crosswalk's eight columns were byte-identical duplicates of `src_google_sheets__people__locations_v3` — verified against prod across all 17 rows, 0 unmatched and 0 differences on `Region`, `Grade_Band`, `PowerSchool_School_ID`, `Reporting_School_ID`, `Abbreviation`, and `Is_Pathways`. The drift had already started: one location carried a wrong campus on the locations sheet.

### Changes

- `sources-external.yml` — `sheet_range` moves to the new `src_people__campus_crosswalk_v2` named range covering columns A and B, plus an explicit `columns:` block. Sheets header autodetect cannot infer names for an all-string range, so the block is required.
- `stg_google_sheets__people__campus_crosswalk.yml` — contract narrows to `Name` and `Location_Name`, keeping the `unique` test at severity error.
- `stg_google_sheets__people__locations` — stops selecting `Campus_Name`, and it comes off the contract. The source-level `columns:` block deliberately keeps its `Campus_Name` entry: an explicit external schema maps positionally, so removing a mid-list column would shift every column after it.
- `int_people__location_crosswalk.campus_name` and `dim_locations.campus` — resolve by joining the crosswalk on `clean_name = location_name`. Grain is safe; `Location_Name` is unique.
- `rpt_illuminate__roles` — keeps its INNER JOIN, which is the membership filter deciding who receives a role. `is_pathways` and the site id move to `int_people__staff_roster`, which already carries both. Value-neutral: 0 differences across all 623 rows where the join matched.
- `rpt_clever__staff` and `rpt_clever__sections` — join deleted. The `coalesce(ccw.powerschool_school_id, sr.home_work_location_powerschool_school_id)` override was vestigial.
- `rpt_appsheet__seat_tracker_roster` — join deleted in favor of the `int_people__location_crosswalk` join already present two lines above.
- `rpt_gsheets__pm_assignment_roster` — unchanged. It reads only `Name`, which is kept.

### Why the source is not retired outright

The 17-row membership encodes no derivable rule — among locations with `is_campus = false` and `is_pathways = false`, 15 are members and 14 are not. Dropping the sheet would remove the Illuminate filter and provision roles for every non-Pathways location.

## Accepted behavior change

Two locations stop reporting a campus and report null instead:

| Location | campus before | campus after | active staff |
| --- | --- | --- | --- |
| `KIPP Miami - North Campus` | itself | null | 6 |
| `KIPP Miami - Poinciana Campus` | `KIPP Miami - North Campus` (wrong) | null | 4 |

This matches how campus records already behave. Of the 10 campus records outside the crosswalk, 8 already carry a null campus today, covering 251 active staff at `Room 9`, `Room 10`, and `Room 12`. North Campus was the anomaly, and Poinciana was simply wrong — the two are separate campuses.

An earlier revision resolved a campus record to itself instead. That was reverted: it would have invented a campus for those 251 staff equal to their own room name.

The coalesce-guarded consumers — the seat tracker, the stipend app roster, and the PM assignment roster — fall back to the location name and are unaffected. The bare-reference consumers are roughly 15 Tableau extracts plus `dim_locations.campus`.

## Self-review

### dbt

- [x] No new models, so no new properties file is needed.
- [x] No exposure change. The `seat_tracker_app` exposure still depends on `stg_google_sheets__people__campus_crosswalk`, which still exists with two columns.
- [x] **Breaking change to two contracted models.** The campus crosswalk loses 6 columns and the locations staging model loses `campus_name`. Every consumer of both is repointed in this PR. Rollback is to revert `sheet_range`, drop the `columns:` block, restore both contracts, and re-stage.
- [x] **The external source is modified**, so `stage_external_sources` must run with `--target staging` before CI can pass, and with `--target prod` after merge.

Local verification from the feature branch, against the real v2 named range staged into a personal dev schema:

- `dbt parse --target prod` — clean on every commit.
- `dbt build --select stg_google_sheets__people__campus_crosswalk stg_google_sheets__people__locations int_people__location_crosswalk dim_locations --target dev --defer` — **PASS=37**, both narrowed contracts satisfied, all 33 `dim_locations` foreign-key relationships tests green.
- The staged v2 external reports exactly `Name` and `Location_Name`, and preserves all 17 rows.
- `int_people__location_crosswalk` holds 251 rows in dev and 251 in prod. `campus_name` differs on 4 rows, which at alias grain resolve to exactly 2 locations: North Campus and Poinciana Campus. No other location moves.
- The `powerschool_school_id` override removed from both Clever feeds was confirmed vestigial: 0 differences across all 623 matching rows.
- `trunk check --force` over every changed file, run from inside the worktree — no issues.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — requires the staging re-stage described above before it can pass.
- [ ] **Dagster Cloud** — passes or not triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
