### PR TITLE
docs(dbt): sweep inline SQL comments against the properties-file rule

### DIFF
--- a/src/dbt/CLAUDE.md
+++ b/src/dbt/CLAUDE.md
@@ -1088,13 +1088,15 @@ validation/profiling goes through BigQuery MCP, not `dbt show`.
 - **`DISTINCT` — grain projection only, never dup-masking.** Use `DISTINCT` for
   a `GROUP BY` with no aggregation, and for pure grain projection (every
   projected column is functionally determined by the partition key, so
-  byte-identical tuples coalesce) — annotate the latter with
-  `grain projection: every selected column is functionally determined / by the partition key; not a mask for upstream duplicates`.
-  NEVER `SELECT DISTINCT` or `qualify row_number() over (...) = 1` to mask
-  upstream duplicates, and never `DISTINCT` when a projected column varies
-  within the partition (`min()`, `first_value()`) — use
-  `dbt_utils.deduplicate()` (see _Row picking, dedup & surrogate keys_) with a
-  `-- TODO:` naming the upstream fix.
+  byte-identical tuples coalesce). Annotate the latter with the one-line
+  `grain projection, not dup-masking` — the annotation is what tells a reviewer
+  the `DISTINCT` is deliberate rather than a fan-out mask or a wrong-grain
+  source, so it is required. Name the partition key on the same comment when the
+  `SELECT` list does not make it obvious. NEVER `SELECT DISTINCT` or
+  `qualify row_number() over (...) = 1` to mask upstream duplicates, and never
+  `DISTINCT` when a projected column varies within the partition (`min()`,
+  `first_value()`) — use `dbt_utils.deduplicate()` (see _Row picking, dedup &
+  surrogate keys_) with a `-- TODO:` naming the upstream fix.
 - **No one-sided calculations in join predicates.** Any expression computable
   from a single table's columns is precomputed as a named column upstream — `ON`
   matches plain columns. Expressions that inherently combine columns from both

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_custom_attributes.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__contact_custom_attributes.sql
@@ -228,12 +228,12 @@ select
     s_withdrawal_school_txt as withdrawal_school_txt,
     s_withdrawal_transfer_type_ss as withdrawal_transfer_type_ss,
 
-    -- normalize to E.164 here, the earliest point these phones exist as scalar
-    -- columns: they arrive inside the `custom_attributes` repeated struct, so
-    -- staging cannot reach them. Roughly a third are hand-entered with
-    -- punctuation (dashes, parens, a leading `+`) — much messier than the base
-    -- `phone_N_number` fields. Anything not confidently parseable passes
-    -- through de-garbled rather than nulling.
+    -- Normalize to E.164 here, the earliest point these phones exist as scalar
+    -- columns. They arrive inside the `custom_attributes` repeated struct, so
+    -- staging cannot reach them. About a third are hand-entered with
+    -- punctuation, which makes them messier than the base `phone_N_number`
+    -- fields. A number that does not parse confidently passes through
+    -- de-garbled rather than nulled.
     {{ clean_phone("s_additional_phone_number_1_phone_number") }}
     as additional_phone_number_1_phone_number,
     {{ clean_phone("s_emrg_1_phone_1_number") }} as emrg_1_phone_1_number,

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_address_of_record.sql
@@ -49,12 +49,12 @@ with
     ),
 
     sourced as (
-        -- Parent 1's household is the address of record; the student's own is
-        -- the fallback. The reverse order used to be correct because a parent
-        -- carries more households and the old rule withheld on any ambiguity —
-        -- once the contact model picks a winner, the parent's larger household
-        -- count costs nothing. The student tier must stay: some students hold
-        -- an address while their Parent 1 holds none.
+        -- Parent 1's household is the address of record. The student's own
+        -- household is the fallback, and that tier must stay: some students
+        -- hold an address while their Parent 1 holds none. The reverse order
+        -- was correct while the old rule withheld on any ambiguity, because a
+        -- parent carries more households. The contact model now picks a
+        -- winner, so the parent's larger household count costs nothing.
         select
             finalsite_enrollment_id,
             primary_contact_id,

--- a/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/finalsite/models/api/intermediate/int_finalsite__student_contacts.sql
@@ -1,12 +1,10 @@
 with
     parent_candidates as (
-        -- A parent candidate is any relationship flagged `primary` or
-        -- `financial` whose related contact is an ADULT. Finalsite marks adults
-        -- with status `not_in_workflow`; every other status (enrolled, inquiry,
-        -- waitlisted, ...) belongs to a student record, and a student is never
-        -- a parent. This guard -- not `rel_type` -- is what keeps a co-resident
-        -- sibling out of a parent slot, which matters because an adult sibling
-        -- CAN legitimately be a guardian and must still qualify.
+        -- The adult guard, not `rel_type`, is what keeps a co-resident sibling
+        -- out of a parent slot. Filtering on `rel_type` would also drop an
+        -- adult sibling who is a legitimate guardian. Finalsite marks adults
+        -- with status `not_in_workflow`; every other status belongs to a
+        -- student record, and a student is never a parent.
         select
             r.finalsite_enrollment_id,
             r.relationship_id,

--- a/src/dbt/focus/models/intermediate/int_focus__attendance_daily.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__attendance_daily.sql
@@ -1,13 +1,13 @@
 with
-    -- Focus dates a school transfer with the departing stint's exitdate EQUAL to
-    -- the arriving stint's startdate, so an inclusive date range counts that day
-    -- twice and breaks the (student_number, school_date) grain. Measured against
-    -- prod: 78 stints network-wide are transfer boundaries, while 1,755 stints
-    -- legitimately end on an in-session day the student attended -- so a blanket
-    -- half-open range would drop 1,755 real attendance days to fix 4 duplicates.
-    -- Trim only the transfer day, which assigns it to the ARRIVING school. The
-    -- join must also exclude a stint matching its own row, or a single-day stint
-    -- loses its only day.
+    -- Focus dates a school transfer with the departing stint's `exitdate` equal
+    -- to the arriving stint's `startdate`. An inclusive date range counts that
+    -- day twice and breaks the (`student_number`, `school_date`) grain. Trim
+    -- only the transfer day, which assigns it to the ARRIVING school. Measured
+    -- against prod: 78 stints network-wide are transfer boundaries, while 1,755
+    -- stints legitimately end on an in-session day the student attended, so a
+    -- blanket half-open range drops 1,755 real attendance days to fix 4
+    -- duplicates. The join must also exclude a stint matching its own row, or a
+    -- single-day stint loses its only day.
     stint_starts as (
         -- distinct is defensive, not collapsing:
         -- int_focus__student_enrollment_roster already dedupes to one row per
@@ -42,39 +42,39 @@ with
             on e.student_number = s.student_number
             and e.academic_year = s.academic_year
             and e.exitdate = s.startdate
-            -- Without this, a single-day stint (startdate = exitdate) matches its
-            -- OWN row in stint_starts, trims its exitdate to startdate - 1, and
-            -- silently loses the student's only membership day. 73 AY2026 stints
-            -- are single-day and all fall on in-session days. startdate is unique
-            -- per student-year, so requiring a different startdate isolates a
-            -- genuine transfer from a self-match.
+            -- Without this exclusion, a single-day stint (`startdate` =
+            -- `exitdate`) matches its OWN row in `stint_starts`, trims its
+            -- `exitdate` to `startdate` - 1, and loses the student's only
+            -- membership day. 73 AY2026 stints are single-day, and all fall on
+            -- in-session days. `startdate` is unique per student-year, so
+            -- requiring a different `startdate` isolates a genuine transfer.
             and e.startdate <> s.startdate
     ),
 
-    -- Focus's attendance_calendar carries one row per school per day it treats
-    -- as in session. There is no insession flag -- presence in the table IS the
-    -- flag. minutes is the sentinel 999 on every 2026 row and is not read.
-    -- distinct is grain projection, not dup-masking: stg_focus__attendance_calendar
-    -- has no unique test on (school_id, syear, school_date) and prod carries
-    -- exact-duplicate rows on that key going back to syear 2016 (a Focus/SIS
-    -- data-quality issue, not introduced here); every column selected below IS
-    -- that key, so identical tuples collapse with no information loss. Without
-    -- this, the inner join two CTEs down fans out the membership scaffold by the
-    -- duplicate count for every enrolled student on the affected school/day.
+    -- Focus's `attendance_calendar` carries one row per school per day it treats
+    -- as in session. There is no `insession` flag: presence in the table IS the
+    -- flag. `minutes` is the sentinel 999 on every 2026 row and is not read.
+    -- grain projection, not dup-masking. `stg_focus__attendance_calendar` has no
+    -- unique test on (`school_id`, `syear`, `school_date`), and prod carries
+    -- exact-duplicate rows on that key back to syear 2016 — a Focus data-quality
+    -- issue, not one introduced here. Every column selected below IS that key,
+    -- so identical tuples collapse with no loss. Without the `distinct`, the
+    -- inner join 2 CTEs down fans out the membership scaffold by the duplicate
+    -- count for every enrolled student on the affected school-day.
     calendar_days as (
         select distinct school_id, syear, school_date,
         from {{ ref("stg_focus__attendance_calendar") }}
     ),
 
-    -- The membership scaffold. int_focus__attendance_day cannot represent a day
-    -- it holds no row for, so absences that were never recorded are invisible
-    -- at its grain; crossing enrollment with in-session days is what makes them
-    -- representable. Enrollment is the inner side deliberately, which drops the
-    -- four misconfigured Focus schools that enrolled nobody. It does NOT drop
-    -- school 60 (Applicants), which carries one AY2026 enrollment against a
-    -- 212-day holiday-inclusive calendar -- that school has no locations-sheet
-    -- row, so the kipptaf crosswalk drops it before anything published reads it.
-    -- The calendar misconfiguration is tracked with Ops, not filtered here.
+    -- The membership scaffold. `int_focus__attendance_day` cannot represent a
+    -- day it holds no row for, so absences nobody recorded are invisible at its
+    -- grain. Crossing enrollment with in-session days makes them representable.
+    -- Enrollment is the inner side on purpose, which drops the 4 misconfigured
+    -- Focus schools that enrolled nobody. It does NOT drop school 60
+    -- (Applicants), which carries 1 AY2026 enrollment against a 212-day
+    -- holiday-inclusive calendar. School 60 has no locations-sheet row, so the
+    -- kipptaf crosswalk drops it before anything published reads it. Ops tracks
+    -- the calendar misconfiguration; this model does not filter it.
     membership as (
         select
             e.student_number,

--- a/src/dbt/focus/models/intermediate/int_focus__calendar_day.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__calendar_day.sql
@@ -1,11 +1,11 @@
--- distinct is grain projection, not dup-masking. stg_focus__attendance_calendar
--- carries 1,555 exact duplicate rows (15,067 raw against 13,512 distinct
--- (school_id, syear, school_date) keys; including `minutes` still yields 13,512, so
--- the duplication is total). Every column below derives from that key, so identical
--- tuples collapse with no information loss. Without it this model breaks its own
--- (schoolid, academic_year, school_date) grain and double-counts in-session days in
--- dim_school_calendars, which is not year-scoped. AY2026 happens to be clean; the
--- duplicates are all in historical years. Same source and same fix as Task 1.
+-- grain projection, not dup-masking. `stg_focus__attendance_calendar` carries
+-- 1,555 exact duplicate rows: 15,067 raw against 13,512 distinct (`school_id`,
+-- `syear`, `school_date`) keys, and including `minutes` still yields 13,512, so
+-- the duplication is total. Every column below derives from that key, so
+-- identical tuples collapse with no loss. Without the `distinct` this model
+-- breaks its own (`schoolid`, `academic_year`, `school_date`) grain and
+-- double-counts in-session days in `dim_school_calendars`, which is not
+-- year-scoped. The duplicates all sit in historical years; AY2026 is clean.
 select distinct
     school_id as schoolid,
     school_date,

--- a/src/dbt/focus/models/intermediate/int_focus__report_card_grades.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__report_card_grades.sql
@@ -76,10 +76,10 @@ left join
     course_flag_options as f2
     on g.course_flag_2 in (f2.option_id, f2.code)
     and f2.column_name = 'custom_2'
--- DY is the cron admin account's snapshot of yesterday's grade, mirroring the
--- DT row's grade with no grade_scale_id. Carrying it would double-count every
+-- DY is the cron admin account's snapshot of yesterday's grade. It mirrors the
+-- DT row's grade with no `grade_scale_id`, so carrying it double-counts every
 -- live Miami grade downstream. DT (the running gradebook) and E (an exam) are
--- distinct measures and both stay -- no E row exists yet, so filtering to DT
+-- distinct measures, and both stay. No E row exists yet, so filtering to DT
 -- alone would silently drop exam grades the moment they post. Imported course
 -- history carries no token and is unaffected.
 where coalesce(g.grade_type_token, '') != 'DY'

--- a/src/dbt/focus/models/intermediate/int_focus__students.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students.sql
@@ -89,12 +89,12 @@ with
             end as lep_status,
 
             -- FLDOE homeless codes describe the student's nighttime residence. Any
-            -- residence type means homeless; N is the not-homeless default. The network
-            -- domain splits homeless by custody instead, so the separate
+            -- residence type means homeless, and N is the not-homeless default. The
+            -- network domain splits homeless by custody instead, so the separate
             -- unaccompanied-youth field decides Y2 versus Y1. That field is a
-            -- five-option select, not a flag -- Y, C and U all mean unaccompanied,
-            -- while N means homeless but accompanied and Z means not homeless, so a
-            -- null check would mislabel an accompanied homeless student as Y2.
+            -- 5-option select, not a flag: Y, C and U all mean unaccompanied, N
+            -- means homeless but accompanied, and Z means not homeless. A null check
+            -- would therefore mislabel an accompanied homeless student as Y2.
             case
                 when homeless_c = 'N'
                 then 'N'

--- a/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
+++ b/src/dbt/focus/models/staging/stg_focus__student_report_card_grades.sql
@@ -28,14 +28,14 @@ select
     custom_6 as school_number,
     custom_7 as grade_level,
 
-    -- Focus stores this FK as a string here (int64 everywhere else) and prefixes
-    -- live postings with a grade-type token: DT is the running gradebook, DY is
-    -- yesterday's grade, E is an exam (Focus SIS Level 1 Certification, Day 2).
-    -- The decode strips any alpha prefix and casts the digit tail, rather than
-    -- enumerating the tokens -- the vocabulary grew from 5 values to 8 in 5 days,
-    -- so an enumeration would silently null the next token Focus adds. The token
-    -- is kept as its own column because it is load-bearing for the grain:
-    -- dropping it collapses 3,074 live-posted rows onto 1,542.
+    -- Focus stores this FK as a string here (`int64` everywhere else) and
+    -- prefixes live postings with a grade-type token: DT is the running
+    -- gradebook, DY is yesterday's grade, E is an exam (per Focus SIS Level 1
+    -- Certification). The decode strips any alpha prefix and casts the digit
+    -- tail rather than enumerating the tokens, because the vocabulary grew from
+    -- 5 values to 8 in 5 days. An enumeration would silently null the next token
+    -- Focus adds. The token stays its own column because it is load-bearing for
+    -- the grain: dropping it collapses 3,074 live-posted rows onto 1,542.
     regexp_extract(marking_period_id, r'^[A-Za-z]+') as grade_type_token,
     safe_cast(regexp_extract(marking_period_id, r'\d+$') as int) as marking_period_id,
 from {{ source("focus", "student_report_card_grades") }}

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment_practice.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__college_assessment_practice.sql
@@ -96,12 +96,12 @@ with
 
         from {{ ref("int_assessments__response_rollup") }} as a
         inner join
-            -- `a.assessment_id` is canonical_assessment_id (response_rollup
-            -- output is canonical-grain). Sheet's assessment_id values
-            -- currently align to canonical (12/12 sheet ids = canonical) since
-            -- Practice SAT/ACT haven't been canonicalized into multi-member
-            -- groups. If multipart Practice administrations are added later,
-            -- the sheet must reference the canonical (lowest) assessment_id.
+            -- `a.assessment_id` is `canonical_assessment_id`, because
+            -- `response_rollup` output is canonical-grain. The sheet's
+            -- `assessment_id` values align to canonical today (12 of 12),
+            -- because Practice SAT/ACT are not canonicalized into multi-member
+            -- groups. If multipart Practice administrations arrive later, the
+            -- sheet must reference the canonical (lowest) `assessment_id`.
             conversion as ssk
             on a.assessment_id = ssk.assessment_id
             and a.points between ssk.raw_score_low and ssk.raw_score_high

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__course_enrollments.sql
@@ -19,12 +19,12 @@ with
 
             co.grade_level + 1 as illuminate_grade_level_id,
 
-            -- partitioned on students_student_number rather than cc_studentid:
-            -- Focus leaves cc_studentid null on every Miami row, so a partition
-            -- on it collapses all Miami rows into a single group. The two keys
-            -- are exactly 1:1 within every NJ region (verified against prod:
-            -- distinct cc_studentid = distinct students_student_number =
-            -- distinct pairs, in all three), so NJ output does not move.
+            -- Partitioned on `students_student_number`, not `cc_studentid`:
+            -- Focus leaves `cc_studentid` null on every Miami row, so a
+            -- partition on it collapses all Miami rows into 1 group. The 2 keys
+            -- are exactly 1:1 within every NJ region — verified against prod,
+            -- where distinct `cc_studentid`, distinct `students_student_number`
+            -- and distinct pairs all match — so NJ output does not move.
             max(ce.is_advanced_math) over (
                 partition by
                     ce._dbt_source_project,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -233,13 +233,13 @@ with
         from dibels_scores
     ),
 
-    -- course_subject is the section subject the resolver matches against. For
-    -- internal scores subject_area already equals the inventory's
-    -- illuminate_subject_area; for state scores the state->course mapping is
-    -- already applied upstream (illuminate_subject), so this is a passthrough.
-    -- Derived as a named column (not inline in a join) per src/dbt/CLAUDE.md.
-    -- score_grain_key is the stable per-score handle used for the tier-2
-    -- anti-join (internal grain: canonical; state grain: year/period/subject).
+    -- `course_subject` is the section subject the resolver matches against. For
+    -- internal scores, `subject_area` already equals the inventory's
+    -- `illuminate_subject_area`. For state scores, the state-to-course mapping
+    -- is already applied upstream as `illuminate_subject`, so this is a
+    -- passthrough. `score_grain_key` is the stable per-score handle the tier-2
+    -- anti-join uses: internal grain is canonical, state grain is
+    -- year/period/subject.
     scores_mapped as (
         select
             *,

--- a/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/assessments/intermediate/int_assessments__resolved_section_enrollments.sql
@@ -297,8 +297,7 @@ with
             and ce.cc_dcid is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     resolved_subject_keys as (select distinct score_grain_key, from candidates_subject),
 
     scores_unresolved as (

--- a/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/deanslist/rpt_deanslist__family_contacts.sql
@@ -17,17 +17,17 @@ with
             regexp_replace(lower(sc.phone_mobile), r'[^0-9x]', '') as phone_mobile,
             regexp_replace(lower(sc.phone_untyped), r'[^0-9x]', '') as phone_untyped,
 
-            -- DeansList routes guardian-only automated messaging (reports,
-            -- texts, emails) by ContactType, so the slot ordinal need not be
-            -- encoded anywhere else; Relationship carries the contact's actual
-            -- relationship to the student for every slot, emergency contacts
-            -- included. Overwriting it with a literal `Emergency N` (the prior
-            -- behavior) discarded a label Finalsite populates on essentially
-            -- every emergency row and left school staff unable to tell a parent
-            -- from a neighbor. Parent slots past contact_2 are excluded by the
-            -- `where` below, upstream of this `case`, so they can never fall
-            -- into the `else` branch and be mislabelled `Emergency`. Carrying a
-            -- third parent into DeansList is deliberately out of scope for now.
+            -- DeansList routes guardian-only automated messaging by
+            -- `ContactType`, so nothing else needs to encode the slot ordinal.
+            -- `Relationship` carries the contact's actual relationship to the
+            -- student for every slot, emergency contacts included. The prior
+            -- behavior overwrote it with a literal `Emergency N`, which
+            -- discarded a label Finalsite populates on nearly every emergency
+            -- row and left school staff unable to tell a parent from a
+            -- neighbor. The `where` below excludes parent slots past
+            -- `contact_2` upstream of this `case`, so they never reach the
+            -- `else` branch. Carrying a third parent into DeansList is out of
+            -- scope for now.
             case
                 sc.contact_slot
                 when 'contact_1'

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__contacts.sql
@@ -68,13 +68,13 @@ with
     ),
 
     emergency_long as (
-        -- Positional passthrough: emergency_N is the emrg_N custom-field set
-        -- as-is. Finalsite emergency contacts are custom fields on the
+        -- Positional passthrough: `emergency_N` is the `emrg_N` custom-field
+        -- set as-is. Finalsite emergency contacts are custom fields on the
         -- student's own record, not relationship rows, so they never reach the
-        -- relationship-type filter above. The shape here mirrors
-        -- int_finalsite__student_contacts, which cannot be ref'd — it excludes
-        -- Miami to avoid double-counting against the PowerSchool branch of
-        -- int_students__contacts.
+        -- relationship-type filter above. The shape mirrors
+        -- `int_finalsite__student_contacts`, which this model cannot `ref` —
+        -- that model excludes Miami to avoid double-counting against the
+        -- PowerSchool branch of `int_students__contacts`.
         select
             a.emrg_1_name_first_name as first_name,
             a.emrg_1_name_middle_name as middle_name,
@@ -334,10 +334,10 @@ with
             * except (student_relation, contact_gender),
 
             case
-                -- The next several branches are case-sensitive exact matches
-                -- against controlled-vocabulary fields (Finalsite's guardian
-                -- rel_type, or emrg_N_relationship_ss) -- lowercase 'parent',
-                -- 'guardian', and 'stepparent' below are deliberately
+                -- The next several branches are case-sensitive exact
+                -- matches against controlled-vocabulary fields: Finalsite's
+                -- guardian `rel_type`, or `emrg_N_relationship_ss`. The
+                -- lowercase 'parent', 'guardian' and 'stepparent' below stay
                 -- distinct from the Title-Case free-text fallback further
                 -- down, which would otherwise swallow them before their
                 -- gender split ran.
@@ -374,14 +374,14 @@ with
                 then 'Aunt'
                 when student_relation = 'Great Uncle'
                 then 'Uncle'
-                -- emrg_N_relationship_txt is free text (case and padding not
-                -- guaranteed) -- match it case/whitespace-insensitively, but
-                -- still emit the canonical Title-Case Focus value. Every name
-                -- in this list is a single word, so initcap() reconstructs it
-                -- correctly. Placed last so it only catches values the
-                -- case-sensitive branches above didn't -- otherwise a bare
-                -- lowercase 'parent'/'guardian'/'stepparent' guardian
-                -- rel_type would be swallowed here before its gender split.
+                -- `emrg_N_relationship_txt` is free text, so case and
+                -- padding are not guaranteed. Match it case- and
+                -- whitespace-insensitively, but still emit the canonical
+                -- Title-Case Focus value. Every name in this list is a single
+                -- word, so `initcap()` reconstructs it correctly. This branch
+                -- is last so it catches only values the case-sensitive
+                -- branches above missed. Otherwise it swallows a lowercase
+                -- guardian `rel_type` before its gender split runs.
                 when
                     lower(trim(student_relation)) in (
                         'mother',
@@ -425,18 +425,18 @@ with
     ),
 
     household_compared as (
-        -- resides_with_stud / custody: the first contact per student is
-        -- always Y; a later contact is Y only when it shares a household
-        -- with that first contact. Household membership rather than an
-        -- address string comparison -- '123 Main St' vs '123 Main Street',
-        -- or a unit number that sits in address on one row and address2 on
-        -- the other, would both read as a false N. N is an explicit default
-        -- when household membership is unknown on either side, not a guess.
+        -- `resides_with_stud` / `custody`: the first contact per student is
+        -- always Y. A later contact is Y only when it shares a household with
+        -- that first contact. Household membership beats an address string
+        -- comparison: '123 Main St' against '123 Main Street', or a unit
+        -- number that sits in `address` on one row and `address2` on the
+        -- other, both read as a false N. N is an explicit default when
+        -- household membership is unknown on either side, not a guess.
         --
-        -- "First contact" here means sort_order = 1 -- the same ordering
-        -- `ranked` (above) uses, read directly off sort_order rather than
-        -- re-deriving it from a second copy of the same five-column ORDER BY,
-        -- so the two can't silently drift apart.
+        -- "First contact" means `sort_order` = 1, the same ordering `ranked`
+        -- above uses. Reading `sort_order` directly beats re-deriving it from
+        -- a second copy of the same 5-column ORDER BY, which could silently
+        -- drift.
         select
             *,
 
@@ -582,16 +582,16 @@ with
 
     custody_flagged as (
         -- Derived once here and projected as both RESIDES_WITH_STUD and
-        -- CUSTODY in the final select below -- BigQuery has no lateral
-        -- column aliases, so sort_order (added by ranked, above) can't be
-        -- read in the same select list that produces it.
+        -- CUSTODY in the final select below. BigQuery has no lateral column
+        -- aliases, so the select list that produces `sort_order` (added by
+        -- `ranked` above) cannot also read it.
         --
-        -- sort_order = 1 assumes the student's first contact is a guardian --
-        -- zero students currently have emergency contacts but no guardian
-        -- rows, so an emergency contact never actually lands at sort_order 1
-        -- today. If that ever changes, an emergency contact would land
-        -- sort_order 1 and get Y here regardless of what Finalsite says about
-        -- them living with the student.
+        -- `sort_order` = 1 assumes the student's first contact is a guardian.
+        -- No student currently has emergency contacts but no guardian rows,
+        -- so an emergency contact never lands at `sort_order` 1 today. If that
+        -- changes, an emergency contact lands at `sort_order` 1 and gets Y
+        -- here regardless of what Finalsite says about them living with the
+        -- student.
         select
             * except (shared_household_count),
 

--- a/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
+++ b/src/dbt/kipptaf/models/extracts/focus/rpt_focus__student_enrollment.sql
@@ -9,12 +9,12 @@ with
             l.is_transfer_out,
             l.finalsite_enrollment_id,
 
-            -- Finalsite emits pre-first-day enrolled_dates (contract/registration
-            -- dates); Focus matches enrollment on the first attendance calendar
-            -- date, so floor the start date up to the school year's first day
-            -- (derived per school year from the Focus attendance calendar). Rows
-            -- already on/after the first day, and years with no calendar, are
-            -- left unchanged.
+            -- Finalsite emits pre-first-day `enrolled_date` values, which are
+            -- contract or registration dates. Focus matches enrollment on the
+            -- first attendance calendar date, so floor the start date up to the
+            -- school year's first day, derived per school year from the Focus
+            -- attendance calendar. Rows already on or after the first day, and
+            -- years with no calendar, stay unchanged.
             greatest(
                 l.enrollment_start_date,
                 coalesce(fd.first_day_of_school, l.enrollment_start_date)
@@ -23,11 +23,11 @@ with
         left join
             {{ ref("int_focus__school_year_first_day") }} as fd
             on l.school_year_start = fd.syear
-        -- enrolled-only desired state, all in-scope school years. Pre-enrollment
-        -- statuses carry no enrolled_date and are deferred until Finalsite mints
-        -- enrollment_start_date; a freshly enrolled student with no school
-        -- assignment yet is likewise deferred (Focus needs a school id). The
-        -- kippmiami wrapper scopes this to the current academic year and
+        -- Enrolled-only desired state, across all in-scope school years.
+        -- Pre-enrollment statuses carry no `enrolled_date`, so they wait until
+        -- Finalsite mints `enrollment_start_date`. A freshly enrolled student
+        -- with no school assignment waits too, because Focus needs a school id.
+        -- The kippmiami wrapper scopes this to the current academic year and
         -- reconciles it against live Focus.
         where l.enrollment_start_date is not null and l.assigned_school is not null
     )

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__nsc_enrollment_new.sql
@@ -4,8 +4,7 @@ with
        AND their date windows overlap. Open-ended endpoints on either side
        use 9999-12-31 (NSC term rows may carry a NULL enrollment_end for
        in-progress terms, propagating to stint_end). */
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     covered_stints as (
         select distinct n.contact_id, n.account_id, n.stint_num,
         from {{ ref("int_nsc__enrollment_stints") }} as n

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__schools.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__schools.sql
@@ -1,11 +1,10 @@
 with
     principals as (
         -- ParentSquare wants the principal's given and family name as separate
-        -- fields, but PowerSchool stores only one combined `principal` string
-        -- that also carries honorifics ('Dr. Jane Doe'), so a whitespace split
-        -- would put the honorific in first_name. Resolve the pair from the staff
-        -- roster by email instead. `mail` is unique on the roster, so this
-        -- cannot fan out.
+        -- fields, but PowerSchool stores one combined `principal` string that
+        -- also carries honorifics. A whitespace split would put the honorific in
+        -- `first_name`, so resolve the pair from the staff roster by email
+        -- instead. `mail` is unique on the roster, so this join cannot fan out.
         select
             given_name as principal_first_name,
             family_name_1 as principal_last_name,

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
@@ -19,12 +19,11 @@ with
     ),
 
     grade_sections as (
+        -- grain projection, not dup-masking
         -- Derived from the (school, grade) pairs students are actually enrolled
-        -- in, not from each school's low_grade..high_grade span, so no empty
-        -- section is emitted and every rpt_parentsquare__rosters row is
+        -- in, not from each school's `low_grade`..`high_grade` span. No empty
+        -- section is emitted, and every `rpt_parentsquare__rosters` row is
         -- guaranteed a section to point at.
-        -- grain projection: every selected column is functionally determined by
-        -- the partition key; not a mask for upstream duplicates.
         select distinct school_id, grade_level, code_location, from enrolled
     ),
 

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__sections.sql
@@ -45,19 +45,12 @@ with
         group by code_location
     )
 
--- One synthetic section per (school, grade). The Integration Planner sets
--- granularity at "School + Grade Level only" (question 5) and excludes
--- teacher-classroom rostering, so these stand in for real course sections: they
--- give ParentSquare the grade-level grouping it needs to satisfy sections.csv and
--- rosters.csv without importing any teacher. Mirrors the auto-generated ENR
--- section pattern in rpt_clever__sections.
---
--- The owner join is a LEFT join deliberately. `section_owner` groups by region, so
--- a region whose Ops group is emptied or renamed contributes no owner row — an
--- inner join would silently drop that region's sections entirely, and a zero-row
--- sections.csv is skipped by the extract factory, leaving ParentSquare on a stale
--- file with nothing failing. Preserving the section with a null owner is what lets
--- the `not_null` test on staff_id fire instead.
+-- Mirrors the auto-generated ENR section pattern in rpt_clever__sections.
+-- The owner join is LEFT on purpose. `section_owner` groups by region, so a
+-- region whose Ops group is emptied or renamed contributes no owner row. An
+-- inner join drops that region's sections, and the extract factory skips a
+-- zero-row sections.csv, so ParentSquare keeps a stale file and nothing fails.
+-- A null owner keeps the section and lets the `not_null` test on staff_id fire.
 select
     a.school_id,
     a.code_location,

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__staff.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__staff.sql
@@ -11,28 +11,9 @@ with
     ),
 
     ops_leaders as (
-        -- The ParentSquare user population is the regional Operations leadership
-        -- (Integration Planner question 4: "Regional Operation leaders ... No
-        -- school staff, no teachers, etc"). Membership comes from the
-        -- hand-curated `TS-DL-Regional Ops Leaders` distribution list rather than
-        -- a hardcoded roster of individuals, so Ops owns the list and it tracks
-        -- role changes without a code change. No job-title or job-function rule
-        -- reproduces it: the regional Operations group holds twelve people across
-        -- eight titles, and `job_function` is null for one Managing Director of
-        -- School Operations who shares a title with two included peers — a data
-        -- gap that would silently add or drop them.
-        --
-        -- The group spans all four regions and both regional and school-based
-        -- staff. The scoping below reduces it to regional-office Operations, and
-        -- `code_location` carries each leader's region so the fan-out below stays
-        -- inside it. LDAP join shape follows rpt_clever__staff.
-        -- `google_email` (@apps.teamschools.org), NOT the roster's `mail` /
-        -- `user_principal_name`, which are the AD/Exchange addresses
-        -- (@kippnj.org, @kippteamandfamily.org). The two never coincide for any
-        -- leader in this group, and ParentSquare authenticates these users
-        -- through Google — so an AD address here syncs a staff user nobody can
-        -- sign in as. This is where rpt_parentsquare__staff diverges from
-        -- rpt_clever__staff, whose consumer matches on AD.
+        -- LDAP join shape follows rpt_clever__staff. The group spans both
+        -- regions and school-based staff, so the filters below reduce it to
+        -- regional-office Operations.
         select
             r.employee_number,
             r.job_title,

--- a/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__students.sql
+++ b/src/dbt/kipptaf/models/extracts/parentsquare/rpt_parentsquare__students.sql
@@ -1,9 +1,3 @@
--- Neither `student_email` nor `state_student_id` is sent. Both are optional in
--- ParentSquare's spec, and Ops excluded them: a student email address triggers
--- ParentSquare's automatic account-creation mail to every student in the file
--- (~6,800 for Newark) and student logins are not part of this deployment, while
--- the state id has no consumer on the ParentSquare side. Adding either back is a
--- column add here plus a properties entry — no upstream change.
 select
     student_first_name as first_name,
     student_last_name as last_name,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__schoolmint_grow_observation_details.sql
@@ -1,12 +1,13 @@
 with
     recent_leave as (
-        -- Joins PMS terms only, and AY2026 has no PMS PM1 term row (AY2024 and
-        -- AY2025 did), so this yields PM2/PM3 rows only. The pm_round_eligible
-        -- leave guard is therefore inert for PM1 until Ops re-adds that row.
-        -- grain projection: every selected column is functionally determined by
-        -- (employee_number, academic_year, code) -- recent_leave is a constant,
-        -- so multiple matching roster-history rows collapse to one
-        -- byte-identical tuple. Not a mask for upstream duplicates.
+        -- grain projection, not dup-masking: every selected column is
+        -- determined by (`employee_number`, `academic_year`, `code`), and
+        -- `recent_leave` is a constant, so multiple matching roster-history rows
+        -- collapse to 1 byte-identical tuple.
+        -- Joins PMS terms only, and AY2026 has no PMS PM1 term row where AY2024
+        -- and AY2025 had one, so this yields PM2 and PM3 rows only. The
+        -- `pm_round_eligible` leave guard stays inert for PM1 until Ops re-adds
+        -- that row.
         select distinct
             srh.employee_number, t.academic_year, t.code, true as recent_leave,
         from {{ ref("int_people__staff_roster_history") }} as srh

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_id_attributes.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__contact_id_attributes.sql
@@ -1,12 +1,4 @@
--- Finalsite contacts API layer is enabled only in regions with Finalsite
--- ingestion wired (today: KIPP Miami and the NJ regions Newark, Camden,
--- Paterson). Add each region's relation here when its api layer is enabled.
---
--- focus_student_id_prefixed (the 8400-prefixed Focus student id consumed by the
--- rpt_focus__* extracts) is produced by the package model and flows through the
--- union below; it is null for non-Focus regions (e.g. the NJ regions), so the
--- rpt_focus__* consumers that filter `focus_student_id_prefixed is not null`
--- see only their own region's rows.
+-- Add a region below once its Finalsite API layer is wired.
 with
     union_relations as (
         {{

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_lifecycle.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__enrollment_lifecycle.sql
@@ -1,12 +1,4 @@
--- Finalsite contacts API layer is enabled only in regions with Finalsite
--- ingestion wired (today: KIPP Miami). Add each region's relation here when its
--- api layer is enabled.
---
--- The package model's output schema changed in this PR (is_transfer_out
--- replaces lifecycle_action, withdrawal_reason etc.). This union wrapper reads
--- the district source via compile-time union_relations, so this comment forces
--- state:modified — CI rebuilds it against the reseeded zz_stg copy that carries
--- the new columns.
+-- Add a region below once its Finalsite API layer is wired.
 with
     union_relations as (
         {{

--- a/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__student_contacts.sql
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/int_finalsite__student_contacts.sql
@@ -1,10 +1,6 @@
--- Union of the per-region Finalsite int_finalsite__student_contacts models
--- (grain: finalsite_enrollment_id x contact_slot) — the source for the network
--- contact surface. Union a region here only when it cuts over to Finalsite
--- contacts reporting (today the NJ regions: Newark, Camden, Paterson); its rows
--- flow straight into int_students__contacts' Finalsite branch, so a
--- not-yet-cutover region (e.g. Miami, still PowerSchool-sourced for contacts)
--- must NOT be added here even though its api layer is enabled.
+-- Add a region below only when it cuts over to Finalsite contacts reporting.
+-- These rows flow straight into int_students__contacts' Finalsite branch, so a
+-- region that is still PowerSchool-sourced for contacts double-counts there.
 with
     union_relations as (
         {{

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_id_attributes.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_id_attributes.yml
@@ -4,8 +4,8 @@ models:
       Network-wide union of the per-region Finalsite
       `int_finalsite__contact_id_attributes` models (one row per contact, the
       `id_attributes` identifiers pivoted to columns). Enabled only where the
-      Finalsite API layer is wired (today KIPP Miami); carries
-      `_dbt_source_relation`.
+      Finalsite API layer is wired — today KIPP Miami, Newark, Camden and
+      Paterson; carries `_dbt_source_relation`.
     columns:
       - name: finalsite_enrollment_id
         data_type: string
@@ -13,3 +13,10 @@ models:
         data_tests:
           - unique
           - not_null
+      - name: focus_student_id_prefixed
+        data_type: string
+        description:
+          The 8400-prefixed Focus student id the `rpt_focus__*` extracts
+          consume, produced by the per-region package model. Null outside Miami,
+          which is what limits those extracts to Miami rows when they filter on
+          it being non-null.

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_course_section_teachers.sql
@@ -21,13 +21,12 @@
 -- teacher assigned in Focus at all, plus 13 whose user resolves to no staff
 -- roster row.
 with
-    -- The year boundary keeps the two branches disjoint. Miami's frozen
-    -- PowerSchool archive still holds sectionteacher rows through AY2025, and
-    -- those sections also carry a resolved teachernumber, so an unscoped Focus
-    -- branch would emit a duplicate Lead Teacher row for every archive
-    -- section. coalesce to 9999 fails toward emitting nothing rather than
-    -- duplicating, when int_focus__schedule is empty in an unbuilt --defer dev
-    -- copy.
+    -- The year boundary keeps the 2 branches disjoint. Miami's frozen
+    -- PowerSchool archive still holds `sectionteacher` rows through AY2025, and
+    -- those sections carry a resolved `teachernumber`, so an unscoped Focus
+    -- branch emits a duplicate Lead Teacher row for every archive section.
+    -- `coalesce` to 9999 fails toward emitting nothing rather than duplicating
+    -- when `int_focus__schedule` is empty in an unbuilt --defer dev copy.
     focus_academic_year_boundary as (
         select coalesce(min(academic_year), 9999) as min_academic_year,
         from {{ ref("int_focus__schedule") }}

--- a/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
+++ b/src/dbt/kipptaf/models/marts/bridges/bridge_student_contacts.sql
@@ -28,12 +28,12 @@ with
 
             {{ dbt_utils.generate_surrogate_key(["student_number"]) }} as student_key,
 
-            -- keyed identically to dim_student_contact_persons: parent slots
-            -- (contact_1/contact_2) by the person's real identity, emergency by
-            -- student + contact slot. Slots outside those two shapes (parent
-            -- slots past contact_2) are excluded in the `contacts` CTE above
-            -- for the same reason the dimension excludes them, so this key
-            -- can never orphan against dim_student_contact_persons.
+            -- Keyed identically to `dim_student_contact_persons`: parent slots
+            -- (`contact_1`, `contact_2`) by the person's real identity,
+            -- emergency by student plus contact slot. The `contacts` CTE above
+            -- excludes slots outside those 2 shapes, for the same reason the
+            -- dimension excludes them, so this key cannot orphan against
+            -- `dim_student_contact_persons`.
             if(
                 contact_slot in ('contact_1', 'contact_2'),
                 {{

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessment_administrations.sql
@@ -22,8 +22,7 @@ with
         cross join unnest(regions_array) as region
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State NJ PARCC: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_parcc_administrations as (
@@ -46,8 +45,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State NJ NJSLA: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_njsla_administrations as (
@@ -70,8 +68,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State NJ NJSLA Science: one administration per (testcode, period,
     -- academic_year, _dbt_source_project).
     state_nj_njsla_science_administrations as (
@@ -94,8 +91,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State NJ NJGPA: one administration per (testcode, period, academic_year,
     -- _dbt_source_project).
     state_nj_njgpa_administrations as (
@@ -118,8 +114,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State FL FAST: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_fast_administrations as (
@@ -142,8 +137,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State FL FSA: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_fsa_administrations as (
@@ -166,8 +160,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State FL EOC: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_eoc_administrations as (
@@ -190,8 +183,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- State FL Science: one administration per (test_code, administration_window,
     -- academic_year).
     state_fl_science_administrations as (
@@ -214,8 +206,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- iReady: one administration per (subject, test_round, academic_year,
     -- _dbt_source_project).
     iready_administrations as (
@@ -239,8 +230,7 @@ with
         where overall_scale_score is not null and _dbt_source_project is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- STAR: one administration per (star_subject, screening window,
     -- academic_year, _dbt_source_project).
     star_administrations as (
@@ -267,8 +257,7 @@ with
             and _dbt_source_project is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     -- DIBELS: one administration per (benchmark window, academic_year,
     -- _dbt_source_project); module_code is the Composite measure.
     dibels_administrations as (
@@ -294,8 +283,7 @@ with
     -- College Official: one administration per (score_type, test_date,
     -- administration_round). _dbt_source_project is null because college tests
     -- are region-agnostic.
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     college_administrations as (
         select distinct
             scope,
@@ -344,8 +332,7 @@ with
 
     -- AP: one administration per (subject, academic_year). Test date is
     -- not captured upstream.
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     ap_administrations as (
         select distinct
             title,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -308,12 +308,12 @@ with
         from {{ ref("int_assessments__college_assessment") }}
     ),
 
-    -- One row per (scope, subject_area) — matching Official college's
-    -- per-subject grain (Official uses score_type as module_code, e.g.,
-    -- 'sat_math'). Practice derives a parallel module_code by concatenating
-    -- scope and subject_area so SAT Math, SAT Reading, etc. each get their
-    -- own assessment_key.
     -- grain projection, not dup-masking
+    -- One row per (scope, subject_area), matching Official college's per-subject
+    -- grain, where Official uses `score_type` as `module_code` (for example
+    -- 'sat_math'). Practice derives a parallel `module_code` by concatenating
+    -- scope and subject area, so SAT Math and SAT Reading each get their own
+    -- `assessment_key`.
     practice_assessments as (
         select distinct
             scope,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_assessments.sql
@@ -29,8 +29,7 @@ with
         where m.is_internal_assessment
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_nj_parcc as (
         select distinct
             subject_area,
@@ -53,8 +52,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_nj_njsla as (
         select distinct
             subject_area,
@@ -77,8 +75,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_nj_njsla_science as (
         select distinct
             subject_area,
@@ -101,8 +98,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_nj_njgpa as (
         select distinct
             subject_area,
@@ -125,8 +121,7 @@ with
         where testscalescore is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_fl_fast as (
         select distinct
             assessment_subject as subject_area,
@@ -149,8 +144,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_fl_fsa as (
         select distinct
             assessment_subject as subject_area,
@@ -173,8 +167,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_fl_eoc as (
         select distinct
             assessment_subject as subject_area,
@@ -197,8 +190,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     state_fl_science as (
         select distinct
             assessment_subject as subject_area,
@@ -221,8 +213,7 @@ with
         where scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     iready_assessments as (
         select distinct
             subject as subject_area,
@@ -246,8 +237,7 @@ with
         where overall_scale_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     star_assessments as (
         select distinct
             star_subject as subject_area,
@@ -271,8 +261,7 @@ with
         where completed_date_value is not null and unified_score is not null
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     dibels_assessments as (
         select distinct
             measure_standard as module_code,
@@ -295,8 +284,7 @@ with
         where assessment_type = 'Benchmark' and measure_standard = 'Composite'
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     college_assessments as (
         select distinct
             scope as title,
@@ -325,8 +313,7 @@ with
     -- 'sat_math'). Practice derives a parallel module_code by concatenating
     -- scope and subject_area so SAT Math, SAT Reading, etc. each get their
     -- own assessment_key.
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     practice_assessments as (
         select distinct
             scope,
@@ -352,8 +339,7 @@ with
         from {{ ref("int_assessments__college_assessment_practice") }}
     ),
 
-    -- grain projection: every selected column is functionally determined
-    -- by the partition key; not a mask for upstream duplicates
+    -- grain projection, not dup-masking
     ap_assessments as (
         select distinct
             title,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_cube_access.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_cube_access.sql
@@ -101,11 +101,10 @@ with
     ),
 
     -- Rank the crosswalk role rows so a specific-entity match beats the 'any'
-    -- wildcard, then keep one per staff (role_picked). Prevents the fan-out when
-    -- the sheet carries both a wildcard and a specific row for one
-    -- job_function_code. Window rank as a named column, filtered in the next CTE
-    -- (no QUALIFY, per the SQL guide). A LEFT-join miss yields one null-role row
-    -- (role_rank 1) that coalesces to 'none' downstream.
+    -- wildcard, then keep 1 per staff member (`role_picked`). The rank prevents
+    -- a fan-out when the sheet carries both a wildcard and a specific row for
+    -- one `job_function_code`. A LEFT-join miss yields 1 null-role row at
+    -- `role_rank` 1, which coalesces to 'none' downstream.
     role_ranked as (
         select
             e.staff_key,

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_meal_eligibility_status.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_meal_eligibility_status.sql
@@ -30,12 +30,12 @@ with
 
             person_identifier as student_number,
 
-            -- Titan ships ~14-month annual windows that overlap at academic-year
-            -- boundaries (current year extends past Sept 30, next year begins
-            -- before Aug 1). Trim each row's end to day-before-next-row's-start
-            -- so cross-value transitions don't produce overlapping spans after
-            -- island collapse. Coalesce the open-ended sentinel so nj_leg can
-            -- use a plain max() without re-handling NULL.
+            -- Titan ships roughly 14-month annual windows that overlap at
+            -- academic-year boundaries: the current year extends past Sept 30,
+            -- and the next year begins before Aug 1. Trim each row's end to the
+            -- day before the next row's start, so cross-value transitions do
+            -- not produce overlapping spans after island collapse. Coalesce the
+            -- open-ended sentinel so `nj_leg` can use a plain `max()`.
             least(
                 coalesce(eligibility_end_date, cast('9999-12-31' as date)),
                 coalesce(

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_term.sql
@@ -76,13 +76,13 @@ select
 
     cast(fg.exclude_from_gpa as bool) as is_excluded_from_gpa,
 from {{ ref("int_students__final_grades") }} as fg
--- retained as a row-population filter (term grade must fall within a covering
--- school enrollment); enrollment linkage now flows via
--- student_section_enrollment_key -> dim_student_section_enrollments
--- joined on student_number, not studentid: the Focus branch has no PowerSchool
--- studentid, and student_number is the only student key both branches carry.
--- Row-identical to the studentid join for all 3 NJ regions, measured against
--- prod before the swap.
+-- Retained as a row-population filter: a term grade must fall within a covering
+-- school enrollment. Enrollment linkage now flows through
+-- `student_section_enrollment_key` to `dim_student_section_enrollments`, joined
+-- on `student_number` rather than `studentid`. The Focus branch has no
+-- PowerSchool `studentid`, and `student_number` is the only student key both
+-- branches carry. Measured against prod before the swap: row-identical to the
+-- `studentid` join for all 3 NJ regions.
 inner join
     student_enrollments as enr
     on fg.student_number = enr.student_number

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__ada_term.sql
@@ -26,13 +26,13 @@ with
             and calendardate <= current_date('{{ var("local_timezone") }}')
     ),
 
-    -- Keyed on student_number, not studentid: studentid is a PowerSchool-internal
-    -- id and is null for every Focus-sourced (Miami) row, so grouping on it
-    -- collapses every Miami Focus student into one meaningless aggregate row per
-    -- (kippmiami, academic_year, semester, term) -- SQL treats null as a single
-    -- group. studentid is carried through as max(studentid) so the NJ-only
-    -- downstream consumers that join on it keep working untouched; it stays null
-    -- for Focus rows, which is correct.
+    -- Keyed on `student_number`, not `studentid`. `studentid` is a
+    -- PowerSchool-internal id and is null for every Focus-sourced (Miami) row,
+    -- so grouping on it collapses every Miami Focus student into 1 meaningless
+    -- aggregate row per (kippmiami, `academic_year`, `semester`, `term`) — SQL
+    -- treats null as a single group. `studentid` still comes through as
+    -- `max(studentid)`, so the NJ-only downstream consumers that join on it keep
+    -- working. It stays null for Focus rows, which is correct.
     ada_by_term as (
         select
             _dbt_source_project,

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__u_expectations_qtd_unpivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__u_expectations_qtd_unpivot.sql
@@ -1,10 +1,7 @@
 with
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     term_weeks as (
-        /*
-        grain projection: every selected column is functionally determined
-        by the partition key; not a mask for upstream duplicates
-        */
+        -- grain projection, not dup-masking
         select distinct
             _dbt_source_project,
             region,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_daily.sql
@@ -61,12 +61,12 @@ with
             powerschool_deduped.*,
 
             -- PowerSchool has no analog to Focus's "register never taken"
-            -- signal -- every PowerSchool row IS a recorded attendance row
-            -- (PowerSchool records only absences, so presence is implied).
+            -- signal. Every PowerSchool row IS a recorded attendance row,
+            -- because PowerSchool records only absences and implies presence.
             -- False, not null: this column must never be null network-wide
             -- (see the model's grain/null-scaffold test), and null here would
-            -- misread as "unknown" when it is actually "not the Focus
-            -- recorded-register concept."
+            -- read as "unknown" when it actually means "not the Focus
+            -- recorded-register concept".
             false as is_attendance_recorded,
 
             -- Explicit, system-agnostic discriminator for the calcs CTE's
@@ -98,12 +98,12 @@ with
             true as is_focus_source,
 
             -- Carried through explicitly. Every downstream join keys on
-            -- _dbt_source_project, and student_enrollment_key hashes it, so
-            -- letting it null-fill through `full union all corresponding`
-            -- would break the Miami joins and mis-hash the key. The kipptaf
-            -- passthrough wrapper supplies both: union_relations adds
-            -- _dbt_source_relation and extract_source_project adds
-            -- _dbt_source_project.
+            -- `_dbt_source_project`, and `student_enrollment_key` hashes it,
+            -- so null-filling it through `full union all corresponding` breaks
+            -- the Miami joins and mis-hashes the key. The kipptaf passthrough
+            -- wrapper supplies both: `union_relations` adds
+            -- `_dbt_source_relation`, and `extract_source_project` adds
+            -- `_dbt_source_project`.
             ad._dbt_source_relation,
             ad._dbt_source_project,
 
@@ -237,11 +237,11 @@ with
             ) as is_absent_non_susp,
 
             -- A day that has actually occurred (<= today). The
-            -- membership_reg calendar join emits a row for every in-session
-            -- day in the enrollment span, including future year-end days;
-            -- point-in-time anchors must ignore those or they latch onto the
-            -- future last day of the year and collapse to zero once the fact
-            -- filters to calendardate <= current_date.
+            -- `membership_reg` calendar join emits a row for every in-session
+            -- day in the enrollment span, including future year-end days.
+            -- Point-in-time anchors must ignore those days, or they latch onto
+            -- the future last day of the year and collapse to zero once the
+            -- fact filters to `calendardate` <= `current_date`.
             mem.calendardate
             <= current_date('{{ var("local_timezone") }}') as is_realized,
 
@@ -286,12 +286,13 @@ with
                 partition by schoolid, _dbt_source_project, week_start_monday
             ) as is_enrollment_week_end_record,
 
-            -- Per-stint attendance anchors. Drive the student_attendance
-            -- Cube's latest / month-end / week-end CA snapshots. The stint is
-            -- (student_number, _dbt_source_project, academic_year,
-            -- entrydate) -- the natural key behind student_enrollment_key in
-            -- the fact. Latest is the stint's last realized day; month/week-
-            -- end are its last realized *membership* day in the period.
+            -- Per-stint attendance anchors. These drive the
+            -- `student_attendance` Cube's latest, month-end and week-end CA
+            -- snapshots. The stint is (`student_number`,
+            -- `_dbt_source_project`, `academic_year`, `entrydate`), the
+            -- natural key behind `student_enrollment_key` in the fact. Latest
+            -- is the stint's last realized day; month-end and week-end are its
+            -- last realized membership day in the period.
             calendardate = max(if(is_realized, calendardate, null)) over (
                 partition by
                     student_number, _dbt_source_project, academic_year, entrydate

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_streak.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__attendance_streak.sql
@@ -19,15 +19,15 @@ with
             )
     ),
 
-    -- int_focus__attendance_streak splits the district's overloaded att_code
-    -- into streak_type plus streak_value: a 'daily_code' family (the actual
-    -- Focus attendance code, null on a present day) and a 'state_value' family
-    -- (the stringified present/absent value). int_powerschool__attendance_streak
-    -- unions the same two families (a code streak plus an attendancevalue
-    -- streak), so both Focus families are kept, unfiltered, to reassemble the
-    -- same district shape. Reassemble the code family's district labeling: a
-    -- present streak has a null streak_value because daily_code is null on a
-    -- present day, and PowerSchool labels that same streak 'P'.
+    -- `int_focus__attendance_streak` splits the district's overloaded
+    -- `att_code` into `streak_type` plus `streak_value`. The 'daily_code'
+    -- family carries the actual Focus attendance code, which is null on a
+    -- present day. The 'state_value' family carries the stringified
+    -- present/absent value. `int_powerschool__attendance_streak` unions the
+    -- same 2 families, so both Focus families stay unfiltered here to
+    -- reassemble the same district shape. Reassemble the code family's district
+    -- labeling too: a present streak has a null `streak_value` because
+    -- `daily_code` is null on a present day, and PowerSchool labels it 'P'.
     focus_conformed as (
         select
             fa.student_number,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_day.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_day.sql
@@ -1,8 +1,8 @@
 with
-    -- Focus's school_id is its internal id (14, 15, 58...), not the network
-    -- school number, and it differs from the "school_number" the focus package
+    -- Focus's `school_id` is its internal id (14, 15, 58...), not the network
+    -- school number, and it differs from the `school_number` the focus package
     -- exposes (a Florida code like 2332A). Resolve through both hops. The inner
-    -- join is also the filter that drops Focus's three non-instructional schools
+    -- join is also the filter that drops Focus's 3 non-instructional schools
     -- (Applicants, Virtual Franchise, ZZ Course History), which have no
     -- locations row.
     focus_schools as (
@@ -22,12 +22,12 @@ with
         select focus_start_academic_year, from {{ ref("int_students__sis_cutover") }}
     ),
 
-    -- LEFT JOIN: stg_powerschool__terms only carries isyearrec = 1 windows, and
-    -- some real calendar days (mostly August pre-service dates, plus a 15-day
-    -- Paterson gap) fall outside every window. An INNER JOIN here silently
-    -- dropped those days from the model -- and from dim_school_calendars, which
-    -- reads this model directly. yearid is NULL for a day with no covering
-    -- term; nothing downstream requires it (or academic_year) to be non-null.
+    -- LEFT JOIN: `stg_powerschool__terms` carries only `isyearrec` = 1 windows,
+    -- and some real calendar days fall outside every window — mostly August
+    -- pre-service dates, plus a 15-day Paterson gap. An INNER JOIN silently
+    -- dropped those days from this model and from `dim_school_calendars`, which
+    -- reads it directly. `yearid` is null for a day with no covering term, and
+    -- nothing downstream requires it or `academic_year` to be non-null.
     powerschool_dated as (
         select
             cd._dbt_source_relation,
@@ -68,14 +68,14 @@ with
     ),
 
     -- The frozen PowerSchool archive keeps serving Miami for every year Focus
-    -- does not cover. Scoping by year rather than by project is what preserves
-    -- Miami AY2020 through AY2025. A no-term day is never dropped here, even
-    -- for Miami -- see is_focus_covered_year above.
+    -- does not cover. Scoping by year rather than by project preserves Miami
+    -- AY2020 through AY2025. A no-term day is never dropped here, even for
+    -- Miami — see `is_focus_covered_year` above.
     --
-    -- Dual-exposes the neutral (school_date, academic_year, is_in_session,
-    -- is_in_membership) alongside the legacy names (date_value, yearid,
-    -- insession, membershipvalue) that dim_school_calendars and the NJ-parity
-    -- gate read. See "Dual-exposed names" in the plan.
+    -- Dual-exposes the neutral names (`school_date`, `academic_year`,
+    -- `is_in_session`, `is_in_membership`) alongside the legacy names
+    -- (`date_value`, `yearid`, `insession`, `membershipvalue`) that
+    -- `dim_school_calendars` and the NJ-parity gate read.
     powerschool_conformed as (
         select
             _dbt_source_relation,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_rollup.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_rollup.sql
@@ -17,11 +17,11 @@ with
     ),
 
     -- The frozen PowerSchool archive keeps serving Miami for every year Focus
-    -- does not cover. Scoping by year rather than by project is what preserves
-    -- Miami AY2020 through AY2025. Star qualified to the aliased relation --
-    -- an unqualified `select *,` would leak the cross-joined cutover CTE's
-    -- focus_start_academic_year into the output via `full union all
-    -- corresponding` null-filling it on the focus_conformed side.
+    -- does not cover. Scoping by year rather than by project preserves Miami
+    -- AY2020 through AY2025. The star is qualified to the aliased relation: an
+    -- unqualified `select *,` leaks the cross-joined cutover CTE's
+    -- `focus_start_academic_year` into the output, because `full union all
+    -- corresponding` null-fills it on the `focus_conformed` side.
     powerschool_conformed as (
         select cr.*,
         from {{ ref("int_powerschool__calendar_rollup") }} as cr

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__contacts.sql
@@ -33,19 +33,19 @@ with
     ),
 
     -- Miami Focus branch, replacing the branch that read the frozen
-    -- pre-migration kippmiami_powerschool snapshot. Focus stores the KIPP
-    -- student number 8400-prefixed in local_student_id, so student_number is
-    -- derived by stripping that prefix rather than crosswalked -- the network
+    -- pre-migration `kippmiami_powerschool` snapshot. Focus stores the KIPP
+    -- student number 8400-prefixed in `local_student_id`, so `student_number`
+    -- is derived by stripping that prefix rather than crosswalked. The network
     -- has always keyed Miami students on the unprefixed number, and
-    -- dim_students.student_key hashes it. Strip on the literal prefix rather
-    -- than positionally: one id carries no 8400 at all, and dropping its first
-    -- four characters yields a number matching no student, silently losing
-    -- that student's contacts. Deriving beats
-    -- joining int_finalsite__contact_id_attributes on
-    -- focus_student_id_prefixed: its powerschool_student_number agrees with the
-    -- stripped value wherever it is populated, but it is null for every
-    -- Focus-native student (no pre-migration PowerSchool record), so the join
-    -- would silently drop most of Miami.
+    -- `dim_students.student_key` hashes it. Strip on the literal prefix rather
+    -- than positionally: 1 id carries no 8400 at all, and dropping its first 4
+    -- characters yields a number matching no student, which silently loses that
+    -- student's contacts. Deriving also beats joining
+    -- `int_finalsite__contact_id_attributes` on `focus_student_id_prefixed`.
+    -- Its `powerschool_student_number` agrees with the stripped value wherever
+    -- it is populated, but it is null for every Focus-native student, who has
+    -- no pre-migration PowerSchool record, so that join would silently drop
+    -- most of Miami.
     focus_base as (
         select
             student_id,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
@@ -1,14 +1,9 @@
 with
-    -- Focus is Miami's system of record from AY2026 forward, but the frozen
-    -- archive still holds Miami AY2020 through AY2025. Scope by year rather
-    -- than excluding Miami wholesale, and derive the boundary so a Focus
-    -- backfill of an earlier year does not silently double-count.
-    -- coalesce guards against an empty int_focus__schedule (e.g. an unbuilt
-    -- --defer dev copy): min(academic_year) with no rows is NULL, and NULL >=
-    -- fay.min_academic_year evaluates to NULL rather than false below, so
-    -- `not (...)` also evaluates to NULL and the WHERE filter drops every
-    -- Miami row instead of keeping the archive. 9999 fails toward preserving
-    -- the data that exists.
+    -- coalesce guards an empty int_focus__schedule (an unbuilt --defer dev
+    -- copy): min(academic_year) over no rows is NULL, and NULL >=
+    -- fay.min_academic_year evaluates to NULL rather than false, so `not (...)`
+    -- is NULL too and the WHERE filter drops every Miami row instead of keeping
+    -- the archive. 9999 fails toward preserving the data that exists.
     focus_academic_year_boundary as (
         select coalesce(min(academic_year), 9999) as min_academic_year,
         from {{ ref("int_focus__schedule") }}

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_sections.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_sections.sql
@@ -1,14 +1,9 @@
 with
-    -- Focus is Miami's system of record from AY2026 forward, but the frozen
-    -- archive still holds Miami AY2020 through AY2025. Scope by year rather
-    -- than excluding Miami wholesale, and derive the boundary so a Focus
-    -- backfill of an earlier year does not silently double-count.
-    -- coalesce guards against an empty int_focus__schedule (e.g. an unbuilt
-    -- --defer dev copy): min(academic_year) with no rows is NULL, and NULL >=
-    -- fay.min_academic_year evaluates to NULL rather than false below, so
-    -- `not (...)` also evaluates to NULL and the WHERE filter drops every
-    -- Miami row instead of keeping the archive. 9999 fails toward preserving
-    -- the data that exists.
+    -- coalesce guards an empty int_focus__schedule (an unbuilt --defer dev
+    -- copy): min(academic_year) over no rows is NULL, and NULL >=
+    -- fay.min_academic_year evaluates to NULL rather than false, so `not (...)`
+    -- is NULL too and the WHERE filter drops every Miami row instead of keeping
+    -- the archive. 9999 fails toward preserving the data that exists.
     focus_academic_year_boundary as (
         select coalesce(min(academic_year), 9999) as min_academic_year,
         from {{ ref("int_focus__schedule") }}

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__final_grades.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__final_grades.sql
@@ -123,10 +123,10 @@ with
         -- Imported course history predates the Focus cutover and overlaps the
         -- frozen PowerSchool archive for the years the archive covers. The
         -- archive branch above already owns those years, so admit only rows at
-        -- or after the cutover -- the same boundary, applied from the other side.
-        -- It also carries an invariant the schedule join depends on: every
-        -- course-history row has a null course_period_id (15,278 of 15,278) and
-        -- would drop out of that inner join anyway.
+        -- or after the cutover — the same boundary, applied from the other
+        -- side. Course history also carries an invariant the schedule join
+        -- depends on: every row has a null `course_period_id` (15,278 of
+        -- 15,278) and drops out of that inner join anyway.
         cross join sis_cutover as sc
         where g.academic_year >= sc.focus_start_academic_year
     )

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__fldoe_fte.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__fldoe_fte.sql
@@ -1,12 +1,12 @@
 with
-    -- Keyed on student_number, not studentid: studentid is a PowerSchool-
-    -- internal id and is null for every Focus-sourced (Miami) row, so
-    -- grouping on it collapses every Miami student into one meaningless
-    -- aggregate row per (yearid, fte_survey) -- SQL treats null as a single
+    -- Keyed on `student_number`, not `studentid`. `studentid` is a
+    -- PowerSchool-internal id and is null for every Focus-sourced (Miami) row,
+    -- so grouping on it collapses every Miami student into 1 meaningless
+    -- aggregate row per (`yearid`, `fte_survey`) — SQL treats null as a single
     -- group. This model is Miami-only, so every input row is Focus-sourced.
-    -- studentid is carried through as max(studentid) so nothing reading the
-    -- old column breaks; it stays null here since Miami has no PowerSchool
-    -- studentid.
+    -- `studentid` still comes through as `max(studentid)`, so nothing reading
+    -- the old column breaks. It stays null here, because Miami has no
+    -- PowerSchool `studentid`.
     ada_group as (
         select
             att._dbt_source_relation,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__sis_cutover.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__sis_cutover.sql
@@ -1,17 +1,12 @@
--- Miami left PowerSchool for Focus at the start of AY2026: Miami's PowerSchool
--- attendance stops at AY2025 and Focus's begins at AY2026, with no overlap. Every
--- int_students__* conform splits Miami on this boundary, so it is derived once here
--- rather than five times -- and derived from data rather than hardcoded to 2026.
+-- Recorded attendance, not row presence. int_focus__attendance_daily scaffolds a
+-- present-by-default row for every enrolled student-day back to AY2020, so row
+-- presence spans AY2020 to AY2026 while Focus holds real attendance for AY2026
+-- only. Presence would replace 6 years of real PowerSchool attendance with
+-- fabricated perfect attendance.
 --
--- Derived from RECORDED attendance, not from row presence. int_focus__attendance_daily
--- scaffolds a present-by-default row for every enrolled student-day back to AY2020, so
--- "years with Focus rows" spans AY2020 to AY2026 while Focus holds real attendance for
--- AY2026 only. Deriving from presence would replace six years of real PowerSchool
--- attendance with fabricated perfect attendance.
---
--- A floor, not a set: `min` cannot punch a hole mid-history the way `in (select ...)`
--- can. A Focus year that happened to record no exceptions would otherwise fall back to
--- a PowerSchool archive that holds nothing for it.
+-- A floor, not a set: `min` cannot punch a hole mid-history the way
+-- `in (select ...)` can. A Focus year that recorded no exceptions would fall
+-- back to a PowerSchool archive that holds nothing for it.
 select min(academic_year) as focus_start_academic_year,
 from {{ ref("int_focus__attendance_daily") }}
 where is_attendance_recorded

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
@@ -1,19 +1,4 @@
 with
-    -- The upstream student_number holds the PREFIXED Focus id, not the network
-    -- student number, so it is unprefixed here with the same rule
-    -- int_students__students applies to the student spine. ps_schoolid is the
-    -- PowerSchool-aligned school id the upstream already resolved through the
-    -- locations crosswalk -- Focus's own schoolid is a small internal integer
-    -- with no relation to the network school number.
-    --
-    -- Every Focus year is admitted, back to AY2018. Focus dates a returning
-    -- student's stint to the real first day of school where PowerSchool used a
-    -- July 1 administrative rollover, so 1,421 of Miami's 8,776 historical
-    -- stints carry a different entrydate than the archive did -- concentrated
-    -- in AY2021 (304) and AY2025 (973). entrydate feeds student_enrollment_key,
-    -- so those keys are recomposed rather than preserved. That is deliberate:
-    -- Focus is the system of record, and the archive's dates are not worth
-    -- keeping the archive branch alive for.
     focus_conformed as (
         select
             _dbt_source_relation,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__teacher_grade_levels.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__teacher_grade_levels.sql
@@ -25,13 +25,13 @@ with
             and ct.syear = s.academic_year
     ),
 
-    -- Focus staff ids are not network teacher/employee numbers. Staff Number
-    -- Identifier, Local (a populated custom field on the Focus user) carries
-    -- the network employee_number as a string -- verified against prod: every
+    -- Focus staff ids are not network teacher or employee numbers. Staff Number
+    -- Identifier, Local — a populated custom field on the Focus user — carries
+    -- the network `employee_number` as a string. Verified against prod: every
     -- non-null AY2026 lead-teacher id (77 of 77) and co-teacher id (21 of 21)
-    -- resolves to a kippmiami roster employee_number through this field. ein
-    -- (Focus's own EIN field) resolves fewer of the same ids and never
-    -- disagrees where both are populated, so this field is preferred.
+    -- resolves to a kippmiami roster `employee_number` through this field. The
+    -- `ein` field resolves fewer of the same ids and never disagrees where both
+    -- are populated, so this field wins.
     identified as (
         select
             ts.student_id,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__terms.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__terms.sql
@@ -24,13 +24,12 @@ with
             fs.schoolid,
         from {{ ref("stg_focus__marking_periods") }} as mp
         inner join focus_schools as fs on mp.school_id = fs.focus_school_id
-        -- Progress periods have no PowerSchool terms equivalent. The 2018
+        -- Progress periods have no PowerSchool `terms` equivalent. The 2018
         -- floor is Miami's first school year: Focus carries a full
-        -- year/semester/quarter set for two schools in every syear back to
-        -- 1980, which would fabricate history here. Both filters stay in this
-        -- model rather than in staging -- 321 report card grade rows point at
-        -- pre-2018 marking periods, so flooring the staging model orphans
-        -- them.
+        -- year/semester/quarter set for 2 schools in every syear back to 1980,
+        -- which would fabricate history here. Both filters stay in this model
+        -- rather than in staging, because 321 report card grade rows point at
+        -- pre-2018 marking periods and flooring the staging model orphans them.
         where mp.type in ('year', 'semester', 'quarter') and mp.syear >= 2018
     ),
 
@@ -73,14 +72,14 @@ with
         from {{ ref("int_powerschool__terms") }}
     ),
 
-    -- A small number of historical quarters (a handful of non-instructional
-    -- schoolids, mostly pre-2018) exist in int_powerschool__terms via its
-    -- termbins join but have no corresponding Q1-Q4 row in the raw terms
-    -- table at all -- verified against prod (kippnewark/kippcamden schoolids
+    -- A small number of historical quarters exist in `int_powerschool__terms`
+    -- via its `termbins` join but have no corresponding Q1-Q4 row in the raw
+    -- `terms` table — a handful of non-instructional schoolids, mostly
+    -- pre-2018, verified against prod (kippnewark and kippcamden schoolids
     -- 73252, 73253, 133570965, 179902). A left join from the raw side would
-    -- silently drop those quarters' dates entirely. Full join instead, so an
-    -- unmatched quarter survives as its own row (every raw-only column
-    -- null-fills, matching a row Focus never carried).
+    -- silently drop those quarters' dates. Full join instead, so an unmatched
+    -- quarter survives as its own row and every raw-only column null-fills,
+    -- which matches a row Focus never carried.
     powerschool_joined as (
         select
             p.* except (

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -5,8 +5,11 @@ models:
       in one section. Unions the four PowerSchool district
       `base_powerschool__course_enrollments` sources with Miami's Focus
       schedule, conformed inline to the PowerSchool column vocabulary. The Miami
-      PowerSchool branch is scoped to years before Focus coverage begins.
-      Replaces `base_powerschool__course_enrollments` as the canonical
+      PowerSchool branch is scoped to years before Focus coverage begins, so the
+      frozen archive keeps serving Miami AY2020 through AY2025. The boundary is
+      derived from the Focus schedule rather than hardcoded, so a Focus backfill
+      of an earlier year moves it instead of double-counting that year. Replaces
+      `base_powerschool__course_enrollments` as the canonical
       course-enrollment-grain source.
     config:
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_sections.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_sections.yml
@@ -6,8 +6,10 @@ models:
       sources with Miami's Focus course periods, conformed inline to the
       PowerSchool column vocabulary. The Miami PowerSchool branch is scoped to
       years before Focus coverage begins, so the frozen archive keeps serving
-      Miami AY2020 through AY2025. Replaces `base_powerschool__sections` as the
-      canonical section-grain source.
+      The boundary is derived from the Focus schedule rather than hardcoded, so
+      a Focus backfill of an earlier year moves it instead of double-counting
+      that year. Replaces `base_powerschool__sections` as the canonical
+      section-grain source.
     config:
       materialized: table
     data_tests:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_sections.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_sections.yml
@@ -6,10 +6,10 @@ models:
       sources with Miami's Focus course periods, conformed inline to the
       PowerSchool column vocabulary. The Miami PowerSchool branch is scoped to
       years before Focus coverage begins, so the frozen archive keeps serving
-      The boundary is derived from the Focus schedule rather than hardcoded, so
-      a Focus backfill of an earlier year moves it instead of double-counting
-      that year. Replaces `base_powerschool__sections` as the canonical
-      section-grain source.
+      Miami AY2020 through AY2025. The boundary is derived from the Focus
+      schedule rather than hardcoded, so a Focus backfill of an earlier year
+      moves it instead of double-counting that year. Replaces
+      `base_powerschool__sections` as the canonical section-grain source.
     config:
       materialized: table
     data_tests:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." move model-level explanations out of
inline SQL comments and into the properties files that already own them, and
rewrite the comments that stay so each one reads in a single pass.

A sweep of every `.sql` file in `src/dbt/` found 295 multi-line comment blocks
across 122 model files. Three groups came out of it:

1. 12 blocks explained what or why a model computes, with nothing about the
   line they sat above. Most of that text was already word-for-word in the
   model or column `description:`. Those blocks are gone, and the few facts
   that were missing moved into the description.
2. 46 blocks did explain their own line, but ran 6 to 14 lines. Those are
   rewritten: one idea per sentence, active voice, identifiers in backticks.
3. 30 copies of the same 2-line `grain projection` annotation are now the
   1-line `grain projection, not dup-masking`. The annotation still tells a
   reviewer the `DISTINCT` is deliberate. Only the restated convention text is
   gone, and the SQL guide now asks for the short form.

Two stale comments went with them: one that told CI to rebuild a model for a
pull request that merged long ago, and one that pointed at a plan document.

## Reviewer Notes

- `int_finalsite__contact_id_attributes.yml` said the model was enabled for
  Miami only. The union has read all 4 regions for a while, so the description
  was wrong, not just thin. Fixed here.
- `int_students__course_enrollments` and `int_students__course_sections`
  carried the same 10-line block, character for character. Duplicated prose is
  the clearest sign it belongs in metadata, so it moved.
- No SQL logic changed anywhere in this pull request. Every edit is a comment
  or a description.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; 4 existing properties files gained text.
- [x] Include (or update) an exposure — no model outputs changed.
- [x] **Breaking change?** No. No column or model was renamed or removed.
- [x] If adding or modifying an external source — none touched.

## CI checks

- [x] **Trunk** — `trunk check --force` over the full branch diff: 49 files
      checked, 2 pre-existing issues, no new issues.
- [x] **dbt Cloud** — run 70403222459612 succeeded with 0 warnings.
- [x] **Dagster Cloud** — not triggered; no Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The sweep classified comment blocks by whether
they explain the line they sit on or the model as a whole, per the rule at
`src/dbt/CLAUDE.md`.

Verification: `dbt deps` plus `dbt parse` on `kipptaf`, `kippmiami` and
`kippnewark` — the projects that consume the changed `focus` and `finalsite`
packages — all parse clean. `trunk check --force` over the 32 changed files
reports 1 pre-existing issue and no new ones.

Deliberately left alone: 144 single-line comments, which already read as
line-local notes; the 25 long blocks in `tests/` and 8 in `analyses/`, since
`analyses/` has no properties surface and singular tests carry only 36
`description:` entries repo-wide; and 18 `grain projection` comments that name
their actual partition key, which are more informative than the generic form
and stay as they are.

The `DISTINCT` rule in `src/dbt/CLAUDE.md` previously mandated the exact 2-line
wording. It now mandates `grain projection, not dup-masking` and says why the
annotation is required, so a future reviewer does not read the shorter comment
as an omission.
</details>

