### PR TITLE
fix(clever): grant School Leader in Residence staff access to Paterson schools

### DIFF
--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -138,6 +138,28 @@ with
         inner join staff_roster as sr on up.employee_number = sr.employee_number
         inner join schools as sch on sch.schoolstate = 'NJ'
         where g.cn = 'Group Staff NJ Regional'
+
+        union all
+
+        /* School Leader in Residence (Room 9, Newark) also covers Paterson
+           schools -- #4981
+        */
+        select
+            sr.powerschool_teacher_number,
+            sr.user_principal_name,
+            sr.given_name,
+            sr.family_name_1,
+            sr.home_department_name,
+            sr.sam_account_name,
+
+            sch.school_id,
+        from staff_roster as sr
+        inner join
+            schools as sch
+            on sch.dagster_code_location in ('kippnewark', 'kipppaterson')
+        where
+            sr.job_title = 'School Leader in Residence'
+            and sr.home_work_location_reporting_name = 'Room 9'
     )
 
 select distinct  /* some staff are in multiple assignment groups */


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> When merged, this pull request will grant Newark-based staff holding the
> "School Leader in Residence" role (Room 9 central office) Clever access to
> Paterson schools, in addition to their existing Newark access.

`rpt_clever__staff`'s `assignments` CTE had no branch that expressed "home
region plus one additional region" — every existing path is either
single-school, CMO-wide, home-region-wide, or the `Group Staff NJ Regional` AD
group (which would also grant Camden, not requested). Adds a fifth branch
scoped to `job_title = 'School Leader in Residence'` AND
`home_work_location_reporting_name = 'Room 9'`, granting both Newark and
Paterson schools.

Verified against prod (`int_people__staff_roster`): exactly 3 active staff
match this criteria today. Diffing the old vs. new compiled model output shows
exactly 6 new `(school_id, staff_id)` rows added, across those same 3 staff —
no one else's access changes.

Closes #4981

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address
      valid feedback; dismiss false positives with a brief reply explaining
      why.

### dbt

- [x] No new model — properties file unchanged (no contract columns added)
- [x] No new/changed exposure needed
- [x] Not a breaking change — additive only (existing columns, existing
      contract)
- [x] No external source changes

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Root cause + fix design discussed and refined
across several rounds with the requester (an initial PowerSchool-`schoolstaff`-
derived rule was tested against prod and rejected — it swept in 100+ unrelated
staff network-wide as a data artifact; final criteria is
`job_title`+`home_work_location_reporting_name` only). Verified via
`dbt compile --target prod` + a before/after diff query against prod
`int_people__staff_roster` (see issue #4981 for the query and counts). No PII
included in this PR body or the issue.

</details>
