### PR TITLE
fix(overgrad): declare university_type and public_school on University

### DIFF
--- a/src/dbt/kipptaf/models/overgrad/staging/properties/stg_overgrad__universities.yml
+++ b/src/dbt/kipptaf/models/overgrad/staging/properties/stg_overgrad__universities.yml
@@ -19,7 +19,17 @@ models:
         data_type: string
       - name: object
         data_type: string
+      - name: public_school
+        description: >-
+          Whether Overgrad classifies the institution as publicly controlled.
+          Null where Overgrad has not classified it.
+        data_type: boolean
       - name: state
         data_type: string
       - name: status
+        data_type: string
+      - name: university_type
+        description: >-
+          Overgrad's institution length category: `four_year`, `two_year`, or
+          `less_than_two_year`. Null where Overgrad has not categorized it.
         data_type: string

--- a/src/teamster/libraries/overgrad/schema.py
+++ b/src/teamster/libraries/overgrad/schema.py
@@ -121,8 +121,10 @@ class University(UniversityID):
     city: str | None = None
     name: str | None = None
     object: str | None = None
+    public_school: bool | None = None
     state: str | None = None
     status: str | None = None
+    university_type: str | None = None
 
 
 class DueDate(BaseModel):


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the alert that fires on every
`kipptaf/overgrad/universities` materialization, and start capturing two fields
Overgrad added to its universities endpoint: `university_type` and
`public_school`.

Overgrad began returning both fields around 2026-08-09. We never declared them,
so the Avro writer silently dropped them and the `avro_schema_valid` check
warned on every run. The check is WARN severity, so runs stayed green while
firing an alert each time. This is the same drift that hit the students endpoint
in 5b733b4dd.

Refs #4939

## Reviewer Notes

- **Field types were checked against the live API, not guessed.** A random
  sample of 40 universities gives `university_type` as a string enum
  (`four_year`, `two_year`, `less_than_two_year`) and `public_school` as a bool.
  Both keys appear on all 40 records, sometimes null.
- **The dbt change is not optional.** `stg_overgrad__universities` is a bare
  `select *` under an enforced contract, so two new external-table columns break
  it unless they are declared in the properties file in the same change.
- **The 2,617 universities already in the warehouse will read null for both new
  fields until they are backfilled.** The asset uses
  `AutomationCondition.newly_missing()`, so existing partitions never
  re-materialize on their own. See the rollout note below.

## Rollout

After merge, back-fill all partitions of `kipptaf/overgrad/universities` from
the Dagster UI. Until that finishes, only newly-added universities carry the two
fields. Nothing breaks in the meantime, because BigQuery unions the Avro schemas
across the wildcard rather than reading one representative file.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] Ran `uv run pytest tests/assets/test_assets_overgrad.py::test_universities_kipptaf`
      — passes, and that test asserts the check's `extras` metadata is empty.

### dbt

- [x] Properties file updated for the two new contract columns, with
      descriptions.
- [x] No columns renamed or removed, so no downstream exposure breakage.
- [x] Ran `stage_external_sources --target staging` against
      `gs://teamster-test/dagster/kipptaf` so dbt Cloud CI sees the new schema
      before the prod Avro files are updated. Re-stage to the prod location
      after merge, once the backfill lands.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Investigated with
`superpowers:systematic-debugging` from run
`ee8cf7e5-f411-41bd-ad13-0cddc7ac1447`.

**Root cause.** `University` in `src/teamster/libraries/overgrad/schema.py`
drives the generated Avro schema. `check_avro_schema_valid` in
`src/teamster/core/asset_checks.py` computes `record_fields - schema_fields`, so
any undeclared key surfaces as an extra. Check history: first failure was run
`0ed20d84-6972-4b93-86c8-8f9d2c25b459`; the four executions before it passed
with empty `extras`. No repo commit is implicated — the API changed.

**Type evidence.** A throwaway pytest probe fetched 40 randomly-sampled
university ids through `OvergradResource` (the conftest bootstraps credentials).
Observed Python types were `str`/`NoneType` for `university_type` and
`bool`/`NoneType` for `public_school`, with distinct values `four_year`,
`two_year`, `less_than_two_year` and `true`/`false`. The probe was deleted after
the run.

**Mixed-schema behavior, verified rather than assumed.** The concern was that
2,617 existing per-id Avro files keep the old 7-field schema while new
partitions write 9, and Google's documentation does not state how an external
Avro table resolves that. Tested it directly: wrote one old-schema file and one
new-schema file to the test bucket, staged an external table over just those
two, and read it back. BigQuery **unions** the fields — all nine columns
present, with the old file's row reading null for both new fields. So the
contract holds as soon as the first new-schema partition lands, and the backfill
is a data-completeness follow-up rather than a merge blocker.

**Column order.** The properties file lists the two new columns in the same
positions the pydantic model emits them (alphabetical within `University`).
Contract enforcement matches on name plus type rather than order, so this is
cosmetic consistency, not a requirement.

</details>
