### PR TITLE
perf(dagster): cron ten high-churn eager dbt nodes

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -8,6 +8,21 @@ models:
       enrollment span.
     config:
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~98 executions/day on the eager table condition. Every downstream
+          # consumer is either the assessment star (dim_assessments,
+          # fct_assessment_scores_*, the expectation bridges) already on
+          # `0 0,10,13,15,17 * * *`, or a topline weekly on `0 0 * * *` — which
+          # the 00:00 tick covers. The deanslist mod extracts run `25 1 * * *`,
+          # after the 00:00 tick.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__resolved_section_enrollments.yml
@@ -17,6 +17,19 @@ models:
       and region so consumers can resolve a score's reporting quarter by date.
     config:
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~93 executions/day on the eager table condition. Its ONLY consumer
+          # is fct_assessment_scores_enrollment_scoped, already on
+          # `0 0,10,13,15,17 * * *`. Sharing that tick lets the deps-in-progress
+          # guard serialize the pass instead of rebuilding per upstream change.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: source_type
         data_type: string

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__scaffold.yml
@@ -7,6 +7,18 @@ models:
       source for assessment-administration bridges.
     config:
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~95 executions/day on the eager table condition. Same downstream
+          # closure as int_assessments__course_enrollments: the assessment star
+          # on `0 0,10,13,15,17 * * *` plus topline weeklies on `0 0 * * *`.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__finalsite_student_scaffold.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__finalsite_student_scaffold.yml
@@ -2,6 +2,18 @@ models:
   - name: int_tableau__finalsite_student_scaffold
     config:
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~118 executions/day on the eager table condition. Only 3 models
+          # depend on it and its sole exposure, fresh_dashboard, refreshes at
+          # `0 5 * * *`. A 04:00 tick leads it.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 4 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -7,6 +7,20 @@ models:
     config:
       schema: extracts
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~109 executions/day on the eager table condition. Only 4 models
+          # depend on it; the earliest scheduled consumer is
+          # int_extracts__gradebook_audit_student_flags at `0 3 * * *`, then
+          # the gradebook_and_gpa_dashboard exposure at `0 4 * * *`. A 02:00
+          # tick leads both.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 2 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__gradebook_audit_student_flags.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__gradebook_audit_student_flags.yml
@@ -13,6 +13,21 @@ models:
     config:
       schema: extracts
       materialized: table
+      meta:
+        dagster:
+          # Nightly instead of the default eager table condition, which re-fires
+          # on ANY upstream data change — ~120 executions/day, the highest of
+          # any eager table. Neither consumer sees that churn:
+          # rpt_tableau__gradebook_audit feeds the `gradebook_audit` exposure,
+          # which declares no cron_schedule and so never gets a
+          # ScheduleDefinition (kipptaf/tableau/schedules.py) — its asset has
+          # zero materializations ever; the other exposure,
+          # gradebook_audit_teacher_report, is `enabled: false`. The Google
+          # Sheet extract, rpt_gsheets__gradebook_audit_student_flags, last
+          # built 2026-07-21. 03:00 leads the neighbouring
+          # gradebook_and_gpa_dashboard tick at `0 4 * * *`. Refs #4821
+          automation_condition:
+            cron_schedule: 0 3 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects.yml
@@ -3,6 +3,16 @@ models:
     config:
       schema: extracts
       materialized: table
+      meta:
+        dagster:
+          # Nightly instead of the default eager table condition, which re-fires
+          # on ANY upstream data change — ~113 executions/day. All 10 downstream
+          # exposures are Dagster-scheduled at 02:00 or later (earliest:
+          # kipp_miami_fast_iready_analysis `0 2 * * *`; latest:
+          # attendance_dashboard `0 15 * * *`), so a 01:00 tick leads every
+          # consumer. Refs #4821
+          automation_condition:
+            cron_schedule: 0 1 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__graduation_path_codes.yml
@@ -2,6 +2,21 @@ models:
   - name: int_students__graduation_path_codes
     config:
       materialized: table
+      meta:
+        dagster:
+          # Cron instead of the default eager table condition, which
+          # re-fires on ANY upstream data change, recursing through view
+          # chains up to 10 levels.
+          # ~119 executions/day on the eager table condition. Two ticks, not
+          # one: the kipp_forward_data_suite exposure refreshes at BOTH
+          # `0 4 * * *` and `0 17 * * *`, so a single nightly tick would leave
+          # its afternoon refresh reading stale data. 03:00 and 16:00 lead each.
+          # high_school_early_warning_dashboard (`0 6 * * *`) is covered by the
+          # 03:00 tick.
+          #
+          # Refs #4821
+          automation_condition:
+            cron_schedule: 0 3,16 * * *
     data_tests:
       - distinct_count:
           arguments:

--- a/src/dbt/kipptaf/snapshots/kippadb.yml
+++ b/src/dbt/kipptaf/snapshots/kippadb.yml
@@ -32,6 +32,19 @@ snapshots:
       dbt_valid_to_current: "'9999-12-31'"
       meta:
         dagster:
+          # Nightly instead of the default eager snapshot condition. A
+          # snapshot inherits dbt_table_automation_condition() (materialized is
+          # 'snapshot', not view/ephemeral), so it re-fires on ANY upstream data
+          # change, recursing through view chains — ~101 executions/day. Its only
+          # consumer, int_topline__college_matriculation_weekly, is itself on
+          # `0 0 * * *`, so every other execution was invisible downstream.
+          #
+          # Zero history is lost: this snapshot last captured a change on 2026-07-22, ~2,200
+          # executions ago.
+          # Sharing the consumer's tick lets the deps-in-progress guard
+          # serialize the pass. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0 * * *
           asset_key:
             - kipptaf
             - kippadb

--- a/src/dbt/kipptaf/snapshots/students.yml
+++ b/src/dbt/kipptaf/snapshots/students.yml
@@ -16,6 +16,19 @@ snapshots:
       meta:
         dagster:
           group: students
+          # Nightly instead of the default eager snapshot condition. A
+          # snapshot inherits dbt_table_automation_condition() (materialized is
+          # 'snapshot', not view/ephemeral), so it re-fires on ANY upstream data
+          # change, recursing through view chains — ~25 executions/day. Its only
+          # consumer, int_topline__attendance_interventions_weekly, is itself on
+          # `0 0 * * *`, so every other execution was invisible downstream.
+          #
+          # Zero history is lost: this snapshot last captured a change on 2026-07-17, ~675
+          # executions ago.
+          # Sharing the consumer's tick lets the deps-in-progress guard
+          # serialize the pass. Refs #4821
+          automation_condition:
+            cron_schedule: 0 0 * * *
           asset_key:
             - kipptaf
             - students


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will move **ten dbt nodes** off the eager
automation condition onto a cron that leads or matches their earliest scheduled
consumer, cutting roughly **19,000 wasted executions per month** and about
**$700/year** at current on-demand rates.

Found while checking in on #4822 two days post-merge. That PR cut dbt CI cost per
invocation by 56%, which flipped the cost profile: prod (Dagster) is now **59.3%**
of BigQuery spend and CI only 12.1%.

### Why they run so often

`CustomDagsterDbtTranslator.get_automation_condition()` falls through to
`dbt_table_automation_condition()` for anything not `view`/`ephemeral` -- the
**eager** condition that re-fires on any upstream data change, recursing through
view chains up to 10 levels. A dbt snapshot's `config.materialized` is
`'snapshot'`, so snapshots inherit it too. None of these ten declared an
`automation_condition`.

| Node | /day | new cron | $/yr |
| --- | --- | --- | --- |
| `int_extracts__gradebook_audit_student_flags` | ~120 | `0 3 * * *` | 151 |
| `snapshot_students__attendance_interventions_rollup` | ~27 | `0 0 * * *` | 132 |
| `int_extracts__student_enrollments_subjects` | ~113 | `0 1 * * *` | 103 |
| `int_extracts__course_enrollments_by_term` | ~109 | `0 2 * * *` | 68 |
| `int_assessments__resolved_section_enrollments` | ~93 | star | 62 |
| `int_assessments__course_enrollments` | ~98 | star | 45 |
| `int_students__graduation_path_codes` | ~119 | `0 3,16 * * *` | 44 |
| `int_assessments__scaffold` | ~95 | star | 43 |
| `int_tableau__finalsite_student_scaffold` | ~118 | `0 4 * * *` | 37 |
| `snapshot_kippadb__app_rollup` | ~101 | `0 0 * * *` | 18 |

`star` = `0 0,10,13,15,17 * * *`, the assessment marts' existing cadence.

Each snapshot execution issues a `CREATE_TABLE_AS_SELECT` **plus** a `MERGE`,
roughly doubling its per-run cost.

### Why the snapshots lose no history

Both are `strategy: check` snapshots, so they only write when `check_cols`
differ. Querying `dbt_valid_from`:

- `attendance_interventions_rollup` last captured a change on **2026-07-17** --
  ~675 executions ago
- `kippadb__app_rollup` last captured a change on **2026-07-22** -- ~2,200
  executions ago

Neither has written a row in over three weeks. Each also has exactly one
consumer, and both consumers are already on `0 0 * * *`
(`int_topline__attendance_interventions_weekly` and
`int_topline__college_matriculation_weekly`) -- weekly rollups reading a
nightly-cron model, so every execution between midnights was invisible
downstream.

### How each cron was chosen

Every cron leads or matches the earliest **scheduled** consumer, where a consumer
is a dbt exposure (Tableau workbook refresh), a Dagster extract asset that
queries an `rpt_*` table on a job schedule, or a downstream model that already
carries its own cron.

- **`student_enrollments_subjects` -> `0 1 * * *`.** 10 downstream exposures, all
  at 02:00 or later (earliest `kipp_miami_fast_iready_analysis` `0 2 * * *`,
  latest `attendance_dashboard` `0 15 * * *`).
- **`course_enrollments_by_term` -> `0 2 * * *`.** Only 4 downstream models;
  earliest is `gradebook_audit_student_flags` at 03:00, then
  `gradebook_and_gpa_dashboard` at 04:00.
- **The three assessment models -> the star cron.** Their consumers are the
  assessment marts already on `0 0,10,13,15,17 * * *`, plus topline weeklies on
  `0 0 * * *` that the 00:00 tick covers. Sharing the tick lets the
  deps-in-progress guard serialize the pass.
- **`graduation_path_codes` -> `0 3,16 * * *`.** Two ticks, not one: the
  `kipp_forward_data_suite` exposure refreshes at **both** `0 4 * * *` and
  `0 17 * * *`, so a single nightly tick would leave its afternoon refresh
  reading stale data.
- **`finalsite_student_scaffold` -> `0 4 * * *`.** Sole exposure
  `fresh_dashboard` at `0 5 * * *`.
- **`gradebook_audit_student_flags` -> `0 3 * * *`.** Neither consumer sees the
  current churn: `rpt_tableau__gradebook_audit` feeds the `gradebook_audit`
  exposure, which declares no `cron_schedule`. `tableau/schedules.py` builds a
  `ScheduleDefinition` only for exposures that declare one, and the
  workbook-refresh asset carries no automation condition -- so that asset has
  **zero materializations, ever**. The sibling exposure,
  `gradebook_audit_teacher_report`, is `enabled: false` (disabled 2026-03-19).
  The Google Sheet extract last built **2026-07-21**. 03:00 leads the
  neighbouring `gradebook_and_gpa_dashboard` tick at `0 4 * * *`.

**Open question for the owner:** the gradebook-audit lineage was rebuilt on
2026-07-18, which is not how a dead branch behaves. Whether that dashboard is
still being wired up decides whether the branch keeps a cron or gets retired --
worth confirming with @GabyRangelB. The cron is the right setting either way.

## Verification

Verified at the runtime path rather than the YAML, since the whole change rests
on whether the translator honors a cron override for these node types at all.
Parsed the manifest with `--no-partial-parse` and called
`get_automation_condition()` on all ten nodes plus three untouched controls.

Every one of the ten resolves to a `CronTickPassedCondition` carrying its
declared `cron_schedule` and `cron_timezone='America/New_York'`. All three
controls -- `snapshot_powerschool__gpa_term`,
`int_extracts__student_enrollments`, `int_powerschool__ada_term_pivot` -- have no
cron node anywhere in their condition tree. The controls matter: they confirm the
branch is selected by the new config, not by something incidental about the node
type.

## Deliberately not included

- **`int_extracts__student_enrollments` and `int_powerschool__ada_term_pivot`**
  ($119/year combined) reach the `ops_dashboard` exposure on `0 * * * *` and the
  six Clever extracts on `@hourly`. An intraday consumer means no daily tick is
  safe, and both sit on ~160-model downstream closures. Left eager.
- **`snapshot_powerschool__gpa_term` / `_gpa_cumulative`** ($117 and $65/year)
  also run eagerly but genuinely capture changes ~36-39x/day. Slowing them WOULD
  coarsen SCD history. Whether that churn is real GPA movement or upstream
  recomputation noise is a judgment call worth making separately.

That closes out every eager table above $30/year: ten fixed, four examined and
deliberately left alone.

Worth noting the systemic number: **319 table/snapshot nodes run on eager
conditions; 28 had a cron before this PR.** The pattern proven by #4559 is what
8f2ec7766 applied to `int_topline__student_metrics` on 2026-07-27 -- it dropped
from 45-112 executions/day to exactly 1/day the next day, and from roughly
$100/month to $0.60/month. That commit is the evidence this works.

## AI Assistance

Claude Code authored this PR. The cost attribution, the eager-condition
diagnosis, the `dbt_valid_from` staleness evidence, and the downstream-cadence
analysis were AI-executed; the decision to start on snapshots and to extend the
change to the eight extract and assessment tables was human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
      -- not done, needs a human
- [ ] Review the **Claude Code Review** comment posted on this PR

### dbt

- [x] Properties file / exposures / contracts -- config only, no schema change
- [x] **Breaking change?** No schema or column change. The behavior change is
      rebuild cadence, evidenced above as lossless for each node. **Rollback:**
      revert; all ten return to the eager condition on the next deploy
- [x] `stage_external_sources` -- N/A

### Dagster

- [x] Automation conditions verified by calling the translator directly against
      the parsed manifest, with three untouched control nodes

## CI checks

- [ ] **Trunk** -- `trunk check --force` clean locally on all ten files
- [ ] **dbt Cloud** -- config-only change; note that a green check here is weak
      validation for config that only takes effect on a Dagster tick
- [ ] **Dagster Cloud** -- awaiting CI

## Post-merge verification

A properties-only change does not fire `code_version_changed`, so each node keeps
its current behavior until the first cron tick. After that:

1. Confirm executions/day drops to the declared tick count for all ten, via
   `CREATE_TABLE_AS_SELECT` counts in
   `region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
1. Confirm `max(dbt_valid_from)` on the two snapshots still advances whenever the
   source genuinely changes
1. Confirm the `kipp_forward_data_suite` 17:00 refresh still sees
   same-day `graduation_path_codes` data

Refs #4821
