### PR TITLE
feat(dbt): add salesforce_contact_id to rpt_gsheets__gpa_roster

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__gpa_roster.yml
@@ -70,3 +70,8 @@ models:
           Weighted projected cumulative Y1 GPA, incorporating current
           in-progress grades not yet stored.
         data_type: float64
+      - name: salesforce_contact_id
+        description:
+          Salesforce contact ID for the student, used to join this roster to
+          KIPP Forward records in Salesforce.
+        data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gpa_roster.sql
@@ -8,6 +8,7 @@ with
             co.team,
             co.student_number,
             co.student_name,
+            co.salesforce_id,
             co.iep_status,
             co.gender,
             co.lep_status,
@@ -83,4 +84,6 @@ select
     cumulative_y1_gpa_projected_s1_unweighted,
     cumulative_y1_gpa,
     cumulative_y1_gpa_projected,
+
+    salesforce_id as salesforce_contact_id,
 from roster pivot (max(gpa_term) as gpa for term in ('Q1', 'Q2', 'Q3', 'Q4'))


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add `salesforce_contact_id` as the final
column of `rpt_gsheets__gpa_roster`.

The value is passed through from `int_extracts__student_enrollments` (where it is
exposed as `salesforce_id`, itself an alias of the upstream
`salesforce_contact_id`), so no new join or ref was needed — just one extra
column carried through the `roster` CTE and emitted last.

Purpose: the data team needs the Salesforce contact ID alongside the GPA roster
to support periodic uploads into other systems. It is not intended for display
to sheet readers.

Not a breaking change — additive column only, no renames or removals. Rollback
is a straight revert of this commit.

### Validation

Built in dev with `--defer --favor-state` so all three upstream refs resolved to
prod relations (an initial build without `--favor-state` silently read stale
personal `zz_` copies and undercounted by ~600 rows — worth flagging for anyone
validating extract models locally):

- 6,227 rows / 6,227 distinct students, exactly matching the current prod
  relation — grain preserved, no fan-out from the added column through the
  `pivot`
- 1,802 populated IDs, all distinct, all exactly 18 characters (valid Salesforce
  18-char IDs)
- `trunk check --force` clean on both changed files

Population is high-school-only by nature (0% in grades 5-7, 78% in grade 9,
rising to 99.5% in grade 12) — Salesforce contacts are created as students reach
high school, so middle-school rows are legitimately blank. Confirmed with the
requester that blank values are expected for their use case.

## AI Assistance

Human-directed: the request, the output column name (`salesforce_contact_id`,
chosen over `salesforce_id` / `contact_id` to match the existing gsheets
precedent), and the decision to accept null middle-school rows.

AI-assisted (Claude Code): locating the upstream column, the SQL and YAML edits,
the dev build, and the validation queries above.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — the
      existing `properties/rpt_gsheets__gpa_roster.yml` is updated with the new
      column and a description
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — this
      model's exposure already exists in `models/exposures/google-sheets.yml`;
      adding a column does not change it
- [x] **Breaking change?** No — additive column only. No contracted column was
      renamed or removed, so no downstream exposure breaks.
- [ ] If adding or modifying an external source, run `stage_external_sources` —
      N/A, no external source touched

### Dagster / Docs

Skipped — no Dagster, schedule, sensor, or integration changes. No column list
exists in Dagster config for this extract, so nothing outside dbt needs updating.

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered
