### PR TITLE
fix(dbt): populate the Focus enrollment flags that silently dropped Miami

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollments.sql
@@ -27,6 +27,19 @@ with
         }}
     ),
 
+    -- int_focus__student_enrollment_roster carries first_day_of_school but no
+    -- year-end date, and is_enrolled_recent needs one.
+    -- int_students__calendar_week already unions both SIS calendars and remaps
+    -- Focus's internal school id to the network school number -- the same id
+    -- the roster's ps_schoolid carries. School numbers are network-unique, so
+    -- no region filter is needed to keep the join unambiguous.
+    focus_school_year_end as (
+        select
+            academic_year, schoolid, max(last_day_school_year) as last_day_school_year,
+        from {{ ref("int_students__calendar_week") }}
+        group by academic_year, schoolid
+    ),
+
     -- One row per Miami student per year, carrying the prior year's grade so
     -- boy_status and is_retained_year reproduce the PowerSchool derivation.
     -- rn_year = 1 picks the primary stint, matching the year grain PowerSchool
@@ -103,6 +116,44 @@ with
             (enr.academic_year + 13) + (-1 * enr.grade_level) as cohort_primary,
 
             if(yg.grade_level_prev = enr.grade_level, true, false) as is_retained_year,
+
+            /* PowerSchool derives both of these from enrollment dates. The Focus
+            branch omitted them, so `full union all corresponding` filled null,
+            and `not null` is null in a where clause -- every consumer filtering
+            on either one dropped all of Miami without saying so (#4996).
+            rpt_tableau__miami_fast held zero rows for this reason, and the two
+            rpt_gsheets__csgf_hs_* extracts filter on is_enrolled_recent, so
+            Miami would vanish from both as its high school grows.
+
+            exitdate is never null here -- the roster coalesces a missing
+            end_date to June 30 -- so is_enrolled_y1 is true on every Miami
+            stint. That matches PowerSchool, where it is also true on every row.
+            Reproducing the expression rather than writing `true` keeps the two
+            branches derived the same way if the roster stops coalescing. */
+            if(enr.exitdate is not null, true, false) as is_enrolled_y1,
+
+            case
+                when enr.exitdate >= sye.last_day_school_year
+                then true
+                when
+                    current_date('{{ var("local_timezone") }}')
+                    between enr.startdate and enr.exitdate
+                then true
+                else false
+            end as is_enrolled_recent,
+
+            /* PowerSchool reads this off the same specprog row that sets
+            reporting_schoolid and school_level to 'OD'. This branch already
+            gives every Miami row a real reporting_schoolid and an ES/MS/HS
+            school_level, never 'OD', so false records a claim the branch makes
+            already rather than inventing one.
+
+            is_self_contained stays null by deliberate contrast. It is a SPED
+            service-delivery fact Focus does not carry -- ese_fefp_code_label
+            encodes Florida funding levels, not placement -- and false there
+            would assert a verified negative the data cannot support (#4968).
+            rpt_tableau__dibels_dashboard therefore still excludes Miami. */
+            false as is_out_of_district,
         from {{ ref("int_focus__student_enrollment_roster") }} as enr
         left join
             {{ ref("int_focus__students") }} as stu
@@ -118,11 +169,26 @@ with
             and enr.academic_year = adv.academic_year
             and enr.schoolid = adv.schoolid
             and enr._dbt_source_project = adv._dbt_source_project
+        left join
+            focus_school_year_end as sye
+            on enr.academic_year = sye.academic_year
+            and enr.ps_schoolid = sye.schoolid
     ),
 
     focus_windowed as (
         select
-            *,
+            * except (is_enrolled_y1, is_enrolled_recent),
+
+            -- PowerSchool takes both to the year grain with max() over
+            -- (studentid, yearid), so a student with several stints counts as
+            -- enrolled when any one stint qualifies. Same rule, Focus keys.
+            max(is_enrolled_y1) over (
+                partition by student_number, academic_year
+            ) as is_enrolled_y1,
+
+            max(is_enrolled_recent) over (
+                partition by student_number, academic_year
+            ) as is_enrolled_recent,
 
             max(if(year_in_school = 1, cohort_primary, null)) over (
                 partition by student_number, schoolid

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollments.sql
@@ -27,12 +27,10 @@ with
         }}
     ),
 
-    -- int_focus__student_enrollment_roster carries first_day_of_school but no
-    -- year-end date, and is_enrolled_recent needs one.
-    -- int_students__calendar_week already unions both SIS calendars and remaps
-    -- Focus's internal school id to the network school number -- the same id
-    -- the roster's ps_schoolid carries. School numbers are network-unique, so
-    -- no region filter is needed to keep the join unambiguous.
+    -- The roster has first_day_of_school but no year-end date.
+    -- int_students__calendar_week remaps Focus's internal school id to the
+    -- network school number, which is the id ps_schoolid carries; school
+    -- numbers are network-unique, so no region filter is needed here.
     focus_school_year_end as (
         select
             academic_year, schoolid, max(last_day_school_year) as last_day_school_year,
@@ -117,19 +115,10 @@ with
 
             if(yg.grade_level_prev = enr.grade_level, true, false) as is_retained_year,
 
-            /* PowerSchool derives both of these from enrollment dates. The Focus
-            branch omitted them, so `full union all corresponding` filled null,
-            and `not null` is null in a where clause -- every consumer filtering
-            on either one dropped all of Miami without saying so (#4996).
-            rpt_tableau__miami_fast held zero rows for this reason, and the two
-            rpt_gsheets__csgf_hs_* extracts filter on is_enrolled_recent, so
-            Miami would vanish from both as its high school grows.
-
-            exitdate is never null here -- the roster coalesces a missing
-            end_date to June 30 -- so is_enrolled_y1 is true on every Miami
-            stint. That matches PowerSchool, where it is also true on every row.
-            Reproducing the expression rather than writing `true` keeps the two
-            branches derived the same way if the roster stops coalescing. */
+            -- #4996. PowerSchool's own expressions, reproduced rather than
+            -- simplified: exitdate is never null here because the roster
+            -- coalesces it, so is_enrolled_y1 is always true today, and a
+            -- `true` literal would silently diverge if that ever changes.
             if(enr.exitdate is not null, true, false) as is_enrolled_y1,
 
             case
@@ -142,17 +131,10 @@ with
                 else false
             end as is_enrolled_recent,
 
-            /* PowerSchool reads this off the same specprog row that sets
-            reporting_schoolid and school_level to 'OD'. This branch already
-            gives every Miami row a real reporting_schoolid and an ES/MS/HS
-            school_level, never 'OD', so false records a claim the branch makes
-            already rather than inventing one.
-
-            is_self_contained stays null by deliberate contrast. It is a SPED
-            service-delivery fact Focus does not carry -- ese_fefp_code_label
-            encodes Florida funding levels, not placement -- and false there
-            would assert a verified negative the data cannot support (#4968).
-            rpt_tableau__dibels_dashboard therefore still excludes Miami. */
+            -- #4996. False rather than null: reporting_schoolid and
+            -- school_level above already carry non-OD values for every Miami
+            -- row, and PowerSchool reads this flag off that same specprog row.
+            -- is_self_contained has no such twin, so it stays null (#4968).
             false as is_out_of_district,
         from {{ ref("int_focus__student_enrollment_roster") }} as enr
         left join
@@ -179,9 +161,8 @@ with
         select
             * except (is_enrolled_y1, is_enrolled_recent),
 
-            -- PowerSchool takes both to the year grain with max() over
-            -- (studentid, yearid), so a student with several stints counts as
-            -- enrolled when any one stint qualifies. Same rule, Focus keys.
+            -- Year grain, matching PowerSchool's max() over
+            -- (studentid, yearid): any qualifying stint counts.
             max(is_enrolled_y1) over (
                 partition by student_number, academic_year
             ) as is_enrolled_y1,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollments.yml
@@ -13,11 +13,18 @@ models:
 
       Also carries the demographic data and student identifiers the enrollment
       consumers read. Columns PowerSchool supplies and Focus does not are null
-      for Miami -- `is_self_contained` and `is_out_of_district` (no
-      special-programs equivalent in Focus), the KIPP Forward exit codes
-      (`exit_code_kf`, `exit_code_ts`), `advisor_teachernumber` (no network
-      teacher number in Focus), `rn_school`, `rn_undergrad`,
-      `is_enrolled_y1`, `is_enrolled_recent`, `track`, and `cohort_graduated`.
+      for Miami -- `is_self_contained` (a SPED service-delivery fact Focus does
+      not carry, left null rather than asserted false per #4968), the KIPP
+      Forward exit codes (`exit_code_kf`, `exit_code_ts`),
+      `advisor_teachernumber` (no network teacher number in Focus), `rn_school`,
+      `rn_undergrad`, `track`, and `cohort_graduated`.
+
+      `is_enrolled_y1` and `is_enrolled_recent` are derived for Miami from the
+      roster's enrollment dates, using PowerSchool's expressions, and
+      `is_out_of_district` is false there -- the Focus branch already assigns
+      every Miami row a real `reporting_schoolid` and an ES/MS/HS
+      `school_level`, never `OD`. All three were null before #4996, which
+      silently removed Miami from every consumer that filtered on them.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollments.yml
@@ -34,6 +34,33 @@ models:
               - schoolid
               - entrydate
     columns:
+      - name: is_enrolled_y1
+        data_type: boolean
+        description: >-
+          Whether the student held an enrollment at any point in the academic
+          year. Derived from the enrollment dates on both SIS branches, taken to
+          the year grain so any qualifying stint counts. True on every row in
+          every region today, because neither branch leaves an exit date unset.
+        data_tests:
+          - not_null
+      - name: is_enrolled_recent
+        data_type: boolean
+        description: >-
+          Whether the student completed the academic year or is currently
+          enrolled. Mid-year withdrawals are false, which is how consumers drop
+          them. Derived on both SIS branches from the enrollment dates against
+          the last day of the school year, taken to the year grain.
+        data_tests:
+          - not_null
+      - name: is_out_of_district
+        data_type: boolean
+        description: >-
+          Whether the student is served in an out-of-district placement. Always
+          false for Miami, which is consistent with the reporting school and
+          school level the Focus branch assigns every Miami row -- PowerSchool
+          derives all three from the same special-programs record.
+        data_tests:
+          - not_null
       - name: homeless_code
         data_type: string
         data_tests:
@@ -381,15 +408,11 @@ models:
         data_type: int64
       - name: year_in_network
         data_type: int64
-      - name: is_enrolled_y1
-        data_type: boolean
       - name: is_enrolled_oct01
         data_type: boolean
       - name: is_enrolled_oct15
         data_type: boolean
       - name: is_enrolled_mar15
-        data_type: boolean
-      - name: is_enrolled_recent
         data_type: boolean
       - name: is_retained_year
         data_type: boolean
@@ -421,8 +444,13 @@ models:
         data_type: int64
       - name: is_self_contained
         data_type: boolean
-      - name: is_out_of_district
-        data_type: boolean
+        description: >-
+          Whether the student is served in a self-contained classroom. Null for
+          Miami: Focus records no placement fact, and the nearest field
+          (`ese_fefp_code_label`) encodes Florida funding levels rather than
+          placement, so false would assert a verified negative the data cannot
+          support. Consumers that filter `not is_self_contained` therefore still
+          exclude Miami.
       - name: reporting_schoolid
         data_type: int64
       - name: reporting_school_name


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." make Miami show up in the reports that
have been quietly leaving it out.

`int_students__student_enrollments` builds Miami's rows from Focus and New
Jersey's rows from PowerSchool, then stacks them. Three true/false columns were
only ever filled in on the PowerSchool side: `is_enrolled_y1`,
`is_enrolled_recent`, and `is_out_of_district`. Miami got a blank instead.

A blank is not a "no" in SQL. A report that asks for rows where a student is
**not** out of district throws away every row where the answer is blank. So
Miami disappeared, and no report said it had done that.

The damage is bigger than it sounds. `rpt_tableau__miami_fast` holds **zero
rows** — not zero Miami rows, zero rows of any kind — because it only keeps
students where `is_enrolled_y1` is true. That is the Miami FAST dashboard, and
it has been empty since Miami moved to Focus.

This pull request fills in all three columns for Miami:

- `is_enrolled_y1` and `is_enrolled_recent` are worked out from the same
  enrollment dates PowerSchool uses, with the same formula. Nothing is invented.
- `is_out_of_district` is set to false for Miami. The Focus side already gives
  every Miami student a real school and a real school level, never the
  out-of-district placeholder, so false just writes down what the model already
  says.
- `is_self_contained` is deliberately left blank. Focus does not record whether a
  student is in a self-contained classroom, and writing false would claim we
  checked when we did not. `rpt_tableau__dibels_dashboard` still leaves Miami
  out because of this, and the model description now says so out loud.

New Jersey does not move. Every edit sits in the Focus half of the model.

Scope decisions for all 40 affected reports are ratified on #4996.

## Reviewer Notes

- **The `is_out_of_district` = false call.** This is the one judgement here.
  Worth a look at the comment explaining why false is safe when the same model
  refuses to write false for `is_self_contained`.
- **A new upstream link.** The model now reads `int_students__calendar_week` to
  find the last day of school. Checked that this does not create a loop.
- **Row counts held.** The new lookup adds no duplicate rows. Numbers in the
  fold-out.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; the existing properties file is updated.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no new
      consumers.
- [x] **Breaking change?** No. No column is added, removed, or renamed. Only
      values change, and only for Miami rows.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external source changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — passes. `trunk check --force` clean on both changed files.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Scope decisions ratified by the requester on
#4996 before any edit.

**The premise of #4996 is stale, and this PR does not follow it.** #4996 asked
for `not coalesce(is_dropped_section, false)` across 40 files. Measured against
prod 2026-08-27: `is_dropped_section` and `is_dropped_course` are non-null on all
19,363 Miami AY2026 rows of `base_powerschool__course_enrollments`, and all 40
files read both flags from that relation and nowhere else. `not
is_dropped_section` already passes 18,787 Miami rows. The coalesce is a no-op in
every one of the 40, and doubly so in the 18 where the filter sits only on a
LEFT JOIN. #4996's own Sequencing section predicted this outcome if #4968 landed
first, which it did.

**Nullability, prod, AY2026, `int_students__student_enrollments`:**

| Flag | Miami null | Newark / Camden / Paterson null |
| --- | --- | --- |
| `is_enrolled_y1` | 1,760 / 1,760 | 0 |
| `is_enrolled_recent` | 1,760 / 1,760 | 0 |
| `is_out_of_district` | 1,760 / 1,760 | 0 |
| `is_self_contained` | 1,760 / 1,760 | 0 |
| `is_504` | 1,760 / 1,760 | 0 |

`is_504` is untouched — its Miami null is deliberate and already documented in
the model ("null means unknown, not the fabricated negative false would imply"),
and nothing filters on it bare.

**Derivations reproduced from the powerschool package.**
`int_powerschool__student_enrollment_union:254` gives `is_enrolled_y1` as
`if(exitdate is not null, true, false)`;
`powerschool/models/sis/base/base_powerschool__student_enrollments.sql:16-26`
gives `is_enrolled_recent`; both are taken to the year grain by `max()` over
`(studentid, yearid)` at lines 56 and 72. The Focus branch now uses the same
expressions over `(student_number, academic_year)`.

`exitdate` is never null in `int_focus__student_enrollment_roster` — it coalesces
a missing `end_date` to `date(syear + 1, 6, 30)`. So `is_enrolled_y1` resolves
true on every Miami stint, which matches PowerSchool, where it is also true on
every row in every region. The expression is reproduced rather than shortcut to
`true` so the two branches stay derived the same way if the roster stops
coalescing.

**Why false is defensible for `is_out_of_district` and not for
`is_self_contained`.** In the powerschool package both come off the same
`spenrollments` join: `coalesce(ood.is_out_of_district, false)` at line 151, and
that same `ood` row drives `reporting_schoolid`, `reporting_school_name` and
`school_level` to the out-of-district values at lines 153-157. The Focus branch
already sets `reporting_schoolid` from `enr.ps_schoolid` and `school_level` from
the roster, and prod confirms Miami's `school_level` is only ever ES, MS or HS —
never `OD`. So false is already asserted structurally.

`is_self_contained` has no such structural twin. Focus's nearest field is
`ese_fefp_code_label` (`int_focus__students__pivot`), whose Miami values are 3,890
null, 104 `4-8 Basic ESE Services [112]`, 57 `PK-3 Basic ESE Services [111]`, and
1 `ESE Support Level 4 [254]`. Support Level 4 is a Florida funding-matrix level,
not a placement label, so mapping it to PowerSchool's named SPED program is a
SPED-semantics call. Left to Ops. Requester chose "leave null, document it".

**Verification against prod upstreams** (compiled SQL, dev schemas rewritten to
prod; `bq` CLI tokens had expired and the prod manifests at `target/prod` and
`target/prodmain` both predate `int_focus__student_enrollment_roster`, so
`--defer --favor-state` could not resolve it):

- `focus_school_year_end` is 204 rows over 204 distinct `(academic_year,
  schoolid)` keys, so the LEFT JOIN cannot fan out.
- 1,760 roster rows AY2026 in, 1,760 conformed rows out.
- `is_enrolled_y1`: 1,760 true, 0 null.
- `is_enrolled_recent`: 1,513 true, 247 false, 0 null — discriminating, and the
  247 are mid-year withdrawals, which is the intended semantics.
- The join key holds: 1,759 of 1,760 Miami rows match a calendar row; the one
  miss has a null `schoolid` and is currently-active, so the `current_date`
  branch still resolves it true.

**Downstream effect, measured.** `rpt_tableau__miami_fast` goes from 0 rows to
~4,772 before its assessment LEFT JOINs (2,148 AY2025 + 2,624 AY2026, from
`int_extracts__student_enrollments_subjects` where `region = 'Miami' and rn_year
= 1 and grade_level >= 3`). `rpt_tableau__gradebook_gpa` and the ES/MS leg of
`rpt_tableau__ddi_dashboard` unblock on `is_out_of_district`; `ddi_dashboard`
already showed 5,378 Miami rows through its other union legs, so its exclusion
was partial. Both `rpt_gsheets__csgf_hs_*` extracts filter on
`is_enrolled_recent` and were latently exposed — masked today only because their
window is `current_academic_year - 1`, before Miami had a high school.

**Why New Jersey cannot move.** Every hunk lands in `focus_school_year_end`
(new), `focus_conformed`, or `focus_windowed`. `union_relations` and
`powerschool_conformed` are byte-identical. The only non-additive line is `*,`
becoming `* except (is_enrolled_y1, is_enrolled_recent)` inside `focus_windowed`.
The final union is `full union all corresponding`, which matches by name, so
adding columns to the Focus branch cannot reorder the PowerSchool branch. No
column enters or leaves the model output, so `dbt_union_relations_automation_condition()`
has no column-set change to race on — #4290 does not apply.

**Carved out deliberately.** `int_extracts__course_enrollments_by_term` is
classified INCLUDE on #4996 but is not fixed here. Its blocker is
`sections_no_of_students != 0`, and that column is null on all 19,363 Miami
AY2026 rows — a Focus-package gap, not an enrollment flag. Miami had 50,155 rows
in AY2025 and has 0 now. Fixing it means deciding what
`sections_no_of_students` should be for a Focus section, which belongs in the
focus package and would drag this PR into the #4290 cross-project deploy race.
Requester agreed to carve it out; it needs its own issue.

Refs #4996
Refs #4973
Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
