### PR TITLE
feat(dagster): ingest the Focus student_gpa_calculated table

### DIFF
--- a/src/teamster/code_locations/kippmiami/dlt/focus/assets.py
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/assets.py
@@ -14,12 +14,15 @@ sql_database_credentials = resolve_configuration(
     ConnectionStringCredentials(), sections=("FOCUS_DB",)
 )
 
+config_assets = yaml.safe_load(config_file.read_text())["assets"]
+
 tables = [
     # a["cursor_column"], not .get(): a new table added without a declared
     # cursor must fail loudly at module load, not silently become count-only.
     ProbeTable(name=a["table_name"], cursor_column=a["cursor_column"])
-    for a in yaml.safe_load(config_file.read_text())["assets"]
+    for a in config_assets
 ]
+
 """Module-level so sensors.py can import it instead of re-parsing the YAML.
 
 Keeps the credential resolution and config parse to one copy per code-location
@@ -27,10 +30,22 @@ import — both `assets.py` and `sensors.py` load unconditionally via
 `dlt/focus/__init__.py`.
 """
 
+widen_numeric_tables = frozenset(
+    a["table_name"] for a in config_assets if a.get("widen_unbounded_numeric")
+)
+"""Tables whose unbounded Postgres `numeric` columns need an explicit scale.
+
+`.get()`, not `[...]`: this key is absent on all but the tables that need it.
+Opt-in rather than source-wide because widening retypes the column to BigQuery
+BIGNUMERIC, and 45 already-loaded Focus tables carry 200 NUMERIC columns that
+`replace` cannot retype in place.
+"""
+
 assets = [
     build_focus_dlt_assets(
         sql_database_credentials=sql_database_credentials,
         code_location=CODE_LOCATION,
         tables=tables,
+        widen_numeric_tables=widen_numeric_tables,
     )
 ]

--- a/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
@@ -79,6 +79,8 @@ assets:
   # Grades
   - table_name: student_report_card_grades
     cursor_column: updated_at
+  - table_name: student_gpa_calculated
+    cursor_column: updated_at
   - table_name: report_card_grades
     cursor_column: updated_at
   - table_name: report_card_grade_scales

--- a/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
@@ -81,6 +81,9 @@ assets:
     cursor_column: updated_at
   - table_name: student_gpa_calculated
     cursor_column: updated_at
+    # weighted_gpa is an unbounded Postgres numeric holding more than 9 decimal
+    # places, which the default decimal128(38, 9) cannot represent.
+    widen_unbounded_numeric: true
   - table_name: report_card_grades
     cursor_column: updated_at
   - table_name: report_card_grade_scales

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -141,8 +141,16 @@ def widen_unbounded_numeric_adapter(col_type: TypeEngine) -> TypeEngine:
     more than 9 decimal places, and the extract dies with
     ``Rescaling Decimal value would cause data loss`` —
     ``student_gpa_calculated.weighted_gpa`` is the first Focus column to hit it.
+    It also overflowed ``decimal128(38, 18)``, so it carries more than 18
+    decimal places: Focus stores an unrounded division result.
 
-    ``Numeric(38, 18)`` maps to BigQuery BIGNUMERIC, not NUMERIC, so a dbt
+    ``(76, 38)`` is the destination ceiling, not a tuning choice. dlt maps
+    precision above 38 to ``decimal256``, and BigQuery declares exactly
+    ``wei_precision=(76, 38)`` — BIGNUMERIC. Nothing wider exists to fall back
+    to. Postgres ``numeric`` scale is unbounded in principle, so a future column
+    could still overflow this; rounding in the query would be the only fix left.
+
+    ``Numeric(76, 38)`` maps to BigQuery BIGNUMERIC, not NUMERIC, so a dbt
     staging model over an opted-in table should ``cast(col as numeric)`` to keep
     contracts on NUMERIC. That retype is also why this is opt-in per table
     rather than applied to the whole source: 200 NUMERIC columns across 45
@@ -159,7 +167,10 @@ def widen_unbounded_numeric_adapter(col_type: TypeEngine) -> TypeEngine:
         return col_type
 
     if isinstance(col_type, Numeric) and col_type.precision is None:
-        return Numeric(precision=38, scale=18)
+        # ponytail: destination maximum, chosen because Focus is unreachable
+        # from CI so the real scale cannot be measured. Narrow it once a loaded
+        # value can be inspected in BigQuery.
+        return Numeric(precision=76, scale=38)
 
     return col_type
 

--- a/src/teamster/libraries/dlt/focus/assets.py
+++ b/src/teamster/libraries/dlt/focus/assets.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any, get_args
 
 import dlt
@@ -15,7 +15,7 @@ from dlt.extract.items import DataItemWithMeta
 from dlt.extract.resource import DltResource
 from dlt.sources.sql_database import remove_nullability_adapter
 from dlt.sources.sql_database.helpers import table_rows
-from sqlalchemy import BigInteger
+from sqlalchemy import BigInteger, Float, Numeric
 from sqlalchemy.sql.sqltypes import _AbstractInterval
 from sqlalchemy.types import TypeEngine
 
@@ -133,10 +133,49 @@ def interval_to_microseconds_adapter(col_type: TypeEngine) -> TypeEngine | None:
     return col_type
 
 
+def widen_unbounded_numeric_adapter(col_type: TypeEngine) -> TypeEngine:
+    """Give unbounded Postgres ``numeric`` an explicit precision and scale.
+
+    Unbounded ``numeric`` reflects as ``precision=None``, which dlt renders as
+    ``decimal128(38, 9)``. pyarrow then refuses to rescale any value needing
+    more than 9 decimal places, and the extract dies with
+    ``Rescaling Decimal value would cause data loss`` —
+    ``student_gpa_calculated.weighted_gpa`` is the first Focus column to hit it.
+
+    ``Numeric(38, 18)`` maps to BigQuery BIGNUMERIC, not NUMERIC, so a dbt
+    staging model over an opted-in table should ``cast(col as numeric)`` to keep
+    contracts on NUMERIC. That retype is also why this is opt-in per table
+    rather than applied to the whole source: 200 NUMERIC columns across 45
+    already-loaded Focus tables would need recreating, and ``replace`` cannot
+    change a column's type in place.
+
+    ``Float`` subclasses ``Numeric`` and also reflects ``precision=None``, so it
+    is returned untouched — otherwise every ``double precision`` column in an
+    opted-in table would land as BIGNUMERIC. (Illuminate's
+    ``unbounded_numeric_adapter`` omits that guard; it has no float columns
+    reaching this path today.)
+    """
+    if isinstance(col_type, Float):
+        return col_type
+
+    if isinstance(col_type, Numeric) and col_type.precision is None:
+        return Numeric(precision=38, scale=18)
+
+    return col_type
+
+
+def _widening_type_adapter(col_type: TypeEngine) -> TypeEngine | None:
+    """Both Focus type adapters, for tables that opt into numeric widening."""
+    return interval_to_microseconds_adapter(widen_unbounded_numeric_adapter(col_type))
+
+
 def _focus_table_items(
     sql_database_credentials: ConnectionStringCredentials,
     table_name: str,
     db_schema: str | None,
+    type_adapter: Callable[
+        [TypeEngine], TypeEngine | None
+    ] = interval_to_microseconds_adapter,
 ) -> Iterator:
     """Yield one Focus table's items, appending a materialize marker if empty.
 
@@ -165,7 +204,7 @@ def _focus_table_items(
             table_adapter_callback=remove_nullability_adapter,
             reflection_level="full_with_precision",
             backend_kwargs={},
-            type_adapter_callback=interval_to_microseconds_adapter,
+            type_adapter_callback=type_adapter,
             included_columns=None,
             excluded_columns=None,
             query_adapter_callback=None,
@@ -189,6 +228,7 @@ def _build_focus_resource(
     table_name: str,
     db_schema: str | None = FOCUS_DB_SCHEMA,
     signature: dict | None = None,
+    widen_numeric: bool = False,
 ) -> DltResource:
     """Build one full-replace dlt resource for a Focus table.
 
@@ -218,6 +258,11 @@ def _build_focus_resource(
             sql_database_credentials=sql_database_credentials,
             table_name=table_name,
             db_schema=db_schema,
+            type_adapter=(
+                _widening_type_adapter
+                if widen_numeric
+                else interval_to_microseconds_adapter
+            ),
         )
 
     return _focus_table
@@ -229,6 +274,7 @@ def build_focus_source(
     tables: list[ProbeTable],
     signatures: dict[str, dict] | None = None,
     db_schema: str | None = FOCUS_DB_SCHEMA,
+    widen_numeric_tables: frozenset[str] = frozenset(),
 ) -> Iterator:
     """One resource per table. The source name must stay `focus` — it is the dlt
     schema name the destination's stored schema and state are keyed on."""
@@ -240,6 +286,7 @@ def build_focus_source(
             table_name=table.name,
             db_schema=db_schema,
             signature=signatures.get(table.name),
+            widen_numeric=table.name in widen_numeric_tables,
         )
 
 
@@ -247,6 +294,7 @@ def build_focus_dlt_assets(
     sql_database_credentials: ConnectionStringCredentials,
     code_location: str,
     tables: list[ProbeTable],
+    widen_numeric_tables: frozenset[str] = frozenset(),
     op_tags: dict[str, object] | None = None,
 ):
     """Build ONE two-mode @dlt_assets over all Focus tables.
@@ -271,7 +319,9 @@ def build_focus_dlt_assets(
         # The full source only defines the asset specs; the op runs a narrowed
         # one.
         dlt_source=build_focus_source(
-            sql_database_credentials=sql_database_credentials, tables=tables
+            sql_database_credentials=sql_database_credentials,
+            tables=tables,
+            widen_numeric_tables=widen_numeric_tables,
         ),
         dlt_pipeline=dlt_pipeline,
         name=f"{code_location}__dlt__{FOCUS_SOURCE_NAME}",
@@ -375,6 +425,7 @@ def build_focus_dlt_assets(
                 sql_database_credentials=sql_database_credentials,
                 tables=selected,
                 signatures=signatures,
+                widen_numeric_tables=widen_numeric_tables,
             ),
             dlt_pipeline=dlt_pipeline,
             dagster_dlt_translator=translator,

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Focus dlt `interval` type adapter (issue #4676).
+"""Unit tests for the Focus dlt type adapters (issues #4676, #5021).
 
 Focus added an `interval` column (`time_limit`) to `public.gradebook_assignments`,
 which dlt cannot map: the reflected type matches none of the branches in
@@ -8,6 +8,12 @@ backend infers `duration[us]` from the `timedelta` values, and dlt raises
 
 `interval_to_microseconds_adapter` declares `BigInteger` for those columns so
 dlt casts the duration to int64 microseconds instead.
+
+`widen_unbounded_numeric_adapter` covers the second case: unbounded Postgres
+`numeric` reflects as `precision=None`, dlt renders it `decimal128(38, 9)`, and
+pyarrow refuses any value needing more than 9 decimal places
+(`student_gpa_calculated.weighted_gpa`). It is opt-in per table, so these tests
+also pin that the opt-in routes to the right adapter.
 """
 
 from datetime import timedelta
@@ -28,12 +34,13 @@ from dlt.sources.sql_database.schema_types import (
     sqla_col_to_column_schema,
 )
 from sqlalchemy import BigInteger, Column, Integer, MetaData, String, Table
-from sqlalchemy.dialects.postgresql import INTERVAL
+from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, INTERVAL
 from sqlalchemy.sql import sqltypes
 
 from teamster.libraries.dlt.focus.assets import (
     build_focus_dlt_assets,
     interval_to_microseconds_adapter,
+    widen_unbounded_numeric_adapter,
 )
 from teamster.libraries.dlt.probe import ProbeTable
 
@@ -244,3 +251,55 @@ def test_interval_column_with_adapter_loads_as_bigint_microseconds():
         48 * 60 * 60 * 1_000_000,
         -30 * 60 * 1_000_000,
     ]
+
+
+def test_widen_unbounded_numeric_adapter_only_touches_unbounded_numeric():
+    """Unbounded `numeric` gains a scale; bounded numeric and floats do not."""
+    widened = widen_unbounded_numeric_adapter(sqltypes.Numeric())
+
+    assert isinstance(widened, sqltypes.Numeric)
+    assert (widened.precision, widened.scale) == (38, 18)
+
+    bounded = sqltypes.Numeric(precision=10, scale=2)
+    assert widen_unbounded_numeric_adapter(bounded) is bounded
+
+    # Float subclasses Numeric and also reflects precision=None. Without the
+    # guard every `double precision` column would land as BIGNUMERIC.
+    double = DOUBLE_PRECISION()
+    assert widen_unbounded_numeric_adapter(double) is double
+
+
+def test_widening_type_adapter_keeps_the_interval_mapping():
+    """Opting into numeric widening must not drop the interval mapping."""
+    from teamster.libraries.dlt.focus import assets as focus_assets
+
+    assert isinstance(focus_assets._widening_type_adapter(INTERVAL()), BigInteger)
+
+    widened = focus_assets._widening_type_adapter(sqltypes.Numeric())
+    assert isinstance(widened, sqltypes.Numeric)
+    assert (widened.precision, widened.scale) == (38, 18)
+
+
+def test_widen_numeric_flag_selects_the_type_adapter(monkeypatch):
+    """The per-table opt-in is what reaches `table_rows`, not a source-wide flag."""
+    from teamster.libraries.dlt.focus import assets as focus_assets
+
+    captured: dict[str, Any] = {}
+
+    def spy_table_rows(**kwargs):
+        captured[kwargs["table"]] = kwargs["type_adapter_callback"]
+        return iter(())
+
+    monkeypatch.setattr(focus_assets, "table_rows", spy_table_rows)
+
+    for table_name, widen in (("plain", False), ("widened", True)):
+        resource = focus_assets._build_focus_resource(
+            sql_database_credentials=ConnectionStringCredentials("sqlite://"),
+            table_name=table_name,
+            db_schema="public",
+            widen_numeric=widen,
+        )
+        list(resource())
+
+    assert captured["plain"] is interval_to_microseconds_adapter
+    assert captured["widened"] is focus_assets._widening_type_adapter

--- a/tests/libraries/test_dlt_focus_type_adapter.py
+++ b/tests/libraries/test_dlt_focus_type_adapter.py
@@ -258,7 +258,7 @@ def test_widen_unbounded_numeric_adapter_only_touches_unbounded_numeric():
     widened = widen_unbounded_numeric_adapter(sqltypes.Numeric())
 
     assert isinstance(widened, sqltypes.Numeric)
-    assert (widened.precision, widened.scale) == (38, 18)
+    assert (widened.precision, widened.scale) == (76, 38)
 
     bounded = sqltypes.Numeric(precision=10, scale=2)
     assert widen_unbounded_numeric_adapter(bounded) is bounded
@@ -277,7 +277,7 @@ def test_widening_type_adapter_keeps_the_interval_mapping():
 
     widened = focus_assets._widening_type_adapter(sqltypes.Numeric())
     assert isinstance(widened, sqltypes.Numeric)
-    assert (widened.precision, widened.scale) == (38, 18)
+    assert (widened.precision, widened.scale) == (76, 38)
 
 
 def test_widen_numeric_flag_selects_the_type_adapter(monkeypatch):


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will load the Focus `student_gpa_calculated` table
into `dagster_kippmiami_dlt_focus`.

Focus computes GPA and class rank itself and stores both in that table. We never
ingested it. That is why `fct_grades_gpa` holds no Miami rows, in any year.
Reading the vendor's own numbers is the right way to fill that gap, because the
PowerSchool GPA chain needs inputs the Focus side mostly does not have.

This is the ingestion half of #5021. The dbt half comes in a second pull request
and cannot start until this table exists in prod with rows in it.

Adding the table to the config was 2 lines. It then failed to load, so this pull
request also adds a per-table numeric widening adapter. See Reviewer Notes.

The table is already loaded and verified in prod — a branch-deployment run writes
to the prod dataset, because dlt has no branch-deployment redirect.

## Reviewer Notes

**The 2-line config change was not enough, and the failure is the interesting
part.** `weighted_gpa` is an unbounded Postgres `numeric`. dlt renders that as
`decimal128(38, 9)`, and pyarrow refuses to rescale a value that needs more
decimal places, so the extract died before writing anything. Measured after the
load succeeded: the real values carry up to **20** decimal places. Focus stores
an unrounded division result.

**Why the widening is opt-in per table rather than source-wide.** Illuminate
applies `unbounded_numeric_adapter` to its whole source. Focus cannot: the
widened type maps to BigQuery BIGNUMERIC, and 45 already-loaded Focus tables
carry 200 NUMERIC columns that the `replace` disposition cannot retype in place.
Making it source-wide would require recreating all 45. So a
`widen_unbounded_numeric` key in `focus.yaml` routes exactly one table.

**`(76, 38)` is a ceiling, not a tuning choice.** dlt maps precision above 38 to
`decimal256`, and the BigQuery destination declares `wei_precision=(76, 38)`.
Nothing wider exists. I went straight to it after `(38, 18)` also overflowed,
rather than guessing a third intermediate scale.

**The adapter returns `Float` untouched, and Illuminate's does not.** `Float`
subclasses `Numeric` and also reflects `precision=None`, so without that guard
every `double precision` column in an opted-in table would land as BIGNUMERIC. I
did not change Illuminate's copy; no float column reaches its path today.

**For the dbt half:** `gpa`, `weighted_gpa`, `cumulative_gpa` and the
`custom_*_gpa` columns land as **BIGNUMERIC**, not NUMERIC.
`libraries/dlt/CLAUDE.md` says to `cast(col as numeric)` at the staging layer to
keep contracts on NUMERIC.

**Not fixed here:** those same 45 tables will hit this identical failure the
moment any of their unbounded `numeric` columns receives a high-scale value —
the same latent shape as the `interval` bug in #4676. That needs a source-wide
adapter plus a recreate migration, which is its own issue.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why. —
      per-finding verdicts posted as a comment; its numeric note was the actual
      blocker

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location —
      cannot run locally, see below
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code
      location — same blocker, fails identically on `main`
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager — adds a table and a
      config key to an existing integration

`dagster definitions validate -m teamster.code_locations.kippmiami.definitions`
fails in the codespace with `ConfigFieldMissingException: Missing 1 field(s) ...
drivername`, because the Focus database credentials are not present here. It
fails the same way on unmodified `main`, so this is a codespace limitation, not a
regression. Covered instead by the Dagster Cloud deploy check and by an actual
prod load.

### Docs

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py` — Focus is already absent
      from `docs/reference/automations.md` entirely, and regenerating it needs
      the same credentials the codespace lacks. Tracked separately, not fixed
      here.

## CI checks

- [x] **Trunk** — `trunk check --force` clean on all changed files
- [x] **dbt Cloud** — passed; no dbt changes
- [x] **Dagster Cloud** — all 5 code locations deployed

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

### Verification trail

3 branch-deployment runs of `kippmiami/dlt/focus/student_gpa_calculated`, each
writing to the prod dataset:

| Run | Commit | Result |
| --- | --- | --- |
| `ad883ce0` | `739ff90a` | failed — `inferred_arrow_type=decimal128(38, 9)` |
| `811a7381` | `f974d576` | failed — `inferred_arrow_type=decimal128(38, 18)` |
| `f18848eb` | `a00c7387` | success, 1 materialization |

The second failure is what proves the per-table opt-in routes correctly: the
reported arrow type moved from `(38, 9)` to `(38, 18)` while the other 78 tables
kept the old adapter. The first failure is what proves `cursor_column:
updated_at` exists — the probe runs `SELECT COUNT(*), MAX(updated_at)` before
extraction, and it succeeded.

### Loaded shape

441 rows, 47 columns, `syear = 2026` only.

- Grain is `(student_id, school_id)`: 441 of 441 distinct, and `id` likewise. 122
  of 319 students carry a row at 2 schools.
- **Every row is `marking_period_id = -1`.** The course-history GPA is the whole
  table, not a subset to filter to. `mp` is null throughout.
- `gpa` is null on 167 of 441 rows (38%), concentrated in school 15 (161 of 170)
  and school 68 (6 of 6).
- `class_rank` is populated on **3 rows**, all at school 58.
- Max decimal scale: `weighted_gpa` 20, `gpa` 3, `cumulative_credits` 1. Only
  school 58 carries the high-scale values.

### Two premises on #5021 that the data contradicts

**"Class rank is a bonus."** 3 populated rows out of 441. It is not usable as a
fact column yet.

**`marking_period_id = -1` reads as a filter in the issue body.** It is not a
discriminator here — no other value exists, so there is no term-level GPA in this
table at all. That has consequences for what `fct_grades_gpa`'s term-grained
columns can be filled with on the Focus side.

Both are for #5021's dbt half to resolve; neither changes this pull request.

</details>

Refs #5021
