### PR TITLE
perf: twice-daily cron table for the college-assessments hub

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__all_college_assessments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__all_college_assessments.yml
@@ -38,11 +38,14 @@ models:
           # 11.1 GiB/day to save 6.6.
           #
           # Both ticks come from int_assessments__response_rollup's own set, so
-          # ~any_deps_in_progress serializes the pass and it builds first. 00:00
-          # precedes this lineage's heaviest reader, a scheduled job at 02:00 ET
-          # feeding the 2 college_assessments sheets; 13:00 serves afternoon
-          # ad-hoc use. All 5 of response_rollup's ticks would cost 6.95 GiB/day
-          # and nothing reads this more than twice a day.
+          # the 2 are requested in one Dagster run and dbt's own DAG ordering
+          # builds response_rollup first. NOT ~any_deps_in_progress: that guard
+          # reads direct deps only, and response_rollup is 2 hops up through
+          # int_assessments__college_assessment_practice. 00:00 precedes this
+          # lineage's heaviest reader, a scheduled job at 02:00 ET feeding the 2
+          # college_assessments sheets; 13:00 serves afternoon ad-hoc use. All 5
+          # of response_rollup's ticks would cost 6.95 GiB/day and nothing reads
+          # this more than twice a day.
           #
           # Trade-off: scores read up to ~13h old. Every consumer is a nightly
           # job, the daily CARAT Tableau extract (0 6 * * *), or ad-hoc, and

--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__all_college_assessments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__all_college_assessments.yml
@@ -22,6 +22,34 @@ models:
 
 
       See docs/models/carat-dashboard-data-model.md.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 2x/day table instead of an eager view. This model costs 1.390 GiB to
+          # rebuild and its window functions block column pruning -- selecting 1
+          # column also costs 1.388 GiB -- so all 9 downstream views pay the
+          # whole recompute, each costing 1.39 to 1.46 GiB against 0.004 to
+          # 0.073 GiB of work of their own. The table is ~6 MB at 43,081 rows.
+          #
+          # Eager would cost more than it saves. Upstream tables update 6 to 8
+          # times a day: response_rollup 5.4, the 2 kippfwd sheets 0.1 each, and
+          # int_kippadb__standardized_test_unpivot 2.5. So eager bills 8.3 to
+          # 11.1 GiB/day to save 6.6.
+          #
+          # Both ticks come from int_assessments__response_rollup's own set, so
+          # ~any_deps_in_progress serializes the pass and it builds first. 00:00
+          # precedes this lineage's heaviest reader, a scheduled job at 02:00 ET
+          # feeding the 2 college_assessments sheets; 13:00 serves afternoon
+          # ad-hoc use. All 5 of response_rollup's ticks would cost 6.95 GiB/day
+          # and nothing reads this more than twice a day.
+          #
+          # Trade-off: scores read up to ~13h old. Every consumer is a nightly
+          # job, the daily CARAT Tableau extract (0 6 * * *), or ad-hoc, and
+          # each lands after a tick. Same call as #4821 on
+          # fct_assessment_scores_enrollment_scoped. Refs #5035
+          automation_condition:
+            cron_schedule: 0 0,13 * * *
     data_tests:
       # scale_score, not rn_highest. rn_highest is a row_number over
       # (student, scope, score_type) in all 3 upstream hubs, so a key holding it


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make `int_assessments__all_college_assessments` a table that rebuilds twice a day, at 00:00 and 13:00 Eastern.

It was a view costing 1.390 GiB to rebuild, and its window functions block column pruning -- selecting 1 column also costs 1.388 GiB. So all 9 downstream views paid the whole recompute. Each cost 1.39 to 1.46 GiB while doing only 0.004 to 0.073 GiB of work of its own.

That bill: dbt Cloud CI spent 680 GB on 14 tests over this lineage between 8/25 and 8/27, which was 23% of all CI test spend in those 3 days. Prod reads cost 7.0 GiB per day.

A dev build confirms the fix. The table build cost 1.3896 GiB against the 1.390 predicted, and every downstream test now reads a 6 MB table instead of the chain:

| Test | Before | After |
| --- | --- | --- |
| the hub's own uniqueness test | ~1.39 GiB | 0.005 GiB |
| `int_tableau__college_assessment_roster_scores` | ~1.39 | 0.015 |
| `int_students__college_assessment_participation_roster` | ~1.39 | 0.020 |
| each of the 4 `rpt_tableau__college_assessment_dashboard` tests | ~1.40 | 0.021 |

The whole build-and-test pass cost 1.63 GiB against about 14 GiB before.

## Reviewer Notes

**The cron is load-bearing, not a safety cap.** Without it the model inherits `dbt_table_automation_condition()`, which fires on any upstream data change. Upstream tables update 6 to 8 times a day, so eager would bill 8.3 to 11.1 GiB/day to save 6.6 -- worse than leaving it a view. Please do not simplify the config down to `materialized: table`.

**Why 2 ticks and not response_rollup's 5.** Both ticks come from `int_assessments__response_rollup`'s own set, so `~any_deps_in_progress` serializes the pass and it builds first. All 5 would cost 6.95 GiB/day, and no consumer reads this lineage more than twice a day. The heaviest reader is a scheduled job at 02:00 ET, which the 00:00 tick precedes; 13:00 serves afternoon ad-hoc use.

**One pre-existing warn, unrelated to this change.** `rpt_tableau__college_assessment_dashboard_roster` returns 71,632 rows with 37 duplicate-key rows in both prod, where the hub is a view, and the dev build, where it is a table. Identical on both sides, so the flip is behavior-neutral. Worth its own look, not fixed here.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location — no files under `src/teamster/` changed. The automation condition was verified directly instead, see below.
- [x] Run `uv run pytest tests/test_dagster_definitions.py` — same, no Dagster code changed.
- [x] New integrations follow the Library + Config pattern — not a new integration.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the 3 reachable exposures already exist and are unchanged.
- [x] **Breaking change?** No. No column, name, or SQL changed, so no contract or consumer is affected. Rollback is `git revert`; the next tick rebuilds the relation.
- [x] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** — no external source changed.

## CI checks

- [x] **Trunk** — `trunk check --force --no-fix` on the changed file reports `✔ No issues`.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered. No files under `src/teamster/` changed, so this should not fire.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found while investigating a BigQuery cost increase that started 8/25. Closes #5035, which carries the full measurement set.

Verification actually run:

- `dbt parse --target staging` clean.
- `dbt build --select int_assessments__all_college_assessments+ --target dev --defer --favor-state --state <prod manifest>`: `PASS=16 WARN=1 ERROR=0 SKIP=0 NO-OP=3`, 1 table model, 9 view models, 7 data tests, 29 seconds. The 1 warn is the pre-existing `_roster` case in Reviewer Notes.
- `CustomDagsterDbtTranslator.get_automation_condition()` on the parsed node returns a tree carrying `CronTickPassedCondition(cron_schedule='0 0,13 * * *', cron_timezone='America/New_York')`. The timezone comes from the code location's `LOCAL_TIMEZONE`, passed as `str(LOCAL_TIMEZONE)` in `code_locations/kipptaf/dbt/assets.py:14`, so the ticks are Eastern and match the consumer times measured below. 4 controls behaved correctly: `int_assessments__response_rollup` returned its own `0,10,13,15,17`, the eager table `int_kippadb__standardized_test_unpivot` returned no cron, and both `int_assessments__college_assessment` and `rpt_tableau__college_assessment_dashboard_scores`, still views, returned no cron.
- Per-node bytes above come from `` `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT `` filtered to the dev build's own window, not from estimates.
- `trunk check --force --no-fix`: `✔ No issues`.

`_get_dbt_meta` in `libraries/dbt/dagster_dbt_translator.py` is an or-short-circuit on the whole dict, so `config.meta` hides every top-level `meta` key. Checked the parsed node: the only top-level `meta.dagster` key present is the one this change adds, so nothing is shadowed.

Consumers, measured over 14 days, times in America/New_York:

| Reader | Jobs/day | GiB/14d | Hours | What it is |
| --- | --- | --- | --- | --- |
| `awalters@` | 4.3 | 53.58 | 02, 03 | scheduled, reads only `_wide` and `_long` |
| `grangel@` | 2.3 | 43.64 | 06-15 | ad-hoc across 5 dashboards |
| `tableau@` | 0.1 | 1.33 | 12 | extract refresh |
| dagster agent | 1.9 | 0.00 | 11 | the 8/18 deploy's view rebuilds, 0 bytes, not a consumer |

No intraday automated consumer exists, so nothing vetoes a cron under the rule in `src/dbt/kipptaf/CLAUDE.md`. The CARAT Tableau exposure declares `0 6 * * *`.

Read counts were matched on `` r'[.`](<model>)`' ``, which accepts both quoting styles: dbt compiles `` `dataset`.`model` `` while people and Tableau write `` `project.dataset.model` ``. A pattern matching only the first form hid about 98 GiB of real reads over 14 days. A pattern matching the bare name is worse: it matches code comments, which is how `fct_assessment_scores_student_scoped.sql:119` briefly looked like an intraday consumer of `_benchmark_calcs`. It is a comment, and that model refs the 2 sub-hubs, never the dashboard view.

Ancestor update rates over 14 days, which is what eager would fire on: `int_assessments__response_rollup` 5.4/day, `int_kippadb__standardized_test_unpivot` 2.5/day (eager table), `stg_google_sheets__kippfwd__scaffold` 0.1/day, `stg_google_sheets__kippfwd__practice_scale_score_conversion` 0.1/day, `int_collegeboard__psat_unpivot` 0/day. That gives 6 to 8 hub rebuilds/day once Dagster batches coincident ticks.

Why this node and not an upstream one. The practice sub-hub is the real choke point: it emits 7,587 rows but scans `int_assessments__response_rollup` at 23.5M rows, costing 4.667 GiB. Materializing it would also make `fct_assessment_scores_student_scoped` cheap, and it is still the wrong node, because 4.667 GiB per build beats 1.390. The hub is the efficient point precisely because it drops the practice columns nothing downstream reads. The official sub-hub is already cheap at 0.006 GiB.

Rollout note from `src/dbt/kipptaf/CLAUDE.md`: a properties-yml-only flip does not fire `code_version_changed`, because `code_version` hashes raw SQL. The relation stays a view until the first cron tick, so do not judge the deploy by BigQuery object types. Confirm with `INFORMATION_SCHEMA.TABLES` after 00:00 or 13:00 ET.

Two side effects, both wanted. Plan depth for all 9 descendants drops, which matters because this repo has hit BigQuery's 16-view nesting limit before. And the hub's uniqueness test now runs twice a day instead of only on a code change, since the data-change automation condition skips views.

Out of scope, worth its own issue: `fct_assessment_scores_student_scoped` rebuilds 5.4 times a day at 1.55 GiB, recomputing both sub-hubs each time, which is 8.4 GiB/day. It refs the sub-hubs directly, so this change does not touch it.

Also surfaced and not a code problem: the largest prod reader of this lineage is a job running nightly under one person's personal credentials, 53.58 GiB over 14 days. Worth knowing who owns it, and it is what constrains the 00:00 tick.

</details>
