### PR TITLE
fix(dbt): dedupe same-start-date Focus enrollment stints

### DIFF
--- a/src/dbt/focus/models/intermediate/int_focus__student_enrollment.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_enrollment.sql
@@ -1,4 +1,5 @@
 with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     enrollment as (
         select
             s.first_name as student_first_name,
@@ -94,7 +95,25 @@ with
             {{ ref("int_focus__school_year_first_day") }} as fd on e.syear = fd.syear
     ),
 
+    -- Focus permits two open stints for the same student, year, and start
+    -- date; SY26 is the first year of Focus data where it has happened. The
+    -- incomplete record is demoted, then the most recently created one wins.
+    -- Deduping here, ahead of with_flags, keeps rn_year contiguous --
+    -- consumers filter on rn_year = 1 and would lose a student left holding
+    -- only rn_year = 2.
+    -- TODO: drop once Focus stops accepting duplicate open stints (#4905).
+    deduplicate as (
+        {{
+            dbt_utils.deduplicate(
+                relation="enrollment",
+                partition_by="student_number, academic_year, startdate",
+                order_by="(schoolid is null) asc, student_enrollment_id desc",
+            )
+        }}
+    ),
+
     with_flags as (
+        -- trunk-ignore(sqlfluff/AM04): deduplicate resolves columns at run time
         select
             *,
 
@@ -129,7 +148,7 @@ with
                 partition by student_number
                 order by academic_year desc, exitdate desc, startdate desc
             ) as rn_all,
-        from enrollment
+        from deduplicate
     ),
 
     with_year_counts as (

--- a/src/dbt/focus/models/intermediate/int_focus__student_enrollment.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_enrollment.sql
@@ -17,6 +17,7 @@ with
             ) as network_student_number,
 
             e.id as student_enrollment_id,
+            e.created_at as enrollment_created_at,
             e.syear as academic_year,
             e.school_id as schoolid,
             e.start_date as startdate,
@@ -98,6 +99,9 @@ with
     -- Focus permits two open stints for the same student, year, and start
     -- date; SY26 is the first year of Focus data where it has happened. The
     -- incomplete record is demoted, then the most recently created one wins.
+    -- Recency reads enrollment_created_at, not the id: Focus assigns ids in
+    -- batches, and 20% of SY26 id pairs order differently than creation time,
+    -- so the id alone is not a recency proxy. The id breaks exact ties.
     -- Deduping here, ahead of with_flags, keeps rn_year contiguous --
     -- consumers filter on rn_year = 1 and would lose a student left holding
     -- only rn_year = 2.
@@ -107,7 +111,11 @@ with
             dbt_utils.deduplicate(
                 relation="enrollment",
                 partition_by="student_number, academic_year, startdate",
-                order_by="(schoolid is null) asc, student_enrollment_id desc",
+                order_by="""
+                    (schoolid is null) asc,
+                    enrollment_created_at desc,
+                    student_enrollment_id desc
+                """,
             )
         }}
     ),

--- a/src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__student_enrollment.yml
@@ -21,6 +21,11 @@ models:
           - not_null:
               config:
                 severity: error
+      - name: enrollment_created_at
+        description: >-
+          Timestamp the Focus enrollment record was created. Projected for the
+          same-start-date dedupe tie-break, which needs a real recency signal --
+          Focus assigns ids in batches, so id order and creation order disagree.
       - name: academic_year
         description: Focus school year start year (e.g. 2025 = 2025-26).
       - name: academic_year_display

--- a/src/dbt/focus/models/intermediate/unit_tests.yml
+++ b/src/dbt/focus/models/intermediate/unit_tests.yml
@@ -89,3 +89,72 @@ unit_tests:
           is_homeless: true
           homeless_primary_nighttime_residence_code: 3
           lunchstatus: F
+
+  - name: test_int_focus__student_enrollment_dedupes_same_start_date_stints
+    model: int_focus__student_enrollment
+    description: >-
+      Focus permits two open stints sharing a student, year, and start date.
+      Student 1 covers the demotion leg: the schoolid-null stub loses even
+      though it was created later. Student 2 covers the recency leg: the newer
+      stint wins on enrollment_created_at while carrying the LOWER id, so a pass
+      only if the ordering reads the timestamp rather than the id.
+    given:
+      - input: ref('stg_focus__students')
+        format: sql
+        rows: |
+          select 1 as student_id, 'A' as first_name, 'One' as last_name,
+            cast(null as string) as florida_education_identifier,
+            cast(null as string) as student_e_mail_address,
+            cast(null as timestamp) as birthdate
+          union all
+          select 2, 'B', 'Two', cast(null as string), cast(null as string),
+            cast(null as timestamp)
+      - input: ref('stg_focus__student_enrollment')
+        format: sql
+        rows: |
+          select 10 as id, 1 as student_id, 2026 as syear,
+            100 as school_id, cast(null as int64) as grade_id,
+            cast(null as int64) as enrollment_code,
+            cast(null as int64) as drop_code,
+            date '2026-08-12' as start_date, cast(null as date) as end_date,
+            timestamp '2026-07-01 00:00:00' as created_at
+          union all
+          select 11, 1, 2026, cast(null as int64), cast(null as int64),
+            cast(null as int64), cast(null as int64),
+            date '2026-08-12', cast(null as date),
+            timestamp '2026-08-11 00:00:00'
+          union all
+          select 25, 2, 2026, 100, cast(null as int64),
+            cast(null as int64), cast(null as int64),
+            date '2026-08-12', cast(null as date),
+            timestamp '2026-07-01 00:00:00'
+          union all
+          select 24, 2, 2026, 200, cast(null as int64),
+            cast(null as int64), cast(null as int64),
+            date '2026-08-12', cast(null as date),
+            timestamp '2026-08-12 00:00:00'
+      # empty: left-joined, contributes nothing to the dedupe under test
+      - input: ref('int_focus__schools')
+        rows: []
+      # empty: left-joined, contributes nothing to the dedupe under test
+      - input: ref('int_focus__student_enrollment__pivot')
+        rows: []
+      # empty: left-joined, contributes nothing to the dedupe under test
+      - input: ref('stg_focus__school_gradelevels')
+        rows: []
+      # empty: left-joined, contributes nothing to the dedupe under test
+      - input: ref('stg_focus__student_enrollment_codes')
+        rows: []
+      # empty: left-joined, contributes nothing to the dedupe under test
+      - input: ref('int_focus__school_year_first_day')
+        rows: []
+    expect:
+      rows:
+        - student_number: 1
+          academic_year: 2026
+          startdate: 2026-08-12
+          student_enrollment_id: 10
+        - student_number: 2
+          academic_year: 2026
+          startdate: 2026-08-12
+          student_enrollment_id: 24


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...stop two malformed Focus enrollment records from failing the whole `kipptaf__dbt_assets` build step.

Closes #4904.

Focus permits two open enrollment stints for the same student, school year, and start date. Two Miami students hit this for SY26 — the first occurrence in nine years of Focus data (syears 2018 through 2025 have zero). In each pair one record is an incomplete stub: no enrollment code, and in one case no school or grade either.

The duplicates flowed into `int_extracts__student_enrollments` and failed its uniqueness test on `(_dbt_source_project, student_number, academic_year, entrydate)`, which fails the build step and skips everything downstream of the extract.

**The fix**: dedupe in `int_focus__student_enrollment`, in a CTE between `enrollment` and `with_flags`.

Placement is the load-bearing part. It has to land **before** `rn_year` / `year_in_school` / `year_in_network` are assigned, because downstream consumers filter on `rn_year = 1` — `focus_year_grain` in `int_students__student_enrollments` and the `next_year_school` CTE in the extract. Dedupe after the ranks and you can strand a student holding only `rn_year = 2`, dropping them out of those joins entirely.

Dedupe key is `student_number, academic_year, startdate`. Tie-break demotes the incomplete record, then takes the most recently created:

```text
(schoolid is null) asc, enrollment_created_at desc, student_enrollment_id desc
```

Recency reads `enrollment_created_at`, not the id. Focus assigns ids in batches — 299,995 of 1,493,856 SY26 id pairs order differently by id than by creation time — so the id is not a recency proxy. It survives only as a deterministic final tie-break for exact timestamp ties.

### Already caught upstream, deliberately left as a warning

`stg_focus__student_enrollment` carries two uniqueness tests that already detect this, both `severity: warn`. The `(student_id, syear)` where `end_date is null` one — "a student is enrolled twice right now" — has been failing with `failed_row_count: 2` on every kippmiami build.

They stay at `warn` by decision, and they sit upstream of the dedupe, so they keep firing. That is the standing signal that Focus needs cleaning; this PR only stops the malformed data from breaking the network build.

The two bad records themselves are a Focus data-entry fix for Miami ops. No separate tracking issue: the shim's expiry condition is stated in full in the model comment at the derivation site.

### Verification

Built against prod upstreams (`--defer --favor-state`):

| check | result |
| --- | --- |
| row count | 10,044 to 10,042 — exactly 2 rows dropped |
| rows dropped | the stale MS stint and the blank stub, as intended |
| duplicate keys on `(student_number, academic_year, startdate)` | 2 to 0 |
| students holding `rn_year = 1` | 4,024 before, 4,024 after |
| student-years missing a `rn_year = 1` row | 0 |
| model tests | PASS=4 ERROR=0, including the new unit test |

The first build attempt gave a false 181-row delta — plain `--defer` prefers an existing dev relation over prod, so it read stale `zz_cbini_*` staging copies. `--favor-state` forces prod and gives the numbers above.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] No new models, so no new properties file. `int_focus__student_enrollment.yml` already documents this model and its grain is unchanged — still one row per enrollment stint.
- [x] No exposure change. Internal model; the `rpt_` layer above it is untouched.
- [x] Not a breaking change. No columns renamed, removed, or retyped. Two source rows stop appearing, which is the intent.
- [x] No external source change, so no `stage_external_sources` run needed.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes, and `get_job_run_error(warning_only=true)` reports `total_warnings: 0`.
- [x] **Dagster Cloud** — not triggered (no Dagster paths changed).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found by debugging a failed prod run, traced back through `int_extracts__student_enrollments` to `base_powerschool__student_enrollments` to `int_focus__student_enrollment` to the raw Focus rows.

The part worth scrutiny is the dedupe placement relative to the rank CTEs, and the tie-break ordering — `(schoolid is null) asc` is the documented BigQuery-safe form, since `array_agg` rejects explicit `nulls last`.

The `trunk-ignore(sqlfluff/ST03)` and `trunk-ignore(sqlfluff/AM04)` comments follow the existing repo idiom for macro-resolved column sets — see `int_focus__advisory.sql` for ST03 and the `union_relations` staging models for AM04.

A unit test pins both legs of the tie-break and was verified by mutation — dropping either leg from the `order_by` fails it. `expect` uses `format: dict`; `format: sql` makes dbt demand all 39 model columns in the fixture.

#4905 was a duplicate of #4904, filed minutes later, and is closed.

</details>
