### PR TITLE
fix(dbt): repoint the Miami course-enrollment joins off PowerSchool internal ids

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
@@ -19,20 +19,41 @@ with
 
             co.grade_level + 1 as illuminate_grade_level_id,
 
+            -- partitioned on students_student_number rather than cc_studentid:
+            -- Focus leaves cc_studentid null on every Miami row, so a partition
+            -- on it collapses all Miami rows into a single group. The two keys
+            -- are exactly 1:1 within every NJ region (verified against prod:
+            -- distinct cc_studentid = distinct students_student_number =
+            -- distinct pairs, in all three), so NJ output does not move.
             max(ce.is_advanced_math) over (
                 partition by
                     ce._dbt_source_project,
-                    ce.cc_studentid,
+                    ce.students_student_number,
                     ce.cc_academic_year,
                     ce.courses_credittype
             ) as is_advanced_math_student,
         from {{ ref("base_powerschool__course_enrollments") }} as ce
+        -- cc_studentid is null on every Focus row, and #4972 moved Miami's
+        -- student enrollments wholesale onto Focus for every year back to
+        -- AY2018 -- so this join dropped all 93,858 Miami rows, archive years
+        -- included, not just AY2026. student_number carries both SIS branches.
+        --
+        -- Deliberately NOT keyed on schoolid, unlike the (student_number,
+        -- schoolid, academic_year) join in dim_student_section_enrollments:
+        -- this join never carried schoolid, and adding it drops NJ rows where a
+        -- student's course school differs from their enrollment school --
+        -- Newark -2,271, Camden -389, Paterson -63, measured against prod. The
+        -- student-key swap on its own is exactly NJ-neutral.
         inner join
             {{ ref("base_powerschool__student_enrollments") }} as co
-            on ce.cc_studentid = co.studentid
+            on ce.students_student_number = co.student_number
             and ce.cc_academic_year = co.academic_year
             and ce._dbt_source_project = co._dbt_source_project
             and co.rn_year = 1
+        -- TODO(#4996): is_dropped_course is null on every Focus row and
+        -- `not null` is null, so this still removes Miami AY2026 even with the
+        -- join above repointed. Miami's archive years carry real flags and do
+        -- flow through. #4996 owns the coalesce decision for this filter.
         where not ce.is_dropped_course
 
         union all

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -6,6 +6,14 @@ models:
       Illuminate assessments are joined against. One row per (student, academic
       year, subject area, date enrolled), deduplicated to the latest exit per
       enrollment span.
+
+
+      Covers Miami through AY2025 only. The student join keys on
+      `student_number` rather than PowerSchool's internal `cc_studentid`, which
+      Focus leaves null -- before that change this model held no Miami rows in
+      any year. Miami AY2026 forward is still excluded, because the `not
+      is_dropped_course` filter drops rows whose flag is null and Focus never
+      sets it. #4996 owns that filter.
     config:
       materialized: table
       meta:

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
@@ -1,31 +1,103 @@
-select
-    {{
-        dbt_utils.generate_surrogate_key(
-            ["sec.sections_dcid", "sec._dbt_source_project"]
-        )
-    }} as course_section_key,
+-- Focus, Miami's system of record from AY2026 forward, has no equivalent of
+-- PowerSchool's sectionteacher table, so the PowerSchool branch below resolves
+-- no teacher for a Miami section in those years. Focus models a single lead
+-- teacher per course period, already resolved to the staff roster in
+-- int_students__course_sections, so the Focus branch reads that resolved
+-- teachernumber rather than re-deriving it.
+--
+-- Two Focus limitations, both source-data shape rather than modeling gaps:
+--
+-- * Lead teacher only. Focus carries co-teachers in stg_focus__co_teachers,
+-- which is not surfaced into kipptaf, so the Co-teacher, Gradebook Access
+-- and Blended Learning roles PowerSchool supplies have no Miami
+-- counterpart from AY2026 forward.
+-- * effective_start_date and effective_end_date are null. Focus attaches a
+-- teacher to a course period without dating the assignment; inventing the
+-- term dates would assert an assignment history the source does not
+-- record.
+--
+-- 743 of Miami's 823 AY2026 sections resolve a lead teacher. The 80 that do
+-- not are the documented Focus floor from #4972: 67 course periods with no
+-- teacher assigned in Focus at all, plus 13 whose user resolves to no staff
+-- roster row.
+with
+    -- The year boundary keeps the two branches disjoint. Miami's frozen
+    -- PowerSchool archive still holds sectionteacher rows through AY2025, and
+    -- those sections also carry a resolved teachernumber, so an unscoped Focus
+    -- branch would emit a duplicate Lead Teacher row for every archive
+    -- section. coalesce to 9999 fails toward emitting nothing rather than
+    -- duplicating, when int_focus__schedule is empty in an unbuilt --defer dev
+    -- copy.
+    focus_academic_year_boundary as (
+        select coalesce(min(academic_year), 9999) as min_academic_year,
+        from {{ ref("int_focus__schedule") }}
+    ),
 
-    {{ dbt_utils.generate_surrogate_key(["sr.employee_number"]) }} as staff_key,
+    powerschool_teachers as (
+        select
+            {{
+                dbt_utils.generate_surrogate_key(
+                    ["sec.sections_dcid", "sec._dbt_source_project"]
+                )
+            }} as course_section_key,
 
-    r.name as `role`,
+            {{ dbt_utils.generate_surrogate_key(["sr.employee_number"]) }} as staff_key,
 
-    cast(st.start_date as date) as effective_start_date,
-    cast(st.end_date as date) as effective_end_date,
+            r.name as `role`,
 
-from {{ ref("base_powerschool__sections") }} as sec
-inner join
-    {{ ref("stg_powerschool__sectionteacher") }} as st
-    on sec.sections_id = st.sectionid
-    and sec._dbt_source_project = st._dbt_source_project
-inner join
-    {{ ref("int_powerschool__teachers") }} as t
-    on st.teacherid = t.id
-    and sec.sections_schoolid = t.schoolid
-    and st._dbt_source_project = t._dbt_source_project
-inner join
-    {{ ref("stg_powerschool__roledef") }} as r
-    on st.roleid = r.id
-    and st._dbt_source_project = r._dbt_source_project
-inner join
-    {{ ref("int_people__staff_roster") }} as sr
-    on t.teachernumber = sr.powerschool_teacher_number
+            cast(st.start_date as date) as effective_start_date,
+            cast(st.end_date as date) as effective_end_date,
+
+        from {{ ref("base_powerschool__sections") }} as sec
+        inner join
+            {{ ref("stg_powerschool__sectionteacher") }} as st
+            on sec.sections_id = st.sectionid
+            and sec._dbt_source_project = st._dbt_source_project
+        inner join
+            {{ ref("int_powerschool__teachers") }} as t
+            on st.teacherid = t.id
+            and sec.sections_schoolid = t.schoolid
+            and st._dbt_source_project = t._dbt_source_project
+        inner join
+            {{ ref("stg_powerschool__roledef") }} as r
+            on st.roleid = r.id
+            and st._dbt_source_project = r._dbt_source_project
+        inner join
+            {{ ref("int_people__staff_roster") }} as sr
+            on t.teachernumber = sr.powerschool_teacher_number
+    ),
+
+    focus_teachers as (
+        select
+            {{
+                dbt_utils.generate_surrogate_key(
+                    ["sec.sections_dcid", "sec._dbt_source_project"]
+                )
+            }} as course_section_key,
+
+            {{ dbt_utils.generate_surrogate_key(["sr.employee_number"]) }} as staff_key,
+
+            -- matches the stg_powerschool__roledef vocabulary so both branches
+            -- share one role domain
+            'Lead Teacher' as `role`,
+
+            cast(null as date) as effective_start_date,
+            cast(null as date) as effective_end_date,
+
+        from {{ ref("base_powerschool__sections") }} as sec
+        cross join focus_academic_year_boundary as fay
+        inner join
+            {{ ref("int_people__staff_roster") }} as sr
+            on sec.teachernumber = sr.powerschool_teacher_number
+        where
+            sec._dbt_source_project = 'kippmiami'
+            and sec.terms_academic_year >= fay.min_academic_year
+    )
+
+select *,
+from powerschool_teachers
+
+union all
+
+select *,
+from focus_teachers

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
@@ -94,10 +94,14 @@ with
             and sec.terms_academic_year >= fay.min_academic_year
     )
 
-select *,
+-- columns enumerated rather than `select *`: BigQuery binds UNION ALL
+-- branches by position, so two star branches whose column order drifts would
+-- bind the wrong columns to each other, and role / effective_start_date are
+-- not same-typed enough to fail loudly in every case.
+select course_section_key, staff_key, `role`, effective_start_date, effective_end_date,
 from powerschool_teachers
 
 union all
 
-select *,
+select course_section_key, staff_key, `role`, effective_start_date, effective_end_date,
 from focus_teachers

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -7,6 +7,16 @@ models:
       change. FKs to dim_course_sections via course_section_key and to dim_staff
       via staff_key.
 
+
+      Two SIS branches. PowerSchool sections resolve every role recorded in
+      sectionteacher. Focus sections -- Miami from AY2026 forward -- resolve the
+      lead teacher only, with null effective dates: Focus has no sectionteacher
+      equivalent, does not date a teacher's attachment to a course period, and
+      its co-teachers are not yet surfaced into kipptaf. So Miami carries no
+      Co-teacher, Gradebook Access or Blended Learning rows from AY2026 forward.
+      Miami archive years (AY2025 and earlier) still flow through the
+      PowerSchool branch with their full role set.
+
     constraints:
       - type: primary_key
         columns: [course_section_key, staff_key, effective_start_date]
@@ -48,6 +58,9 @@ models:
           User configurable name uniquely identifying the role to the user
           within a Role Module Required.
 
+          Always 'Lead Teacher' on the Focus branch, which carries no other
+          role.
+
         config:
           meta:
             source_system: PowerSchool
@@ -57,6 +70,7 @@ models:
         data_type: date
         description: >-
           The start date of the association of this teacher to this section.
+          Null on the Focus branch, which does not date the assignment.
 
         config:
           meta:
@@ -66,7 +80,8 @@ models:
       - name: effective_end_date
         data_type: date
         description: >-
-          The end date of the association of this teacher to this section.
+          The end date of the association of this teacher to this section. Null
+          on the Focus branch, which does not date the assignment.
 
         config:
           meta:

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_course_section_teachers.yml
@@ -63,7 +63,7 @@ models:
 
         config:
           meta:
-            source_system: PowerSchool
+            source_system: PowerSchool and Focus
             source_model: stg_powerschool__roledef
             source_column: name
       - name: effective_start_date
@@ -74,7 +74,7 @@ models:
 
         config:
           meta:
-            source_system: PowerSchool
+            source_system: PowerSchool and Focus
             source_model: stg_powerschool__sectionteacher
             source_column: start_date
       - name: effective_end_date
@@ -85,7 +85,7 @@ models:
 
         config:
           meta:
-            source_system: PowerSchool
+            source_system: PowerSchool and Focus
             source_model: stg_powerschool__sectionteacher
             source_column: end_date
     data_tests:

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -8,6 +8,19 @@ models:
       enrollment period. FK to dim_student_section_enrollments, dim_terms, and
       dim_dates (role-playing via due_date_key). Reaches dim_student_enrollments
       by traversing student_section_enrollment_key.
+
+
+      PowerSchool only. Miami is absent from AY2026 forward, and repointing this
+      model's join keys would not change that, because the gradebook itself has
+      no Focus branch. int_powerschool__gradebook_assignments_scores unions the
+      district PowerSchool packages, and Miami left that package when it moved
+      to Focus, so its archive stops at AY2025 -- 523,021 rows for AY2025 and
+      zero for AY2026, measured against prod. Focus does hold gradebook data
+      (int_focus__gradebook_grades in the focus package), but it has no kipptaf
+      wrapper, so nothing reaches the network layer. Wiring that branch is
+      tracked in #5010, and was ruled out of #4995 on measurement. Miami's null
+      is_dropped_section also trips this model's `not is_dropped_section`
+      filter; that half is #4996.
     columns:
       - name: grades_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_category.yml
@@ -7,6 +7,18 @@ models:
       Categories are the grade reporting breakdowns within a term (e.g., quarter
       grades vs exam grades). FK to dim_student_section_enrollments and
       dim_terms.
+
+
+      PowerSchool only. Miami is absent from AY2026 forward, and repointing this
+      model's join keys would not change that, because the source itself has no
+      Focus branch. int_powerschool__category_grades unions the district
+      PowerSchool packages, and Miami left that package when it moved to Focus,
+      so its archive stops at AY2025 -- 255,668 rows for AY2025 and zero for
+      AY2026, measured against prod. Focus report-card and gradebook grades
+      exist in the focus package but have no kipptaf wrapper. Wiring that branch
+      is tracked in #5010, and was ruled out of #4995 on measurement. cc_yearid
+      and cc_abs_sectionid, this model's other two join keys, are likewise null
+      on all 19,350 Miami AY2026 rows.
     columns:
       - name: grades_category_key
         data_type: string

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -61,7 +61,6 @@ with
             e._dbt_source_project,
             e.cc_academic_year,
             e.cc_schoolid,
-            e.cc_studentid,
             e.cc_dateenrolled as dateenrolled,
             e.cc_dateleft as dateleft,
             e.cc_sectionid as sectionid,
@@ -73,6 +72,11 @@ with
             e.courses_course_name as course_name,
             e.courses_excludefromgpa as exclude_from_gpa,
             e.sections_termid as termid,
+
+            -- cc_studentid is null on every Focus row, so this model carried
+            -- zero Miami rows in every year. student_number carries both SIS
+            -- branches and is 1:1 with cc_studentid throughout NJ.
+            e.students_student_number as student_number,
             e.teachernumber as teacher_number,
             e.teacher_lastfirst as teacher_name,
             e.is_ap_course,
@@ -116,7 +120,7 @@ with
             s._dbt_source_project,
             s.cc_academic_year,
             s.cc_schoolid,
-            s.cc_studentid,
+            s.student_number,
             s.course_number,
             s.`quarter`,
 
@@ -135,7 +139,7 @@ with
             s._dbt_source_project,
             s.cc_academic_year,
             s.cc_schoolid,
-            s.cc_studentid,
+            s.student_number,
             s.course_number,
             s.`quarter`
     ),
@@ -188,7 +192,7 @@ with
                 partition by
                     s._dbt_source_project,
                     s.cc_academic_year,
-                    s.cc_studentid,
+                    s.student_number,
                     s.course_number,
                     s.`quarter`
                 order by e.exitdate desc, s.dateleft desc
@@ -199,7 +203,7 @@ with
             schedule_by_terms as s
             on e.academic_year = s.cc_academic_year
             and e.schoolid = s.cc_schoolid
-            and e.studentid = s.cc_studentid
+            and e.student_number = s.student_number
             and e._dbt_source_project = s._dbt_source_project
             and e.entrydate <= s.dateleft_alt
             and e.exitdate >= s.dateenrolled_alt
@@ -207,7 +211,7 @@ with
             days_course_enrolled as d
             on s.cc_academic_year = d.cc_academic_year
             and s.cc_schoolid = d.cc_schoolid
-            and s.cc_studentid = d.cc_studentid
+            and s.student_number = d.student_number
             and s.course_number = d.course_number
             and s.`quarter` = d.`quarter`
             and s._dbt_source_project = d._dbt_source_project

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -4,6 +4,14 @@ models:
       One row per student per academic year per course per quarter based on
       course enrollment overlap with term dates. Students who re-enrolled in the
       same course within a quarter are deduped to the most recent stint.
+
+
+      Covers Miami through AY2025 only. The student join keys on
+      `student_number` rather than PowerSchool's internal `cc_studentid`, which
+      Focus leaves null -- before that change this model held no Miami rows in
+      any year. Miami AY2026 forward is still excluded, because the `not
+      is_dropped_section` and `sections_no_of_students != 0` filters both drop
+      rows whose value is null and Focus sets neither. #4996 owns those filters.
     config:
       schema: extracts
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -22,12 +22,18 @@ models:
           automation_condition:
             cron_schedule: 0 2 * * *
     data_tests:
+      # grain keyed on student_number, not studentid: studentid is null on
+      # every Focus row, so Miami's rows would all collide on a null key.
+      # student_number is non-null on both SIS branches and matches the
+      # model's own dedup partition. It is also the stricter assertion --
+      # distinct student_number equals the row count exactly, where distinct
+      # studentid does not.
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - _dbt_source_project
               - academic_year
-              - studentid
+              - student_number
               - course_number
               - quarter
           config:
@@ -38,7 +44,9 @@ models:
       - name: studentid
         data_type: int64
         description:
-          The internal number and ID of the associated Students record.
+          The internal number and ID of the associated Students record. Null for
+          Miami from AY2026 forward -- Focus has no equivalent internal id. Use
+          student_number to identify a student across both SIS branches.
         config:
           meta:
             source_system: PowerSchool
@@ -1240,7 +1248,8 @@ models:
       - name: rn
         data_type: int64
         description: >
-          Row number within (project, academic_year, studentid, course_number,
-          quarter), ordered by school exitdate desc then CC dateleft desc.
-          Always 1 in this model's output — filtered by a WHERE clause after
-          computing the window, not QUALIFY. Retained for downstream reference.
+          Row number within (project, academic_year, student_number,
+          course_number, quarter), ordered by school exitdate desc then CC
+          dateleft desc. Always 1 in this model's output — filtered by a WHERE
+          clause after computing the window, not QUALIFY. Retained for
+          downstream reference.

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -373,6 +373,25 @@ data_tests:
           ref:
             name: dim_student_section_enrollments
 
+  - name: test_focus_course_enrollment_joins_resolve_miami
+    description: >-
+      Fails when either repointed course-enrollment model holds zero Miami rows.
+      Both models once joined students on PowerSchool's internal `cc_studentid`
+      / `studentid`, which Focus leaves null on every row, so both returned no
+      Miami data in any academic year while every test stayed green -- the
+      breakage produced no error, only absent rows. This asserts presence rather
+      than a count, because Miami's volume moves with enrollment and a floor
+      would drift stale or fire on legitimate change, while zero is always
+      wrong. Note this guards the archive years: Miami AY2026 forward stays
+      excluded from both models by their `is_dropped_*` filters until #4996
+      resolves them, so a year-scoped assertion would fail today by design.
+    config:
+      severity: error
+      meta:
+        dagster:
+          ref:
+            name: int_extracts__course_enrollments_by_term
+
   - name: test_focus_course_sections_teacher_resolves
     description: >-
       Warns on Focus course periods whose lead teacher does not resolve through

--- a/src/dbt/kipptaf/tests/test_focus_course_enrollment_joins_resolve_miami.sql
+++ b/src/dbt/kipptaf/tests/test_focus_course_enrollment_joins_resolve_miami.sql
@@ -1,0 +1,28 @@
+-- Guards the join-key repoint in int_assessments__course_enrollments and
+-- int_extracts__course_enrollments_by_term. Both once joined on PowerSchool's
+-- internal cc_studentid / studentid, which Focus leaves null, so both silently
+-- held zero Miami rows in every year -- a failure with no error anywhere. A
+-- revert to those keys would re-drop Miami just as quietly, so assert the rows
+-- are present rather than trusting the join to stay correct.
+--
+-- Deliberately a presence check, not a count floor: Miami's row count moves
+-- with enrollment, and a floor would either drift stale or fire on real
+-- change. Zero rows is the only value that is always wrong.
+with
+    miami_rows as (
+        select
+            'int_assessments__course_enrollments' as model_name,
+            countif(_dbt_source_project = 'kippmiami') as miami_row_count,
+        from {{ ref("int_assessments__course_enrollments") }}
+
+        union all
+
+        select
+            'int_extracts__course_enrollments_by_term' as model_name,
+            countif(_dbt_source_project = 'kippmiami') as miami_row_count,
+        from {{ ref("int_extracts__course_enrollments_by_term") }}
+    )
+
+select model_name, miami_row_count,
+from miami_rows
+where miami_row_count = 0


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put Miami back into three kipptaf models that
had been dropping it silently.

Miami moved to the Focus SIS. Focus does not populate `cc_studentid`, PowerSchool's
internal student id, so any model joining on it matched no Miami row and quietly
returned nothing. #4995 listed four such models plus a bridge table.

Measuring each one first changed the plan. Only two of the four are fixable by
swapping the join key. The other two are blocked by something a key swap cannot
reach, so this pull request documents that instead of guessing.

**Two models repointed.** `int_assessments__course_enrollments` and
`int_extracts__course_enrollments_by_term` now join on `student_number`, which both
SIS branches populate. New Jersey does not move. Miami gains 59,188 and 169,597
rows.

**The bridge gains a Focus branch.** `bridge_course_section_teachers` inner-joins a
PowerSchool-only table that holds no Miami rows for AY2026. It now reads the lead
teacher that `int_students__course_sections` already resolves for Focus. That adds
743 rows for Miami AY2026 — the only AY2026 win in this pull request.

**Two models documented, not changed.** `fct_grades_assignments` and
`fct_grades_category` read gradebook sources that hold zero Miami AY2026 rows.
Miami left the PowerSchool package, and Focus gradebook data has no kipptaf
wrapper, so no join key can produce a Miami row. Both model descriptions now say
this. #5010 tracks the real fix.

## Reviewer Notes

**The issue's premise was half wrong, and that is the main thing to check.** #4995
says repointing four joins will bring back Miami AY2026. It will not. Two of the
four inner-join a source with no Miami AY2026 rows at all. Please sanity-check that
call before merging — the numbers are in the fold-out below.

**Miami AY2026 is still missing from the two repointed models, and that is
expected.** Their `is_dropped_section` and `is_dropped_course` filters still remove
it, because Focus leaves those flags null. #4996 owns that decision and #4995 put it
out of scope. What this pull request restores is Miami's archive years, which were
also broken.

**One join deliberately does not follow the pattern #4972 set.**
`dim_student_section_enrollments` keys on `(student_number, schoolid, academic_year)`.
The assessments join never carried `schoolid`, and adding it drops New Jersey rows.
Reasoning and measured counts are in the fold-out.

**The Focus branch of the bridge carries less than the PowerSchool branch.** It has
the lead teacher only, and its effective dates are null. Both are source-data limits,
not shortcuts, and both are written into the model description.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

No new models, so no new properties file. No exposure changes: the three touched
models keep their column sets, so nothing downstream needs coordinating. No column
was renamed or removed — `int_extracts__course_enrollments_by_term` changes an
internal CTE column only, and its output column list is unchanged. No external
sources changed.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. All values measured against prod on 2026-08-26.

### Why two of the four models were not repointed

#4995 inherited its four-model list from #4973's analysis, which was not
re-verified. Two of the four inner-join a source that holds no Miami AY2026 rows,
so the join key is not what blocks them:

| Source model | Miami AY2025 | Miami AY2026 |
| --- | --- | --- |
| `int_powerschool__gradebook_assignments_scores` | 523,021 | 0 |
| `int_powerschool__category_grades` | 255,668 | 0 |

Both union the district PowerSchool packages. `src/dbt/kippmiami/packages.yml` no
longer lists `powerschool`, so Miami's archive stops at AY2025. Focus holds the
data (`int_focus__gradebook_grades`, `int_focus__report_card_grades` in the focus
package) but neither has a kipptaf wrapper. Tracked in #5010.

Their other join keys are null for Miami too, so a `cc_studentid` swap alone would
not have been enough even with a source: `students_dcid` and `cc_abs_sectionid` are
null on all 19,350 Miami AY2026 rows of `base_powerschool__course_enrollments`,
alongside `cc_studentid`, `cc_yearid`, `is_dropped_section`, `is_dropped_course`
and `sections_no_of_students`. All six are non-null on every NJ row.

`fct_grades_assignments` also carries `cc_academic_year - 1990 = enr.yearid`. That
term is untouched here. The 1990 offset is a PowerSchool `yearid` convention with
no Focus equivalent, and it only needs solving once #5010 supplies a Focus branch.

### The breakage is wider than AY2026

`int_assessments__course_enrollments` holds zero Miami rows in **every** year, not
just AY2026. #4972 moved Miami's student enrollments wholesale onto Focus back to
AY2018, and Focus leaves `studentid` null, so the archive years broke too. The
prod table was rebuilt at 19:03 on 2026-08-26, after #4972 merged at 14:26, so
that state is post-merge. `int_extracts__course_enrollments_by_term` shows the
same zero-Miami shape.

### NJ parity method

A straight new-vs-prod count is not a valid check here: the live year drifts within
a single day, exactly as #4972 warned. A first comparison showed Newark -24 and
Camden -8, both confined to the live year.

So both join variants were run against the **same live upstream** in one query,
which removes drift entirely. Result: zero differing rows for Camden, Newark and
Paterson in every year, on `count(*)` and on a distinct count of the grain key.
The only differences are Miami.

Key-level parity backs this up. In `int_students__student_enrollments` at
`rn_year = 1`, `(academic_year, studentid)` and `(academic_year, student_number)`
have identical distinct counts equal to the row count in all three NJ regions. In
`base_powerschool__course_enrollments`, distinct `cc_studentid` = distinct
`students_student_number` = distinct pairs for all three.

Miami gains, by model:

| Model | Miami rows gained | Years |
| --- | --- | --- |
| `int_assessments__course_enrollments` | 59,188 | AY2018-AY2025 |
| `int_extracts__course_enrollments_by_term` | 169,597 | AY2020-AY2025 |
| `bridge_course_section_teachers` | 743 | AY2026 |

### Why the assessments join does not gain schoolid

Adding `schoolid` to that join drops NJ rows where a student's course school
differs from their enrollment school: Newark -2,271, Camden -389, Paterson -63.
The student-key swap alone is exactly NJ-neutral. `dim_student_section_enrollments`
can carry `schoolid` because its join always had it;
`int_assessments__course_enrollments` never did.

`int_extracts__course_enrollments_by_term` already joined on `schoolid` and
`academic_year`, so only the student key changed there.

### Bridge verification

Running the compiled model against prod:

- PowerSchool branch: 87,557 rows, matching the prod table exactly. Zero rows lost.
- Focus branch: 743 rows.
- Primary-key duplicates on `(course_section_key, staff_key, effective_start_date)`: 0.
- Rows in prod but not in the new model: 0.
- Rows in the new model but not in prod: 743, all Focus.

743 of Miami's 823 AY2026 sections resolve a lead teacher. The 80 that do not are
#4972's documented floor: 67 course periods with no teacher assigned in Focus, plus
13 whose user resolves to no staff roster row.

The Focus branch is year-scoped off the same `focus_academic_year_boundary` CTE the
sibling models use. Without it the branch would emit a duplicate Lead Teacher row
for every Miami archive section, since those sections carry both a `sectionteacher`
row and a resolved `teachernumber`. `stg_powerschool__sectionteacher` does hold
19,529 Miami rows — #4995 says it has none, which is wrong for the archive years
though right for AY2026.

### Checked and clear

`base_powerschool__sections` is a VIEW in prod as of 14:53 on 2026-08-26, so
#4972's required post-merge full-refresh did happen. The bridge comparison above
would have been meaningless against a stale table.

### Not done

The `is_dropped_section` / `is_dropped_course` filters are untouched, per #4995 and
#4996. That is why Miami AY2026 is still absent from the two repointed models.

</details>

Closes #4995
Refs #4973
Refs #4996
Refs #5010
Refs #4972
