### PR TITLE
feat(dbt): add ADA columns to gpa_roster and student_course_grades

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
@@ -25,6 +25,16 @@ models:
         data_type: string
       - name: is_504
         data_type: boolean
+      - name: unweighted_ada
+        description:
+          Unweighted average daily attendance across the full academic year.
+        data_type: float64
+      - name: weighted_ada
+        description:
+          Weighted average daily attendance across the full academic year. This
+          is the value network reporting uses for high school students from SY26
+          onward.
+        data_type: float64
       - name: gpa_q1
         data_type: float64
       - name: gpa_q2

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
@@ -13,6 +13,8 @@ with
             co.lep_status,
             co.is_504,
             co.gifted_and_talented,
+            co.unweighted_ada,
+            co.weighted_ada,
 
             term,
 
@@ -66,6 +68,8 @@ select
     lep_status,
     gifted_and_talented,
     is_504,
+    unweighted_ada,
+    weighted_ada,
 
     gpa_q1,
     gpa_q2,

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -144,6 +144,14 @@ models:
       - name: ada
         data_type: float64
         description: Average daily attendance for the year.
+      - name: unweighted_ada
+        data_type: float64
+        description: Unweighted average daily attendance for the year.
+      - name: weighted_ada
+        data_type: float64
+        description: >-
+          Weighted average daily attendance for the year, the value used for
+          high school students from SY26 onward.
       - name: ada_above_or_at_80
         data_type: boolean
         description: ADA at or above 80 percent.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -180,6 +180,8 @@ with
             enr.is_counseling_services,
             enr.is_student_athlete,
             enr.ada,
+            enr.unweighted_ada,
+            enr.weighted_ada,
             enr.ada_above_or_at_80,
             enr.hos,
             enr.school_leader,
@@ -900,6 +902,8 @@ select
     s.is_counseling_services,
     s.is_student_athlete,
     s.ada,
+    s.unweighted_ada,
+    s.weighted_ada,
     s.ada_above_or_at_80,
 
     s.`quarter`,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...expose unweighted and weighted average daily attendance on two GPA extracts, sourced from `int_extracts__student_enrollments` and declared in each model's enforced contract.

| Model                                | Columns added                    |
| ------------------------------------ | -------------------------------- |
| `rpt_gsheets__gpa_roster`            | `unweighted_ada`, `weighted_ada` |
| `rpt_tableau__student_course_grades` | `unweighted_ada`, `weighted_ada` |

Additive only. Nothing was renamed or removed, and the existing `ada` / `ada_above_or_at_80` on `rpt_tableau__student_course_grades` are untouched.

### Naming

Upstream already exposes a column named `ada` that is SY26-aware: HS students at `academic_year >= 2025` resolve to weighted ADA, everyone else to unweighted.

`rpt_gsheets__gpa_roster` filters `grade_level >= 5`, so it spans both MS and HS. An initial draft aliased `unweighted_ada as ada` there, which would have published raw unweighted values under a name the rest of the network reads as weighted for HS students — a silent reconciliation mismatch against other ADA reports rather than a loud error. Both values now carry explicit names in both models and no bare `ada` alias is introduced. The gradebook extract keeps its existing `ada`, which already carries the convention-correct value, so the three columns coexist deliberately.

## AI Assistance

Claude Code authored the column additions, contract updates, and validation. Human-directed: which models to change, and the decision to expose both values under explicit names rather than alias either one to `ada`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file included for all changed models — both `properties/` YAMLs
      carry the new columns with `data_type: float64` plus descriptions.
- [ ] Exposure included or updated — `rpt_gsheets__gpa_roster` already has one
      (`exposures/google-sheets.yml`). **`rpt_tableau__student_course_grades`
      has no exposure at all**, which is a pre-existing gap rather than
      something this PR introduces: no column here is consumed differently for
      the lack of it. Adding one would need the Tableau workbook LSID and URL,
      and is deliberately out of scope for this PR rather than guessed at.
- [x] **Breaking change?** No. Column additions only — nothing renamed or
      removed, so no downstream exposure breaks and no rollback plan is needed
      beyond reverting the commits.
- [x] External sources — n/a. No external source added or modified, so no
      `stage_external_sources` run is required.

### Validation

Both models built green against dev, which is what actually exercises contract enforcement (`assert_columns_equivalent` runs inside `dbt build`, not `parse`):

```text
dbt build --select <model> --target dev --favor-state --defer --state target/prod
```

Contract enforcement was confirmed active on each model (`contract: {enforced: True, alias_types: True}` as parsed) rather than assumed, so the green builds validated the column sets instead of passing vacuously. `trunk check --force` is clean on all four changed files.

Two build failures encountered along the way were both local environment staleness, not defects in this change: a prod manifest predating `int_students__terms` (regenerated via `dbt parse --target prod`), and a stale personal dev copy of `base_powerschool__course_enrollments` missing `_dbt_source_project` (resolved with `--favor-state`, confirmed by reading the compiled `FROM` clause).

The pre-existing warn-level uniqueness test on `rpt_tableau__student_course_grades` returns 12 duplicate key combinations, all in `academic_year` 2025. Prod returns exactly the same 12, consistent with the documented `TODO(#3915)` storedgrades double-write. Unchanged by this PR — the added columns are projections and cannot alter a key.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes. Note that `state:modified+` will pull
      `rpt_tableau__student_course_grades` and its descendant graph into the
      build, so expect a wide selection and a longer run than the diff suggests.
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the
      `pull_request` paths.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

Closes #4845
