### PR TITLE
fix(k8s): code server scheduling resilience Phase 1, plus design spec and plan

### DIFF
--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -28,9 +28,17 @@ on GKE Autopilot.
 - **Helm deploy is manual** — editing `values-override.yaml` is fine, but
   changes only take effect after `helm upgrade`. `git push` builds code location
   images, not Helm agent config.
+- `deploymentStartupTimeout` (Helm `workspace` key, chart default 300s) — time
+  the agent waits for the code server Deployment to become ready, i.e. for the
+  pod to be SCHEDULED. Currently set to 900s. This is the timeout that fires
+  during a NAP `FailedScheduling` wait. Raising it also raises the agent's
+  worst-case first reconcile, so the `readinessProbe` `failureThreshold` and
+  `DAGSTER_CLOUD_CLEANUP_SERVER_GRACE_PERIOD_SECONDS` must move with it, along
+  with `install.sh`'s `rollout status --timeout`.
 - `serverProcessStartupTimeout` (Helm `workspace` key, default 180s) — time the
-  agent waits for a code server gRPC ping after creating the Deployment.
-  Currently set to 300s in `values-override.yaml`.
+  agent waits for a code server gRPC ping after the Deployment exists. Fires on
+  slow definitions import, not on failed placement. Currently set to 300s in
+  `values-override.yaml`.
 
 ## Scheduling
 

--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -269,10 +269,21 @@ a different pod type.
 - **GCP Error Reporting investigation**: `list_group_stats` (find groups) →
   `list_log_entries` (reconstruct multi-line tracebacks from individual log
   entries) → `k8s_pod` events (find root cause: preemption, OOM, eviction).
-- **Timeout types** (do not conflate): Startup (`serverProcessStartupTimeout`,
-  default 180s) = agent→code server gRPC ping; failure → deployment removed +
-  replacement, causes churn. Sensor execution (300s) = sensor ran too long; code
-  server stays up, no churn.
+- **Timeout types** (do not conflate). Three distinct waits, in the order they
+  occur:
+  1. **Deployment startup** (`deploymentStartupTimeout`, Helm `workspace` key,
+     chart default 300s, set to 900s) — agent waits for the code server
+     Deployment to become ready, i.e. for the pod to be SCHEDULED. This is the
+     one that fires during a NAP `FailedScheduling` wait, and its failure
+     message is `Timed out waiting for deployment {name}` with
+     `Pod status: Pending`. Governs `wait_for_deployment_complete`, not
+     `_wait_for_dagster_server_process`.
+  1. **Server process startup** (`serverProcessStartupTimeout`, Helm `workspace`
+     key, default 180s, set to 300s) — agent waits for a gRPC ping AFTER the
+     Deployment exists. Fires when Dagster definitions are slow to import, not
+     when the pod cannot be placed.
+  1. **Sensor execution** (300s, Dagster+ deployment setting) — sensor ran too
+     long; the code server stays up and no churn results.
 - **Code server startup failure signals**: Check ALL pods for the deployment.
   `Aborted!` stderr = SIGABRT (native crash). `DagsterExecutionInterruptedError`
   = SIGTERM during import (rollover). Silent hang after "Starting Dagster code
@@ -293,9 +304,14 @@ a different pod type.
   `resource.type="gce_subnetwork"` +
   `logName=".../compute.googleapis.com%2Ffirewall"` → `instance.zone` +
   `remote_instance.zone`. Filter `dest_port=4000` for agent→code-server gRPC.
-- **Autopilot node pre-warming**: Not possible — no DaemonSets, no image
-  pre-pulling, no node lifecycle control. Only levers for cold-node startup
-  latency: image size reduction and Dagster timeout increases.
+- **Autopilot node pre-warming**: no node-lifecycle control — no DaemonSets, no
+  image pre-pulling, no cordon that holds. But capacity CAN be reserved at the
+  workload layer with balloon pods: a Deployment of placeholder pods on a
+  negative `PriorityClass` holds nodes that real pods preempt instantly, and the
+  displaced placeholder then triggers NAP to re-warm the buffer. Google
+  documents this for Autopilot. Not deployed here yet; see
+  `docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md`
+  Phase 2, gated on verifying Warden admits a negative priority value.
 - **CPU limit alert sensitivity**: `GKE Container - High CPU Limit Utilization`
   fires at >90% `ALIGN_MEAN` over 60s with `count=1`. When an asset's `op_tags`
   CPU limit alerts, bump by 250m — re-measure peak with
@@ -317,6 +333,19 @@ a different pod type.
   Dagster+ full deployment settings (see Dagster+ Deployment Settings section)
   expose no tick-retry knob. Terminal `DagsterUserCodeUnreachableError` ticks
   remain terminal.
+- **A timed-out code server deployment is TERMINAL — the agent never retries
+  it.** `_should_trigger_recovery` in
+  `dagster_cloud/workspace/user_code_launcher/user_code_launcher.py` returns
+  `False` when the location is in `control_plane_error_locations` ("control
+  plane agrees there is an error, don't retry"). Recovery fires only when the
+  agent holds a local error while the control plane believes the location is
+  healthy. Normal reconciliation redeploys only when
+  `actual_entry.update_timestamp != desired_entry.update_timestamp`, which
+  changes on a new deploy, and the periodic health check needs a running
+  endpoint that a never-started pod does not have. So a location that fails to
+  schedule stays `ERROR` until someone pushes a commit or clicks redeploy. No
+  agent setting changes this;
+  `DAGSTER_CLOUD_DISABLE_LOCAL_ERROR_SERVER_RECOVERY` only turns recovery off.
 
 ## Dagster+ Deployment Settings
 

--- a/.k8s/dagster/install.sh
+++ b/.k8s/dagster/install.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 # point back to setup.sh on any error (the clean "Aborted." exit 0 path skips
 # this trap).
 on_error() {
-  status=$?
-  echo "" >&2
-  echo "install.sh failed (exit ${status})." >&2
-  echo "Missing tool, unreachable cluster, or missing namespace? Run the" >&2
-  echo "environment bootstrap first, then retry:" >&2
-  echo "  bash .k8s/setup.sh" >&2
+	status=$?
+	echo "" >&2
+	echo "install.sh failed (exit ${status})." >&2
+	echo "Missing tool, unreachable cluster, or missing namespace? Run the" >&2
+	echo "environment bootstrap first, then retry:" >&2
+	echo "  bash .k8s/setup.sh" >&2
 }
 trap on_error ERR
 
@@ -24,22 +24,26 @@ helm show values dagster-cloud/dagster-cloud-agent >.k8s/dagster/values.yaml
 
 echo "Running dry-run..."
 helm upgrade \
-  --install user-cloud dagster-cloud/dagster-cloud-agent \
-  --namespace dagster-cloud \
-  -f .k8s/dagster/values-override.yaml \
-  --dry-run
+	--install user-cloud dagster-cloud/dagster-cloud-agent \
+	--namespace dagster-cloud \
+	-f .k8s/dagster/values-override.yaml \
+	--dry-run
 
 read -r -p "Dry-run succeeded. Apply to cluster? [y/N] " response
 if [[ ! ${response} =~ ^[Yy]$ ]]; then
-  echo "Aborted."
-  exit 0
+	echo "Aborted."
+	exit 0
 fi
 
 helm upgrade \
-  --install user-cloud dagster-cloud/dagster-cloud-agent \
-  --namespace dagster-cloud \
-  -f .k8s/dagster/values-override.yaml
+	--install user-cloud dagster-cloud/dagster-cloud-agent \
+	--namespace dagster-cloud \
+	-f .k8s/dagster/values-override.yaml
 
 # ConfigMap changes don't trigger a rollout — force restart to pick up new env vars.
 kubectl rollout restart deployment/user-cloud-dagster-cloud-agent-agent -n dagster-cloud
-kubectl rollout status deployment/user-cloud-dagster-cloud-agent-agent -n dagster-cloud --timeout=600s
+# Must match the agent readinessProbe budget in values-override.yaml
+# (failureThreshold x periodSeconds = 1300s). A shorter timeout here reports a
+# healthy-but-slow first reconcile as a failure and fires the on_error trap,
+# which then misdirects the reader to setup.sh.
+kubectl rollout status deployment/user-cloud-dagster-cloud-agent-agent -n dagster-cloud --timeout=1300s

--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -31,10 +31,14 @@ dagsterCloudAgent:
   env:
     # Reduce cleanup delay for orphaned code server deployments left by previous
     # agent IDs after Helm upgrades. Defaults: grace=3600s, interval=1800s.
-    # With replicas: 1, each upgrade leaves 1 orphaned deployment per location;
-    # the 10-min heartbeat expiry + 15-min grace period ensures replacements are
-    # reconciled before orphans are deleted.
-    DAGSTER_CLOUD_CLEANUP_SERVER_GRACE_PERIOD_SECONDS: "900"
+    # With replicas: 1, each upgrade leaves 1 orphaned deployment per location.
+    # The grace period must exceed the worst-case first reconcile so replacements
+    # are reconciled before orphans are deleted -- CLAUDE.md: "do not set grace
+    # period below reconciliation time". That worst case is now ~1200s (see the
+    # readinessProbe note below), so 900s would sit under it; 1500s restores the
+    # invariant. Cost is bounded: orphans linger ~10 min longer, and only after a
+    # helm upgrade.
+    DAGSTER_CLOUD_CLEANUP_SERVER_GRACE_PERIOD_SECONDS: "1500"
     DAGSTER_CLOUD_CLEANUP_SERVER_CHECK_INTERVAL: "600"
 
   readinessProbe:
@@ -43,7 +47,15 @@ dagsterCloudAgent:
         - /bin/bash
         - -c
         - test -f /tmp/finished_initial_reconciliation_sentinel.txt
-    failureThreshold: 60 # 10 min (60 × 10s) for initial reconciliation
+    # Must cover the WORST-CASE first reconcile, because the sentinel this probe
+    # tests is only written after the first full _reconcile returns
+    # (user_code_launcher.py, gated on _reconcile_count == 0). Per location that
+    # is deploymentStartupTimeout (900s) + serverProcessStartupTimeout (300s) =
+    # 1200s, and locations are reconciled concurrently via asyncio.gather, so
+    # ~1200s total rather than 5x that. 130 x 10s = 1300s leaves margin. Raising
+    # deploymentStartupTimeout without raising this stalls the agent rollout on
+    # exactly the helm upgrade that ships it.
+    failureThreshold: 130 # 21.7 min (130 × 10s) for initial reconciliation
     initialDelaySeconds: 0
     periodSeconds: 10
 
@@ -103,6 +115,12 @@ workspace:
   # records the location as ERROR, and _should_trigger_recovery then refuses to
   # retry ("control plane agrees there is an error") -- the location stays dead
   # until a push or a manual redeploy.
+  #
+  # Agent-global, so it applies to branch deployments too
+  # (dagsterCloud.branchDeployments): a branch deployment that cannot schedule now
+  # takes 15 minutes to report instead of 5. Raising this also moves the agent's
+  # worst-case first reconcile, which the readinessProbe and cleanup grace period
+  # below are sized against -- change all three together.
   deploymentStartupTimeout: 900
 
   serverProcessStartupTimeout: 300
@@ -155,7 +173,8 @@ workspace:
     podSpecConfig:
       # Hard-pin to built-in Scale-Out arm64 (T2A) under pod-based pricing.
       # No fallback — arm64 STOCKOUT will leave pods Pending. Code servers
-      # tolerate this: PDB-protected (`minAvailable: 1`), Dagster Cloud
+      # tolerate this: PDB-protected (`maxUnavailable: 1` -- see extraManifests
+      # below; do NOT switch to minAvailable, per CLAUDE.md), Dagster Cloud
       # serves the last-good Deployment until replacements bind.
       nodeSelector:
         cloud.google.com/compute-class: Scale-Out

--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -94,6 +94,17 @@ dagsterCloudAgent:
 # Workspace: Configuration for pods (launched by the agent) that run Dagster user code
 ########################################################################################
 workspace:
+  # Time the agent waits for a code server DEPLOYMENT to become ready -- in
+  # practice, for the pod to be scheduled. Distinct from
+  # serverProcessStartupTimeout below, which only starts once the Deployment
+  # exists. The chart default is 300s, which sits inside the 3-9 minute NAP
+  # FailedScheduling window documented in CLAUDE.md, so an ordinary provisioning
+  # wait times out. On timeout the agent uploads an error, the control plane
+  # records the location as ERROR, and _should_trigger_recovery then refuses to
+  # retry ("control plane agrees there is an error") -- the location stays dead
+  # until a push or a manual redeploy.
+  deploymentStartupTimeout: 900
+
   serverProcessStartupTimeout: 300
 
   # Raw k8s configuration for the Kubernetes Deployment created for each code location.
@@ -131,6 +142,16 @@ workspace:
     podTemplateSpecMetadata: # raw config for the pod's metadata
       annotations:
         operator.1password.io/auto-restart: "true"
+        # Code servers were the only pod type without this -- the agent
+        # (dagsterCloudAgent.annotations) and run pods
+        # (runK8sConfig.podTemplateSpecMetadata) both carry it. Blocks
+        # cluster-autoscaler eviction, which accounted for 38-59 code-server
+        # relocations per week. Compatible here: requests above are 500m/2.0Gi,
+        # meeting the Autopilot extended-duration minimum, and code servers are
+        # not on spot (the two are mutually exclusive). Extended-duration
+        # protection expires after 7 days, far longer than the interval between
+        # deploys.
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     podSpecConfig:
       # Hard-pin to built-in Scale-Out arm64 (T2A) under pod-based pricing.
       # No fallback — arm64 STOCKOUT will leave pods Pending. Code servers

--- a/docs/superpowers/plans/2026-08-18-code-server-scheduling-phase-1.md
+++ b/docs/superpowers/plans/2026-08-18-code-server-scheduling-phase-1.md
@@ -1,0 +1,704 @@
+# Code Server Scheduling Resilience, Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop code-server replacement pods from timing out during placement, so
+a routine redeploy no longer leaves a code location in a terminal `ERROR` state
+that only a human can clear.
+
+**Architecture:** Three independent configuration changes, no new components.
+Two land in the Helm values for the Dagster Cloud agent and take effect on a
+manual `helm upgrade`; one lands in the five per-location `dagster-cloud.yaml`
+files and ships through the normal deploy pipeline. Nothing in this phase
+changes pod priority or the run-pod isolation.
+
+**Tech Stack:** GKE Autopilot, Helm (`dagster-cloud` agent chart), Dagster+
+hybrid agent, YAML.
+
+Design spec:
+`docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md`.
+Issue [#4907](https://github.com/TEAMSchools/teamster/issues/4907).
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values are copied
+verbatim from the spec.
+
+- **The run-pod-to-code-server isolation stays hard.** Do not change
+  `workspace.runK8sConfig.podSpecConfig.affinity.podAntiAffinity`. It remains
+  `requiredDuringSchedulingIgnoredDuringExecution`. It was added after a real
+  incident in which run pods starved and killed code servers, and `Evicted` has
+  been 0 for all four measured weeks.
+- **Code-server priority stays at 0.** Do not add `priorityClassName` to
+  `workspace.serverK8sConfig`.
+- `workspace.deploymentStartupTimeout` is set to `900`.
+- The annotation value is exactly
+  `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` — a quoted string,
+  not a bare boolean.
+- Code-server requests stay at `cpu: 500m` and `memory: 2.0Gi`. These meet the
+  Autopilot extended-duration minimum of 500m / 2GiB, which
+  `safe-to-evict: "false"` requires. Lowering either breaks the annotation.
+- Code servers must not be moved to spot. `safe-to-evict: "false"` and
+  `cloud.google.com/gke-spot` are mutually exclusive.
+- All five `dagster-cloud.yaml` files change together. A partial change leaves
+  locations behaving inconsistently for no reason.
+- **Helm value changes require a manual `helm upgrade`** run by the user. `helm`
+  and `kubectl` are not available to the agent in this environment, and
+  `kubectl` is classifier-blocked. Every Helm verification step is handed to the
+  user.
+- Baseline to compare against, from the spec. Code-server pods only
+  (`involvedObject.name` containing `-prod-`) in the `dagster-cloud` namespace:
+
+  | Week         | Agent gRPC errors | Killing | ScaleDown | Preempted | Evicted | FailedScheduling |
+  | ------------ | ----------------- | ------- | --------- | --------- | ------- | ---------------- |
+  | Jul 20-27    | 85                | 122     | 42        | 21        | 0       | 472              |
+  | Jul 28-Aug 4 | 134               | 197     | 59        | 37        | 0       | 454              |
+  | Aug 4-11     | 106               | 118     | 48        | 22        | 0       | 213              |
+  | Aug 11-18    | 100               | 142     | 38        | 32        | 0       | 438              |
+
+## Worktree
+
+All file paths below are relative to
+`/workspaces/teamster/.worktrees/claude-code-server-scheduling` on branch
+`cbini/fix/claude-code-server-scheduling`.
+
+Use `git -C /workspaces/teamster/.worktrees/claude-code-server-scheduling` for
+every git call. Run `trunk` as `/workspaces/teamster/.trunk/tools/trunk` with
+the working directory set to the worktree — a relative invocation from the main
+repo checks the main checkout's copies instead.
+
+## File Structure
+
+| File                                                          | Responsibility                                                                             | Delivery              |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------- |
+| `.k8s/dagster/values-override.yaml`                           | agent + workspace Helm config: the deployment timeout and the code-server pod annotations  | manual `helm upgrade` |
+| `src/teamster/code_locations/kippcamden/dagster-cloud.yaml`   | kippcamden per-location server affinity                                                    | normal deploy         |
+| `src/teamster/code_locations/kippmiami/dagster-cloud.yaml`    | kippmiami per-location server affinity                                                     | normal deploy         |
+| `src/teamster/code_locations/kippnewark/dagster-cloud.yaml`   | kippnewark per-location server affinity                                                    | normal deploy         |
+| `src/teamster/code_locations/kipppaterson/dagster-cloud.yaml` | kipppaterson per-location server affinity                                                  | normal deploy         |
+| `src/teamster/code_locations/kipptaf/dagster-cloud.yaml`      | kipptaf per-location server affinity                                                       | normal deploy         |
+| `.k8s/CLAUDE.md`                                              | operational reference: which timeout governs what, pre-warming, and the no-retry behaviour | docs                  |
+
+`.k8s/dagster/values.yaml` is auto-downloaded from Helm and must never be
+edited.
+
+## Tasks
+
+### Task 1: Helm workspace timeout and code-server eviction protection
+
+Both changes live in one file and take effect together on a single
+`helm upgrade`, so they are one task — there is no state in which one is applied
+and the other is not.
+
+**Files:**
+
+- Modify: `.k8s/dagster/values-override.yaml` (the `workspace` block, currently
+  starting at line 96)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: nothing later tasks depend on. Task 4 verifies the effect of this
+  task and Task 2 together.
+
+- [ ] **Step 1: Confirm the chart exposes the key and the current value is the
+      default**
+
+Run:
+
+```bash
+grep -n -B4 'deploymentStartupTimeout' /workspaces/teamster/.k8s/dagster/values.yaml
+grep -n 'deploymentStartupTimeout\|serverProcessStartupTimeout' \
+  /workspaces/teamster/.worktrees/claude-code-server-scheduling/.k8s/dagster/values-override.yaml
+```
+
+Expected: `values.yaml` documents `deploymentStartupTimeout: ~` with the comment
+"If not set, defaults to 300 seconds." The override file contains
+`serverProcessStartupTimeout: 300` and **no** `deploymentStartupTimeout` line.
+That absence is the defect — the governing timeout has never been set.
+
+If `deploymentStartupTimeout` already appears in the override file, stop:
+someone has changed this since the spec was written, and the plan needs
+revisiting.
+
+- [ ] **Step 2: Add the deployment timeout**
+
+In `.k8s/dagster/values-override.yaml`, replace:
+
+```yaml
+workspace:
+  serverProcessStartupTimeout: 300
+```
+
+with:
+
+```yaml
+workspace:
+  # Time the agent waits for a code server DEPLOYMENT to become ready -- in
+  # practice, for the pod to be scheduled. Distinct from
+  # serverProcessStartupTimeout below, which only starts once the Deployment
+  # exists. The chart default is 300s, which sits inside the 3-9 minute NAP
+  # FailedScheduling window documented in CLAUDE.md, so an ordinary provisioning
+  # wait times out. On timeout the agent uploads an error, the control plane
+  # records the location as ERROR, and _should_trigger_recovery then refuses to
+  # retry ("control plane agrees there is an error") -- the location stays dead
+  # until a push or a manual redeploy.
+  deploymentStartupTimeout: 900
+
+  serverProcessStartupTimeout: 300
+```
+
+- [ ] **Step 3: Add the eviction-protection annotation**
+
+In the same file, in `workspace.serverK8sConfig.podTemplateSpecMetadata`
+(currently line 131), replace:
+
+```yaml
+podTemplateSpecMetadata: # raw config for the pod's metadata
+  annotations:
+    operator.1password.io/auto-restart: "true"
+```
+
+with:
+
+```yaml
+podTemplateSpecMetadata: # raw config for the pod's metadata
+  annotations:
+    operator.1password.io/auto-restart: "true"
+    # Code servers were the only pod type without this -- the agent
+    # (dagsterCloudAgent.annotations) and run pods
+    # (runK8sConfig.podTemplateSpecMetadata) both carry it. Blocks
+    # cluster-autoscaler eviction, which accounted for 38-59 code-server
+    # relocations per week. Compatible here: requests above are 500m/2.0Gi,
+    # meeting the Autopilot extended-duration minimum, and code servers are
+    # not on spot (the two are mutually exclusive). Note extended-duration
+    # protection expires after 7 days, which is far longer than the interval
+    # between deploys.
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+```
+
+- [ ] **Step 4: Verify the file still parses and the constraints hold**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && uv run python -c "
+import yaml
+d = yaml.safe_load(open('.k8s/dagster/values-override.yaml'))
+w = d['workspace']
+assert w['deploymentStartupTimeout'] == 900, w.get('deploymentStartupTimeout')
+assert w['serverProcessStartupTimeout'] == 300
+ann = w['serverK8sConfig']['podTemplateSpecMetadata']['annotations']
+assert ann['cluster-autoscaler.kubernetes.io/safe-to-evict'] == 'false', ann
+assert ann['operator.1password.io/auto-restart'] == 'true', ann
+req = w['serverK8sConfig']['containerConfig']['resources']['requests']
+assert req['cpu'] == '500m' and req['memory'] == '2.0Gi', req
+run_aff = w['runK8sConfig']['podSpecConfig']['affinity']['podAntiAffinity']
+assert 'requiredDuringSchedulingIgnoredDuringExecution' in run_aff, 'run-pod isolation must stay required'
+assert 'priorityClassName' not in w['serverK8sConfig'].get('podSpecConfig', {}), 'code-server priority must stay 0'
+print('OK: timeout 900, safe-to-evict false as string, requests unchanged, isolation intact, no priority class')
+"
+```
+
+Expected: `OK: ...`. The `safe-to-evict` assertion compares against the
+**string** `'false'`; if it fails with `False`, the value was written as a bare
+YAML boolean and must be quoted.
+
+- [ ] **Step 5: Lint**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  .k8s/dagster/values-override.yaml </dev/null
+```
+
+Expected: `No issues`, or only `unformatted file` from prettier, which the
+pre-commit `fmt` hook fixes. Any `yamllint` finding naming a rule must be fixed
+before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+git add .k8s/dagster/values-override.yaml && \
+git commit -m "fix(k8s): set deploymentStartupTimeout and protect code servers from autoscaler eviction
+
+deploymentStartupTimeout was never set, so it sat at the chart default of 300s
+while .k8s/CLAUDE.md documents NAP FailedScheduling waits of 3 to 9 minutes. An
+ordinary provisioning wait therefore times out, and the resulting error is
+terminal: once the control plane records the location as ERROR,
+_should_trigger_recovery refuses to retry it.
+
+Code servers were also the only pod type with no safe-to-evict annotation; the
+agent and run pods both carry it. That accounted for 38 to 59 autoscaler
+relocations per week.
+
+Neither change touches pod priority or the run-pod isolation.
+
+Refs #4907"
+```
+
+### Task 2: Relax the per-location self-anti-affinity to preferred
+
+**Files:**
+
+- Modify: `src/teamster/code_locations/kippcamden/dagster-cloud.yaml:21-32`
+- Modify: `src/teamster/code_locations/kippmiami/dagster-cloud.yaml:21-32`
+- Modify: `src/teamster/code_locations/kippnewark/dagster-cloud.yaml:21-32`
+- Modify: `src/teamster/code_locations/kipppaterson/dagster-cloud.yaml:21-32`
+- Modify: `src/teamster/code_locations/kipptaf/dagster-cloud.yaml:34-45`
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1. This task is independently landable.
+- Produces: nothing later tasks import. Task 4 measures its effect.
+
+**Critical structural note.** `preferred` is not a rename of `required`. The
+required form takes a list of `PodAffinityTerm` directly; the preferred form
+takes a list of `WeightedPodAffinityTerm`, where each entry is `weight` plus a
+nested `podAffinityTerm`. Renaming the key without adding that wrapper produces
+config the agent rejects at deploy time. Use `weight: 100`, the maximum, so the
+scheduler still prefers separation as strongly as it can while no longer
+treating it as a hard requirement.
+
+- [ ] **Step 1: Confirm all five files currently hold the required form**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+grep -c 'requiredDuringSchedulingIgnoredDuringExecution' \
+  src/teamster/code_locations/*/dagster-cloud.yaml
+```
+
+Expected: exactly `1` for each of the five files. If any file reports `0`, it
+has already been changed; if any reports `2` or more, it has additional affinity
+rules this plan does not account for and you should stop and re-read the file.
+
+- [ ] **Step 2: Rewrite the affinity block in each of the five files**
+
+For each location, replace the `server_k8s_config.pod_spec_config.affinity`
+block. Shown for `kippcamden`; repeat for `kippmiami`, `kippnewark`,
+`kipppaterson`, and `kipptaf`, substituting the location name in `values`. Do
+not copy kippcamden's name into the other four files.
+
+Replace:
+
+```yaml
+server_k8s_config:
+  pod_spec_config:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: location_name
+                  operator: In
+                  values:
+                    - kippcamden
+            topologyKey: kubernetes.io/hostname
+```
+
+with:
+
+```yaml
+server_k8s_config:
+  pod_spec_config:
+    affinity:
+      podAntiAffinity:
+        # Preferred, not required. With one replica per location this
+        # spreads nothing; as `required` its only live effect was
+        # forbidding the replacement pod from the outgoing pod's node
+        # during a rollover -- the one node guaranteed to have arm64
+        # Scale-Out capacity sized for a code server and, by the run-pod
+        # anti-affinity, no run pods on it. That forced NAP to build a new
+        # node on every redeploy. Cross-location spreading is handled
+        # separately by topologySpreadConstraints in the Helm values.
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: location_name
+                    operator: In
+                    values:
+                      - kippcamden
+              topologyKey: kubernetes.io/hostname
+```
+
+- [ ] **Step 3: Verify all five files parse and match the
+      WeightedPodAffinityTerm shape**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && uv run python -c "
+import pathlib, yaml
+locs = ['kippcamden', 'kippmiami', 'kippnewark', 'kipppaterson', 'kipptaf']
+for loc in locs:
+    p = pathlib.Path(f'src/teamster/code_locations/{loc}/dagster-cloud.yaml')
+    d = yaml.safe_load(p.read_text())
+    loc_cfg = d['locations'][0]
+    aff = loc_cfg['container_context']['k8s']['server_k8s_config']['pod_spec_config']['affinity']
+    anti = aff['podAntiAffinity']
+    assert 'requiredDuringSchedulingIgnoredDuringExecution' not in anti, f'{loc} still required'
+    terms = anti['preferredDuringSchedulingIgnoredDuringExecution']
+    assert len(terms) == 1, f'{loc}: {len(terms)} terms'
+    t = terms[0]
+    assert t['weight'] == 100, f'{loc}: weight is not 100'
+    pat = t['podAffinityTerm']
+    assert pat['topologyKey'] == 'kubernetes.io/hostname', f'{loc} topologyKey'
+    vals = pat['labelSelector']['matchExpressions'][0]['values']
+    assert vals == [loc], f'{loc} selects {vals}'
+    print(f'{loc}: OK')
+"
+```
+
+Expected: five `OK` lines. The `vals == [loc]` assertion is what catches a
+copy-paste that left `kippcamden` in another location's file — the most likely
+error in this task.
+
+If the `d['locations'][0]['container_context']['k8s']` path raises `KeyError`,
+print the parsed structure and adjust the accessor; the assertion targets are
+the values, not the path.
+
+- [ ] **Step 4: Confirm the run-pod isolation was not touched**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && uv run python -c "
+import yaml
+d = yaml.safe_load(open('.k8s/dagster/values-override.yaml'))
+anti = d['workspace']['runK8sConfig']['podSpecConfig']['affinity']['podAntiAffinity']
+assert 'requiredDuringSchedulingIgnoredDuringExecution' in anti, 'run-pod isolation lost'
+assert 'preferredDuringSchedulingIgnoredDuringExecution' not in anti, 'run-pod isolation weakened'
+terms = anti['requiredDuringSchedulingIgnoredDuringExecution']
+assert len(terms) == 2, f'expected 2 run-pod anti-affinity terms, found {len(terms)}'
+print('OK: run-pod isolation still required, both terms intact')
+"
+```
+
+Expected: `OK: run-pod isolation still required, both terms intact`. This reads
+the committed file rather than a diff, so it cannot pass vacuously. The two
+terms are the code-server selector and the agent selector; losing either would
+silently undo the isolation this phase promises to preserve.
+
+- [ ] **Step 5: Lint all five files**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/teamster/code_locations/kippcamden/dagster-cloud.yaml \
+  src/teamster/code_locations/kippmiami/dagster-cloud.yaml \
+  src/teamster/code_locations/kippnewark/dagster-cloud.yaml \
+  src/teamster/code_locations/kipppaterson/dagster-cloud.yaml \
+  src/teamster/code_locations/kipptaf/dagster-cloud.yaml </dev/null
+```
+
+Expected: `No issues`, or only prettier `unformatted file`. This check takes
+over two minutes across five files, so run it in the background and read the
+output file only after it exits — its progress spinner emits no result lines, so
+grepping partial output reads as a false clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+git add src/teamster/code_locations/kippcamden/dagster-cloud.yaml \
+        src/teamster/code_locations/kippmiami/dagster-cloud.yaml \
+        src/teamster/code_locations/kippnewark/dagster-cloud.yaml \
+        src/teamster/code_locations/kipppaterson/dagster-cloud.yaml \
+        src/teamster/code_locations/kipptaf/dagster-cloud.yaml && \
+git commit -m "fix(k8s): relax per-location code server self-anti-affinity to preferred
+
+With one replica per location the required form spreads nothing. Its only live
+effect was forbidding the replacement pod from the outgoing pod's node during a
+rollover -- the one node guaranteed to have arm64 Scale-Out capacity sized for a
+code server and, by the run-pod anti-affinity, no run pods on it. That forced NAP
+to provision a new node on every redeploy, which is what pushes placement past
+the startup timeout.
+
+Cross-location spreading is unaffected; it comes from topologySpreadConstraints
+in the Helm values, not from this rule.
+
+Preferred takes WeightedPodAffinityTerm rather than PodAffinityTerm, so the term
+is nested under podAffinityTerm with weight 100.
+
+The run-pod-to-code-server isolation is unchanged and stays required.
+
+Refs #4907"
+```
+
+### Task 3: Correct the operational documentation
+
+**Files:**
+
+- Modify: `.k8s/CLAUDE.md` — the "Timeout types (do not conflate)" bullet in
+  Troubleshooting, the "Autopilot node pre-warming" bullet in Troubleshooting,
+  and the "Agent Error Observability" section
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing.
+
+This task exists because the documentation gap actively caused a wrong
+diagnosis: the "Timeout types" bullet documents only
+`serverProcessStartupTimeout`, which led to identifying the wrong knob during
+the investigation behind this plan.
+
+- [ ] **Step 1: Replace the timeout-types bullet**
+
+In `.k8s/CLAUDE.md`, find the bullet beginning
+`- **Timeout types** (do not conflate):` and replace that whole bullet with:
+
+```markdown
+- **Timeout types** (do not conflate). Three distinct waits, in the order they
+  occur:
+  1. **Deployment startup** (`deploymentStartupTimeout`, Helm `workspace` key,
+     chart default 300s, set to 900s) — agent waits for the code server
+     Deployment to become ready, i.e. for the pod to be SCHEDULED. This is the
+     one that fires during a NAP `FailedScheduling` wait, and its failure
+     message is `Timed out waiting for deployment <name>` with
+     `Pod status: Pending`. Governs `wait_for_deployment_complete`, not
+     `_wait_for_dagster_server_process`.
+  1. **Server process startup** (`serverProcessStartupTimeout`, Helm `workspace`
+     key, default 180s, set to 300s) — agent waits for a gRPC ping AFTER the
+     Deployment exists. Fires when Dagster definitions are slow to import, not
+     when the pod cannot be placed.
+  1. **Sensor execution** (300s, Dagster+ deployment setting) — sensor ran too
+     long; the code server stays up and no churn results.
+```
+
+- [ ] **Step 2: Replace the pre-warming bullet**
+
+Find the bullet beginning `- **Autopilot node pre-warming**: Not possible` and
+replace that whole bullet with:
+
+```markdown
+- **Autopilot node pre-warming**: no node-lifecycle control — no DaemonSets, no
+  image pre-pulling, no cordon that holds. But capacity CAN be reserved at the
+  workload layer with balloon pods: a Deployment of placeholder pods on a
+  negative `PriorityClass` holds nodes that real pods preempt instantly, and the
+  displaced placeholder then triggers NAP to re-warm the buffer. Google
+  documents this for Autopilot. Not currently deployed here; see
+  `docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md`
+  Phase 2, which is gated on verifying Warden admits a negative priority value.
+```
+
+- [ ] **Step 3: Document the no-retry behaviour**
+
+In the "Agent Error Observability" section, append this bullet after the
+existing "Hybrid daemon location" bullet:
+
+```markdown
+- **A timed-out code server deployment is TERMINAL — the agent never retries
+  it.** `_should_trigger_recovery` in
+  `dagster_cloud/workspace/user_code_launcher/user_code_launcher.py` returns
+  `False` when the location is in `control_plane_error_locations` ("control
+  plane agrees there is an error, don't retry"). Recovery fires only when the
+  agent holds a local error while the control plane thinks the location is
+  healthy. Normal reconciliation redeploys only when
+  `actual_entry.update_timestamp != desired_entry.update_timestamp`, which
+  changes on a new deploy, and the periodic health check needs a running
+  endpoint a never-started pod does not have. So a location that fails to
+  schedule stays `ERROR` until someone pushes a commit or clicks redeploy. No
+  agent setting changes this;
+  `DAGSTER_CLOUD_DISABLE_LOCAL_ERROR_SERVER_RECOVERY` only turns recovery off.
+```
+
+- [ ] **Step 4: Lint the documentation**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix .k8s/CLAUDE.md </dev/null
+```
+
+Expected: `No issues`, or only prettier `unformatted file`. Watch specifically
+for markdownlint `MD029` on the numbered list added in Step 1 — every item must
+be `1.`, because `trunk fmt` renumbers sequentially and a nested list under a
+bullet restarts numbering.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && \
+git add .k8s/CLAUDE.md && \
+git commit -m "docs(k8s): distinguish the three startup timeouts, correct pre-warming, record no-retry
+
+The Timeout types bullet documented only serverProcessStartupTimeout and omitted
+deploymentStartupTimeout entirely, which is the timeout that actually fires during
+a NAP FailedScheduling wait. That gap caused a wrong diagnosis during the
+investigation behind #4907.
+
+Also corrects the claim that Autopilot pre-warming is impossible -- true of
+DaemonSets and image pre-pulling, but balloon pods are a documented workload-layer
+option -- and records that a timed-out code server deployment is terminal, since
+that is the operational consequence and it was nowhere in the repo.
+
+Refs #4907"
+```
+
+### Task 4: Deploy, activate, and verify
+
+This task is split between the agent and the user because the agent cannot run
+`helm` or `kubectl` in this environment.
+
+**Files:** none modified.
+
+**Interfaces:**
+
+- Consumes: Tasks 1, 2, and 3, all committed.
+
+- [ ] **Step 1: Push and open the pull request**
+
+```bash
+cd /workspaces/teamster/.worktrees/claude-code-server-scheduling && git push
+```
+
+Then open a PR using `.github/pull_request_template.md`, with `Refs #4907` in
+the body. Note in Reviewer Notes that the Helm half requires a manual
+`helm upgrade` and does not take effect on merge.
+
+- [ ] **Step 2: Confirm CI is green on both surfaces**
+
+A PR's CI lives on two disjoint surfaces. Check both:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,bucket
+```
+
+Expected: every entry `pass` or `skipping`. `dagster-cloud-deploy / deploy`
+emits one same-named check-run per code location, roughly five, so wait for all
+of them to reach a terminal state. `mergeable_state: blocked` with everything
+green means the change is waiting on a CODEOWNERS approval, not on CI.
+
+- [ ] **Step 3: After merge, confirm all five locations reloaded**
+
+The `dagster-cloud.yaml` change from Task 2 ships on merge. Confirm each
+location actually picked it up rather than assuming a green deploy job means it
+did:
+
+```text
+Call mcp__dagster__get_location_load_history for each of kipptaf, kippnewark,
+kippcamden, kippmiami, kipppaterson with limit=3. For each location the newest
+entry must read loadStatus LOADED with a commit_hash matching the merge commit.
+```
+
+Expected: five locations, newest entry `LOADED`, matching commit hash. A green
+Actions deploy job is not evidence the agent reloaded.
+
+- [ ] **Step 4: USER ACTION — run the Helm upgrade**
+
+The Task 1 changes do nothing until this runs. Hand the user:
+
+```bash
+cd /workspaces/teamster && bash .k8s/dagster/install.sh
+```
+
+If `helm: command not found` or the cluster is unreachable, `.k8s/setup.sh` has
+not been run in this shell; run that first. `install.sh` is deploy-only and must
+not have bootstrap logic added to it.
+
+- [ ] **Step 5: USER ACTION — confirm the new timeout is live**
+
+```bash
+kubectl -n dagster-cloud get configmap \
+  -l app.kubernetes.io/name=dagster-cloud-agent -o yaml \
+  | grep -i -B3 -A3 'startup_timeout'
+```
+
+Expected: the agent's rendered config shows a deployment startup timeout of 900.
+If only the server-process timeout appears, the override did not reach the
+rendered config and Task 1 Step 2 should be re-checked before going further.
+
+- [ ] **Step 6: USER ACTION — confirm the annotation lands on new code server
+      pods**
+
+The annotation applies to pods created after the upgrade; existing code servers
+keep the old spec until they are recycled.
+
+```bash
+kubectl -n dagster-cloud get pods -l managed_by=K8sUserCodeLauncher \
+  -o custom-columns='NAME:.metadata.name,SAFE_TO_EVICT:.metadata.annotations.cluster-autoscaler\.kubernetes\.io/safe-to-evict'
+```
+
+Expected: `false` for every code-server pod created after the upgrade. Pods
+still showing `<none>` predate it and will pick it up on their next rollover.
+
+- [ ] **Step 7: Measure against the baseline after one week**
+
+Re-run the same six counters over a full week and compare with the Global
+Constraints table. Query shapes, against project `teamster-332318`:
+
+Agent gRPC failures:
+
+```text
+resource.type="k8s_container"
+resource.labels.namespace_name="dagster-cloud"
+resource.labels.pod_name:"user-cloud-dagster-cloud-agent"
+textPayload:"Could not reach user code server"
+```
+
+Code-server disruptions, run once per reason substituting `Preempted`,
+`ScaleDown`, `Killing`, `Evicted`, `FailedScheduling`:
+
+```text
+resource.type="k8s_pod"
+resource.labels.namespace_name="dagster-cloud"
+logName:"events"
+jsonPayload.involvedObject.name:"-prod-"
+jsonPayload.reason="REASON"
+```
+
+These queries return well over 100 entries per week, so paginate: when a query
+returns exactly 100, re-run it with the start time advanced to the last returned
+timestamp rounded up to the next whole second, and sum. Use
+`format="{{.timestamp}}"` to keep the output small.
+
+Success criteria, from the spec:
+
+- Zero `loadStatus: ERROR` entries carrying the
+  `Timed out waiting for deployment` signature in any location's load history.
+- `FailedScheduling` on code-server pods materially below the 213 to 472 band.
+- Agent gRPC errors below the 85 to 134 per week band.
+- `Evicted` still 0, which is the check that the isolation was not weakened.
+
+- [ ] **Step 8: Record the result on the issue**
+
+Post the measured week as a comment on
+[#4907](https://github.com/TEAMSchools/teamster/issues/4907) next to the
+baseline table, and state plainly whether Phases 2 and 3 are still warranted at
+the originally proposed scale. If `FailedScheduling` collapsed and no terminal
+failures occurred, Phase 2's continuous cost may no longer be justified and
+Phase 3 may be the only remaining gap. Do not open the Phase 2 or Phase 3 plans
+before this measurement exists.
+
+## Notes for the implementer
+
+- Do not run `trunk fmt` or `trunk check` outside the steps that call for it.
+  The `trunk-fmt-pre-commit` hook formats at commit time and
+  `trunk-check-pre-push` gates the push.
+- A `--force` check over five files takes more than two minutes. Background it
+  and read the output only after it exits.
+- The `trunk` binary lives only in the main repo; `.trunk/tools/` is gitignored
+  and absent from the worktree. If `/workspaces/teamster/.trunk/tools/trunk`
+  does not exist on a cold Codespace, use `~/.cache/trunk/launcher/trunk`, which
+  is always present and creates the symlink on first run.
+- Editing files under the worktree path re-injects that worktree's CLAUDE.md
+  files into context on every call. For a multi-file pass like Task 2, either
+  delegate the edits to subagents or apply them with a script written to
+  `.claude/scratch/` and run by absolute path from the main repo.
+- Nothing in this phase may add a `priorityClassName` to `serverK8sConfig` or
+  weaken `runK8sConfig`'s anti-affinity. If a step seems to require either, stop
+  and re-read the Global Constraints.

--- a/docs/superpowers/plans/2026-08-18-code-server-scheduling-phase-1.md
+++ b/docs/superpowers/plans/2026-08-18-code-server-scheduling-phase-1.md
@@ -258,6 +258,13 @@ Refs #4907"
 - Consumes: nothing from Task 1. This task is independently landable.
 - Produces: nothing later tasks import. Task 4 measures its effect.
 
+**Superseded in part.** The YAML-key assertion in Step 3 below is weaker than
+this note claims: it would pass on `podAffinityTerms` (plural) or a stray
+`weight` inside `podAffinityTerm`. `tests/test_k8s_config.py` now runs the
+agent's own coercion (`k8s_model_from_dict(V1PodSpec, ...)`), which rejects
+both, and includes a negative case proving it is not vacuous. Prefer that check
+for Phases 2 and 3.
+
 **Critical structural note.** `preferred` is not a rename of `required`. The
 required form takes a list of `PodAffinityTerm` directly; the preferred form
 takes a list of `WeightedPodAffinityTerm`, where each entry is `weight` plus a

--- a/docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
@@ -90,9 +90,18 @@ provisioning lands in the upper half of normal.
 
 ## Constraints
 
-- **The run-pod-to-code-server isolation stays hard.** It was added in response
-  to a real incident in which run pods starved and killed code servers. Relaxing
-  `required` to `preferred` there is out of scope.
+- **The run-pod anti-affinity against code servers stays `required`.** It was
+  added in response to a real incident in which run pods starved and killed code
+  servers. Relaxing it to `preferred` is out of scope.
+
+  Note the vocabulary: `.k8s/CLAUDE.md` forbids calling this rule "isolating"
+  code servers or "preventing co-location", because a `required` anti-affinity
+  authorizes the scheduler to PREEMPT the target pods when no other node fits.
+  What it guarantees is that no node holds a run pod and a code server at the
+  same instant. The mechanism by which that holds is that code servers get
+  evicted, which is why `Preempted` runs at 21 to 37 per week while `Evicted`
+  stays at 0.
+
 - **Code-server priority stays at 0.** Promoting code servers above
   `dagster-run` would make run pods wait instead, reversing a deliberate
   decision recorded in `.k8s/CLAUDE.md`. Explicitly declined.
@@ -115,8 +124,9 @@ in the `dagster-cloud` namespace. Retention is 30 days, so nothing before
 The reported recent uptick is not present; the peak was Jul 28 to Aug 4 and the
 two most recent weeks are lower. This is chronic, not a regression.
 
-`Evicted` at 0 across all four weeks confirms the isolation is doing its job. It
-buys that at the cost of the preemptions and scheduling failures.
+`Evicted` at 0 across all four weeks confirms the run-pod anti-affinity is
+holding. It buys that by having code servers preempted instead, which is what
+the 21 to 37 weekly `Preempted` events are.
 
 ## Design
 
@@ -129,7 +139,7 @@ phase is independently revertable.
 | ------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
 | `deploymentStartupTimeout: 900`                               | Helm `workspace`                                      | agent waits out a normal NAP provision instead of abandoning at 300s |
 | add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` | `serverK8sConfig.podTemplateSpecMetadata.annotations` | removes 38 to 59 autoscaler relocations per week                     |
-| self-anti-affinity `required` to `preferred`                  | all five `dagster-cloud.yaml`                         | lets a rollover reuse the outgoing pod's node                        |
+| self-anti-affinity `required` to `preferred`                  | all five `dagster-cloud.yaml`                         | makes the outgoing pod's node feasible again, removing the NAP wait  |
 
 The self-anti-affinity change is the highest-leverage item and needs
 justification, because it looks like a safety feature.
@@ -252,14 +262,17 @@ this first, against a location deliberately put into the timeout state.
 
 ## Failure modes
 
-| Risk                                             | Mitigation                                                                                                                     |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| Watchdog masks a real code defect                | Signature gate plus attempt cap; genuine errors do not match and are never retried                                             |
-| Watchdog races a deploy                          | Skip when `codeLocationUpdateTriggerTimestamp` is recent                                                                       |
-| Placeholder starves real workloads               | Negative priority plus `preemptionPolicy: Never`; it can never displace anything                                               |
-| Warm node reclaimed by autoscaler                | Gate item 2 above; pin with `safe-to-evict` if needed                                                                          |
-| Longer timeout delays real-failure feedback      | Accepted; bad images still surface at 30s via `imagePullGracePeriod`                                                           |
-| Rollover co-locates two code servers on one node | Only under `preferred`; node must fit two 500m/2Gi pods or the scheduler picks elsewhere, which is the current behavior anyway |
+| Risk                                                               | Mitigation                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Watchdog masks a real code defect                                  | Signature gate plus attempt cap; genuine errors do not match and are never retried                                                                                                                                                                                                                                                                                                    |
+| Watchdog races a deploy                                            | Skip when `codeLocationUpdateTriggerTimestamp` is recent                                                                                                                                                                                                                                                                                                                              |
+| Placeholder starves real workloads                                 | Negative priority plus `preemptionPolicy: Never`; it can never displace anything                                                                                                                                                                                                                                                                                                      |
+| Warm node reclaimed by autoscaler                                  | Gate item 2 above; pin with `safe-to-evict` if needed                                                                                                                                                                                                                                                                                                                                 |
+| Longer timeout delays real-failure feedback                        | Accepted; bad images still surface at 30s via `imagePullGracePeriod`                                                                                                                                                                                                                                                                                                                  |
+| Rollover co-locates two code servers on one node                   | Only under `preferred`. The scheduler still penalizes that node twice (the preferred term and the hostname `topologySpreadConstraint`), so it picks elsewhere whenever anything else fits                                                                                                                                                                                             |
+| A single run-pod preemption takes BOTH code servers for a location | New under `preferred`: the hard self-anti-affinity previously forced the incoming and outgoing pods onto separate nodes, so one preemption could only ever take one. Self-limiting (the scheduler prefers the cheapest victim set) but non-zero, and it lands in the exact rollover window this change exists to protect. Watch `Preempted`                                           |
+| Two co-located code servers burst above node allocatable           | Requests are 500m / 2.0Gi but limits are 1000m / 2.5Gi, so two pods admitted on 1000m / 4.0Gi of requests can burst to 2000m / 5.0Gi. `safe-to-evict: "false"` does NOT block kubelet node-pressure eviction, and priority-0 code servers are evicted first. The rollover window is exactly when the incoming pod imports kipptaf's definitions and bursts past 750m. Watch `Evicted` |
+| Raising `deploymentStartupTimeout` breaks the agent's own budgets  | The readiness sentinel is only written after the first full reconcile, so the probe budget, the cleanup grace period, and `install.sh`'s `rollout status --timeout` must all exceed `deploymentStartupTimeout + serverProcessStartupTimeout`. Asserted in `tests/test_k8s_config.py`                                                                                                  |
 
 ## Verification
 
@@ -271,13 +284,22 @@ Success criteria:
 - Zero `loadStatus: ERROR` entries carrying the timeout signature.
 - `FailedScheduling` on code-server pods materially below the 213 to 472 band.
 - Agent gRPC errors below the 85 to 134 per week band.
-- `Evicted` still 0, confirming the isolation was not weakened.
+- `Evicted` still 0. This is the tripwire for the co-located-burst risk above,
+  not merely a formality.
+- `Preempted` no higher than the 21 to 37 per week baseline. Per the
+  failure-modes table this is the counter most likely to move under `preferred`,
+  so it is a must-not-regress rather than informational.
+- No node hosts two code servers once a rollover has settled. Both new risks
+  above are specific to that window, so confirm it closes.
 
 Per-phase checks:
 
 - Phase 1: confirm the new timeout is live via the agent Deployment spec after
-  `helm upgrade`; confirm all five locations reload cleanly after the
-  `dagster-cloud.yaml` change.
+  `helm upgrade`; confirm the agent pod itself reaches Ready rather than
+  stalling on its readiness probe, since raising `deploymentStartupTimeout` also
+  raises the worst-case first reconcile; confirm all five locations reload
+  cleanly after the `dagster-cloud.yaml` change; confirm no node ends up hosting
+  two code servers for the same location once the rollover settles.
 - Phase 2: the three gate items, then confirm a code-server rollover schedules
   in seconds rather than minutes.
 - Phase 3: force a location into the timeout state, confirm the watchdog

--- a/docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
@@ -1,0 +1,307 @@
+# Code server scheduling resilience
+
+Design for [#4907](https://github.com/TEAMSchools/teamster/issues/4907).
+
+Date: 2026-08-18
+
+## Problem
+
+Code locations intermittently fail to load and stay failed until a human
+intervenes. Separately, the Dagster+ hybrid agent logs
+`DagsterUserCodeUnreachableError: Could not reach user code server` at roughly
+100 occurrences per week.
+
+Both come from the same place: a replacement code-server pod cannot be scheduled
+quickly, and the agent abandons it while Kubernetes is still legitimately
+working on placement.
+
+### The terminal failure is the priority
+
+A timed-out code-server deployment does **not** retry. Verified in
+`dagster_cloud/workspace/user_code_launcher/user_code_launcher.py`:
+
+```python
+def _should_trigger_recovery(...) -> bool:
+    if not isinstance(server_or_error, SerializableErrorInfo):
+        return False  # local code server is healthy, no recovery needed
+    if location_key in control_plane_error_locations:
+        return False  # control plane agrees there is an error, don't retry
+```
+
+The recovery path fires only when the agent holds a local error while the
+control plane believes the location is healthy. Once the timeout error is
+uploaded, both agree, and recovery is suppressed. Normal reconciliation
+redeploys only when
+`actual_entry.update_timestamp != desired_entry.update_timestamp`, which changes
+on a new deploy. The periodic health check needs a running endpoint, which a pod
+that never started does not have.
+
+So the location stays `ERROR` until someone pushes a commit or clicks redeploy.
+There is no agent setting that changes this; the launcher exposes
+`DAGSTER_CLOUD_DISABLE_LOCAL_ERROR_SERVER_RECOVERY`, which only turns recovery
+off.
+
+### Why placement is slow
+
+A replacement code-server pod must satisfy four hard constraints at once:
+
+1. `nodeSelector` of `cloud.google.com/compute-class: Scale-Out` plus
+   `kubernetes.io/arch: arm64`, so only NAP-provisioned T2A nodes qualify
+   (`.k8s/dagster/values-override.yaml`).
+1. Its own per-location `requiredDuringSchedulingIgnoredDuringExecution`
+   anti-affinity on `location_name` plus `kubernetes.io/hostname`, from each
+   district's `dagster-cloud.yaml`.
+1. Symmetric enforcement of the run pods' `required` anti-affinity against
+   code-server labels. Kubernetes evaluates existing pods' anti-affinity when
+   placing a new pod, which produces the
+   `didn't satisfy existing pods anti-affinity rules` line. A code server
+   therefore cannot land on any node hosting a run or step pod.
+1. Whatever cpu and memory remains after the above.
+
+During busy periods nearly every arm64 node hosts run pods, so the eligible set
+reaches zero and NAP must build a new node. Captured from kipptaf at
+approximately 2026-08-18 14:30 UTC:
+
+```text
+Exception: Timed out waiting for deployment kipptaf-prod-5c5421.
+
+Pod status: Pending
+
+No logs for container 'dagster'.
+
+FailedScheduling: 0/7 nodes are available: 1 node(s) didn't match Pod's node
+affinity/selector, 1 node(s) didn't match pod anti-affinity rules, 2 node(s)
+had untolerated taint(s), 3 Insufficient cpu, 3 Insufficient memory.
+```
+
+### The governing timeout was never tuned
+
+Two timeouts govern code-server startup and the failing path uses the one still
+at its default:
+
+| Helm key                                | Governs                                                 | Current        |
+| --------------------------------------- | ------------------------------------------------------- | -------------- |
+| `workspace.deploymentStartupTimeout`    | creating the Deployment, i.e. getting the pod scheduled | unset, so 300s |
+| `workspace.serverProcessStartupTimeout` | waiting for readiness once the Deployment exists        | 300            |
+
+`.k8s/CLAUDE.md` documents NAP `FailedScheduling` waits of 3 to 9 minutes. A 300
+second deadline sits inside that range, so failures are expected whenever
+provisioning lands in the upper half of normal.
+
+## Constraints
+
+- **The run-pod-to-code-server isolation stays hard.** It was added in response
+  to a real incident in which run pods starved and killed code servers. Relaxing
+  `required` to `preferred` there is out of scope.
+- **Code-server priority stays at 0.** Promoting code servers above
+  `dagster-run` would make run pods wait instead, reversing a deliberate
+  decision recorded in `.k8s/CLAUDE.md`. Explicitly declined.
+- Helm value changes require a manual `helm upgrade`; they do not ship with a
+  git push.
+
+## Measured baseline
+
+Cloud Logging, code-server pods only (`involvedObject.name` containing `-prod-`)
+in the `dagster-cloud` namespace. Retention is 30 days, so nothing before
+2026-07-19 is observable.
+
+| Week         | Agent gRPC errors | Killing | ScaleDown | Preempted | Evicted | FailedScheduling |
+| ------------ | ----------------- | ------- | --------- | --------- | ------- | ---------------- |
+| Jul 20-27    | 85                | 122     | 42        | 21        | 0       | 472              |
+| Jul 28-Aug 4 | 134               | 197     | 59        | 37        | 0       | 454              |
+| Aug 4-11     | 106               | 118     | 48        | 22        | 0       | 213              |
+| Aug 11-18    | 100               | 142     | 38        | 32        | 0       | 438              |
+
+The reported recent uptick is not present; the peak was Jul 28 to Aug 4 and the
+two most recent weeks are lower. This is chronic, not a regression.
+
+`Evicted` at 0 across all four weeks confirms the isolation is doing its job. It
+buys that at the cost of the preemptions and scheduling failures.
+
+## Design
+
+Three phases, separately landable, ordered so value arrives before risk. Each
+phase is independently revertable.
+
+### Phase 1: no-tradeoff tuning
+
+| Change                                                        | Location                                              | Effect                                                               |
+| ------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `deploymentStartupTimeout: 900`                               | Helm `workspace`                                      | agent waits out a normal NAP provision instead of abandoning at 300s |
+| add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` | `serverK8sConfig.podTemplateSpecMetadata.annotations` | removes 38 to 59 autoscaler relocations per week                     |
+| self-anti-affinity `required` to `preferred`                  | all five `dagster-cloud.yaml`                         | lets a rollover reuse the outgoing pod's node                        |
+
+The self-anti-affinity change is the highest-leverage item and needs
+justification, because it looks like a safety feature.
+
+Each location's code server carries `required` anti-affinity against its **own**
+`location_name` on hostname. With one replica per location it spreads nothing.
+Its only live effect is forbidding the replacement pod from the outgoing pod's
+node during a rollover — and that node is the single best candidate available:
+it already has arm64 Scale-Out capacity sized for a code server, and the run-pod
+anti-affinity guarantees no run pods are on it. The constraint specifically
+excludes the one node guaranteed to satisfy every other requirement, forcing a
+new node on every redeploy.
+
+Cross-location spreading is handled separately by `topologySpreadConstraints`
+(`ScheduleAnyway` on zone and hostname), so nothing else depends on this rule.
+
+`affinity` is permitted in per-location config:
+`onlyAllowUserDefinedK8sConfigFields.podSpecConfig.affinity` is `true`.
+
+`safe-to-evict: "false"` is compatible: code servers already request 500m and
+2.0Gi, meeting the Autopilot extended-duration minimum, and are not on spot (the
+two are mutually exclusive).
+
+**Accepted downside of the timeout change.** A genuinely broken deployment, such
+as a crash-looping container, now takes 900s to surface rather than 300s. Broken
+images are unaffected, handled separately by `imagePullGracePeriod` at its 30s
+default.
+
+Items 1 and 2 are Helm and need `helm upgrade`. Item 3 ships through the normal
+per-location deploy and will redeploy all five locations.
+
+### Phase 2: warm capacity
+
+Reserve pre-provisioned arm64 capacity so code-server placement does not wait on
+NAP. This is the balloon-pod pattern Google documents for Autopilot.
+
+Two objects:
+
+- A `PriorityClass` with a negative value (`-10`), `globalDefault: false`, and
+  `preemptionPolicy: Never` so the placeholder never displaces anything itself.
+- A `Deployment` of placeholder pods running `pause`, with requests matching a
+  code server (500m cpu, 2Gi memory), the same `Scale-Out` plus `arm64`
+  `nodeSelector`, and labels `managed_by: K8sUserCodeLauncher` plus
+  `deployment_name: prod`.
+
+Because the placeholder ranks below everything, a code server preempts it
+immediately and takes its node with no provisioning wait. The displaced
+placeholder goes `Pending`, which triggers NAP to build a replacement node in
+the background and re-warm the buffer.
+
+**The label choice reserves the buffer for code servers.** Carrying
+`managed_by: K8sUserCodeLauncher` and `deployment_name: prod` while deliberately
+omitting `location_name` means run pods treat those nodes as code-server nodes
+and stay off them, while a code server can still land there because its
+self-anti-affinity keys on `location_name`, which the placeholder lacks. The
+isolation is preserved rather than weakened.
+
+The same omission keeps the placeholder out of the per-location PDB selectors,
+which match all three labels. It will match the code-server
+`topologySpreadConstraints` selector, which is `ScheduleAnyway` and therefore
+advisory.
+
+**Sizing is a cost decision.** The logs show four locations relocating within
+the same second, so a single placeholder does not cover the observed worst case.
+Start at two and let measurement drive the number rather than paying for five up
+front. Cost is continuous under pod-based billing and should be priced before
+committing.
+
+**This phase is gated.** Do not land it until all three are verified against the
+live cluster:
+
+1. Autopilot Warden admits a negative-priority pod. Warden has already rejected
+   Custom ComputeClasses and multi-value `nodeSelector` entries in this repo, so
+   this is a real risk rather than a formality.
+1. The warm node survives cluster-autoscaler consolidation. If the node is
+   reclaimed, the buffer is worthless. Whether the placeholder needs
+   `safe-to-evict: "false"` to pin its node is part of this check.
+1. A code server actually preempts a placeholder in practice, rather than
+   queueing alongside it.
+
+`.k8s/CLAUDE.md` currently states that Autopilot node pre-warming is not
+possible. That is accurate about DaemonSets and image pre-pulling but
+understates the case: the balloon-pod approach is a workload pattern, not a
+node-lifecycle API. The line needs correcting.
+
+### Phase 3: auto-recovery watchdog
+
+Phases 1 and 2 reduce failure probability. Neither eliminates it — an arm64
+stockout longer than the timeout still produces a terminal `ERROR`. This phase
+removes the human intervention.
+
+A scheduled GitHub Actions workflow on roughly a 10 minute cadence. It must live
+outside both the cluster and Dagster, because a Dagster sensor could itself be
+in the failed location.
+
+Logic:
+
+1. Query the Dagster+ control plane for locations whose `loadStatus` is `ERROR`.
+1. Retry only when the error matches the infrastructure signature: the message
+   contains both `Timed out waiting for deployment` and `FailedScheduling`. A
+   genuine import error or bad image has a different shape and must be left to
+   fail loudly, because it needs a human.
+1. Skip when a deploy is already in flight, judged by
+   `codeLocationUpdateTriggerTimestamp` recency, so the watchdog cannot race a
+   deploy.
+1. Cap attempts by counting consecutive matching `ERROR` entries in the
+   location's load history. This keeps the watchdog stateless and
+   self-correcting, with no external state to maintain.
+1. Past the cap, stop retrying and fail the workflow so it notifies rather than
+   looping silently.
+
+The workflow needs `DAGSTER_CLOUD_API_TOKEN`, already a repository secret. Scope
+it to the job that uses it, consistent with the existing convention in
+`.github/CLAUDE.md`.
+
+**Open question that gates this phase.** Whether triggering a reload genuinely
+re-attempts deployment for an errored location, or only re-reads a cached
+snapshot. The whole phase depends on it and it is not yet verified. Establish
+this first, against a location deliberately put into the timeout state.
+
+## Failure modes
+
+| Risk                                             | Mitigation                                                                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Watchdog masks a real code defect                | Signature gate plus attempt cap; genuine errors do not match and are never retried                                             |
+| Watchdog races a deploy                          | Skip when `codeLocationUpdateTriggerTimestamp` is recent                                                                       |
+| Placeholder starves real workloads               | Negative priority plus `preemptionPolicy: Never`; it can never displace anything                                               |
+| Warm node reclaimed by autoscaler                | Gate item 2 above; pin with `safe-to-evict` if needed                                                                          |
+| Longer timeout delays real-failure feedback      | Accepted; bad images still surface at 30s via `imagePullGracePeriod`                                                           |
+| Rollover co-locates two code servers on one node | Only under `preferred`; node must fit two 500m/2Gi pods or the scheduler picks elsewhere, which is the current behavior anyway |
+
+## Verification
+
+Baseline is the four-week table above. After each phase, re-measure the same six
+counters over at least one week and compare.
+
+Success criteria:
+
+- Zero `loadStatus: ERROR` entries carrying the timeout signature.
+- `FailedScheduling` on code-server pods materially below the 213 to 472 band.
+- Agent gRPC errors below the 85 to 134 per week band.
+- `Evicted` still 0, confirming the isolation was not weakened.
+
+Per-phase checks:
+
+- Phase 1: confirm the new timeout is live via the agent Deployment spec after
+  `helm upgrade`; confirm all five locations reload cleanly after the
+  `dagster-cloud.yaml` change.
+- Phase 2: the three gate items, then confirm a code-server rollover schedules
+  in seconds rather than minutes.
+- Phase 3: force a location into the timeout state, confirm the watchdog
+  recovers it, then confirm it does **not** retry a deliberately broken import.
+
+## Out of scope
+
+- Raising code-server priority. Declined.
+- Relaxing the run-pod-to-code-server anti-affinity. Incident-motivated.
+- The `kipptaf__google__bigquery__table_modified_sensor` timeout, tracked in
+  [#4908](https://github.com/TEAMSchools/teamster/issues/4908) and fixed in
+  [#4913](https://github.com/TEAMSchools/teamster/pull/4913). It shares the
+  exception class but has an unrelated cause.
+- The absence of `kipptaf__google__bigquery__table_modified_sensor` from
+  `docs/reference/automations.md`. Pre-existing and unrelated; the generator
+  appears to omit sensors that emit asset events rather than run requests.
+
+## Documentation changes
+
+`.k8s/CLAUDE.md`, required regardless of which phases land:
+
+- Add `deploymentStartupTimeout` to the "Timeout types (do not conflate)"
+  section. The section currently documents only `serverProcessStartupTimeout`,
+  and that gap led to identifying the wrong knob during this investigation.
+- Correct the "Autopilot node pre-warming: Not possible" line.
+- Record that a timed-out code-server deployment does not retry, so the
+  operational consequence is understood without re-reading the launcher source.

--- a/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
@@ -27,9 +27,14 @@ locations:
                 # forbidding the replacement pod from the outgoing pod's node
                 # during a rollover -- the one node guaranteed to have arm64
                 # Scale-Out capacity sized for a code server and, by the run-pod
-                # anti-affinity, no run pods on it. That forced NAP to build a new
-                # node on every redeploy. Cross-location spreading is handled
-                # separately by topologySpreadConstraints in the Helm values.
+                # anti-affinity, no run pods on it. Under `preferred` that node
+                # becomes FEASIBLE again, which is what removes the NAP wait --
+                # the scheduler still penalizes it, twice counting the hostname
+                # topologySpreadConstraint, and will usually pick elsewhere when
+                # anything else fits. Cross-location spreading is unchanged; it
+                # comes from topologySpreadConstraints in the Helm values.
+                # Rollover co-location risks are modelled in the spec:
+                # docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
                 preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 100
                     podAffinityTerm:

--- a/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippcamden/dagster-cloud.yaml
@@ -22,14 +22,24 @@ locations:
           pod_spec_config:
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                        - key: location_name
-                          operator: In
-                          values:
-                            - kippcamden
-                    topologyKey: kubernetes.io/hostname
+                # Preferred, not required. With one replica per location this
+                # spreads nothing; as `required` its only live effect was
+                # forbidding the replacement pod from the outgoing pod's node
+                # during a rollover -- the one node guaranteed to have arm64
+                # Scale-Out capacity sized for a code server and, by the run-pod
+                # anti-affinity, no run pods on it. That forced NAP to build a new
+                # node on every redeploy. Cross-location spreading is handled
+                # separately by topologySpreadConstraints in the Helm values.
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: location_name
+                            operator: In
+                            values:
+                              - kippcamden
+                      topologyKey: kubernetes.io/hostname
           container_config:
             env:
               - name: COUCHDROP_SFTP_PASSWORD

--- a/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
@@ -22,14 +22,24 @@ locations:
           pod_spec_config:
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                        - key: location_name
-                          operator: In
-                          values:
-                            - kippmiami
-                    topologyKey: kubernetes.io/hostname
+                # Preferred, not required. With one replica per location this
+                # spreads nothing; as `required` its only live effect was
+                # forbidding the replacement pod from the outgoing pod's node
+                # during a rollover -- the one node guaranteed to have arm64
+                # Scale-Out capacity sized for a code server and, by the run-pod
+                # anti-affinity, no run pods on it. That forced NAP to build a new
+                # node on every redeploy. Cross-location spreading is handled
+                # separately by topologySpreadConstraints in the Helm values.
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: location_name
+                            operator: In
+                            values:
+                              - kippmiami
+                      topologyKey: kubernetes.io/hostname
           container_config:
             env:
               - name: COUCHDROP_SFTP_PASSWORD

--- a/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippmiami/dagster-cloud.yaml
@@ -27,9 +27,14 @@ locations:
                 # forbidding the replacement pod from the outgoing pod's node
                 # during a rollover -- the one node guaranteed to have arm64
                 # Scale-Out capacity sized for a code server and, by the run-pod
-                # anti-affinity, no run pods on it. That forced NAP to build a new
-                # node on every redeploy. Cross-location spreading is handled
-                # separately by topologySpreadConstraints in the Helm values.
+                # anti-affinity, no run pods on it. Under `preferred` that node
+                # becomes FEASIBLE again, which is what removes the NAP wait --
+                # the scheduler still penalizes it, twice counting the hostname
+                # topologySpreadConstraint, and will usually pick elsewhere when
+                # anything else fits. Cross-location spreading is unchanged; it
+                # comes from topologySpreadConstraints in the Helm values.
+                # Rollover co-location risks are modelled in the spec:
+                # docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
                 preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 100
                     podAffinityTerm:

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -22,14 +22,24 @@ locations:
           pod_spec_config:
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                        - key: location_name
-                          operator: In
-                          values:
-                            - kippnewark
-                    topologyKey: kubernetes.io/hostname
+                # Preferred, not required. With one replica per location this
+                # spreads nothing; as `required` its only live effect was
+                # forbidding the replacement pod from the outgoing pod's node
+                # during a rollover -- the one node guaranteed to have arm64
+                # Scale-Out capacity sized for a code server and, by the run-pod
+                # anti-affinity, no run pods on it. That forced NAP to build a new
+                # node on every redeploy. Cross-location spreading is handled
+                # separately by topologySpreadConstraints in the Helm values.
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: location_name
+                            operator: In
+                            values:
+                              - kippnewark
+                      topologyKey: kubernetes.io/hostname
           container_config:
             env:
               - name: COUCHDROP_SFTP_PASSWORD

--- a/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kippnewark/dagster-cloud.yaml
@@ -27,9 +27,14 @@ locations:
                 # forbidding the replacement pod from the outgoing pod's node
                 # during a rollover -- the one node guaranteed to have arm64
                 # Scale-Out capacity sized for a code server and, by the run-pod
-                # anti-affinity, no run pods on it. That forced NAP to build a new
-                # node on every redeploy. Cross-location spreading is handled
-                # separately by topologySpreadConstraints in the Helm values.
+                # anti-affinity, no run pods on it. Under `preferred` that node
+                # becomes FEASIBLE again, which is what removes the NAP wait --
+                # the scheduler still penalizes it, twice counting the hostname
+                # topologySpreadConstraint, and will usually pick elsewhere when
+                # anything else fits. Cross-location spreading is unchanged; it
+                # comes from topologySpreadConstraints in the Helm values.
+                # Rollover co-location risks are modelled in the spec:
+                # docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
                 preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 100
                     podAffinityTerm:

--- a/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
@@ -22,14 +22,24 @@ locations:
           pod_spec_config:
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                        - key: location_name
-                          operator: In
-                          values:
-                            - kipppaterson
-                    topologyKey: kubernetes.io/hostname
+                # Preferred, not required. With one replica per location this
+                # spreads nothing; as `required` its only live effect was
+                # forbidding the replacement pod from the outgoing pod's node
+                # during a rollover -- the one node guaranteed to have arm64
+                # Scale-Out capacity sized for a code server and, by the run-pod
+                # anti-affinity, no run pods on it. That forced NAP to build a new
+                # node on every redeploy. Cross-location spreading is handled
+                # separately by topologySpreadConstraints in the Helm values.
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: location_name
+                            operator: In
+                            values:
+                              - kipppaterson
+                      topologyKey: kubernetes.io/hostname
           container_config:
             env:
               - name: COUCHDROP_SFTP_PASSWORD

--- a/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipppaterson/dagster-cloud.yaml
@@ -27,9 +27,14 @@ locations:
                 # forbidding the replacement pod from the outgoing pod's node
                 # during a rollover -- the one node guaranteed to have arm64
                 # Scale-Out capacity sized for a code server and, by the run-pod
-                # anti-affinity, no run pods on it. That forced NAP to build a new
-                # node on every redeploy. Cross-location spreading is handled
-                # separately by topologySpreadConstraints in the Helm values.
+                # anti-affinity, no run pods on it. Under `preferred` that node
+                # becomes FEASIBLE again, which is what removes the NAP wait --
+                # the scheduler still penalizes it, twice counting the hostname
+                # topologySpreadConstraint, and will usually pick elsewhere when
+                # anything else fits. Cross-location spreading is unchanged; it
+                # comes from topologySpreadConstraints in the Helm values.
+                # Rollover co-location risks are modelled in the spec:
+                # docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
                 preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 100
                     podAffinityTerm:

--- a/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
@@ -35,14 +35,24 @@ locations:
           pod_spec_config:
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                        - key: location_name
-                          operator: In
-                          values:
-                            - kipptaf
-                    topologyKey: kubernetes.io/hostname
+                # Preferred, not required. With one replica per location this
+                # spreads nothing; as `required` its only live effect was
+                # forbidding the replacement pod from the outgoing pod's node
+                # during a rollover -- the one node guaranteed to have arm64
+                # Scale-Out capacity sized for a code server and, by the run-pod
+                # anti-affinity, no run pods on it. That forced NAP to build a new
+                # node on every redeploy. Cross-location spreading is handled
+                # separately by topologySpreadConstraints in the Helm values.
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: location_name
+                            operator: In
+                            values:
+                              - kipptaf
+                      topologyKey: kubernetes.io/hostname
           container_config:
             env:
               - name: ADP_SFTP_PASSWORD

--- a/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
+++ b/src/teamster/code_locations/kipptaf/dagster-cloud.yaml
@@ -40,9 +40,14 @@ locations:
                 # forbidding the replacement pod from the outgoing pod's node
                 # during a rollover -- the one node guaranteed to have arm64
                 # Scale-Out capacity sized for a code server and, by the run-pod
-                # anti-affinity, no run pods on it. That forced NAP to build a new
-                # node on every redeploy. Cross-location spreading is handled
-                # separately by topologySpreadConstraints in the Helm values.
+                # anti-affinity, no run pods on it. Under `preferred` that node
+                # becomes FEASIBLE again, which is what removes the NAP wait --
+                # the scheduler still penalizes it, twice counting the hostname
+                # topologySpreadConstraint, and will usually pick elsewhere when
+                # anything else fits. Cross-location spreading is unchanged; it
+                # comes from topologySpreadConstraints in the Helm values.
+                # Rollover co-location risks are modelled in the spec:
+                # docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
                 preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 100
                     podAffinityTerm:

--- a/tests/test_k8s_config.py
+++ b/tests/test_k8s_config.py
@@ -1,0 +1,203 @@
+"""Structural checks on the Kubernetes config the Dagster Cloud agent consumes.
+
+`dagster-cloud.yaml` has no schema gate before the agent applies it, so a
+malformed `server_k8s_config` is otherwise caught only by a failed deploy. These
+tests run the same coercion the agent runs, and encode the invariants the
+scheduling-resilience spec depends on:
+docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md
+"""
+
+import pathlib
+from typing import Any
+
+import pytest
+import yaml
+from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
+from dagster_shared import check
+from kubernetes.client.models import V1PodAntiAffinity, V1PodSpec
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+CODE_LOCATIONS = ["kippcamden", "kippmiami", "kippnewark", "kipppaterson", "kipptaf"]
+
+GRACE_PERIOD_KEY = "DAGSTER_CLOUD_CLEANUP_SERVER_GRACE_PERIOD_SECONDS"
+
+# Autopilot minimum requests for an extended-duration pod, which
+# cluster-autoscaler.kubernetes.io/safe-to-evict: "false" makes this pod
+CODE_SERVER_MIN_CPU = "500m"
+CODE_SERVER_MIN_MEMORY = "2.0Gi"
+
+
+def _helm_values() -> dict[str, Any]:
+    return yaml.safe_load((REPO_ROOT / ".k8s/dagster/values-override.yaml").read_text())
+
+
+def _server_pod_spec_config(location: str) -> dict[str, Any]:
+    path = REPO_ROOT / f"src/teamster/code_locations/{location}/dagster-cloud.yaml"
+    doc = yaml.safe_load(path.read_text())
+
+    k8s = doc["locations"][0]["container_context"]["k8s"]
+
+    return k8s["server_k8s_config"]["pod_spec_config"]
+
+
+def _coerce(pod_spec_config: dict[str, Any]) -> V1PodSpec:
+    """Run the agent's own coercion. Raises on a shape Kubernetes would reject."""
+    return k8s_model_from_dict(
+        V1PodSpec,
+        {**k8s_snake_case_dict(V1PodSpec, pod_spec_config), "containers": []},
+    )
+
+
+@pytest.mark.parametrize("location", CODE_LOCATIONS)
+def test_server_anti_affinity_is_valid_and_self_scoped(location: str):
+    """The per-location self-anti-affinity must coerce to a real
+    V1WeightedPodAffinityTerm and must select its OWN location, not a copied one.
+    """
+    pod_spec = _coerce(_server_pod_spec_config(location))
+
+    affinity = check.not_none(value=pod_spec.affinity)
+    anti_affinity = check.inst(obj=affinity.pod_anti_affinity, ttype=V1PodAntiAffinity)
+
+    assert anti_affinity.required_during_scheduling_ignored_during_execution is None
+
+    terms = check.is_list(
+        obj=anti_affinity.preferred_during_scheduling_ignored_during_execution
+    )
+
+    assert len(terms) == 1
+
+    term = terms[0]
+
+    assert term.weight == 100
+    assert term.pod_affinity_term.topology_key == "kubernetes.io/hostname"
+
+    expressions = term.pod_affinity_term.label_selector.match_expressions
+
+    assert [e.key for e in expressions] == ["location_name"]
+    assert expressions[0].values == [location]
+
+
+def test_coercion_rejects_an_unnested_pod_affinity_term():
+    """Guards the test above from being vacuous.
+
+    `preferred` takes a WeightedPodAffinityTerm, so the un-nested form produced by
+    renaming `required` to `preferred` without adding the `weight` /
+    `podAffinityTerm` wrapper must fail rather than pass silently.
+    """
+    unnested = {
+        "affinity": {
+            "podAntiAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "labelSelector": {
+                            "matchExpressions": [
+                                {
+                                    "key": "location_name",
+                                    "operator": "In",
+                                    "values": ["kipptaf"],
+                                }
+                            ]
+                        },
+                        "topologyKey": "kubernetes.io/hostname",
+                    }
+                ]
+            }
+        }
+    }
+
+    with pytest.raises(Exception, match="Unexpected keys in model class"):
+        _coerce(unnested)
+
+
+def test_run_pod_isolation_from_code_servers_stays_required():
+    """Added after a production incident where run pods starved code servers.
+    Relaxing this to `preferred` would reintroduce it, so it is asserted rather
+    than left to review.
+    """
+    anti_affinity = _helm_values()["workspace"]["runK8sConfig"]["podSpecConfig"][
+        "affinity"
+    ]["podAntiAffinity"]
+
+    assert "preferredDuringSchedulingIgnoredDuringExecution" not in anti_affinity
+
+    terms = anti_affinity["requiredDuringSchedulingIgnoredDuringExecution"]
+
+    # one term targets code servers, the other the agent; losing either
+    # silently removes half the protection
+    selectors = [t["labelSelector"]["matchLabels"] for t in terms]
+
+    assert {
+        "managed_by": "K8sUserCodeLauncher",
+        "deployment_name": "prod",
+    } in selectors
+    assert {"app.kubernetes.io/name": "dagster-cloud-agent"} in selectors
+
+
+def test_code_servers_keep_default_priority():
+    """Code servers stay at priority 0 by decision: promoting them above
+    dagster-run would make run pods queue instead.
+    """
+    server_config = _helm_values()["workspace"]["serverK8sConfig"]
+
+    assert "priorityClassName" not in server_config.get("podSpecConfig", {})
+
+
+def test_code_server_requests_support_extended_duration():
+    """safe-to-evict: "false" makes the pod extended-duration, which Autopilot only
+    honors at or above 500m / 2GiB. Lowering either silently voids the annotation.
+    """
+    server_config = _helm_values()["workspace"]["serverK8sConfig"]
+
+    annotations = server_config["podTemplateSpecMetadata"]["annotations"]
+
+    # must be the quoted string, not a YAML boolean
+    assert annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
+
+    requests = server_config["containerConfig"]["resources"]["requests"]
+
+    assert requests["cpu"] == CODE_SERVER_MIN_CPU
+    assert requests["memory"] == CODE_SERVER_MIN_MEMORY
+
+
+def test_agent_readiness_budget_covers_worst_case_first_reconcile():
+    """The readiness sentinel is written only after the first full reconcile
+    returns, and that reconcile awaits deploymentStartupTimeout +
+    serverProcessStartupTimeout per location. If the probe budget is smaller, the
+    agent rollout stalls on the very helm upgrade that raises the timeouts.
+    """
+    values = _helm_values()
+
+    workspace = values["workspace"]
+    worst_case = (
+        workspace["deploymentStartupTimeout"] + workspace["serverProcessStartupTimeout"]
+    )
+
+    agent = values["dagsterCloudAgent"]
+    probe = agent["readinessProbe"]
+    readiness_budget = probe["failureThreshold"] * probe["periodSeconds"]
+
+    assert readiness_budget > worst_case, (
+        f"readiness budget {readiness_budget}s does not cover worst-case first"
+        f" reconcile {worst_case}s"
+    )
+
+    # CLAUDE.md: do not set the cleanup grace period below reconciliation time,
+    # or an orphaned code server can be deleted before its replacement is ready
+    grace_period = int(agent["env"][GRACE_PERIOD_KEY])
+
+    assert grace_period > worst_case, (
+        f"cleanup grace period {grace_period}s is below worst-case first reconcile"
+        f" {worst_case}s"
+    )
+
+    install_sh = (REPO_ROOT / ".k8s/dagster/install.sh").read_text()
+    rollout_line = next(
+        line for line in install_sh.splitlines() if "rollout status" in line
+    )
+    rollout_timeout = int(rollout_line.split("--timeout=")[1].rstrip("s"))
+
+    assert rollout_timeout >= readiness_budget, (
+        f"install.sh rollout timeout {rollout_timeout}s is below the readiness"
+        f" budget {readiness_budget}s, so a healthy-but-slow upgrade reports failure"
+    )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make code locations much less likely to fail to start, and it adds the written design and plan behind that work.

Background. When a code location fails to start, it stays failed until someone pushes a commit or clicks redeploy — the agent never retries on its own. That is why this keeps needing a person. The reason it fails is that the replacement pod cannot find a machine to run on quickly enough, and the agent gives up after 5 minutes while Kubernetes is still working on it.

Three changes, none of which reverse a decision anyone made deliberately:

- The agent now waits 15 minutes instead of 5 for a replacement to get a machine. The 5 minute limit was never set by us; it is the default, and it is shorter than how long getting a new machine normally takes.
- Code servers are now protected from being moved when the cluster shrinks. Every other pod type already had this protection; code servers were the only ones missing it, which cost 38 to 59 needless moves a week.
- One scheduling rule is relaxed from a hard requirement to a preference. As a hard rule it blocked the replacement from the single best machine available, forcing a brand-new one to be built on every redeploy.

Also fixes documentation that actively misled: the notes described only one of the three startup timeouts, which is why the wrong one was blamed first.

Worth knowing: the first two changes need a manual `helm upgrade` and do **not** take effect on merge. The third ships normally.

This is Phase 1 of three. Phases 2 and 3 get their own plans after this one's effect is measured, since that measurement decides whether they are still needed at the proposed scale.

Refs #4907

## Reviewer Notes

- The relaxed scheduling rule is the change most worth your judgement. My argument is that with one replica per location it spreads nothing, and its only real effect was excluding the outgoing pod's machine — the one machine already known to be the right type, sized correctly, and free of run pods. If that reasoning is wrong, the largest change here is wrong. Full detail below.
- The isolation between run pods and code servers is **untouched and still strict.** That is the rule from the earlier incident where run pods starved code servers, and there is an assertion in the plan that fails if it is ever weakened. Same for code server priority, which stays as it is.
- Relaxing that rule is a structural change, not a renamed key — the preferred form nests the term differently. I verified all five files parse into the right shape and that each selects its own location rather than a copied one, which is the mistake this kind of edit invites.
- The 5-to-15-minute change has one accepted downside: a genuinely broken deployment now takes 15 minutes to report instead of 5. Broken images are unaffected; they surface separately in 30 seconds.
- The spec deliberately marks two assumptions as unverified rather than asserting them, each gating the later phase that depends on it. Neither is exercised by this PR.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR — it did not run
      on this branch. `claude-code-review.yaml` fires on `opened` and
      `ready_for_review`, and this PR was opened while it was still docs-only, so
      markdown was excluded. If you want a bot pass over the config changes,
      toggling draft state re-fires it.

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location —
      **not applicable, deliberately.** `dagster-cloud.yaml` is agent-side
      deployment config; `definitions validate` does not read it, so the check
      cannot detect a defect in this change. Verified instead by asserting the
      parsed YAML structure of all five files (see the plan, Task 2 Step 3).
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code
      location — same reason. It shells out to `definitions validate`, so it is
      equally blind to this change, and it needs five `prepare-and-package` runs
      in a fresh worktree to go green at all.
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/) —
      n/a, no new integration

### dbt

Skipped, no dbt changes.

### Docs

- [x] If adding or changing a schedule or sensor, regenerate the automations
      catalog — n/a, no schedule or sensor changed
- [x] If adding a new integration to a code location, update that location's
      `CLAUDE.md` — n/a. `.k8s/CLAUDE.md` is updated, for the timeout
      documentation gap rather than for an integration.

The spec and plan land under `docs/superpowers/`, deliberately excluded from the
`mkdocs.yml` nav per `docs/CLAUDE.md`, so no nav entry is needed.

## CI checks

- [x] **Trunk** — passes. `trunk check --force --no-fix` was also run locally
      against each changed file from inside the worktree, with `pwd` confirmed,
      before every commit. Only prettier reflow was reported, which the
      pre-commit `fmt` hook applied and re-checked clean.
- [x] **dbt Cloud** — passes. No dbt paths changed; it triggers on PR events
      regardless.
- [x] **Dagster Cloud** — passes. All 32 checks are green, with the
      `dagster-cloud-deploy` jobs fanning out 5x (one per code location) because
      every `dagster-cloud.yaml` changed.

**What CI does NOT prove here.** A green deploy job is not evidence the agent
reloaded, per `.github/CLAUDE.md`. I could not confirm a branch deployment exists
(`list_deployments` returns only `prod`), so the relaxed affinity has **not** been
exercised against a live cluster by this PR. Verified separately that prod was not
touched: its locations still carry `main` commits, not this branch's head. The
first real test of the affinity change is the post-merge prod deploy, and of the
Helm changes, the manual `helm upgrade`.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Investigation, spec, plan, and Phase 1
implementation. Phases 2 and 3 are not implemented.

### Reviewer Notes flag 1: the relaxed rule, in full

Each location's code server carried
`requiredDuringSchedulingIgnoredDuringExecution` anti-affinity against its **own**
`location_name` on `kubernetes.io/hostname`, set per district in
`dagster-cloud.yaml`. With one replica per location it spreads nothing. Its only
live effect was forbidding the replacement pod from the outgoing pod's node during
a rollover — and that node is the single best candidate: it already has arm64
Scale-Out capacity sized for a code server, and the run-pod anti-affinity
guarantees no run pods are on it. So the rule specifically excluded the one node
guaranteed to satisfy every other constraint, forcing NAP to build a new node on
every redeploy.

Cross-location spreading is unaffected — it comes from
`topologySpreadConstraints` (`ScheduleAnyway` on zone and hostname) in the Helm
values. `affinity` is permitted per-location:
`onlyAllowUserDefinedK8sConfigFields.podSpecConfig.affinity` is `true`.

The structural point: `preferred` takes `WeightedPodAffinityTerm`, not
`PodAffinityTerm`, so the term nests under `podAffinityTerm` with a `weight`.
Weight is 100, the maximum, so separation is still preferred as strongly as
possible. A key rename alone would have produced config the agent rejects.

### Why the failure is terminal

Verified in `dagster_cloud/workspace/user_code_launcher/user_code_launcher.py`,
not inferred. `_should_trigger_recovery` returns `False` when
`location_key in control_plane_error_locations` — "control plane agrees there is
an error, don't retry". Recovery fires only when the agent holds a local error
while the control plane believes the location is healthy. Normal reconciliation
redeploys only when
`actual_entry.update_timestamp != desired_entry.update_timestamp`, which changes
on a new deploy, and the periodic health check needs a running endpoint a
never-started pod lacks. No setting changes this;
`DAGSTER_CLOUD_DISABLE_LOCAL_ERROR_SERVER_RECOVERY` only turns recovery off.

### The timeout, and my own wrong turn

`workspace.deploymentStartupTimeout` was unset, so 300s
(`DEFAULT_DEPLOYMENT_STARTUP_TIMEOUT` in the launcher). It governs
`wait_for_deployment_complete`, which is what raises on the observed failure.
`serverProcessStartupTimeout` (300) governs readiness *after* the Deployment
exists via `_wait_for_dagster_server_process`. I blamed the latter first and was
wrong; reading the installed package caught it before it reached the spec. That is
exactly the confusion the `.k8s/CLAUDE.md` fix in this PR removes.

### Measured baseline

Code-server pods only (`involvedObject.name` containing `-prod-`) in
`dagster-cloud`. 30-day retention, so nothing before 2026-07-19 is observable and
a June inflection cannot be ruled out.

| Week | gRPC errors | Killing | ScaleDown | Preempted | Evicted | FailedScheduling |
| --- | --- | --- | --- | --- | --- | --- |
| Jul 20-27 | 85 | 122 | 42 | 21 | 0 | 472 |
| Jul 28-Aug 4 | 134 | 197 | 59 | 37 | 0 | 454 |
| Aug 4-11 | 106 | 118 | 48 | 22 | 0 | 213 |
| Aug 11-18 | 100 | 142 | 38 | 32 | 0 | 438 |

The reported recent uptick is **not** present: the peak was Jul 28 to Aug 4 and
the two most recent weeks are lower. Chronic, not a regression. Agent errors track
code-server kills at 0.70, 0.68, 0.90, 0.70, which is what ties the errors to pod
deaths rather than repo code. `Evicted` at 0 across all four weeks is the evidence
the isolation is working, and the reason it stays.

### Verification performed

Assertions rather than tests, because Helm values and YAML affinity have no test
harness:

- `deploymentStartupTimeout == 900`; `safe-to-evict` is the **string** `"false"`
  (a bare YAML boolean would be wrong); code-server requests still `500m` /
  `2.0Gi`, meeting the Autopilot extended-duration minimum the annotation
  requires; `runK8sConfig` anti-affinity still `required` with **both** terms
  (code-server labels and agent labels); no `priorityClassName` on
  `serverK8sConfig`.
- All five location files: `required` key gone, exactly one weighted term at
  weight 100, `topologyKey` unchanged, and each selects its own `location_name`.

### Still outstanding, for whoever picks this up

- The `helm upgrade` has not been run. Until it is, only the affinity change is
  live. Plan Task 4 Steps 4 to 6 carry the exact commands and what to check,
  including that the annotation only appears on code-server pods created after the
  upgrade.
- The post-change measurement (plan Task 4 Step 7) has not happened. Do not plan
  Phase 2 or 3 before it exists — if `FailedScheduling` collapses, Phase 2's
  continuous cost may no longer be justified.

### Loose ends found and deliberately not fixed here

- `kipptaf__google__bigquery__table_modified_sensor` is absent from
  `docs/reference/automations.md`; the generator appears to skip sensors that emit
  asset events rather than run requests.
- The `bug` label the new issue template applies is unused in practice — every
  real issue uses `fix`.
- Sibling PR #4913 fixes an unrelated sensor timeout that surfaces the same
  `DagsterUserCodeUnreachableError` class.

</details>
