### PR TITLE
refactor(clever): replace 12 hardcoded region filters with one shared macro

### DIFF
--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -35,11 +35,12 @@ vars:
   # fresh-dashboard skill's "Update the Finalsite recruitment year" procedure
   # before bumping this.
   finalsite_recruitment_year: 2026
-  # Code locations that no longer roster through PowerSchool current-state, so
-  # the current-state extracts exclude them. Miami moved to Focus in AY2026 and
-  # rosters into Clever from there. Historical models must NOT read this var --
+  # Code locations whose PowerSchool instance is frozen. Miami itself is not
+  # frozen -- it moved to Focus in AY2026 and rosters into Clever from there --
+  # but its PowerSchool stops at AY2025, so extracts built on PowerSchool
+  # current-state have to drop it. Historical models must NOT read this var:
   # Miami's frozen PowerSchool history has to stay readable. See #4670.
-  frozen_code_locations: [kippmiami]
+  frozen_powerschool_code_locations: [kippmiami]
 
 models:
   kipptaf:

--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -35,6 +35,11 @@ vars:
   # fresh-dashboard skill's "Update the Finalsite recruitment year" procedure
   # before bumping this.
   finalsite_recruitment_year: 2026
+  # Code locations that no longer roster through PowerSchool current-state, so
+  # the current-state extracts exclude them. Miami moved to Focus in AY2026 and
+  # rosters into Clever from there. Historical models must NOT read this var --
+  # Miami's frozen PowerSchool history has to stay readable. See #4670.
+  frozen_code_locations: [kippmiami]
 
 models:
   kipptaf:

--- a/src/dbt/kipptaf/macros/utils.sql
+++ b/src/dbt/kipptaf/macros/utils.sql
@@ -8,10 +8,12 @@
     initcap(regexp_extract({{ table }}._dbt_source_project, r'kipp(\w+)'))
 {% endmacro %}
 
-{# Current-state exclusion for regions whose SIS is frozen. `column` is any
-   code-location column -- `_dbt_source_project` on a union model, or
-   `dagster_code_location` / `home_work_location_dagster_code_location` on the
-   staff roster. Add or remove a region in the frozen_code_locations var. #}
+{# Drops code locations whose PowerSchool instance is frozen, for extracts
+   built on PowerSchool current-state. `column` is any code-location column --
+   `_dbt_source_project` on a union model, or `dagster_code_location` /
+   `home_work_location_dagster_code_location` on the staff roster. Add or remove
+   a region in the frozen_powerschool_code_locations var. #}
 {% macro exclude_frozen(column) -%}
-    {{ column }} not in ('{{ var("frozen_code_locations") | join("', '") }}')
+    {%- set locations = var("frozen_powerschool_code_locations") -%}
+    {{ column }} not in ('{{ locations | join("', '") }}')
 {%- endmacro %}

--- a/src/dbt/kipptaf/macros/utils.sql
+++ b/src/dbt/kipptaf/macros/utils.sql
@@ -7,3 +7,11 @@
 {% macro extract_region(table) %}
     initcap(regexp_extract({{ table }}._dbt_source_project, r'kipp(\w+)'))
 {% endmacro %}
+
+{# Current-state exclusion for regions whose SIS is frozen. `column` is any
+   code-location column -- `_dbt_source_project` on a union model, or
+   `dagster_code_location` / `home_work_location_dagster_code_location` on the
+   staff roster. Add or remove a region in the frozen_code_locations var. #}
+{% macro exclude_frozen(column) -%}
+    {{ column }} not in ('{{ var("frozen_code_locations") | join("', '") }}')
+{%- endmacro %}

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__enrollments.sql
@@ -14,8 +14,7 @@ inner join
     and s.enroll_status in (0, -1)
 where
     cc.dateleft >= current_date('{{ var("local_timezone") }}')
-    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
-    and cc._dbt_source_relation not like '%kippmiami%'
+    and {{ exclude_frozen("cc._dbt_source_project") }}
 
 union all
 
@@ -30,4 +29,4 @@ select
 
     student_number as student_id,
 from {{ ref("stg_powerschool__students") }}
-where enroll_status in (0, -1) and _dbt_source_relation not like '%kippmiami%'
+where enroll_status in (0, -1) and {{ exclude_frozen("_dbt_source_project") }}

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__schools.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__schools.sql
@@ -22,9 +22,7 @@ select
 from {{ ref("stg_powerschool__schools") }}
 where
     /* filter out summer school and graduated students */
-    state_excludefromreporting = 0
-    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
-    and _dbt_source_relation not like '%kippmiami%'
+    state_excludefromreporting = 0 and {{ exclude_frozen("_dbt_source_project") }}
 
 union all
 

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__sections.sql
@@ -12,9 +12,7 @@ with
         from {{ ref("int_people__staff_roster") }} as sr
         where
             sr.assignment_status != 'Terminated'
-            -- Miami rosters into Clever directly from Focus; excluded from all
-            -- six feeds
-            and sr.home_work_location_dagster_code_location != 'kippmiami'
+            and {{ exclude_frozen("sr.home_work_location_dagster_code_location") }}
             and sr.job_title in (
                 'Director of Campus Operations',
                 'Director Campus Operations',
@@ -38,7 +36,7 @@ with
         from {{ ref("stg_powerschool__schools") }}
         where
             state_excludefromreporting = 0
-            and _dbt_source_relation not like '%kippmiami%'
+            and {{ exclude_frozen("_dbt_source_project") }}
     ),
 
     teachers_long as (
@@ -109,9 +107,7 @@ with
             and st._dbt_source_project = t._dbt_source_project
         where
             sec.terms_yearid = ({{ var("current_academic_year") - 1990 }})
-            -- Miami rosters into Clever directly from Focus; excluded from all
-            -- six feeds
-            and sec._dbt_source_relation not like '%kippmiami%'
+            and {{ exclude_frozen("sec._dbt_source_project") }}
 
         union all
 

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__staff.sql
@@ -17,9 +17,7 @@ with
         where
             not is_prestart
             and worker_status_code != 'Terminated'
-            -- Miami rosters into Clever directly from Focus; excluded from all
-            -- six feeds
-            and home_work_location_dagster_code_location != 'kippmiami'
+            and {{ exclude_frozen("home_work_location_dagster_code_location") }}
 
         union all
 
@@ -39,7 +37,7 @@ with
             title as job_title,
         from {{ ref("int_people__temp_staff") }}
         where
-            dagster_code_location != 'kippmiami'
+            {{ exclude_frozen("dagster_code_location") }}
             -- int_people__temp_staff gates on idauto_status and the AD account
             -- flag, neither of which flips on offboarding. A populated
             -- idauto_person_term_date is the only termination signal it carries.
@@ -58,7 +56,7 @@ with
         from {{ ref("stg_powerschool__schools") }}
         where
             state_excludefromreporting = 0
-            and _dbt_source_relation not like '%kippmiami%'
+            and {{ exclude_frozen("_dbt_source_project") }}
     ),
 
     assignments as (

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__students.sql
@@ -89,5 +89,4 @@ where
     and sr.rn_year = 1
     and not sr.is_out_of_district
     and sr.enroll_status in (0, -1)
-    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
-    and sr._dbt_source_relation not like '%kippmiami%'
+    and {{ exclude_frozen("sr._dbt_source_project") }}

--- a/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
+++ b/src/dbt/kipptaf/models/extracts/clever/rpt_clever__teachers.sql
@@ -23,8 +23,7 @@ where
     and worker_status_code != 'Terminated'
     and employee_number is not null
     and home_work_location_powerschool_school_id is not null
-    -- Miami rosters into Clever directly from Focus; excluded from all six feeds
-    and home_work_location_dagster_code_location != 'kippmiami'
+    and {{ exclude_frozen("home_work_location_dagster_code_location") }}
 
 union all
 
@@ -47,7 +46,7 @@ select
     null as `password`,
 from {{ ref("int_people__temp_staff") }}
 where
-    dagster_code_location != 'kippmiami'
+    {{ exclude_frozen("dagster_code_location") }}
     -- int_people__temp_staff gates on idauto_status and the AD account flag,
     -- neither of which flips on offboarding. A populated
     -- idauto_person_term_date is the only termination signal it carries.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make adding or removing a region from the
six Clever feeds a one-line edit.

The exclusion that keeps Miami out of the Clever feeds was written out 12 times
across the six `rpt_clever__*` models, in two different syntaxes. #4653 happened
because those copies drifted apart. #4667 fixed the drift but left all 12
copies in place, so the same bug stayed available.

Now there is one list and one macro:

- `frozen_powerschool_code_locations: [kippmiami]` — a var in
  `src/dbt/kipptaf/dbt_project.yml`. This is the one place to edit. It names the
  PowerSchool instance, not the region: Miami itself is not frozen, it moved to
  Focus in AY2026 and rosters into Clever from there. Only its PowerSchool stops
  at AY2025, and that is why the PowerSchool-derived extracts drop it.
- `exclude_frozen(column)` — a macro in `src/dbt/kipptaf/macros/utils.sql`, next
  to the existing `extract_source_project`.

Every one of the 12 sites now reads
`and {{ exclude_frozen("cc._dbt_source_project") }}`.

**Why option 2 (a macro) and not option 1 (a var alone).** A var alone cannot
do the job. A dbt var holding a list renders as `['kippmiami']`, which
BigQuery rejects, so every call site needs Jinja to turn the list into
`('kippmiami')`. That Jinja is the macro. A var alone also cannot reconcile the
two syntaxes the issue names, because one is a `LIKE` on a relation name and
the other is an equality on a code-location column. The var is still the
one-place edit — the macro just reads it.

**The two syntaxes collapse into one.** `_dbt_source_project` is defined as
`regexp_extract(_dbt_source_relation, r'(kipp\w+)_')`, so it already holds
exactly the code location. The seven
`_dbt_source_relation not like '%kippmiami%'` sites therefore become the same
`not in (...)` form the other five already used. One syntax network-wide, and
it matches the `_dbt_source_project != 'kippmiami'` idiom the rest of the
project already prefers.

The change also deletes the 12 duplicated
`-- Miami rosters into Clever directly from Focus` comments. The reason now
sits once, on the var.

The wider audit the issue asks for is below, under "Reviewer Notes". Per the
issue's scope control it is a report only — no models outside
`models/extracts/clever/` changed.

## Reviewer Notes

**One region literal stays in `rpt_clever__staff`, on purpose.** Line 157 reads
`on sch.dagster_code_location in ('kippnewark', 'kipppaterson')`. That is the
School Leader in Residence rule from #4981 — a Newark-based leader who also
covers Paterson schools. It is an inclusion for one job title, not a
frozen-PowerSchool exclusion, so the shared var cannot express it and should not
try.

**The audit found 68 more region literals in `kipptaf`, and they are not all
the same thing.** Sorting them matters more than counting them, because
pointing the wrong ones at this var would break reporting.

Adopt next — same policy, same shape, 19 sites in 12 models:

| feed | models | sites |
| --- | --- | --- |
| `rpt_illuminate__*` | courses, roles, sites, terms, users | 9 |
| `rpt_parentsquare__*` | emergency_contacts, parents, rosters, schools, sections, staff, students | 10 |

Both are current-state rostering feeds excluding Miami for the same reason
Clever does. Both are also feed *sets* that have to agree with each other, so
they carry the exact #4653 bug class. `rpt_illuminate__roles` and
`rpt_illuminate__users` even use the same two syntaxes this PR just merged.
Illuminate and ParentSquare are the highest-value follow-ups.

Adopt with care — 16 sites in 14 models: the shared intermediates
(`int_students__students`, `__schools`, `__terms`, `__student_enrollment_union`,
`__student_core_fields`, `__student_user_fields`, `__teacher_grade_levels`,
`int_powerschool__gradebook_assignment_scores_rollup`,
`stg_people__student_logins`, `int_extracts__gradebook_audit_student_flags`,
`int_tableau__fresh_enrollment_scaffold`, `rpt_tableau__gradebook_audit`,
`rpt_tableau__okrts_behavior`, `rpt_deanslist__missing_assignments`). Same
reason as Clever, but these sit on the shared spine, so one edit moves many
marts. Worth its own PR with its own row-count checks.

Do not adopt — 22 sites: everything spelled `region != 'Miami'`. Two reasons.
The column holds `Miami`, not `kippmiami`, so the var does not fit. More
importantly, several of these exclude Miami because Miami is in Florida, not
because its PowerSchool is frozen: `rpt_tableau__nj_school_register`,
`rpt_gsheets__nj_state_test_roster`, `rpt_gsheets__njsmart_transfer_unverified`
and `int_topline__state_assessments_weekly` are New Jersey state reporting.
Pointing them at this var would silently pull Miami back into NJ reporting on
the day Miami's PowerSchool unfreezes. These should stay literal, or get a
separate `nj_only` list.

Separate list — 9 sites: the Paterson gates (`region != 'Paterson'`,
`home_work_location_dagster_code_location != 'kipppaterson'`) in
`rpt_tableau__sight_words_dashboard`, `rpt_tableau__assessment_dashboard`,
`rpt_schoolmint_grow__users`, `rpt_gsheets__historical_suspensions`,
`rpt_gsheets__athletic_eligibility`, `int_students__athletic_eligibility` and
two `int_topline__*` models. "Paterson is not live yet" is a different policy
from "this region's PowerSchool is frozen". If those get consolidated they need
their own var, not this one.

One bug found while auditing (the last 2 of the 68): `rpt_tableau__crdc_roster`
lines 181 and 247 filter with
`regexp_extract(_dbt_source_relation, r'(kipp\w+)_') != 'kippmiami'` — a
function applied to a column inside `WHERE`, which the repo's dbt conventions
forbid. `_dbt_source_project` is the same value as a plain column. Not fixed
here; it is outside this PR's scope.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Verdicts on
      both Minor findings are posted as a PR comment — one declined with
      reasoning, one agreed with no action needed.

### dbt

- [x] No new models, so no new properties files. The 6 models and their
      properties files are unchanged apart from the filter lines.
- [x] No exposure change. These views feed the Dagster BigQuery-to-SFTP extract
      assets, not a dashboard.
- [x] **Not a breaking change.** No column is renamed, removed, or retyped. Only
      `WHERE` clauses changed, and they select the same rows — see the proof
      below. Rollback is a plain revert.
- [x] No external source added or modified.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes. This PR is kipptaf-only. `dbt_project.yml` and
      `macros/utils.sql` are project-wide files, so `state:modified+` will
      select far more than the 6 models.
- [ ] **Dagster Cloud** — not triggered; the `pull_request` paths exclude
      `src/dbt/`.

<details>
<summary>For Claude</summary>

**Claude-authored, human-directed.** Charlie picked P5 off the #4985 backlog and
set the scope: 6 clever models only, pick between the issue's options 1 and 2,
report the wider audit rather than expanding the PR, and leave the powerschool
`union_relations` views alone. Charlie also caught the first var name,
`frozen_code_locations`, as asserting something false about Miami; it became
`frozen_powerschool_code_locations`. Claude chose option 2, verified
equivalence, and ran everything below.

**Proof the predicate swap keeps the same rows.** The risk in this refactor is
the 7 sites that moved from `_dbt_source_relation not like '%kippmiami%'` to
`_dbt_source_project not in ('kippmiami')`. Both predicates were counted
against every affected prod upstream:

| upstream | total rows | old kept | new kept | delta | null `_dbt_source_project` |
| --- | --: | --: | --: | --: | --: |
| `stg_powerschool__cc` | 868,495 | 769,630 | 769,630 | 0 | 0 |
| `stg_powerschool__students` | 30,909 | 26,964 | 26,964 | 0 | 0 |
| `stg_powerschool__schools` | 32 | 27 | 27 | 0 | 0 |
| `base_powerschool__sections` | 33,663 | 29,407 | 29,407 | 0 | 0 |
| `int_extracts__student_enrollments` | 134,291 | 124,216 | 124,216 | 0 | 0 |

1,067,390 rows, zero delta, no nulls. `_dbt_source_project` cannot be null
here: `dbt_utils.union_relations` always populates `_dbt_source_relation`, and
`extract_source_project` derives the project from it.

`base_powerschool__sections` needed a second look because it passes through
`int_students__course_sections`, which unions PowerSchool and Focus. Focus rows
carry `_dbt_source_relation` = `...kippmiami_focus...` and
`_dbt_source_project` = `kippmiami`, so both predicates drop them. The delta of
0 above confirms it on real data.

**Build and tests**, deferred to the prod manifest:

```text
uv run dbt build --select "path:models/extracts/clever" --target dev \
  --defer --favor-state --state src/dbt/kipptaf/target/prod
Done. PASS=11 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=12
```

`rpt_clever__school_id_resolves_to_schools_feed` passes at `severity: error`.
`rpt_clever__enrollments__student_id_resolves_to_students_feed` warns with 3
orphan student ids locally and 4 in dbt Cloud CI. Those are pre-existing and
unrelated: the same orphans come back from the same query against the prod views
right now, and that test is deliberately `severity: warn` for the vintage-gap
reason its own `tests/properties.yml` description spells out. The zero row delta
above means this change cannot alter feed membership, so it cannot add an
orphan. Ids withheld here — they are student numbers.

**One-place-edit proof.** Compiling with
`--vars '{frozen_powerschool_code_locations: [kippmiami, kipppaterson]}'` renders
every site as `not in ('kippmiami', 'kipppaterson')`, with no other edit.

**Macro name.** `exclude_frozen` is short on purpose.
`sr.home_work_location_dagster_code_location` at 12 spaces of indent leaves 19
characters for the macro name before the 88-column limit, so
`exclude_frozen_powerschool` would force sqlfmt to wrap that call across 5 lines
— harder to read than the literal it replaces. The macro's doc comment names
PowerSchool in its first line instead.

**Lint.** `trunk check --force` over all changed files: no issues. sqlfmt wanted
one `WHERE` in `rpt_clever__schools.sql` collapsed onto one line; that fix was
applied by hand before committing, then re-checked clean.

</details>

Refs #4670
