### PR TITLE
chore: ignore locally installed third-party agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,48 @@ dagster-tmp
 .claude/scheduled_tasks.lock
 .superpowers/
 
+# Third-party agent skills installed via `npx skills add` (local-only).
+# `.agents/skills/<name>` holds the source; `.claude/skills/<name>` is a symlink
+# to it. Listed explicitly rather than ignoring `.claude/skills/*` wholesale so
+# new repo-owned skills still show up in `git status`.
+.agents/
+skills-lock.json
+.claude/skills/ask-matt
+.claude/skills/claude-handoff
+.claude/skills/code-review
+.claude/skills/codebase-design
+.claude/skills/diagnosing-bugs
+.claude/skills/domain-modeling
+.claude/skills/git-guardrails-claude-code
+.claude/skills/grill-me
+.claude/skills/grill-with-docs
+.claude/skills/grilling
+.claude/skills/handoff
+.claude/skills/implement
+.claude/skills/improve-codebase-architecture
+.claude/skills/loop-me
+.claude/skills/migrate-to-shoehorn
+.claude/skills/prototype
+.claude/skills/research
+.claude/skills/resolving-merge-conflicts
+.claude/skills/scaffold-exercises
+.claude/skills/setup-matt-pocock-skills
+.claude/skills/setup-pre-commit
+.claude/skills/setup-ts-deep-modules
+.claude/skills/tdd
+.claude/skills/teach
+.claude/skills/to-questionnaire
+.claude/skills/to-spec
+.claude/skills/to-tickets
+.claude/skills/triage
+.claude/skills/wait-what
+.claude/skills/wayfinder
+.claude/skills/wizard
+.claude/skills/writing-beats
+.claude/skills/writing-for-agents
+.claude/skills/writing-fragments
+.claude/skills/writing-shape
+
 # Created by https://www.toptal.com/developers/gitignore/api/linux,macos,windows,python,dbt
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,macos,windows,python,dbt
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop locally installed third-party agent skills from showing up as untracked files in `git status`.

The skills tooling writes sources under `.agents/skills/` and symlinks them into `.claude/skills/`, alongside a `skills-lock.json` manifest. None of it is repo-owned, but all of it landed in `git status` — 37 untracked entries, enough to bury real changes and make a routine `git stash` look like it had lost work.

Paths are listed explicitly rather than ignoring `.claude/skills` wholesale, so genuinely repo-owned skills (`fresh-dashboard`, `gradebook-audit`, and the rest) still surface in `git status` as they should. That is the whole reason for the long list instead of a one-line glob.

## AI Assistance

Claude Code authored the ignore block and its comment. Human-directed: the decision to land this separately from the unrelated dbt work it was originally tangled up with.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster

Skipped — no Dagster changes.

### dbt

Skipped — no dbt changes.

### Docs

Skipped — no schedule, sensor, or integration changes.

### Verification

`git status` goes from 37 untracked entries to clean. The ignored set was diffed against the untracked set to confirm they match exactly, with no repo-owned skill caught by the list. `trunk check --force` reports no issues on `.gitignore`.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — expected to be a trivial no-op; this PR touches no dbt
      paths, so it selects no models. Green here is not validation of anything.
- [ ] **Dagster Cloud** — not triggered.

## Troubleshooting

- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
