### PR TITLE
fix(clever): pin the ENR section teacher order to the DSO

### DIFF
--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
@@ -4,6 +4,11 @@ with
             sr.powerschool_teacher_number,
             sr.home_work_location_dagster_code_location,
             sr.home_work_location_powerschool_school_id as school_id,
+
+            -- The DSO is the intended ENR "teacher"; School Leader is the backup.
+            -- Every school matches both, so without an explicit rank the pivot's
+            -- row_number tie-break is arbitrary and the two swap between runs.
+            if(sr.job_title = 'School Leader', 2, 1) as sortorder,
         from {{ ref("int_people__staff_roster") }} as sr
         where
             sr.assignment_status != 'Terminated'
@@ -127,7 +132,7 @@ with
                 right('{{ var("current_fiscal_year") }}', 2)
             ) as terms_abbreviation,
 
-            1 as sortorder,
+            dsos.sortorder,
 
             dsos.powerschool_teacher_number as teachernumber,
 
@@ -171,7 +176,9 @@ with
 
             concat(
                 'teacher_',
-                row_number() over (partition by section_id order by sortorder asc),
+                row_number() over (
+                    partition by section_id order by sortorder asc, teachernumber asc
+                ),
                 '_id'
             ) as input_column,
         from teachers_long

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -456,6 +456,23 @@ data_tests:
           ref:
             name: int_people__staff_roster
 
+  - name: rpt_clever__sections__enr_teacher_id_is_the_dso
+    description: >-
+      The auto-generated ENR sections must list the school's DSO as their
+      primary teacher, never the School Leader. Both titles match the same
+      filter in rpt_clever__sections, so the pick is stable only because
+      sortorder ranks them -- without that rank the two swap on BigQuery's scan
+      order, which is how ~90 sections silently changed hands and tripped
+      Clever's churn alert in August 2026. Errors rather than warns: Clever
+      derives each section's display name from its primary teacher, so a
+      regression here rewrites every ENR section name in the feed.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: rpt_clever__sections
+
   - name: rpt_clever__school_id_resolves_to_schools_feed
     description: >-
       Cross-feed referential integrity for the six Clever SFTP extracts -- every

--- a/src/dbt/kipptaf/tests/rpt_clever__sections__enr_teacher_id_is_the_dso.sql
+++ b/src/dbt/kipptaf/tests/rpt_clever__sections__enr_teacher_id_is_the_dso.sql
@@ -1,0 +1,20 @@
+-- The auto-generated ENR sections carry the school's DSO as their primary
+-- teacher and the School Leader as the backup. Both match the same job-title
+-- filter, so the pick is only stable because `sortorder` ranks them; drop that
+-- rank and the two swap on scan order, silently and without failing anything.
+-- Clever names each section after its primary teacher, so a swap rewrites every
+-- ENR section name and trips its churn alert. A teacher_id that resolves to no
+-- active roster row at all lands here too.
+select s.section_id, s.teacher_id, sr.job_title,
+from {{ ref("rpt_clever__sections") }} as s
+left join
+    {{ ref("int_people__staff_roster") }} as sr
+    on s.teacher_id = sr.powerschool_teacher_number
+    and sr.assignment_status != 'Terminated'
+where
+    s.course_number = 'ENR'
+    and coalesce(sr.job_title, 'unresolved') not in (
+        'Director of Campus Operations',
+        'Director Campus Operations',
+        'Director School Operations'
+    )


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the "Enroll" (ENR) sections in the
Clever feed from randomly swapping their listed teacher between the school's
DSO and the school's School Leader.

Every NJ school has exactly two people who match the job-title list that picks
the ENR "teacher" — one DSO and one School Leader — and the model gave both the
same sort rank. With nothing to break the tie, BigQuery picked the primary
teacher by whatever order it happened to scan the rows, so the two could trade
places on any run with no change in PowerSchool or ADP. Clever names each
section after its primary teacher, so every swap wrote two change records and
eventually tripped Clever's section-churn alert (11% of NJ sections, ~200
changes, reported 2026-08-19).

This ranks the DSO ahead of the School Leader so the assignment is stable and
matches what the model always intended.

Refs #4928

## Reviewer Notes

- The School Leader stays in the title list. Whether to drop it entirely is a
  separate open question with the Ops team; this PR only makes the current
  behavior deterministic. Dropping it later is a one-line follow-up.
- There is a third change beyond the two that fix ENR: a residual tie-break on
  the pivot's row_number. That one guards the regular-section branch, which can
  hit the same class of bug whenever two teachers on a section share a roledef
  sort order.
- Expect one last burst of churn in Clever when this ships, then it stops. The
  6 ENR schools that are currently inverted snap back to the DSO, plus 5 regular
  sections whose co-teachers tie on roledef sort order. Measured, not estimated:
  845 regular sections carry such a tie, but only 5 of the 2,491 non-ENR
  sections actually change hands under the new order.
- A regression test now guards the invariant (`d60771dd6`). It returns 37 rows
  against prod's current pre-fix values and 0 against the fix.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; `rpt_clever__sections.yml` already exists and needs no change.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      change; the existing Clever extract exposure still applies.
- [x] **Breaking change?** No. No columns renamed, removed, or retyped. Only
      which teacher number lands in `teacher_id` vs `teacher_2_id` changes.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      not applicable, no source changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Root cause was traced from a Slack report, not
guessed.

Mechanism: the `dsos` CTE matches four job titles, one of which is
`School Leader`. All 19 NJ schools match exactly two staff — one DSO-flavored
title plus one School Leader. The ENR branch of `teachers_long` hardcoded
`1 as sortorder` for both, making
`row_number() over (partition by section_id order by sortorder asc)` in
`pre_pivot` a pure tie resolved by scan order.

The tie has existed since the model was created (`3ec16f4d4b`, 2023-07-24); the
title list is byte-identical from then to now, so `School Leader` was not added
recently. The likely re-roll trigger is `54da6e6404` (2026-08-11), which removed
a `LEFT JOIN` from the `dsos` CTE and changed the query plan without touching
any teacher logic.

Direction confirms it is a tie-break re-roll rather than an org change: in the
reported batch two schools moved School Leader to DSO while one moved DSO to
School Leader. A real org change moves one way.

Verification. `dbt build --select rpt_clever__sections` in the worktree
compiles and creates the view, and the
`dbt_utils_unique_combination_of_columns` test passes. The build proves
compilation only, not values — every `ref` resolved to a stale, empty
`zz_cbini_*` dev copy rather than deferring to prod, so the dev view returned
zero rows. The behavioral check therefore reran the compiled ENR path against
prod upstreams: all 90 ENR sections now place a DSO-flavored title in
`teacher_id` (82 Director School Operations, 8 Director Campus Operations) and
School Leader in `teacher_2_id`, versus 6 of 19 schools inverted before.

The `rpt_clever__school_id_resolves_to_schools_feed` test failed locally with 38
rows. All 38 are in the `teachers` and `staff` feeds and none in `sections`;
prod runs the same test clean. That is stale-dev drift on two models this PR
does not touch, not a regression.

`trunk check --force --no-fix` on the changed SQL: no issues.

</details>

