### PR TITLE
fix(dagster): match Paterson's recurring EdPlan export name

### DIFF
--- a/src/teamster/code_locations/kipppaterson/edplan/assets.py
+++ b/src/teamster/code_locations/kipppaterson/edplan/assets.py
@@ -11,17 +11,13 @@ njsmart_powerschool = build_sftp_file_asset(
     remote_dir_regex=r"Reports",
     # Paterson's EdPlan account exports this report instead of Newark's and
     # Camden's `NJSMART-PowerSchool.txt`. Same 37 columns, same comma delimiter;
-    # only the file name differs, and it carries the export date. The named
-    # group resolves to the partition key, so exactly one file matches per
-    # partition -- the file's mtime date equals the date in its name.
-    remote_file_regex=(
-        r"EDPlan Special Education Data Export-PCG Support-(?P<date>[\d-]+)\.txt"
-    ),
+    # only the name differs, and like theirs it is one file overwritten daily.
+    remote_file_regex=r"EDPlan Special Education Data Export\.txt",
     ssh_resource_key="ssh_edplan",
     avro_schema=NJSMART_POWERSCHOOL_SCHEMA,
     partitions_def=DailyPartitionsDefinition(
-        # First file EdPlan produced for Paterson.
-        start_date="2026-08-24",
+        # First recurring export EdPlan produced for Paterson.
+        start_date="2026-08-26",
         timezone=str(LOCAL_TIMEZONE),
         fmt="%Y-%m-%d",
         end_offset=1,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make Paterson's EdPlan sensor find its file.

The sensor shipped in #4988 has been running in prod and finding nothing. It
looked for `EDPlan Special Education Data Export-PCG Support-<date>.txt`, and no
file by that name is on the server any more.

Two dated files were on the account when #4988 was written. Those were one-off
manual pulls PCG support generated while setting the feed up — "PCG Support" was
in the name — and they have since been cleaned up. The recurring scheduled export
writes `EDPlan Special Education Data Export.txt` and overwrites it daily. PCG
confirmed that name is permanent.

No data was lost while the sensor was skipping, because the export overwrites one
file rather than accumulating.

Closes #4998

## Reviewer Notes

**Paterson is now the same shape as Newark and Camden.** One file, no date,
overwritten in place — the same as their `NJSMART-PowerSchool.txt`. The
`(?P<date>...)` named group is gone because there is nothing left to
disambiguate, and it could not have worked anyway: with no date in the name,
`compose_regex` substitutes the partition key into nothing and compiles a pattern
that matches nothing.

**`start_date` moves for a real reason, not tidiness.** Without the date group the
pattern no longer varies by partition, so backfilling `2026-08-24` would match
today's file and store it under the wrong partition key. Partitions that cannot
resolve are safer than partitions that resolve wrongly. Newark and Camden carry
the same property, so this narrows the window rather than closing it.

**Nothing downstream moves.** The file's contents did not change — same 37
columns, same comma delimiter — so the Avro schema, the staging model, and the
whole dbt layer are untouched.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [x] Run `uv run dagster definitions validate` for any modified code location —
      `kipppaterson` passes. It first failed on a missing
      `src/dbt/kipppaterson/target/manifest.json`, which is the documented
      fresh-worktree condition in `src/teamster/CLAUDE.md`, not this change;
      passes after `dagster-dbt project prepare-and-package`.
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code
      location — covered by the asset test below, which exercises the changed
      regex against the live account rather than only loading definitions.
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager — unchanged from #4988;
      this only edits two arguments to `build_sftp_file_asset`.

### dbt _(skip if no dbt changes)_

No dbt changes. The export's contents and column set are unchanged, so no model,
source, schema, or contract is affected.

### Docs _(skip if no schedule, sensor, or integration changes)_

- [x] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py` — no schedule or sensor
      added, renamed, or re-intervalled. The sensor from #4988 is unchanged; only
      the asset's filename pattern moved, which the catalog does not record.
- [x] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md` — no new
      integration. `code_locations/kipppaterson/CLAUDE.md` already lists `edplan`
      from #4988 and says nothing about the filename.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

### Evidence for the "manual pulls" reading

State of `Reports/` when #4988 was written:

```text
2026-08-24T16:39:10Z   9754   'EDPlan Special Education Data Export-PCG Support-2026-08-24.txt'
2026-08-25T16:38:29Z   9761   'EDPlan Special Education Data Export-PCG Support-2026-08-25.txt'
```

State now:

```text
2026-08-26T16:39:13Z   9761   'EDPlan Special Education Data Export.txt'
```

Two things support reading the dated pair as setup artifacts rather than the
feed: 9,761 bytes matches the 2026-08-25 file exactly, and 16:39 matches the
16:38-16:39 daily cadence those files already had. PCG's confirmation settles it.

### Verification

`pytest tests/assets/test_assets_edplan_sftp.py -k kipppaterson` passes against
the live account. That is the meaningful check here — it resolves the regex,
downloads the matched file, parses it, and runs the Avro schema check, so a
regex that matched nothing or matched two files would fail rather than pass
quietly. The prod symptom was a `SKIPPED` tick with "Sensor function returned an
empty result", which no import-level check would have caught.

Confirmed no `PCG Support` reference survives anywhere in `src/`, `docs/`, or
`tests/`.

### The lesson worth carrying, since this is the second instance

#4988 was written against a live observation of this account, verified carefully
— filename-date versus mtime-date checked on both files — and the sample was
still wrong. Neither the Newark/Camden precedent nor a point-in-time observation
of Paterson's account predicts its filenames. For this integration, prefer a
pattern that fails loudly on a rename over one that tolerates several shapes: a
tolerant pattern here would trip `build_sftp_file_asset`'s multiple-match guard
the moment a dated file reappeared beside the plain one, whereas the strict one
keeps working and raises `FileNotFoundError` if the name moves again.

</details>
