### PR TITLE
feat: use Paterson real U_EXPECTATIONS data and drop the Newark spoof

### DIFF
--- a/.claude/skills/gradebook-audit/SKILL.md
+++ b/.claude/skills/gradebook-audit/SKILL.md
@@ -129,10 +129,15 @@ Current `depends_on` list (update if the exposure changes):
 There is also a disabled exposure `gradebook_audit_teacher_report` — mention it
 only if the user asks about disabled or archived workbooks.
 
-The companion student-flags Google Sheet has its own separate exposure in
-`src/dbt/kipptaf/models/exposures/google-sheets.yml`, named
-`rpt_gsheets__gradebook_audit_student_flags` — check there if asked about the
-gsheets side rather than the Tableau side.
+Two companion Google Sheets have their own exposures in
+`src/dbt/kipptaf/models/exposures/google-sheets.yml` — check there if asked
+about the gsheets side rather than the Tableau side:
+
+- `rpt_gsheets__gradebook_audit_student_flags` — the flagged-student review
+  sheet (read side, carries student PII)
+- `rpt_gsheets__gradebook_audit_template` — the expectations upload template
+  (write side; T&L exports it as the CSV they load into `U_EXPECTATIONS` via the
+  PowerSchool plugin)
 
 ---
 
@@ -246,9 +251,27 @@ correctly.
    region's PowerSchool instance and the `U_EXPECTATIONS` table is populated.
    Plugin source and update instructions:
    [TEAMSchools/ps-plugins](https://github.com/TEAMSchools/ps-plugins)
-2. Verify `int_powerschool__u_expectations_qtd_unpivot` returns rows for the new
+2. Wire the ingestion and the union — four files, in this order (Paterson's
+   rollout in #4879 is the worked example):
+   - add `u_expectations` to
+     `src/teamster/code_locations/<district>/powerschool/sis/dlt/config/assets.yaml`
+     (`cursor_column: whenmodified`, `intraday: true`, `nightly: false`) and
+     bump that district's hardcoded asset counts in `tests/`
+   - drop the `stg_powerschool__u_expectations: +enabled: false` entry from
+     `src/dbt/<district>/dbt_project.yml`
+   - add the `stg_powerschool__u_expectations` source entry to
+     `src/dbt/kipptaf/models/powerschool/sources-<district>.yml`
+   - add the relation to `union_relations` in
+     `src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql`
+3. **Materialize the dlt asset BEFORE enabling the dbt staging model, and
+   confirm the BigQuery table exists.** dlt creates no table at all for the
+   first load of a source table that is empty, and the newly enabled staging
+   model then fails on a missing relation — which cascades into the kipptaf
+   union and takes the whole gradebook audit down, not just the new region. The
+   plugin being installed is not sufficient; the table needs at least one row.
+4. Verify `int_powerschool__u_expectations_qtd_unpivot` returns rows for the new
    region.
-3. No flag sheet changes needed — the flag columns in
+5. No flag sheet changes needed — the flag columns in
    `rpt_tableau__gradebook_audit` apply to all regions. The only exclusions,
    applied in `category_join`'s `WHERE` clause (and matched in
    `int_extracts__gradebook_audit_student_flags`'s own filters, which both
@@ -297,8 +320,9 @@ reads; the gsheets report itself no longer carries any toggle):
 - `src/dbt/kipptaf/models/students/intermediate/int_extracts__gradebook_audit_student_flags.sql`
 - `src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__u_expectations_qtd_unpivot.sql`
 - `src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_es_comments.sql`
+- `src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql`
 
-**Four changes to make:**
+**Five changes to make:**
 
 1. In `rpt_tableau__gradebook_audit` — change the year filter in
    `category_join`'s `WHERE` clause (1 occurrence, marked
@@ -398,7 +422,25 @@ reads; the gsheets report itself no longer carries any toggle):
    fallback data source available; escalate instead of shipping a change that
    silently reports every comment as missing.
 
-Build and verify after all four changes:
+5. In `rpt_gsheets__gradebook_audit_template` — the expectations upload template
+   T&L uses to build the PowerSchool CSV. Change both occurrences (one filters
+   `int_powerschool__calendar_week` in the `term_weeks` CTE, marked
+   `-- summer toggle: see skill`; one stamps the output `academic_year` column,
+   marked `/* summer toggle: see skill */`):
+
+   ```sql
+   -- change this (appears 2 times):
+   {{ var("current_academic_year") }}
+   -- to this:
+   {{ var("current_academic_year") - 1 }}
+   ```
+
+   **While toggled, this model shows the PRIOR year's week grid.** It is the
+   sheet T&L exports to upload the NEW year's expectations, so do not hand it
+   over as the new-year grid until the toggle is reverted — they would be
+   editing last year's weeks.
+
+Build and verify after all five changes:
 
 ```bash
 uv run dbt build \
@@ -406,6 +448,7 @@ uv run dbt build \
     int_extracts__gradebook_audit_student_flags \
     rpt_gsheets__gradebook_audit_student_flags rpt_tableau__gradebook_audit \
     rpt_tableau__gradebook_es_comments \
+    rpt_gsheets__gradebook_audit_template \
   --project-dir src/dbt/kipptaf \
   --defer \
   --state target/prod
@@ -417,7 +460,7 @@ would otherwise read the un-toggled prod copy.
 
 **When to revert:** once the new school year starts and teachers begin entering
 grades in PowerSchool (typically Q1), revert all changes:
-`current_academic_year - 1` → `current_academic_year` in all four files, and
+`current_academic_year - 1` → `current_academic_year` in all five files, and
 `'last_year'` → `'current_year'` in
 `int_extracts__gradebook_audit_student_flags`.
 

--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -52,35 +52,27 @@ The audit operates at several grains:
 
 ### Dashboard coverage (AY 2026-2027)
 
-| Region   | School level | Coverage depth                              | Notes                                                          |
-| -------- | ------------ | ------------------------------------------- | -------------------------------------------------------------- |
-| Camden   | MS, HS       | Full audit (all applicable flags)           |                                                                |
-| Newark   | MS, HS       | Full audit (all applicable flags)           |                                                                |
-| Paterson | MS           | Full audit (all applicable flags)           | Added AY 2026-2027; expectations spoofed from Newark's MS data |
-| Camden   | ES           | EOQ comments only (`qt_es_comment_missing`) | ES schools do not enter assignments in PS gradebook            |
-| Newark   | ES           | EOQ comments only (`qt_es_comment_missing`) | ES schools do not enter assignments in PS gradebook            |
-| Paterson | ES           | EOQ comments only (`qt_es_comment_missing`) | Added AY 2026-2027                                             |
-| Miami    | n/a          | Removed                                     | Moved to Focus gradebook; excluded at scaffold level           |
+| Region   | School level | Coverage depth                              | Notes                                                |
+| -------- | ------------ | ------------------------------------------- | ---------------------------------------------------- |
+| Camden   | MS, HS       | Full audit (all applicable flags)           |                                                      |
+| Newark   | MS, HS       | Full audit (all applicable flags)           |                                                      |
+| Paterson | MS           | Full audit (all applicable flags)           | Added AY 2026-2027                                   |
+| Camden   | ES           | EOQ comments only (`qt_es_comment_missing`) | ES schools do not enter assignments in PS gradebook  |
+| Newark   | ES           | EOQ comments only (`qt_es_comment_missing`) | ES schools do not enter assignments in PS gradebook  |
+| Paterson | ES           | EOQ comments only (`qt_es_comment_missing`) | Added AY 2026-2027                                   |
+| Miami    | n/a          | Removed                                     | Moved to Focus gradebook; excluded at scaffold level |
 
-!!! note "Paterson GradeBook plugin" The **KIPP NJ Gradebook Audit** plugin
-cannot be installed on Paterson's PowerSchool instance, so `U_EXPECTATIONS` is
-never populated there natively. `kipptaf`'s own
-`stg_powerschool__u_expectations` model handles this directly: a
-`paterson_spoof` CTE reads Newark's real U_EXPECTATIONS data via
-`source("kippnewark_powerschool", "stg_powerschool__u_expectations")`, filtered
-to `school_level = 'MS'`, with a hardcoded
-`'kipppaterson' as _dbt_source_project` (bypassing the usual
-`extract_source_project()` regex-on-schema-name derivation, since the physical
-relation really is Newark's — deriving from it would mislabel these rows as
-`kippnewark`). This is `UNION ALL`-ed alongside the real Camden/Newark union
-(`src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql`).
-There is no per-district override model in `kipppaterson` anymore — that
-approach (a `kipppaterson`-project model reading Newark's source under a
-misleadingly-named `kippnewark_powerschool` source declaration) was replaced
-after review; see PR #4132 review discussion.
-`int_powerschool__u_expectations_qtd_unpivot`'s kipptaf-level union picks this
-up as a third region alongside Camden and Newark — no different from a real
-region's data at that point. Tracked:
+!!! note "Paterson GradeBook plugin" The **KIPP NJ Gradebook Audit** plugin is
+now installed on Paterson's PowerSchool instance, so `U_EXPECTATIONS` is
+populated there natively and Paterson is an ordinary third region in the
+kipptaf-level union
+(`src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql`),
+alongside Camden and Newark. The raw table is ingested by the
+`kipppaterson/powerschool/sis/u_expectations` dlt asset. History: the plugin
+could not originally be installed on Paterson, so from AY 2026-2027 launch until
+the install, Paterson MS ran on _spoofed_ expectations — Newark's MS values,
+relabeled `kipppaterson`. That spoof was removed in #4879; see #4132 for the
+review discussion that shaped it. Tracked:
 [#3908](https://github.com/TEAMSchools/teamster/issues/3908)
 
 ---
@@ -170,6 +162,14 @@ int_powerschool__u_expectations_qtd_unpivot ┼───────────
 int_powerschool__gradebook_assignment_scores_rollup ┘
 ```
 
+Alongside that read path, one model runs in the opposite direction — it feeds
+the sheet T&L uses to push expectations back INTO PowerSchool:
+
+```text
+int_powerschool__calendar_week ──┐
+stg_powerschool__u_expectations ─┴──► rpt_gsheets__gradebook_audit_template
+```
+
 **Why changed:** `rpt_tableau__gradebook_audit` used to carry a `student_course`
 branch with full student PII (name, student number) into a Tableau-facing
 report. The July 2026 split moved that branch's logic into its own model,
@@ -239,6 +239,38 @@ completed week per quarter. One row per
 cutoff — is the Sunday ending the most recently completed school week (the
 latest calendar week with
 `week_start_monday < date_trunc(current_date, isoweek)`).
+
+### Expectations upload template: `rpt_gsheets__gradebook_audit_template`
+
+Feeds the Google Sheet the T&L team uses to build the CSV they upload back into
+PowerSchool's `U_EXPECTATIONS` via the plugin — the write side of the same table
+`int_powerschool__u_expectations_qtd_unpivot` reads. Exposure:
+`rpt_gsheets__gradebook_audit_template` in
+`src/dbt/kipptaf/models/exposures/google-sheets.yml`.
+
+One row per
+`region × school_level × quarter × week_number_quarter × assignment_category_code`
+(uniqueness-tested). It shares the QTD unpivot's `term_weeks` CTE and category
+decode, but differs in two ways: it keeps **every** school week rather than
+collapsing to the most recently completed one per quarter, and it takes
+`school_week_end_date` (aliased `week_end_friday`) instead of `week_end_sunday`.
+
+Two gotchas worth knowing before editing it:
+
+- **`week_end_friday` is not always a Friday.** It is the last _in-session_ day
+  of the school week, so it lands on Thursday or earlier when a holiday or PD
+  day shortens the week (~11% of AY 2025 weeks). That is deliberate — a short
+  week should be visible to whoever is setting per-week assignment counts.
+- **`int_powerschool__calendar_week` is per-`schoolid`, and
+  `school_week_end_date` varies across the schools in one region** when only
+  some of them lose a day (e.g. Newark MS Q3 week 6 splits across 2026-03-19 and
+  2026-03-20). `term_weeks` therefore aggregates with
+  `max(school_week_end_date)` and an explicit `GROUP BY`; a `SELECT DISTINCT`
+  fans the join out to one row per distinct end date and breaks the grain.
+
+Coverage follows the inner join to `stg_powerschool__u_expectations` — Newark
+and Camden at MS and HS, Paterson at MS, no ES and no Miami — so it needs no
+region filter of its own.
 
 ### Assignment and category rollup layer
 
@@ -497,6 +529,12 @@ current state of expectations in PowerSchool. Until the T&L team member
 responsible for gradebook expectations updates the table for the new year, the
 audit will continue to report against the prior year's expectation values.
 
+`rpt_gsheets__gradebook_audit_template` (see above) exists to support this step:
+it lands every school week's current expectations in a Google Sheet, which T&L
+edits and exports as the CSV they upload through the plugin. Because it is
+driven by the same toggled year filter as the audit models, check the summer
+toggle's state before reading it as the new year's grid.
+
 Plugin source and update instructions:
 [TEAMSchools/ps-plugins](https://github.com/TEAMSchools/ps-plugins)
 
@@ -506,8 +544,9 @@ If the summer toggle was applied during the off-season (switching year filters
 to `current_academic_year - 1`, grades type to `'last_year'` where applicable)
 to `rpt_tableau__gradebook_audit`,
 `int_extracts__gradebook_audit_student_flags`,
-`int_powerschool__u_expectations_qtd_unpivot`, and
-`rpt_tableau__gradebook_es_comments`, revert all changes in all four files
+`int_powerschool__u_expectations_qtd_unpivot`,
+`rpt_tableau__gradebook_es_comments`, and
+`rpt_gsheets__gradebook_audit_template`, revert all changes in all five files
 before the new school year begins. See the `gradebook-audit` skill for the exact
 lines — the student grade/comment toggle now lives in
 `int_extracts__gradebook_audit_student_flags` (the July 2026 intermediate
@@ -520,20 +559,12 @@ why).
 
 ## Open questions and future work
 
-Three known future-work items remain. The rest of the AY 2026-2027 build is
+Two known future-work items remain. The rest of the AY 2026-2027 build is
 delivered — see [#3908](https://github.com/TEAMSchools/teamster/issues/3908) and
 the
 [implementation plan](../superpowers/plans/2026-05-14-gradebook-audit-ay2627-revamp.md)
 for that history.
 
-- **Install the gradebook-audit plugin on Paterson's PowerSchool instance.** The
-  KIPP NJ Gradebook Audit plugin cannot currently be installed on Paterson, so
-  `U_EXPECTATIONS` is not populated there natively and Paterson MS runs on
-  _spoofed_ expectations — Newark's MS values, via the `paterson_spoof` CTE in
-  `stg_powerschool__u_expectations` (see the Paterson note above). Once the
-  plugin can be installed on Paterson, it should use its own real expectations
-  and the spoof can be removed. Plugin source:
-  [TEAMSchools/ps-plugins](https://github.com/TEAMSchools/ps-plugins).
 - **Make student-course selection deterministic when enrollment dates overlap.**
   `int_extracts__course_enrollments_by_term` picks one section per
   student/course/quarter with a `row_number()` tiebreaker

--- a/src/dbt/kipppaterson/dbt_project.yml
+++ b/src/dbt/kipppaterson/dbt_project.yml
@@ -106,8 +106,6 @@ models:
             +enabled: false
           stg_powerschool__u_clg_et_stu_alt:
             +enabled: false
-          stg_powerschool__u_expectations:
-            +enabled: false
           stg_powerschool__u_storedgrades_de:
             +enabled: false
   titan:

--- a/src/dbt/kipptaf/models/exposures/google-sheets.yml
+++ b/src/dbt/kipptaf/models/exposures/google-sheets.yml
@@ -806,6 +806,20 @@ exposures:
           kinds:
             - googlesheets
 
+  - name: rpt_gsheets__gradebook_audit_template
+    label: Gradebook Audit Expectations Upload Template
+    type: application
+    owner:
+      name: Data Team - grangel
+    url: https://docs.google.com/spreadsheets/d/1ofCxW0pLniywn_XZT69S23vhcDs6y9ElAtJa5fTtiT0
+    depends_on:
+      - ref("rpt_gsheets__gradebook_audit_template")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - googlesheets
+
   - name: rpt_gsheets__historical_suspensions
     label: Historical Suspensions
     type: analysis

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gradebook_audit_template.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gradebook_audit_template.yml
@@ -1,0 +1,71 @@
+models:
+  - name: rpt_gsheets__gradebook_audit_template
+    description: >
+      Every school week's assignment expectations, one row per category, for
+      building the CSV that C3 uploads into PowerSchool's U_EXPECTATIONS via the
+      KIPP NJ Gradebook Audit plugin. Unlike
+      int_powerschool__u_expectations_qtd_unpivot, which collapses to the most
+      recently completed week per quarter for the audit's quarter-to-date
+      counts, this keeps every week so the upload covers the full year. Coverage
+      follows the inner join to stg_powerschool__u_expectations — Newark and
+      Camden at MS and HS, Paterson at MS, no ES and no Miami.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - region
+              - school_level
+              - quarter
+              - week_number_quarter
+              - assignment_category_code
+    columns:
+      - name: region
+        data_type: string
+        description: District region (e.g. Newark, Camden, Paterson).
+      - name: school_level
+        data_type: string
+        description: School level grouping (MS / HS).
+      - name: quarter
+        data_type: string
+        quote: true
+        description: Academic quarter (Q1–Q4).
+      - name: week_number_quarter
+        data_type: int64
+        description:
+          Week number within the quarter that this expectation row applies to.
+      - name: week_start_monday
+        data_type: date
+        description:
+          Monday of the school week represented by week_number_quarter.
+      - name: week_end_friday
+        data_type: date
+        description: >
+          Last in-session day of the school week, from
+          int_powerschool__calendar_week.school_week_end_date. Friday on a full
+          week, but earlier (Thursday or before) when the week is shortened by a
+          holiday or PD day — so a short week is visible when setting counts.
+      - name: notes
+        data_type: string
+        description: Free-text note carried through from the U_EXPECTATIONS row.
+      - name: assignment_category_code
+        data_type: string
+        description: Single-letter category code (W, H, F, or S).
+      - name: expectation
+        data_type: int64
+        description:
+          Count of expected assignments for this category in this week.
+      - name: academic_year
+        data_type: int64
+        description: >
+          Academic year (starting year). Stamped as a literal — U_EXPECTATIONS
+          reflects whatever is currently live in PowerSchool and carries no year
+          of its own.
+      - name: assignment_category_term
+        data_type: string
+        description:
+          Category code concatenated with quarter number (e.g. W1, H2, F3, S4).
+      - name: assignment_category_name
+        data_type: string
+        description:
+          Human-readable category name (Work Habits, Homework, Formative
+          Mastery, Summative Mastery).

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
@@ -1,0 +1,91 @@
+with
+    term_weeks as (
+        /*
+        calendar_week is per-schoolid; school_week_end_date varies across the
+        schools in a region when only some of them lose a day to a holiday or
+        PD, so take the region's latest in-session day rather than distinct
+        (which would fan the join out to one row per end date)
+        */
+        select
+            _dbt_source_project,
+            region,
+            school_level,
+            `quarter`,
+            week_number_quarter,
+            week_start_monday,
+
+            max(school_week_end_date) as school_week_end_date,
+
+        from {{ ref("int_powerschool__calendar_week") }}
+        where
+            -- summer toggle: see skill
+            academic_year = {{ var("current_academic_year") - 1 }}
+            and week_start_monday
+            < date_trunc(current_date('{{ var("local_timezone") }}'), isoweek)
+        group by
+            _dbt_source_project,
+            region,
+            school_level,
+            `quarter`,
+            week_number_quarter,
+            week_start_monday
+    ),
+
+    week_expectations as (
+        select
+            u.school_level,
+            u.`quarter`,
+            u.cnt_w,
+            u.cnt_h,
+            u.cnt_f,
+            u.cnt_s,
+            u.notes,
+
+            tw.region,
+            tw.week_number_quarter,
+            tw.week_start_monday,
+            tw.school_week_end_date,
+
+        from {{ ref("stg_powerschool__u_expectations") }} as u
+        inner join
+            term_weeks as tw
+            on u.school_level = tw.school_level
+            and u.`quarter` = tw.`quarter`
+            and u.week_number = tw.week_number_quarter
+            and u._dbt_source_project = tw._dbt_source_project
+    )
+
+select
+    region,
+    school_level,
+    `quarter`,
+    week_number_quarter,
+    week_start_monday,
+    school_week_end_date as week_end_friday,
+    notes,
+
+    assignment_category_code,
+    expectation,
+
+    {{ var("current_academic_year") - 1 }} as academic_year,  /* summer toggle: see skill */
+
+    concat(assignment_category_code, right(`quarter`, 1)) as assignment_category_term,
+
+    case
+        assignment_category_code
+        when 'W'
+        then 'Work Habits'
+        when 'H'
+        then 'Homework'
+        when 'F'
+        then 'Formative Mastery'
+        when 'S'
+        then 'Summative Mastery'
+    end as assignment_category_name,
+
+from
+    week_expectations unpivot (
+        expectation for assignment_category_code
+        in (`cnt_w` as 'W', `cnt_h` as 'H', `cnt_f` as 'F', `cnt_s` as 'S')
+    )
+where expectation is not null

--- a/src/dbt/kipptaf/models/powerschool/sources-kipppaterson.yml
+++ b/src/dbt/kipptaf/models/powerschool/sources-kipppaterson.yml
@@ -545,6 +545,15 @@ sources:
                 - kipppaterson
                 - powerschool
                 - stg_powerschool__u_def_ext_students
+      - name: stg_powerschool__u_expectations
+        config:
+          meta:
+            dagster:
+              group: powerschool
+              asset_key:
+                - kipppaterson
+                - powerschool
+                - stg_powerschool__u_expectations
       - name: stg_powerschool__u_studentsuserfields
         config:
           meta:

--- a/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
+++ b/src/dbt/kipptaf/models/powerschool/staging/stg_powerschool__u_expectations.sql
@@ -9,65 +9,13 @@ with
                     source(
                         "kippnewark_powerschool", "stg_powerschool__u_expectations"
                     ),
+                    source(
+                        "kipppaterson_powerschool", "stg_powerschool__u_expectations"
+                    ),
                 ]
             )
         }}
-    ),
-
-    real_union as (
-        select
-            id,
-            school_level,
-            `quarter`,
-            week_number,
-            cnt_w,
-            cnt_h,
-            cnt_f,
-            cnt_s,
-            notes,
-            whocreated,
-            whencreated,
-            whomodified,
-            whenmodified,
-
-            {{ extract_source_project("union_relations") }} as _dbt_source_project,
-
-        from union_relations
-    ),
-
-    -- TODO(#3908): remove once Paterson gets its own U_EXPECTATIONS source
-    -- (native plugin support or another data path). Paterson's PowerSchool
-    -- instance cannot run the KIPP NJ Gradebook Audit plugin, so
-    -- U_EXPECTATIONS is never populated there. Spoof MS expectations from
-    -- Newark's real plugin data until a native solution exists -- see
-    -- docs/models/gradebook-audit-data-model.md "Paterson GradeBook
-    -- plugin".
-    paterson_spoof as (
-        select
-            id,
-            school_level,
-            `quarter`,
-            week_number,
-            cnt_w,
-            cnt_h,
-            cnt_f,
-            cnt_s,
-            notes,
-            whocreated,
-            whencreated,
-            whomodified,
-            whenmodified,
-
-            'kipppaterson' as _dbt_source_project,
-
-        from {{ source("kippnewark_powerschool", "stg_powerschool__u_expectations") }}
-        where school_level = 'MS'
     )
 
-select *,
-from real_union
-
-union all
-
-select *,
-from paterson_spoof
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
+from union_relations

--- a/src/teamster/code_locations/kipppaterson/CLAUDE.md
+++ b/src/teamster/code_locations/kipppaterson/CLAUDE.md
@@ -30,7 +30,7 @@ database through an in-process paramiko SSH tunnel (`ssh_powerschool` resource,
 `enable_legacy_rsa=True`) and landing to BigQuery via keyless ADC (issue #3807).
 This is the pilot/template for migrating the ODBC districts (`kippnewark`,
 `kippcamden`, `kippmiami`) off `sshpass`. ONE `@dlt_assets` multi-asset covers
-all 48 tables (`powerschool/sis/dlt/`); `cursor_column: null` tables always
+all 49 tables (`powerschool/sis/dlt/`); `cursor_column: null` tables always
 replace. Config in `powerschool/sis/dlt/config/assets.yaml` (per-table
 `cursor_column` + `intraday`/`nightly` membership booleans). Intraday selection
 is decided by `kipppaterson__powerschool__dlt__intraday_sensor` (probe +

--- a/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
+++ b/src/teamster/code_locations/kipppaterson/powerschool/sis/dlt/config/assets.yaml
@@ -80,6 +80,10 @@ assets:
     cursor_column: transaction_date
     intraday: true
     nightly: false
+  - table_name: u_expectations
+    cursor_column: whenmodified
+    intraday: true
+    nightly: false
   - table_name: u_studentsuserfields
     cursor_column: whenmodified
     intraday: true

--- a/src/teamster/libraries/dlt/CLAUDE.md
+++ b/src/teamster/libraries/dlt/CLAUDE.md
@@ -218,9 +218,19 @@ changes on existing tables.
   function body or a `selected=False` resource never round-trip
   (spike-confirmed, silent) — this is why the per-table signature write lives
   inside the extracted resource, not the source.
-- `.fetch_row_count()` on the `run()` iterator adds per-table `row_count`
-  metadata; log `pipeline.last_trace.last_normalize_info.row_counts` in an
-  `except` so a load failure is legible without walking the exception chain.
+- Per-table `row_count` metadata comes from `fetch_row_count_metadata()`; log
+  `pipeline.last_trace.last_normalize_info.row_counts` in an `except` so a load
+  failure is legible without walking the exception chain. **Do NOT call
+  `.fetch_row_count()` on the `run()` iterator** — it raises on any
+  materialization with no `jobs` metadata, which is what dlt emits for the first
+  load of a table that extracts zero rows (`_handle_empty_tables` writes the
+  empty truncate file only once a table has `seen_data`). With one multi-asset
+  op per district that raise kills every other table in the run. `powerschool/`
+  iterates `run()` directly and enriches each event through `_with_row_count()`,
+  which falls back to the un-enriched materialization; copy that shape rather
+  than the chained call. A stub standing in for the `run()` return value must
+  therefore be **iterable**, not expose `.fetch_row_count()` (see
+  `tests/libraries/test_powerschool_dlt_extract_workers.py`).
 - **Stream dlt progress into the Dagster event log**: in the op, set
   `dlt_pipeline.collector = LogCollector(logger=context.log, log_period=30.0)`
   (`context.log` is a `logging.Logger`). The factory default `logger="stdout"`

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -201,10 +201,7 @@ def _with_row_count(
         context.log.warning(f"no row_count for {event.asset_key}: {e}")
         return event
 
-    if not event.metadata:
-        return event
-
-    return event._replace(metadata={**row_count_metadata, **event.metadata})
+    return event._replace(metadata={**row_count_metadata, **(event.metadata or {})})
 
 
 def build_powerschool_dlt_assets(

--- a/src/teamster/libraries/dlt/powerschool/assets.py
+++ b/src/teamster/libraries/dlt/powerschool/assets.py
@@ -4,6 +4,9 @@ import dlt
 import sqlalchemy as sa
 from dagster import AssetExecutionContext, AssetKey, AssetSpec, Config
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
+
+# not re-exported from `dagster_dlt`
+from dagster_dlt.dlt_event_iterator import DltEventType, fetch_row_count_metadata
 from dlt import config as dlt_config
 from dlt.common.runtime.collector import LogCollector
 from dlt.destinations import bigquery
@@ -178,6 +181,32 @@ def _powerschool_source(
         )
 
 
+def _with_row_count(
+    event: DltEventType,
+    context: AssetExecutionContext,
+    dlt_pipeline: dlt.Pipeline,
+) -> DltEventType:
+    """Attach dagster-dlt's `row_count` metadata, tolerating a resource with no job.
+
+    `fetch_row_count()` raises when a materialization carries no `jobs` metadata,
+    which is what a first-load table with zero rows produces. All tables share one
+    op, so that raise kills every other table in the run. Enrich per event and
+    fall back to the plain event instead.
+    """
+    try:
+        row_count_metadata = fetch_row_count_metadata(
+            event, context=context, dlt_pipeline=dlt_pipeline
+        )
+    except Exception as e:
+        context.log.warning(f"no row_count for {event.asset_key}: {e}")
+        return event
+
+    if not event.metadata:
+        return event
+
+    return event._replace(metadata={**row_count_metadata, **event.metadata})
+
+
 def build_powerschool_dlt_assets(
     code_location: str,
     tables: list[ProbeTable],
@@ -288,10 +317,10 @@ def build_powerschool_dlt_assets(
             )
 
             try:
-                # fetch_row_count() attaches an authoritative per-table row_count
+                # _with_row_count() attaches an authoritative per-table row_count
                 # to each materialization's metadata (surfaced in the asset
                 # catalog) alongside dagster-dlt's default load metadata.
-                yield from dlt.run(
+                for event in dlt.run(
                     context=context,
                     dlt_source=_powerschool_source(
                         selected, signatures, connection_url, arraysize
@@ -299,7 +328,8 @@ def build_powerschool_dlt_assets(
                     dlt_pipeline=dlt_pipeline,
                     dagster_dlt_translator=translator,
                     write_disposition="replace",
-                ).fetch_row_count()
+                ):
+                    yield _with_row_count(event, context, dlt_pipeline)
             except Exception:
                 # Surface dlt's per-table extracted row counts in the run log so a
                 # load failure is legible without walking the exception chain.

--- a/tests/assets/test_powerschool_dlt_paterson_defs.py
+++ b/tests/assets/test_powerschool_dlt_paterson_defs.py
@@ -11,7 +11,7 @@ def test_paterson_powerschool_dlt_asset_keys():
 
     config = yaml.safe_load(config_file.read_text())
 
-    assert len(config["assets"]) == 48
+    assert len(config["assets"]) == 49
 
     keys = {key for a in assets.assets for key in a.keys}
     assert keys == {

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -99,7 +99,14 @@ def test_config_matches_spec_membership_map():
     entries = yaml.safe_load(CONFIG.read_text())["assets"]
     by_name = {e["table_name"]: e for e in entries}
 
-    assert len(entries) == 49
+    # derived, not a fourth hand-maintained literal: a table added to the YAML
+    # but not to a spec set fails here instead of drifting silently
+    assert len(entries) == len(
+        INTRADAY_TRANSACTION_DATE
+        | INTRADAY_WHENMODIFIED
+        | NIGHTLY_WHENMODIFIED
+        | NIGHTLY_NO_CURSOR
+    )
 
     for name in INTRADAY_TRANSACTION_DATE:
         assert by_name[name] == {

--- a/tests/libraries/test_dlt_powerschool_assets.py
+++ b/tests/libraries/test_dlt_powerschool_assets.py
@@ -44,6 +44,12 @@ INTRADAY_TRANSACTION_DATE = {
     "sections",
     "termbins",
     "terms",
+    # moved off whenmodified in afbd8239b (#4754): these three carry both
+    # columns, and an in-place UPDATE that leaves whenmodified alone is
+    # invisible to the probe's COUNT(*) + MAX(cursor_column) signature.
+    "schoolstaff",
+    "sectionteacher",
+    "users",
 }
 INTRADAY_WHENMODIFIED = {
     "gradescaleitem",
@@ -52,12 +58,10 @@ INTRADAY_WHENMODIFIED = {
     "s_nj_ren_x",
     "s_nj_stu_x",
     "s_stu_x",
-    "schoolstaff",
-    "sectionteacher",
     "studentcorefields",
     "studentrace",
+    "u_expectations",
     "u_studentsuserfields",
-    "users",
     "userscorefields",
 }
 NIGHTLY_WHENMODIFIED = {
@@ -95,7 +99,7 @@ def test_config_matches_spec_membership_map():
     entries = yaml.safe_load(CONFIG.read_text())["assets"]
     by_name = {e["table_name"]: e for e in entries}
 
-    assert len(entries) == 48
+    assert len(entries) == 49
 
     for name in INTRADAY_TRANSACTION_DATE:
         assert by_name[name] == {
@@ -151,7 +155,7 @@ def test_assets_module_exposes_single_def():
     )
 
     assert len(assets) == 1
-    assert len(list(assets[0].keys)) == 48
+    assert len(list(assets[0].keys)) == 49
 
 
 def test_nightly_targets_sis_keys_and_counts():

--- a/tests/libraries/test_powerschool_dlt_extract_workers.py
+++ b/tests/libraries/test_powerschool_dlt_extract_workers.py
@@ -49,9 +49,9 @@ def test_resolve_extract_workers_tag_no_param():
 
 
 class _FakeRunResult:
-    """Stand-in for dlt's `LoadInfo`; the op chains `.fetch_row_count()`."""
+    """Stand-in for dlt's `LoadInfo`; the op iterates it for materializations."""
 
-    def fetch_row_count(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[Any]:
         return iter(())
 
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make Paterson's gradebook-audit expectations
use Paterson's own `U_EXPECTATIONS` data instead of values spoofed from Newark,
and adds the Google Sheet T&L uses to push expectations back into PowerSchool.

Paterson MS expectations were spoofed from Newark because the KIPP NJ Gradebook
Audit plugin could not be installed on Paterson's PowerSchool instance —
`U_EXPECTATIONS` was never populated there, and `u_expectations` had been pruned
from Paterson's dlt asset config after a `NoSuchTableError`. The workaround was a
`paterson_spoof` CTE reading Newark's relation filtered to `school_level = 'MS'`
and relabelled `kipppaterson`, which returned 41 rows byte-identical to Newark
MS.

The plugin is now installed, so the spoof comes out.

## Action required by the merger

One warehouse `DROP` needs running, ideally **before** the post-merge prod
rebuild. The PR author does not have DDL rights:

```sql
drop table `teamster-332318.kipppaterson_powerschool.stg_powerschool__u_expectations`;
```

This is an orphan left behind when the original spoof override model was deleted
in `af1e53b67` — dbt dropped the model but not the relation, so it survives as a
real table holding 41 stale Newark-derived rows.

Order matters. Enabling the staging model makes dbt `create or replace` that same
relation, so a **successful** build overwrites it harmlessly. But if the build
ever fails, the orphan stays and the kipptaf union reads those 41 stale rows as
though they were real Paterson data. Dropping it first converts that silent
wrong-data mode into a loud missing-relation error.

### AI Assistance

Claude Code authored the commits. Human-directed: the decision to un-spoof, the
sequencing (prove ingestion before cutting over), the single-PR structure, the
template model's design, and accepting sparse Paterson data. AI-assisted:
tracing the spoof history, auditing warehouse state, diagnosing the ingestion
failure, and writing the config, test, SQL, and docs changes.

## Commits

| Commit | What |
| --- | --- |
| `0176d15ef` | Add `u_expectations` to Paterson's dlt config; bump three asset counts; repair a stale test spec map |
| `df1ff0ab4` | Library fix — tolerate a dlt resource that produced no load job |
| `53ce59042` | Derive the Paterson table count from the spec sets (review finding) |
| `f62ee6f28` | Enable the staging model, add the source and union relation, delete the spoof |
| `ef1a26d77` | Add `rpt_gsheets__gradebook_audit_template` plus docs and skill updates |

## Verification

The dlt asset was materialized against the branch deployment before the cut-over
commits landed. First run **failed**: Paterson's `U_EXPECTATIONS` existed in
Oracle but held zero rows, so dlt produced no load job and created no BigQuery
table. After one row was entered in PowerSchool, the re-run succeeded and
`dagster_kipppaterson_dlt_powerschool.u_expectations` now exists.

That failure is what commit `df1ff0ab4` fixes. `dagster_dlt`'s
`fetch_row_count()` raises when a materialization carries no `jobs` metadata,
which is what dlt emits for the first load of a table that extracts zero rows —
`_handle_empty_tables` only writes the empty truncate file once a table has
`seen_data`. Because all PowerSchool tables share one multi-asset op, that raise
aborts the whole step. Combined with the intraday sensor treating a missing
baseline as drift, Paterson would have re-selected the table every 15 minutes and
taken its other PowerSchool tables down with it. Established tables were never
at risk.

`rpt_gsheets__gradebook_audit_template` builds clean with its uniqueness test
passing, and returns the intended coverage: Newark MS/HS, Camden MS/HS, Paterson
MS; no ES, no Miami.

## Known trade-offs and follow-ups

- **Paterson data is sparse.** Academics has entered one AY 2026-2027
  expectations row, so Paterson goes from 41 spoofed rows to that single real
  one. Category flags will be nearly empty until the full set is loaded.
  Accepted deliberately.
- **dbt Cloud CI cannot validate the cut-over.**
  `zz_stg_kipppaterson_powerschool.stg_powerschool__u_expectations` still holds
  the 41 spoofed rows, so the union wrapper compiles green against stale data
  either way. Refreshing it needs a `dbt clone --target staging --full-refresh`.
- **An orphaned relation needs a manual drop** — left behind when the original
  override model was deleted; a real table with 41 stale rows, last modified on
  the spoof PR date. Dropping it BEFORE the prod rebuild converts a
  silent-wrong-data failure mode into a loud missing-relation one:

  ```sql
  drop table `teamster-332318.kipppaterson_powerschool.stg_powerschool__u_expectations`;
  ```

- **`docs/reference/automations.md` has no `kipppaterson` PowerSchool dlt rows
  at all.** Flagged by review and confirmed — only the retired couchdrop SFTP
  sensor's asset list remains under that section. Pre-existing staleness, not
  caused here, and out of scope: per `docs/CLAUDE.md` the catalog can only be
  regenerated where every code location imports, which a codespace cannot do.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Reviewed the **Claude Code Review** comment; per-finding verdicts posted as
      a PR comment.

### Dagster

- [x] `uv run pytest tests/libraries/test_dlt_powerschool_assets.py tests/assets/test_powerschool_dlt_paterson_defs.py` — 10 passed
- [x] dlt asset materialized successfully against the branch deployment

### dbt

- [x] Properties file included for the new model, with contract column types and
      a uniqueness test
- [x] Exposure added for the new Google Sheet
- [x] No contracted column renames or removals — the union model returns to its
      pre-spoof shape
- [x] No external source added or modified, so no `stage_external_sources` run
      is needed

### Docs

- [x] No schedule or sensor change — dlt trigger membership derives from
      `assets.yaml`, so the new table is covered by the existing sensor without
      a config edit. Note this does **not** mean the automations catalog is
      current for this integration; see the follow-up above.
- [x] Updated `src/teamster/code_locations/kipppaterson/CLAUDE.md`, the
      gradebook-audit reference doc, and the `gradebook-audit` skill.

Closes #4878
Refs #3908
