### PR TITLE
feat(dbt): send culture lead email in the DeansList student misc extract

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__student_misc.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__student_misc.yml
@@ -51,6 +51,8 @@ models:
         data_type: string
       - name: culture_lead
         data_type: string
+      - name: culture_lead_email
+        data_type: string
       - name: family_access_id
         data_type: string
       - name: student_email

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__student_misc.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__student_misc.sql
@@ -49,6 +49,7 @@ with
             sch.principal,
             sch.schoolphone,
             sch.asstprincipal as culture_lead,
+            sch.asstprincipalemail as culture_lead_email,
 
             concat(co.student_web_id, '.fam') as family_access_id,
             concat(co.student_web_password, 'kipp') as student_web_password,


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will send the school culture lead's email address alongside their name in the DeansList student misc extract, so the MS/HS progress report back page can show both in its Contact Us box.

The redesigned back page resolves its contact from the `MISCSTU` custom data object, which this model feeds. That object carried `culture_lead` (the assistant principal's name) but no email, so the report had to fall back to the advisor — a different person.

Two lines:

```sql
sch.asstprincipal as culture_lead,
sch.asstprincipalemail as culture_lead_email,
```

Plus the matching contract column in the properties file.

**No fallback needed.** `stg_powerschool__schools.asstprincipalemail` is populated wherever `asstprincipal` is, at every operating school — Newark 12 of 12, Camden 5 of 5. The only records missing an AP are the `Summer School` and `Graduated Students` placeholders in both districts, plus KIPP Newark Community Prep and KIPP Truth Academy, which closed several years ago. So a coalesce to `principal` would only ever fire on non-operating rows.

Rollback is a revert; this adds a column and changes nothing existing.

## AI Assistance

Claude located the extract, verified source-column population across all four districts, and made the edit. The decision to use the culture lead rather than the advisor, and confirmation that the two unpopulated schools are closed, were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file updated with the new contract column
- [ ] Exposure — not applicable; no new model, and the existing consumer is the nightly DeansList push
- [x] **Breaking change?** No. This adds a column to a contracted model; nothing is renamed or removed
- [x] No external source added or modified

## CI checks

- [ ] **Trunk** — `trunk check --force` clean locally on both changed files
- [ ] **dbt Cloud** — this is a kipptaf model, so CI builds it for real and will exercise contract enforcement
- [ ] **Dagster Cloud** — not triggered; `src/dbt/**` is excluded from the deploy paths

## Downstream

The column reaches DeansList on the first nightly push after merge; the custom data object will not carry it before then. Once it lands, the report template switches its Contact Us box from `advisor_name` / `advisor_email` to `culture_lead` / `culture_lead_email` — a change made in the DeansList Report Manager, not this repo.

Refs #4859
