### PR TITLE
docs: replace the retired dbt-sxs.py in the SFTP integration guide

### DIFF
--- a/docs/guides/sftp-integration.md
+++ b/docs/guides/sftp-integration.md
@@ -132,17 +132,30 @@ Stage the external table and build the staging model in your personal dev schema
 (`zz_<user>_*`). This is for local iteration — verifying type casts, column
 definitions, and test results.
 
-`dbt-sxs.py` has two independent flags:
+Stage with the **dbt: Stage External Sources** VS Code task (Terminal > Run
+Task). It prompts for project, target, and source selector. `scripts/CLAUDE.md`
+documents it in full.
 
-- `--test` — points the external table at the `teamster-test` GCS bucket (use
-  when prod data doesn't exist yet)
-- `--target` — controls the BigQuery schema: `dev` (default, personal
-  `zz_<user>_*`) or `staging` (shared `z_dev_*` used by CI)
+The task always points the external table at the project's PRODUCTION GCS
+bucket. Step 6 wrote your sample to `teamster-test`, so for a source whose
+production data does not exist yet, run the operation directly and override
+`cloud_storage_uri_base` to the test bucket:
 
 ```bash
-uv run scripts/dbt-sxs.py <district_project> --test --select <source_name>.<asset_name>
+uv run dbt run-operation stage_external_sources \
+  --project-dir src/dbt/<district_project> \
+  --target dev \
+  --vars '{"ext_full_refresh": "true", "cloud_storage_uri_base": "gs://teamster-test/dagster/<district_project>"}' \
+  --args 'select: <source_name>.<asset_name>'
+
 uv run dbt build -s <model_name> --project-dir src/dbt/<district_project>
 ```
+
+The path under the bucket is unchanged — the avro IO manager's `test=True` only
+swaps the bucket and adds a local JSON copy, not the blob path.
+
+`--target` controls the BigQuery schema: `dev` (personal `zz_<user>_*`) or
+`staging` (shared, read by CI).
 
 Review the output — check for contract violations, test failures, and data
 quality warnings. Run this for each district project.
@@ -156,12 +169,20 @@ exist there before kipptaf CI can build.
 Re-run the stage and build with `--target staging`:
 
 ```bash
-uv run scripts/dbt-sxs.py <district_project> --test --target staging --select <source_name>.<asset_name>
+uv run dbt run-operation stage_external_sources \
+  --project-dir src/dbt/<district_project> \
+  --target staging \
+  --vars '{"ext_full_refresh": "true", "cloud_storage_uri_base": "gs://teamster-test/dagster/<district_project>"}' \
+  --args 'select: <source_name>.<asset_name>'
+
 uv run dbt build -s <model_name> --project-dir src/dbt/<district_project> --target staging
 ```
 
-!!! note Once the asset is materialized in production, drop `--test` so the
-external table points at the production GCS bucket instead of `teamster-test`.
+!!! note Once the asset is materialized in production, re-stage without the
+`cloud_storage_uri_base` override — the **dbt: Stage External Sources** task at
+`--target staging` does exactly that — so the external table points at the
+production bucket instead of `teamster-test`. Skip it and CI keeps reading your
+test sample indefinitely.
 
 ## Summary
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the SFTP integration guide from telling
you to run a script that no longer exists.

Steps 7 and 8 of `docs/guides/sftp-integration.md` both called
`scripts/dbt-sxs.py`, which is retired. Anyone following the guide hit "no such
file or directory" and had to work out the replacement themselves. I hit it while
adding EdPlan to Paterson (#4988).

The guide was the only stale reference. `scripts/CLAUDE.md` already says the
script was replaced by the **dbt: Stage External Sources** VS Code task.

Closes #5004

## Reviewer Notes

**The rename was not the whole problem.** `dbt-sxs.py` had a `--test` flag that
pointed the external table at the `teamster-test` bucket, for a source whose
production data does not exist yet. Steps 6 through 8 are built around it, and
the replacement task has no equivalent — its script hardcodes the production
bucket. So swapping the command name alone would have left the guide describing
something you cannot do. Both steps now point at the task for the normal case and
give a direct `run-operation` call with `cloud_storage_uri_base` overridden for
the no-production-data case.

**Worth deciding separately:** whether to add a test-bucket option to the task,
so the guide can point at it for every step instead of dropping to a raw command
for one. Noted in the issue; deliberately not done here.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

Skipped — no dbt project changes. The guide documents a dbt command, but no
model, source, or config is touched.

### Docs _(skip if no schedule, sensor, or integration changes)_

- [x] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py` — not applicable, no
      schedule or sensor changed.
- [x] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md` — not
      applicable, no integration added.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Docs-only, one file, `trunk check --force`
clean.

**Why the override is sufficient**, which the guide now states in one line: the
avro IO manager's `test=True` swaps the bucket to `teamster-test` and writes an
extra local JSON copy, but does not change the blob path
(`src/teamster/core/io_managers/gcs.py:115-131`, and `gcs_prefix` defaults to
`dagster`). So `gs://teamster-test/dagster/<project>` holds the same
`<asset_key>/<partition dims>` layout as the production bucket, and pointing
`cloud_storage_uri_base` at it is all that is needed.

**Verified rather than asserted.** The exact override in the new Step 8 text is
what I ran against `kipppaterson` `edplan` earlier today: the external table
created cleanly over `gs://teamster-test/dagster/kipppaterson`, and
`dbt build -s stg_edplan__njsmart_powerschool+ --target staging` returned PASS=3
WARN=0 ERROR=0 with 67 rows through both models.

**`ext_full_refresh`** is carried through from the terminal equivalent in
`scripts/CLAUDE.md:48-53` and from `.vscode/scripts/dbt-stage-external-sources.sh:24`
rather than invented — I did not include it in my own ad-hoc run today, but the
guide should match what the task does.

**Not changed:** `scripts/CLAUDE.md:39` already reads "Replaced `dbt-sxs.py`" and
is correct. I checked for other references repo-wide; the three in this guide
were the only live ones. The remaining hits are in
`docs/superpowers/specs/` and `docs/superpowers/plans/`, which are historical
working documents excluded from the mkdocs nav, so they are expected to describe
superseded tooling and were left alone.

</details>
