### PR TITLE
feat(dbt): branch fct_grades_gpa onto Focus for Miami

### DIFF
--- a/src/dbt/focus/models/staging/properties/stg_focus__student_gpa_calculated.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__student_gpa_calculated.yml
@@ -1,0 +1,126 @@
+models:
+  - name: stg_focus__student_gpa_calculated
+    description: >-
+      Focus's own GPA and class-rank calculations. One row per student per
+      school. Every row carries `marking_period_id = -1`, which the vendor
+      defines as the course-history GPA — GPA over grades imported into a
+      student's official academic history, not GPA for work done in the current
+      marking period. There is no term-grained row in this table.
+
+
+      Coverage is narrow and that is a property of the source, not of this
+      model. Measured on the first prod load: 441 rows for 319 students, against
+      1,757 Miami students enrolled in AY2026. Every student with imported
+      course history has a row here, all 290 of them with no exceptions, plus 29
+      more. Rows appear at every grade level from K through 9, so this is not a
+      high-school-only table.
+
+
+      `gpa` and `cumulative_gpa` are the same measure at different rounding —
+      they differ by at most 0.0005 across every populated row — as are
+      `weighted_gpa` and `cumulative_weighted_gpa`. Prefer the cumulative pair
+      downstream.
+
+
+      The five decimal columns arrive from dlt as BIGNUMERIC, because
+      `weighted_gpa` is an unbounded Postgres `numeric` carrying up to 20
+      decimal places and needs the `widen_unbounded_numeric` dlt adapter to load
+      at all. They are cast to NUMERIC here, which keeps this package's decimal
+      vocabulary consistent and costs at most 5e-10 of rounding.
+
+
+      The 21 `custom_*_gpa`, `custom_*_rank` and `ncaa_gpa` columns in the
+      source are omitted: all are 100% null, as is `mp`. Add one when Focus
+      starts populating it.
+    columns:
+      - name: id
+        description: Primary key — Focus student GPA calculation id.
+        data_type: int
+        data_tests:
+          - unique:
+              config:
+                severity: error
+          - not_null:
+              config:
+                severity: error
+      - name: student_id
+        description: >-
+          Focus student id. Note this is the network student number prefixed
+          with `8400` (Miami-Dade's FLDOE district number), not the bare student
+          number.
+        data_type: int
+        data_tests:
+          - not_null:
+              config:
+                severity: error
+          - relationships:
+              arguments:
+                to: ref('stg_focus__students')
+                field: student_id
+              config:
+                severity: error
+        config:
+          meta:
+            contains_pii: true
+      - name: school_id
+        description: >-
+          Focus school the calculation belongs to. A student can hold a row at
+          more than one school — 122 of 319 students did on the first load — so
+          the grain is student and school, not student alone.
+        data_type: int
+      - name: syear
+        description: Focus school year (start year).
+        data_type: int
+      - name: marking_period_id
+        description: >-
+          Marking period the calculation covers. `-1` marks the course-history
+          GPA, per Focus SIS Level 1 Certification, Day 2. It is the only value
+          present.
+        data_type: int
+      - name: grade_id
+        description: >-
+          Grade level the student held when the calculation ran. Null on the
+          rows that carry no `grade_total`.
+        data_type: int
+      - name: grade_total
+        description: Number of grades the calculation was computed over.
+        data_type: int
+      - name: class_rank
+        description: >-
+          Class rank Focus computed. Populated on 3 of 441 rows on the first
+          load, so it is not yet usable as a reporting measure.
+        data_type: int
+      - name: weighted_class_rank
+        description: Class rank by weighted GPA. Populated on 3 of 441 rows.
+        data_type: int
+      - name: unweighted_class_rank
+        description: Class rank by unweighted GPA. Populated on 3 of 441 rows.
+        data_type: int
+      - name: rank_last_modified
+        description: Date Focus last recomputed the rank for this row.
+        data_type: date
+      - name: created_at
+        description: Row creation timestamp in Focus.
+        data_type: timestamp
+      - name: updated_at
+        description: Row last-update timestamp in Focus.
+        data_type: timestamp
+      - name: gpa
+        description: >-
+          Unweighted GPA over the student's course history. Equal to
+          `cumulative_gpa` to within 0.0005 on every populated row.
+        data_type: numeric
+      - name: weighted_gpa
+        description: >-
+          Weighted GPA over the student's course history. Equal to
+          `cumulative_weighted_gpa` to within 0.0005 on every populated row.
+        data_type: numeric
+      - name: cumulative_gpa
+        description: Cumulative unweighted GPA.
+        data_type: numeric
+      - name: cumulative_weighted_gpa
+        description: Cumulative weighted GPA.
+        data_type: numeric
+      - name: cumulative_credits
+        description: Credits the cumulative GPA was computed over.
+        data_type: numeric

--- a/src/dbt/focus/models/staging/sources-bigquery.yml
+++ b/src/dbt/focus/models/staging/sources-bigquery.yml
@@ -342,6 +342,15 @@ sources:
                 - dlt
                 - focus
                 - student_report_card_grades
+      - name: student_gpa_calculated
+        config:
+          meta:
+            dagster:
+              asset_key:
+                - "{{ project_name }}"
+                - dlt
+                - focus
+                - student_gpa_calculated
       - name: report_card_grades
         config:
           meta:

--- a/src/dbt/focus/models/staging/stg_focus__student_gpa_calculated.sql
+++ b/src/dbt/focus/models/staging/stg_focus__student_gpa_calculated.sql
@@ -1,0 +1,21 @@
+select
+    id,
+    student_id,
+    school_id,
+    syear,
+    marking_period_id,
+    grade_id,
+    grade_total,
+    class_rank,
+    weighted_class_rank,
+    unweighted_class_rank,
+    rank_last_modified,
+    created_at,
+    updated_at,
+
+    cast(gpa as numeric) as gpa,
+    cast(weighted_gpa as numeric) as weighted_gpa,
+    cast(cumulative_gpa as numeric) as cumulative_gpa,
+    cast(cumulative_weighted_gpa as numeric) as cumulative_weighted_gpa,
+    cast(cumulative_credits as numeric) as cumulative_credits,
+from {{ source("focus", "student_gpa_calculated") }}

--- a/src/dbt/kipptaf/models/focus/sources-kippmiami.yml
+++ b/src/dbt/kipptaf/models/focus/sources-kippmiami.yml
@@ -238,3 +238,12 @@ sources:
                 - kippmiami
                 - focus
                 - int_focus__calendar_rollup
+      - name: stg_focus__student_gpa_calculated
+        config:
+          meta:
+            dagster:
+              group: focus
+              asset_key:
+                - kippmiami
+                - focus
+                - stg_focus__student_gpa_calculated

--- a/src/dbt/kipptaf/models/focus/staging/properties/stg_focus__student_gpa_calculated.yml
+++ b/src/dbt/kipptaf/models/focus/staging/properties/stg_focus__student_gpa_calculated.yml
@@ -1,0 +1,11 @@
+models:
+  - name: stg_focus__student_gpa_calculated
+    description: >-
+      Kipptaf-level union_relations passthrough of kippmiami's
+      stg_focus__student_gpa_calculated, exposing Focus's own GPA and class-rank
+      calculations at network level. One row per student per school, all of them
+      course-history GPA (`marking_period_id = -1`). Column docs/tests live on
+      the kippmiami source model.
+    columns:
+      - name: _dbt_source_project
+        description: District code location derived from _dbt_source_relation.

--- a/src/dbt/kipptaf/models/focus/staging/stg_focus__student_gpa_calculated.sql
+++ b/src/dbt/kipptaf/models/focus/staging/stg_focus__student_gpa_calculated.sql
@@ -1,0 +1,13 @@
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source("kippmiami_focus", "stg_focus__student_gpa_calculated"),
+                ]
+            )
+        }}
+    )
+
+select *, {{ extract_source_project("union_relations") }} as _dbt_source_project,
+from union_relations

--- a/src/dbt/kipptaf/models/marts/facts/fct_grades_gpa.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_grades_gpa.sql
@@ -2,9 +2,7 @@ with
     student_enrollments as (
         select
             _dbt_source_project,
-            studentid,
             schoolid,
-            yearid,
             student_number,
             entrydate,
             exitdate,
@@ -28,35 +26,34 @@ with
 
     gpa_term as (
         select
-            gt._dbt_source_project,
-            gt.studentid,
-            gt.schoolid,
-            gt.yearid,
-            gt.term_name,
-            gt.semester,
-            gt.is_current,
-            gt.gpa_term,
-            gt.gpa_y1,
-            gt.gpa_y1_unweighted,
-            gt.gpa_semester,
-            gt.n_failing_y1,
-            gt.total_credit_hours_term,
-            gt.total_credit_hours_y1,
-            gt.grade_avg_term,
-            gt.grade_avg_y1,
-
-            gc.cumulative_y1_gpa,
-            gc.cumulative_y1_gpa_unweighted,
-            gc.cumulative_y1_gpa_projected,
-            gc.earned_credits_cum,
-            gc.potential_credits_cum,
+            _dbt_source_project,
+            schoolid,
+            yearid,
+            academic_year,
+            student_number,
+            term_name,
+            semester,
+            gpa_term,
+            gpa_y1,
+            gpa_y1_unweighted,
+            gpa_semester,
+            n_failing_y1,
+            total_credit_hours_term,
+            total_credit_hours_y1,
+            grade_avg_term,
+            grade_avg_y1,
+            cumulative_y1_gpa,
+            cumulative_y1_gpa_unweighted,
+            cumulative_y1_gpa_projected,
+            earned_credits_cum,
+            potential_credits_cum,
 
             row_number() over (
-                partition by gt._dbt_source_project, gt.studentid, gt.schoolid
+                partition by _dbt_source_project, student_number, schoolid
                 order by
-                    gt.yearid desc,
+                    academic_year desc,
                     case
-                        gt.term_name
+                        term_name
                         when 'Q4'
                         then 4
                         when 'Q3'
@@ -69,12 +66,7 @@ with
                     end desc
             ) as rn_current,
 
-        from {{ ref("int_powerschool__gpa_term") }} as gt
-        left join
-            {{ ref("int_powerschool__gpa_cumulative") }} as gc
-            on gt.studentid = gc.studentid
-            and gt.schoolid = gc.schoolid
-            and gt._dbt_source_project = gc._dbt_source_project
+        from {{ ref("int_students__gpa") }}
     )
 
 select
@@ -143,9 +135,9 @@ select
 from gpa_term as gt
 inner join
     student_enrollments as enr
-    on gt.studentid = enr.studentid
+    on gt.student_number = enr.student_number
     and gt.schoolid = enr.schoolid
-    and gt.yearid = enr.yearid
+    and gt.academic_year = enr.academic_year
     and gt._dbt_source_project = enr._dbt_source_project
 left join
     reporting_terms as rt

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__gpa.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__gpa.sql
@@ -2,7 +2,14 @@ with
     -- One row. See int_students__sis_cutover for why the boundary is a floor
     -- and why it is derived from recorded attendance rather than row presence.
     sis_cutover as (
-        select focus_start_academic_year, from {{ ref("int_students__sis_cutover") }}
+        select
+            focus_start_academic_year,
+
+            -- PowerSchool yearid form of the same boundary, so the archive
+            -- branch filters on a bare gt.yearid instead of recomputing
+            -- yearid + 1990 per row in WHERE.
+            focus_start_academic_year - 1990 as focus_start_yearid,
+        from {{ ref("int_students__sis_cutover") }}
     ),
 
     -- dcid >= 1 is the placeholder filter. See the model description for why
@@ -65,7 +72,7 @@ with
         where
             not (
                 gt._dbt_source_project = 'kippmiami'
-                and (gt.yearid + 1990) >= sc.focus_start_academic_year
+                and gt.yearid >= sc.focus_start_yearid
             )
     ),
 

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__gpa.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__gpa.sql
@@ -1,0 +1,140 @@
+with
+    -- One row. See int_students__sis_cutover for why the boundary is a floor
+    -- and why it is derived from recorded attendance rather than row presence.
+    sis_cutover as (
+        select focus_start_academic_year, from {{ ref("int_students__sis_cutover") }}
+    ),
+
+    -- dcid >= 1 is the placeholder filter. See the model description for why
+    -- student_number is the join key.
+    powerschool_students as (
+        select id as studentid, student_number, _dbt_source_project,
+        from {{ ref("stg_powerschool__students") }}
+        where dcid >= 1
+    ),
+
+    powerschool_conformed as (
+        select
+            gt._dbt_source_relation,
+            gt._dbt_source_project,
+            gt.studentid,
+            gt.schoolid,
+            gt.yearid,
+            gt.term_name,
+            gt.semester,
+            gt.gpa_term,
+            gt.gpa_y1,
+            gt.gpa_y1_unweighted,
+            gt.gpa_semester,
+            gt.n_failing_y1,
+            gt.total_credit_hours_term,
+            gt.total_credit_hours_y1,
+            gt.grade_avg_term,
+            gt.grade_avg_y1,
+
+            gc.cumulative_y1_gpa,
+            gc.cumulative_y1_gpa_unweighted,
+            gc.cumulative_y1_gpa_projected,
+            gc.earned_credits_cum,
+            gc.potential_credits_cum,
+
+            ps.student_number,
+
+            -- PowerSchool's yearid is academic_year - 1990. gpa_term carries no
+            -- academic_year of its own, and the Focus branch has no yearid, so
+            -- both columns are derived on whichever side lacks them.
+            gt.yearid + 1990 as academic_year,
+
+            -- The PowerSchool GPA chain does not produce class rank at all.
+            cast(null as int64) as class_rank,
+        from {{ ref("int_powerschool__gpa_term") }} as gt
+        cross join sis_cutover as sc
+        left join
+            {{ ref("int_powerschool__gpa_cumulative") }} as gc
+            on gt.studentid = gc.studentid
+            and gt.schoolid = gc.schoolid
+            and gt._dbt_source_project = gc._dbt_source_project
+        -- left, not inner: an inner join would silently drop any GPA row whose
+        -- student fails the dcid >= 1 placeholder filter, changing the NJ
+        -- population. Measured at zero such rows, but the join type is what
+        -- guarantees it stays that way.
+        left join
+            powerschool_students as ps
+            on gt.studentid = ps.studentid
+            and gt._dbt_source_project = ps._dbt_source_project
+        where
+            not (
+                gt._dbt_source_project = 'kippmiami'
+                and (gt.yearid + 1990) >= sc.focus_start_academic_year
+            )
+    ),
+
+    focus_conformed as (
+        select
+            g._dbt_source_relation,
+            g._dbt_source_project,
+
+            g.syear as academic_year,
+
+            g.class_rank,
+
+            st.student_number,
+            loc.powerschool_school_id as schoolid,
+
+            -- Derived so the reporting-terms join in fct_grades_gpa keeps
+            -- working for both branches, even though no Focus row resolves a
+            -- term.
+            g.syear - 1990 as yearid,
+
+            cast(null as int64) as studentid,
+
+            -- Focus's student_gpa_calculated is course-history GPA only: every
+            -- row carries marking_period_id = -1 and there is no term-grained
+            -- row in the table. So no term, semester or year-to-date measure has
+            -- a Focus analog. Null rather than copied from the cumulative value:
+            -- a term GPA that silently equals the cumulative one reads as a real
+            -- term measure and is not one.
+            cast(null as string) as term_name,
+            cast(null as string) as semester,
+            cast(null as float64) as gpa_term,
+            cast(null as float64) as gpa_y1,
+            cast(null as float64) as gpa_y1_unweighted,
+            cast(null as float64) as gpa_semester,
+            cast(null as int64) as n_failing_y1,
+            cast(null as float64) as total_credit_hours_term,
+            cast(null as float64) as total_credit_hours_y1,
+            cast(null as float64) as grade_avg_term,
+            cast(null as float64) as grade_avg_y1,
+
+            -- PowerSchool's cumulative_y1_gpa is the weighted measure and
+            -- cumulative_y1_gpa_unweighted the unweighted one, so the two Focus
+            -- columns map across that way round rather than by name.
+            cast(g.cumulative_weighted_gpa as float64) as cumulative_y1_gpa,
+            cast(g.cumulative_gpa as float64) as cumulative_y1_gpa_unweighted,
+            cast(g.cumulative_credits as float64) as earned_credits_cum,
+
+            -- Focus projects neither a year-end GPA nor potential credits.
+            cast(null as float64) as cumulative_y1_gpa_projected,
+            cast(null as float64) as potential_credits_cum,
+
+        from {{ ref("stg_focus__student_gpa_calculated") }} as g
+        inner join
+            {{ ref("int_focus__students") }} as st on g.student_id = st.student_id
+        inner join {{ ref("int_focus__schools") }} as fs on g.school_id = fs.id
+        left join
+            {{ ref("stg_google_sheets__people__locations") }} as loc
+            on fs.school_number = loc.focus_school_id
+        -- The archive branch above owns Miami's years before the cutover, so
+        -- admit only rows at or after it — the same boundary, applied from the
+        -- other side.
+        cross join sis_cutover as sc
+        where g.syear >= sc.focus_start_academic_year
+    )
+
+select *,
+from powerschool_conformed
+
+full union all corresponding
+
+select *,
+from focus_conformed

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
@@ -94,8 +94,9 @@ models:
       - name: schoolid
         data_type: int64
         description: >-
-          PowerSchool school id. Resolved on the Focus branch through
-          `stg_google_sheets__people__locations.focus_school_id`.
+          PowerSchool school id. On the Focus branch it is
+          `stg_google_sheets__people__locations.powerschool_school_id`, reached
+          by joining Focus's `school_number` to that model's `focus_school_id`.
       - name: yearid
         data_type: int64
         description: >-

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
@@ -1,0 +1,171 @@
+models:
+  - name: int_students__gpa
+    description: >-
+      SIS-neutral GPA spine. Unions the PowerSchool GPA chain
+      (`int_powerschool__gpa_term` left-joined to
+      `int_powerschool__gpa_cumulative`) with Miami's Focus
+      `student_gpa_calculated`, conformed inline to the PowerSchool column
+      vocabulary. The Miami PowerSchool branch is scoped to years before Focus
+      coverage begins, and the Focus branch to years at or after it, so the
+      frozen archive and the live SIS never overlap. Replaces the two
+      `int_powerschool__gpa_*` models as the source `fct_grades_gpa` reads.
+
+
+      **The Focus branch is cumulative-only.** Focus's `student_gpa_calculated`
+      carries `marking_period_id = -1` on every row, which the vendor defines as
+      the course-history GPA. There is no term-grained row in the table, so
+      `term_name`, `semester`, `gpa_term`, `gpa_semester`, the year-to-date
+      measures and the term credit-hour measures are all null on Miami rows.
+      Recomputing them from Focus grades is not possible either: only 145 of
+      Miami's 1,808 AY2026 rows in `int_students__final_grades` carry
+      `exclude_from_gpa = 0`, and Miami posts a single `storecode` against the
+      NJ regions' 4.
+
+
+      **Miami coverage is partial and that is a property of the source.** On the
+      first prod load Focus held 441 rows for 319 students against 1,757
+      students enrolled in AY2026, spread across every grade K through 9. Every
+      student with imported course history has a row, all 290 of them. So a
+      Miami student absent from this model has no imported course history, not a
+      broken join.
+
+
+      Keyed on `student_number` rather than PowerSchool's `studentid`, for the
+      same reason as `int_students__final_grades`: the Focus branch has no
+      PowerSchool `studentid`, and `int_students__student_enrollment_union`
+      leaves `studentid` and `yearid` null on all 10,075 Miami rows, so that
+      join could never have matched a Focus row. `(studentid, yearid)` and
+      `(student_number, academic_year)` are exactly 1:1 inside every NJ
+      district, so the swap is row-preserving there. Measured against prod:
+      Camden 47,018, Newark 165,670 and Paterson 2,536 rows join enrollment
+      identically under both keys.
+
+
+      **The key swap also surfaces Miami's pre-Focus GPA history**, which the
+      old key silently hid. 13,928 Miami PowerSchool rows for AY2020 through
+      AY2025 now reach `fct_grades_gpa`; under the `studentid` join they matched
+      nothing, because the enrollment union leaves `studentid` null on every
+      Miami row. That is a gain, not a regression — the archive was always meant
+      to stay readable — but it is a visible change to a fact that previously
+      held no Miami row in any year.
+    config:
+      materialized: table
+    data_tests:
+      # Scoped to rows that resolved a student_number. int_powerschool__gpa_term
+      # carries 4 Camden AY2015 rows at schoolid 0 whose student fails the
+      # dcid >= 1 placeholder filter, so the left join leaves student_number
+      # null and they collide with each other. They are kept rather than
+      # dropped, and fct_grades_gpa excludes them anyway on its inner join to
+      # enrollment.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - academic_year
+              - schoolid
+              - term_name
+              - _dbt_source_project
+          config:
+            where: student_number is not null
+    columns:
+      - name: _dbt_source_relation
+        data_type: string
+      - name: _dbt_source_project
+        data_type: string
+        description: District code location derived from `_dbt_source_relation`.
+      - name: student_number
+        data_type: int64
+        description: >-
+          Network student number. The only student key both branches share, and
+          what `fct_grades_gpa` joins enrollment on.
+        config:
+          meta:
+            contains_pii: true
+      - name: academic_year
+        data_type: int64
+        description: >-
+          Academic year. Derived as `yearid + 1990` on the PowerSchool branch
+          and taken from Focus's `syear` on the Focus branch.
+      - name: studentid
+        data_type: int64
+        description: >-
+          PowerSchool student id. Null on every Focus row — Focus has no
+          PowerSchool student id.
+      - name: schoolid
+        data_type: int64
+        description: >-
+          PowerSchool school id. Resolved on the Focus branch through
+          `stg_google_sheets__people__locations.focus_school_id`.
+      - name: yearid
+        data_type: int64
+        description: >-
+          PowerSchool year id, `academic_year - 1990`. Derived on the Focus
+          branch so `fct_grades_gpa`'s reporting-terms join keeps working for
+          both branches.
+      - name: term_name
+        data_type: string
+        description: >-
+          Reporting term the row covers. Null on every Focus row, which carries
+          no term.
+      - name: semester
+        data_type: string
+        description: Semester the term falls in. Null on every Focus row.
+      - name: gpa_term
+        data_type: float64
+        description: Term GPA. Null on every Focus row.
+      - name: gpa_y1
+        data_type: float64
+        description: Year-to-date weighted GPA. Null on every Focus row.
+      - name: gpa_y1_unweighted
+        data_type: float64
+        description: Year-to-date unweighted GPA. Null on every Focus row.
+      - name: gpa_semester
+        data_type: float64
+        description: Semester GPA. Null on every Focus row.
+      - name: n_failing_y1
+        data_type: int64
+        description: Year-to-date failing course count. Null on every Focus row.
+      - name: total_credit_hours_term
+        data_type: float64
+        description:
+          Credit hours attempted in the term. Null on every Focus row.
+      - name: total_credit_hours_y1
+        data_type: float64
+        description:
+          Year-to-date credit hours attempted. Null on every Focus row.
+      - name: grade_avg_term
+        data_type: float64
+        description: Term percent-grade average. Null on every Focus row.
+      - name: grade_avg_y1
+        data_type: float64
+        description:
+          Year-to-date percent-grade average. Null on every Focus row.
+      - name: cumulative_y1_gpa
+        data_type: float64
+        description: >-
+          Cumulative weighted GPA. Mapped from Focus's
+          `cumulative_weighted_gpa`, which is the weighted measure despite the
+          unqualified PowerSchool column name.
+      - name: cumulative_y1_gpa_unweighted
+        data_type: float64
+        description: >-
+          Cumulative unweighted GPA. Mapped from Focus's `cumulative_gpa`.
+      - name: cumulative_y1_gpa_projected
+        data_type: float64
+        description: >-
+          Projected year-end cumulative GPA. Null on every Focus row — Focus
+          projects nothing.
+      - name: earned_credits_cum
+        data_type: float64
+        description: >-
+          Cumulative credits earned. Mapped from Focus's `cumulative_credits`.
+      - name: potential_credits_cum
+        data_type: float64
+        description: >-
+          Cumulative credits attempted. Null on every Focus row.
+      - name: class_rank
+        data_type: int64
+        description: >-
+          Class rank as the SIS computed it. Null on every PowerSchool row —
+          that chain does not produce a rank at all — and populated on only 3 of
+          441 Focus rows so far, so it is not yet usable as a reporting measure.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put Miami rows into `fct_grades_gpa` for the
first time, in any year.

It adds `stg_focus__student_gpa_calculated` to the focus package and its kipptaf
wrapper, then routes `fct_grades_gpa` through a new SIS-neutral
`int_students__gpa` instead of reading `int_powerschool__gpa_term` and
`int_powerschool__gpa_cumulative` directly. That follows the
`int_students__final_grades` precedent from #5020 rather than branching the
PowerSchool GPA chain in place.

The ingestion half shipped in #5034.

## Reviewer Notes

**Read this before reviewing the SQL: what Focus actually gives us is much less
than #5021 assumed.** Three of that issue's premises are wrong, measured against
the loaded table:

- `marking_period_id = -1` is not a filter to apply. It is the only value in the
  table, so Focus supplies **no term-grained GPA at all**. Term, semester and
  year-to-date columns are null on every Miami row.
- Class rank is not "a bonus". It is populated on **3 of 441 rows**.
- Coverage is 319 students against 1,757 enrolled. Not a join bug: every student
  with imported course history has a row, all 290 of them, plus 29 more. This is
  GPA over grades imported from a prior school.

I raised this before building and was asked to ship the cumulative-only branch
anyway, so that is what this is. The nulls are deliberate and documented rather
than filled from the cumulative value, which would read as a real term measure.

**The key swap surfaces Miami's pre-Focus history, which is a visible change
beyond the issue's ask.** Moving the enrollment join from
`(studentid, schoolid, yearid)` to `(student_number, schoolid, academic_year)`
adds **13,928** Miami PowerSchool rows for AY2020 through AY2025. Those rows
existed all along; `int_students__student_enrollment_union` leaves `studentid`
null on every Miami row, so the old join matched nothing. It is a gain, and it
satisfies the issue's "Miami historical GPA still readable" criterion directly,
but a reviewer should know the fact goes from zero Miami rows to ~14k.

**NJ parity is exact**, measured against prod with both join forms:

| Region | Old key | New key |
| --- | --- | --- |
| kippcamden | 47,018 | 47,018 |
| kippnewark | 165,670 | 165,670 |
| kipppaterson | 2,536 | 2,536 |

**The `unique` test on `grades_gpa_key` warns with 8 duplicates. Those are
pre-existing** — prod has the same 8 keys, verified by set comparison, and this
branch adds none.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — all 3
      new models have one
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application —
      `fct_grades_gpa`'s existing exposures are unchanged; no column was added,
      removed or retyped
- [x] **Breaking change?** No. `fct_grades_gpa` keeps its exact column set and
      types; only its upstream and its enrollment join key change. No
      versioning needed.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — not applicable, the Focus source is a
      BigQuery-native dlt landing dataset, not an external table

## CI checks

- [ ] **Trunk** — `trunk check --force` clean on all 9 files locally (2 prettier
      reflows, applied by the commit hook)
- [ ] **dbt Cloud** — see the open question below; this will fail until the
      kipptaf source can resolve
- [ ] **Dagster Cloud** — not triggered, no `src/teamster/` change

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

### Local validation

Built against prod upstreams with `--favor-state --defer`:

| Model | Result |
| --- | --- |
| `stg_focus__student_gpa_calculated` (package) | 441 rows, contract enforced, 4 tests pass including the FK to `stg_focus__students` |
| `int_students__gpa` | 240,300 rows, grain test passes |
| `fct_grades_gpa` | builds; `term_key` and `student_enrollment_key` FK tests pass |

`dbt build --empty` over `int_students__gpa+ fct_grades_gpa+
stg_focus__student_gpa_calculated+`: 7 pass, 0 error.

Note the first build ran without `--favor-state` and produced a Focus-only
`int_students__gpa` of 441 rows, plus 267 phantom FK orphans — `--defer` had
resolved the PowerSchool upstreams to stale personal dev tables. Both symptoms
vanished with `--favor-state`. Recorded because both look like catastrophic
findings and neither was real.

### Branch composition, measured

| Region | Branch | Years | Rows | Reaching the fact |
| --- | --- | --- | --- | --- |
| kippmiami | Focus | 2026 | 441 | 265 |
| kippmiami | PowerSchool archive | 2019–2025 | 16,512 | 13,796 |
| kippcamden | PowerSchool | 2015–2026 | 47,734 | 46,774 |
| kippnewark | PowerSchool | 2002–2026 | 173,062 | 165,178 |
| kipppaterson | PowerSchool | 2023–2026 | 2,520 | 2,520 |

The cutover boundary holds with no overlap: Miami's PowerSchool arm stops at
2025, its Focus arm starts at 2026. 16,512 matches the archive count stated on
#5021 exactly.

441 Focus rows become 265 in the fact because the enrollment join also matches
on school, and a course-history GPA row can sit at a school the student is not
currently enrolled at. NJ behaves the same way.

### Grain-test scope

`int_students__gpa`'s `unique_combination_of_columns` is scoped
`where: student_number is not null`. `int_powerschool__gpa_term` carries 4 Camden
AY2015 rows at `schoolid = 0` whose student fails the `dcid >= 1` placeholder
filter, so the left join leaves `student_number` null and they collide. They are
kept rather than dropped, and `fct_grades_gpa` excludes them on its inner join
anyway.

### Column mapping choice

Focus's `cumulative_weighted_gpa` maps to PowerSchool's `cumulative_y1_gpa` and
`cumulative_gpa` to `cumulative_y1_gpa_unweighted` — across the naming, not by
name, because the unqualified PowerSchool column is the weighted one.
`gpa`/`weighted_gpa` are dropped: they equal the cumulative pair to within
0.0005 on every populated row.

`cumulative_y1_gpa_projected` and `potential_credits_cum` are null on Focus rows;
Focus projects nothing.

</details>

Refs #5021
