### PR TITLE
feat(dbt): pivot college assessments long subjects wide by administration

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -1,5 +1,16 @@
 models:
   - name: rpt_gsheets__college_assessments_long
+    description:
+      One row per student per test administration, with scores and readiness
+      flags pivoted wide across the three aligned subjects (Total, EBRW/Reading,
+      Math).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - test_type
+              - test_date
     columns:
       - name: region
         data_type: string
@@ -55,15 +66,66 @@ models:
         data_type: numeric
       - name: test_type
         data_type: string
+        description:
+          Assessment scope -- SAT, ACT, PSAT 8/9, PSAT10 or PSAT NMSQT.
       - name: test_date
         data_type: date
-      - name: test_subject
-        data_type: string
-      - name: scale_score
+        description: Date of the administration. One row per student per date.
+      - name: total_scale_score
         data_type: numeric
-      - name: highest_score_by_test
+        description:
+          Composite or combined scale score for this administration. Null when
+          the administration produced no overall score.
+      - name: total_highest_score_by_test
         data_type: string
-      - name: hs_grad_ready
+        description:
+          Whether this administration is the student's highest total score for
+          this test type.
+      - name: total_hs_grad_ready
         data_type: string
-      - name: college_ready
+        description:
+          Whether the total score meets the HS-Ready benchmark. NA when no
+          benchmark exists for this score type.
+      - name: total_college_ready
         data_type: string
+        description:
+          Whether the total score meets the College-Ready benchmark. NA when no
+          benchmark exists for this score type.
+      - name: ebrw_reading_scale_score
+        data_type: numeric
+        description:
+          EBRW scale score, or ACT Reading where the test type reports Reading
+          instead.
+      - name: ebrw_reading_highest_score_by_test
+        data_type: string
+        description:
+          Whether this administration is the student's highest EBRW or Reading
+          score for this test type.
+      - name: ebrw_reading_hs_grad_ready
+        data_type: string
+        description:
+          Whether the EBRW or Reading score meets the HS-Ready benchmark. NA
+          when no benchmark exists for this score type.
+      - name: ebrw_reading_college_ready
+        data_type: string
+        description:
+          Whether the EBRW or Reading score meets the College-Ready benchmark.
+          NA when no benchmark exists for this score type.
+      - name: math_scale_score
+        data_type: numeric
+        description: Math section scale score for this administration.
+      - name: math_highest_score_by_test
+        data_type: string
+        description:
+          Whether this administration is the student's highest math score for
+          this test type.
+      - name: math_hs_grad_ready
+        data_type: string
+        description:
+          Whether the math score meets the HS-Ready benchmark. NA when no
+          benchmark exists for this score type.
+      - name: math_college_ready
+        data_type: string
+        description:
+          Whether the math score meets the College-Ready benchmark. NA when no
+          benchmark exists for this score type.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -14,63 +14,114 @@ models:
     columns:
       - name: region
         data_type: string
+        description: Region the student's school belongs to.
       - name: schoolid
         data_type: int64
+        description: The School_Number of the associated Schools record.
       - name: school
         data_type: string
+        description: Name of the school the student attends.
       - name: student_number
         data_type: int64
+        description: Student Number assigned by the school. Indexed.
       - name: salesforce_id
         data_type: string
+        description:
+          Identifier for the student's matching kippadb contact record.
       - name: student_name
         data_type: string
+        description: Last, First, Mi. Indexed.
       - name: student_first_name
         data_type: string
+        description: Students' first name.
       - name: student_last_name
         data_type: string
+        description: Students last name.
       - name: grade_level
         data_type: int64
+        description:
+          The grade the student is in. Since this is an integer, 0=Kindergarten
+          1, -2=Preschool. Indexed.
       - name: student_email
         data_type: string
+        description: The student's school-issued email address.
       - name: enroll_status
         data_type: string
+        description:
+          The enrollment status of the student. Categorical mapping of
+          enroll_status.
       - name: ktc_cohort
         data_type: int64
+        description: KIPP Through College cohort year.
       - name: graduation_year
         data_type: int64
+        description: Student graduation year.
       - name: year_in_network
         data_type: int64
+        description: Years enrolled in the network as of that year.
       - name: iep_status
         data_type: string
+        description:
+          Database extension field associated to the Students table. Conditional
+          on spedlep.
       - name: grad_iep_exempt_status_overall
         data_type: string
+        description:
+          The enrollment status of the student. Conditional on enroll_status,
+          grad_iep_exempt_overall.
       - name: cumulative_y1_gpa
         data_type: float64
+        description: Cumulative weighted Y1 GPA through this academic year.
       - name: cumulative_y1_gpa_projected
         data_type: float64
+        description:
+          Weighted projected cumulative Y1 GPA, incorporating current
+          in-progress grades not yet stored.
       - name: college_match_gpa
         data_type: numeric
+        description: Cumulative GPA used for college match categorization.
       - name: college_match_gpa_bands
         data_type: string
+        description: GPA band grouping for college match purposes.
       - name: ccr_course
         data_type: string
+        description:
+          Name of the College and Career course the student is enrolled in this
+          academic year. No Data when the student has no such enrollment.
       - name: ccr_teacher_name
         data_type: string
+        description:
+          Teacher of record for that College and Career section. No Data when
+          the student has no such enrollment.
       - name: ccr_section
         data_type: string
+        description:
+          Section identifier for that College and Career course. No Data when
+          the student has no such enrollment.
       - name: sat_total_superscore
         data_type: numeric
+        description:
+          The student's lifetime SAT superscore — highest section scores summed
+          across administrations, not a single sitting.
       - name: sat_ebrw_highest
         data_type: numeric
+        description:
+          The student's highest SAT EBRW section score across all
+          administrations.
       - name: sat_math_highest
         data_type: numeric
+        description:
+          The student's highest SAT Math section score across all
+          administrations.
       - name: test_type
         data_type: string
         description:
-          Assessment scope -- SAT, ACT, PSAT 8/9, PSAT10 or PSAT NMSQT.
+          Assessment scope — SAT, ACT, PSAT 8/9, PSAT10 or PSAT NMSQT.
       - name: test_date
         data_type: date
-        description: Date of the administration. One row per student per date.
+        description:
+          Date of the administration. One row per student per test type per
+          date, since a student may sit two different assessments on one day.
       - name: total_scale_score
         data_type: numeric
         description:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -131,45 +131,56 @@ with
             cumulative_y1_gpa_projected,
             college_match_gpa,
             college_match_gpa_bands,
+            /*
+            Grouped, not aggregated. The CCR course/teacher/section triple
+            comes from one joined row, so independent max() calls could pair a
+            course with another row's teacher if a student ever held two
+            College and Career sections in a year. Grouping keeps the triple
+            intact and surfaces such a student as a duplicate row for the
+            uniqueness test to flag, rather than silently blending two rows.
+            Same reasoning for the three lifetime SAT highs, which tie-break
+            independently on rn_highest.
+            */
+            ccr_course,
+            ccr_teacher_name,
+            ccr_section,
+            sat_total_superscore,
+            sat_ebrw_highest,
+            sat_math_highest,
             scope as test_type,
             test_date,
-
-            /*
-            Aggregated rather than grouped: a student enrolled in two College
-            and Career sections, or a tie on the rn_highest superscore joins,
-            would otherwise split the row and break the grain.
-            */
-            max(ccr_course) as ccr_course,
-            max(ccr_teacher_name) as ccr_teacher_name,
-            max(ccr_section) as ccr_section,
-            max(sat_total_superscore) as sat_total_superscore,
-            max(sat_ebrw_highest) as sat_ebrw_highest,
-            max(sat_math_highest) as sat_math_highest,
 
             /*
             max() over 'Yes'/'No' resolves to 'Yes', which is correct for both
             flags: the sitting is the student's highest, or meets the
             benchmark, if any duplicate upstream row says so. Duplicate
-            kippadb records are tracked in #4871.
+            kippadb records are tracked in #4871. 'NA' means no benchmark
+            exists for that score type, distinct from a 'No' that missed one.
             */
             max(if(aligned_subject = 'Total', scale_score, null)) as total_scale_score,
             max(
                 if(aligned_subject = 'Total', highest_score_by_test, null)
             ) as total_highest_score_by_test,
-            max(
-                if(
-                    aligned_subject = 'Total' and expected_metric_name = 'HS-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'Total' and expected_metric_name = 'HS-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as total_hs_grad_ready,
-            max(
-                if(
-                    aligned_subject = 'Total'
-                    and expected_metric_name = 'College-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'Total'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as total_college_ready,
 
             max(
@@ -178,40 +189,53 @@ with
             max(
                 if(aligned_subject = 'EBRW/Reading', highest_score_by_test, null)
             ) as ebrw_reading_highest_score_by_test,
-            max(
-                if(
-                    aligned_subject = 'EBRW/Reading'
-                    and expected_metric_name = 'HS-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'EBRW/Reading'
+                        and expected_metric_name = 'HS-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as ebrw_reading_hs_grad_ready,
-            max(
-                if(
-                    aligned_subject = 'EBRW/Reading'
-                    and expected_metric_name = 'College-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'EBRW/Reading'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as ebrw_reading_college_ready,
 
             max(if(aligned_subject = 'Math', scale_score, null)) as math_scale_score,
             max(
                 if(aligned_subject = 'Math', highest_score_by_test, null)
             ) as math_highest_score_by_test,
-            max(
-                if(
-                    aligned_subject = 'Math' and expected_metric_name = 'HS-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'Math' and expected_metric_name = 'HS-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as math_hs_grad_ready,
-            max(
-                if(
-                    aligned_subject = 'Math' and expected_metric_name = 'College-Ready',
-                    met_minimum,
-                    null
-                )
+            coalesce(
+                max(
+                    if(
+                        aligned_subject = 'Math'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
             ) as math_college_ready,
 
         from final
@@ -236,6 +260,12 @@ with
             cumulative_y1_gpa_projected,
             college_match_gpa,
             college_match_gpa_bands,
+            ccr_course,
+            ccr_teacher_name,
+            ccr_section,
+            sat_total_superscore,
+            sat_ebrw_highest,
+            sat_math_highest,
             scope,
             test_date
     )
@@ -274,17 +304,17 @@ select
 
     total_scale_score,
     total_highest_score_by_test,
-    coalesce(total_hs_grad_ready, 'NA') as total_hs_grad_ready,
-    coalesce(total_college_ready, 'NA') as total_college_ready,
+    total_hs_grad_ready,
+    total_college_ready,
 
     ebrw_reading_scale_score,
     ebrw_reading_highest_score_by_test,
-    coalesce(ebrw_reading_hs_grad_ready, 'NA') as ebrw_reading_hs_grad_ready,
-    coalesce(ebrw_reading_college_ready, 'NA') as ebrw_reading_college_ready,
+    ebrw_reading_hs_grad_ready,
+    ebrw_reading_college_ready,
 
     math_scale_score,
     math_highest_score_by_test,
-    coalesce(math_hs_grad_ready, 'NA') as math_hs_grad_ready,
-    coalesce(math_college_ready, 'NA') as math_college_ready,
+    math_hs_grad_ready,
+    math_college_ready,
 
 from pivoted

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -36,9 +36,8 @@ with
             e.college_match_gpa_bands,
 
             sc.scope,
-            sc.subject_area,
+            sc.aligned_subject,
             sc.test_date,
-            sc.score_type,
             sc.scale_score,
 
             g.expected_metric_name,
@@ -99,6 +98,146 @@ with
             and e.graduation_year >= {{ var("current_academic_year") + 1 }}
             and e.school_level = 'HS'
             and e.rn_year = 1
+            /*
+            The three subjects pivoted below. Equivalent to the prior
+            score_type exclusion list: every excluded score_type maps to
+            Reading, Math Test, Reading Test, English or Science. Being a
+            positive filter, it also excludes students with no qualifying
+            score, which the prior list did implicitly -- a null score_type
+            never satisfied `not in`.
+            */
+            and sc.aligned_subject in ('Total', 'EBRW/Reading', 'Math')
+    ),
+
+    pivoted as (
+        select
+            region,
+            schoolid,
+            school,
+            student_number,
+            salesforce_id,
+            student_name,
+            student_first_name,
+            student_last_name,
+            grade_level,
+            student_email,
+            enroll_status,
+            ktc_cohort,
+            graduation_year,
+            year_in_network,
+            iep_status,
+            grad_iep_exempt_status_overall,
+            cumulative_y1_gpa,
+            cumulative_y1_gpa_projected,
+            college_match_gpa,
+            college_match_gpa_bands,
+            scope as test_type,
+            test_date,
+
+            /*
+            Aggregated rather than grouped: a student enrolled in two College
+            and Career sections, or a tie on the rn_highest superscore joins,
+            would otherwise split the row and break the grain.
+            */
+            max(ccr_course) as ccr_course,
+            max(ccr_teacher_name) as ccr_teacher_name,
+            max(ccr_section) as ccr_section,
+            max(sat_total_superscore) as sat_total_superscore,
+            max(sat_ebrw_highest) as sat_ebrw_highest,
+            max(sat_math_highest) as sat_math_highest,
+
+            /*
+            max() over 'Yes'/'No' resolves to 'Yes', which is correct for both
+            flags: the sitting is the student's highest, or meets the
+            benchmark, if any duplicate upstream row says so. Duplicate
+            kippadb records are tracked in #4871.
+            */
+            max(if(aligned_subject = 'Total', scale_score, null)) as total_scale_score,
+            max(
+                if(aligned_subject = 'Total', highest_score_by_test, null)
+            ) as total_highest_score_by_test,
+            max(
+                if(
+                    aligned_subject = 'Total' and expected_metric_name = 'HS-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as total_hs_grad_ready,
+            max(
+                if(
+                    aligned_subject = 'Total'
+                    and expected_metric_name = 'College-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as total_college_ready,
+
+            max(
+                if(aligned_subject = 'EBRW/Reading', scale_score, null)
+            ) as ebrw_reading_scale_score,
+            max(
+                if(aligned_subject = 'EBRW/Reading', highest_score_by_test, null)
+            ) as ebrw_reading_highest_score_by_test,
+            max(
+                if(
+                    aligned_subject = 'EBRW/Reading'
+                    and expected_metric_name = 'HS-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as ebrw_reading_hs_grad_ready,
+            max(
+                if(
+                    aligned_subject = 'EBRW/Reading'
+                    and expected_metric_name = 'College-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as ebrw_reading_college_ready,
+
+            max(if(aligned_subject = 'Math', scale_score, null)) as math_scale_score,
+            max(
+                if(aligned_subject = 'Math', highest_score_by_test, null)
+            ) as math_highest_score_by_test,
+            max(
+                if(
+                    aligned_subject = 'Math' and expected_metric_name = 'HS-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as math_hs_grad_ready,
+            max(
+                if(
+                    aligned_subject = 'Math' and expected_metric_name = 'College-Ready',
+                    met_minimum,
+                    null
+                )
+            ) as math_college_ready,
+
+        from final
+        group by
+            region,
+            schoolid,
+            school,
+            student_number,
+            salesforce_id,
+            student_name,
+            student_first_name,
+            student_last_name,
+            grade_level,
+            student_email,
+            enroll_status,
+            ktc_cohort,
+            graduation_year,
+            year_in_network,
+            iep_status,
+            grad_iep_exempt_status_overall,
+            cumulative_y1_gpa,
+            cumulative_y1_gpa_projected,
+            college_match_gpa,
+            college_match_gpa_bands,
+            scope,
+            test_date
     )
 
 select
@@ -130,26 +269,22 @@ select
     sat_ebrw_highest,
     sat_math_highest,
 
-    scope as test_type,
+    test_type,
     test_date,
-    subject_area as test_subject,
-    scale_score,
-    highest_score_by_test,
 
-    coalesce(hs_grad_ready, 'NA') as hs_grad_ready,
-    coalesce(college_ready, 'NA') as college_ready,
+    total_scale_score,
+    total_highest_score_by_test,
+    coalesce(total_hs_grad_ready, 'NA') as total_hs_grad_ready,
+    coalesce(total_college_ready, 'NA') as total_college_ready,
 
-from
-    final pivot (
-        any_value(met_minimum) for expected_metric_name
-        in ('HS-Grad Ready' as hs_grad_ready, 'College-Ready' as college_ready)
-    )
-where
-    score_type not in (
-        'act_science',
-        'act_english',
-        'psat10_reading',
-        'psat10_math_test',
-        'sat_reading_test_score',
-        'sat_math_test_score'
-    )
+    ebrw_reading_scale_score,
+    ebrw_reading_highest_score_by_test,
+    coalesce(ebrw_reading_hs_grad_ready, 'NA') as ebrw_reading_hs_grad_ready,
+    coalesce(ebrw_reading_college_ready, 'NA') as ebrw_reading_college_ready,
+
+    math_scale_score,
+    math_highest_score_by_test,
+    coalesce(math_hs_grad_ready, 'NA') as math_hs_grad_ready,
+    coalesce(math_college_ready, 'NA') as math_college_ready,
+
+from pivoted


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will reshape `rpt_gsheets__college_assessments_long` so the College Assessments Long sheet stays long by student and administration but reads **wide by subject** — one row per sitting with a score and readiness column per subject, instead of three rows per sitting.

**7,434 rows to 2,425. 33 columns to 40. Same 1,306 students.**

Three subject columns, not five. The trailing `score_type` exclusion filter already removed `act_english`, `act_science`, `psat10_reading`, `psat10_math_test`, `sat_reading_test_score` and `sat_math_test_score`, so exactly three subjects survive per test type — and `int_assessments__college_assessment.aligned_subject` already collapses them to `Total` / `EBRW/Reading` / `Math` across all five scopes. No new alignment logic was needed. If ACT data returns, `act_reading` lands in the `ebrw_reading` column alongside SAT EBRW; ACT contributes zero rows today, since kippadb ACT scores stop at 2024-10-26.

Removed (5): `test_subject`, `scale_score`, `highest_score_by_test`, `hs_grad_ready`, `college_ready`.

Added (12), grouped by subject so the sheet reads in blocks:

| Total | EBRW/Reading | Math |
| --- | --- | --- |
| `total_scale_score` | `ebrw_reading_scale_score` | `math_scale_score` |
| `total_highest_score_by_test` | `ebrw_reading_highest_score_by_test` | `math_highest_score_by_test` |
| `total_hs_grad_ready` | `ebrw_reading_hs_grad_ready` | `math_hs_grad_ready` |
| `total_college_ready` | `ebrw_reading_college_ready` | `math_college_ready` |

The 26 roster and context columns through `sat_math_highest`, plus `test_type` and `test_date`, are unchanged.

### Two behaviour changes reviewers should see

**`hs_grad_ready` starts carrying values.** It read `NA` on all 7,434 rows because the pivot looked for `HS-Grad Ready` while `stg_google_sheets__kippfwd__goals` spells it `HS-Ready`. Now 741 Yes / 1,684 No. This is a fix, not a regression — but it will look like new data appearing in the sheet.

**159 duplicate rows collapse.** They differed only on `highest_score_by_test`, carried identical scores, and are entirely Camden class of 2027 on the April 2026 school-day SAT — the population already documented in #4871. Nothing is fixed here; the pivot collapses them incidentally, and `max()` over Yes/No picks Yes, which is correct since the sitting is the student's highest if any duplicate row says so. Per-subject reconciliation: SAT Combined 853, EBRW 854, Math 855 all become 801, i.e. 52 + 53 + 54 = 159.

### Filter change

The six-item `score_type` exclusion list becomes `where aligned_subject in ('Total', 'EBRW/Reading', 'Math')`. Equivalent across all 21 `(scope, score_type, aligned_subject)` combinations — every excluded score type maps to `Reading`, `Math Test`, `Reading Test`, `English` or `Science`. Being a positive filter it also excludes score-less students explicitly, which the prior list did implicitly, since a null `score_type` never satisfied `not in`. That preserves the current population exactly: 1,306 of 1,931 roster students. Surfacing the other 625 as blank-score rows so advisors can see who has not tested is a separate ask, noted in the issue.

### Rollback plan

Revert the commit. The model name, the exposure and the Dagster asset key are unchanged, so a revert restores the prior column set with no coordination beyond re-refreshing the sheet tab.

## AI Assistance

Claude Code authored the SQL, the properties file and the verification queries. Human-directed: the request to pivot subjects wide, and the four design decisions — three aligned subject columns rather than a five-column superset, per-subject rather than total-only flags, reshaping in place rather than renaming the model, and fixing the `hs_grad_ready` mismatch in this PR rather than deferring it.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — properties file updated with all 40 contract columns, descriptions on the 12 new ones, and a `dbt_utils.unique_combination_of_columns` test on `(student_number, test_type, test_date)`. This view has never carried a uniqueness test; the collapse makes one possible. Left at the project default `warn` rather than `error` — new invariant on a sheet extract, and the `ccr_course` join could in principle fan out if a student enrolled in two College and Career courses in one year (zero cases today). Closes the `rpt_gsheets__college_assessments_long` bullet of #4871 item 3; the other two views there still depend on the `strategy_case` decision.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the existing `google-sheets.yml` exposure needs no change (same model name, same sheet URL).
- [x] **Breaking change?** Yes — five columns removed from a contracted `rpt_` model. The only consumer is the Google Sheet named in the exposure, owned by the Data Team. **The sheet owner must refresh or re-point that tab after merge**: the column set goes from 33 to 40 and the row count falls by roughly two thirds. Rollback plan above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — not applicable, no external source changes.

## Verification

`extracts/` materializes as a view, so a green `dbt build` proves only column resolution. Built into a dev schema with `--defer --favor-state` against the production manifest, then compared to production:

- Contract satisfied, build clean, **uniqueness test passes** against real data — 2,425 rows, 2,425 distinct keys
- 40 columns confirmed via `INFORMATION_SCHEMA.COLUMNS`
- 2,425 rows / 1,306 students, matching a pre-implementation prototype run against production
- **Zero key differences and zero value mismatches** on all three subject scores, the highest-score flags and the readiness flags, via a full join to the production view pivoted the same way
- `hs_grad_ready` no longer uniformly `NA` — 741 Yes / 1,684 No, zero NA
- Re-verified after the pre-commit `sqlfmt` pass rewrote the SQL, so the formatted version is what was validated
- `trunk check --force` on both files — no rule violations; the two formatting findings were fixed by the commit hook, which then re-checked clean

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered (no Dagster paths changed).

Closes #4875
Refs #4871
