### PR TITLE
feat(dbt): include Paterson in the kipptaf GPA reporting surfaces

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -8,9 +8,8 @@ models:
       Student-grain as-of-today measures (cumulative GPA, needed-GPA, 1/2/4-week
       lookbacks) populate current-year rows only. Students filtered to
       is_enrolled_recent — the year was completed or the enrollment is currently
-      active, so mid-year withdrawals drop. Newark and Camden only — Miami is
-      hard-excluded (region unsupported in the rebuilt dashboard) and Paterson
-      is pending gradebook data.
+      active, so mid-year withdrawals drop. Newark, Camden and Paterson; Miami
+      is hard-excluded (region unsupported in the rebuilt dashboard).
     data_tests:
       # TODO(#3915): returns to error when the storedgrades double-write cleanup
       # completes. All duplicates are prior-year storedgrades rows; current-year
@@ -38,7 +37,8 @@ models:
         description: Display form of the academic year (e.g. 2025-26).
       - name: region
         data_type: string
-        description: District region (Newark or Camden; see model description).
+        description: >-
+          District region (Newark, Camden or Paterson; see model description).
       - name: school_level
         data_type: string
         description: School level (ES/MS/HS) from the year's enrollment.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa_cumulative.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa_cumulative.sql
@@ -48,4 +48,3 @@ where
     and not is_out_of_district
     and school_level_alt in ('MS', 'HS')
     and enroll_status in (0, 3)
-    and region != 'Paterson'

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -358,13 +358,7 @@ with
             and enr.academic_year <= {{ var("current_academic_year") }}
             /* Miami hard-excluded: region unsupported in the rebuilt
                dashboard (#4340) */
-            /* TODO(#4340): add Paterson once PS gradebook data is populated.
-               That change also has to add a kipppaterson source to
-               int_powerschool__gradescaleitem_lookup, which unions Newark,
-               Camden and Miami only — otherwise the grade_scale_ladder join
-               below finds no scale and need_next_* stays silently null for
-               every Paterson row. */
-            and enr.region in ('Newark', 'Camden')
+            and enr.region in ('Newark', 'Camden', 'Paterson')
     ),
 
     course_enrollments as (

--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
@@ -30,9 +30,3 @@ where
        for AY2025 that was 382 of 398 grade-12 students, reporting the cohort at
        0 percent attainment. */
     and sr.is_enrolled_recent
-    /* TODO(#4581): Paterson is excluded until int_powerschool__gpa_term and
-       int_powerschool__gpa_cumulative union kipppaterson (both are
-       newark/camden/miami only today). Without this, Paterson HS students carry
-       null GPA measures yet still count in org-level denominators, silently
-       deflating the rate. */
-    and sr._dbt_source_project != 'kipppaterson'

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_cumulative_year.yml
@@ -2,10 +2,10 @@ models:
   - name: int_powerschool__gpa_cumulative_year
     description: >-
       Network union of the district int_powerschool__gpa_cumulative_year models
-      (Newark, Camden, Miami) — one row per student, school, and academic year
-      with cumulative Y1 GPA as of the end of that year; current-year rows are
-      projected (is_projected = true) and match int_powerschool__gpa_cumulative
-      projected values exactly.
+      (Newark, Camden, Miami, Paterson) — one row per student, school, and
+      academic year with cumulative Y1 GPA as of the end of that year;
+      current-year rows are projected (is_projected = true) and match
+      int_powerschool__gpa_cumulative projected values exactly.
     config:
       materialized: table
     data_tests:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will surface KIPP Paterson on the kipptaf GPA
reporting surfaces by lifting three downstream gates whose stated preconditions
are already satisfied, and correct two stale region lists in model
documentation.

Paterson's GPA models were wired into the kipptaf unions back in `b3df984b2`,
which added `kipppaterson` to `int_powerschool__gpa_term`,
`int_powerschool__gpa_cumulative`, `int_powerschool__gpa_cumulative_year` and
`int_powerschool__gradescaleitem_lookup` as a side-effect of a Clever fix. That
commit silently satisfied the preconditions of three gated Paterson TODOs and
none of the gates were lifted. This PR sweeps them.

**Changes**

- `rpt_tableau__gradebook_gpa_cumulative` — drop the Paterson exclusion, adding
  **280 Paterson MS students** (166 with a projected unweighted GPA today, 114
  without, including all 54 grade-5 entrants who are new to the grade band).
- `rpt_tableau__student_course_grades` — widen the region gate to include
  Paterson (Miami stays hard-excluded, unchanged) and remove the `TODO(#4340)`
  whose two stated preconditions are both met.
- `int_gpa__goal_student_metrics` — delete the `kipppaterson` filter and its
  comment, which asserted the unions were newark/camden/miami only. **Zero row
  change**: `school_level = 'HS'` already excludes a region with no high school.
- Correct the stale region lists in the `int_powerschool__gpa_cumulative_year`
  and `rpt_tableau__student_course_grades` descriptions.

**Verified against prod before changing anything**

| Claim | Result |
| --- | --- |
| Paterson MS cumulative GPA computes correctly | distribution mode 3.00, n=194 |
| Grade scale 278 resolves | 100% of Y1 rows, AY2023-2025, letter-to-points exact (A+ 4.33 to F 0.0) |
| `potentialcrhrs` populated | 99-100% on every year and grade |
| Cross-region collisions | **zero** — studentid and schoolid namespaces disjoint across all four instances |
| AY2026 term structure | quarters; `pgfinalgrades` carries roughly 9,500 rows per quarter storecode |

**Two known non-gaps, recorded so they are not re-investigated**

- Term GPA for AY2023-2024 is absent by decision. Those years predate the
  current charter operator, printed report cards cover them, and both years were
  trimestered while the `gpa_term` prior-year branch is quarter-only.
- Weighted GPA equals unweighted for all 246 Paterson students. This is
  **correct, not a defect** — weighting is a high-school construct and Paterson
  runs grades K-8.

Paterson's Q1 grade entry is currently sparse (0.6% of rows resolved, against
Camden 15.6%) because staff have not been trained on grade entry yet. Data will
flow in as entry ramps; no code change addresses this and it is not tracked.

## AI Assistance

AI-assisted throughout, human-directed on every scope decision. Claude did the
warehouse profiling, the gate inventory, and the edits. The decisions that
shaped this PR were the author's: that trimester-year term GPA is permanently
out of scope, that MS weighted-equals-unweighted is correct rather than a bug,
that credittype problems get fixed upstream in PowerSchool rather than patched
in dbt, and that Paterson should be un-gated now rather than held for grade
entry to catch up. Claude's initial analysis wrongly treated three of these as
defects; they were corrected by the author before any code was written.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; two existing properties files updated.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard — no new consumers; existing
      exposures unchanged.
- [x] **Breaking change?** No. No columns renamed or removed. The changes widen
      row coverage on two reporting models and remove a no-op filter on a third.
      Rollback is a straight revert of this commit.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      not applicable, no external sources touched.

## CI checks

- [ ] **Trunk** — `trunk check --force --no-fix` passed locally on all 5 changed
      files (No issues).
- [ ] **dbt Cloud** — `dbt parse --no-partial-parse` and `dbt compile` on the
      three changed models both clean locally (exit 0, 0 errors).
- [ ] **Dagster Cloud** — not triggered, no Dagster paths changed.

Refs #4348
Refs #3384
