### PR TITLE
chore(launch): remove Content Team (MIA) from tool catalog

### DIFF
--- a/src/launch/links.yml
+++ b/src/launch/links.yml
@@ -56,15 +56,6 @@
   system: tableau
   status: verified
 
-- id: content_team
-  name: Content Team (MIA)
-  url: https://tableau.kipp.org/t/KIPPNJ/views/ContentTeamDashboard/Home?:embed=y
-  description:
-    Information from CTM Rubric and O3s for Instructional Leads in Miami.
-  audiences: [leaders]
-  system: tableau
-  status: needs-review
-
 - id: data_quality_dashboard
   name: Data Quality Dashboard
   url: https://tableau.kipp.org/t/KIPPNJ/views/DataQualityDashboard/Home?:embed=y


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will remove the `content_team` entry — Content
Team (MIA) — from the data launch page tool catalog in `src/launch/links.yml`.

The entry was one of the originals scraped from the existing Google Site and had
been sitting at `status: needs-review`. Rather than verify it, it is being
dropped from the catalog. Because only `status: verified` entries publish, this
does not change what staff currently see on the launch page — it removes the
entry from the review queue so the catalog reflects the tools we actually intend
to publish.

This continues the tool-inventory verification pass from the earlier commits on
this branch.

## AI Assistance

Human-directed. The `links.yml` edit was authored manually. Claude Code was used
only to diagnose why the push was failing (the `tool-inventory` remote branch
had been auto-deleted after PR #4767 merged, leaving the local branch tracking a
ref that no longer existed) and to re-push the branch and open this PR. No code
or catalog content was AI-authored.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### Dagster

Not applicable — no Dagster changes.

### dbt

Not applicable — no dbt changes. `src/launch/links.yml` is catalog metadata for
the launch page, not a dbt model, so no properties file or exposure update is
needed.

### Docs

Not applicable — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes or not triggered
- [ ] **Dagster Cloud** — passes or not triggered
