### PR TITLE
feat(dbt): add college counselor to kippadb contact and kfwd dashboard

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__kfwd_dashboard.yml
@@ -558,6 +558,8 @@ models:
         data_type: numeric
       - name: postsec_advisor
         data_type: string
+      - name: college_counselor
+        data_type: string
       - name: recent_cumulative_gpa
         data_type: numeric
       - name: recent_transcript_date

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__kfwd_dashboard.sql
@@ -293,6 +293,7 @@ select
     c.exit_grade_level,
     c.powerschool_enroll_status,
     c.contact_postsec_advisor_name as postsec_advisor,
+    c.contact_college_counselor_name as college_counselor,
     c.best_guess_pathway as bgp,
     c.desired_pathway,
     c.is_ed_ea,

--- a/src/dbt/kipptaf/models/kippadb/base/base_kippadb__contact.sql
+++ b/src/dbt/kipptaf/models/kippadb/base/base_kippadb__contact.sql
@@ -14,6 +14,7 @@ select
     c.actual_college_graduation_date as contact_actual_college_graduation_date,
     c.actual_hs_graduation_date as contact_actual_hs_graduation_date,
     c.advising_provider as contact_advising_provider,
+    c.college_counselor_id as contact_college_counselor_id,
     c.college_graduated_from as contact_college_graduated_from,
     c.college_match_display_gpa as contact_college_match_display_gpa,
     c.current_college_cumulative_gpa as contact_current_college_cumulative_gpa,
@@ -78,6 +79,8 @@ select
 
     psc.name as contact_postsec_advisor_name,
 
+    ccc.name as contact_college_counselor_name,
+
     c.last_name || ', ' || c.first_name as contact_lastfirst,
 
     (
@@ -89,3 +92,4 @@ from {{ ref("stg_kippadb__contact") }} as c
 left join {{ ref("stg_kippadb__user") }} as u on c.owner_id = u.id
 left join {{ ref("stg_kippadb__record_type") }} as rt on c.record_type_id = rt.id
 left join {{ ref("stg_kippadb__contact") }} as psc on c.postsec_advisor = psc.id
+left join {{ ref("stg_kippadb__contact") }} as ccc on c.college_counselor_id = ccc.id

--- a/src/dbt/kipptaf/models/kippadb/base/properties/base_kippadb__contact.yml
+++ b/src/dbt/kipptaf/models/kippadb/base/properties/base_kippadb__contact.yml
@@ -31,6 +31,8 @@ models:
         data_type: date
       - name: contact_advising_provider
         data_type: string
+      - name: contact_college_counselor_id
+        data_type: string
       - name: contact_college_graduated_from
         data_type: string
       - name: contact_college_match_display_gpa
@@ -145,6 +147,11 @@ models:
         data_type: string
       - name: contact_postsec_advisor_name
         data_type: string
+      - name: contact_college_counselor_name
+        data_type: string
+        description:
+          Derived from contact_college_counselor_id, resolved against the
+          counselor's own contact record.
       - name: contact_lastfirst
         data_type: string
         description: Derived from first_name, last_name.

--- a/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
+++ b/src/dbt/kipptaf/models/kippadb/intermediate/int_kippadb__roster.sql
@@ -214,6 +214,7 @@ with
             c.contact_actual_college_graduation_date,
             c.contact_actual_hs_graduation_date,
             c.contact_advising_provider,
+            c.contact_college_counselor_id,
             c.contact_college_graduated_from,
             c.contact_college_match_display_gpa,
             c.contact_current_college_cumulative_gpa,
@@ -270,6 +271,7 @@ with
             c.record_type_last_modified_by_id,
             c.record_type_namespace_prefix,
             c.contact_postsec_advisor_name,
+            c.contact_college_counselor_name,
             c.years_out_of_hs,
 
             os.id as overgrad_students_id,

--- a/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__contact.yml
+++ b/src/dbt/kipptaf/models/kippadb/staging/properties/stg_kippadb__contact.yml
@@ -36,6 +36,11 @@ models:
         data_type: date
       - name: advising_provider
         data_type: string
+      - name: college_counselor_id
+        data_type: string
+        description:
+          Salesforce contact id of the college counselor assigned to this
+          contact. Names resolve by joining back to this model on id.
       - name: college_graduated_from
         data_type: string
       - name: college_match_display_gpa

--- a/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__contact.sql
+++ b/src/dbt/kipptaf/models/kippadb/staging/stg_kippadb__contact.sql
@@ -15,6 +15,7 @@ select
     actual_college_graduation_date__c as actual_college_graduation_date,
     actual_hs_graduation_date__c as actual_hs_graduation_date,
     advising_provider__c as advising_provider,
+    college_counselor__c as college_counselor_id,
     college_graduated_from__c as college_graduated_from,
     college_match_display_gpa__c as college_match_display_gpa,
     current_college_cumulative_gpa__c as current_college_cumulative_gpa,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will surface the Salesforce
`Contact.College_Counselor__c` field through the kippadb contact chain and onto
the KIPP Forward Tableau dashboard.

The raw field is an 18-character Salesforce Contact lookup id (`003` prefix), not
free text — so it is handled the same way as its sibling `postsec_advisor`:

| Model | Change |
| --- | --- |
| `stg_kippadb__contact` | `college_counselor__c as college_counselor_id` |
| `base_kippadb__contact` | id passthrough, plus `contact_college_counselor_name` resolved by a self-join on `stg_kippadb__contact` (mirrors the existing `psc` join for `contact_postsec_advisor_name`) |
| `int_kippadb__roster` | both columns passed through |
| `rpt_tableau__kfwd_dashboard` | exposes the name as `college_counselor`, matching the neighbouring `contact_postsec_advisor_name as postsec_advisor` |

### Data caveat

887 non-deleted contacts carry a counselor id, but only **788 resolve to a
name** — the remaining 99 reference a `Contact` record that has been deleted in
Salesforce. Those rows will show a blank `college_counselor` on the dashboard
while the id is populated upstream. This is why **no `relationships` test was
added** on `college_counselor_id`: it would fail on 4 of the 10 distinct ids
present. If the blanks matter to the KIPP Forward team, the fix is upstream in
Salesforce rather than in dbt.

### Validation

- `dbt build` (target `dev`, `--favor-state --defer`) across all four models:
  `PASS=6 WARN=1 ERROR=0`. The single WARN is `test_sf_contact_note_duplicate`
  (4 duplicate contact *notes*) — pre-existing on `main`, pulled into the
  selection only because it refs `stg_kippadb__contact`.
- Contract enforcement passed on both contracted models
  (`stg_kippadb__contact`, `rpt_tableau__kfwd_dashboard`).
- `trunk check --force` on all 7 changed files: no issues.
- Row counts confirmed end-to-end in dev: `int_kippadb__roster` 883 ids / 784
  names; `rpt_tableau__kfwd_dashboard` 1,568 rows across 6 distinct counselors.
- No contracted `select *` consumer sits downstream of the roster or base model,
  so the added column cannot break one.

### Rollback plan

Additive only — no column renamed or removed, so no downstream exposure breaks.
Reverting this commit and rebuilding the four models restores the prior state.

## AI Assistance

Claude authored the model changes and ran the validation above. Column naming
(`college_counselor_id` plus a joined `college_counselor_name`), the decision to
surface it on the KIPP Forward dashboard, and overall scope were human-directed.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Properties files updated for every changed model
      (`stg_kippadb__contact.yml`, `base_kippadb__contact.yml`,
      `rpt_tableau__kfwd_dashboard.yml`), including contract `data_type` entries
      for the two contracted models.
- [x] Exposure — no change needed. `rpt_tableau__kfwd_dashboard` already has an
      exposure, and this is an additive column to an existing model.
- [x] **Not a breaking change.** No column renamed or removed in any contracted
      model; both additions are new columns.
- [x] No external source added or modified, so `stage_external_sources` is not
      required.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes. `rpt_tableau__kfwd_dashboard` is `state:modified`,
      so this gets a real (non-trivial) CI build.
- [ ] **Dagster Cloud** — not triggered (dbt-only change).
