### PR TITLE
feat(dbt): add Focus id, status, and name-id hash to kippfwd Miami roster

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_miami_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_miami_roster.yml
@@ -210,3 +210,42 @@ models:
           Prior academic year's FLDOE FAST math progress monitoring 3
           achievement level and scale score.
         data_type: string
+      - name: focus_student_id
+        description: >-
+          Focus student id - the network student number prefixed with 8400,
+          Miami-Dade's FLDOE district number. This is the value Focus displays
+          and the id to search on there. One known student carries an id without
+          the prefix, which passes through unchanged.
+        data_type: int64
+        config:
+          meta:
+            contains_pii: true
+      - name: focus_exit_code
+        description: >-
+          Raw Focus withdrawal code closing this academic year's enrollment
+          span, for example W01 in-school transfer, W02 in-district transfer,
+          W06 graduated, DNE did not enter. Null while the span is still open.
+          Focus rolls students forward by closing the prior span with a transfer
+          code, so a completed academic year carries a code even for students
+          who never left - read focus_enrollment_status, not this column, to
+          tell who is still here.
+        data_type: string
+      - name: focus_enrollment_status
+        description: >-
+          Whether the student is currently enrolled at a KIPP Miami school,
+          Enrolled or Not Enrolled. Resolved from the student's open
+          current-year Focus enrollment rather than from this row's exit code,
+          so a prior-year row reflects where the student is now. A student whose
+          enrollment starts later in the current year reads Enrolled.
+          Student-level, so every row for the same student carries the same
+          value.
+        data_type: string
+      - name: student_name_id_hash
+        description: >-
+          Student name and Focus student id joined by a hyphen, formatted as
+          Last, First - 8400000000. Matches the identifier format the other KIPP
+          Forward sheet rosters use for lookups.
+        data_type: string
+        config:
+          meta:
+            contains_pii: true

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
@@ -56,6 +56,7 @@ with
             sex_label,
             ese_fefp_code,
             cast(disis_id as string) as mdcps_id_raw,
+            cast(student_id as string) as student_id_string,
         from {{ ref("int_focus__students") }}
     ),
 
@@ -142,6 +143,24 @@ select
 
     fp_prev.ela_pm3 as ela_pm3_prev,
     fp_prev.math_pm3 as math_pm3_prev,
+
+    s.student_id as focus_student_id,
+
+    e.exitcode as focus_exit_code,
+
+    concat(e.student_name, ' - ', s.student_id_string) as student_name_id_hash,
+
+    /* Plain in-or-out flag, resolved from the student's open current-year
+       enrollment rather than from this row's exit code. Focus rolls students
+       forward by closing the prior span with an in-school or in-district
+       transfer code, so an exit-code reading would call hundreds of students
+       not enrolled who never left. Reusing open_enrollment also keeps this in
+       lockstep with the derived enroll_status above instead of duplicating its
+       branches: a student who has not started yet still has an open
+       current-year span and correctly reads Enrolled. */
+    if(
+        oe.student_number is not null, 'Enrolled', 'Not Enrolled'
+    ) as focus_enrollment_status,
 from {{ ref("int_focus__student_enrollments") }} as e
 left join students as s on e.student_number = s.student_id
 left join open_enrollment as oe on e.student_number = oe.student_number


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will append four columns to
`rpt_gsheets__kippfwd_miami_roster` for the KIPP Forward Miami team. All four
land at the end of the select, so existing sheet column positions are unchanged.

| Column                    | Type   | Value                                                                                                     |
| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
| `focus_student_id`        | int64  | The 8400-prefixed Focus student id, which is Focus `students.student_id` and the value Focus itself displays |
| `focus_exit_code`         | string | Raw Focus withdrawal code closing that academic year's span (`W01`, `W02`, `DNE`, and so on), null while the span is still open |
| `student_name_id_hash`    | string | `Last, First - 8400000000`, matching the `rpt_gsheets__kfwd_rem_roster` format                             |
| `focus_enrollment_status` | string | Plain in-or-out flag, `Enrolled` or `Not Enrolled`                                                          |

### Why the enrollment flag does not read the exit code

Focus rolls students forward by closing the prior year's span with an in-school
(`W01`) or in-district (`W02`) transfer code. Those two codes cover 359 of 365
AY2025 grade 7-8 rows, while only 4 students actually left mid-year. A flag
derived from the exit code would mark hundreds of currently enrolled students as
gone.

`focus_enrollment_status` instead reuses the model's existing `open_enrollment`
CTE, the same input the derived `enroll_status` already uses. That keeps the two
in lockstep without duplicating the CASE branches, and it handles the
pre-first-day case correctly, since a student who has not started yet still has
an open current-year span.

`focus_exit_code` is kept alongside it as the reason a student shows as Not
Enrolled, but note it answers how that year's span closed, not whether the
student left.

### Validation

- `dbt build` plus all 6 data tests pass against the committed state.
- Row counts unchanged at 365 for AY2025 and 376 for AY2026, so nothing fans
  out.
- No nulls in any of the four new columns across all 741 rows.
- `student_name_id_hash` is well formed on every row, and the id it embeds
  matches `focus_student_id` on every row.
- `focus_enrollment_status` agrees with `enroll_status = 0` on all 741 rows,
  confirming it restates current standing rather than introducing a second
  source of truth.
- `trunk check --force` clean on both files.

Column ordering inside the new block follows sqlfluff ST06 (plain references,
then functions, then logicals), which is why the hash sits before the flag.

## AI Assistance

Authored by Claude Code. Human-directed: which columns to add, using the
prefixed Focus id, and the call to reduce an exit-code decode down to a plain
in-or-out flag. AI-assisted: finding the naming precedent, identifying the
rollover-code trap, writing the SQL and properties, and running the validation
above.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file updated with all four new contract columns, each with a
      description. Both id columns and the hash carry `contains_pii`.
- [x] Exposure already covers this model. The `access_denied` exposure in
      `models/exposures/google-sheets.yml` depends on the model rather than on
      its column list, so no exposure change is needed.
- [x] Not a breaking change. Columns are added, none renamed or removed, and
      they append at the end so existing sheet positions hold. Rollback is a
      straight revert.
- [x] No external source added or modified.

### Docs

Skipped, no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk**
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — expected not to trigger, no Dagster paths changed.

Refs #4873
