### PR TITLE
feat(gradebook-audit): pivot the expectations upload template wide

### DIFF
--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -275,9 +275,11 @@ Three gotchas worth knowing before editing it:
   the gap was invisible in the sheet; wide, it surfaces as an empty cell for
   whoever is setting counts to fill in. Adding an all-null guard would hide
   exactly what the template exists to show, and re-uploading a blank row writes
-  back the blank state it came from. Measured 2026-08-18, all 205
-  `U_EXPECTATIONS` rows carry a count in all four columns, so no guard would
-  filter anything today anyway.
+  back the blank state it came from. Measured 2026-08-18, all 205 rows in
+  `stg_powerschool__u_expectations` carry a count in all four columns, so no
+  guard would filter anything today anyway. That 205 is the raw source count,
+  not this model's output — the template emits 202 rows, because `term_weeks`
+  keeps only weeks that have already started.
 
 Coverage follows the inner join to `stg_powerschool__u_expectations` — Newark
 and Camden at MS and HS, Paterson at MS, no ES and no Miami — so it needs no

--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -248,14 +248,16 @@ PowerSchool's `U_EXPECTATIONS` via the plugin — the write side of the same tab
 `rpt_gsheets__gradebook_audit_template` in
 `src/dbt/kipptaf/models/exposures/google-sheets.yml`.
 
-One row per
-`region × school_level × quarter × week_number_quarter × assignment_category_code`
-(uniqueness-tested). It shares the QTD unpivot's `term_weeks` CTE and category
-decode, but differs in two ways: it keeps **every** school week rather than
-collapsing to the most recently completed one per quarter, and it takes
-`school_week_end_date` (aliased `week_end_friday`) instead of `week_end_sunday`.
+One row per `region × school_level × quarter × week_number_quarter`
+(uniqueness-tested), carrying the four category counts as **columns** — `W`,
+`H`, `F`, `S` — rather than one row each. It shares the QTD unpivot's
+`term_weeks` CTE but differs in three ways: it keeps **every** school week
+rather than collapsing to the most recently completed one per quarter; it takes
+`school_week_end_date` (aliased `week_end_friday`) instead of `week_end_sunday`;
+and it stays wide, because the sheet is an upload grid a person fills in, not an
+analytical long table.
 
-Two gotchas worth knowing before editing it:
+Three gotchas worth knowing before editing it:
 
 - **`week_end_friday` is not always a Friday.** It is the last _in-session_ day
   of the school week, so it lands on Thursday or earlier when a holiday or PD
@@ -267,6 +269,15 @@ Two gotchas worth knowing before editing it:
   2026-03-20). `term_weeks` therefore aggregates with
   `max(school_week_end_date)` and an explicit `GROUP BY`; a `SELECT DISTINCT`
   fans the join out to one row per distinct end date and breaks the grain.
+- **A blank category cell is meaningful — don't filter it away.** The model
+  applies no null guard to the four counts. Under the pre-wide long shape an
+  unset category produced no row at all (BigQuery `UNPIVOT` excludes nulls), so
+  the gap was invisible in the sheet; wide, it surfaces as an empty cell for
+  whoever is setting counts to fill in. Adding an all-null guard would hide
+  exactly what the template exists to show, and re-uploading a blank row writes
+  back the blank state it came from. Measured 2026-08-18, all 205
+  `U_EXPECTATIONS` rows carry a count in all four columns, so no guard would
+  filter anything today anyway.
 
 Coverage follows the inner join to `stg_powerschool__u_expectations` — Newark
 and Camden at MS and HS, Paterson at MS, no ES and no Miami — so it needs no

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gradebook_audit_template.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gradebook_audit_template.yml
@@ -1,14 +1,15 @@
 models:
   - name: rpt_gsheets__gradebook_audit_template
     description: >
-      Every school week's assignment expectations, one row per category, for
-      building the CSV that C3 uploads into PowerSchool's U_EXPECTATIONS via the
-      KIPP NJ Gradebook Audit plugin. Unlike
-      int_powerschool__u_expectations_qtd_unpivot, which collapses to the most
-      recently completed week per quarter for the audit's quarter-to-date
-      counts, this keeps every week so the upload covers the full year. Coverage
-      follows the inner join to stg_powerschool__u_expectations — Newark and
-      Camden at MS and HS, Paterson at MS, no ES and no Miami.
+      Every school week's assignment expectations, one row per week with the
+      four category counts as columns (W, H, F, S), for building the CSV that C3
+      uploads into PowerSchool's U_EXPECTATIONS via the KIPP NJ Gradebook Audit
+      plugin. Unlike int_powerschool__u_expectations_qtd_unpivot, which
+      collapses to the most recently completed week per quarter for the audit's
+      quarter-to-date counts, this keeps every week so the upload covers the
+      full year. Coverage follows the inner join to
+      stg_powerschool__u_expectations — Newark and Camden at MS and HS, Paterson
+      at MS, no ES and no Miami.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -17,7 +18,6 @@ models:
               - school_level
               - quarter
               - week_number_quarter
-              - assignment_category_code
     columns:
       - name: region
         data_type: string
@@ -47,25 +47,33 @@ models:
       - name: notes
         data_type: string
         description: Free-text note carried through from the U_EXPECTATIONS row.
-      - name: assignment_category_code
-        data_type: string
-        description: Single-letter category code (W, H, F, or S).
-      - name: expectation
+      - name: W
         data_type: int64
+        quote: true
         description:
-          Count of expected assignments for this category in this week.
+          Count of expected Work Habits assignments for this week. Blank when
+          the U_EXPECTATIONS row leaves the category unset.
+      - name: H
+        data_type: int64
+        quote: true
+        description:
+          Count of expected Homework assignments for this week. Blank when the
+          U_EXPECTATIONS row leaves the category unset.
+      - name: F
+        data_type: int64
+        quote: true
+        description:
+          Count of expected Formative Mastery assignments for this week. Blank
+          when the U_EXPECTATIONS row leaves the category unset.
+      - name: S
+        data_type: int64
+        quote: true
+        description:
+          Count of expected Summative Mastery assignments for this week. Blank
+          when the U_EXPECTATIONS row leaves the category unset.
       - name: academic_year
         data_type: int64
         description: >
           Academic year (starting year). Stamped as a literal — U_EXPECTATIONS
           reflects whatever is currently live in PowerSchool and carries no year
           of its own.
-      - name: assignment_category_term
-        data_type: string
-        description:
-          Category code concatenated with quarter number (e.g. W1, H2, F3, S4).
-      - name: assignment_category_name
-        data_type: string
-        description:
-          Human-readable category name (Work Habits, Homework, Formative
-          Mastery, Summative Mastery).

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
@@ -63,29 +63,11 @@ select
     week_start_monday,
     school_week_end_date as week_end_friday,
     notes,
-
-    assignment_category_code,
-    expectation,
+    cnt_w as `W`,
+    cnt_h as `H`,
+    cnt_f as `F`,
+    cnt_s as `S`,
 
     {{ var("current_academic_year") - 1 }} as academic_year,  /* summer toggle: see skill */
 
-    concat(assignment_category_code, right(`quarter`, 1)) as assignment_category_term,
-
-    case
-        assignment_category_code
-        when 'W'
-        then 'Work Habits'
-        when 'H'
-        then 'Homework'
-        when 'F'
-        then 'Formative Mastery'
-        when 'S'
-        then 'Summative Mastery'
-    end as assignment_category_name,
-
-from
-    week_expectations unpivot (
-        expectation for assignment_category_code
-        in (`cnt_w` as 'W', `cnt_h` as 'H', `cnt_f` as 'F', `cnt_s` as 'S')
-    )
-where expectation is not null
+from week_expectations


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...pivot `rpt_gsheets__gradebook_audit_template` so the four assignment
categories are **columns** — `W`, `H`, `F`, `S` — instead of four rows.

This model feeds the Google Sheet T&L exports as the CSV they upload into
PowerSchool's `U_EXPECTATIONS` via the KIPP NJ Gradebook Audit plugin. It is an
upload grid a person fills in, not an analytical long table, so the wide shape
matches how it is actually used. It also means a category with no count now
shows up as a blank cell to fill in, rather than silently vanishing as a missing
row.

Alongside the pivot:

- Dropped `assignment_category_code`, `expectation`,
  `assignment_category_term`, and `assignment_category_name` — all lose their
  meaning once the categories are columns.
- Narrowed the uniqueness test to
  `region` + `school_level` + `quarter` + `week_number_quarter`.
- Removed the dead `where expectation is not null` filter. BigQuery `UNPIVOT`
  already excludes nulls by default, so that filter never dropped a row.
- Updated the published reference doc, whose stated grain and "category decode"
  description are now wrong, and recorded why there is deliberately no all-null
  guard so it does not get added later as a tidy-up.

Both `/* summer toggle: see skill */` markers are untouched.

### Validation

Built against prod upstreams with `--favor-state`, after confirming from the
compiled SQL that both refs resolve to `kipptaf_powerschool` rather than stale
personal dev copies (the first build read the dev copies, which would have made
the parity check meaningless).

| Check                                | Result                                                                                   |
| ------------------------------------ | ---------------------------------------------------------------------------------------- |
| `dbt build`, contract enforced       | PASS                                                                                     |
| Uniqueness test on the 4-column key  | PASS                                                                                     |
| Row count                            | 202 (was 808, i.e. 202 x 4)                                                              |
| Columns                              | `W` / `H` / `F` / `S` as `INT64`, ordinal positions 8-11                                 |
| Value parity vs the prod long output | 0 differences across all four categories and every passthrough column; 0 keys gained/lost |

### Rollback plan

Revert the commit. The model is a view, so the prior long shape is restored on
the next build with no backfill needed. No dbt model refs this one, so nothing
downstream in the project is affected.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties file updated — new `W` / `H` / `F` / `S` columns declared with
      `data_type` and `quote: true`, removed columns dropped, model description
      and uniqueness test updated.
- [x] Exposure is current — `rpt_gsheets__gradebook_audit_template` in
      `models/exposures/google-sheets.yml` already covers this model; no change
      needed since neither the model name nor its consumer changed.
- [x] **Breaking change — yes, deliberately.** This removes four columns from a
      contracted `rpt_` model and changes the sheet's headers, cutting it from
      808 rows to 202. Any formula or IMPORTRANGE built on the long shape will
      break. The exposure owner (Data Team - grangel) is the PR author and is
      aware; rollback plan is in the summary above.
- [ ] n/a — no external source added or modified.

## CI checks

- [ ] **Trunk** — `trunk check --force` was run locally on all three changed
      files before pushing: no issues.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — n/a, dbt-only change.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

Worth a close look: the removal of `where expectation is not null`. It is safe
because BigQuery's `UNPIVOT` excludes NULL values by default, so the predicate
could never have matched a row — but that reasoning is the crux of the change,
so please check it rather than assume it.

Deliberately out of scope, please do not flag:

- The summer toggle. Both `{{ var("current_academic_year") - 1 }}` expressions
  and their `summer toggle: see skill` markers are intentionally left as-is.
- Adding an all-null guard such as
  `where coalesce(cnt_w, cnt_h, cnt_f, cnt_s) is not null`. This was considered
  and rejected on purpose: it filters zero rows today (verified — all 205
  `U_EXPECTATIONS` rows carry a count in all four columns), and in the only
  future where it would fire it would hide exactly the gap this template exists
  to surface. The reasoning is recorded in the reference doc.
- The backticks on the `W` / `H` / `F` / `S` aliases. They are there because
  `src/dbt/` contains zero unquoted uppercase aliases and sqlfluff CP02 defaults
  to `consistent`; they do not change the emitted column names, and they match
  how `` `quarter` `` is already written in the same file.

No GitHub issue — the user explicitly declined one for this change.

</details>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217604903764513