### PR TITLE
fix(dbt): resolve the Focus full-year marking-period sentinel in int_focus__schedule

### DIFF
--- a/src/dbt/focus/models/intermediate/int_focus__schedule.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__schedule.sql
@@ -1,3 +1,19 @@
+with
+    marking_periods as (
+        select
+            marking_period_id,
+            syear,
+            school_id,
+            title,
+            short_name,
+            type,
+            start_date,
+            end_date,
+
+            if(type = 'year', 0, marking_period_id) as schedule_marking_period_id,
+        from {{ ref("stg_focus__marking_periods") }}
+    )
+
 select
     s.id as student_schedule_id,
     s.syear as academic_year,
@@ -5,9 +21,6 @@ select
     s.student_id,
     s.course_id,
     s.course_period_id,
-    -- resolved, never the raw sentinel: mkp supplies the school's year-level id
-    -- on a full-year row and the schedule's own id on a term-specific one
-    mkp.marking_period_id,
     s.mp,
     s.course_weight,
     s.days,
@@ -48,6 +61,8 @@ select
     c.course_hours,
     c.homeroom,
 
+    -- aliased mkp, not mp: schedule has its own mp column (the FY/SEM/QTR code)
+    mkp.marking_period_id,
     mkp.title as marking_period_title,
     mkp.short_name as marking_period_short_name,
     mkp.type as marking_period_type,
@@ -59,18 +74,8 @@ inner join
     {{ ref("stg_focus__course_periods") }} as cp
     on s.course_period_id = cp.course_period_id
 inner join {{ ref("stg_focus__courses") }} as c on s.course_id = c.course_id
-/*
-   Focus writes marking_period_id = 0 on a schedule row to mean the full year.
-   It resolves to the school's type = 'year' marking period, per the vendor's
-   documented join. Scoped on syear and school_id as well as the id because
-   each school gets its own year-level row.
-
-   Aliased mkp, not mp: schedule has its own mp column (the FY/SEM/QTR code),
-   which is how a resolved full-year row stays distinguishable from a
-   natively-termed one.
-*/
 left join
-    {{ ref("stg_focus__marking_periods") }} as mkp
+    marking_periods as mkp
     on s.syear = mkp.syear
     and s.school_id = mkp.school_id
-    and s.marking_period_id = if(mkp.type = 'year', 0, mkp.marking_period_id)
+    and s.marking_period_id = mkp.schedule_marking_period_id

--- a/src/dbt/focus/models/intermediate/int_focus__schedule.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__schedule.sql
@@ -1,33 +1,3 @@
-with
-    student_schedule as (
-        select
-            id,
-            syear,
-            school_id,
-            student_id,
-            course_id,
-            course_period_id,
-            mp,
-            course_weight,
-            days,
-            rotation_days,
-            start_date,
-            end_date,
-            fefp_number,
-            dual_enrollment_indicator,
-            class_minutes_weekly,
-            reading_intervention_component,
-            basic_skills_exam,
-            location_of_student,
-            eoc_exam_term,
-            exempt_from_total_clock_hours,
-            exclude_from_fte,
-            pmrn,
-
-            nullif(marking_period_id, 0) as marking_period_id,
-        from {{ ref("stg_focus__schedule") }}
-    )
-
 select
     s.id as student_schedule_id,
     s.syear as academic_year,
@@ -35,7 +5,9 @@ select
     s.student_id,
     s.course_id,
     s.course_period_id,
-    s.marking_period_id,
+    -- resolved, never the raw sentinel: mkp supplies the school's year-level id
+    -- on a full-year row and the schedule's own id on a term-specific one
+    mkp.marking_period_id,
     s.mp,
     s.course_weight,
     s.days,
@@ -82,12 +54,23 @@ select
     mkp.start_date as marking_period_start_date,
     mkp.end_date as marking_period_end_date,
 
-from student_schedule as s
+from {{ ref("stg_focus__schedule") }} as s
 inner join
     {{ ref("stg_focus__course_periods") }} as cp
     on s.course_period_id = cp.course_period_id
 inner join {{ ref("stg_focus__courses") }} as c on s.course_id = c.course_id
--- aliased mkp, not mp: schedule has its own mp column (the FY/SEM/QTR term code)
+/*
+   Focus writes marking_period_id = 0 on a schedule row to mean the full year.
+   It resolves to the school's type = 'year' marking period, per the vendor's
+   documented join. Scoped on syear and school_id as well as the id because
+   each school gets its own year-level row.
+
+   Aliased mkp, not mp: schedule has its own mp column (the FY/SEM/QTR code),
+   which is how a resolved full-year row stays distinguishable from a
+   natively-termed one.
+*/
 left join
     {{ ref("stg_focus__marking_periods") }} as mkp
-    on s.marking_period_id = mkp.marking_period_id
+    on s.syear = mkp.syear
+    and s.school_id = mkp.school_id
+    and s.marking_period_id = if(mkp.type = 'year', 0, mkp.marking_period_id)

--- a/src/dbt/focus/models/intermediate/properties/int_focus__schedule.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__schedule.yml
@@ -6,8 +6,9 @@ models:
       as stg_focus__schedule. Course period and course are inner-joined because
       a schedule row without them is not interpretable; stg_focus__schedule
       carries relationships tests on both keys so an orphan fails there rather
-      than silently disappearing here. Marking period is left-joined and is null
-      for full-year schedules, which Focus records with a 0 marking-period id.
+      than silently disappearing here. Marking period is left-joined on syear
+      and school_id as well as the id, resolving Focus's full-year sentinel
+      (marking_period_id 0) to the school's year-level marking period.
       Internal-only — a rpt_ view must sit between this model and any external
       consumer.
     columns:
@@ -35,12 +36,14 @@ models:
           Focus course-period (section) id the student is scheduled into.
       - name: marking_period_id
         description: >-
-          Focus marking-period id the schedule row covers, with the full-year
-          sentinel 0 normalized to null.
+          Focus marking-period id the schedule row covers. A full-year row
+          carries the school's year-level marking-period id, resolved from
+          Focus's 0 sentinel; it is never the raw 0.
       - name: mp
         description: >-
           Term the schedule row covers as a code — FY full year, SEM semester,
-          QTR quarter. FY rows are the ones with a null marking_period_id.
+          QTR quarter. FY rows are the ones whose marking_period_id was resolved
+          from the full-year sentinel, so marking_period_type reads year.
       - name: course_weight
         description: >-
           Weighting applied to the course when computing GPA for this scheduled
@@ -157,18 +160,21 @@ models:
         description: Whether the course is a homeroom rather than instructional.
       - name: marking_period_title
         description: >-
-          Marking-period name from stg_focus__marking_periods; null for
-          full-year schedules.
+          Marking-period name from stg_focus__marking_periods; the school's
+          year-level marking period on a full-year schedule.
       - name: marking_period_short_name
         description: >-
-          Abbreviated marking-period name; null for full-year schedules.
+          Abbreviated marking-period name; the school's year-level marking
+          period on a full-year schedule.
       - name: marking_period_type
         description: >-
           Marking-period granularity (year, semester, quarter, progress period);
-          null for full-year schedules.
+          reads year on a full-year schedule.
       - name: marking_period_start_date
-        description:
-          First date of the marking period; null for full-year schedules.
+        description: >-
+          First date of the marking period; the first day of the school year on
+          a full-year schedule.
       - name: marking_period_end_date
-        description:
-          Last date of the marking period; null for full-year schedules.
+        description: >-
+          Last date of the marking period; the last day of the school year on a
+          full-year schedule.

--- a/src/dbt/focus/models/intermediate/unit_tests.yml
+++ b/src/dbt/focus/models/intermediate/unit_tests.yml
@@ -303,3 +303,89 @@ unit_tests:
         - student_number: 503
           schoolid: 58
           school_date: 2026-08-14
+
+  - name: test_int_focus__schedule_full_year_sentinel_resolves
+    model: int_focus__schedule
+    description: >-
+      Focus writes marking_period_id = 0 to mean the full year. Row 1 carries
+      the sentinel and must resolve to its own school's type = 'year' marking
+      period, not the decoy year row belonging to school 200 — a pass only if
+      the join is scoped on school_id. Row 2 is term-specific and must pass
+      through untouched.
+    given:
+      - input: ref('stg_focus__schedule')
+        format: sql
+        rows: |
+          select 1 as id, 2026 as syear, 100 as school_id, 10 as student_id,
+            20 as course_id, 30 as course_period_id, 0 as marking_period_id,
+            'FY' as mp, cast(null as string) as course_weight,
+            cast(null as string) as days,
+            cast(null as string) as rotation_days,
+            cast(null as date) as start_date, cast(null as date) as end_date,
+            cast(null as string) as fefp_number,
+            cast(null as string) as dual_enrollment_indicator,
+            cast(null as string) as class_minutes_weekly,
+            cast(null as string) as reading_intervention_component,
+            cast(null as string) as basic_skills_exam,
+            cast(null as string) as location_of_student,
+            cast(null as string) as eoc_exam_term,
+            cast(null as string) as exempt_from_total_clock_hours,
+            cast(null as string) as exclude_from_fte,
+            cast(null as string) as pmrn
+          union all
+          select 2, 2026, 100, 10, 20, 30, 501, 'QTR', cast(null as string),
+            cast(null as string), cast(null as string), cast(null as date),
+            cast(null as date), cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string), cast(null as string),
+            cast(null as string), cast(null as string)
+      - input: ref('stg_focus__marking_periods')
+        format: sql
+        rows: |
+          select 500 as marking_period_id, 2026 as syear, 100 as school_id,
+            'Full Year' as title, 'FY' as short_name, 'year' as type,
+            date '2026-08-10' as start_date, date '2027-06-11' as end_date
+          union all
+          select 501, 2026, 100, 'Quarter 1', 'Q1', 'quarter',
+            date '2026-08-10', date '2026-10-16'
+          union all
+          select 600, 2026, 200, 'Full Year', 'FY', 'year',
+            date '2026-08-10', date '2027-06-11'
+      - input: ref('stg_focus__course_periods')
+        format: sql
+        rows: |
+          select 30 as course_period_id, cast(null as string) as title,
+            cast(null as string) as short_name,
+            cast(null as string) as custom_title,
+            cast(null as int64) as teacher_id, cast(null as string) as room,
+            cast(null as int64) as period_id,
+            cast(null as int64) as calendar_id,
+            cast(null as int64) as team_id,
+            cast(null as int64) as grade_scale_id,
+            cast(null as string) as credits,
+            cast(null as string) as does_attendance,
+            cast(null as string) as does_grades,
+            cast(null as string) as does_gpa
+      - input: ref('stg_focus__courses')
+        format: sql
+        rows: |
+          select 20 as course_id, cast(null as string) as title,
+            cast(null as string) as short_name,
+            cast(null as int64) as subject_id,
+            cast(null as int64) as grad_subject_id,
+            cast(null as string) as grade_level,
+            cast(null as numeric) as credit_hours,
+            cast(null as numeric) as course_hours,
+            cast(null as string) as homeroom
+    expect:
+      rows:
+        - student_schedule_id: 1
+          mp: FY
+          marking_period_id: 500
+          marking_period_type: year
+          marking_period_start_date: 2026-08-10
+        - student_schedule_id: 2
+          mp: QTR
+          marking_period_id: 501
+          marking_period_type: quarter
+          marking_period_start_date: 2026-08-10

--- a/src/dbt/focus/models/staging/properties/stg_focus__schedule.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__schedule.yml
@@ -75,8 +75,8 @@ models:
         description: >-
           Focus marking-period id the schedule row covers. Focus stores 0 rather
           than null for a full-year schedule, so this does not resolve to
-          stg_focus__marking_periods for every row — int_focus__schedule
-          normalizes the 0 to null before joining.
+          stg_focus__marking_periods directly — int_focus__schedule resolves the
+          0 to the school's type = 'year' marking period.
         data_type: int
       - name: mp
         description: >-

--- a/src/dbt/kipptaf/models/extracts/littlesis/rpt_littlesis__enrollments.sql
+++ b/src/dbt/kipptaf/models/extracts/littlesis/rpt_littlesis__enrollments.sql
@@ -71,18 +71,6 @@ with
         where academic_year = {{ var("current_academic_year") }}
     ),
 
-    /*
-       Full-year course periods carry Focus's marking_period_id = 0 sentinel,
-       which int_focus__schedule normalizes to null. Little SIS gets the
-       school's year-level marking period for those instead of a null term, so
-       every row carries a term the way the PowerSchool branch does.
-    */
-    focus_year_terms as (
-        select syear, school_id, marking_period_id,
-        from {{ ref("stg_focus__marking_periods") }}
-        where type = 'year'
-    ),
-
     focus_users as (
         select
             staff_id,
@@ -110,7 +98,7 @@ with
             -- lives in school_periods, which is not exposed at kipptaf yet
             cast(null as string) as `period`,
 
-            coalesce(sch.marking_period_id, fyt.marking_period_id) as term_id,
+            sch.marking_period_id as term_id,
 
             concat(
                 sch.course_title,
@@ -127,10 +115,6 @@ with
         inner join
             {{ ref("int_people__staff_roster") }} as scw
             on fu.employee_number = scw.employee_number
-        left join
-            focus_year_terms as fyt
-            on sch.academic_year = fyt.syear
-            and sch.schoolid = fyt.school_id
     )
 
 select

--- a/src/dbt/kipptaf/models/focus/intermediate/int_focus__schedule.sql
+++ b/src/dbt/kipptaf/models/focus/intermediate/int_focus__schedule.sql
@@ -24,6 +24,6 @@ with
         dbt_utils.deduplicate(
             relation="schedule_raw",
             partition_by="student_id, course_period_id",
-            order_by="(end_date is not null) asc, (mp != 'FY') asc",
+            order_by="(end_date is not null) asc, (mp is distinct from 'FY') asc",
         )
     }}

--- a/src/dbt/kipptaf/models/focus/intermediate/int_focus__schedule.sql
+++ b/src/dbt/kipptaf/models/focus/intermediate/int_focus__schedule.sql
@@ -18,12 +18,12 @@ with
     -- Focus schedules some students into the same course period twice: a
     -- same-day-superseded stint (start_date = end_date) alongside the current
     -- open one (end_date null). Keep the open stint per
-    -- (student_id, course_period_id); demote marking_period_id as a secondary
+    -- (student_id, course_period_id); prefer the full-year row as a secondary
     -- tiebreak in case a genuine full-year/term-specific duplicate ever occurs.
     {{
         dbt_utils.deduplicate(
             relation="schedule_raw",
             partition_by="student_id, course_period_id",
-            order_by="(end_date is not null) asc, (marking_period_id is not null) asc",
+            order_by="(end_date is not null) asc, (mp != 'FY') asc",
         )
     }}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will give every Miami full-year course schedule
row its marking period back.

Focus writes `marking_period_id = 0` on a schedule row to mean "the full year."
It is a code, not missing data, and it points at the school's year-level marking
period. `int_focus__schedule` read it as missing and threw it away. Because 5
output columns all come from that one join, all 5 went null together on 16,119
of Miami's 19,649 AY2026 schedule rows — 82% of them.

This joins the marking period the way the Focus vendor documents it, so the code
resolves instead of being discarded. Measured against prod:

| Measure, AY2026 | Before | After |
| --- | --- | --- |
| Rows with no marking-period dates | 16,119 | **0** |
| Row count | 19,649 | 19,649 |
| Distinct schedule keys | 19,649 | 19,649 |
| Resolved period in a different school or year | — | 0 |

One report, `rpt_littlesis__enrollments`, had already built this fix for itself
in a local block. That block is now deleted. Its `term_id` output does not move.

## Reviewer Notes

- **The join gained two conditions, `syear` and `school_id`.** Each of the 10
  schools has its own year-level marking period, so matching on the id alone is
  not enough. All 3,530 rows that already matched still match — the extra scope
  drops nothing.
- **Telling the two kinds of row apart still works.** The schedule's own `mp`
  column reads `FY` on exactly the 16,119 rows that carry the code, so no new
  flag was needed.
- **One change is outside the issue.** The kipptaf wrapper picked which
  duplicate row to keep partly by asking whether `marking_period_id` was null,
  which meant "prefer the full-year row." Nothing is null now, so that question
  is dead. It now asks `mp is distinct from 'FY'`, which means the same thing.
  It decides none of the 299 duplicate pairs either way.
- **A unit test guards the fix.** It puts a decoy year-level marking period on a
  second school, so it fails if the `school_id` scope is ever dropped.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

Only the first item applies. This pull request adds no model, adds no column,
renames nothing, and touches no external source.

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

## CI checks

- [x] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [x] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [x] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. This is P1 of the Focus dbt modeling backlog
(#4985). Value-only across both projects, no column-set change, so it is not
exposed to the #4290 deploy race and ships as one PR.

### The join

```sql
with
    marking_periods as (
        select
            marking_period_id,
            syear,
            school_id,
            ...
            if(type = 'year', 0, marking_period_id) as schedule_marking_period_id,
        from {{ ref("stg_focus__marking_periods") }}
    )
...
left join
    marking_periods as mkp
    on s.syear = mkp.syear
    and s.school_id = mkp.school_id
    and s.marking_period_id = mkp.schedule_marking_period_id
```

This is the vendor's `student_report_card_grades` pattern from Focus SIS Level 1
Certification, Day 2, quoted on #4987. The sentinel expression sits in a CTE
rather than the `ON` clause, per the "no one-sided calculations in join
predicates" rule; the two forms are value-identical against prod, 19,649 rows
each with `except distinct` returning 0 both ways.

The output column is `mkp.marking_period_id`, not `s.marking_period_id`, so the
raw `0` can never reach a consumer. The `nullif` and the `student_schedule` CTE
that held it are both gone; the final select already enumerated every column, so
that CTE was a redundant projection.

### Verification against prod, not the dev build

The dev build is not the evidence here. It confirms the SQL compiles and
materializes 19,649 rows with 0 null `marking_period_start_date` and 19,649
distinct keys, but `zz_cbini_kipptaf_extracts.rpt_littlesis__enrollments` built
only 5,711 of prod's 18,878 Focus rows — stale personal copies of upstream
staging models shadowed `--defer`. Every number below comes from running the old
and new logic side by side against prod staging tables.

Model level, AY2026:

| Measure | Value |
| --- | --- |
| Rows | 19,649, unchanged |
| Distinct `student_schedule_id` | 19,649 — no fan-out |
| Null `marking_period_start_date` | 16,119 to 0 |
| Resolved period in a different `school_id` or `syear` | 0 |
| `mp = 'FY'` rows resolving to `type = 'year'` | 16,119 of 16,119 |
| Non-FY rows resolving to `type = 'year'` | 0 |

`term_id`, old expression versus new, through the wrapper dedupe, over the full
prod population: 19,350 rows each side, `except distinct` returns 0 in both
directions, 0 nulls. That covers all 18,878 prod Focus rows, which the dev build
could not.

### Three checks the issue's reproduce steps did not cover

1. **`mp` is a clean discriminator.** `mp = 'FY'` matches the sentinel exactly,
   16,119 for 16,119, so #4987's "check whether it already serves this before
   adding a flag" resolves to yes.
1. **No fan-out risk in any year.** Exactly one `type = 'year'` row per
   (`syear`, `school_id`) across `syear` 1980 to 2026.
1. **No earlier-year Focus rows to verify.** `stg_focus__schedule` holds only
   `syear = 2026`, so #4987's "verify AY2025 and earlier" is vacuous rather than
   passing.

Prod counts run today are 13 rows above #4987's, which was written against an
earlier snapshot: 19,649 not 19,636, and 16,119 not 16,104. Same ratio, same
conclusion.

### The unit test

`test_int_focus__schedule_full_year_sentinel_resolves` mocks 2 schedule rows —
one carrying the 0 sentinel, one term-specific — against 3 marking periods: the
school's year row, a quarter row, and a decoy year row on a second school.
Removing `and s.school_id = mkp.school_id` makes it fail, which I ran rather
than assumed.

### Warnings seen locally, both pre-existing

- `relationships_stg_focus__schedule_student_id` (475) and
  `relationships_stg_focus__co_teachers_course_period_id` (4) are stale-dev
  `--defer` drift. Prod has 0 orphans for both.
- `test_focus_course_sections_teacher_resolves` warns 80. The same query run
  entirely against prod also returns 80.

### The first dbt Cloud failure was not this change

Run 70403222330862 failed on `unique_int_kippadb__roster_student_number` with
`Not found: Table zz_stg_kipptaf_edplan.int_edplan__njsmart_powerschool_union`.
That shared staging table was created at 18:59:29 with 54,163 rows, after the
test ran. `int_kippadb__roster` reaches it through
`int_extracts__student_enrollments` and landed in the build set only because this
change sits far upstream. The re-run passed with no code change to that path.

### Blast radius

`rpt_littlesis__enrollments` is the only consumer that reads any marking-period
column. `int_students__course_enrollments`, `int_students__course_sections`,
`int_students__teacher_grade_levels`, and `int_focus__advisory` reference none of
them, so nothing else changes value. `int_focus__report_card_grades` joins
marking periods off its own key, not off the schedule.

`marking_period_id` moved into the `mkp` column group in the second commit, on
review. Consumers resolve columns by name — `dbt_utils.union_relations` builds
its list from the relation schema, and `rpt_littlesis__enrollments` names every
column it reads — so the position carried no weight.

### Gates #4970

#5002 needs schedule dates comparable to their term bounds. This supplies real
`marking_period_start_date` and `marking_period_end_date` on 82% of Miami's
AY2026 schedule rows, which previously had none.

Refs #4985
</details>
