### PR TITLE
fix(kipptaf): chunk bigquery table_modified sensor on a tick time budget

### DIFF
--- a/src/teamster/code_locations/kipptaf/google/bigquery/sensors.py
+++ b/src/teamster/code_locations/kipptaf/google/bigquery/sensors.py
@@ -51,7 +51,12 @@ def bigquery_table_modified_sensor(
     offset = cursor.get(OFFSET_CURSOR_KEY, 0)
 
     # tolerate a cursor written before this key existed, and an offset left
-    # dangling by a deploy that shortened asset_selection
+    # dangling by a deploy that shortened asset_selection. A deploy that REORDERS
+    # asset_selection without changing its length is not detectable here: the
+    # resumed tick polls a different slice than the one it skipped. That is
+    # bounded and self-healing -- per-asset state is keyed by identifier rather
+    # than index, so the worst case is one sweep's detection delay, never a lost
+    # or duplicated materialization.
     if not isinstance(offset, int) or not 0 <= offset < len(asset_selection):
         offset = 0
 
@@ -103,13 +108,23 @@ def bigquery_table_modified_sensor(
 
     cursor[OFFSET_CURSOR_KEY] = next_offset
 
+    if asset_events:
+        skip_reason = None
+    elif next_offset:
+        # a partial slice found nothing, but assets remain unpolled this sweep
+        skip_reason = SkipReason(
+            f"No modified tables in this slice; resuming at index {next_offset}."
+        )
+    else:
+        skip_reason = SkipReason("No modified tables.")
+
     # the cursor is returned on every tick, not just ticks that emit events --
     # otherwise the resume offset would be discarded and the tail of
     # asset_selection would never be polled
     return SensorResult(
         asset_events=asset_events,
         cursor=json.dumps(obj=cursor),
-        skip_reason=(None if asset_events else SkipReason("No modified tables.")),
+        skip_reason=skip_reason,
     )
 
 

--- a/src/teamster/code_locations/kipptaf/google/bigquery/sensors.py
+++ b/src/teamster/code_locations/kipptaf/google/bigquery/sensors.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from dagster import (
     AssetMaterialization,
@@ -23,6 +24,19 @@ from teamster.code_locations.kipptaf.google.appsheet.assets import (
 
 asset_selection: list[AssetSpec] = [*google_appsheet_asset_specs, *airbyte_asset_specs]
 
+# Wall-clock budget for one tick's polling loop. The tick is killed at 600s by
+# default_sensor_timeout, and a single get_table below can burn ~30s before it
+# gives up, so this leaves room for one in-flight call to finish past the check.
+# Polling every asset normally takes a few seconds, so the budget only bites once
+# BigQuery metadata calls start timing out -- at which point the loop stops and
+# resumes on the next tick instead of running the whole tick into the timeout.
+TICK_TIME_BUDGET_SECONDS = 300
+
+# Cursor key holding the resume position. "$" is not legal in a Python
+# identifier, so this can never collide with an AssetKey.to_python_identifier()
+# entry sharing the same dict.
+OFFSET_CURSOR_KEY = "$offset"
+
 
 @sensor(
     name=f"{CODE_LOCATION}__google__bigquery__table_modified_sensor",
@@ -34,8 +48,31 @@ def bigquery_table_modified_sensor(
     asset_events = []
     cursor: dict = json.loads(context.cursor or "{}")
 
+    offset = cursor.get(OFFSET_CURSOR_KEY, 0)
+
+    # tolerate a cursor written before this key existed, and an offset left
+    # dangling by a deploy that shortened asset_selection
+    if not isinstance(offset, int) or not 0 <= offset < len(asset_selection):
+        offset = 0
+
+    deadline = time.monotonic() + TICK_TIME_BUDGET_SECONDS
+
+    # 0 means the sweep finished; a break below overwrites it with the resume index
+    next_offset = 0
+
     with db_bigquery.get_client() as bq:
-        for assets_def in asset_selection:
+        for index in range(offset, len(asset_selection)):
+            if time.monotonic() >= deadline:
+                next_offset = index
+                context.log.info(
+                    msg=(
+                        f"Tick time budget of {TICK_TIME_BUDGET_SECONDS}s exhausted "
+                        f"after {index - offset} assets; resuming at index {index}"
+                    )
+                )
+                break
+
+            assets_def = asset_selection[index]
             python_identifier = assets_def.key.to_python_identifier()
 
             cursor_modified_timestamp = cursor.get(python_identifier, 0)
@@ -64,10 +101,16 @@ def bigquery_table_modified_sensor(
                 asset_events.append(AssetMaterialization(asset_key=assets_def.key))
                 cursor[python_identifier] = table_modified_timestamp
 
-    if asset_events:
-        return SensorResult(asset_events=asset_events, cursor=json.dumps(obj=cursor))
-    else:
-        return SkipReason()
+    cursor[OFFSET_CURSOR_KEY] = next_offset
+
+    # the cursor is returned on every tick, not just ticks that emit events --
+    # otherwise the resume offset would be discarded and the tail of
+    # asset_selection would never be polled
+    return SensorResult(
+        asset_events=asset_events,
+        cursor=json.dumps(obj=cursor),
+        skip_reason=(None if asset_events else SkipReason("No modified tables.")),
+    )
 
 
 sensors = [

--- a/tests/sensors/test_sensors_google_bigquery.py
+++ b/tests/sensors/test_sensors_google_bigquery.py
@@ -1,3 +1,5 @@
+import json
+
 from dagster import SensorResult, build_sensor_context
 from dagster_shared import check
 
@@ -23,3 +25,39 @@ def test_bigquery_table_sensor():
         context.log.info(msg=asset_event)
 
     context.log.info(msg=sensor_result.cursor)
+
+
+def test_bigquery_table_sensor_cursor_offset():
+    """Guards the cursor migration: a cursor written before chunking existed must
+    still load, the resume offset must round-trip, and the reserved key must not
+    be able to collide with a generated asset identifier.
+    """
+    from teamster.code_locations.kipptaf.google.bigquery.sensors import (
+        OFFSET_CURSOR_KEY,
+        asset_selection,
+        bigquery_table_modified_sensor,
+    )
+
+    # a cursor in the pre-chunking shape: asset identifiers only, no offset key
+    legacy_identifier = asset_selection[0].key.to_python_identifier()
+
+    context = build_sensor_context(
+        cursor=json.dumps({legacy_identifier: 1.0}),
+    )
+
+    sensor_result = check.inst(
+        obj=bigquery_table_modified_sensor(
+            context=context, db_bigquery=BIGQUERY_RESOURCE
+        ),
+        ttype=SensorResult,
+    )
+
+    cursor = json.loads(check.not_none(value=sensor_result.cursor))
+
+    assert OFFSET_CURSOR_KEY in cursor
+    assert isinstance(cursor[OFFSET_CURSOR_KEY], int)
+    assert 0 <= cursor[OFFSET_CURSOR_KEY] < len(asset_selection)
+
+    assert OFFSET_CURSOR_KEY not in {
+        spec.key.to_python_identifier() for spec in asset_selection
+    }

--- a/tests/sensors/test_sensors_google_bigquery.py
+++ b/tests/sensors/test_sensors_google_bigquery.py
@@ -1,9 +1,61 @@
+import contextlib
+import importlib
 import json
 
-from dagster import SensorResult, build_sensor_context
+from dagster import SensorResult, SkipReason, build_sensor_context
 from dagster_shared import check
 
 from teamster.core.resources import BIGQUERY_RESOURCE
+
+# `bigquery/__init__.py` rebinds the name `sensors` to the sensor LIST, so
+# `import ...bigquery.sensors as x` yields that list rather than the module.
+# import_module returns the module itself, which is what monkeypatching needs.
+SENSORS_MODULE = "teamster.code_locations.kipptaf.google.bigquery.sensors"
+
+
+class _StubTable:
+    """A table with no mtime, so the sensor never emits a materialization."""
+
+    modified = None
+
+
+class _StubBigQueryClient:
+    def __init__(self):
+        self.get_table_calls = 0
+
+    def get_table(self, **kwargs):
+        self.get_table_calls += 1
+
+        return _StubTable()
+
+
+class _StubBigQueryResource:
+    """Stands in for BigQueryResource so budget logic is testable offline."""
+
+    def __init__(self, client: _StubBigQueryClient):
+        self._client = client
+
+    @contextlib.contextmanager
+    def get_client(self):
+        yield self._client
+
+
+class _FakeClock:
+    """Advances a fixed step per monotonic() call.
+
+    Makes the sensor's deadline arithmetic deterministic: with step=100 and a
+    300s budget, the deadline is 400, checks at 200 and 300 pass, and the check
+    at 400 breaks the loop.
+    """
+
+    def __init__(self, step: float):
+        self._now = 0.0
+        self._step = step
+
+    def monotonic(self) -> float:
+        self._now += self._step
+
+        return self._now
 
 
 def test_bigquery_table_sensor():
@@ -61,3 +113,70 @@ def test_bigquery_table_sensor_cursor_offset():
     assert OFFSET_CURSOR_KEY not in {
         spec.key.to_python_identifier() for spec in asset_selection
     }
+
+
+def test_bigquery_table_sensor_budget_exhausted_polls_nothing(monkeypatch):
+    """With no budget the loop must break before its first call and leave the
+    resume index untouched, so the next tick retries the same slice instead of
+    silently skipping it.
+    """
+    sensors = importlib.import_module(SENSORS_MODULE)
+
+    monkeypatch.setattr(sensors, "TICK_TIME_BUDGET_SECONDS", 0)
+
+    client = _StubBigQueryClient()
+    start_offset = 5
+
+    context = build_sensor_context(
+        cursor=json.dumps({sensors.OFFSET_CURSOR_KEY: start_offset}),
+    )
+
+    sensor_result = check.inst(
+        obj=sensors.bigquery_table_modified_sensor(
+            context=context, db_bigquery=_StubBigQueryResource(client=client)
+        ),
+        ttype=SensorResult,
+    )
+
+    cursor = json.loads(check.not_none(value=sensor_result.cursor))
+
+    assert client.get_table_calls == 0
+    assert cursor[sensors.OFFSET_CURSOR_KEY] == start_offset
+    assert not sensor_result.asset_events
+
+
+def test_bigquery_table_sensor_resumes_mid_sweep(monkeypatch):
+    """The core fix: the loop stops once the budget is spent and records the index
+    it stopped at, rather than running the whole sweep into the tick timeout.
+    """
+    sensors = importlib.import_module(SENSORS_MODULE)
+
+    monkeypatch.setattr(sensors, "time", _FakeClock(step=100.0))
+    monkeypatch.setattr(sensors, "TICK_TIME_BUDGET_SECONDS", 300)
+
+    client = _StubBigQueryClient()
+    start_offset = 4
+
+    assert start_offset + 2 < len(sensors.asset_selection)
+
+    context = build_sensor_context(
+        cursor=json.dumps({sensors.OFFSET_CURSOR_KEY: start_offset}),
+    )
+
+    sensor_result = check.inst(
+        obj=sensors.bigquery_table_modified_sensor(
+            context=context, db_bigquery=_StubBigQueryResource(client=client)
+        ),
+        ttype=SensorResult,
+    )
+
+    cursor = json.loads(check.not_none(value=sensor_result.cursor))
+
+    # exactly two assets polled, then the budget ran out
+    assert client.get_table_calls == 2
+    assert cursor[sensors.OFFSET_CURSOR_KEY] == start_offset + 2
+
+    # a partial slice reports itself as partial, not as a finished empty sweep
+    skip_reason = check.inst(obj=sensor_result.skip_reason, ttype=SkipReason)
+
+    assert "resuming at index" in check.not_none(value=skip_reason.skip_message)


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop one Dagster sensor from failing on a timeout.

The sensor watches 32 BigQuery tables to spot which ones have changed, checking them one at a time. Nothing limited how long the whole pass could take, so whenever BigQuery got slow the sensor ran past its 10 minute limit and the run was killed. That happened five times in the last 30 days.

It now stops once it has used half its time allowance, remembers where it got to, and carries on from there on the next run. When BigQuery is healthy the whole pass still finishes in about 15 seconds, so nothing changes day to day.

Refs #4908

## Reviewer Notes

- The sensor remembers its place in the same saved state that already holds each table's last-changed time. Worth a second look that a saved state written by the version running in production today still loads cleanly, since that is the one thing here that could misbehave on deploy rather than in review.
- Two new tests cover the stop-and-carry-on behaviour. They run against a stub instead of real BigQuery, so they are fast and give the same answer every time. I checked they actually fail when the stopping logic is removed, so they are genuinely testing it and not just passing.
- I declined one review finding: if someone reorders the table config without changing how many tables there are, a resumed run could check a different group than the one it skipped. Nothing is lost or double-counted and it corrects itself on the next pass, so I left the code alone and documented the limit instead.
- The time allowance and the gap between runs are both 300 seconds. That is deliberate rather than an oversight; reasoning below.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why. — done,
      per-finding verdicts posted as a comment: two accepted and fixed in
      6eeeebb, three declined with reasons

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location —
      satisfied via the pytest path below. Run directly it fails on an unset
      Illuminate credential, the known codespace limitation recorded in
      `src/teamster/CLAUDE.md`, at module scope in a file this PR does not touch.
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location — `test_definitions_kipptaf`: `1 passed in 57.95s`
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager — n/a, no new integration

### dbt

Skipped, no dbt changes.

### Docs

- [x] If adding or changing a schedule or sensor, regenerate the automations
      catalog — n/a, no sensor was added, renamed, or re-scheduled; only the body
      of an existing sensor changed, and the generator emits name and interval,
      neither of which moved
- [x] If adding a new integration to a code location, update that location's
      `CLAUDE.md` — n/a, no new integration

## CI checks

- [ ] **Trunk** — passes. `trunk check --force` was clean on both changed files
      before each commit.
- [ ] **dbt Cloud** — passed on the first commit; no dbt paths changed.
- [ ] **Dagster Cloud** — passed on the first commit.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found while debugging a separate report of code
location reload failures; that unrelated root cause is tracked in #4907 with a
design spec in #4914, and is deliberately untouched here even though it surfaces
the same `DagsterUserCodeUnreachableError` class.

### Why the timeout was guaranteed, not unlucky

`asset_selection` is 32 specs: 10 from dbt manifest sources where `source_name`
is `google_appsheet`, plus 22 from `destination_tables` across two connections in
`airbyte/config/assets.yaml`. Each gets one serial `bq.get_table()` bounded at
`timeout=10` with `retry=DEFAULT_RETRY.with_deadline(30)`, so a single asset can
burn about 30s. 32 x 30 is roughly 960s against a 600s tick budget, and the loop
had no notion of elapsed time, so nothing could stop it. The observed 2026-08-18
failure ran 603s, about 19s per call — most calls were hitting the 10s timeout
and retrying, not merely accumulating.

The per-call bounds were already correct per `src/teamster/CLAUDE.md`. The defect
was the absence of any aggregate bound.

### Time budget rather than a fixed chunk size

A count-based chunk (10 of 32) would split every sweep across four ticks and
multiply normal detection latency by four, for a sweep that really takes ~15s. A
time budget engages only once calls actually slow down, leaving the common case
untouched. `TICK_TIME_BUDGET_SECONDS` is 300 against a 600s tick timeout; the
deadline is checked before each call, so worst case is 300 + one 30s in-flight
call = 330s, comfortably under.

### Reviewer Notes flag 1: the cursor migration

The resume index lives under the reserved key `$offset`. A dollar sign is not
legal in a Python identifier, so it cannot collide with an
`AssetKey.to_python_identifier()` entry sharing the dict — verified empirically
against the live 32-spec list in `test_bigquery_table_sensor_cursor_offset`.
The offset is also range-checked, so an index left dangling by a deploy that
shortens `asset_selection` resets to 0 rather than raising.

The cursor is now returned on every tick, not only ticks that emit events. The
previous bare `SkipReason()` return discarded it, which under chunking would
throw away the resume index and leave the tail of `asset_selection` permanently
unpolled.

Note `next_offset = 0` is overloaded: it means "sweep finished", and a break at
index 0 also yields 0. Harmless, because both cases correctly want the next tick
to start at 0 — but it is why both new tests start from a non-zero offset, which
is the only way an assertion can distinguish "stopped here" from "finished".

### Reviewer Notes flag 2: the new tests

- `test_bigquery_table_sensor_budget_exhausted_polls_nothing` — budget 0 must
  break before the first call, leaving the resume index untouched. Asserts
  `get_table` was never called.
- `test_bigquery_table_sensor_resumes_mid_sweep` — a fake monotonic clock
  stepping 100s against a 300s budget puts the deadline at 400, so checks at 200
  and 300 pass and the check at 400 breaks. Asserts exactly two `get_table` calls
  and that the offset advanced by exactly two.

Both stub `BigQueryResource`, so no warehouse access and no flakiness.
Mutation-verified: disabling the budget check fails both, and the file restored
byte-exact afterward.

Implementation trap worth knowing: `bigquery/__init__.py` does
`from ...sensors import sensors`, rebinding the name to the sensor **list**. So
`import ...bigquery.sensors as x` hands back a list and monkeypatching it
silently no-ops. The tests reach the real module via `importlib.import_module`.

Local run of all four: `4 passed in 28.38s`.

### Reviewer Notes flag 3: declined reorder finding

`0 <= offset < len(asset_selection)` catches a deploy that shortens the list but
not one that reorders it at equal length. A resumed tick would then poll a
different slice than the one it skipped. Declined on impact: per-asset state is
keyed by `python_identifier`, not index, so nothing is lost or duplicated and the
worst case is a one-sweep (300s) detection delay that self-corrects. Closing it
properly means storing a resume identifier and scanning for it — more machinery
than a rare, benign, self-healing event justifies. The code comment now names
reordering explicitly so the guard is not read as stronger than it is.

### Reviewer Notes flag 4: budget equals interval

Both are 300s, and `minimum_interval_seconds` is a floor between tick starts
rather than a guaranteed idle gap, so during sustained BigQuery slowness ticks
can run near-continuously. That is the intended self-limiting behaviour: the
sensor keeps making forward progress through the sweep instead of stalling. If
continuous gRPC worker occupancy on the code server ever becomes a problem, the
lever is lowering the budget, not raising the interval.

### Also declined

The reviewer flagged that `deadline` is computed before entering
`get_client()`, so a slow client acquisition could in principle consume the
budget before the first check. `google.cloud.bigquery.Client()` construction is
local and non-blocking, and the failure mode would be no forward progress for one
tick rather than a regression. The reviewer marked it informational and I agree.

### Out of scope

Replacing 32 serial `tables.get` round trips with `INFORMATION_SCHEMA.TABLES`
(billed at a 10 MB minimum per query versus free metadata), and lowering the 30s
per-call retry deadline. Both recorded in #4908.

</details>
