### PR TITLE
fix(dbt): restore Paterson in the kipptaf EdPlan union

### DIFF
--- a/src/dbt/kipptaf/models/edplan/intermediate/int_edplan__njsmart_powerschool_union.sql
+++ b/src/dbt/kipptaf/models/edplan/intermediate/int_edplan__njsmart_powerschool_union.sql
@@ -11,6 +11,10 @@ with
                         "kippcamden_edplan",
                         "int_edplan__njsmart_powerschool_union",
                     ),
+                    source(
+                        "kipppaterson_edplan",
+                        "int_edplan__njsmart_powerschool_union",
+                    ),
                 ]
             )
         }}


### PR DESCRIPTION
# Pull Request

> **DRAFT — do not merge until `kipppaterson_edplan.int_edplan__njsmart_powerschool_union`
> exists in prod with rows.** It does not yet. Merging early recreates the exact asset
> failure that `8fd0f27ed9` reverted. Gate and order are in Reviewer Notes.

## Summary & Motivation

When merged, this pull request will give Paterson students their IEP data back.

It reinstates the four lines `8fd0f27ed9` removed — the `kipppaterson_edplan`
source in the kipptaf EdPlan union. That revert was right at the time and said so
in its message: "until filename is confirmed." PCG has now confirmed the
recurring export name, and #5018 matches it.

This closes a live gap rather than adding something new. #4988 removed Paterson
from the two PowerSchool IEP fallbacks, because Paterson was joining the EdPlan
union instead. The revert then removed the union leg. Between the two, Paterson
reads nothing at all.

Closes #5025

## Reviewer Notes

**The gap is measurable in prod right now.**

| Metric | kipppaterson | kippmiami | kippnewark |
| --- | --- | --- | --- |
| `dim_student_iep_status` rows | **0** | 10,075 | 18,161 |

All 1,450 Paterson enrollments in AY2025 and AY2026 report `spedlep = 'No IEP'`
with a null special-education code. Newark runs 11 to 13 percent with an IEP over
the same years, so all-zero is not real data.

**Why this is a draft.** `kipppaterson_edplan` is absent from prod
`INFORMATION_SCHEMA.SCHEMATA` — only `zz_stg_kipppaterson_edplan` exists, from a
manual staging run. `dbt_utils.union_relations` introspects each relation at
compile time and, for a missing one, emits all-null casts plus a `from` against
it, which fails at run time. That is the failure the revert cleared.

**Required order before marking ready:**

1. Merge #5018, so the sensor's filename pattern matches what EdPlan writes. The
   sensor is already running in prod and skipping every tick.
1. Let the sensor materialize `kipppaterson/edplan/njsmart_powerschool`, then
   Paterson's dbt assets build `stg_edplan__njsmart_powerschool` and
   `int_edplan__njsmart_powerschool_union` into `kipppaterson_edplan`. Dagster
   stages the prod external table itself, so no manual staging is needed.
1. Confirm the table exists and has rows.
1. Mark this ready and merge.

**The diff is byte-identical to its pre-revert blob** (`8f74fdf026`), so this is
a clean restore, not a re-implementation.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes. The source's `meta.dagster.asset_key` in
`sources-kipppaterson.yml` is unchanged and already present on main — the revert
did not touch it.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; this adds a source leg to an existing union.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      exposure change. Downstream consumers gain Paterson rows; no column set
      moves.
- [x] **Breaking change?** No column renamed or removed. Paterson rows appear
      where there were none, which is the intent. Rollback is re-applying
      `8fd0f27ed9`.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external source is modified here. The
      Paterson external source was already staged for CI; prod is staged by
      Dagster.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Values measured against prod on 2026-08-27.

### Why both IEP legs are empty for Paterson today

`dim_student_iep_status` can build Paterson rows from neither leg:

- `nj_leg` reads `int_edplan__njsmart_powerschool_union`, which has no Paterson
  rows — the revert removed the source.
- `pm_leg` filters `_dbt_source_project = 'kippmiami'` at line 152, so Paterson
  is excluded there too. That narrowing came from #4988 and is correct once the
  union leg is back.

`int_students__student_enrollments` has the same shape at lines 307 and 337: both
read `sped.special_education_code` / `sped.spedlep` for any non-Miami region, and
that join returns nothing for Paterson.

So this one restore fixes both models. No change is needed in either downstream
file — their #4988 state is already correct for a world where Paterson is in the
union.

### CI expectation on this PR

dbt Cloud will likely fail here for two independent reasons, neither of them this
diff:

1. `kipppaterson_edplan.int_edplan__njsmart_powerschool_union` does not exist yet
   — the gate this PR is drafted behind.
1. `int_powerschool__ada_term_pivot__weighted_year_matches_source` is failing on
   unrelated branches with an identical 3,535 rows. Tracked in #5023.

Do not read either as a signal about this change.

### Interim option, deliberately not taken

Putting Paterson back into the two PowerSchool fallbacks would restore
pre-#4988 behavior while the data lands, at the cost of reverting part of #4988
and then re-reverting it. Only worth it if the gap stays open long enough to
affect reporting. That call belongs to whoever owns Paterson reporting, and it is
written up in #5025 rather than decided here.

</details>
