### PR TITLE
feat(dbt): add IntegrationKey to DeansList family contacts extract

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -34,6 +34,12 @@ Authoritative consumer list for a source-system package:
 Packages" prose drifts; `packages.yml` is ground truth. `kipptaf` consumes most
 source data via `source()`, not as a package.
 
+**A model name can exist in both a source-system package and `kipptaf`** (e.g.
+`int_finalsite__student_contacts`). `ref()` resolves to the CURRENT project's
+copy, so when reading a `kipptaf` model's upstream, open the `kipptaf` file —
+the same-named package file is a different model. Confirm with
+`find src/dbt -name '<model>.sql'` before reading.
+
 ## District Variable Defaults
 
 All district projects share these variables (override via `dbt_project.yml`):
@@ -1291,6 +1297,12 @@ alias.
 - YAML `description:` is for what/why a column or model computes. Don't put
   TODOs, history, migration plumbing, or tracking-issue refs (`#3142`, etc.) in
   descriptions — those go in inline SQL comments at the derivation site.
+- The reverse also holds: rationale that needs no code context belongs in
+  `description:`, not an inline SQL comment. Keep SQL comments to what a reader
+  of that line cannot see — a non-obvious fallback, why a filter exists. A
+  comment longer than the expression it annotates belongs in the properties
+  file; the repo's existing multi-paragraph SQL comments are not a precedent to
+  extend.
 
 ### Flattened child-array model naming
 

--- a/src/dbt/kipptaf/CLAUDE.md
+++ b/src/dbt/kipptaf/CLAUDE.md
@@ -211,6 +211,14 @@ actual SFTP feed. Per feed: addresses/contacts/demographics import-once
 additionally reads Focus in kipptaf via a BQ-native source (#4319). Spec:
 `docs/superpowers/specs/2026-06-29-finalsite-focus-idempotent-imports-design.md`.
 
+## Reuse existing entity identity
+
+**Before deriving an entity key in a new model, grep the marts.**
+`dim_student_contact_persons` and `bridge_student_contacts` already define
+`person_identity` and `student_contact_person_key`; an extract that invents its
+own contact key silently disagrees with them. A shared identity expression
+belongs in the `int_` model every consumer reads, not copy-pasted per consumer.
+
 ## `dbt_project.yml` Inherited Defaults
 
 These are set at directory level — **do not repeat per-model** or flag their

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -11,8 +11,10 @@ models:
       contact carries its real Finalsite relationship to the student. Column
       names match the DeansList import template headers exactly. Rows are
       ordered per student with parents before emergency contacts, since
-      DeansList displays contacts in the file's row order. Delivered by the
-      Dagster asset `kipptaf/extracts/deanslist/contacts_txt`.
+      DeansList displays contacts in the file's row order. `IntegrationKey`
+      gives DeansList a stable id for each contact row, so two contacts sharing
+      a name no longer collapse into one on import. Delivered by the Dagster
+      asset `kipptaf/extracts/deanslist/contacts_txt`.
     data_tests:
       # The source grain is (student, contact_slot), but the DeansList template
       # fixes the header set so the slot cannot be projected — name plus
@@ -117,6 +119,32 @@ models:
           Always null — the header is required by the DeansList template, but
           Finalsite parent-language data is not maintained reliably enough to
           send.
+      - name: IntegrationKey
+        data_type: string
+        description:
+          Stable per-contact key DeansList uses to match an imported row to the
+          contact record it already holds. Without it DeansList keys rows on a
+          hash of the contact's name, so two contacts sharing a name collapse
+          into one and a family loses a contact. Formatted `{StudentID}-{contact
+          key}`, where the contact key is the contact's own Finalsite contact
+          UUID for `Parent1`/`Parent2` and the Finalsite contact slot
+          (`emergency_1` through `emergency_4`) for `Emergency`. Parents key on
+          the UUID rather than the slot because parent slots are ranked
+          upstream, so a `primary` flag change swaps `Parent1` and `Parent2` — a
+          slot-keyed row would keep its key and take on the other parent's
+          details. Emergency contacts have no UUID to key on; they are scalar
+          custom fields on the student's own Finalsite record.
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          # A duplicate means one person holds two `primary`/`financial`
+          # relationships to the same student upstream — a Finalsite data-entry
+          # dup, not an extract defect, and DeansList collapsing the two rows is
+          # the right outcome. warn, matching the name-level test above.
+          - unique:
+              config:
+                severity: warn
 
 unit_tests:
   - name: test_family_contacts_slot_contact_types
@@ -135,6 +163,7 @@ unit_tests:
             'enr-001' as finalsite_enrollment_id,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
+            'ct-alice' as finalsite_contact_id,
             'parent' as relationship,
             'Alice' as contact_first_name,
             'Johnson' as contact_last_name,
@@ -145,27 +174,31 @@ unit_tests:
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-001', 'kippnewark', 'contact_2', 'parent',
+            'enr-001', 'kippnewark', 'contact_2', 'ct-adam', 'parent',
             'Adam', 'Johnson', 'adam@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_1', 'grandparent',
+            'enr-001', 'kippnewark', 'emergency_1', cast(null as string),
+            'grandparent',
             'Bob', 'Smith', cast(null as string), cast(null as string),
             cast(null as string), '+13055550200', cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_2', 'aunt',
+            'enr-001', 'kippnewark', 'emergency_2', cast(null as string),
+            'aunt',
             'Carol', 'Diaz', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_3', 'uncle',
+            'enr-001', 'kippnewark', 'emergency_3', cast(null as string),
+            'uncle',
             'Dan', 'Evans', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_4', 'neighbor',
+            'enr-001', 'kippnewark', 'emergency_4', cast(null as string),
+            'neighbor',
             'Erin', 'Fox', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
@@ -195,6 +228,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent1,
             Language: null,
+            IntegrationKey: 123456-ct-alice,
           }
         - {
             StudentID: 123456,
@@ -207,6 +241,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent2,
             Language: null,
+            IntegrationKey: 123456-ct-adam,
           }
         - {
             StudentID: 123456,
@@ -219,6 +254,7 @@ unit_tests:
             Relationship: grandparent,
             ContactType: Emergency,
             Language: null,
+            IntegrationKey: 123456-emergency_1,
           }
         - {
             StudentID: 123456,
@@ -231,6 +267,7 @@ unit_tests:
             Relationship: aunt,
             ContactType: Emergency,
             Language: null,
+            IntegrationKey: 123456-emergency_2,
           }
         - {
             StudentID: 123456,
@@ -243,6 +280,7 @@ unit_tests:
             Relationship: uncle,
             ContactType: Emergency,
             Language: null,
+            IntegrationKey: 123456-emergency_3,
           }
         - {
             StudentID: 123456,
@@ -255,6 +293,7 @@ unit_tests:
             Relationship: neighbor,
             ContactType: Emergency,
             Language: null,
+            IntegrationKey: 123456-emergency_4,
           }
 
   - name: test_family_contacts_excludes_ineligible
@@ -272,6 +311,7 @@ unit_tests:
             'enr-ok' as finalsite_enrollment_id,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
+            'ct-gina' as finalsite_contact_id,
             'parent' as relationship,
             'Gina' as contact_first_name,
             'Hill' as contact_last_name,
@@ -282,17 +322,17 @@ unit_tests:
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-mia', 'kippmiami', 'contact_1', 'parent',
+            'enr-mia', 'kippmiami', 'contact_1', 'ct-hank', 'parent',
             'Hank', 'Ito', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-unenr', 'kippnewark', 'contact_1', 'parent',
+            'enr-unenr', 'kippnewark', 'contact_1', 'ct-ivy', 'parent',
             'Ivy', 'Jones', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-noxwalk', 'kippnewark', 'contact_1', 'parent',
+            'enr-noxwalk', 'kippnewark', 'contact_1', 'ct-kim', 'parent',
             'Kim', 'Lee', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
@@ -332,6 +372,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent1,
             Language: null,
+            IntegrationKey: 200001-ct-gina,
           }
 
   - name: test_family_contacts_excludes_third_parent_slot
@@ -353,6 +394,7 @@ unit_tests:
             'enr-301' as finalsite_enrollment_id,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
+            'ct-one' as finalsite_contact_id,
             'parent' as relationship,
             'Jane' as contact_first_name,
             'One' as contact_last_name,
@@ -363,17 +405,18 @@ unit_tests:
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-301', 'kippnewark', 'contact_2', 'parent',
+            'enr-301', 'kippnewark', 'contact_2', 'ct-two', 'parent',
             'Jane', 'Two', 'jane2@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-301', 'kippnewark', 'contact_3', 'parent',
+            'enr-301', 'kippnewark', 'contact_3', 'ct-three', 'parent',
             'Jane', 'Three', 'jane3@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-301', 'kippnewark', 'emergency_1', 'neighbor',
+            'enr-301', 'kippnewark', 'emergency_1', cast(null as string),
+            'neighbor',
             'Jane', 'Four', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
       - input: ref('int_finalsite__contact_id_attributes')
@@ -403,6 +446,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent1,
             Language: null,
+            IntegrationKey: 300001-ct-one,
           }
         - {
             StudentID: 300001,
@@ -415,6 +459,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent2,
             Language: null,
+            IntegrationKey: 300001-ct-two,
           }
         - {
             StudentID: 300001,
@@ -427,6 +472,7 @@ unit_tests:
             Relationship: neighbor,
             ContactType: Emergency,
             Language: null,
+            IntegrationKey: 300001-emergency_1,
           }
 
   - name: test_family_contacts_untyped_phone_fills_cellphone
@@ -446,6 +492,7 @@ unit_tests:
             'enr-401' as finalsite_enrollment_id,
             'kippcamden' as _dbt_source_project,
             'contact_1' as contact_slot,
+            'ct-nan' as finalsite_contact_id,
             'parent' as relationship,
             'Nan' as contact_first_name,
             'Untyped' as contact_last_name,
@@ -456,7 +503,7 @@ unit_tests:
             '+18564730100' as phone_untyped
           union all
           select
-            'enr-401', 'kippcamden', 'contact_2', 'parent',
+            'enr-401', 'kippcamden', 'contact_2', 'ct-ted', 'parent',
             'Ted', 'Typed', cast(null as string), cast(null as string),
             cast(null as string), '+18564730200', '+18564730300'
       - input: ref('int_finalsite__contact_id_attributes')
@@ -486,6 +533,7 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent1,
             Language: null,
+            IntegrationKey: 400001-ct-nan,
           }
         - {
             StudentID: 400001,
@@ -498,4 +546,119 @@ unit_tests:
             Relationship: parent,
             ContactType: Parent2,
             Language: null,
+            IntegrationKey: 400001-ct-ted,
+          }
+
+  - name: test_family_contacts_integration_key_separates_same_name_contacts
+    description:
+      Locks IntegrationKey against the duplicate-collapse bug it exists to fix.
+      DeansList keys unkeyed rows on a hash of the contact's name, so one
+      student with two same-named parents and two same-named emergency contacts
+      loses one of each. Feeds exactly that student and asserts all four rows
+      carry distinct keys. It also locks the parent key against the slot — both
+      parent keys are the contact's own UUID with no slot token, so a `primary`
+      flag change upstream that swaps Parent1 and Parent2 moves each key with
+      its person rather than leaving it on the slot.
+    model: rpt_deanslist__family_contacts
+    given:
+      - input: ref('int_finalsite__student_contacts')
+        format: sql
+        rows: |
+          select
+            'enr-501' as finalsite_enrollment_id,
+            'kipppaterson' as _dbt_source_project,
+            'contact_1' as contact_slot,
+            'ct-pat' as finalsite_contact_id,
+            'parent' as relationship,
+            'Pat' as contact_first_name,
+            'Ramos' as contact_last_name,
+            cast(null as string) as email,
+            cast(null as string) as phone_home,
+            cast(null as string) as phone_work,
+            cast(null as string) as phone_mobile,
+            cast(null as string) as phone_untyped
+          union all
+          select
+            'enr-501', 'kipppaterson', 'contact_2', 'ct-alex', 'stepparent',
+            'Pat', 'Ramos', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-501', 'kipppaterson', 'emergency_1', cast(null as string),
+            'Aunt',
+            'Sam', 'Ramos', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+          union all
+          select
+            'enr-501', 'kipppaterson', 'emergency_2', cast(null as string),
+            'Uncle',
+            'Sam', 'Ramos', cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string)
+      - input: ref('int_finalsite__contact_id_attributes')
+        format: sql
+        rows: |
+          select
+            'enr-501' as finalsite_enrollment_id,
+            'kipppaterson' as _dbt_source_project,
+            '500001' as powerschool_student_number
+      - input: ref('stg_powerschool__students')
+        format: sql
+        rows: |
+          select
+            500001 as student_number,
+            0 as enroll_status,
+            'kipppaterson' as _dbt_source_project
+    expect:
+      rows:
+        - {
+            StudentID: 500001,
+            ParentFirstName: Pat,
+            ParentLastName: Ramos,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: parent,
+            ContactType: Parent1,
+            Language: null,
+            IntegrationKey: 500001-ct-pat,
+          }
+        - {
+            StudentID: 500001,
+            ParentFirstName: Pat,
+            ParentLastName: Ramos,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: stepparent,
+            ContactType: Parent2,
+            Language: null,
+            IntegrationKey: 500001-ct-alex,
+          }
+        - {
+            StudentID: 500001,
+            ParentFirstName: Sam,
+            ParentLastName: Ramos,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: Aunt,
+            ContactType: Emergency,
+            Language: null,
+            IntegrationKey: 500001-emergency_1,
+          }
+        - {
+            StudentID: 500001,
+            ParentFirstName: Sam,
+            ParentLastName: Ramos,
+            HomePhone: null,
+            WorkPhone: null,
+            CellPhone: null,
+            Email: null,
+            Relationship: Uncle,
+            ContactType: Emergency,
+            Language: null,
+            IntegrationKey: 500001-emergency_2,
           }

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -11,7 +11,8 @@ models:
       contact carries its real Finalsite relationship to the student. Column
       names match the DeansList import template headers exactly. Rows are
       ordered per student with parents before emergency contacts, since
-      DeansList displays contacts in the file's row order. `IntegrationKey`
+      DeansList displays contacts in the file's row order. Sourced from
+      `int_students__contacts`, filtered to the NJ regions. `IntegrationKey`
       gives DeansList a stable id for each contact row, so two contacts sharing
       a name no longer collapse into one on import. Delivered by the Dagster
       asset `kipptaf/extracts/deanslist/contacts_txt`.
@@ -126,14 +127,17 @@ models:
           contact record it already holds. Without it DeansList keys rows on a
           hash of the contact's name, so two contacts sharing a name collapse
           into one and a family loses a contact. Formatted `{StudentID}-{contact
-          key}`, where the contact key is the contact's own Finalsite contact
-          UUID for `Parent1`/`Parent2` and the Finalsite contact slot
+          key}`, where the contact key is the contact's `person_identity` from
+          `int_students__contacts` for `Parent1`/`Parent2` and the contact slot
           (`emergency_1` through `emergency_4`) for `Emergency`. Parents key on
-          the UUID rather than the slot because parent slots are ranked
+          the person rather than the slot because parent slots are ranked
           upstream, so a `primary` flag change swaps `Parent1` and `Parent2` — a
           slot-keyed row would keep its key and take on the other parent's
-          details. Emergency contacts have no UUID to key on; they are scalar
-          custom fields on the student's own Finalsite record.
+          details. Emergency contacts have no `person_identity`; they are scalar
+          custom fields on the student's own Finalsite record. Same split as
+          `bridge_student_contacts.student_contact_person_key`, with the student
+          prefix taking it from that model's person grain down to DeansList's
+          (student, contact) grain.
         data_tests:
           - not_null:
               config:
@@ -145,7 +149,6 @@ models:
           - unique:
               config:
                 severity: warn
-
 unit_tests:
   - name: test_family_contacts_slot_contact_types
     description:
@@ -156,58 +159,49 @@ unit_tests:
       having the emergency ones overwritten with a slot ordinal.
     model: rpt_deanslist__family_contacts
     given:
-      - input: ref('int_finalsite__student_contacts')
+      - input: ref('int_students__contacts')
         format: sql
         rows: |
           select
-            'enr-001' as finalsite_enrollment_id,
+            123456 as student_number,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'ct-alice' as finalsite_contact_id,
+            'ct-alice' as person_identity,
             'parent' as relationship,
             'Alice' as contact_first_name,
             'Johnson' as contact_last_name,
-            'alice@example.com' as email,
+            'alice@example.com' as email_current,
             '+19292255670' as phone_home,
             cast(null as string) as phone_work,
             '+18623007240x216' as phone_mobile,
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-001', 'kippnewark', 'contact_2', 'ct-adam', 'parent',
+            123456, 'kippnewark', 'contact_2', 'ct-adam', 'parent',
             'Adam', 'Johnson', 'adam@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_1', cast(null as string),
+            123456, 'kippnewark', 'emergency_1', cast(null as string),
             'grandparent',
             'Bob', 'Smith', cast(null as string), cast(null as string),
             cast(null as string), '+13055550200', cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_2', cast(null as string),
-            'aunt',
+            123456, 'kippnewark', 'emergency_2', cast(null as string), 'aunt',
             'Carol', 'Diaz', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_3', cast(null as string),
-            'uncle',
+            123456, 'kippnewark', 'emergency_3', cast(null as string), 'uncle',
             'Dan', 'Evans', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-001', 'kippnewark', 'emergency_4', cast(null as string),
+            123456, 'kippnewark', 'emergency_4', cast(null as string),
             'neighbor',
             'Erin', 'Fox', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
-      - input: ref('int_finalsite__contact_id_attributes')
-        format: sql
-        rows: |
-          select
-            'enr-001' as finalsite_enrollment_id,
-            'kippnewark' as _dbt_source_project,
-            '123456' as powerschool_student_number
       - input: ref('stg_powerschool__students')
         format: sql
         rows: |
@@ -299,55 +293,43 @@ unit_tests:
   - name: test_family_contacts_excludes_ineligible
     description:
       Locks the eligibility filters. Three primary-parent contacts, each valid
-      but for one disqualifier — a non-NJ region (Miami), a non-enrolled student
-      (enroll_status != 0), and a null PowerSchool crosswalk — plus one fully
-      eligible NJ student. Only the eligible student is emitted.
+      but for one disqualifier — a non-NJ region (Miami, which reaches
+      int_students__contacts through its Focus branch), a non-enrolled student
+      (enroll_status != 0), and a null student number — plus one fully eligible
+      NJ student. Only the eligible student is emitted.
     model: rpt_deanslist__family_contacts
     given:
-      - input: ref('int_finalsite__student_contacts')
+      - input: ref('int_students__contacts')
         format: sql
         rows: |
           select
-            'enr-ok' as finalsite_enrollment_id,
+            200001 as student_number,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'ct-gina' as finalsite_contact_id,
+            'ct-gina' as person_identity,
             'parent' as relationship,
             'Gina' as contact_first_name,
             'Hill' as contact_last_name,
-            cast(null as string) as email,
+            cast(null as string) as email_current,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
             cast(null as string) as phone_mobile,
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-mia', 'kippmiami', 'contact_1', 'ct-hank', 'parent',
+            200002, 'kippmiami', 'contact_1', 'ct-hank', 'parent',
             'Hank', 'Ito', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-unenr', 'kippnewark', 'contact_1', 'ct-ivy', 'parent',
+            200003, 'kippnewark', 'contact_1', 'ct-ivy', 'parent',
             'Ivy', 'Jones', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-noxwalk', 'kippnewark', 'contact_1', 'ct-kim', 'parent',
+            cast(null as int64), 'kippnewark', 'contact_1', 'ct-kim', 'parent',
             'Kim', 'Lee', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
-      - input: ref('int_finalsite__contact_id_attributes')
-        format: sql
-        rows: |
-          select
-            'enr-ok' as finalsite_enrollment_id,
-            'kippnewark' as _dbt_source_project,
-            '200001' as powerschool_student_number
-          union all
-          select 'enr-mia', 'kippmiami', '200002'
-          union all
-          select 'enr-unenr', 'kippnewark', '200003'
-          union all
-          select 'enr-noxwalk', 'kippnewark', cast(null as string)
       - input: ref('stg_powerschool__students')
         format: sql
         rows: |
@@ -387,45 +369,38 @@ unit_tests:
       all still appear under their correct ContactType.
     model: rpt_deanslist__family_contacts
     given:
-      - input: ref('int_finalsite__student_contacts')
+      - input: ref('int_students__contacts')
         format: sql
         rows: |
           select
-            'enr-301' as finalsite_enrollment_id,
+            300001 as student_number,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'ct-one' as finalsite_contact_id,
+            'ct-one' as person_identity,
             'parent' as relationship,
             'Jane' as contact_first_name,
             'One' as contact_last_name,
-            'jane1@example.com' as email,
+            'jane1@example.com' as email_current,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
             cast(null as string) as phone_mobile,
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-301', 'kippnewark', 'contact_2', 'ct-two', 'parent',
+            300001, 'kippnewark', 'contact_2', 'ct-two', 'parent',
             'Jane', 'Two', 'jane2@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-301', 'kippnewark', 'contact_3', 'ct-three', 'parent',
+            300001, 'kippnewark', 'contact_3', 'ct-three', 'parent',
             'Jane', 'Three', 'jane3@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-301', 'kippnewark', 'emergency_1', cast(null as string),
+            300001, 'kippnewark', 'emergency_1', cast(null as string),
             'neighbor',
             'Jane', 'Four', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
-      - input: ref('int_finalsite__contact_id_attributes')
-        format: sql
-        rows: |
-          select
-            'enr-301' as finalsite_enrollment_id,
-            'kippnewark' as _dbt_source_project,
-            '300001' as powerschool_student_number
       - input: ref('stg_powerschool__students')
         format: sql
         rows: |
@@ -485,34 +460,27 @@ unit_tests:
       untyped number, and the typed Cell must win rather than being displaced.
     model: rpt_deanslist__family_contacts
     given:
-      - input: ref('int_finalsite__student_contacts')
+      - input: ref('int_students__contacts')
         format: sql
         rows: |
           select
-            'enr-401' as finalsite_enrollment_id,
+            400001 as student_number,
             'kippcamden' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'ct-nan' as finalsite_contact_id,
+            'ct-nan' as person_identity,
             'parent' as relationship,
             'Nan' as contact_first_name,
             'Untyped' as contact_last_name,
-            cast(null as string) as email,
+            cast(null as string) as email_current,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
             cast(null as string) as phone_mobile,
             '+18564730100' as phone_untyped
           union all
           select
-            'enr-401', 'kippcamden', 'contact_2', 'ct-ted', 'parent',
+            400001, 'kippcamden', 'contact_2', 'ct-ted', 'parent',
             'Ted', 'Typed', cast(null as string), cast(null as string),
             cast(null as string), '+18564730200', '+18564730300'
-      - input: ref('int_finalsite__contact_id_attributes')
-        format: sql
-        rows: |
-          select
-            'enr-401' as finalsite_enrollment_id,
-            'kippcamden' as _dbt_source_project,
-            '400001' as powerschool_student_number
       - input: ref('stg_powerschool__students')
         format: sql
         rows: |
@@ -556,51 +524,44 @@ unit_tests:
       student with two same-named parents and two same-named emergency contacts
       loses one of each. Feeds exactly that student and asserts all four rows
       carry distinct keys. It also locks the parent key against the slot — both
-      parent keys are the contact's own UUID with no slot token, so a `primary`
-      flag change upstream that swaps Parent1 and Parent2 moves each key with
-      its person rather than leaving it on the slot.
+      parent keys are the contact's `person_identity` with no slot token, so a
+      `primary` flag change upstream that swaps Parent1 and Parent2 moves each
+      key with its person rather than leaving it on the slot.
     model: rpt_deanslist__family_contacts
     given:
-      - input: ref('int_finalsite__student_contacts')
+      - input: ref('int_students__contacts')
         format: sql
         rows: |
           select
-            'enr-501' as finalsite_enrollment_id,
+            500001 as student_number,
             'kipppaterson' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'ct-pat' as finalsite_contact_id,
+            'ct-pat' as person_identity,
             'parent' as relationship,
             'Pat' as contact_first_name,
             'Ramos' as contact_last_name,
-            cast(null as string) as email,
+            cast(null as string) as email_current,
             cast(null as string) as phone_home,
             cast(null as string) as phone_work,
             cast(null as string) as phone_mobile,
             cast(null as string) as phone_untyped
           union all
           select
-            'enr-501', 'kipppaterson', 'contact_2', 'ct-alex', 'stepparent',
+            500001, 'kipppaterson', 'contact_2', 'ct-alex', 'stepparent',
             'Pat', 'Ramos', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-501', 'kipppaterson', 'emergency_1', cast(null as string),
+            500001, 'kipppaterson', 'emergency_1', cast(null as string),
             'Aunt',
             'Sam', 'Ramos', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
           union all
           select
-            'enr-501', 'kipppaterson', 'emergency_2', cast(null as string),
+            500001, 'kipppaterson', 'emergency_2', cast(null as string),
             'Uncle',
             'Sam', 'Ramos', cast(null as string), cast(null as string),
             cast(null as string), cast(null as string), cast(null as string)
-      - input: ref('int_finalsite__contact_id_attributes')
-        format: sql
-        rows: |
-          select
-            'enr-501' as finalsite_enrollment_id,
-            'kipppaterson' as _dbt_source_project,
-            '500001' as powerschool_student_number
       - input: ref('stg_powerschool__students')
         format: sql
         rows: |

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__family_contacts.yml
@@ -12,10 +12,11 @@ models:
       names match the DeansList import template headers exactly. Rows are
       ordered per student with parents before emergency contacts, since
       DeansList displays contacts in the file's row order. Sourced from
-      `int_students__contacts`, filtered to the NJ regions. `IntegrationKey`
-      gives DeansList a stable id for each contact row, so two contacts sharing
-      a name no longer collapse into one on import. Delivered by the Dagster
-      asset `kipptaf/extracts/deanslist/contacts_txt`.
+      `int_students__contacts`, filtered to the NJ regions because that model
+      also carries Miami's Focus contacts. `IntegrationKey` gives DeansList a
+      stable id for each contact row, so two contacts sharing a name no longer
+      collapse into one on import. Delivered by the Dagster asset
+      `kipptaf/extracts/deanslist/contacts_txt`.
     data_tests:
       # The source grain is (student, contact_slot), but the DeansList template
       # fixes the header set so the slot cannot be projected — name plus
@@ -137,7 +138,13 @@ models:
           custom fields on the student's own Finalsite record. Same split as
           `bridge_student_contacts.student_contact_person_key`, with the student
           prefix taking it from that model's person grain down to DeansList's
-          (student, contact) grain.
+          (student, contact) grain — without it a parent with two enrolled
+          children would get one key for two rows. Left readable rather than
+          hashed like that marts key — the longest value is 43 characters
+          against DeansList's 64-character limit, so staff can trace a row back
+          to its Finalsite contact by eye. No region component, since
+          `student_number` is unique across the three NJ regions this extract
+          covers.
         data_tests:
           - not_null:
               config:

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -2,14 +2,13 @@ with
     contacts as (
         select
             sc.contact_slot,
-            sc.finalsite_contact_id,
+            sc.person_identity,
             sc.contact_first_name,
             sc.contact_last_name,
-            sc.email,
+            sc.email_current,
             sc.relationship,
+            sc.student_number,
             sc._dbt_source_project,
-
-            safe_cast(xw.powerschool_student_number as int64) as student_number,
 
             -- DeansList phone fields accept only digits and `x` (extension); strip
             -- the E.164 canonical (leading `+`, etc.) to that shape.
@@ -37,14 +36,15 @@ with
                 then 'Parent2'
                 else 'Emergency'
             end as contact_type,
-        from {{ ref("int_finalsite__student_contacts") }} as sc
-        inner join
-            {{ ref("int_finalsite__contact_id_attributes") }} as xw
-            on sc.finalsite_enrollment_id = xw.finalsite_enrollment_id
-            and sc._dbt_source_project = xw._dbt_source_project
+        -- The network contact surface, not the Finalsite intermediates this
+        -- model used to join itself: int_students__contacts' Finalsite branch
+        -- IS that join (same two refs, same keys, same crosswalk filter), and
+        -- it carries `person_identity`, the shared contact-identity definition
+        -- the marts key on. The region filter stays because that model also
+        -- unions Miami's Focus contacts, which DeansList does not take.
+        from {{ ref("int_students__contacts") }} as sc
         where
             sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
-            and xw.powerschool_student_number is not null
             and (
                 sc.contact_slot in ('contact_1', 'contact_2')
                 or sc.contact_slot like 'emergency\\_%'
@@ -57,7 +57,7 @@ select
     c.contact_last_name as `ParentLastName`,
     c.phone_home as `HomePhone`,
     c.phone_work as `WorkPhone`,
-    c.email as `Email`,
+    c.email_current as `Email`,
     c.relationship as `Relationship`,
     c.contact_type as `ContactType`,
 
@@ -82,19 +82,23 @@ select
     -- key while taking on the other parent's name, phone, and email, dragging
     -- whatever DeansList attached to that key onto the wrong person.
     --
-    -- Emergency contacts have no UUID: they are scalar `emrg_N` custom fields
-    -- on the student's own record, not linked contact records, so the slot IS
-    -- their identity -- the same key `rpt_parentsquare__emergency_contacts`
-    -- uses, for the same reason.
+    -- Emergency contacts have no `person_identity`: they are scalar `emrg_N`
+    -- custom fields on the student's own record, not linked contact records, so
+    -- the slot IS their identity. Same split, and same reasoning, as
+    -- `bridge_student_contacts.student_contact_person_key`; the student prefix
+    -- is what takes this from the dimension's person grain down to DeansList's
+    -- (student, contact) grain, so a parent with two enrolled children gets one
+    -- key per child rather than one shared key.
     --
-    -- Readable rather than hashed like that sibling: a 6-digit student number
-    -- plus a 36-char UUID is 43 chars, so it fits, and staff can trace a row
-    -- back to its Finalsite contact by eye. No region component --
-    -- `student_number` is unique across the three NJ regions covered here.
+    -- Readable rather than hashed like the marts key: a 6-digit student number
+    -- plus a 36-char UUID is 43 chars, so it fits inside DeansList's 64, and
+    -- staff can trace a row back to its Finalsite contact by eye. No region
+    -- component -- `student_number` is unique across the three NJ regions
+    -- covered here.
     concat(
         cast(c.student_number as string),
         '-',
-        coalesce(c.finalsite_contact_id, c.contact_slot)
+        coalesce(c.person_identity, c.contact_slot)
     ) as `IntegrationKey`,
 from contacts as c
 inner join

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -1,6 +1,8 @@
 with
     contacts as (
         select
+            sc.contact_slot,
+            sc.finalsite_contact_id,
             sc.contact_first_name,
             sc.contact_last_name,
             sc.email,
@@ -68,6 +70,32 @@ select
     -- so it is the likeliest fit, and a landline sent here is no worse off than
     -- the blank it replaces. A Finalsite-typed Cell still wins outright.
     coalesce(c.phone_mobile, c.phone_untyped) as `CellPhone`,
+
+    -- DeansList has no id of ours to key contact rows on, so its importer keys
+    -- them on a hash of the contact's name: two contacts sharing a name
+    -- collapse into one row and a family silently loses a contact.
+    -- `IntegrationKey` gives it a real key (any string up to 64 chars).
+    --
+    -- Parents key on their own Finalsite contact UUID, NOT on the slot, because
+    -- parent slots are ranked rather than fixed -- flipping a `primary` flag
+    -- upstream swaps contact_1 and contact_2. A slot-keyed row would keep its
+    -- key while taking on the other parent's name, phone, and email, dragging
+    -- whatever DeansList attached to that key onto the wrong person.
+    --
+    -- Emergency contacts have no UUID: they are scalar `emrg_N` custom fields
+    -- on the student's own record, not linked contact records, so the slot IS
+    -- their identity -- the same key `rpt_parentsquare__emergency_contacts`
+    -- uses, for the same reason.
+    --
+    -- Readable rather than hashed like that sibling: a 6-digit student number
+    -- plus a 36-char UUID is 43 chars, so it fits, and staff can trace a row
+    -- back to its Finalsite contact by eye. No region component --
+    -- `student_number` is unique across the three NJ regions covered here.
+    concat(
+        cast(c.student_number as string),
+        '-',
+        coalesce(c.finalsite_contact_id, c.contact_slot)
+    ) as `IntegrationKey`,
 from contacts as c
 inner join
     {{ ref("stg_powerschool__students") }} as s

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -36,14 +36,9 @@ with
                 then 'Parent2'
                 else 'Emergency'
             end as contact_type,
-        -- The network contact surface, not the Finalsite intermediates this
-        -- model used to join itself: int_students__contacts' Finalsite branch
-        -- IS that join (same two refs, same keys, same crosswalk filter), and
-        -- it carries `person_identity`, the shared contact-identity definition
-        -- the marts key on. The region filter stays because that model also
-        -- unions Miami's Focus contacts, which DeansList does not take.
         from {{ ref("int_students__contacts") }} as sc
         where
+            -- that model also carries Miami's Focus contacts; DeansList is NJ only
             sc._dbt_source_project in ('kippnewark', 'kippcamden', 'kipppaterson')
             and (
                 sc.contact_slot in ('contact_1', 'contact_2')
@@ -71,30 +66,7 @@ select
     -- the blank it replaces. A Finalsite-typed Cell still wins outright.
     coalesce(c.phone_mobile, c.phone_untyped) as `CellPhone`,
 
-    -- DeansList has no id of ours to key contact rows on, so its importer keys
-    -- them on a hash of the contact's name: two contacts sharing a name
-    -- collapse into one row and a family silently loses a contact.
-    -- `IntegrationKey` gives it a real key (any string up to 64 chars).
-    --
-    -- Parents key on their own Finalsite contact UUID, NOT on the slot, because
-    -- parent slots are ranked rather than fixed -- flipping a `primary` flag
-    -- upstream swaps contact_1 and contact_2. A slot-keyed row would keep its
-    -- key while taking on the other parent's name, phone, and email, dragging
-    -- whatever DeansList attached to that key onto the wrong person.
-    --
-    -- Emergency contacts have no `person_identity`: they are scalar `emrg_N`
-    -- custom fields on the student's own record, not linked contact records, so
-    -- the slot IS their identity. Same split, and same reasoning, as
-    -- `bridge_student_contacts.student_contact_person_key`; the student prefix
-    -- is what takes this from the dimension's person grain down to DeansList's
-    -- (student, contact) grain, so a parent with two enrolled children gets one
-    -- key per child rather than one shared key.
-    --
-    -- Readable rather than hashed like the marts key: a 6-digit student number
-    -- plus a 36-char UUID is 43 chars, so it fits inside DeansList's 64, and
-    -- staff can trace a row back to its Finalsite contact by eye. No region
-    -- component -- `student_number` is unique across the three NJ regions
-    -- covered here.
+    -- person_identity is null on emergency slots, so the slot stands in there.
     concat(
         cast(c.student_number as string),
         '-',

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
@@ -9,8 +9,7 @@ with
             is_custodial,
             is_household_member,
             _dbt_source_project,
-
-            coalesce(finalsite_contact_id, personid) as person_identity,
+            person_identity,
         from {{ ref("int_students__contacts") }}
         where
             contact_slot in ('contact_1', 'contact_2')

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_student_contacts.yml
@@ -109,8 +109,7 @@ unit_tests:
             500001 as student_number,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'con1' as finalsite_contact_id,
-            cast(null as string) as personid,
+            'con1' as person_identity,
             'parent' as relationship,
             false as is_emergency,
             cast(null as bool) as is_pickup,
@@ -118,18 +117,18 @@ unit_tests:
             cast(null as bool) as is_household_member
           union all
           select
-            500001, 'kippnewark', 'contact_2', 'con2', cast(null as string),
+            500001, 'kippnewark', 'contact_2', 'con2',
             'parent', false, cast(null as bool), cast(null as bool),
             cast(null as bool)
           union all
           select
-            500001, 'kippnewark', 'contact_3', 'con3', cast(null as string),
+            500001, 'kippnewark', 'contact_3', 'con3',
             'parent', false, cast(null as bool), cast(null as bool),
             cast(null as bool)
           union all
           select
             500001, 'kippnewark', 'emergency_1', cast(null as string),
-            cast(null as string), 'neighbor', true, true, false, false
+            'neighbor', true, true, false, false
     expect:
       rows:
         - { contact_slot: contact_1, relationship: parent, is_emergency: false }

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_contact_persons.sql
@@ -12,8 +12,7 @@ with
             phone_primary,
             address_home,
             _dbt_source_project,
-
-            coalesce(finalsite_contact_id, personid) as person_identity,
+            person_identity,
         from {{ ref("int_students__contacts") }}
     ),
 

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_student_contact_persons.yml
@@ -123,8 +123,7 @@ unit_tests:
             500001 as student_number,
             'kippnewark' as _dbt_source_project,
             'contact_1' as contact_slot,
-            'con1' as finalsite_contact_id,
-            cast(null as string) as personid,
+            'con1' as person_identity,
             'Jane Doe1' as contact_name,
             'jane1@example.com' as email_current,
             cast(null as string) as phone_mobile,
@@ -135,20 +134,20 @@ unit_tests:
             '1 Main St' as address_home
           union all
           select
-            500001, 'kippnewark', 'contact_2', 'con2', cast(null as string),
+            500001, 'kippnewark', 'contact_2', 'con2',
             'Jane Doe2', 'jane2@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string),
             '+19170000002', '1 Main St'
           union all
           select
-            500001, 'kippnewark', 'contact_3', 'con3', cast(null as string),
+            500001, 'kippnewark', 'contact_3', 'con3',
             'Jane Doe3', 'jane3@example.com', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string),
             '+19170000003', '1 Main St'
           union all
           select
             500001, 'kippnewark', 'emergency_1', cast(null as string),
-            cast(null as string), 'Jane Doe4', cast(null as string),
+            'Jane Doe4', cast(null as string),
             cast(null as string), cast(null as string), cast(null as string),
             cast(null as string), '+19170000004', cast(null as string)
     expect:

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -248,19 +248,5 @@ with
         from focus
     )
 
-select
-    *,
-
-    -- The contact's identity as a PERSON, independent of which student they are
-    -- attached to or which slot they occupy: the Finalsite contact UUID on the
-    -- Finalsite branch, the Focus person id on the Focus branch. Null for every
-    -- emergency slot on both branches -- those are scalar custom fields on the
-    -- student's own record, not linked contact records -- so a consumer keying
-    -- on a person must fall back to (student, slot) there.
-    --
-    -- Derived here rather than in each consumer: dim_student_contact_persons,
-    -- bridge_student_contacts, and rpt_deanslist__family_contacts all key on
-    -- this and must agree, or the DeansList extract and the marts disagree
-    -- about who is the same person.
-    coalesce(finalsite_contact_id, personid) as person_identity,
+select *, coalesce(finalsite_contact_id, personid) as person_identity,
 from all_contacts

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -194,54 +194,73 @@ with
             cast(null as string) as finalsite_contact_id,
         from focus_slotted
         where student_number is not null
+    ),
+
+    all_contacts as (
+        select
+            student_number,
+            _dbt_source_project,
+            contact_slot,
+            personid,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email_current,
+            phone_mobile,
+            phone_home,
+            phone_daytime,
+            phone_work,
+            phone_untyped,
+            phone_primary,
+            address_home,
+            is_emergency,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+        from finalsite
+
+        union all
+
+        select
+            student_number,
+            _dbt_source_project,
+            contact_slot,
+            personid,
+            finalsite_contact_id,
+            contact_name,
+            contact_first_name,
+            contact_last_name,
+            relationship,
+            email_current,
+            phone_mobile,
+            phone_home,
+            phone_daytime,
+            phone_work,
+            phone_untyped,
+            phone_primary,
+            address_home,
+            is_emergency,
+            is_pickup,
+            is_custodial,
+            is_household_member,
+        from focus
     )
 
 select
-    student_number,
-    _dbt_source_project,
-    contact_slot,
-    personid,
-    finalsite_contact_id,
-    contact_name,
-    contact_first_name,
-    contact_last_name,
-    relationship,
-    email_current,
-    phone_mobile,
-    phone_home,
-    phone_daytime,
-    phone_work,
-    phone_untyped,
-    phone_primary,
-    address_home,
-    is_emergency,
-    is_pickup,
-    is_custodial,
-    is_household_member,
-from finalsite
+    *,
 
-union all
-
-select
-    student_number,
-    _dbt_source_project,
-    contact_slot,
-    personid,
-    finalsite_contact_id,
-    contact_name,
-    contact_first_name,
-    contact_last_name,
-    relationship,
-    email_current,
-    phone_mobile,
-    phone_home,
-    phone_daytime,
-    phone_work,
-    phone_untyped,
-    phone_primary,
-    address_home,
-    is_emergency,
-    is_pickup,
-    is_custodial,
-    is_household_member,
-from focus
+    -- The contact's identity as a PERSON, independent of which student they are
+    -- attached to or which slot they occupy: the Finalsite contact UUID on the
+    -- Finalsite branch, the Focus person id on the Focus branch. Null for every
+    -- emergency slot on both branches -- those are scalar custom fields on the
+    -- student's own record, not linked contact records -- so a consumer keying
+    -- on a person must fall back to (student, slot) there.
+    --
+    -- Derived here rather than in each consumer: dim_student_contact_persons,
+    -- bridge_student_contacts, and rpt_deanslist__family_contacts all key on
+    -- this and must agree, or the DeansList extract and the marts disagree
+    -- about who is the same person.
+    coalesce(finalsite_contact_id, personid) as person_identity,
+from all_contacts

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__contacts.yml
@@ -68,6 +68,21 @@ models:
           regions. Used with `_dbt_source_project` to key the contact person in
           the dimension — the id space is per-source-system, so the region is
           always part of the key.
+      - name: person_identity
+        data_type: string
+        description:
+          The contact's identity as a person, independent of the student they
+          are attached to and the slot they occupy — the Finalsite contact UUID
+          on the Finalsite branch, the Focus person id on the Focus branch. Null
+          for every emergency slot on both branches, which are scalar custom
+          fields on the student's own record rather than linked contact records;
+          a consumer keying on a person falls back to (student, slot) there.
+          `dim_student_contact_persons`, `bridge_student_contacts`, and
+          `rpt_deanslist__family_contacts` all key on this column, so they agree
+          on who is the same person.
+        config:
+          meta:
+            contains_pii: true
       - name: finalsite_contact_id
         data_type: string
         description:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will give DeansList a stable ID for every family contact we send it, so contacts who share a name stop disappearing. It also settles where that ID comes from, for every model that needs one.

DeansList has no ID of ours to key contact rows on. Its importer builds one by hashing the contact's name. Two contacts on the same student who share a name collapse into a single row, and the family loses one of them. Against current production data that is **1,711 contact rows across 1,605 students**.

Matt Robins (DeansList) confirmed their importer reads a column named `IntegrationKey` and accepts any string up to 64 characters. Emily maps the column once after the new file drops. The extract is a whole-table export, so no Dagster change is needed — the column just appears in `contacts.txt`.

The key is `{StudentID}-{contact key}`:

- **Parents** use the contact's `person_identity`, their identity as a person.
- **Emergency contacts** use the contact slot, `emergency_1` through `emergency_4`.

Two models already made that same split and each derived it privately, so this adds `person_identity` to `int_students__contacts` and has all three read it. `rpt_deanslist__family_contacts` also moves onto that shared model instead of re-deriving its Finalsite join.

Source: Slack thread with Matt Robins and Laszlo de Simon, 2026-08-24.

## Reviewer Notes

**This does not match what Laszlo asked for, on purpose.** He asked for a purely positional key, `[studentid][contacttype][rn]`, for every row. That is right for emergency contacts and wrong for parents.

Parent slots are ranked, not fixed. Parents are ordered by the `primary` flag, then by whether they share a household with the student, then by relationship id. Flip a `primary` flag in Finalsite and `contact_1` and `contact_2` swap. Under a positional key the DeansList row keyed to Parent1 keeps its key and takes on the other parent's name, phone, and email, dragging anything DeansList attached to that key onto the wrong person. A person's identity never moves. Emergency contacts have no such identity to use, so the slot stays their identity there.

**The identity rule now lives in one place.** `coalesce(finalsite_contact_id, personid)` was copy-pasted into `dim_student_contact_persons` and `bridge_student_contacts`, and this change was about to add a third variant. All three key contacts on it and all three must agree on who is the same person, so it moves to `int_students__contacts` as `person_identity`.

**`rpt_parentsquare__emergency_contacts` is deliberately left alone.** Its `contact_id` omits the region component the marts key includes, so folding it in would change every value it emits and re-key the emergency contacts ParentSquare already holds. That is a migration, not a cleanup.

**The DeansList rewire is the riskiest part, so it is checked against production.** The new logic and the current production table both yield 34,232 rows with an empty symmetric difference in both directions.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No. `IntegrationKey` and `person_identity` are both
      new columns. Nothing is renamed or removed, and every key this touches was
      verified to reproduce its production values exactly.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      No external source changed.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Charlie directed both the deviation from Laszlo's instruction and the upstream consolidation.

Two commits: the DeansList column, then the `person_identity` refactor.

### person_identity

Added at the union tail of `int_students__contacts` as `coalesce(finalsite_contact_id, personid)` — the Finalsite contact UUID on the Finalsite branch, the Focus person id on the Focus branch, null for every emergency slot on both. `dim_student_contact_persons` and `bridge_student_contacts` now select the column instead of recomputing the identical expression. No consumer selects `*` from `int_students__contacts` and the model is not contracted, so the added column is safe.

### DeansList rewire

`rpt_deanslist__family_contacts` previously joined `int_finalsite__student_contacts` to `int_finalsite__contact_id_attributes` itself. That join is exactly the Finalsite branch of `int_students__contacts`: same two refs, same join keys, same `powerschool_student_number is not null` filter, same `safe_cast(... as int64)`. The model now reads `int_students__contacts` and keeps the NJ region filter, since that model also unions Miami's Focus contacts. `sc.email` became `email_current`, and the separate crosswalk-null test case became a null `student_number` case, since that filter now lives upstream.

Key expression:

```sql
concat(
    cast(c.student_number as string),
    '-',
    coalesce(c.person_identity, c.contact_slot)
) as `IntegrationKey`
```

The student prefix is what takes this from the dimension's person grain down to DeansList's (student, contact) grain. Without it a parent with two enrolled children gets one key for two rows: 5,032 of 17,081 NJ parent rows would collide. Matt asked for the student number for exactly this reason.

### Verification against production

- **DeansList rewire is behavior-preserving.** New logic over prod upstreams vs the current `kipptaf_extracts.rpt_deanslist__family_contacts`: 34,232 rows each, `EXCEPT DISTINCT` empty in both directions, across all nine shared columns.
- **Marts keys unchanged.** Recomputing `student_contact_person_key` from `person_identity` reproduces all 39,379 distinct prod keys in `dim_student_contact_persons`, zero extra, zero missing.
- **IntegrationKey shape.** 34,232 rows, 34,232 distinct keys, 0 nulls, max length 43 against the 64-character limit. 20,439 emergency rows (slot-keyed), 13,793 parent rows (identity-keyed).
- **Current loss quantified.** 1,711 rows across 1,605 students collapse under DeansList's name hash today.
- **dbt.** `dbt build` across `int_students__contacts`, both marts, both ParentSquare extracts, and the DeansList extract: PASS=43, 0 errors, 0 warnings.

One local caveat worth knowing: a first `--defer` run resolved to stale `zz_cbini_*` dev schemas and returned 0 rows, which made those data-test passes vacuous, and it surfaced an unrelated failure in `int_extracts__student_enrollments` from a stale dev copy of `int_deanslist__roster_assignments` (7 columns, missing `_dbt_source_project`; prod has 8). Neither is caused by this branch. Every number above comes from querying production tables directly rather than from that run.

### Tests

- `not_null` (error) and `unique` (warn) on `IntegrationKey`. `unique` is warn because a duplicate means one person holds two `primary`/`financial` relationships to the same student upstream — a Finalsite data-entry duplicate, where DeansList collapsing the rows is the right outcome. Matches the existing name-level test's severity.
- `test_family_contacts_integration_key_separates_same_name_contacts` — one student with two same-named parents and two same-named emergency contacts; asserts four distinct keys, and that both parent keys carry no slot token.
- The four existing DeansList unit tests were rewritten to mock `int_students__contacts` and to assert `IntegrationKey` in every `expect` row.
- The `dim_student_contact_persons` and `bridge_student_contacts` unit-test fixtures now supply `person_identity` instead of `finalsite_contact_id` plus `personid`.

</details>
