### PR TITLE
feat(kipptaf): add reading_group and math_group to kippfwd_miami_roster

### DIFF
--- a/docs/superpowers/specs/2026-08-10-focus-miami-kippfwd-roster-design.md
+++ b/docs/superpowers/specs/2026-08-10-focus-miami-kippfwd-roster-design.md
@@ -200,7 +200,8 @@ partitioned by (`student_number`, `academic_year`).
   recoverable by coalescing across years — none of the 81 has a prior-year Focus
   row with a non-null `fteid`.
 - **`enroll_status` reads `-1` for the whole current year until the first day of
-  school**, by deliberate choice — see the `enroll_status` derivation above.
+  school (2026-08-12 for AY2026, per `int_focus__school_year_first_day`), then
+  clears**, by deliberate choice — see the `enroll_status` derivation above.
 - **`contact_1_phone_home` is sparse** — 55 of 338 primary contacts. Expected.
 
 ## Testing

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_miami_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_miami_roster.yml
@@ -38,9 +38,10 @@ models:
           enroll_status column directly since it keys on grad_type and is
           correct — see the inline SQL comment for why the rest is derived
           locally. -1 fires for every row in the current academic year until the
-          first day of school and self-heals afterward; consumers filtering to 0
-          see zero current-year students until then, a deliberate and disclosed
-          tradeoff.
+          first day of school (2026-08-12 for AY2026, per
+          int_focus__school_year_first_day) and self-heals afterward, clearing
+          once that date passes; consumers filtering to 0 see zero current-year
+          students until then, a deliberate and disclosed tradeoff.
       - name: iep_status
         data_type: string
         data_tests:
@@ -209,4 +210,22 @@ models:
         description: >-
           Prior academic year's FLDOE FAST math progress monitoring 3
           achievement level and scale score.
+        data_type: string
+      - name: reading_group
+        description: >-
+          Focus course-period cohort(s) (short_name, e.g. AA- Cohort 5) for the
+          student's intensive reading block in this academic year, comma
+          separated if the student holds more than one section. Roughly three
+          quarters of the grade 7-8 roster sits in a reading cohort — this is
+          the default middle-school block, not an intervention indicator. Sparse
+          for prior-year rows, which predate this course structure.
+        data_type: string
+      - name: math_group
+        description: >-
+          Focus course-period cohort(s) (short_name, e.g. AA- Cohort 5) for the
+          student's foundational-skills math block in this academic year, comma
+          separated if the student holds more than one section. Roughly three
+          quarters of the grade 7-8 roster sits in a math cohort — this is the
+          default middle-school block, not an intervention indicator. Sparse for
+          prior-year rows, which predate this course structure.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
@@ -67,6 +67,59 @@ with
         select _dbt_source_project, studentid, yearid, schoolid, gpa_y1,
         from {{ ref("int_powerschool__gpa_term") }}
         where is_current
+    ),
+
+    /* Reading-intensive and foundational-skills math are the default grade
+       7-8 blocks (roughly three quarters of the grade sits in each), not
+       intervention placements -- classify by course title, not a custom
+       intervention flag. FOUNDATION is deliberately excluded from the math
+       pattern: it also matches GR4/GR5 CS FOUNDATIONS, which are Computer
+       Science courses, not the FDN SKL math block. */
+    course_domains as (
+        select
+            sch.student_id,
+            sch.academic_year,
+
+            cp.short_name,
+
+            case
+                when upper(c.title) like '%INTENS%'
+                then 'reading'
+                when upper(c.title) like '%FDN SKL%'
+                then 'math'
+            end as course_domain,
+        from {{ ref("int_focus__schedule") }} as sch
+        inner join
+            {{ ref("int_focus__course_periods") }} as cp
+            on sch.course_period_id = cp.course_period_id
+        inner join
+            {{ ref("int_focus__courses") }} as c
+            on cp.course_id = c.course_id
+            and cp.syear = c.syear
+    ),
+
+    /* One row per student per academic year per domain, with the cohort's
+       short_name aggregated to avoid the fan-out from a student holding two
+       sections in the same domain. short_name is used deliberately over
+       title -- title embeds teacher names, which must not flow into this
+       distributed sheet. */
+    course_groups as (
+        select
+            student_id,
+            academic_year,
+            string_agg(
+                distinct if(course_domain = 'reading', short_name, null),
+                ', '
+                order by if(course_domain = 'reading', short_name, null)
+            ) as reading_group,
+            string_agg(
+                distinct if(course_domain = 'math', short_name, null),
+                ', '
+                order by if(course_domain = 'math', short_name, null)
+            ) as math_group,
+        from course_domains
+        where course_domain is not null
+        group by student_id, academic_year
     )
 
 select
@@ -111,10 +164,11 @@ select
     case
         when e.startdate > current_date('{{ var("local_timezone") }}')
         /* Fires for the whole current academic year until the first day of
-           school (Miami's is roughly Aug 17), then self-heals as
-           enrollment startdates fall in the past. Until then, consumers
-           filtering enroll_status = 0 see zero current-year students -- a
-           deliberate, disclosed tradeoff, not a bug. */
+           school (2026-08-12 for AY2026, per
+           int_focus__school_year_first_day), then self-heals as enrollment
+           startdates fall in the past and this -1 state clears. Until then,
+           consumers filtering enroll_status = 0 see zero current-year
+           students -- a deliberate, disclosed tradeoff, not a bug. */
         then -1
         when e.enroll_status = 3
         then 3
@@ -142,6 +196,9 @@ select
 
     fp_prev.ela_pm3 as ela_pm3_prev,
     fp_prev.math_pm3 as math_pm3_prev,
+
+    cg.reading_group,
+    cg.math_group,
 from {{ ref("int_focus__student_enrollments") }} as e
 left join students as s on e.student_number = s.student_id
 left join open_enrollment as oe on e.student_number = oe.student_number
@@ -171,6 +228,10 @@ left join
     and psy.yearid = gpa.yearid
     and psy.schoolid = gpa.schoolid
     and psy._dbt_source_project = gpa._dbt_source_project
+left join
+    course_groups as cg
+    on e.student_number = cg.student_id
+    and e.academic_year = cg.academic_year
 where
     e.rn_year = 1
     and e.grade_level in (7, 8)


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request adds two columns to `rpt_gsheets__kippfwd_miami_roster` — `reading_group` and `math_group` — carrying the Focus cohort each grade 7-8 student sits in for their intensive reading and foundational math blocks.

It also corrects the first-day-of-school date in the `enroll_status` disclosure that shipped with #4782, from an estimated "roughly Aug 17" to the authoritative 2026-08-12 taken from `int_focus__school_year_first_day`.

Follows #4782, which re-sourced this roster from Focus. Refs #4782.

### What these columns are, and are not

KIPP Miami groups grade 7-8 students into cohorts for two blocks. The cohort label lives on the course period's `short_name` — values look like `AA- Cohort 5`, `BN- Cohort 4`, `7th - Cohort 0`.

**They are deliberately not an intervention flag.** The investigation started as a search for intervention groups. There is no usable intervention data in the ingested Focus set:

| Candidate | Finding |
| --- | --- |
| `student_groups` table | 14 rows, all named `Bus Route_N`. Transportation |
| MTSS tier checkboxes on `students` — Tier 1, Reading/Math/Behavior/Attendance Tier 2 and 3 | Defined in the catalog, **0 of 4,008 students populated**, any year |
| Course-period flags — Math Intervention Component, Reading Intervention Component, Pull-out | Populated but uniformly `N - No` |
| `SSSEventStepInstance` — Focus Student Support Services, **1,727 custom fields**, the largest module in the catalog | **Not ingested.** No SSS table appears in the dlt config |

Course enrollment is the only live signal, and it does not mean intervention either: 75.5% of the grade sits in the math course and 75.8% in a reading course. These are the default middle-school blocks. So the columns are named and described as group assignment, and the PR adds no boolean intervention indicator.

The section grouping is still real and useful — 26 sections across the four courses — which is why the columns carry the cohort rather than nothing.

### Verification, both years

| Check | AY2025 | AY2026 |
| --- | --- | --- |
| Rows | 365 | 376 |
| Grain, rows vs distinct keys | no fan-out | no fan-out |
| `reading_group` / `math_group` populated | 0 / 0 | **284 / 284** |
| `previous_year_ada` | 269 | 295 |
| `advisor_lastfirst` / `gpa_cumulative` | 362 / 338 | 0 / 0 |
| `enroll_status` (0 / 2) | 213 / 150 | 347 / 29 |

`dbt build` passes with all 6 tests green, including the current-year-not-empty guard added in #4782.

AY2025 group values are near-zero by design — Focus holds only 3 such sections that year against 50 in AY2026.

Reading and math cohorts differ for a meaningful share of students, which is why this is two columns rather than one. One student sits in two sections per domain; the aggregation renders that as a comma-joined value and leaves the roster grain unchanged.

### Implementation notes

- Reads `int_focus__schedule`, which main already exposes to kipptaf — this PR adds no new source.
- Course classification is a title match on `INTENS` for reading and `FDN SKL` for math. `FOUNDATION` is deliberately **not** matched — it falsely catches `GR4 CS FOUNDATIONS` and `GR5 CS FOUNDATIONS`, which are Computer Science.
- The cohort label comes from the course period `short_name`, never `title` — `title` embeds staff names, which must not flow into a distributed sheet. Verified: the emitted values contain teacher initials only.
- Both columns are appended at the end of the select, so the Google Sheet gains two columns on the right and no existing column shifts.

### enroll_status resolved itself

#4782 disclosed that `enroll_status` would read `-1` for the whole current year until the first day of school. School started 2026-08-12, so every AY2026 startdate is now in the past and the column reads 347 at `0`, 29 at `2`, and zero at `-1`. The behavior worked as designed; only the estimated date in the disclosure was wrong, which this PR corrects.

### Rollback plan

Additive columns only. Revert drops `reading_group` and `math_group` from the contract and the sheet; nothing else is affected.

## AI Assistance

Authored by Claude Code, human-directed. The engineer directed the search for intervention groups, chose group assignment over an intervention flag once the 75% coverage was surfaced, and approved the two-column shape. Every figure above was verified against BigQuery.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties file updated — both new columns carry descriptions stating they are cohort assignment, that roughly three quarters of the grade sits in each so they are not an intervention indicator, and that prior-year values are sparse
- [x] Exposure unchanged — the `ref()` name is stable
- [x] **Breaking change?** Additive only. No column renamed, removed, retyped, or reordered. The sheet gains two columns on the right
- [x] No external sources added or modified

### Docs

- [x] No schedule, sensor, or integration changes. The design spec under `docs/superpowers/` is updated

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
