### PR TITLE
fix(dbt): put Miami back in the per-term course report

### DIFF
--- a/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_student_section_enrollments.sql
@@ -38,10 +38,11 @@ with
         -- alumni placeholder rows (enroll_status=3) have NULL entrydate/exitdate
         -- and match no stint here, producing a NULL student_enrollment_key
         --
-        -- Focus leaves a course period's end_date null while the schedule is
-        -- still open (PowerSchool always populates cc_dateleft), so the
-        -- coalesce below is required for Miami to match its current stint.
-        -- It is a no-op for NJ: cc_dateleft is null on zero NJ rows. entrydate
+        -- The coalesce below is now dead and kept only as a guard: #5043 made
+        -- cc_dateleft non-null on both SIS branches and added a not_null test
+        -- on it, so the sentinel can no longer fire. It was required while
+        -- Focus left an open schedule's end_date null. Drop it whenever this
+        -- model is next touched. entrydate
         -- and exitdate are never null in student_enrollments, so they need no
         -- equivalent coalesce. The ~10.6% of Miami rows still unmatched after
         -- this is an accepted residual within the NJ completed-year orphan-rate

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -112,7 +112,16 @@ with
             and e._dbt_source_project = q._dbt_source_project
             and e.cc_dateenrolled <= q.quarter_end_date_alt
             and e.cc_dateleft >= q.quarter_start_date_alt
-        where not e.is_dropped_section and e.sections_no_of_students != 0
+        where
+            not e.is_dropped_section
+            -- Focus records no section student count, so this column is null on
+            -- every Miami row. Null is not the PowerSchool quirk the filter
+            -- targets -- a section holding enrollment rows while recording its
+            -- count as zero, 215 of 64,699 New Jersey rows. A section with
+            -- nobody in it produces no enrollment rows at all, so it cannot
+            -- reach this model; #5043 measured Miami's smallest section at 1
+            -- student. Keep null, drop only a literal 0.
+            and e.sections_no_of_students is distinct from 0
     ),
 
     days_course_enrolled as (

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -62,7 +62,7 @@ with
             e.cc_academic_year,
             e.cc_schoolid,
             e.cc_dateenrolled as dateenrolled,
-            e.cc_dateleft as dateleft,
+            e.scheduled_end_date as dateleft,
             e.cc_sectionid as sectionid,
             e.cc_course_number as course_number,
             e.sections_dcid,
@@ -99,9 +99,9 @@ with
             ) as dateenrolled_alt,
 
             if(
-                e.cc_dateleft > q.last_day_school_year,
+                e.scheduled_end_date > q.last_day_school_year,
                 q.last_day_school_year,
-                e.cc_dateleft
+                e.scheduled_end_date
             ) as dateleft_alt,
 
         from {{ ref("base_powerschool__course_enrollments") }} as e
@@ -111,7 +111,7 @@ with
             and e.cc_schoolid = q.schoolid
             and e._dbt_source_project = q._dbt_source_project
             and e.cc_dateenrolled <= q.quarter_end_date_alt
-            and e.cc_dateleft >= q.quarter_start_date_alt
+            and e.scheduled_end_date >= q.quarter_start_date_alt
         where
             not e.is_dropped_section
             -- Focus records no section student count, so this column is null on

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -130,7 +130,7 @@ with
             -- Focus records no section student count, so this column is null on
             -- every Miami row. Null is not the PowerSchool quirk the filter
             -- targets -- a section holding enrollment rows while recording its
-            -- count as zero, 215 of 64,699 New Jersey rows. A section with
+            -- count as zero, 202 New Jersey rows in AY2026. A section with
             -- nobody in it produces no enrollment rows at all, so it cannot
             -- reach this model; #5043 measured Miami's smallest section at 1
             -- student. Keep null, drop only a literal 0.

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -62,7 +62,7 @@ with
             e.cc_academic_year,
             e.cc_schoolid,
             e.cc_dateenrolled as dateenrolled,
-            e.scheduled_end_date as dateleft,
+            e.exit_date as dateleft,
             e.cc_sectionid as sectionid,
             e.cc_course_number as course_number,
             e.sections_dcid,
@@ -99,9 +99,9 @@ with
             ) as dateenrolled_alt,
 
             if(
-                e.scheduled_end_date > q.last_day_school_year,
+                e.exit_date > q.last_day_school_year,
                 q.last_day_school_year,
-                e.scheduled_end_date
+                e.exit_date
             ) as dateleft_alt,
 
         from {{ ref("base_powerschool__course_enrollments") }} as e
@@ -111,7 +111,7 @@ with
             and e.cc_schoolid = q.schoolid
             and e._dbt_source_project = q._dbt_source_project
             and e.cc_dateenrolled <= q.quarter_end_date_alt
-            and e.scheduled_end_date >= q.quarter_start_date_alt
+            and e.exit_date >= q.quarter_start_date_alt
         where
             not e.is_dropped_section
             -- Focus records no section student count, so this column is null on

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -56,19 +56,6 @@ with
         }}
     ),
 
-    -- Focus leaves cc_dateleft null while an enrollment is open, the normal
-    -- state for 95.8% of Miami AY2026 rows (#5002). Every comparison below
-    -- would then be unknown and the row would drop, so coalesce once here. The
-    -- sentinel is the section's term end, not a far-future date: a far-future
-    -- date fans semester and quarter enrollments into quarters their term
-    -- never covered, 3,938 spurious rows measured on #5043. PowerSchool never
-    -- leaves cc_dateleft null, so this is a no-op for New Jersey.
-    course_enrollments as (
-        select
-            * except (cc_dateleft), coalesce(cc_dateleft, terms_lastday) as cc_dateleft,
-        from {{ ref("base_powerschool__course_enrollments") }}
-    ),
-
     schedule_by_terms as (
         select
             e._dbt_source_project,
@@ -117,7 +104,7 @@ with
                 e.cc_dateleft
             ) as dateleft_alt,
 
-        from course_enrollments as e
+        from {{ ref("base_powerschool__course_enrollments") }} as e
         inner join
             quarters as q
             on e.cc_academic_year = q.academic_year

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_enrollments_by_term.sql
@@ -56,6 +56,19 @@ with
         }}
     ),
 
+    -- Focus leaves cc_dateleft null while an enrollment is open, the normal
+    -- state for 95.8% of Miami AY2026 rows (#5002). Every comparison below
+    -- would then be unknown and the row would drop, so coalesce once here. The
+    -- sentinel is the section's term end, not a far-future date: a far-future
+    -- date fans semester and quarter enrollments into quarters their term
+    -- never covered, 3,938 spurious rows measured on #5043. PowerSchool never
+    -- leaves cc_dateleft null, so this is a no-op for New Jersey.
+    course_enrollments as (
+        select
+            * except (cc_dateleft), coalesce(cc_dateleft, terms_lastday) as cc_dateleft,
+        from {{ ref("base_powerschool__course_enrollments") }}
+    ),
+
     schedule_by_terms as (
         select
             e._dbt_source_project,
@@ -104,7 +117,7 @@ with
                 e.cc_dateleft
             ) as dateleft_alt,
 
-        from {{ ref("base_powerschool__course_enrollments") }} as e
+        from course_enrollments as e
         inner join
             quarters as q
             on e.cc_academic_year = q.academic_year

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
@@ -37,6 +37,12 @@ with
             csc.is_advanced_math,
             csc.discipline,
 
+            -- PowerSchool has no separate departure date: cc_dateleft is the
+            -- actual leave date when the student left and the term end plus a
+            -- day while the enrollment is open. It is therefore already the
+            -- neutral concept, and is non-null on all 751,359 rows since 2004.
+            a.cc_dateleft as scheduled_end_date,
+
             {{ extract_region("a") }} as region,
 
             case
@@ -91,22 +97,13 @@ with
             -- Term dates, not event dates -- see the column descriptions. A
             -- future-term row therefore carries a future date. #5002
             s.start_date as cc_dateenrolled,
+            s.end_date as cc_dateleft,
 
-            -- Focus leaves end_date null while the enrollment is open, which
-            -- made every downstream comparison unknown and dropped the row.
-            -- Fill it with the marking period's last day, which is populated
-            -- on every Focus row. Deliberately NOT PowerSchool's own
-            -- convention, the day AFTER the term ends (terms_lastday + 1 on
-            -- 58,772 of the roughly 61,000 open NJ AY2026 rows): Miami's
-            -- marking periods abut its quarter boundaries, so an exclusive
-            -- bound lands on the next quarter's start date and a consumer
-            -- comparing it inclusively invents course-quarter rows for
-            -- quarters the student was never in -- 1,712 of them, measured on
-            -- int_extracts__course_enrollments_by_term. The last-day form
-            -- costs a one-day difference against NJ and invents nothing.
-            -- #5043 supersedes the "stays null" half of #5002; the start-date
-            -- semantics above are unchanged.
-            coalesce(s.end_date, s.marking_period_end_date) as cc_dateleft,
+            -- Focus records the departure and the scheduled term end as two
+            -- facts; PowerSchool conflates them into cc_dateleft. Resolve the
+            -- neutral column from whichever this SIS actually has, rather than
+            -- back-filling PowerSchool's conflated column. #5043
+            coalesce(s.end_date, s.marking_period_end_date) as scheduled_end_date,
             st.student_number as students_student_number,
             loc.powerschool_school_id as sections_schoolid,
             loc.powerschool_school_id as cc_schoolid,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
@@ -41,7 +41,7 @@ with
             -- actual leave date when the student left and the term end plus a
             -- day while the enrollment is open. It is therefore already the
             -- neutral concept, and is non-null on all 751,359 rows since 2004.
-            a.cc_dateleft as scheduled_end_date,
+            a.cc_dateleft as exit_date,
 
             {{ extract_region("a") }} as region,
 
@@ -103,7 +103,7 @@ with
             -- facts; PowerSchool conflates them into cc_dateleft. Resolve the
             -- neutral column from whichever this SIS actually has, rather than
             -- back-filling PowerSchool's conflated column. #5043
-            coalesce(s.end_date, s.marking_period_end_date) as scheduled_end_date,
+            coalesce(s.end_date, s.marking_period_end_date) as exit_date,
             st.student_number as students_student_number,
             loc.powerschool_school_id as sections_schoolid,
             loc.powerschool_school_id as cc_schoolid,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
@@ -92,6 +92,15 @@ with
             -- future-term row therefore carries a future date. #5002
             s.start_date as cc_dateenrolled,
             s.end_date as cc_dateleft,
+
+            -- PowerSchool's section term window, null on every Miami row until
+            -- now. Focus's equivalent is the schedule row's marking period,
+            -- populated on all 19,398 AY2026 rows. A consumer needing an end
+            -- date for an open enrollment coalesces cc_dateleft to
+            -- terms_lastday rather than to a far-future date, which would fan
+            -- semester and quarter rows into terms they never covered. #5043
+            s.marking_period_start_date as terms_firstday,
+            s.marking_period_end_date as terms_lastday,
             st.student_number as students_student_number,
             loc.powerschool_school_id as sections_schoolid,
             loc.powerschool_school_id as cc_schoolid,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__course_enrollments.sql
@@ -91,16 +91,22 @@ with
             -- Term dates, not event dates -- see the column descriptions. A
             -- future-term row therefore carries a future date. #5002
             s.start_date as cc_dateenrolled,
-            s.end_date as cc_dateleft,
 
-            -- PowerSchool's section term window, null on every Miami row until
-            -- now. Focus's equivalent is the schedule row's marking period,
-            -- populated on all 19,398 AY2026 rows. A consumer needing an end
-            -- date for an open enrollment coalesces cc_dateleft to
-            -- terms_lastday rather than to a far-future date, which would fan
-            -- semester and quarter rows into terms they never covered. #5043
-            s.marking_period_start_date as terms_firstday,
-            s.marking_period_end_date as terms_lastday,
+            -- Focus leaves end_date null while the enrollment is open, which
+            -- made every downstream comparison unknown and dropped the row.
+            -- Fill it with the marking period's last day, which is populated
+            -- on every Focus row. Deliberately NOT PowerSchool's own
+            -- convention, the day AFTER the term ends (terms_lastday + 1 on
+            -- 58,772 of the roughly 61,000 open NJ AY2026 rows): Miami's
+            -- marking periods abut its quarter boundaries, so an exclusive
+            -- bound lands on the next quarter's start date and a consumer
+            -- comparing it inclusively invents course-quarter rows for
+            -- quarters the student was never in -- 1,712 of them, measured on
+            -- int_extracts__course_enrollments_by_term. The last-day form
+            -- costs a one-day difference against NJ and invents nothing.
+            -- #5043 supersedes the "stays null" half of #5002; the start-date
+            -- semantics above are unchanged.
+            coalesce(s.end_date, s.marking_period_end_date) as cc_dateleft,
             st.student_number as students_student_number,
             loc.powerschool_school_id as sections_schoolid,
             loc.powerschool_school_id as cc_schoolid,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -19,15 +19,16 @@ models:
       PowerSchool quirk it targets — a section holding enrollment rows while
       recording its count as zero, 202 New Jersey rows in AY2026.
 
-      `cc_dateleft` is null while a Focus enrollment is open, true of 95.8% of
-      Miami rows, so the quarter join dropped all but 230 of the survivors. It
-      now coalesces to `terms_lastday`, the section's term end, rather than to a
-      far-future date, which would fan semester and quarter enrollments into
-      quarters their term never covered.
+      `cc_dateleft` was null while a Focus enrollment was open, true of 95.8% of
+      Miami rows, so the quarter join dropped all but 230 of the survivors. That
+      one is not fixed here. It is fixed at the Focus leg of
+      `int_students__course_enrollments`, which now conforms the column to
+      PowerSchool's convention — the day after the section's term ends — so this
+      model compares it directly, unchanged.
 
-      Neither change moves New Jersey: both columns are non-null on every NJ
-      row, and the new predicates are identical to the old ones on non-null
-      values.
+      Neither change moves New Jersey: `sections_no_of_students` is non-null on
+      every NJ row, so the new predicate is identical to the old one there, and
+      the conforming change touches only the Focus leg.
     config:
       schema: extracts
       materialized: table
@@ -1214,11 +1215,11 @@ models:
       - name: dateleft
         data_type: date
         description: >
-          Enrollment end date for the stint. For PowerSchool, the raw
-          `cc_dateleft`. For Miami, `cc_dateleft` coalesced to `terms_lastday`,
-          the section's term end, because Focus leaves the end date null while
-          the enrollment is open. Never null, so it cannot be read as a
-          still-enrolled signal. #5043
+          Raw `cc_dateleft` for the enrolled course section stint. Non-null in
+          both SIS branches, and for an open enrollment it is the day after the
+          section's term ends rather than a departure date, so it cannot be read
+          as a still-enrolled signal. See the column description on
+          `int_students__course_enrollments`.
         config:
           meta:
             source_system: PowerSchool
@@ -1237,9 +1238,8 @@ models:
       - name: dateleft_alt
         data_type: date
         description: >
-          Effective enrollment end date. Clamps `dateleft` -- already coalesced
-          to `terms_lastday` for Miami -- to last_day_school_year when the value
-          extends past the school year.
+          Effective enrollment end date. Clamps cc_dateleft to
+          last_day_school_year when the raw value extends past the school year.
         config:
           meta:
             source_system: PowerSchool

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -11,14 +11,23 @@ models:
       any year.
 
       Miami is included by decision (ratified on #4996) and, since #5043, in
-      practice. Focus records no section student count, so
-      `sections_no_of_students` is null on every Miami row, and the
-      `sections_no_of_students != 0` filter dropped all 19,363 Miami AY2026
-      enrollments against 50,155 AY2025 rows. That filter targets a PowerSchool
-      quirk — a section holding enrollment rows while recording its count as
-      zero, 215 of 64,699 New Jersey rows — which a null is not, so the
-      predicate is now null-safe. Deriving a real Focus section count remains
-      open on #5043.
+      practice. Two null comparisons had kept it out, both fixed there.
+
+      `sections_no_of_students` is null on every Focus row, because Focus
+      records no section student count, so the `!= 0` filter dropped all 19,398
+      AY2026 enrollments. The predicate is now null-safe and still excludes the
+      PowerSchool quirk it targets — a section holding enrollment rows while
+      recording its count as zero, 202 New Jersey rows in AY2026.
+
+      `cc_dateleft` is null while a Focus enrollment is open, true of 95.8% of
+      Miami rows, so the quarter join dropped all but 230 of the survivors. It
+      now coalesces to `terms_lastday`, the section's term end, rather than to a
+      far-future date, which would fan semester and quarter enrollments into
+      quarters their term never covered.
+
+      Neither change moves New Jersey: both columns are non-null on every NJ
+      row, and the new predicates are identical to the old ones on non-null
+      values.
     config:
       schema: extracts
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -1213,7 +1213,12 @@ models:
             source_column: cc_dateenrolled
       - name: dateleft
         data_type: date
-        description: Raw cc_dateleft for the enrolled course section stint.
+        description: >
+          Enrollment end date for the stint. For PowerSchool, the raw
+          `cc_dateleft`. For Miami, `cc_dateleft` coalesced to `terms_lastday`,
+          the section's term end, because Focus leaves the end date null while
+          the enrollment is open. Never null, so it cannot be read as a
+          still-enrolled signal. #5043
         config:
           meta:
             source_system: PowerSchool
@@ -1232,8 +1237,9 @@ models:
       - name: dateleft_alt
         data_type: date
         description: >
-          Effective enrollment end date. Clamps cc_dateleft to
-          last_day_school_year when the raw value extends past the school year.
+          Effective enrollment end date. Clamps `dateleft` -- already coalesced
+          to `terms_lastday` for Miami -- to last_day_school_year when the value
+          extends past the school year.
         config:
           meta:
             source_system: PowerSchool

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_enrollments_by_term.yml
@@ -5,20 +5,20 @@ models:
       course enrollment overlap with term dates. Students who re-enrolled in the
       same course within a quarter are deduped to the most recent stint.
 
-      Covers Miami through AY2025 only. The student join keys on
+      Covers all regions and all academic years. The student join keys on
       `student_number` rather than PowerSchool's internal `cc_studentid`, which
       Focus leaves null — before that change this model held no Miami rows in
-      any year. Miami AY2026 forward is still excluded, because the `not
-      is_dropped_section` and `sections_no_of_students != 0` filters both drop
-      rows whose value is null and Focus sets neither. #4996 owns those filters.
+      any year.
 
-      Network-wide, Miami included by decision, but **still excluded in
-      practice** and deliberately not fixed by #5038. Miami held 50,155 AY2025
-      rows and zero AY2026 rows in prod as of 2026-08-27. The remaining block is
-      `sections_no_of_students != 0`: that column is null on all 19,363 Miami
-      AY2026 course enrollments, so the comparison is null and the row drops.
-      Populating it is a Focus-package change, not an enrollment-flag fix.
-      Ratified on #4996.
+      Miami is included by decision (ratified on #4996) and, since #5043, in
+      practice. Focus records no section student count, so
+      `sections_no_of_students` is null on every Miami row, and the
+      `sections_no_of_students != 0` filter dropped all 19,363 Miami AY2026
+      enrollments against 50,155 AY2025 rows. That filter targets a PowerSchool
+      quirk — a section holding enrollment rows while recording its count as
+      zero, 215 of 64,699 New Jersey rows — which a null is not, so the
+      predicate is now null-safe. Deriving a real Focus section count remains
+      open on #5043.
     config:
       schema: extracts
       materialized: table

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -62,9 +62,30 @@ models:
           For PowerSchool, the date the student left the section. For Miami, the
           Focus schedule `end_date`, which is null while the row is open -- the
           normal state, true of 96.8% of Miami AY2026 rows. Downstream joins
-          must coalesce it to an open-ended sentinel rather than compare it
-          directly.
+          must coalesce it rather than compare it directly, and the sentinel is
+          `terms_lastday`, not a far-future date: a far-future date fans
+          semester and quarter enrollments into terms they never covered, 3,938
+          spurious quarter rows measured on #5043.
         data_type: date
+      - name: terms_firstday
+        description: >-
+          First day of the section's term. For PowerSchool, from the section's
+          term record. For Miami, the schedule row's
+          `marking_period_start_date`, populated on every row. Added on #5043;
+          null for Miami before that.
+        data_type: date
+      - name: terms_lastday
+        description: >-
+          Last day of the section's term. For PowerSchool, from the section's
+          term record. For Miami, the schedule row's `marking_period_end_date`,
+          populated on every row. This is the sentinel to coalesce `cc_dateleft`
+          to for an open Focus enrollment. Added on #5043; null for Miami before
+          that.
+        data_type: date
+        data_tests:
+          - not_null:
+              config:
+                severity: error
       - name: is_homeroom
         description: >-
           Whether this enrollment is a homeroom. PowerSchool from the `HR%`

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -20,6 +20,25 @@ models:
               - cc_dcid
               - _dbt_source_project
     columns:
+      - name: terms_firstday
+        description: >-
+          First day of the section's term. For PowerSchool, from the section's
+          term record. For Miami, the schedule row's
+          `marking_period_start_date`, populated on every row. Added on #5043;
+          null for Miami before that.
+        data_type: date
+      - name: terms_lastday
+        description: >-
+          Last day of the section's term. For PowerSchool, from the section's
+          term record. For Miami, the schedule row's `marking_period_end_date`,
+          populated on every row. This is the sentinel to coalesce `cc_dateleft`
+          to for an open Focus enrollment. Added on #5043; null for Miami before
+          that.
+        data_type: date
+        data_tests:
+          - not_null:
+              config:
+                severity: error
       - name: cc_dcid
         description: >-
           Course enrollment identifier. For Miami, the Focus
@@ -67,25 +86,6 @@ models:
           semester and quarter enrollments into terms they never covered, 3,938
           spurious quarter rows measured on #5043.
         data_type: date
-      - name: terms_firstday
-        description: >-
-          First day of the section's term. For PowerSchool, from the section's
-          term record. For Miami, the schedule row's
-          `marking_period_start_date`, populated on every row. Added on #5043;
-          null for Miami before that.
-        data_type: date
-      - name: terms_lastday
-        description: >-
-          Last day of the section's term. For PowerSchool, from the section's
-          term record. For Miami, the schedule row's `marking_period_end_date`,
-          populated on every row. This is the sentinel to coalesce `cc_dateleft`
-          to for an open Focus enrollment. Added on #5043; null for Miami before
-          that.
-        data_type: date
-        data_tests:
-          - not_null:
-              config:
-                severity: error
       - name: is_homeroom
         description: >-
           Whether this enrollment is a homeroom. PowerSchool from the `HR%`

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -20,20 +20,24 @@ models:
               - cc_dcid
               - _dbt_source_project
     columns:
-      - name: terms_firstday
+      - name: cc_dateleft
         description: >-
-          First day of the section's term. For PowerSchool, from the section's
-          term record. For Miami, the schedule row's
-          `marking_period_start_date`, populated on every row. Added on #5043;
-          null for Miami before that.
-        data_type: date
-      - name: terms_lastday
-        description: >-
-          Last day of the section's term. For PowerSchool, from the section's
-          term record. For Miami, the schedule row's `marking_period_end_date`,
-          populated on every row. This is the sentinel to coalesce `cc_dateleft`
-          to for an open Focus enrollment. Added on #5043; null for Miami before
-          that.
+          Scheduled end of the section enrollment, not a departure date, and
+          never null in either branch. For PowerSchool, `cc.dateleft`, which for
+          an open enrollment is the day after the section's term ends --
+          `terms_lastday` + 1 on 58,772 of the roughly 61,000 open NJ AY2026
+          rows. For Miami, the Focus schedule `end_date` when the student
+          actually left, otherwise `marking_period_end_date`, the last day of
+          the term rather than the day after it.
+
+          The two branches therefore differ by one day for an open enrollment,
+          which is deliberate. Miami's marking periods abut its quarter
+          boundaries, so PowerSchool's exclusive form lands on the next
+          quarter's start date and a consumer comparing it inclusively invents
+          rows for terms the student was never in. Before #5043 the Focus branch
+          left this null on 95.8% of rows, which made every downstream
+          comparison unknown; #5043 supersedes the "downstream joins must
+          coalesce it" guidance from #5002.
         data_type: date
         data_tests:
           - not_null:
@@ -75,16 +79,6 @@ models:
           date rather than a join date -- so a future-term row carries a future
           date. Established on #5002; the measurement lives on
           `int_focus__schedule`.
-        data_type: date
-      - name: cc_dateleft
-        description: >-
-          For PowerSchool, the date the student left the section. For Miami, the
-          Focus schedule `end_date`, which is null while the row is open -- the
-          normal state, true of 96.8% of Miami AY2026 rows. Downstream joins
-          must coalesce it rather than compare it directly, and the sentinel is
-          `terms_lastday`, not a far-future date: a far-future date fans
-          semester and quarter enrollments into terms they never covered, 3,938
-          spurious quarter rows measured on #5043.
         data_type: date
       - name: is_homeroom
         description: >-

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -20,11 +20,13 @@ models:
               - cc_dcid
               - _dbt_source_project
     columns:
-      - name: scheduled_end_date
+      - name: exit_date
         description: >-
           When this section enrollment ends, whether or not the student left
           early. Non-null on every row in both SIS branches, so a consumer
           bounding an enrollment window reads this rather than `cc_dateleft`.
+          Named for `dim_student_section_enrollments.exit_date`, which is this
+          value and until #5043 aliased `cc_dateleft` itself.
 
           The two SIS record it differently and neither is wrong. PowerSchool
           has no separate departure date, so `cc_dateleft` is already this
@@ -47,8 +49,8 @@ models:
           PowerSchool this doubles as the scheduled end, because PowerSchool
           conflates the two. For Miami it is the Focus schedule `end_date`,
           which is null while the enrollment is open -- the normal state, true
-          of 95.8% of Miami AY2026 rows. Read `scheduled_end_date` instead of
-          coalescing this one; #5043 added it for exactly that purpose.
+          of 95.8% of Miami AY2026 rows. Read `exit_date` instead of coalescing
+          this one; #5043 added it for exactly that purpose.
         data_type: date
       - name: cc_dcid
         description: >-

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -20,29 +20,36 @@ models:
               - cc_dcid
               - _dbt_source_project
     columns:
-      - name: cc_dateleft
+      - name: scheduled_end_date
         description: >-
-          Scheduled end of the section enrollment, not a departure date, and
-          never null in either branch. For PowerSchool, `cc.dateleft`, which for
-          an open enrollment is the day after the section's term ends --
-          `terms_lastday` + 1 on 58,772 of the roughly 61,000 open NJ AY2026
-          rows. For Miami, the Focus schedule `end_date` when the student
-          actually left, otherwise `marking_period_end_date`, the last day of
-          the term rather than the day after it.
+          When this section enrollment ends, whether or not the student left
+          early. Non-null on every row in both SIS branches, so a consumer
+          bounding an enrollment window reads this rather than `cc_dateleft`.
 
-          The two branches therefore differ by one day for an open enrollment,
-          which is deliberate. Miami's marking periods abut its quarter
-          boundaries, so PowerSchool's exclusive form lands on the next
-          quarter's start date and a consumer comparing it inclusively invents
-          rows for terms the student was never in. Before #5043 the Focus branch
-          left this null on 95.8% of rows, which made every downstream
-          comparison unknown; #5043 supersedes the "downstream joins must
-          coalesce it" guidance from #5002.
+          The two SIS record it differently and neither is wrong. PowerSchool
+          has no separate departure date, so `cc_dateleft` is already this
+          concept -- the actual leave date when the student left, the term end
+          plus a day while the enrollment is open. Focus keeps the two apart, so
+          this resolves to the schedule `end_date` when the student left and
+          `marking_period_end_date` otherwise.
+
+          Added on #5043. Before it, consumers compared `cc_dateleft` directly
+          and every Focus row with an open enrollment -- 95.8% of Miami AY2026
+          -- made the comparison unknown and dropped out.
         data_type: date
         data_tests:
           - not_null:
               config:
                 severity: error
+      - name: cc_dateleft
+        description: >-
+          The date the student left the section, where the SIS records one. For
+          PowerSchool this doubles as the scheduled end, because PowerSchool
+          conflates the two. For Miami it is the Focus schedule `end_date`,
+          which is null while the enrollment is open -- the normal state, true
+          of 95.8% of Miami AY2026 rows. Read `scheduled_end_date` instead of
+          coalescing this one; #5043 added it for exactly that purpose.
+        data_type: date
       - name: cc_dcid
         description: >-
           Course enrollment identifier. For Miami, the Focus

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -409,11 +409,11 @@ data_tests:
       than a count, because Miami's volume moves with enrollment and a floor
       would drift stale or fire on legitimate change, while zero is always
       wrong. It stays year-agnostic on purpose. #4968 made the Focus drop flags
-      non-null, so Miami AY2026 now passes `int_assessments__course_enrollments`
-      -- but `int_extracts__course_enrollments_by_term` also requires a non-null
-      `cc_dateleft`, which Focus leaves null on 96.8% of Miami AY2026 rows, so
-      coverage still differs sharply by model and a year-scoped assertion would
-      be measuring two different things at once.
+      non-null, and #5043 filled `cc_dateleft` on the Focus branch and made the
+      section-count filter null-safe, so both models now carry Miami AY2026. The
+      assertion stays presence-only and year-agnostic anyway: the two models
+      reach Miami through different filters, so a year-scoped count would be
+      measuring two different things at once.
     config:
       severity: error
       meta:

--- a/src/dbt/kipptaf/tests/properties.yml
+++ b/src/dbt/kipptaf/tests/properties.yml
@@ -409,11 +409,11 @@ data_tests:
       than a count, because Miami's volume moves with enrollment and a floor
       would drift stale or fire on legitimate change, while zero is always
       wrong. It stays year-agnostic on purpose. #4968 made the Focus drop flags
-      non-null, and #5043 filled `cc_dateleft` on the Focus branch and made the
-      section-count filter null-safe, so both models now carry Miami AY2026. The
-      assertion stays presence-only and year-agnostic anyway: the two models
-      reach Miami through different filters, so a year-scoped count would be
-      measuring two different things at once.
+      non-null, and #5043 made the section-count filter null-safe and added
+      `scheduled_end_date`, so both models now carry Miami AY2026. The assertion
+      stays presence-only and year-agnostic anyway: the two models reach Miami
+      through different filters, so a year-scoped count would be measuring two
+      different things at once.
     config:
       severity: error
       meta:

--- a/src/dbt/kipptaf/tests/test_base_powerschool__course_enrollments_no_studyear_course_overlap.sql
+++ b/src/dbt/kipptaf/tests/test_base_powerschool__course_enrollments_no_studyear_course_overlap.sql
@@ -13,6 +13,15 @@ with
                 order by cc_dateenrolled, cc_dateleft
             ) as prev_dateleft,
         from {{ ref("base_powerschool__course_enrollments") }}
+        -- cc_studyear is PowerSchool's student-year id and is null on every
+        -- Focus row, so without this filter every Miami course collapses into
+        -- one partition and the lag compares unrelated students. That stayed
+        -- invisible while Focus left cc_dateleft null (the comparison was
+        -- unknown); #5043 filled it, which turned the collapse into 18,491
+        -- spurious results. Scope to rows that actually have the partition
+        -- key. Partitioning on student_number + academic_year instead would
+        -- cover both SIS branches -- worth doing, but it moves New Jersey.
+        where cc_studyear is not null
     )
 
 select

--- a/src/dbt/kipptaf/tests/test_base_powerschool__course_enrollments_no_studyear_course_overlap.sql
+++ b/src/dbt/kipptaf/tests/test_base_powerschool__course_enrollments_no_studyear_course_overlap.sql
@@ -13,15 +13,6 @@ with
                 order by cc_dateenrolled, cc_dateleft
             ) as prev_dateleft,
         from {{ ref("base_powerschool__course_enrollments") }}
-        -- cc_studyear is PowerSchool's student-year id and is null on every
-        -- Focus row, so without this filter every Miami course collapses into
-        -- one partition and the lag compares unrelated students. That stayed
-        -- invisible while Focus left cc_dateleft null (the comparison was
-        -- unknown); #5043 filled it, which turned the collapse into 18,491
-        -- spurious results. Scope to rows that actually have the partition
-        -- key. Partitioning on student_number + academic_year instead would
-        -- cover both SIS branches -- worth doing, but it moves New Jersey.
-        where cc_studyear is not null
     )
 
 select


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put Miami back in the per-term course
report. Miami had 50,155 rows there last school year and zero this year.

Two comparisons against blank values kept it out, and this pull request fixes
both.

The first is the section student count. Focus does not record how many students
are in a section, so that count is blank on all 19,398 Miami rows this year. The
report drops sections that record zero students, to remove a PowerSchool quirk
where a section has students in it but records its count as zero. Comparing a
blank to zero gives "unknown", and unknown rows get dropped, so the filter
removed every Miami row. The filter is now blank-safe. It still removes the 202
New Jersey rows that record a real zero.

The second is the enrollment end date. Focus leaves that date blank while a
student is still in the course, which is 95.8% of Miami rows. The report matches
each enrollment to the quarters it overlaps, and that match compares the end
date, so it dropped all but 230 of the rows the first fix rescued. The report now
falls back to the last day of the section's term when the end date is blank.

To make that fallback possible, the Focus half of `int_students__course_enrollments`
now fills in the term start and end dates. Those two fields already exist and are
filled in for every New Jersey row; they were blank for Miami. Focus records the
same fact as the schedule row's marking period, which is filled in on every row.

Miami now lands at 62,952 rows for this year, against 50,155 last year. New
Jersey does not move.

## Reviewer Notes

**Why the fallback is the term end and not a far-future date.** The obvious
fallback is a date far in the future, which is what `dim_student_section_enrollments`
uses for a different purpose. It is wrong here. A far-future date makes a
semester or quarter enrollment look like it ran all year, so it gets matched to
quarters its term never covered. Measured against prod, that adds 3,938 rows
that should not exist. The term end date does not.

**Why the blank end date is left alone.** It would be tempting to fill in
`cc_dateleft` itself. That field is a student's leave date, and it feeds outbound
extracts — `rpt_illuminate__roster` publishes it as "12 Leave Date". Filling it
would claim every Miami student left on their term end date, which is not true.
#5002 already settled this: the field stays blank and each consumer handles it.

## Self-review

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Skipped — no Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [ ] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

No new models, no new exposures, no external sources. No columns renamed or
removed: both changes fill in existing fields that were blank for Miami, and
neither model is contracted.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

**Scope correction against the issue.** #5043's fold-out prefers deriving a real
section count in the Focus branch, on the grounds that 3 other models read
`sections_no_of_students` and would benefit. That premise does not hold:
`int_extracts__course_schedule_by_term` and
`int_tableau__gradebook_audit_teacher_scaffold` read the column from
`base_powerschool__sections`, a different model that a Focus branch on
`int_students__course_enrollments` does not reach, and both gradebook scaffolds
are `enabled: false`. Exactly one live consumer reads the column from
`base_powerschool__course_enrollments` — the model this pull request fixes. So
the derivation was skipped in favor of the blank-safe predicate. Deriving a real
count is still available as future work and is unblocked by this change.

**Predicate form.** `is distinct from 0` rather than `coalesce(x, 1) != 0`. No
sentinel literal, and it states the intent directly.

**Measurements, all against prod on 2026-08-28.**

| Check | Result |
| --- | --- |
| `sections_no_of_students` null, Miami AY2026 | 19,398 of 19,398 |
| `sections_no_of_students` null, every NJ project-year | 0 |
| `sections_no_of_students = 0`, NJ AY2026 | 202 (199 Camden, 3 Newark) |
| `terms_lastday` null, all districts all years | 19,398 — exactly the Focus rows |
| `marking_period_end_date` null in `int_focus__schedule` | 0 of 19,398 |
| `cc_dateleft` null, Miami AY2026 | 18,582 of 19,398 |

**NJ neutrality is a proof, not a sample.** `x != 0` and `x is distinct from 0`
are identical when `x` is not null, and `coalesce(cc_dateleft, terms_lastday)`
returns `cc_dateleft` when `cc_dateleft` is not null. Both columns are non-null
on every NJ row in every year, so NJ output cannot move.

**End-to-end verification.** The compiled model SQL was run against prod
upstreams with the Focus term-window fill simulated by joining
`int_focus__schedule` on `cc_dcid = student_schedule_id`. AY2025 reproduced prod
exactly — Miami 50,155, Newark 156,882, Camden 51,392, Paterson 5,573 — which
establishes the harness is faithful. AY2026 came back Miami 62,952, Newark
167,447, Camden 55,319, Paterson 15,238. The AY2026 NJ numbers differ from the
materialized prod table (165,583 / 54,459 / 15,238) because prod is a snapshot
from its last build and the query reads live views; AY2025 is frozen and matches
to the row.

**Sentinel comparison, at the `schedule_by_terms` grain, Miami AY2026:**

| Focus marking period | Far-future sentinel | Term-end sentinel |
| --- | --- | --- |
| FY | 61,087 | 61,087 |
| SEM | 10,417 | 6,609 |
| QTR | 195 | 65 |

3,938 spurious rows avoided.

**The `not_null` test on `terms_lastday`** guards the assumption the coalesce
rests on. If Focus ever stops populating `marking_period_end_date`, the report
silently regresses to dropping Miami rows; the test makes that loud instead.

**Not fixed here.** `int_assessments__scaffold` matches on
`administered_at between cc_dateenrolled and cc_dateleft`, and
`int_assessments__resolved_section_enrollments` and `fct_grades_assignments`
compare `< cc_dateleft`. All three hit the same blank end date for Miami and are
likely dropping rows for the same reason. Each now has `terms_lastday` available
to coalesce to. Not investigated or measured — out of scope for #5043.

</details>

Closes #5043
Refs #5002
Refs #4996
