### PR TITLE
fix(k8s): revert safe-to-evict on code servers, it multiplied preemption

### DIFF
--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -160,16 +160,24 @@ workspace:
     podTemplateSpecMetadata: # raw config for the pod's metadata
       annotations:
         operator.1password.io/auto-restart: "true"
-        # Code servers were the only pod type without this -- the agent
-        # (dagsterCloudAgent.annotations) and run pods
-        # (runK8sConfig.podTemplateSpecMetadata) both carry it. Blocks
-        # cluster-autoscaler eviction, which accounted for 38-59 code-server
-        # relocations per week. Compatible here: requests above are 500m/2.0Gi,
-        # meeting the Autopilot extended-duration minimum, and code servers are
-        # not on spot (the two are mutually exclusive). Extended-duration
-        # protection expires after 7 days, far longer than the interval between
-        # deploys.
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        # Do NOT add cluster-autoscaler.kubernetes.io/safe-to-evict: "false" here.
+        # It was added 2026-08-18 to stop the 38-59 autoscaler relocations per week
+        # and reverted the same day. Measured over the hour after it went live:
+        # agent "Could not reach user code server" errors ran ~62x the four-week
+        # baseline (40/hour against ~0.65) and code-server Preempted ran ~118x
+        # (20/hour against ~0.17), while Evicted stayed flat at 0 the whole time.
+        #
+        # Mechanism: the annotation blocks CLUSTER-AUTOSCALER eviction but not
+        # SCHEDULER preemption. Pinning code servers to their nodes stops the
+        # autoscaler relocating them, so capacity fragments and run pods
+        # (priority 1000) can only obtain it by preempting code servers
+        # (priority 0). It converted graceful relocations into preemptions, each
+        # of which recreates the Service and produces a fresh ClusterIP -- which
+        # is the churn the annotation was meant to reduce.
+        #
+        # Evicted holding at 0 is what isolates this from the `preferred`
+        # self-anti-affinity: that change's risk shows up as kubelet eviction, and
+        # it never fired.
     podSpecConfig:
       # Hard-pin to built-in Scale-Out arm64 (T2A) under pod-based pricing.
       # No fallback — arm64 STOCKOUT will leave pods Pending. Code servers

--- a/tests/test_k8s_config.py
+++ b/tests/test_k8s_config.py
@@ -22,8 +22,7 @@ CODE_LOCATIONS = ["kippcamden", "kippmiami", "kippnewark", "kipppaterson", "kipp
 
 GRACE_PERIOD_KEY = "DAGSTER_CLOUD_CLEANUP_SERVER_GRACE_PERIOD_SECONDS"
 
-# Autopilot minimum requests for an extended-duration pod, which
-# cluster-autoscaler.kubernetes.io/safe-to-evict: "false" makes this pod
+# Autopilot minimum requests for a Scale-Out pod using workload separation
 CODE_SERVER_MIN_CPU = "500m"
 CODE_SERVER_MIN_MEMORY = "2.0Gi"
 
@@ -143,18 +142,36 @@ def test_code_servers_keep_default_priority():
     assert "priorityClassName" not in server_config.get("podSpecConfig", {})
 
 
-def test_code_server_requests_support_extended_duration():
-    """safe-to-evict: "false" makes the pod extended-duration, which Autopilot only
-    honors at or above 500m / 2GiB. Lowering either silently voids the annotation.
+def test_code_servers_are_not_pinned_against_the_autoscaler():
+    """safe-to-evict: "false" was tried on code servers and reverted the same day.
+
+    It blocks autoscaler relocation but not scheduler preemption, so it converted
+    graceful relocations into preemptions: measured ~62x the baseline gRPC error
+    rate and ~118x Preempted over one hour, with Evicted flat at 0. Asserted here
+    so it cannot be reintroduced without the reasoning resurfacing.
     """
     server_config = _helm_values()["workspace"]["serverK8sConfig"]
 
     annotations = server_config["podTemplateSpecMetadata"]["annotations"]
 
-    # must be the quoted string, not a YAML boolean
-    assert annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
+    assert "cluster-autoscaler.kubernetes.io/safe-to-evict" not in annotations
 
-    requests = server_config["containerConfig"]["resources"]["requests"]
+    # the agent and run pods DO carry it, and should keep it -- they are not
+    # preemptible by run pods the way priority-0 code servers are
+    agent_annotations = _helm_values()["dagsterCloudAgent"]["annotations"]
+
+    assert (
+        agent_annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
+    )
+
+
+def test_code_server_requests_meet_scale_out_minimum():
+    """Autopilot requires 500m / 2GiB for Scale-Out pods using workload
+    separation, which the nodeSelector opts these pods into.
+    """
+    requests = _helm_values()["workspace"]["serverK8sConfig"]["containerConfig"][
+        "resources"
+    ]["requests"]
 
     assert requests["cpu"] == CODE_SERVER_MIN_CPU
     assert requests["memory"] == CODE_SERVER_MIN_MEMORY


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will remove one annotation added earlier today, because measuring it showed it made things substantially worse rather than better.

The annotation stopped the cluster autoscaler moving code servers around, which was costing 38 to 59 needless moves a week. It worked, in the narrow sense. But it also pinned each code server to its machine, so when the cluster ran short of capacity the only remaining way to free that machine was for a higher-priority job pod to forcibly evict the code server. Forcible eviction is worse than a graceful move: it recreates the network address the agent talks to, which is exactly the disruption the annotation was meant to prevent.

Measured over the hour after it went live, the error you originally reported ran roughly **62 times** its normal rate, and forcible evictions of code servers ran roughly **118 times** normal. Both held steady rather than settling down, so this was not just churn from the deploy.

The other two changes from the same batch stay. Neither can cause this, and between them they fix the failure that used to leave a code location dead until someone noticed.

Refs #4907

## Reviewer Notes

- The measurement is the whole argument, so it is worth a look at whether you find it convincing: four readings, 15 minutes each, in the commit message and below. The reason I trust it over "it's just deploy churn" is that the last two readings were the highest, not the lowest.
- One counter staying at **zero** for the full hour is what tells us which of the two changes to blame. The other change's risk shows up as a different kind of eviction, and that never happened once. So this reverts one thing, not both.
- I left a comment at the site explaining why the annotation is gone, and a test that fails if someone adds it back. The reasoning that led to adding it was sound on its face, so without a note somebody will reasonably try it again.
- The agent and the job pods keep the same annotation. They are not vulnerable the way code servers are, and removing theirs would be a different and unmeasured change.
- Nothing happens on merge. This needs a manual `helm upgrade` like the change it reverts.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location —
      n/a. This touches Helm values and a test; no code location changed.
- [x] Run `uv run pytest tests/test_dagster_definitions.py` — n/a, same reason.
      `tests/test_k8s_config.py` is the relevant suite: **11 passed in 17.10s**.
- [x] New integrations follow the Library + Config pattern — n/a

### dbt

Skipped, no dbt changes.

### Docs

- [x] Regenerate the automations catalog — n/a, no schedule or sensor changed
- [x] Update a code location's `CLAUDE.md` — n/a. The reasoning is recorded at the
      config site and in the test rather than in `.k8s/CLAUDE.md`, since it is a
      "do not do this" note tied to a specific line.

## CI checks

- [ ] **Trunk** — passes. `trunk check --force --no-fix` locally reported only a
      ruff line-length reflow, which the pre-commit `fmt` hook applied and
      re-checked clean.
- [ ] **dbt Cloud** — no dbt paths changed.
- [ ] **Dagster Cloud** — expected to pass or skip.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Reverts one of the three config changes from
#4914, on measurement.

### The measurement

Four 15-minute readings, taken via `gcloud logging read` over the hour after the
`helm upgrade` that shipped #4914:

| reading | grpc unreachable | code-server Preempted | Evicted |
| --- | --- | --- | --- |
| 1 | 0 | 0 | 0 |
| 2 | 2 | 3 | 0 |
| 3 | 20 | 8 | 0 |
| 4 | 18 | 9 | 0 |
| **hour** | **40** | **20** | **0** |

Four-week baseline, from #4907: 85 to 134 gRPC errors and 21 to 37 `Preempted`
per **week**, i.e. ~0.65 and ~0.17 per hour. So ~62x and ~118x.

Readings 3 and 4 being the highest is what rules out "rollover churn decaying".
Reading 1 being clean is a quiet gap in a bursty signal — I briefly misread it as
exoneration before readings 3 and 4 landed.

Counting filters are in `.claude/scratch/measure-counters.sh` (gitignored); the
equivalent LQL is in the Phase 1 plan, Task 4 Step 7.

### Mechanism

`cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` blocks
cluster-autoscaler eviction. It does **not** block scheduler preemption —
`.k8s/CLAUDE.md` states this explicitly under Eviction and Priority. Code servers
run at priority 0; run and step pods run at `dagster-run` priority 1000 and are
hard-anti-affine to code servers, which authorizes the scheduler to preempt them.

So pinning code servers removed the graceful path (autoscaler relocation) while
leaving the violent one (preemption) open. Under capacity pressure — and the
`FailedScheduling` messages during the window showed `Insufficient cpu` and
`Insufficient memory` on 5 of 9 to 11 nodes — preemption became the only way to
free a code server's node. Each preemption recreates the Service with a fresh
ClusterIP (`unique_resource_name()` appends a new uuid; Services are
delete-then-create), which is the gRPC gap the annotation was meant to reduce.

### Why only this change is reverted

`Evicted` stayed at 0 for all four readings. The `preferred` self-anti-affinity's
modelled risks are both kubelet-eviction-shaped — a single preemption taking two
co-located pods, and two co-located pods bursting above node allocatable — and
neither fired. Its own mechanism also cannot raise the *number* of preemption
events; at most it would raise the blast radius per event.

`deploymentStartupTimeout: 900` and the readiness / cleanup / rollout budgets
cannot cause preemption at all, and they are what fixed the terminal-failure mode
(`_should_trigger_recovery` refusing to retry an errored location). Reverting them
would give that back for nothing.

### Follow-up

- The Phase 1 measurement in the spec's Verification section should be re-run
  after this lands, against a settled window, to establish whether the remaining
  two changes actually moved `FailedScheduling` and the error rate. #4907 is
  closed, so that is currently untracked.
- #4920 covers Phase 3, the auto-recovery watchdog, which is the remaining gap on
  the original complaint.
- The spec's failure-modes table should gain a row for this: pinning a
  priority-0 pod against the autoscaler converts relocation into preemption. That
  is the generalisable lesson and it is not currently written down anywhere but
  this PR.

</details>
