### PR TITLE
revert(extracts): drop es_attended and ms_attended from the contact feed

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__student_contact_info.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__student_contact_info.yml
@@ -1,21 +1,5 @@
 models:
   - name: rpt_gsheets__student_contact_info
-    data_tests:
-      # Pin the prior-level banding so it stays a standing invariant rather than
-      # a point-in-time check. Bands are grades K-4 elementary, 5-8 middle, 9-12
-      # high; a student is blank on every band at or below the one they are
-      # currently in. Both tests are scoped by grade, so a grade_level outside
-      # the K-12 domain is skipped rather than flagged.
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: es_attended is null
-          config:
-            where: grade_level in ('K', '1', '2', '3', '4')
-      - dbt_utils.expression_is_true:
-          arguments:
-            expression: ms_attended is null
-          config:
-            where: grade_level in ('K', '1', '2', '3', '4', '5', '6', '7', '8')
     columns:
       - name: student_number
         data_type: int64
@@ -113,25 +97,3 @@ models:
         data_type: string
       - name: home_language
         data_type: string
-      - name: es_attended
-        data_type: string
-        description: >-
-          Most recent KIPP school the student attended while in grades K through
-          4. Blank while the student is currently in grades K through 4, so the
-          column reads as prior history rather than the current placement.
-          Banded by the grade the student was enrolled in rather than by the
-          school's designated level, so a school serving grades outside its
-          designation is attributed to the right band. Distinct from the
-          identically named column on int_extracts__student_enrollments, which
-          bands by school level and includes the student's current school.
-      - name: ms_attended
-        data_type: string
-        description: >-
-          Most recent KIPP school the student attended while in grades 5 through
-          8. Blank while the student is currently in grade 8 or below, so the
-          column reads as prior history rather than the current placement.
-          Banded by the grade the student was enrolled in rather than by the
-          school's designated level, so a school serving grades outside its
-          designation is attributed to the right band. Distinct from the
-          identically named column on int_extracts__student_enrollments, which
-          bands by school level and includes the student's current school.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__student_contact_info.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__student_contact_info.sql
@@ -1,69 +1,3 @@
-with
-    -- Band every enrollment by the GRADE the student was in, not by the school's
-    -- school_level. An increasing number of schools are off-model (e.g. an
-    -- ES-coded school serving grades 5-8), so school_level misfiles their
-    -- enrollments -- it would report such a school as a student's elementary
-    -- school while they attend it for middle school.
-    grade_band_enrollments as (
-        select
-            _dbt_source_project,
-            student_number,
-            school_abbreviation,
-            exitdate,
-
-            case
-                when grade_level between 0 and 4
-                then 'ES'
-                when grade_level between 5 and 8
-                then 'MS'
-                when grade_level between 9 and 12
-                then 'HS'
-            end as grade_band,
-        from {{ ref("base_powerschool__student_enrollments") }}
-    ),
-
-    grade_band_ranked as (
-        select
-            _dbt_source_project,
-            student_number,
-            school_abbreviation,
-            grade_band,
-
-            row_number() over (
-                partition by _dbt_source_project, student_number, grade_band
-                order by exitdate desc, school_abbreviation asc
-            ) as rn_grade_band,
-        from grade_band_enrollments
-        where grade_band is not null
-    ),
-
-    most_recent_school_by_grade_band as (
-        select _dbt_source_project, student_number, school_abbreviation, grade_band,
-        from grade_band_ranked
-        where rn_grade_band = 1
-    ),
-
-    enrollments as (
-        select
-            e.*,
-
-            es.school_abbreviation as most_recent_es,
-
-            ms.school_abbreviation as most_recent_ms,
-        from {{ ref("int_extracts__student_enrollments") }} as e
-        left join
-            most_recent_school_by_grade_band as es
-            on e.student_number = es.student_number
-            and e._dbt_source_project = es._dbt_source_project
-            and es.grade_band = 'ES'
-        left join
-            most_recent_school_by_grade_band as ms
-            on e.student_number = ms.student_number
-            and e._dbt_source_project = ms._dbt_source_project
-            and ms.grade_band = 'MS'
-        where e.enroll_status in (0, -1) and e.rn_all = 1
-    )
-
 -- trunk-ignore(sqlfluff/ST06)
 select
     student_number,
@@ -167,14 +101,5 @@ select
     gifted_and_talented,
     salesforce_id as salesforce_contact_id,
     home_language,
-
-    -- Prior-level history only. The picks above include the student's current
-    -- enrollment, so blank every band at or below the band they are in now.
-    -- That makes these read as "KIPP schools attended before this one". Keyed
-    -- on grade_level rather than school_level for the off-model reason above.
-    -- The es_attended and ms_attended columns on
-    -- int_extracts__student_enrollments are NOT these -- they band by
-    -- school_level and include the current school.
-    if(grade_level between 0 and 4, null, most_recent_es) as es_attended,
-    if(grade_level between 0 and 8, null, most_recent_ms) as ms_attended,
-from enrollments
+from {{ ref("int_extracts__student_enrollments") }}
+where enroll_status in (0, -1) and rn_all = 1


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will remove the `es_attended` and `ms_attended`
columns from `rpt_gsheets__student_contact_info`, backing out #4812 in full.
Those two prior-level banding columns pushed the Student Contact Info Google
Sheet over its file size limit, so the feed returns to its pre-#4812 shape.

Both files are restored to their merge-base blobs, which makes this diff the
exact inverse of #4812 (verified line-for-line, +2/-115):

- removes the `grade_band_enrollments`, `grade_band_ranked`,
  `most_recent_school_by_grade_band`, and `enrollments` CTEs, plus the
  `base_powerschool__student_enrollments` ref
- removes the `es_attended` and `ms_attended` columns and their descriptions
- removes the two `expression_is_true` tests that pinned the banding invariant

The identically named columns on `int_extracts__student_enrollments`, and the
Tableau reports that read them, are untouched. Those band by `school_level` and
are a separate lineage from the grade-banded columns removed here.

Worth a follow-up look, not blocking this revert: two string columns over
~11.4k rows is roughly 23k cells, so if a spreadsheet is up against a hard
ceiling, this buys modest headroom. Since four distinct spreadsheets read this
view, the first step on that follow-up is confirming which one actually hit the
limit, then auditing what else is wide in it.

Local verification:

- `dbt build --select rpt_gsheets__student_contact_info` passes, which is what
  runs contract enforcement — 48 columns, down from 50
- `dbt parse --no-partial-parse` on both sides drops exactly the two intended
  test nodes and nothing else (804 to 802 tests); model node count unchanged
- the reverted view returns 11,439 rows, identical to prod, so the revert is
  row-neutral, with zero leftover band columns in `INFORMATION_SCHEMA`
- `trunk check --force` clean on both files

## AI Assistance

AI-assisted. Claude Code identified the originating PR, performed the revert as
a merge-base blob restore, and ran the verification above. Human-directed: the
decision to back the columns out, and the branch and issue strategy.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt

- [x] Properties file updated alongside the model — the two column blocks and
      the two model-level tests are removed from
      `rpt_gsheets__student_contact_info.yml`
- [x] Exposure — `gsheets_student_contact_info` already exists and still points
      at this model; no exposure change is needed for a column removal
- [x] **Breaking change?** Yes — this removes two columns from a contracted
      `rpt_` model, and that removal is the entire point of the change. Correcting
      my earlier wording in this box: this view feeds **four** Sheets exposures,
      each a distinct spreadsheet, not one — `gsheets_student_contact_info`,
      `miami_demographic_update_sy25`, `miami_demographic_update_sy24`, and
      `gsheets_student_logins`. All four lose the two columns. All four also only
      gained them one week ago in #4812, so no dashboard or analysis has had time
      to build on them, and exposures don't declare columns so none needs editing.
      **Rollback plan:** revert this PR, which restores #4812 verbatim.
- [ ] External sources — not applicable, no external source added or modified.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
