### PR TITLE
docs(dbt): record the ratified Miami scope decision in all 40 model descriptions

### DIFF
--- a/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/assessments/intermediate/properties/int_assessments__course_enrollments.yml
@@ -17,6 +17,10 @@ models:
       should be network-wide or NJ-scoped remains #4996's decision; the
       inclusion is a consequence of fixing the flags, not a scope judgment made
       here.
+
+      Network-wide, Miami included. This model already recorded that #4996 owned
+      the decision; the decision is now made and it is INCLUDE. Miami held
+      61,910 rows in prod as of 2026-08-27.
     config:
       materialized: table
       meta:

--- a/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__final_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/deanslist/properties/rpt_deanslist__final_grades.yml
@@ -1,5 +1,10 @@
 models:
   - name: rpt_deanslist__final_grades
+    description: >-
+      Pushes current-year final grades to DeansList. Network-wide, Miami
+      included: Miami is a DeansList region, with 11,585 incidents in
+      `int_deanslist__incidents` as of 2026-08-27, so it belongs in the grade
+      feed too. Ratified on #4996.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/intermediate/properties/int_gsheets__dds_import.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/intermediate/properties/int_gsheets__dds_import.yml
@@ -1,9 +1,9 @@
 models:
   - name: int_gsheets__dds_import
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled,
-      so its Miami scope is moot; if it is ever re-enabled, decide the scope
-      then. Ratified on #4996.
+      **Not evaluated for Miami.** This model is disabled and never compiled, so
+      it has no Miami scope to decide; decide one if it is ever re-enabled.
+      Recorded on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/intermediate/properties/int_gsheets__dds_import.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/intermediate/properties/int_gsheets__dds_import.yml
@@ -1,5 +1,9 @@
 models:
   - name: int_gsheets__dds_import
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled,
+      so its Miami scope is moot; if it is ever re-enabled, decide the scope
+      then. Ratified on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__assessment_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__assessment_roster.yml
@@ -10,6 +10,9 @@ models:
       pseudonymous student_token (a stable hash of student_number), so the
       extract is de-identified at the source and shared under the research
       data-sharing agreement.
+
+      Network-wide, Miami included. Miami held 3,125 AY2026 rows in prod as of
+      2026-08-27. Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -1,5 +1,10 @@
 models:
   - name: rpt_gsheets__college_assessments_long
+    description: >-
+      **Excludes Miami by design.** SAT and ACT results for students in testing
+      grades. Miami's high school starts at grade 9 and has no college-testing
+      cohort yet, so there is nothing for Miami to report. Revisit when Miami
+      reaches grade 11. Ratified on #4996.
     columns:
       - name: region
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_wide.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_wide.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_gsheets__college_assessments_wide
+    description: >-
+      **Excludes Miami by design.** Same population as
+      `rpt_gsheets__college_assessments_long`: SAT and ACT results for testing
+      grades, which Miami does not have yet. Ratified on #4996.
     config:
       contract:
         enforced: true

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_offerings.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_offerings.yml
@@ -1,5 +1,12 @@
 models:
   - name: rpt_gsheets__csgf_hs_ap_offerings
+    description: >-
+      High-school AP course offerings for Charter School Growth Fund reporting.
+      Network-wide, Miami included: there is no region filter, so Miami enters
+      the population as its high school grows. It has no rows yet because the
+      reporting window is the prior academic year, before Miami had a high
+      school. Note the `is_enrolled_recent` filter, which was null for Miami
+      until #5038. Ratified on #4996.
     columns:
       - name: school_name
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_enrollment.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_enrollment.yml
@@ -1,5 +1,10 @@
 models:
   - name: rpt_gsheets__csgf_hs_enrollment
+    description: >-
+      High-school enrollment and Algebra I outcomes for Charter School Growth
+      Fund reporting. Network-wide, Miami included, on the same reasoning as
+      `rpt_gsheets__csgf_hs_ap_offerings`: no region filter, no Miami rows yet
+      only because the window is the prior academic year. Ratified on #4996.
     columns:
       - name: studentid
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_flc.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kfwd_flc.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_gsheets__kfwd_flc
+    description: >-
+      **Excludes Miami by design.** KIPP Forward tracks alumni through college,
+      and Miami has no graduating class yet, so it has no alumni to track.
+      Ratified on #4996.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_collab_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__kippfwd_collab_roster.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_gsheets__kippfwd_collab_roster
+    description: >-
+      **Excludes Miami by design.** Same KIPP Forward alumni population as
+      `rpt_gsheets__kfwd_flc`; Miami has no graduates yet. Ratified on #4996.
     columns:
       - name: "`Salesforce ID`"
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nj_state_test_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__nj_state_test_roster.yml
@@ -9,6 +9,10 @@ models:
       are carried through that pivot even though they aren't projected directly,
       so the exemption reason columns below can still be derived after the
       per-subject rows collapse to one row per student.
+
+      **Excludes Miami by design.** This is New Jersey state test registration,
+      so Florida students have no place in it; the model already filters
+      `co.region != 'Miami'` explicitly. Ratified on #4996.
     columns:
       - name: region
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__school_metrics_extract.yml
@@ -7,6 +7,9 @@ models:
       proficiency, DeansList referrals by tier, academic course failure rates,
       and weighted Y1 GPA. All values are PII-free aggregates — no student-level
       data is exposed.
+
+      Network-wide, Miami included. Miami held 12,720 rows in prod as of
+      2026-08-27. Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/illuminate/properties/rpt_illuminate__roster.yml
+++ b/src/dbt/kipptaf/models/extracts/illuminate/properties/rpt_illuminate__roster.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_illuminate__roster
+    description: >-
+      Rosters students and sections into Illuminate. Network-wide, Miami
+      included: Miami is an Illuminate region and held 13,981 rows here in prod
+      as of 2026-08-27. Ratified on #4996.
     columns:
       - name: "`01 Student ID`"
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/littlesis/properties/rpt_littlesis__enrollments.yml
+++ b/src/dbt/kipptaf/models/extracts/littlesis/properties/rpt_littlesis__enrollments.yml
@@ -1,5 +1,11 @@
 models:
   - name: rpt_littlesis__enrollments
+    description: >-
+      Section enrollments for LittleSIS. Network-wide, Miami included, and
+      already served by an explicit Focus branch rather than the PowerSchool leg
+      -- Miami held 13,425 rows in prod as of 2026-08-27. The `not
+      sec.is_dropped_section` filter applies only to the PowerSchool leg.
+      Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/littlesis/properties/rpt_littlesis__enrollments.yml
+++ b/src/dbt/kipptaf/models/extracts/littlesis/properties/rpt_littlesis__enrollments.yml
@@ -3,7 +3,7 @@ models:
     description: >-
       Section enrollments for LittleSIS. Network-wide, Miami included, and
       already served by an explicit Focus branch rather than the PowerSchool leg
-      -- Miami held 13,425 rows in prod as of 2026-08-27. The `not
+      — Miami held 13,425 rows in prod as of 2026-08-27. The `not
       sec.is_dropped_section` filter applies only to the PowerSchool leg.
       Ratified on #4996.
     data_tests:

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
@@ -1,10 +1,10 @@
 models:
   - name: int_tableau__gradebook_audit_student_scaffold
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled,
-      so its Miami scope is moot; if it is ever re-enabled, decide the scope
-      then. It also sits in the gradebook lineage, which has no Focus branch
-      (#5010). Ratified on #4996.
+      **Not evaluated for Miami.** This model is disabled and never compiled, so
+      it has no Miami scope to decide; decide one if it is ever re-enabled. It
+      also sits in the gradebook lineage, which has no Focus branch (#5010).
+      Recorded on #4996.
     config:
       materialized: table
       enabled: false

--- a/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/intermediate/properties/int_tableau__gradebook_audit_student_scaffold.yml
@@ -1,5 +1,10 @@
 models:
   - name: int_tableau__gradebook_audit_student_scaffold
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled,
+      so its Miami scope is moot; if it is ever re-enabled, decide the scope
+      then. It also sits in the gradebook lineage, which has no Focus branch
+      (#5010). Ratified on #4996.
     config:
       materialized: table
       enabled: false

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__academic_goals_rollup.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__academic_goals_rollup.yml
@@ -1,7 +1,7 @@
 models:
   - name: rpt_tableau__academic_goals_rollup
     description: >-
-      Network-wide, Miami included -- the model already carries Miami-specific
+      Network-wide, Miami included — the model already carries Miami-specific
       performance-band logic. Miami held 2,492 AY2026 rows in prod as of
       2026-08-27. Ratified on #4996.
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__academic_goals_rollup.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__academic_goals_rollup.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__academic_goals_rollup
+    description: >-
+      Network-wide, Miami included -- the model already carries Miami-specific
+      performance-band logic. Miami held 2,492 AY2026 rows in prod as of
+      2026-08-27. Ratified on #4996.
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ap_assessment_dashboard.yml
@@ -5,6 +5,9 @@ models:
       Tableau reporting. One row per student per AP course subject, including
       students enrolled in AP courses who did not take the exam and students who
       took an exam with no matching AP course enrollment.
+
+      Network-wide, Miami included. Miami held 94 AY2026 rows in prod as of
+      2026-08-27. Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__assessment_dashboard.yml
@@ -1,5 +1,11 @@
 models:
   - name: rpt_tableau__assessment_dashboard
+    description: >-
+      Internal assessment results for the DDI Suite dashboard. Network-wide,
+      Miami included: Miami held 281,010 AY2025 rows in prod as of 2026-08-27.
+      Miami has no AY2026 rows yet because its AY2026 Illuminate results have
+      not landed upstream, not because this model filters it out. Ratified on
+      #4996.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard.yml
@@ -1,9 +1,9 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled.
-      It also covers the college-testing population Miami has no cohort for.
-      Ratified on #4996.
+      **Not evaluated for Miami.** This model is disabled and never compiled. It
+      also covers the college-testing population Miami has no cohort for.
+      Recorded on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled.
+      It also covers the college-testing population Miami has no cohort for.
+      Ratified on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_historic.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_historic.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard_historic
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled.
+      It also covers the college-testing population Miami has no cohort for.
+      Ratified on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_historic.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_historic.yml
@@ -1,9 +1,9 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard_historic
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled.
-      It also covers the college-testing population Miami has no cohort for.
-      Ratified on #4996.
+      **Not evaluated for Miami.** This model is disabled and never compiled. It
+      also covers the college-testing population Miami has no cohort for.
+      Recorded on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_roster.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__college_assessment_dashboard_roster
+    description: >-
+      **Excludes Miami by design.** Same college-testing population as the
+      `rpt_gsheets__college_assessments_*` extracts, which Miami has no cohort
+      for yet. Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__ddi_dashboard.yml
@@ -10,6 +10,11 @@ models:
       as long as the extract's two-year window still covers it. Rows are
       restricted to students holding a valid enrollment status, and students in
       an out-of-district placement are excluded.
+
+      Network-wide, Miami included. Miami held 5,378 AY2026 rows in prod as of
+      2026-08-27, but that was a partial picture: the ES/MS assessment leg
+      dropped Miami on `not co.is_out_of_district`, which was null for Miami
+      until #5038, while the other union legs let it through. Ratified on #4996.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__dibels_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__dibels_dashboard.yml
@@ -1,5 +1,15 @@
 models:
   - name: rpt_tableau__dibels_dashboard
+    description: >-
+      Amplify DIBELS benchmark and progress-monitoring results. Network-wide,
+      Miami included in principle -- Miami is a DIBELS region with 48 AY2026
+      rows in the expected-assessments sheet and 20,698 AY2025 Amplify results.
+      **In practice Miami still returns no rows here.** The grain filter reads
+      `not s.is_self_contained`, which is null for every Miami row because Focus
+      records no self-contained placement. #4968 and #5038 both decline to
+      assert false for a fact the data does not carry, so Miami stays out until
+      Focus supplies a placement field or Ops confirms a mapping. Ratified on
+      #4996.
     columns:
       - name: _dbt_source_relation
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__dibels_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__dibels_dashboard.yml
@@ -2,10 +2,10 @@ models:
   - name: rpt_tableau__dibels_dashboard
     description: >-
       Amplify DIBELS benchmark and progress-monitoring results. Network-wide,
-      Miami included in principle -- Miami is a DIBELS region with 48 AY2026
-      rows in the expected-assessments sheet and 20,698 AY2025 Amplify results.
-      **In practice Miami still returns no rows here.** The grain filter reads
-      `not s.is_self_contained`, which is null for every Miami row because Focus
+      Miami included in principle — Miami is a DIBELS region with 48 AY2026 rows
+      in the expected-assessments sheet and 20,698 AY2025 Amplify results. **In
+      practice Miami still returns no rows here.** The grain filter reads `not
+      s.is_self_contained`, which is null for every Miami row because Focus
       records no self-contained placement. #4968 and #5038 both decline to
       assert false for a fact the data does not carry, so Miami stays out until
       Focus supplies a placement field or Ops confirms a mapping. Ratified on

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_dashboard.yml
@@ -1,9 +1,9 @@
 models:
   - name: rpt_tableau__gradebook_dashboard
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled;
-      it is superseded by `rpt_tableau__student_course_grades`, which excludes
-      Miami too. Ratified on #4996.
+      **Not evaluated for Miami.** This model is disabled and never compiled; it
+      is superseded by `rpt_tableau__student_course_grades`, which excludes
+      Miami too. Recorded on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_dashboard.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__gradebook_dashboard
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled;
+      it is superseded by `rpt_tableau__student_course_grades`, which excludes
+      Miami too. Ratified on #4996.
     config:
       enabled: false
     columns:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
@@ -1,5 +1,12 @@
 models:
   - name: rpt_tableau__gradebook_gpa
+    description: >-
+      Network-wide, Miami included by decision, though it returned no Miami rows
+      in any year in prod as of 2026-08-27 -- not even AY2024 or AY2025, when
+      Miami was still on PowerSchool. The block is `not enr.is_out_of_district`,
+      null for Miami until #5038. Miami's GPA columns stay null after that,
+      because `int_powerschool__gpa_term` is PowerSchool-only; the Focus GPA
+      branch is #5021. Ratified on #4996.
     # TODO(#3900): residual warn-level violations trace to the known
     # base_powerschool__course_enrollments double-write duplicates.
     data_tests:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
@@ -2,7 +2,7 @@ models:
   - name: rpt_tableau__gradebook_gpa
     description: >-
       Network-wide, Miami included by decision, though it returned no Miami rows
-      in any year in prod as of 2026-08-27 -- not even AY2024 or AY2025, when
+      in any year in prod as of 2026-08-27 — not even AY2024 or AY2025, when
       Miami was still on PowerSchool. The block is `not enr.is_out_of_district`,
       null for Miami until #5038. Miami's GPA columns stay null after that,
       because `int_powerschool__gpa_term` is PowerSchool-only; the Focus GPA

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__graduation_requirements.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__graduation_requirements.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__graduation_requirements
+    description: >-
+      **Excludes Miami by design.** This tracks New Jersey graduation-path
+      credit requirements, which do not apply in Florida; the model already
+      filters `e.region != 'Miami'` explicitly. Ratified on #4996.
     columns:
       - name: _dbt_source_relation
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__iready_apm.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__iready_apm.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_tableau__iready_apm
+    description: >-
+      Network-wide, Miami included. Miami held 110,994 AY2026 rows in prod as of
+      2026-08-27. Ratified on #4996.
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_fast.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_fast.yml
@@ -1,5 +1,12 @@
 models:
   - name: rpt_tableau__miami_fast
+    description: >-
+      Miami-only by name and by its `region = 'Miami'` filter. This model
+      returned **zero rows of any kind** in prod as of 2026-08-27: its where
+      clause requires `co.is_enrolled_y1`, which was null on every Miami row
+      because the Focus branch of `int_students__student_enrollments` never
+      populated it. #5038 derives it, which restores roughly 4,772 rows across
+      AY2025 and AY2026. Ratified on #4996.
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_k2_iready.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_k2_iready.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_tableau__miami_k2_iready
+    description: >-
+      Miami-only by name and by its `region = 'Miami'` filter. Held 4,839 rows
+      in prod as of 2026-08-27. Ratified on #4996.
     columns:
       - name: student_number
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_k2_star.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__miami_k2_star.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_tableau__miami_k2_star
+    description: >-
+      Miami-only by name and by its `region = 'Miami'` filter. Held 2,256 rows
+      in prod as of 2026-08-27. Ratified on #4996.
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__power_standards.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__power_standards.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__power_standards
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled,
+      and it already filters `co.region != 'Miami'` explicitly. Ratified on
+      #4996.
     config:
       enabled: false
       contract:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__power_standards.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__power_standards.yml
@@ -1,8 +1,8 @@
 models:
   - name: rpt_tableau__power_standards
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled,
-      and it already filters `co.region != 'Miami'` explicitly. Ratified on
+      **Not evaluated for Miami.** This model is disabled and never compiled,
+      and it already filters `co.region != 'Miami'` explicitly. Recorded on
       #4996.
     config:
       enabled: false

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__qbl.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__qbl.yml
@@ -1,8 +1,8 @@
 models:
   - name: rpt_tableau__qbl
     description: >-
-      **Excludes Miami by design.** This model is disabled and never compiled,
-      and it already filters `co.region != 'Miami'` explicitly. Ratified on
+      **Not evaluated for Miami.** This model is disabled and never compiled,
+      and it already filters `co.region != 'Miami'` explicitly. Recorded on
       #4996.
     config:
       enabled: false

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__qbl.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__qbl.yml
@@ -1,5 +1,9 @@
 models:
   - name: rpt_tableau__qbl
+    description: >-
+      **Excludes Miami by design.** This model is disabled and never compiled,
+      and it already filters `co.region != 'Miami'` explicitly. Ratified on
+      #4996.
     config:
       enabled: false
       contract:

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__state_assessments_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__state_assessments_dashboard.yml
@@ -6,8 +6,8 @@ models:
       comparison proficiency rates from city, state, and neighborhood school
       benchmarks. One row per student per assessment per academic year.
 
-      Network-wide, Miami included -- this model carries FLDOE FAST results and
-      a Miami-only Civics rule, so Miami is plainly intended. **It returned no
+      Network-wide, Miami included — this model carries FLDOE FAST results and a
+      Miami-only Civics rule, so Miami is plainly intended. **It returned no
       Miami rows in prod as of 2026-08-27.** The grain is an inner join from
       Pearson scores to enrollments on `pearson_local_student_identifier`, which
       is a New Jersey key, so the FLDOE leg never reaches the output. That is a

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__state_assessments_dashboard.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__state_assessments_dashboard.yml
@@ -5,6 +5,14 @@ models:
       with student enrollment demographics, performance-band goals, and
       comparison proficiency rates from city, state, and neighborhood school
       benchmarks. One row per student per assessment per academic year.
+
+      Network-wide, Miami included -- this model carries FLDOE FAST results and
+      a Miami-only Civics rule, so Miami is plainly intended. **It returned no
+      Miami rows in prod as of 2026-08-27.** The grain is an inner join from
+      Pearson scores to enrollments on `pearson_local_student_identifier`, which
+      is a New Jersey key, so the FLDOE leg never reaches the output. That is a
+      separate join defect, not a scope decision, and not fixed by #5038.
+      Ratified on #4996.
     columns:
       - name: academic_year
         data_type: int64

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -10,6 +10,9 @@ models:
       is_enrolled_recent — the year was completed or the enrollment is currently
       active, so mid-year withdrawals drop. Newark, Camden and Paterson; Miami
       is hard-excluded (region unsupported in the rebuilt dashboard).
+
+      Miami's exclusion is ratified on #4996, matching the hard exclusion
+      already stated above.
     data_tests:
       # TODO(#3915): returns to error when the storedgrades double-write cleanup
       # completes. All duplicates are prior-year storedgrades rows; current-year

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_info_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_info_audit.yml
@@ -1,5 +1,8 @@
 models:
   - name: rpt_tableau__student_info_audit
+    description: >-
+      Network-wide data quality audit, Miami included. Miami held 12,294 rows in
+      prod as of 2026-08-27. Ratified on #4996.
     columns:
       - name: db_name
         data_type: string

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -21,6 +21,10 @@ models:
       tracked in #5010, and was ruled out of #4995 on measurement. Miami's null
       is_dropped_section also trips this model's `not is_dropped_section`
       filter; that half is #4996.
+
+      Miami's absence is ratified as intentional on #4996. The gradebook has no
+      Focus branch, so no filter change here brings Miami back; wiring that
+      branch is #5010.
     columns:
       - name: grades_assignment_key
         data_type: string

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments_scores.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gradebook_assignments_scores.yml
@@ -1,5 +1,10 @@
 models:
   - name: int_powerschool__gradebook_assignments_scores
+    description: >-
+      PowerSchool gradebook assignments and scores. **Excludes Miami from AY2026
+      by design**, and by name: this unions the district PowerSchool packages,
+      and Miami left that package when it moved to Focus. Its archive stops at
+      AY2025. The Focus gradebook branch is #5010. Ratified on #4996.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -5,10 +5,9 @@ models:
       course enrollment overlap with term dates. Students who re-enrolled in the
       same course within a quarter are deduped to the most recent stint.
 
-
       Covers Miami through AY2025 only. The student join keys on
       `student_number` rather than PowerSchool's internal `cc_studentid`, which
-      Focus leaves null -- before that change this model held no Miami rows in
+      Focus leaves null — before that change this model held no Miami rows in
       any year. Miami AY2026 forward is still excluded, because the `not
       is_dropped_section` and `sections_no_of_students != 0` filters both drop
       rows whose value is null and Focus sets neither. #4996 owns those filters.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -12,6 +12,14 @@ models:
       any year. Miami AY2026 forward is still excluded, because the `not
       is_dropped_section` and `sections_no_of_students != 0` filters both drop
       rows whose value is null and Focus sets neither. #4996 owns those filters.
+
+      Network-wide, Miami included by decision, but **still excluded in
+      practice** and deliberately not fixed by #5038. Miami held 50,155 AY2025
+      rows and zero AY2026 rows in prod as of 2026-08-27. The remaining block is
+      `sections_no_of_students != 0`: that column is null on all 19,363 Miami
+      AY2026 course enrollments, so the comparison is null and the row drops.
+      Populating it is a Focus-package change, not an enrollment-flag fix.
+      Ratified on #4996.
     config:
       schema: extracts
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
@@ -1,5 +1,11 @@
 models:
   - name: int_extracts__student_enrollments
+    description: >-
+      Network-wide enrollment extract, Miami included. Miami held 1,760 AY2026
+      rows in prod as of 2026-08-27. Consumers that filter on `is_enrolled_y1`,
+      `is_enrolled_recent` or `is_out_of_district` dropped Miami entirely until
+      #5038 populated those flags upstream; `is_self_contained` is still null
+      for Miami by design. Ratified on #4996.
     config:
       schema: extracts
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments_subjects.yml
@@ -1,5 +1,10 @@
 models:
   - name: int_extracts__student_enrollments_subjects
+    description: >-
+      Network-wide subject scaffold, Miami included. Miami held 3,520 AY2026
+      rows in prod as of 2026-08-27. Carries the same enrollment flags as
+      `int_extracts__student_enrollments`, with the same Miami caveats. Ratified
+      on #4996.
     config:
       schema: extracts
       materialized: table


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." write down, for all 40 reports #4996
flagged, whether Miami belongs in them and why.

#4996 found 40 kipptaf models that filter on the Focus drop flags. Its point was
not really about the filter. It was that a report which quietly leaves a whole
region out is broken even when the number it prints is correct, because nobody
reading it can tell. So each of the 40 needed a decision, and the decision needed
to be written somewhere a reader would find it.

That is what this does. 23 reports include Miami. 17 do not. Every one now says
which, and why, in its model description. The full table is ratified on #4996.

Nothing else changes. No SQL, no columns, no tests.

Three of the descriptions say something uncomfortable on purpose: the report is
meant to include Miami, and it still shows nothing. An empty result nobody
explained is the same problem as an exclusion nobody explained, so each says what
is actually blocking it:

- `rpt_tableau__dibels_dashboard` — blocked because Focus does not record whether
  a student is in a self-contained classroom. We left that blank rather than
  guess, so Miami stays out for now.
- `rpt_tableau__state_assessments_dashboard` — it carries Florida FAST results and
  a Miami-only Civics rule, so Miami is clearly intended, but it joins test scores
  to students using a New Jersey ID. The Florida side never connects. That is a
  separate bug.
- `int_extracts__course_enrollments_by_term` — blocked by a Focus section-size
  column that is empty for Miami. Fixing it means changing the Focus package, so
  it was deliberately left out of #5038.

29 of the 40 models had no description at all. Those get one short line saying
what the model is, then the scope sentence, so the new text reads like
documentation instead of a lone footnote.

## Reviewer Notes

- **Read the #4996 table first**, not this diff. The diff is 40 near-identical
  paragraphs; the judgement all lives in the ratified table.
- **The three honest-failure descriptions** listed above are the ones worth a
  second look. If you disagree that a report should admit it is empty, say so.
- **No drop-flag `coalesce` here, and none in #5038 either.** #4996 asked for one
  and it turned out to be a no-op. Details in the fold-out.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models. All 40 properties files already existed.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      consumer changes.
- [x] **Breaking change?** No. Descriptions only.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external source changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — passes. `trunk check --force` clean on all 40 files.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. **The ratified decision table is
#4996#issuecomment-5443235788, with the ratification and corrections in
#4996#issuecomment-5443390602.** Read both before reviewing this diff; the diff
carries none of the reasoning.

**Final tally: 23 INCLUDE, 17 EXCLUDE, reconciled by name against the 40 files
the issue's grep returns.** The first table comment listed 20 INCLUDE and 17
EXCLUDE and left `rpt_tableau__student_info_audit` out of both sections through a
transcription error; the ratification comment corrects it to INCLUDE (network-wide
data quality audit, Miami 12,294 rows in prod). The three files marked UNSURE in
the first comment — `rpt_tableau__gradebook_gpa`,
`int_extracts__course_enrollments_by_term`, and the `rpt_gsheets__csgf_hs_*` pair
— were all ratified INCLUDE.

**Why there is no drop-flag `coalesce` in this PR or in #5038.** #4996 asked for
`not coalesce(is_dropped_section, false)` on every include-Miami file. Measured
against prod 2026-08-27: both `is_dropped_section` and `is_dropped_course` are
non-null on all 19,363 Miami AY2026 rows of
`base_powerschool__course_enrollments`, and all 40 files read both flags from that
relation and nowhere else — checked per file, alias by alias. `not
is_dropped_section` already passes 18,787 Miami rows and `not is_dropped_course`
passes 19,244. The coalesce changes zero rows in zero files. It is doubly dead in
18 of the 40, where the filter sits only on a LEFT JOIN and cannot remove a row
at all — including all three Miami anchors the issue named. #4996's own Sequencing
section predicted exactly this if #4968 landed first, which it did.

**The live trap, which #5038 fixes.** Four flags on
`int_students__student_enrollments` were null on 100% of Miami's 1,760 AY2026 rows
and non-null on every NJ row: `is_enrolled_y1`, `is_enrolled_recent`,
`is_out_of_district`, `is_self_contained` (plus `is_504`, whose Miami null is
deliberate and already documented). `rpt_tableau__miami_fast` held **zero rows of
any kind** because its where clause requires `is_enrolled_y1`. #5038 derives the
first two from the roster's dates using PowerSchool's own expressions, sets
`is_out_of_district` false on the grounds that the Focus branch already assigns
every Miami row a real `reporting_schoolid` and an ES/MS/HS `school_level` rather
than the out-of-district values, and leaves `is_self_contained` null.

**Why `is_self_contained` stays null.** Focus's nearest field is
`ese_fefp_code_label`, whose Miami values are 3,890 null, 104 `4-8 Basic ESE
Services [112]`, 57 `PK-3 Basic ESE Services [111]`, and 1 `ESE Support Level 4
[254]`. Support Level 4 is a Florida funding-matrix level, not a placement label,
so mapping it onto PowerSchool's named SPED program is a SPED-semantics call for
Ops rather than a code change. Requester chose "leave null, document it", which is
why `rpt_tableau__dibels_dashboard`'s description now states the exclusion
outright instead of the dashboard silently returning nothing.

**Row counts in the descriptions** are prod as of 2026-08-27, AY2026 unless the
sentence says otherwise. They are a snapshot for the reader's orientation, not an
invariant — they will drift, and that is fine. The scope verdict is the durable
part.

**Mechanics.** Applied by a script with a per-file exact-anchor assertion (abort
unless the `- name: <model>` block matched exactly once), so no file was edited
blind. 11 of the new descriptions needed `trunk fmt` for prettier's YAML block
scalar wrapping; formatting is committed, and `trunk check --force` is clean on
all 40 afterwards. An earlier pass wrapped `PowerSchool-only` across a line break,
which a folded YAML scalar would have rendered as "PowerSchool- only"; fixed by
disabling hyphen breaks before the committed pass. `dbt parse` succeeds on the
project, which is the real YAML validation.

**Stacking.** This PR and #5038 both branch from `main` and share no files, so
they can merge in either order. The descriptions here reference #5038 in the past
tense ("was null for Miami until #5038"), which reads correctly once both land.

Refs #4996
Refs #4973
Refs #4968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
