### PR TITLE
fix(dbt): sort DeansList family contacts extract parents before emergency

### DIFF
--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -9,8 +9,10 @@ models:
       `emergency_4`). `ContactType` distinguishes `Parent1` / `Parent2` /
       `Emergency` so DeansList can scope automated guardian messaging, and every
       contact carries its real Finalsite relationship to the student. Column
-      names match the DeansList import template headers exactly. Delivered by
-      the Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
+      names match the DeansList import template headers exactly. Rows are
+      ordered per student with parents before emergency contacts, since
+      DeansList displays contacts in the file's row order. Delivered by the
+      Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
     data_tests:
       # The source grain is (student, contact_slot), but the DeansList template
       # fixes the header set so the slot cannot be projected — name plus

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -74,3 +74,7 @@ inner join
     on c.student_number = s.student_number
     and c._dbt_source_project = s._dbt_source_project
     and s.enroll_status = 0
+-- DeansList's importer displays contacts in the order this file lists them per
+-- student (no independent sort on their end), so Parent1/Parent2 must precede
+-- Emergency here or families see emergency contacts ranked above parents.
+order by c.student_number, if(c.contact_type = 'Emergency', 1, 0), c.contact_type

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -77,4 +77,4 @@ inner join
 -- DeansList's importer displays contacts in the order this file lists them per
 -- student (no independent sort on their end), so Parent1/Parent2 must precede
 -- Emergency here or families see emergency contacts ranked above parents.
-order by c.student_number, if(c.contact_type = 'Emergency', 1, 0), c.contact_type
+order by c.student_number asc, (c.contact_type = 'Emergency') asc, c.contact_type asc


### PR DESCRIPTION
## Summary & Motivation

> "When merged, this pull request will..."

...add an explicit `ORDER BY` to `rpt_deanslist__family_contacts` so
Parent1/Parent2 contacts sort ahead of Emergency contacts, per student.

DeansList support confirmed (via the linked Zendesk thread) that their
importer displays a student's contacts in the row order they arrive in the
file, with no independent sort of their own. The extract had no `ORDER BY` at
all, so row order was whatever BigQuery happened to return — currently
Emergency-first, the reverse of last year and the reverse of what schools
expect (parents/guardians at the top).

## AI Assistance

Investigated and drafted entirely by Claude Code from a DeansList support
email thread, including locating the model, confirming the terminal-extract
`ORDER BY` exception has precedent elsewhere in `extracts/`, adding the sort,
running the model's dbt unit tests, and `trunk check --force`. Human-directed
review before merge.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address
      valid feedback; dismiss false positives with a brief reply explaining
      why.

### dbt

- [x] No new model — properties file already existed, description updated to
      document the new row order.
- [ ] No exposure change needed (Dagster asset `deanslist/contacts_txt`
      already documented in the model description).
- [ ] Not a breaking change — no columns added, renamed, or removed.
- [ ] No external source changes.

## CI checks

- [ ] **Trunk** — passes locally (`trunk check --force` on both changed
      files, clean).
- [ ] **dbt Cloud** — this PR touches `kipptaf` directly, so CI will actually
      build/test this model (not a no-op run). Model's 4 unit tests + 7 data
      tests pass locally against `--target dev --defer <prod>`.
- [ ] **Dagster Cloud** — not triggered; no Dagster code changed, dbt-only
      change.
