### PR TITLE
fix(dbt): strip grade-type token from focus marking_period_id cast

### DIFF
--- a/src/dbt/focus/models/intermediate/properties/int_focus__report_card_grades.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__report_card_grades.yml
@@ -72,7 +72,7 @@ models:
       - name: course_history
         description: >-
           Whether the row is imported course history rather than a grade posted
-          in Focus. Y on every Miami row today.
+          in Focus. Y on imported rows, empty on grades posted live in Focus.
       - name: grade_level
         description: >-
           Zero-padded grade level the student was in when the grade was earned

--- a/src/dbt/focus/models/intermediate/properties/int_focus__report_card_grades.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__report_card_grades.yml
@@ -37,7 +37,11 @@ models:
       - name: student_id
         description: Focus student id the grade belongs to.
       - name: marking_period_id
-        description: Focus marking-period id the grade was earned in.
+        description: >-
+          Focus marking-period id the grade was earned in. Null on grades posted
+          live in Focus, which store a token-prefixed id that staging cannot
+          safely decode — the marking_period_ columns below are null on those
+          rows too.
       - name: grad_subject_id
         description: >-
           Focus graduation-subject id the course counts toward, populated only

--- a/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
@@ -2,15 +2,16 @@ models:
   - name: stg_focus__student_report_card_grades
     description: >-
       Focus student report-card grades — one row per student per course per
-      marking period. Every row Miami carries today is imported course history
+      marking period. Nearly every row is imported course history
       (course_history is Y) spanning school years well before the Focus rollout,
-      so the letter grade, GPA points and credits are denormalized onto the row
-      and the foreign keys a live report card would use — report_card_grade_id,
-      grade_scale_id, course_period_id, course_id — are all empty and are not
-      projected. Add them once Focus starts posting live report-card grades in
-      Miami. Distinct from stg_focus__report_card_grades, which is the grade
-      definition table (the available letter grades and their GPA values), not
-      student grades.
+      so the letter grade, GPA points and credits are denormalized onto the row.
+      Miami began posting live grades in Focus in August 2026; those rows leave
+      course_history empty and do populate the foreign keys a live report card
+      uses — report_card_grade_id, grade_scale_id, course_period_id, course_id —
+      which are still not projected here. Add them once live posting volume
+      warrants it. Distinct from stg_focus__report_card_grades, which is the
+      grade definition table (the available letter grades and their GPA values),
+      not student grades.
     columns:
       - name: id
         description: Primary key — Focus student_report_card_grades id.
@@ -38,11 +39,13 @@ models:
       - name: marking_period_id
         description: >-
           Focus marking-period id the grade was earned in. Focus stores this as
-          text on this table alone, so it is cast to an integer here to match
-          stg_focus__marking_periods and every other reference to a marking
-          period. Tested not_null as well as for referential integrity —
-          relationships skips null foreign keys, so it alone would not catch the
-          column going empty.
+          text on this table alone and prefixes live postings with a grade-type
+          token (e.g. DT7181), so only the trailing digits are kept and cast to
+          an integer here, matching stg_focus__marking_periods and every other
+          reference to a marking period. The token is not carried forward.
+          Tested not_null as well as for referential integrity — relationships
+          skips null foreign keys, so it alone would not catch the column going
+          empty.
         data_type: int
         data_tests:
           - not_null:

--- a/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
@@ -38,20 +38,16 @@ models:
                 severity: error
       - name: marking_period_id
         description: >-
-          Focus marking-period id the grade was earned in. Focus stores this as
-          text on this table alone and prefixes live postings with a grade-type
-          token (e.g. DT7181), so only the digits are kept and cast to an
-          integer here, matching stg_focus__marking_periods and every other
-          reference to a marking period. The token is not carried forward, and a
-          value matching neither shape extracts null so that not_null catches
-          it. Tested not_null as well as for referential integrity —
-          relationships skips null foreign keys, so it alone would not catch the
-          column going empty.
+          Focus marking-period id the grade was earned in, as an integer to
+          match stg_focus__marking_periods and every other reference to a
+          marking period. Focus stores this as text on this table alone and
+          prefixes live postings with a grade-type token (e.g. DT7181); those
+          values are safe cast to null rather than decoded, so a live-posted
+          grade carries no marking period until the token vocabulary is known.
+          Nullable by design for that reason — only referential integrity is
+          tested, and relationships skips null foreign keys.
         data_type: int
         data_tests:
-          - not_null:
-              config:
-                severity: error
           - relationships:
               arguments:
                 to: ref('stg_focus__marking_periods')

--- a/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__student_report_card_grades.yml
@@ -40,12 +40,13 @@ models:
         description: >-
           Focus marking-period id the grade was earned in. Focus stores this as
           text on this table alone and prefixes live postings with a grade-type
-          token (e.g. DT7181), so only the trailing digits are kept and cast to
-          an integer here, matching stg_focus__marking_periods and every other
-          reference to a marking period. The token is not carried forward.
-          Tested not_null as well as for referential integrity — relationships
-          skips null foreign keys, so it alone would not catch the column going
-          empty.
+          token (e.g. DT7181), so only the digits are kept and cast to an
+          integer here, matching stg_focus__marking_periods and every other
+          reference to a marking period. The token is not carried forward, and a
+          value matching neither shape extracts null so that not_null catches
+          it. Tested not_null as well as for referential integrity —
+          relationships skips null foreign keys, so it alone would not catch the
+          column going empty.
         data_type: int
         data_tests:
           - not_null:
@@ -115,7 +116,7 @@ models:
       - name: course_history
         description: >-
           Whether the row is imported course history rather than a grade posted
-          in Focus. Y on every Miami row today.
+          in Focus. Y on imported rows, empty on grades posted live in Focus.
         data_type: string
       - name: course_flag_1
         description: >-

--- a/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
+++ b/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
@@ -25,13 +25,13 @@ select
     custom_7 as grade_level,
 
     -- Focus stores this FK as a string here (int64 everywhere else) and prefixes
-    -- live postings with a grade-type token (e.g. DT7181), so strip the token
-    -- before casting: downstream joins to stg_focus__marking_periods then compare
-    -- plain columns. The pattern is anchored so an unrecognized format extracts
-    -- null and fails not_null, rather than silently yielding a wrong id.
-    -- TODO: the token itself is dropped; decode it from the raw dlt table if it
-    -- turns out to distinguish grade types.
-    cast(
-        regexp_extract(marking_period_id, r'^[A-Z]*([0-9]+)$') as int
-    ) as marking_period_id,
+    -- live postings with a grade-type token (e.g. DT7181). safe_cast keeps only
+    -- values that are already a plain id, so downstream joins to
+    -- stg_focus__marking_periods compare plain columns; a prefixed value goes
+    -- null rather than being decoded, since stripping a token cannot be done
+    -- safely without knowing Focus's full token vocabulary — the trailing digit
+    -- run of an unknown token could collide with a real id.
+    -- TODO: decode the token from the raw dlt table once its vocabulary is
+    -- known, so live postings recover their marking period.
+    safe_cast(marking_period_id as int) as marking_period_id,
 from {{ source("focus", "student_report_card_grades") }}

--- a/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
+++ b/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
@@ -24,7 +24,10 @@ select
     custom_6 as school_number,
     custom_7 as grade_level,
 
-    -- Focus stores this FK as a string here (int64 everywhere else); cast once so
-    -- downstream joins to stg_focus__marking_periods compare plain columns
-    cast(marking_period_id as int) as marking_period_id,
+    -- Focus stores this FK as a string here (int64 everywhere else) and prefixes
+    -- live postings with a grade-type token (e.g. DT7181), so strip the token
+    -- before casting: downstream joins to stg_focus__marking_periods then compare
+    -- plain columns. TODO: the token itself is dropped; decode it from the raw
+    -- dlt table if it turns out to distinguish grade types.
+    cast(regexp_extract(marking_period_id, r'[0-9]+$') as int) as marking_period_id,
 from {{ source("focus", "student_report_card_grades") }}

--- a/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
+++ b/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
@@ -27,7 +27,11 @@ select
     -- Focus stores this FK as a string here (int64 everywhere else) and prefixes
     -- live postings with a grade-type token (e.g. DT7181), so strip the token
     -- before casting: downstream joins to stg_focus__marking_periods then compare
-    -- plain columns. TODO: the token itself is dropped; decode it from the raw
-    -- dlt table if it turns out to distinguish grade types.
-    cast(regexp_extract(marking_period_id, r'[0-9]+$') as int) as marking_period_id,
+    -- plain columns. The pattern is anchored so an unrecognized format extracts
+    -- null and fails not_null, rather than silently yielding a wrong id.
+    -- TODO: the token itself is dropped; decode it from the raw dlt table if it
+    -- turns out to distinguish grade types.
+    cast(
+        regexp_extract(marking_period_id, r'^[A-Z]*([0-9]+)$') as int
+    ) as marking_period_id,
 from {{ source("focus", "student_report_card_grades") }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will unblock the `kippmiami_dbt_assets` step,
which has failed on every automation-condition tick since Miami posted its first
live report-card grade this morning
([failing run](https://kipptaf.dagster.cloud/prod/runs/3d770372-c72a-4b36-b7f1-aea66598f85e)).

`stg_focus__student_report_card_grades` cast `marking_period_id` straight to
int64. Focus stores that FK as text on this table alone — the only one of the 8
Focus tables carrying the column where it is not INT64 — because it prefixes
live grade postings with a grade-type token. The first such row, `DT7181`, was
created 2026-08-12 16:33 UTC and failed the build with
`Bad int64 value: DT7181`. All 14,786 pre-existing rows are imported course
history with bare-digit ids, which is why the cast held until today. Today is
also the first day of Q1 2026, so more live postings arrive daily.

Fix:

```sql
safe_cast(marking_period_id as int) as marking_period_id,
```

A prefixed value goes null rather than being decoded. The token *could* be
stripped — `7181` is a real marking period (Quarter 1, school 58, syear 2026,
matching the grade row) — but stripping cannot be done safely without knowing
Focus's full token vocabulary: marking period ids run 3 to 4 digits (212 to
7198), so the trailing digit run of some future token could concatenate into a
*valid* id and pass silently. Nulling is the honest failure mode. The consequence
is that a live-posted grade carries no marking period, and the
`marking_period_` columns on `int_focus__report_card_grades` are null for those
rows, until the vocabulary is known and the token decoded deliberately.

`not_null` is dropped from the column, which is now nullable by design;
`relationships` stays and skips nulls.

This also refreshes descriptions the change invalidates. The model description
still asserted that every row was imported course history and that the FKs a live
report card uses were all empty; the `course_history` column description said "Y
on every Miami row today" in both the staging and intermediate properties files.
All stopped being true this morning.

## AI Assistance

Claude ran the diagnosis (Dagster run logs, then BigQuery profiling of the source
column, then a local reproduction), wrote the fix, and updated the descriptions.
Human-directed throughout, including the decision to null rather than decode.

## Self-review

### Verification

Built in a worktree against real prod dlt data, since a district-only dbt PR gets
no branch deployment and dbt Cloud CI builds only `kipptaf` — a local build is
the only pre-merge validation here.

- Before the fix: reproduced `Bad int64 value: DT7181` exactly.
- After: `stg_focus__student_report_card_grades+` builds PASS=9, ERROR=0.
- Result table: 14,787 rows, exactly 1 null `marking_period_id`, and it is the
  live-posted row — 0 nulls among the 14,786 imported-history rows.
- `trunk check --force` on all three changed files: no issues.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Reviewed the **Claude Code Review** comment. All three findings verified and
      addressed; verdicts posted per finding, including the residual it surfaced,
      which is what drove the switch to `safe_cast`.

### dbt

- [x] Properties files updated alongside the models (no new models).
- [x] **Behavior change, not a contract change** — `marking_period_id` keeps its
      name and `int` type. It becomes nullable for live-posted grades, and its
      `not_null` test is dropped. No exposure or external-source changes; the only
      consumer is `int_focus__report_card_grades`, which has no consumers of its
      own.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes (a trivial no-op: this PR touches only the `focus`
      package and selects zero `kipptaf` models).
- [ ] **Dagster Cloud** — not triggered; `deploy-prod-*.yaml` excludes
      `src/dbt/**` from `pull_request` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
