### PR TITLE
docs(github): add For Claude sections to PR/issue templates

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -135,5 +135,9 @@ principal itself.
 
 ## Other Files
 
-- `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections).
+- `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections),
+  plus a "For Claude" section for AI-assistance notes and review focus.
+- `ISSUE_TEMPLATE/` — `bug_report.md` and `feature_request.md`, each with a "For
+  Claude" section for `@claude`-driven issues; `config.yml` disables blank
+  issues.
 - `actionlint.yaml` — self-hosted runner labels for actionlint.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,9 +23,10 @@ labels: bug
 
 ## For Claude
 
-> Fill in if you're opening this for `@claude` to investigate or fix.
+> Write this as a prompt to `@claude` — what it needs to investigate or fix this
+> — not a form to fill out. Delete if you're not looping Claude in.
 
-- **Relevant files, models, or assets:**
-- **Suspected root cause (if known):**
-- **What "fixed" looks like:** the check that proves it — a test, query, or run
-  status
+@claude: <!-- e.g. "Start with int_focus__schedule — the dedup logic there
+looks like the root cause. Reproduce with
+`uv run dbt build --select +int_focus__schedule`. This is fixed when the
+row-count check in the linked query returns 0." -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: "fix: "
+labels: bug
+---
+
+## What's happening
+
+<!-- What you expected, and what actually happened -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Where
+
+- **Code location / dbt project:**
+- **Environment:** prod / branch deployment / local
+- **Run, PR, or dashboard link (if any):**
+
+## For Claude
+
+> Fill in if you're opening this for `@claude` to investigate or fix.
+
+- **Relevant files, models, or assets:**
+- **Suspected root cause (if known):**
+- **What "fixed" looks like:** the check that proves it — a test, query, or run
+  status

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,12 +21,15 @@ labels: bug
 - **Environment:** prod / branch deployment / local
 - **Run, PR, or dashboard link (if any):**
 
-## For Claude
+<details>
+<summary>For Claude</summary>
 
-> Write this as a prompt to `@claude` — what it needs to investigate or fix this
-> — not a form to fill out. Delete if you're not looping Claude in.
+> Context, not instructions — relevant files/models/assets, a suspected root
+> cause if you have one, what "fixed" looks like. Delete if you're not looping
+> Claude in.
 
-@claude: <!-- e.g. "Start with int_focus__schedule — the dedup logic there
-looks like the root cause. Reproduce with
-`uv run dbt build --select +int_focus__schedule`. This is fixed when the
-row-count check in the linked query returns 0." -->
+<!-- e.g. "int_focus__schedule's dedup logic looks like the root cause.
+Reproduce with `uv run dbt build --select +int_focus__schedule`. Fixed means
+the row-count check in the linked query returns 0." -->
+
+</details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "feat: "
+labels: enhancement
+---
+
+## What and why
+
+<!-- The outcome you want, and the problem it solves -->
+
+## Proposed approach
+
+<!-- Optional -- how you think this could work -->
+
+## For Claude
+
+> Fill in if you're opening this for `@claude` to design or implement.
+
+- **Relevant files, models, or assets:**
+- **Constraints or things to avoid:**
+- **Acceptance criteria:** how to verify it's done

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,11 +13,14 @@ labels: enhancement
 
 <!-- Optional -- how you think this could work -->
 
-## For Claude
+<details>
+<summary>For Claude</summary>
 
-> Write this as a prompt to `@claude` — what it needs to design or build this —
-> not a form to fill out. Delete if you're not looping Claude in.
+> Context, not instructions — relevant files/models/assets, constraints or
+> things to avoid, acceptance criteria. Delete if you're not looping Claude in.
 
-@claude: <!-- e.g. "Add a `--dry-run` flag to scripts/gen-automations-doc.py
-that prints the diff without writing. Done when running it twice with no
+<!-- e.g. "Add a `--dry-run` flag to scripts/gen-automations-doc.py that
+prints the diff without writing. Done when running it twice with no
 underlying change produces no diff and exits 0." -->
+
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,8 +15,9 @@ labels: enhancement
 
 ## For Claude
 
-> Fill in if you're opening this for `@claude` to design or implement.
+> Write this as a prompt to `@claude` — what it needs to design or build this —
+> not a form to fill out. Delete if you're not looping Claude in.
 
-- **Relevant files, models, or assets:**
-- **Constraints or things to avoid:**
-- **Acceptance criteria:** how to verify it's done
+@claude: <!-- e.g. "Add a `--dry-run` flag to scripts/gen-automations-doc.py
+that prints the diff without writing. Done when running it twice with no
+underlying change produces no diff and exits 0." -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -70,12 +70,15 @@
 - [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
 - [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
 
-## For Claude
+<details>
+<summary>For Claude</summary>
 
-> Write this as a prompt to `@claude` — the context it needs to review or
-> resolve this PR — not a form to fill out. Delete if there's nothing to add.
+> Context, not instructions — AI involvement, what to focus on, what's
+> intentionally out of scope, related issues/PRs. Delete if there's nothing to
+> add.
 
-@claude: <!-- e.g. "This PR was Claude-assisted, human-directed. Focus on the
-retry logic in src/x.py — that's the risky part. Ignore the reformatted
-imports, that's just `ruff --fix`. Closes #123; verify with
-`uv run pytest tests/test_x.py -k retry`." -->
+<!-- e.g. "Claude-assisted, human-directed. The risky part is the retry logic
+in src/x.py; the reformatted imports are just `ruff --fix` noise. Closes
+#123; verified with `uv run pytest tests/test_x.py -k retry`." -->
+
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -72,11 +72,10 @@
 
 ## For Claude
 
-> Fill in if this PR was AI-assisted, or if you want `@claude` (mentioned in a
-> comment) or the automated PR review to focus its attention.
+> Write this as a prompt to `@claude` — the context it needs to review or
+> resolve this PR — not a form to fill out. Delete if there's nothing to add.
 
-- **AI involvement:** none / drafted by Claude / Claude-assisted, human-directed
-- **Focus review on:** files, logic, or edge cases you want scrutinized
-- **Already known / out of scope:** anything intentionally left as-is — don't
-  flag it
-- **Related context:** linked issues, prior PRs, relevant `CLAUDE.md` sections
+@claude: <!-- e.g. "This PR was Claude-assisted, human-directed. Focus on the
+retry logic in src/x.py — that's the risky part. Ignore the reformatted
+imports, that's just `ruff --fix`. Closes #123; verify with
+`uv run pytest tests/test_x.py -k retry`." -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,6 @@
 
 > "When merged, this pull request will..."
 
-## AI Assistance
-
-> If Claude Code authored or co-authored this PR, briefly note what was
-> AI-assisted vs. human-directed in the summary above
-
 ## Self-review
 
 > Complete only the sections relevant to your changes.
@@ -74,3 +69,14 @@
 - [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
 - [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
 - [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)
+
+## For Claude
+
+> Fill in if this PR was AI-assisted, or if you want `@claude` (mentioned in a
+> comment) or the automated PR review to focus its attention.
+
+- **AI involvement:** none / drafted by Claude / Claude-assisted, human-directed
+- **Focus review on:** files, logic, or edge cases you want scrutinized
+- **Already known / out of scope:** anything intentionally left as-is — don't
+  flag it
+- **Related context:** linked issues, prior PRs, relevant `CLAUDE.md` sections

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -99,6 +99,15 @@ jobs:
             lower-severity findings. Include a confidence level and a severity
             label for each finding so a human can rank them.
 
+            Response format: lead the comment with a short, plain-language
+            summary for human skimming — the overall verdict and only the
+            highest-severity findings, no jargon. Then add a collapsed
+            <details><summary>Full findings</summary> fold-out listing every
+            finding, including lower-severity and uncertain ones, each with
+            file:line, confidence, severity, and the specific convention or
+            citation. This mirrors this repo's PR/issue template pattern:
+            human-readable content first, denser context folded below.
+
             Execution model: this job is a single non-interactive turn sequence.
             There is no wake-up and no second invocation — when you stop
             producing output the process exits and any unfinished work is lost.

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -105,8 +105,10 @@ jobs:
             <details><summary>Full findings</summary> fold-out listing every
             finding, including lower-severity and uncertain ones, each with
             file:line, confidence, severity, and the specific convention or
-            citation. This mirrors this repo's PR/issue template pattern:
-            human-readable content first, denser context folded below.
+            citation. Leave a blank line after <summary>Full findings</summary>
+            before the findings list, or GitHub renders the list as inert HTML
+            instead of markdown. This mirrors this repo's PR/issue template
+            pattern: human-readable content first, denser context folded below.
 
             Execution model: this job is a single non-interactive turn sequence.
             There is no wake-up and no second invocation — when you stop


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restructure the PR template and add
issue templates (`bug_report.md`, `feature_request.md` — none existed
before) so both lead with plain, human-readable sections and close with a
collapsible "For Claude" fold-out: Claude-oriented context, not a task list,
hidden by default so it doesn't clutter the visible body. It also updates the
`claude-code-review` workflow's prompt so the bot's own review comments
follow the same pattern — a short plain-language summary first, full
findings folded into a collapsed `<details>` block below.

## Self-review

### General

- [x] No due date/assignee needed — docs-only, not a tracked Asana item
- [x] Review the **Claude Code Review** comment posted on this PR. Address
      valid feedback; dismiss false positives with a brief reply explaining
      why. _(N/A — the workflow only auto-runs on `opened`/`ready_for_review`,
      and this PR has only been pushed to since opening, so it hasn't fired.)_

## CI checks

- [x] **Trunk** — passes
- [x] **dbt Cloud** — passes (runs on every PR regardless of paths touched;
      no dbt changes in this PR)
- [x] **Dagster Cloud** — not triggered, no relevant paths changed

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed — the user drove every format iteration: an
initial fields-based section, then an `@claude:` prompt block, then this
collapsed context fold-out, then extending the same pattern to the
`claude-code-review` workflow's own comment format. Check: (1) the
`ISSUE_TEMPLATE/*.md` frontmatter is well-formed, (2) `<details>` renders
correctly and doesn't trip markdownlint (verified locally with
`trunk check --force`), (3) `pull_request_template.md`'s checklist items
still match current repo practice — already spot-checked
`tests/test_dagster_definitions.py`, `scripts/gen-automations-doc.py`, the
`Library + Config` pattern doc, `stage_external_sources --target staging`,
and the `#model-properties-file`/`#exposures` anchors, all current — and (4)
the new "Response format" paragraph in `claude-code-review.yaml`'s prompt
resolves correctly inside the folded YAML block scalar (verified with a
local `yaml.safe_load`). Out of scope: no bug/feature template split beyond
the two added, no YAML issue forms (kept markdown to match the existing PR
template style), no linked issue (declined for this docs-only change).

</details>
