### PR TITLE
docs(github): split reviewer-visible detail from Claude-only context in PR template

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -136,12 +136,13 @@ principal itself.
 ## Other Files
 
 - `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections).
-  Keep "Summary & Motivation" plain-language; put tradeoffs, edge cases, and
-  verification detail a human reviewer needs to weigh in the visible "Reviewer
-  Notes" section instead. The "For Claude" fold-out at the end holds whatever
-  got simplified or cut from the sections above for plain-language readability,
-  plus AI-involvement notes and anything a future `@claude` invocation needs —
-  not judgment calls a human reviewer needs to see.
+  Three tiers, plain to detailed: "Summary & Motivation" is plain-language, what
+  and why. "Reviewer Notes" is also plain-language — name what's worth a second
+  look and why, a line or two each, not the full reasoning. The "For Claude"
+  fold-out at the end holds the full technical detail behind each Reviewer Notes
+  flag (exact values, edge cases, full reasoning), plus whatever else got
+  simplified or cut from Summary for plain-language readability, AI-involvement
+  notes, and anything a future `@claude` invocation needs.
 - `ISSUE_TEMPLATE/` — `bug_report.md` and `feature_request.md`, each with a "For
   Claude" section for `@claude`-driven issues; `config.yml` disables blank
   issues.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -137,10 +137,11 @@ principal itself.
 
 - `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections).
   Keep "Summary & Motivation" plain-language; put tradeoffs, edge cases, and
-  verification detail in the visible "Reviewer Notes" section instead — that
-  content is for every reviewer, not just Claude. The "For Claude" fold-out at
-  the end is narrower: AI-involvement notes and anything a future `@claude`
-  invocation needs, nothing a human reviewer needs to see.
+  verification detail a human reviewer needs to weigh in the visible "Reviewer
+  Notes" section instead. The "For Claude" fold-out at the end holds whatever
+  got simplified or cut from the sections above for plain-language readability,
+  plus AI-involvement notes and anything a future `@claude` invocation needs —
+  not judgment calls a human reviewer needs to see.
 - `ISSUE_TEMPLATE/` — `bug_report.md` and `feature_request.md`, each with a "For
   Claude" section for `@claude`-driven issues; `config.yml` disables blank
   issues.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -135,8 +135,12 @@ principal itself.
 
 ## Other Files
 
-- `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections),
-  plus a "For Claude" section for AI-assistance notes and review focus.
+- `pull_request_template.md` — checklist for PRs (Dagster, dbt, docs sections).
+  Keep "Summary & Motivation" plain-language; put tradeoffs, edge cases, and
+  verification detail in the visible "Reviewer Notes" section instead — that
+  content is for every reviewer, not just Claude. The "For Claude" fold-out at
+  the end is narrower: AI-involvement notes and anything a future `@claude`
+  invocation needs, nothing a human reviewer needs to see.
 - `ISSUE_TEMPLATE/` — `bug_report.md` and `feature_request.md`, each with a "For
   Claude" section for `@claude`-driven issues; `config.yml` disables blank
   issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@
 
 ## Reviewer Notes
 
-> Optional. Technical decisions, tradeoffs, edge cases, or verification detail
-> worth a second look — visible to every reviewer, not just Claude. Delete if
-> there's nothing here.
+> Optional. Plain language, like Summary above — name what's worth a second look
+> and why, in a line or two each. Full technical detail, exact values, and edge
+> cases belong in "For Claude" below. Delete if there's nothing here.
 
 ## Self-review
 
@@ -83,14 +83,15 @@
 <details>
 <summary>For Claude</summary>
 
-> Detail simplified or cut from the sections above for plain-language
-> readability — exact values, edge cases, full technical grounding — plus AI
-> involvement and anything a future `@claude` invocation needs. Not for judgment
-> calls a human reviewer needs to weigh — those belong in "Reviewer Notes",
-> visible to everyone. Delete if there's nothing to add.
+> Full technical detail behind the Reviewer Notes flags above — exact values,
+> edge cases, full reasoning — plus anything else simplified or cut from Summary
+> for plain-language readability, AI involvement, and anything a future
+> `@claude` invocation needs. Delete if there's nothing to add.
 
-<!-- e.g. "Claude-assisted, human-directed. `state_value` isn't actually an
-FK to attendance_codes despite the name -- see the full column notes in
-migration_details.md if you need them." -->
+<!-- e.g. "Claude-assisted, human-directed. Reviewer Notes flags the column-
+projection call -- full reasoning: it matches
+stg_focus__gradebook_assignments, which projects unpopulated columns for the
+same reason, but the schedule / student_report_card_grades precedent goes
+the other way for wide Florida-reporting tables." -->
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,17 @@
 
 ## Summary & Motivation
 
-> "When merged, this pull request will..."
+> Plain language, no jargon — what changed and why. A reviewer skimming just
+> this section should understand the change. Save tradeoffs, edge cases, and
+> verification detail for "Reviewer Notes" below.
+
+"When merged, this pull request will..."
+
+## Reviewer Notes
+
+> Optional. Technical decisions, tradeoffs, edge cases, or verification detail
+> worth a second look — visible to every reviewer, not just Claude. Delete if
+> there's nothing here.
 
 ## Self-review
 
@@ -73,12 +83,10 @@
 <details>
 <summary>For Claude</summary>
 
-> Context, not instructions — AI involvement, what to focus on, what's
-> intentionally out of scope, related issues/PRs. Delete if there's nothing to
-> add.
+> AI involvement, and anything a future `@claude` invocation needs that isn't
+> already covered above. Not for review judgment calls — those belong in
+> "Reviewer Notes", visible to every reviewer. Delete if there's nothing to add.
 
-<!-- e.g. "Claude-assisted, human-directed. The risky part is the retry logic
-in src/x.py; the reformatted imports are just `ruff --fix` noise. Closes
-#123; verified with `uv run pytest tests/test_x.py -k retry`." -->
+<!-- e.g. "Claude-assisted, human-directed." -->
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -83,10 +83,14 @@
 <details>
 <summary>For Claude</summary>
 
-> AI involvement, and anything a future `@claude` invocation needs that isn't
-> already covered above. Not for review judgment calls — those belong in
-> "Reviewer Notes", visible to every reviewer. Delete if there's nothing to add.
+> Detail simplified or cut from the sections above for plain-language
+> readability — exact values, edge cases, full technical grounding — plus AI
+> involvement and anything a future `@claude` invocation needs. Not for judgment
+> calls a human reviewer needs to weigh — those belong in "Reviewer Notes",
+> visible to everyone. Delete if there's nothing to add.
 
-<!-- e.g. "Claude-assisted, human-directed." -->
+<!-- e.g. "Claude-assisted, human-directed. `state_value` isn't actually an
+FK to attendance_codes despite the name -- see the full column notes in
+migration_details.md if you need them." -->
 
 </details>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ file; domain specifics live in the nearest subdirectory CLAUDE.md.
   `mcp__github__issue_write`; label with conventional commit type, related
   source systems, and `dagster`/`dbt` when applicable.
 
+- **Opening any GitHub issue** (via `mcp__github__issue_write`, whether for a
+  spec/plan or a quick-fix bug/feature report): `issue_write` does NOT apply a
+  repo issue template — that's a GitHub web-UI-only convenience (the "New issue"
+  picker), invisible to the API. Read the matching template under
+  `.github/ISSUE_TEMPLATE/` yourself (`bug_report.md` or `feature_request.md`)
+  and structure the body to match it — plain-language sections first, a "For
+  Claude" fold-out last — rather than writing free-form.
+
 - **Before creating a branch**: ask the user — worktree or branch switch? Do not
   choose for them. When an issue isn't already required (i.e. quick fixes, not
   specs/plans), also ask whether to anchor the branch with one, and honor a


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a visible "Reviewer Notes" section
to the PR template and narrow the "For Claude" fold-out to genuinely
AI-only context, so technical detail meant for reviewers stops landing
either in the wrong place or hidden behind a collapsed section. It also
fixes a separate gap: Claude sessions opening issues via
`mcp__github__issue_write` were skipping the issue templates entirely,
because the API never applies them — that's a GitHub web-UI-only
convenience. The root `CLAUDE.md` now tells sessions to read the matching
template themselves before opening an issue.

## Reviewer Notes

[PR #4906](https://github.com/TEAMSchools/teamster/pull/4906) is the
motivating example: its "Summary & Motivation" carries a full decisions
table, column-projection rationale, and validation output (all jargon-heavy,
not plain language), while the "For Claude" fold-out holds the actual
second-opinion-worthy judgment calls ("the judgement calls most worth a
second opinion...") — exactly the content a human reviewer needs to see,
hidden behind a collapsed `<details>` block by default.

This PR doesn't touch #4906. It fixes the template so the next PR has a
natural home for that content: "Reviewer Notes" is visible, sits right after
the now-genuinely-plain "Summary & Motivation", and "For Claude" is narrowed
to AI-involvement notes and anything a future `@claude` invocation needs —
nothing a human reviewer has to see.

## Self-review

### General

- [x] No due date/assignee needed — docs-only, not a tracked Asana item
- [x] Review the **Claude Code Review** comment posted on this PR. Address
      valid feedback; dismiss false positives with a brief reply explaining
      why.

## CI checks

- [ ] **Trunk** — passes locally (`trunk check --force`, both files, no
      issues); CI not yet observed
- [ ] **dbt Cloud** — expected to pass trivially, no dbt changes
- [ ] **Dagster Cloud** — not expected to trigger, no relevant paths changed

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed — the user flagged PR #4906 as evidence the
prior template design wasn't working in practice, then separately flagged
that Claude sessions weren't using the issue templates at all. Check: (1)
whether "Reviewer Notes" vs. "For Claude" is actually the right split, or
whether a different structure would separate the two audiences more
cleanly; (2) whether the `.github/CLAUDE.md` "Other Files" wording
accurately guides future authors on which section content belongs in; (3)
whether pulling the issue-template instruction into its own root `CLAUDE.md`
bullet (rather than nesting it under "Before writing any spec or plan," which
only fires for spec/plan-gated issues) actually fixes the discoverability gap
for quick-fix issues.

</details>
