### PR TITLE
fix(dbt): drop the frozen Miami PowerSchool attendance archive

### DIFF
--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -7,6 +7,18 @@ models:
       year are reached via dim_student_enrollments and dim_terms — not stored on
       the fact. FK to dim_student_enrollments, dim_dates, and dim_terms.
 
+      Miami carries no attendance before AY2026. The frozen Miami PowerSchool
+      archive (AY2020 through AY2025) was dropped in #4803: Focus re-dated
+      Miami's enrollment stints to the real first day of school where
+      PowerSchool used a July 1 administrative rollover, so 153,577 archive rows
+      carried a student_enrollment_key that no longer resolved to
+      dim_student_enrollments. Re-keying those rows from Focus enrollment dates
+      was measured and rejected in favor of the ops migration — Focus is the
+      system of record and does not carry pre-AY2026 attendance, so the gap is
+      deliberate rather than a modeling defect. fct_student_attendance_streaks
+      still carries Miami absence streaks for those years from an independent
+      leg, so the two facts disagree on Miami history by design.
+
       Four numeric attendance measures coexist — use the right one for the
       question:
 
@@ -49,6 +61,16 @@ models:
               arguments:
                 to: ref('dim_student_enrollments')
                 field: student_enrollment_key
+              config:
+                # Baseline, not a target. 2,286 rows across 15 enrollment keys
+                # predate the Focus cutover and are unrelated to it: 10 Newark
+                # stints (AY2016-2024), 4 Camden (AY2020, AY2023), 1 Paterson
+                # (AY2025). #4803 took this from 155,863 down to the residue by
+                # dropping the frozen Miami PowerSchool archive, whose 153,577
+                # AY2025 rows keyed to enrollment records Focus re-dated. Warn
+                # above the residue so a NEW orphan source stays visible; do
+                # not raise the threshold to silence one.
+                warn_if: ">2286"
       - name: date_key
         data_type: date
         description: >-

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
@@ -13,8 +13,10 @@ with
     -- One row. See int_students__sis_cutover for why the boundary is a floor
     -- derived from recorded attendance rather than from Focus row presence:
     -- int_focus__attendance_daily scaffolds a present-by-default row back to
-    -- AY2020, so scoping on the years it contains would replace six years of
-    -- real PowerSchool attendance with fabricated perfect attendance.
+    -- AY2020, so scoping on the years it contains would fill Miami's AY2020
+    -- through AY2025 gap with fabricated perfect attendance. Since #4803 that
+    -- gap is real and intended -- Miami has no attendance in this model before
+    -- AY2026 -- which the scaffold would silently paper over.
     cutover as (
         select focus_start_academic_year, from {{ ref("int_students__sis_cutover") }}
     ),
@@ -52,10 +54,17 @@ with
         }}
     ),
 
-    -- Year-scoped, not project-scoped. Focus starts at AY2026 and the frozen
-    -- archive holds Miami AY2020 through AY2025, so excluding kippmiami
-    -- outright (the way int_students__terms does) would delete six years of
-    -- history.
+    -- Project-scoped, the way int_students__terms is. The frozen Miami
+    -- PowerSchool archive is excluded outright rather than year-scoped.
+    -- Focus re-dated 959 of Miami's AY2025 stints to the real first day of
+    -- school where PowerSchool used a July 1 administrative rollover, and
+    -- entrydate feeds student_enrollment_key, so 153,577 archive rows keyed
+    -- to enrollment records dim_student_enrollments no longer holds. Dropping
+    -- the archive costs Miami AY2020 through AY2025 (793,259 rows, 2,582
+    -- students) and is the ops-migration decision recorded on #4803: Focus is
+    -- the system of record and does not carry that history, so the marts show
+    -- an honest gap rather than an unjoinable one. Re-keying from Focus
+    -- enrollment dates was measured and rejected there.
     powerschool_conformed as (
         select
             powerschool_deduped.*,
@@ -76,12 +85,7 @@ with
             -- leaving this model.
             false as is_focus_source,
         from powerschool_deduped
-        cross join cutover as c
-        where
-            not (
-                powerschool_deduped._dbt_source_project = 'kippmiami'
-                and powerschool_deduped.yearid >= c.focus_start_academic_year - 1990
-            )
+        where powerschool_deduped._dbt_source_project != 'kippmiami'
     ),
 
     -- The whole Focus-to-network translation lives here. See "The conform
@@ -140,9 +144,16 @@ with
         from {{ ref("int_focus__attendance_daily") }} as ad
         inner join focus_schools as fs on ad.schoolid = fs.focus_school_id
         cross join cutover as c
-        -- Required, not belt-and-braces. Without it Focus's AY2020 through
-        -- AY2025 rows land beside PowerSchool's real rows for the same Miami
-        -- school-days and break this model's own grain test.
+        -- Required, and since #4803 the ONLY thing holding Miami's pre-AY2026
+        -- rows out. The grain test used to catch a missing filter here,
+        -- because these rows collided with PowerSchool's real Miami rows on
+        -- the same school-days; dropping that archive removed the collision,
+        -- so the test now passes without this predicate. What remains is
+        -- worse because it is silent: int_focus__attendance_daily scaffolds a
+        -- present-by-default row (is_attendance_recorded = false) back to
+        -- AY2020, so relaxing this filter fills Miami's AY2020 through AY2025
+        -- gap with fabricated perfect attendance instead of leaving it empty.
+        -- Do not relax it.
         where ad.academic_year >= c.focus_start_academic_year
     ),
 

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
@@ -54,17 +54,12 @@ with
         }}
     ),
 
-    -- Project-scoped, the way int_students__terms is. The frozen Miami
-    -- PowerSchool archive is excluded outright rather than year-scoped.
-    -- Focus re-dated 959 of Miami's AY2025 stints to the real first day of
-    -- school where PowerSchool used a July 1 administrative rollover, and
-    -- entrydate feeds student_enrollment_key, so 153,577 archive rows keyed
-    -- to enrollment records dim_student_enrollments no longer holds. Dropping
-    -- the archive costs Miami AY2020 through AY2025 (793,259 rows, 2,582
-    -- students) and is the ops-migration decision recorded on #4803: Focus is
-    -- the system of record and does not carry that history, so the marts show
-    -- an honest gap rather than an unjoinable one. Re-keying from Focus
-    -- enrollment dates was measured and rejected there.
+    -- Project-scoped, the way int_students__terms is: the frozen Miami
+    -- PowerSchool archive is excluded outright rather than year-scoped,
+    -- because Focus re-dated Miami's enrollment stints and the archive's rows
+    -- no longer join to dim_student_enrollments. See #4803 for the
+    -- measurements and the rejected re-key alternative; the model description
+    -- carries what the marts lose.
     powerschool_conformed as (
         select
             powerschool_deduped.*,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__attendance_daily.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__attendance_daily.yml
@@ -5,10 +5,16 @@ models:
       to int_powerschool__ps_adaadm_daily_ctod, which is now a thin PowerSchool
       union. Holds every derived flag, point-in-time anchor, and running calc
       for both SIS branches, so there is one definition rather than one per
-      branch. The PowerSchool branch is year-scoped, so the frozen Miami archive
-      keeps serving AY2020 through AY2025 while Focus serves AY2026 forward. Six
-      flags are null for Focus-sourced Miami rows because Focus has no day-grain
-      source for them — see #4927.
+      branch. The PowerSchool branch is project-scoped: Miami is served by Focus
+      from AY2026 forward and by nothing before that. The frozen Miami
+      PowerSchool archive (AY2020 through AY2025, 793,259 rows, 2,582 students)
+      was dropped in #4803 rather than re-keyed, because Focus re-dated Miami's
+      enrollment stints and 153,577 archive rows no longer joined to
+      dim_student_enrollments. Miami daily attendance before AY2026 is absent
+      from this model by decision, not by defect. Note that int_students__ada
+      and int_students__attendance_streak keep independent Miami legs and still
+      carry pre-AY2026 history. Six flags are null for Focus-sourced Miami rows
+      because Focus has no day-grain source for them — see #4927.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -39,8 +45,8 @@ models:
           branch, that PowerSchool has no such concept — it records only
           absences), which is distinct from a recorded presence. Never null
           network-wide. On the Focus branch, this — not studentid — is the real
-          recorded/unrecorded signal; on the PowerSchool branch (including the
-          frozen Miami archive) it is always false by construction.
+          recorded/unrecorded signal; on the PowerSchool branch (NJ regions only
+          since #4803) it is always false by construction.
         data_tests:
           - not_null:
               config:
@@ -51,11 +57,12 @@ models:
           per-district source, or the Focus kipptaf passthrough).
       - name: studentid
         description: >-
-          PowerSchool internal student id. Null for every Focus-sourced row
-          (Miami AY2026 forward) — Phase 1 left it unpopulated for Focus, so
-          joins use student_number. Retained for existing consumers built
-          against the PowerSchool branch; the #4927 null flags are discriminated
-          on the explicit is_focus_source flag, not on this column.
+          PowerSchool internal student id. Null for every Focus-sourced row,
+          which since #4803 is every Miami row — Phase 1 left it unpopulated for
+          Focus, so joins use student_number. Retained for existing consumers
+          built against the PowerSchool branch; the #4927 null flags are
+          discriminated on the explicit is_focus_source flag, not on this
+          column.
       - name: schoolid
         description: Network school number.
       - name: entrydate


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will remove Miami's pre-AY2026 daily attendance
from the marts, and reset the enrollment relationships test to the small number
of unrelated failures that remain.

Miami left PowerSchool for Focus at the start of AY2026. Its older attendance
stayed behind in a frozen PowerSchool archive, and that archive still labels
each row with the enrollment start date PowerSchool used. Focus dates a
returning student's enrollment to the real first day of school. PowerSchool
used a July 1 administrative rollover instead. Focus is now the only source of
Miami enrollment, so 959 of Miami's AY2025 enrollment records changed date, and
153,577 attendance rows ended up pointing at enrollment records that no longer
exist.

This drops the Miami archive from the PowerSchool attendance branch instead of
re-dating it. Miami loses AY2020 through AY2025 daily attendance, which is
793,259 rows covering 2,582 students. Focus keeps serving AY2026 forward, so
the current school year is unaffected.

The trade was measured on #4803 and decided there. Re-dating the archive would
have kept all 6 years and fixed every broken row, but it keeps a retired system
alive under a key borrowed from its replacement. Dropping it treats the missing
years as an ops data migration: Focus is the system of record, Focus does not
carry that history, so the marts show an honest gap.

## Reviewer Notes

**Miami attendance history does not disappear everywhere, only here.**
`int_students__ada` and `int_students__attendance_streak` read their own
PowerSchool sources, not this model. Both keep Miami back to AY2018, and both
already join to enrollment cleanly with zero broken rows. So after this merge
`fct_student_attendance_streaks` still reports Miami absence streaks for years
where `fct_student_attendance_daily` has no days. That is a real inconsistency
between two facts. It is intentional here, because neither sibling has the
problem this PR fixes, and dropping their Miami data would delete working rows
for no reason.

**The test is re-baselined, not deleted.** The relationships test on
`student_enrollment_key` now warns above 2,286 failures instead of above 0.
That number is the pre-existing residue that has nothing to do with Focus: 10
Newark enrollments spread across AY2016 to AY2024, 4 Camden, and 1 Paterson.
Raising the threshold later to quiet a new failure would defeat the point.

**One comment change matters as much as the code change.** The filter on the
Focus side of the union is now the only thing keeping Miami's older rows out.
Its old comment said the model's own grain test would catch a mistake there.
That is no longer true, and the replacement explains why. See "For Claude"
below.

**11 models read this model directly and lose Miami history.** The one to look
at is `int_students__fldoe_fte`, which is Miami-only Florida state reporting.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. 3 actionable
      findings. Findings 1 and 2 verified and fixed (`ff6774a84` for the
      comment trim; this checklist line for the exposure list). Finding 3
      declined with reasoning — the re-baselined relationships test already
      catches the reversion it worries about. Per-finding verdicts posted as a
      PR comment.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      exposure gains or loses a model. 2 existing Tableau exposures
      (`attendance_dashboard`, `ops_dashboard`) and the Cube exposure lose
      Miami rows for AY2020 through AY2025. `compliance_dashboard` does not:
      its only model, `rpt_tableau__nj_school_register`, already filters
      `region != 'Miami'` at line 59, so it never carried Miami rows.
- [x] **Breaking change?** No column is renamed, removed, or retyped, and no
      contract changes. This removes rows, not columns. Rollback is
      `git revert`; the models are views, so a revert restores the old rows on
      the next build with no backfill.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external source changed.

## CI checks

- [x] **Trunk** — passes. `trunk check --force --no-fix` over the changed files
      reports `✔ No issues`.
- [x] **dbt Cloud** — passes (run `70403222459847` on the fix commit).
      `get_job_run_error(warning_only=true)` returns 9 test warnings, all in
      unrelated domains (surveys, gradebook, college assessment, deanslist
      audit, AP dashboard, kfwd career survey) and none introduced here. No
      attendance, enrollment, Miami, or Focus warning. See "For Claude".
- [x] **Dagster Cloud** — not triggered. No Dagster paths changed.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Closes #4803, which carries the full decision
brief, the measurements behind both options, and the rejected re-key design.

### The change

One predicate in `int_students__attendance_daily`, `powerschool_conformed`:

```sql
-- before
from powerschool_deduped
cross join cutover as c
where
    not (
        powerschool_deduped._dbt_source_project = 'kippmiami'
        and powerschool_deduped.yearid >= c.focus_start_academic_year - 1990
    )

-- after
from powerschool_deduped
where powerschool_deduped._dbt_source_project != 'kippmiami'
```

The `cutover` CTE stays; `focus_conformed` still uses it.

### Verification, all against prod on 2026-08-27

`dbt compile --target prod` clean. Compiled artifact greps confirm the new
predicate is present at line 92, the old `focus_start_academic_year - 1990`
predicate is gone, and the Focus-side guard at line 161 is intact.

Ran the pre-change prod view through the same filter the compiled model
applies, then re-derived the orphan count from the
`(student_number, _dbt_source_project, academic_year, entrydate)` tuple. That
tuple method reproduces the fact-level relationships count exactly — 155,863
both ways before the change — so it is a valid stand-in for the hashed key.

| Check | Result |
| --- | --- |
| Rows removed | 793,259 |
| Distinct students removed | 2,582 |
| Academic years removed | 2020 through 2025 |
| Miami rows kept | 18,244, all AY2026 |
| Network rows kept | 11,726,385 |
| Orphans after, total | **2,286** |
| Orphans after, by region | Newark 1,674, Camden 551, Paterson 61, Miami 0 |

`trunk check --force --no-fix` over the 3 changed files: clean after the
pre-commit `fmt` hook rewrapped 2 YAML descriptions.

### Why the Focus-side filter comment was rewritten

`focus_conformed` filters `ad.academic_year >= c.focus_start_academic_year`.
Its old comment justified the filter on collision: without it, Focus rows for
AY2020 through AY2025 would land beside PowerSchool's real Miami rows on the
same school-days and fail the model's own grain test. This PR deletes those
PowerSchool rows, so the collision is gone and the grain test now passes
without the predicate.

The real hazard survives and is silent. `int_focus__attendance_daily` scaffolds
a present-by-default row for every enrolled Miami student-day back to AY2020,
carrying `is_attendance_recorded = false` — this is the same scaffold that
forced `int_students__sis_cutover` to derive its boundary from recorded
attendance rather than row presence. Relaxing the filter now fills the gap this
PR creates with fabricated perfect attendance rather than leaving it empty. The
new comment says exactly that and says not to relax it.

### The sibling facts, measured

Both were checked for the same defect and do not have it:

| Fact | Orphans today | Miami coverage |
| --- | --- | --- |
| `fct_student_attendance_streaks` | 0 | AY2018 to AY2026 |
| `fct_student_attendance_interventions` | 0 | via `int_students__ada`, AY2018 to AY2026 |

Both carry the same year-scoped Miami predicate in their own conform CTEs
(`int_students__ada` line 17, `int_students__attendance_streak` line 17), and
both read `int_students__sis_cutover`. They were deliberately left alone.
Changing them would delete Miami rows that currently join correctly, which is
scope this PR was not given and which no measurement supports.

`int_students__sis_cutover` itself is untouched. 8 models depend on it and its
description remains accurate for the 7 that still carry a Miami PowerSchool
leg.

### The 11 models that lose Miami history

They read `int_students__attendance_daily` directly rather than through
`dim_student_enrollments`, so the orphan bug never affected them and this
change fully does:

`int_students__fldoe_fte` (Miami-only Florida FTE survey reporting),
`rpt_tableau__attendance_dashboard`, `rpt_tableau__ops_dashboard`,
`rpt_tableau__attendance_chronic_absenteeism_log`, `int_powerschool__ada_term`,
`int_reporting__promotional_status`, `int_topline__truancy_weekly`,
`int_topline__ada_running_weekly`, `int_topline__attendance_contacts`,
`rpt_tableau__okrts_referrals`, and `fct_student_attendance_daily` itself.
`rpt_tableau__nj_school_register` also reads the model but is NJ-scoped and
unaffected.

In Cube, `student_attendance_view` reaches school, region, grade level,
IEP/ELL/meal status, homeroom teacher, and student identity through
`student_school_enrollments`. Before this change, the 153,577 orphaned rows
were already invisible to any query grouping or filtering on those, because the
join produced nulls. After it, they are absent outright. Only a query scoped
purely on `dates.academic_year` could see them before.

### Test baseline mechanics

The project sets `data_tests: +severity: warn` in `dbt_project.yml`, so this
test cannot error. `warn_if: ">2286"` therefore controls it alone: the test
reports PASS at 2,286 failures and WARN above. No severity override was added,
so this does not turn a warning into a CI gate.

</details>
