### PR TITLE
fix(dbt): restore crosswalk schemas as rpt_gsheets views for seat tracker

### DIFF
--- a/src/dbt/kipptaf/models/exposures/google-appsheet.yml
+++ b/src/dbt/kipptaf/models/exposures/google-appsheet.yml
@@ -6,8 +6,8 @@ exposures:
       name: Data Team
     depends_on:
       - ref("rpt_appsheet__seat_tracker_roster")
-      - ref("stg_google_sheets__people__campus_crosswalk")
-      - ref("stg_google_sheets__people__location_crosswalk")
+      - ref("rpt_gsheets__people__campus_crosswalk")
+      - ref("rpt_gsheets__people__location_crosswalk")
     config:
       meta:
         dagster:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__campus_crosswalk.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__campus_crosswalk.yml
@@ -6,24 +6,50 @@ models:
       directly until the source sheet was refactored down to
       `Name` + `Location_Name` and every attribute moved to the `Locations`
       tab. Column names, order, and types are 1:1 with that old table so the
-      app only has to repoint its data source. The attribute columns describe
-      the child `Location_Name`, not the parent campus `Name`.
+      app only has to repoint its data source. Every attribute column
+      describes the child `Location_Name`, not the parent campus `Name` —
+      campus rows in the `Locations` tab carry blank abbreviation and grade
+      band and zero school IDs.
     columns:
       - name: Location_Name
-        description: Canonical location name of the child school.
+        description: |
+          Canonical location name of the child school. Join key to
+          `int_people__staff_roster.home_work_location_reporting_name` and to
+          `int_people__location_crosswalk.location_clean_name`.
         data_type: string
+        data_tests:
+          - unique:
+              config:
+                severity: error
       - name: Name
-        description: Parent campus the location rolls up to.
+        description: |
+          Parent campus the location rolls up to. Repeats across sibling
+          schools sharing a campus, and equals `Location_Name` for a location
+          that is itself a campus.
         data_type: string
       - name: Region
+        description: |
+          Legal-entity name the child school rolls up to (e.g. TEAM Academy
+          Charter School, KIPP Miami).
         data_type: string
       - name: Grade_Band
+        description: Grade band served by the child school (e.g. ES, MS, HS).
         data_type: string
       - name: PowerSchool_School_ID
+        description: PowerSchool school ID of the child school.
         data_type: int64
       - name: Reporting_School_ID
+        description: |
+          Reporting school ID of the child school. AppSheet keys the Seat
+          Tracker campus table on this column.
         data_type: int64
       - name: Abbreviation
+        description: |
+          Short abbreviation for the child school. Not populated for every
+          location.
         data_type: string
       - name: Is_Pathways
+        description: |
+          True when the child school is a KIPP Forward post-secondary
+          (Pathways) program.
         data_type: boolean

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__campus_crosswalk.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__campus_crosswalk.yml
@@ -1,0 +1,29 @@
+models:
+  - name: rpt_gsheets__people__campus_crosswalk
+    description: |
+      Seat Tracker AppSheet feed. Reproduces the pre-2026-08-11 schema of
+      `stg_google_sheets__people__campus_crosswalk`, which the app read
+      directly until the source sheet was refactored down to
+      `Name` + `Location_Name` and every attribute moved to the `Locations`
+      tab. Column names, order, and types are 1:1 with that old table so the
+      app only has to repoint its data source. The attribute columns describe
+      the child `Location_Name`, not the parent campus `Name`.
+    columns:
+      - name: Location_Name
+        description: Canonical location name of the child school.
+        data_type: string
+      - name: Name
+        description: Parent campus the location rolls up to.
+        data_type: string
+      - name: Region
+        data_type: string
+      - name: Grade_Band
+        data_type: string
+      - name: PowerSchool_School_ID
+        data_type: int64
+      - name: Reporting_School_ID
+        data_type: int64
+      - name: Abbreviation
+        data_type: string
+      - name: Is_Pathways
+        data_type: boolean

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__location_crosswalk.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__location_crosswalk.yml
@@ -1,0 +1,37 @@
+models:
+  - name: rpt_gsheets__people__location_crosswalk
+    description: |
+      Seat Tracker AppSheet feed. Reproduces the pre-2026-08-11 schema of
+      `stg_google_sheets__people__location_crosswalk`, which the app read
+      directly until the source sheet was refactored down to
+      `Name` + `Clean_Name` and every attribute moved to the `Locations` tab.
+      Column names, order, and types are 1:1 with that old table so the app
+      only has to repoint its data source. Attributes describe `Clean_Name`,
+      not `Name`.
+    columns:
+      - name: Name
+        description: Location alias as entered in source systems. One row each.
+        data_type: string
+      - name: Clean_Name
+        description: Canonical location name the alias resolves to.
+        data_type: string
+      - name: Abbreviation
+        data_type: string
+      - name: Grade_Band
+        data_type: string
+      - name: Region
+        data_type: string
+      - name: PowerSchool_School_ID
+        data_type: int64
+      - name: Deanslist_School_ID
+        data_type: int64
+      - name: Reporting_School_ID
+        data_type: int64
+      - name: Is_Campus
+        data_type: boolean
+      - name: Is_Pathways
+        data_type: boolean
+      - name: Dagster_Code_Location
+        data_type: string
+      - name: Head_of_Schools_Employee_Number
+        data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__location_crosswalk.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__people__location_crosswalk.yml
@@ -6,32 +6,66 @@ models:
       directly until the source sheet was refactored down to
       `Name` + `Clean_Name` and every attribute moved to the `Locations` tab.
       Column names, order, and types are 1:1 with that old table so the app
-      only has to repoint its data source. Attributes describe `Clean_Name`,
-      not `Name`.
+      only has to repoint its data source. Every attribute column describes
+      `Clean_Name`, not `Name` — sibling aliases of the same school therefore
+      repeat identical attribute values.
     columns:
       - name: Name
-        description: Location alias as entered in source systems. One row each.
+        description: |
+          Location alias as entered in source systems. One row per alias, so
+          several rows can resolve to the same `Clean_Name`.
         data_type: string
+        data_tests:
+          - unique:
+              config:
+                severity: error
       - name: Clean_Name
-        description: Canonical location name the alias resolves to.
+        description: |
+          Canonical location name the alias resolves to. Join key to
+          `stg_google_sheets__people__locations.location_name`.
         data_type: string
       - name: Abbreviation
+        description: |
+          Short location abbreviation (e.g. SPARK, NCA). Not populated for
+          every location.
         data_type: string
       - name: Grade_Band
+        description: Grade band served by the location (e.g. ES, MS, HS).
         data_type: string
       - name: Region
+        description: |
+          Legal-entity name the location rolls up to (e.g. TEAM Academy
+          Charter School, KIPP Cooper Norcross Academy).
         data_type: string
       - name: PowerSchool_School_ID
+        description: PowerSchool school ID. Zero for campus rows.
         data_type: int64
       - name: Deanslist_School_ID
+        description: |
+          DeansList school ID. Null for schools that are not in DeansList.
         data_type: int64
       - name: Reporting_School_ID
+        description: |
+          Reporting school ID used to roll multi-campus schools up to a single
+          reporting unit. Zero for campus rows.
         data_type: int64
       - name: Is_Campus
+        description: |
+          True when the location represents a physical campus rather than an
+          administrative unit.
         data_type: boolean
       - name: Is_Pathways
+        description: |
+          True when the location is a KIPP Forward post-secondary (Pathways)
+          program.
         data_type: boolean
       - name: Dagster_Code_Location
+        description: |
+          Dagster code location identifier (kippnewark, kippcamden, kippmiami,
+          kipppaterson).
         data_type: string
       - name: Head_of_Schools_Employee_Number
+        description: |
+          Employee number of the head of schools responsible for this location.
+          Null where no head of schools is assigned.
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__people__campus_crosswalk.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__people__campus_crosswalk.sql
@@ -1,0 +1,14 @@
+select
+    cc.`Location_Name`,
+    cc.`Name`,
+
+    pl.location_region as `Region`,
+    pl.grade_band as `Grade_Band`,
+    pl.powerschool_school_id as `PowerSchool_School_ID`,
+    pl.reporting_school_id as `Reporting_School_ID`,
+    pl.abbreviation as `Abbreviation`,
+    pl.is_pathways as `Is_Pathways`,
+from {{ ref("stg_google_sheets__people__campus_crosswalk") }} as cc
+left join
+    {{ ref("stg_google_sheets__people__locations") }} as pl
+    on cc.`Location_Name` = pl.location_name

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__people__location_crosswalk.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__people__location_crosswalk.sql
@@ -1,0 +1,14 @@
+select
+    location_name as `Name`,
+    location_clean_name as `Clean_Name`,
+    location_abbreviation as `Abbreviation`,
+    location_grade_band as `Grade_Band`,
+    location_region as `Region`,
+    location_powerschool_school_id as `PowerSchool_School_ID`,
+    location_deanslist_school_id as `Deanslist_School_ID`,
+    location_reporting_school_id as `Reporting_School_ID`,
+    location_is_campus as `Is_Campus`,
+    location_is_pathways as `Is_Pathways`,
+    location_dagster_code_location as `Dagster_Code_Location`,
+    location_head_of_schools_employee_number as `Head_of_Schools_Employee_Number`,
+from {{ ref("int_people__location_crosswalk") }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add two extract views that restore the
pre-2026-08-11 schemas of the people location and campus crosswalks, so the
Seat Tracker AppSheet can be repointed off the staging models it was reading
directly.

**What broke.** The people spreadsheet was refactored: the `Location Crosswalk`
and `Campus Crosswalk` tabs were trimmed to two columns each and every
attribute moved to the `Locations` tab. Both `stg_google_sheets__people__*_crosswalk`
models are `select *`, so they went from 12 and 8 columns to 2. The Seat
Tracker AppSheet connected straight to those staging tables (against
convention) and lost 10 and 6 columns respectively.

**The fix.**

- `rpt_gsheets__people__location_crosswalk` renames
  `int_people__location_crosswalk` back to the old column names. That
  intermediate already performs the alias to `Locations` join.
- `rpt_gsheets__people__campus_crosswalk` joins the trimmed campus tab to
  `stg_google_sheets__people__locations` on `Location_Name`.
- `seat_tracker_app` exposure now depends on the two `rpt_` models instead of
  the `stg_` ones.

Both views are 1:1 with the old tables on column names, order, and types, so
the AppSheet keeps its existing column config (keys, labels, types) and only
needs its data sources repointed to `kipptaf_extracts`.

**Verification.** Diffed both views against the old tables recovered via
BigQuery time travel. Campus matches on all 17 rows. Location matches on 248 of
251; the 3 that differ (Paterson Prep Elementary, Paterson Prep Middle,
Poinciana Campus) are rows where the old table carried nulls and the new view
resolves the attributes correctly from `Locations`.

The attribute columns on the campus crosswalk describe the child
`Location_Name`, not the parent campus `Name` — confirmed against the old data,
where campus rows carry blank abbreviation and grade band and `0` school IDs.

## AI Assistance

Claude Code authored the models, properties files, and exposure update, and ran
the verification queries. Human-directed: the requirement to restore the old
schemas as `rpt_gsheets__*` views rather than revert the spreadsheet refactor,
and the decision to keep the views exactly 1:1 rather than add extra columns
from the `Locations` tab.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models
- [x] Include (or update) an exposure for all models consumed by a dashboard,
      analysis, or application
- [x] **Breaking change?** No. Both models are new; no existing contracted
      column is renamed or removed. Rollback is deleting the two models and
      reverting the exposure, which leaves the AppSheet exactly as it is today.
- [x] No external sources added or modified, so no `stage_external_sources` run
      is needed.

## CI checks

- [ ] **Trunk** — `trunk check --force` clean locally on all 5 changed files.
- [ ] **dbt Cloud** — both views built and passed contract enforcement locally
      against the deferred prod state.
- [ ] **Dagster Cloud** — no Dagster paths changed.
