### PR TITLE
fix(finalsite): route untyped phone numbers into the DeansList and ParentSquare feeds

### DIFF
--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -101,6 +101,11 @@ with
                 if(cp.phone_2_type = 'Work', cp.phone_2_number, null),
                 if(cp.phone_3_type = 'Work', cp.phone_3_number, null)
             ) as phone_work,
+            coalesce(
+                if(cp.phone_1_type is null, cp.phone_1_number, null),
+                if(cp.phone_2_type is null, cp.phone_2_number, null),
+                if(cp.phone_3_type is null, cp.phone_3_number, null)
+            ) as phone_untyped,
             nullif(
                 array_to_string(
                     [cp.address_1, cp.address_2, cp.city, cp.state, cp.zip], ', '
@@ -122,6 +127,7 @@ with
             phone_mobile,
             phone_home,
             phone_work,
+            phone_untyped,
             home_address,
             first_name as contact_first_name,
             last_name as contact_last_name,
@@ -171,6 +177,11 @@ with
                 if(emrg_1_phone_2_type = 'Work', emrg_1_phone_2_number, null),
                 if(emrg_1_phone_3_type = 'Work', emrg_1_phone_3_number, null)
             ) as phone_work,
+            coalesce(
+                if(emrg_1_phone_1_type is null, emrg_1_phone_1_number, null),
+                if(emrg_1_phone_2_type is null, emrg_1_phone_2_number, null),
+                if(emrg_1_phone_3_type is null, emrg_1_phone_3_number, null)
+            ) as phone_untyped,
         from {{ ref("int_finalsite__contact_custom_attributes") }}
         where emrg_1_name_first_name is not null and emrg_1_name_first_name != ''
 
@@ -208,6 +219,11 @@ with
                 if(emrg_2_phone_2_type = 'Work', emrg_2_phone_2_number, null),
                 if(emrg_2_phone_3_type = 'Work', emrg_2_phone_3_number, null)
             ) as phone_work,
+            coalesce(
+                if(emrg_2_phone_1_type is null, emrg_2_phone_1_number, null),
+                if(emrg_2_phone_2_type is null, emrg_2_phone_2_number, null),
+                if(emrg_2_phone_3_type is null, emrg_2_phone_3_number, null)
+            ) as phone_untyped,
         from {{ ref("int_finalsite__contact_custom_attributes") }}
         where emrg_2_name_first_name is not null and emrg_2_name_first_name != ''
 
@@ -245,6 +261,11 @@ with
                 if(emrg_3_phone_2_type = 'Work', emrg_3_phone_2_number, null),
                 if(emrg_3_phone_3_type = 'Work', emrg_3_phone_3_number, null)
             ) as phone_work,
+            coalesce(
+                if(emrg_3_phone_1_type is null, emrg_3_phone_1_number, null),
+                if(emrg_3_phone_2_type is null, emrg_3_phone_2_number, null),
+                if(emrg_3_phone_3_type is null, emrg_3_phone_3_number, null)
+            ) as phone_untyped,
         from {{ ref("int_finalsite__contact_custom_attributes") }}
         where emrg_3_name_first_name is not null and emrg_3_name_first_name != ''
 
@@ -282,6 +303,11 @@ with
                 if(emrg_4_phone_2_type = 'Work', emrg_4_phone_2_number, null),
                 if(emrg_4_phone_3_type = 'Work', emrg_4_phone_3_number, null)
             ) as phone_work,
+            coalesce(
+                if(emrg_4_phone_1_type is null, emrg_4_phone_1_number, null),
+                if(emrg_4_phone_2_type is null, emrg_4_phone_2_number, null),
+                if(emrg_4_phone_3_type is null, emrg_4_phone_3_number, null)
+            ) as phone_untyped,
         from {{ ref("int_finalsite__contact_custom_attributes") }}
         where emrg_4_name_first_name is not null and emrg_4_name_first_name != ''
     ),
@@ -301,6 +327,7 @@ with
             phone_mobile,
             phone_home,
             phone_work,
+            phone_untyped,
             phone_primary,
             is_pickup,
             is_custodial,
@@ -327,6 +354,7 @@ with
             phone_mobile,
             phone_home,
             phone_work,
+            phone_untyped,
             phone_daytime,
             phone_primary,
             home_address,
@@ -350,6 +378,7 @@ with
             phone_mobile,
             phone_home,
             phone_work,
+            phone_untyped,
             phone_daytime,
             phone_primary,
             home_address,
@@ -372,6 +401,7 @@ select
     phone_mobile,
     phone_home,
     phone_work,
+    phone_untyped,
     phone_daytime,
     phone_primary,
     home_address,

--- a/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
+++ b/src/dbt/finalsite/models/api/intermediate/properties/int_finalsite__student_contacts.yml
@@ -129,6 +129,19 @@ models:
         config:
           meta:
             contains_pii: true
+      - name: phone_untyped
+        data_type: string
+        description:
+          The contact's first phone number carrying no type label, if any.
+          Finalsite lets a number be saved without selecting Cell, Home, or
+          Work, and such a number reaches none of the three typed columns above
+          — this column is where it lands, so a consumer can still reach the
+          family. Scans all three phone positions rather than only the first,
+          which is what separates it from `phone_primary`. Already normalized to
+          E.164 upstream.
+        config:
+          meta:
+            contains_pii: true
       - name: phone_daytime
         data_type: string
         description:
@@ -140,9 +153,10 @@ models:
       - name: phone_primary
         data_type: string
         description:
-          The contact's first phone number regardless of type — a fallback for
-          phones with a blank `_type` that the typed columns miss. Already
-          normalized to E.164 upstream.
+          The contact's first phone number regardless of type, whether or not a
+          type label is set. Use `phone_untyped` to recover a number the typed
+          columns miss — it scans all three positions, where this column only
+          ever reports the first. Already normalized to E.164 upstream.
         config:
           meta:
             contains_pii: true
@@ -183,9 +197,11 @@ unit_tests:
     description:
       A contact_1 row routes each of the related person's phones to the slot
       matching its type label — `Cell` to phone_mobile, `Home` to phone_home, an
-      absent type to a null slot — and carries phone_1 through as phone_primary
-      regardless of type. Phones arrive already normalized to E.164 from
-      `stg_finalsite__contacts`; this model passes them through unchanged.
+      absent type to phone_untyped — and carries phone_1 through as
+      phone_primary regardless of type. phone_3 carries a number with no type
+      label, the case that reaches none of the typed columns. Phones arrive
+      already normalized to E.164 from `stg_finalsite__contacts`; this model
+      passes them through unchanged.
     model: int_finalsite__student_contacts
     given:
       - input: ref('stg_finalsite__contact_relationships')
@@ -213,7 +229,7 @@ unit_tests:
             'Cell' as phone_1_type,
             '+19292255670' as phone_2_number,
             'Home' as phone_2_type,
-            cast(null as string) as phone_3_number,
+            '+13055550199' as phone_3_number,
             cast(null as string) as phone_3_type,
             cast(null as string) as address_1,
             cast(null as string) as address_2,
@@ -245,6 +261,7 @@ unit_tests:
           '+18623007240' as phone_mobile,
           '+19292255670' as phone_home,
           cast(null as string) as phone_work,
+          '+13055550199' as phone_untyped,
           '+18623007240' as phone_primary
 
   - name: test_student_contacts_parent_2

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -220,7 +220,11 @@ unit_tests:
       Each phone normalizes to E.164 as it is flattened out of its source struct
       — a control-char-garbled number and a parenthesized-and-dashed number both
       resolve to `+1XXXXXXXXXX`, while a value with no parseable digits passes
-      through as entered rather than becoming null. Also covers the
+      through as entered rather than becoming null. phone_3 carries the empty
+      string Finalsite emits when no type is selected, and the expected
+      phone_3_type of null is what proves the blank-to-null normalization fired
+      — downstream models test for an untyped phone with `is null`, so an empty
+      string reaching them would silently strand the number. Also covers the
       household-address normalization applied in the same select — blank to
       null, state uppercased.
     model: stg_finalsite__contacts
@@ -259,9 +263,7 @@ unit_tests:
                 || code_points_to_string([8236]) as number
             ) as phone_1,
             struct('Home' as phone_type, '(929) 225-5670' as number) as phone_2,
-            struct(
-              cast(null as string) as phone_type, 'no phone' as number
-            ) as phone_3,
+            struct('' as phone_type, 'no phone' as number) as phone_3,
             array<struct<field_name string, value struct<string_value string>>>[]
               as custom_attributes,
             array<struct<field_name string, value struct<string_value string>>>[]

--- a/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
+++ b/src/dbt/finalsite/models/api/staging/properties/stg_finalsite__contacts.yml
@@ -85,7 +85,10 @@ models:
         description: Start year of the prospect's intended entry school year.
       - name: phone_1_type
         data_type: string
-        description: Type label of the first phone.
+        description:
+          Type label of the first phone — `Cell`, `Home`, or `Work`. Null when
+          Finalsite holds the number with no type selected, which it emits as an
+          empty string and this model normalizes to null.
       - name: phone_1_number
         data_type: string
         description:
@@ -96,7 +99,10 @@ models:
           (control characters stripped) rather than becoming null.
       - name: phone_2_type
         data_type: string
-        description: Type label of the second phone.
+        description:
+          Type label of the second phone — `Cell`, `Home`, or `Work`. Null when
+          Finalsite holds the number with no type selected, which it emits as an
+          empty string and this model normalizes to null.
       - name: phone_2_number
         data_type: string
         description:
@@ -104,7 +110,10 @@ models:
           `phone_1_number`.
       - name: phone_3_type
         data_type: string
-        description: Type label of the third phone.
+        description:
+          Type label of the third phone — `Cell`, `Home`, or `Work`. Null when
+          Finalsite holds the number with no type selected, which it emits as an
+          empty string and this model normalizes to null.
       - name: phone_3_number
         data_type: string
         description:

--- a/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
+++ b/src/dbt/finalsite/models/api/staging/stg_finalsite__contacts.sql
@@ -24,16 +24,21 @@ select
     school_year.start_year as school_year_start,
     prospect_entry_year.start_year as prospect_entry_year_start,
 
-    phone_1.phone_type as phone_1_type,
-    phone_2.phone_type as phone_2_type,
-    phone_3.phone_type as phone_3_type,
-
     custom_attributes,
     id_attributes,
     track_attributes,
     households,
 
     safe_cast(birth_date as date) as birth_date,
+
+    -- Finalsite emits an unset phone type as an empty string on a contact
+    -- record, but as NULL in the emrg_N custom-field sets that feed the
+    -- emergency contact slots. Normalize to NULL so every consumer tests for an
+    -- untyped phone the same way -- the same blank-to-null treatment the
+    -- household address fields get below.
+    nullif(phone_1.phone_type, '') as phone_1_type,
+    nullif(phone_2.phone_type, '') as phone_2_type,
+    nullif(phone_3.phone_type, '') as phone_3_type,
 
     households[safe_offset(0)].id as household_1_id,
 

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -94,7 +94,12 @@ models:
             contains_pii: true
       - name: CellPhone
         data_type: string
-        description: Parent contact's phone number typed `Cell`, if any.
+        description:
+          Parent contact's phone number typed `Cell`. Falls back to the
+          contact's untyped number when Finalsite holds one with no type label
+          selected — that number reaches none of the typed columns, and the
+          DeansList template has no header of its own for it, so without the
+          fallback the contact arrives with no callable number at all.
         config:
           meta:
             contains_pii: true
@@ -134,32 +139,33 @@ unit_tests:
             'alice@example.com' as email,
             '+19292255670' as phone_home,
             cast(null as string) as phone_work,
-            '+18623007240x216' as phone_mobile
+            '+18623007240x216' as phone_mobile,
+            cast(null as string) as phone_untyped
           union all
           select
             'enr-001', 'kippnewark', 'contact_2', 'parent',
             'Adam', 'Johnson', 'adam@example.com', cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
             'Bob', 'Smith', cast(null as string), cast(null as string),
-            cast(null as string), '+13055550200'
+            cast(null as string), '+13055550200', cast(null as string)
           union all
           select
             'enr-001', 'kippnewark', 'emergency_2', 'aunt',
             'Carol', 'Diaz', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-001', 'kippnewark', 'emergency_3', 'uncle',
             'Dan', 'Evans', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-001', 'kippnewark', 'emergency_4', 'neighbor',
             'Erin', 'Fox', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |
@@ -270,22 +276,23 @@ unit_tests:
             cast(null as string) as email,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
-            cast(null as string) as phone_mobile
+            cast(null as string) as phone_mobile,
+            cast(null as string) as phone_untyped
           union all
           select
             'enr-mia', 'kippmiami', 'contact_1', 'parent',
             'Hank', 'Ito', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-unenr', 'kippnewark', 'contact_1', 'parent',
             'Ivy', 'Jones', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-noxwalk', 'kippnewark', 'contact_1', 'parent',
             'Kim', 'Lee', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |
@@ -350,22 +357,23 @@ unit_tests:
             'jane1@example.com' as email,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
-            cast(null as string) as phone_mobile
+            cast(null as string) as phone_mobile,
+            cast(null as string) as phone_untyped
           union all
           select
             'enr-301', 'kippnewark', 'contact_2', 'parent',
             'Jane', 'Two', 'jane2@example.com', cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-301', 'kippnewark', 'contact_3', 'parent',
             'Jane', 'Three', 'jane3@example.com', cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
           union all
           select
             'enr-301', 'kippnewark', 'emergency_1', 'neighbor',
             'Jane', 'Four', cast(null as string), cast(null as string),
-            cast(null as string), cast(null as string)
+            cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
         format: sql
         rows: |
@@ -416,5 +424,76 @@ unit_tests:
             Email: null,
             Relationship: neighbor,
             ContactType: Emergency,
+            Language: null,
+          }
+
+  - name: test_family_contacts_untyped_phone_fills_cellphone
+    description:
+      Locks the untyped-phone fallback. Finalsite lets a number be saved with no
+      Cell/Home/Work label, and such a number reaches none of the three typed
+      columns — before the fallback the contact shipped to DeansList with every
+      phone field blank. contact_1 carries only an untyped number and must
+      surface it as CellPhone; contact_2 carries both a typed Cell and an
+      untyped number, and the typed Cell must win rather than being displaced.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-401' as finalsite_enrollment_id,
+            'kippcamden' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Nan' as contact_first_name,
+            'Untyped' as contact_last_name,
+            cast(null as string) as email,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_work,
+            cast(null as string) as phone_mobile,
+            '+18564730100' as phone_untyped
+          union all
+          select
+            'enr-401', 'kippcamden', 'contact_2', 'parent',
+            'Ted', 'Typed', cast(null as string), cast(null as string),
+            cast(null as string), '+18564730200', '+18564730300'
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-401' as finalsite_enrollment_id,
+            'kippcamden' as _dbt_source_project,
+            '400001' as powerschool_student_number
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            400001 as student_number,
+            0 as enroll_status,
+            'kippcamden' as _dbt_source_project
+    expect:
+      rows:
+        - {
+            StudentID: 400001,
+            ParentFirstName: Nan,
+            ParentLastName: Untyped,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: "18564730100",
+            Email: null,
+            Relationship: parent,
+            ContactType: Parent1,
+            Language: null,
+          }
+        - {
+            StudentID: 400001,
+            ParentFirstName: Ted,
+            ParentLastName: Typed,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: "18564730200",
+            Email: null,
+            Relationship: parent,
+            ContactType: Parent2,
             Language: null,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -14,6 +14,7 @@ with
             regexp_replace(lower(sc.phone_home), r'[^0-9x]', '') as phone_home,
             regexp_replace(lower(sc.phone_work), r'[^0-9x]', '') as phone_work,
             regexp_replace(lower(sc.phone_mobile), r'[^0-9x]', '') as phone_mobile,
+            regexp_replace(lower(sc.phone_untyped), r'[^0-9x]', '') as phone_untyped,
 
             -- DeansList routes guardian-only automated messaging (reports,
             -- texts, emails) by ContactType, so the slot ordinal need not be
@@ -54,12 +55,19 @@ select
     c.contact_last_name as `ParentLastName`,
     c.phone_home as `HomePhone`,
     c.phone_work as `WorkPhone`,
-    c.phone_mobile as `CellPhone`,
     c.email as `Email`,
     c.relationship as `Relationship`,
     c.contact_type as `ContactType`,
 
     cast(null as string) as `Language`,
+
+    -- The DeansList template has no header for a number whose Finalsite type
+    -- was never set, so before this fallback such a number reached no column at
+    -- all and the family arrived uncallable. CellPhone is where it rides in:
+    -- across the NJ regions ~95% of the numbers that DO carry a type are Cell,
+    -- so it is the likeliest fit, and a landline sent here is no worse off than
+    -- the blank it replaces. A Finalsite-typed Cell still wins outright.
+    coalesce(c.phone_mobile, c.phone_untyped) as `CellPhone`,
 from contacts as c
 inner join
     {{ ref("stg_powerschool__students") }} as s

--- a/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/properties/rpt_parentsquare__parents.yml
@@ -73,10 +73,15 @@ models:
         data_type: string
         description:
           The parent's mobile number as 10 digits, with the US country code and
-          any extension digits removed. Null when they have no mobile on file,
-          in which case `email` is present. A number that does not reduce to
-          exactly 10 digits is an upstream data-entry typo and is dropped rather
-          than sent in a form ParentSquare would reject.
+          any extension digits removed. Falls back to the parent's untyped
+          Finalsite number when no number is labelled Cell — such a number
+          reaches none of the typed columns, and a parent carrying neither a
+          mobile nor an email is dropped as undeliverable, so without the
+          fallback these families get no ParentSquare account at all. Null when
+          they have no number on file at all, in which case `email` is present.
+          A number that does not reduce to exactly 10 digits is an upstream
+          data-entry typo and is dropped rather than sent in a form ParentSquare
+          would reject.
         config:
           meta:
             contains_pii: true
@@ -97,3 +102,72 @@ models:
         config:
           meta:
             contains_pii: true
+
+unit_tests:
+  - name: test_parents_untyped_phone_fills_mobile
+    description:
+      Locks the untyped-phone fallback and its precedence. Finalsite lets a
+      number be saved with no Cell/Home/Work label, and such a number reaches
+      none of the typed columns — a parent carrying only one had no mobile and
+      no email, so the deliverability filter dropped them and they never got a
+      ParentSquare account. contact_1 carries only an untyped number and must
+      surface it as mobile; contact_2 carries both a typed Cell and an untyped
+      number, and the typed Cell must win. A flipped coalesce argument order
+      would silently resume dropping the first parent.
+    model: rpt_parentsquare__parents
+    given:
+      - input: ref('int_students__contacts')
+        format: sql
+        rows: |
+          select
+            400001 as student_number,
+            'kippnewark' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'parent' as relationship,
+            'Nan' as contact_first_name,
+            'Untyped' as contact_last_name,
+            cast(null as string) as email_current,
+            cast(null as string) as phone_mobile,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_work,
+            '+18564730100' as phone_untyped
+          union all
+          select
+            400001, 'kippnewark', 'contact_2', 'parent',
+            'Ted', 'Typed', cast(null as string), '+18564730200',
+            cast(null as string), cast(null as string), '+18564730300'
+      - input: ref('int_extracts__student_enrollments')
+        format: sql
+        rows: |
+          select
+            400001 as student_number,
+            'kippnewark' as _dbt_source_project,
+            2026 as academic_year,
+            1 as rn_year,
+            false as is_out_of_district,
+            0 as enroll_status,
+            73253 as schoolid
+    expect:
+      rows:
+        - {
+            first_name: Nan,
+            last_name: Untyped,
+            relationship: parent,
+            mobile: "8564730100",
+            secondary_phone: null,
+            email: null,
+            school_id: "73253",
+            code_location: kippnewark,
+            student_id: "400001",
+          }
+        - {
+            first_name: Ted,
+            last_name: Typed,
+            relationship: parent,
+            mobile: "8564730200",
+            secondary_phone: null,
+            email: null,
+            school_id: "73253",
+            code_location: kippnewark,
+            student_id: "400001",
+          }

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__parents.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__parents.sql
@@ -28,9 +28,16 @@ with
             contact_last_name,
             relationship,
             email_current,
-            phone_mobile,
             _dbt_source_project as code_location,
 
+            -- A Finalsite number saved with no type label reaches none of the
+            -- typed columns, so without this fallback the parent has no mobile
+            -- at all -- and a parent carrying neither a mobile nor an email is
+            -- dropped below as undeliverable, which is how untyped-phone
+            -- families went missing from ParentSquare entirely. Nearly every
+            -- tenant number that does carry a type is a Cell, so an untyped
+            -- number is treated as the mobile candidate; a typed Cell wins.
+            coalesce(phone_mobile, phone_untyped) as phone_mobile,
             coalesce(phone_home, phone_work) as phone_secondary,
         from {{ ref("int_students__contacts") }}
         where

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -17,6 +17,7 @@ with
             fc.phone_home,
             fc.phone_daytime,
             fc.phone_work,
+            fc.phone_untyped,
             fc.phone_primary,
             fc.is_emergency,
             fc.is_pickup,
@@ -73,6 +74,11 @@ with
             email as email_current,
             home_address as address_home,
 
+            -- Focus types every phone it stores, so there is no untyped number
+            -- to recover on this branch. The column exists to keep both
+            -- branches union-compatible.
+            cast(null as string) as phone_untyped,
+
             safe_cast(
                 regexp_replace(local_student_id, r'^8400', '') as int64
             ) as student_number,
@@ -124,6 +130,7 @@ with
             phone_home,
             phone_daytime,
             phone_work,
+            phone_untyped,
             phone_primary,
             address_home,
             is_emergency,
@@ -148,6 +155,7 @@ with
             phone_home,
             phone_daytime,
             phone_work,
+            phone_untyped,
             phone_primary,
             address_home,
             is_emergency,
@@ -172,6 +180,7 @@ with
             phone_home,
             phone_daytime,
             phone_work,
+            phone_untyped,
             phone_primary,
             address_home,
             is_emergency,
@@ -202,6 +211,7 @@ select
     phone_home,
     phone_daytime,
     phone_work,
+    phone_untyped,
     phone_primary,
     address_home,
     is_emergency,
@@ -227,6 +237,7 @@ select
     phone_home,
     phone_daytime,
     phone_work,
+    phone_untyped,
     phone_primary,
     address_home,
     is_emergency,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -135,11 +135,23 @@ models:
         config:
           meta:
             contains_pii: true
+      - name: phone_untyped
+        data_type: string
+        description:
+          The contact's first phone number carrying no type label, if any.
+          Finalsite lets a number be saved without selecting a type, and such a
+          number reaches none of the typed columns above — this is where it
+          lands, so a consumer can still reach the family. Always null on the
+          Focus branch, which types every number it stores.
+        config:
+          meta:
+            contains_pii: true
       - name: phone_primary
         data_type: string
         description:
-          The contact's first/best phone number regardless of type — a fallback
-          for phones the typed columns miss.
+          The contact's first/best phone number regardless of type, whether or
+          not a type label is set. To recover a number the typed columns miss,
+          use `phone_untyped`, which reports only genuinely untyped numbers.
         config:
           meta:
             contains_pii: true
@@ -235,6 +247,7 @@ unit_tests:
             cast(null as string) as phone_home,
             cast(null as string) as phone_daytime,
             cast(null as string) as phone_work,
+            cast(null as string) as phone_untyped,
             cast(null as string) as phone_primary,
             cast(null as bool) as is_emergency,
             cast(null as bool) as is_pickup,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop Finalsite phone numbers from being
dropped on their way into DeansList and ParentSquare.

Finalsite lets a phone be saved without selecting a Cell/Home/Work label.
`int_finalsite__student_contacts` derived `phone_mobile` / `phone_home` /
`phone_work` by exact-matching those three labels, so an untyped number reached
none of them and was dropped. `rpt_deanslist__family_contacts` projects only
those three columns, so the family arrived in DeansList with a name, a
relationship, an email, and no callable number. Reported by KIPP Cooper Norcross
High while making attendance calls.

Three changes:

1. `stg_finalsite__contacts` normalizes a blank phone type to NULL. A contact
   record emits an empty string where the `emrg_N` custom-field sets emit NULL,
   and both mean the same thing. `rpt_focus__contacts` already asserts NULL for
   the unset case in its own unit tests, so this brings prod in line with what
   the tests already assume.
2. `int_finalsite__student_contacts` gains `phone_untyped` — the first number
   across all three phone positions carrying no type label, derived in the
   parent branch and in each of the four emergency blocks. `phone_mobile`,
   `phone_home` and `phone_work` keep meaning exactly what they meant before, so
   no existing consumer changes behavior.
3. The two outbound feeds opt in. `rpt_deanslist__family_contacts` coalesces it
   into `CellPhone`, which is where it has to ride in because the DeansList
   template has no header for an untyped number; roughly 95 percent of NJ
   numbers that do carry a type are Cell, and a Finalsite-typed Cell still wins
   outright. `rpt_parentsquare__parents` takes the same fallback for its mobile
   candidate, where a parent carrying neither a mobile nor an email was being
   dropped as undeliverable — which is how these families went missing from
   ParentSquare entirely.

`int_students__contacts` threads the column through so ParentSquare can reach
it. Its Focus branch is a NULL literal: Focus types every number it stores.

### Impact, measured against current prod

Recovers 812 contact rows across the NJ regions — Newark 598, Camden 161,
Paterson 53 — including 46 students who currently have no phone in DeansList at
all despite having one on file in Finalsite.

### AI Assistance

Claude Code did the root-cause investigation, wrote the change, and ran the
verification below. Human-directed: the decision to normalize blank to NULL at
staging rather than work around it downstream, and the scope call to fix both
feeds in one change.

### Rollback plan

Additive. `phone_untyped` is a new column and the two feeds fall back to it only
when all three typed columns are NULL, so reverting restores the prior output
exactly. The staging normalization changes `phone_1_type` / `phone_2_type` /
`phone_3_type` from empty string to NULL, which also reaches
`rpt_focus__contacts` (Miami, Focus CONTACTS import) — that feed passes the
label straight through, and its unit tests already expect NULL for the unset
case.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — column
      docs added for `phone_untyped` on both intermediate models, and the
      `phone_1_type` / `phone_2_type` / `phone_3_type` docs updated to state
      that null means no type was selected.
- [x] **Breaking change?** No columns renamed or removed. One column added to
      two intermediate models, one value normalized in a staging model.

## Verification

Run locally against the worktree:

- `dbt parse --no-partial-parse` — clean on both `kippcamden` and `kipptaf`.
- `dbt build --select stg_finalsite__contacts int_finalsite__student_contacts`
  against `kippcamden` dev — `PASS=11 WARN=3 ERROR=0`. The 3 warns are
  pre-existing contact-slotting and staleness tests that reference no phone
  column.
- Unit tests — 7 pass, covering `int_finalsite__student_contacts` (2),
  `rpt_deanslist__family_contacts` (4) and `int_students__contacts` (1).
  `test_family_contacts_untyped_phone_fills_cellphone` is new and asserts both
  that an untyped number surfaces as `CellPhone` and that a typed Cell still
  wins when both are present.
- `trunk check --force` over all 9 changed files — no issues.

## CI note

This adds a column to a package model that `kipptaf` reads through a
`union_relations` wrapper, so the per-district `zz_stg_*` copies need seeding
before dbt Cloud CI can see `phone_untyped`. Expect the wrapper rebuild to fail
on `Name phone_untyped not found` until that runs.

Refs #4855
