### PR TITLE
fix(ci): drop the retired dignified-python plugin from the Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -52,15 +52,13 @@ jobs:
             superpowers@superpowers-dev
             context7@claude-plugins-official
             dagster-expert@dagster
-            dignified-python@dagster
             dbt@dbt-agent-marketplace
           track_progress: true
           prompt: >-
             /superpowers:requesting-code-review ${{ github.repository
             }}/pull/${{ github.event.pull_request.number }}.
 
-            Apply dignified-python for Python standards, dagster-expert for
-            Dagster assets and pipelines, and
+            Apply dagster-expert for Dagster assets and pipelines, and
             dbt:using-dbt-for-analytics-engineering for dbt models and
             transformations.
 

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -48,7 +48,6 @@ jobs:
             superpowers@superpowers-dev
             context7@claude-plugins-official
             dagster-expert@dagster
-            dignified-python@dagster
             dbt@dbt-agent-marketplace
 
           # Optional: Add claude_args to customize behavior and configuration


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make `Claude Code Review` run again.

It has failed on every pull request since dagster removed `dignified-python` from
their marketplace. Both Claude workflows still asked for that plugin by name, so
plugin setup failed and the job exited before reviewing anything — about 20
seconds, leaving only its "Reviewing…" stub behind. Three consecutive runs failed
across three different people's branches.

Removing the reference is the whole fix.

Closes #5019

## Reviewer Notes

**Only this one reference was broken.** I checked all four marketplaces the
workflows declare. `dagster-io/skills` now serves only `dagster-expert`, and
`dignified-python` is in none of them. `superpowers@superpowers-dev`,
`context7@claude-plugins-official`, `dagster-expert@dagster`, and
`dbt@dbt-agent-marketplace` all still resolve.

**Why nobody noticed locally.** An existing Codespace still resolves the plugin
from its cache, so only CI, which fetches fresh, fails. A new Codespace would hit
the same wall.

**The prompt lost its Python-standards clause.** No marketplace we declare
carries an equivalent, so there was no like-for-like swap. Getting that coverage
back means vendoring the skill or writing the standards into
`src/teamster/CLAUDE.md` — both bigger calls than unblocking CI, and both fine to
do separately.

**One manual step remains, and it is not CI-affecting.**
`.claude/settings.json:215` still enables the plugin. That path is protected, so
it has to be applied by hand. It only affects a fresh plugin sync, not Actions.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes.

### dbt _(skip if no dbt changes)_

No dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. `trunk check --force` clean on both files.

### Marketplace state, checked rather than assumed

```text
dagster-io/skills                    dagster-expert
anthropics/claude-plugins-official   dignified-python absent
dbt-labs/dbt-agent-skills            dbt, dbt-extras, dbt-migration  (name: dbt-agent-marketplace)
obra/superpowers                     superpowers                     (name: superpowers-dev)
```

Read from each repo's `.claude-plugin/marketplace.json`. Every plugin reference
in both workflows was checked against this, not just the one that broke.

### Evidence for the diagnosis

Run `33081619734` on #5018: the step starts, installs bun and 140 packages, then
exits 1 at 20 seconds having only fetched and stamped its tracking comment. Too
fast to have reviewed a diff, and it never reaches the review itself. The
`ANTHROPIC_API_KEY: ` empty value visible in a later cleanup step is a red
herring — the action authenticates via `claude_code_oauth_token`, which is set.

Last success was on #4988 earlier the same day, which brackets the break to the
marketplace change rather than anything in this repo.

### A prediction of mine that was wrong

The issue says pushing a branch that edits `.github/workflows/**` would need a
token with `workflow` scope and might need the OAuth fallback. The plain push
worked. Whoever picks up a similar change should not plan around that constraint.

### Whether this PR self-tests

For `pull_request` events GitHub may use the workflow definition from the base
branch rather than the head, in which case `Claude Code Review` still fails here
and only starts passing after merge. I am not asserting which — worth just
watching what the check does on this PR.

</details>
