### PR TITLE
fix(dbt): dedupe int_students__student_enrollment_union on the enrollment key grain

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
@@ -32,12 +32,32 @@ with
         select *,
         from {{ ref("int_powerschool__student_enrollment_union") }}
         where _dbt_source_project != 'kippmiami'
+    ),
+
+    unioned as (
+        select *,
+        from powerschool_conformed
+
+        full union all corresponding
+
+        select *,
+        from focus_conformed
     )
 
+-- PowerSchool keeps the current enrollment in `students` and prior stints in
+-- `reenrollments`. A re-entry backdated to a still-open stint's entrydate
+-- therefore yields two rows on (student_number, _dbt_source_project,
+-- academic_year, entrydate) -- the grain `student_enrollment_key` hashes -- and
+-- every mart joining that key double-counts the student. Keep the year's
+-- primary stint: rn_year is already ranked exitdate desc upstream, so the
+-- survivor is the open stint and its year_in_school / year_in_network stay
+-- populated. This drops rows, never key values, so no existing hash changes and
+-- no downstream foreign key is orphaned. See #5045.
 select *,
-from powerschool_conformed
-
-full union all corresponding
-
-select *,
-from focus_conformed
+from unioned
+qualify
+    row_number() over (
+        partition by student_number, _dbt_source_project, academic_year, entrydate
+        order by rn_year
+    )
+    = 1

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__student_enrollment_union.sql
@@ -44,20 +44,12 @@ with
         from focus_conformed
     )
 
--- PowerSchool keeps the current enrollment in `students` and prior stints in
--- `reenrollments`. A re-entry backdated to a still-open stint's entrydate
--- therefore yields two rows on (student_number, _dbt_source_project,
--- academic_year, entrydate) -- the grain `student_enrollment_key` hashes -- and
--- every mart joining that key double-counts the student. Keep the year's
--- primary stint: rn_year is already ranked exitdate desc upstream, so the
--- survivor is the open stint and its year_in_school / year_in_network stay
--- populated. This drops rows, never key values, so no existing hash changes and
--- no downstream foreign key is orphaned. See #5045.
-select *,
-from unioned
-qualify
-    row_number() over (
-        partition by student_number, _dbt_source_project, academic_year, entrydate
-        order by rn_year
-    )
-    = 1
+    -- TODO(#5045): remove once Ops corrects the backdated PowerSchool re-entry
+    -- dates that put two stints on one entrydate.
+    {{
+        dbt_utils.deduplicate(
+            relation="unioned",
+            partition_by="student_number, _dbt_source_project, academic_year, entrydate",
+            order_by="rn_year asc",
+        )
+    }}

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollment_union.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollment_union.yml
@@ -11,6 +11,22 @@ models:
       Miami rows at all -- including its alumni graduate placeholders. Replaces
       `int_powerschool__student_enrollment_union` as the canonical
       enrollment-grain source for marts.
+
+
+      Deduplicated to one row per (`student_number`, `_dbt_source_project`,
+      `academic_year`, `entrydate`) -- the grain `student_enrollment_key`
+      hashes. PowerSchool holds a student's current enrollment in `students` and
+      their earlier stints in `reenrollments`, so a re-entry backdated onto a
+      still-open stint puts two rows on one entrydate and every mart joining
+      that key double-counts the student. The survivor is the year's primary
+      stint (`rn_year` 1), which is the open one because `rn_year` is ranked
+      exitdate descending upstream, and which is the row carrying
+      `year_in_school` and `year_in_network`. Deduplicating drops rows, never
+      key values, so no existing hash changes and no downstream foreign key is
+      orphaned. The matching test on `int_powerschool__student_enrollment_union`
+      stays `severity: warn` on purpose -- it keeps alerting on the underlying
+      PowerSchool data-entry error, which only Ops can correct. Tracked in
+      #5045.
     config:
       materialized: table
     data_tests:
@@ -21,6 +37,8 @@ models:
               - _dbt_source_project
               - academic_year
               - entrydate
+          config:
+            severity: error
     columns:
       - name: student_number
         description: >-

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollment_union.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_enrollment_union.yml
@@ -21,8 +21,6 @@ models:
               - _dbt_source_project
               - academic_year
               - entrydate
-          config:
-            severity: warn
     columns:
       - name: student_number
         description: >-


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will stop `dim_student_enrollments` from
returning two rows for the same student enrollment, and stop every fact that
joins it from double-counting those students.

`student_enrollment_key` is a surrogate key over `student_number`,
`_dbt_source_project`, `academic_year`, and `entrydate`. PowerSchool keeps a
student's current enrollment in `students` and their earlier stints in
`reenrollments`. When a school re-enters a student and backdates that re-entry
to a stint that is still open, both tables end up holding a record that starts
on the same day. The 4-part key cannot tell those two records apart, so the
model emits 2 rows where the key promises 1.

`int_students__student_enrollment_union` now keeps one row per key. It keeps the
stint the model already ranks first for the year, which is the open one. That
makes the uniqueness test on those 4 columns true, so this pull request also
raises it from a warning to an error.

Fixes #5045.

## Reviewer Notes

**This is containment for reporting, not a cure. Ops still has work to do.**
The 6 records are entered wrong in PowerSchool, and only Ops can correct them.
In 5 of them a school re-entered a student and backdated the re-entry to a
stint that was still open, so the student reads as starting twice on the same
day. In the 6th, one student holds 2 enrollment records covering the identical
window. Correcting them means fixing the entry dates in PowerSchool, or voiding
the duplicate record.

**The upstream test stays a warning on purpose, and it is the alert.** The
matching `dbt_utils.unique_combination_of_columns` on
`int_powerschool__student_enrollment_union` still fires on all 6 records after
this change, and keeps alerting through its Dagster asset check. So the
data-entry problem stays visible to us until Ops clears it, while the marts
stop double-counting in the meantime. Only the downstream test, which this
change actually makes true, goes to error.

**Deduplicating drops rows, never key values.** Both rows in a colliding pair
hash to the same key, so removing one cannot orphan a foreign key anywhere
downstream. That is what made this the safe option.

**Adding a component to the key was the wrong fix, for 2 reasons.** It would
not have worked, and it would have changed every hash. See the fold-out below.

**#4938 is a separate cause, and this does not fix it.** Measured against prod.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; the existing properties file is updated.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      exposure changes; no columns added or removed.
- [x] **Breaking change?** No. No column is renamed or removed, and no
      `student_enrollment_key` value changes. Only 6 duplicate rows go away.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — not applicable, no external sources touched.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

### What the 8 collisions actually are

The issue measured 8 colliding keys on 2026-08-27. Re-measured on 2026-08-28
there are 6, in 134,343 union rows. All are `academic_year` 2026, all have
`entrydate` 2026-07-01, all are New Jersey, and every prior academic year has
zero. Identifiers are held locally in `.claude/scratch/`, not here.

Every pair is 1 row from `stg_powerschool__students` (null
`reenrollments_dcid`) plus 1 row from `stg_powerschool__reenrollments`. They are
real PowerSchool records, not rows dbt invented.

The issue asked whether they are one pattern or a mix. They are a **mix**:

| Count | Region | Pattern |
| --- | --- | --- |
| 3 | Newark | Short stint exited, then a re-entry backdated to 7/1. Distinct `exitdate`. |
| 1 | Newark | School transfer, both sides backdated to 7/1. Distinct `exitdate` and `schoolid`. |
| 1 | Camden | Backdated re-entry plus a grade-level correction. Distinct `exitdate`. |
| 1 | Paterson | Identical `entrydate` **and** `exitdate`, differing only in `entrycode`. A true double-write. |

So neither branch of the issue's fork holds cleanly. `exitdate` as a
disambiguator fixes 5 and misses Paterson.

### Why the key was not changed

Two independent reasons.

**It would not have fixed the reported symptom.** `grades_gpa_key` is
`(student_number, _dbt_source_project, academic_year, entrydate, term_name)`.
Adding a component makes the 8 duplicate keys distinct, so the `unique` test
passes, but `fct_grades_gpa` still carries 2 rows per student-term holding
identical GPA values. The warning clears and the double-count survives. The
fan-out comes from the join to the enrollment model, so the fix has to be at
the enrollment grain.

**The blast radius is real.** Adding a component rehashes all 134,343 rows.

### Consumers of student_enrollment_key that were checked

13 sites derive the key. All 13 recompute it from source columns at build time.
None stores it incrementally — every marts model is `materialized: table` under
`+contract: enforced`, and no model in `marts/` is incremental. So a key change
would have been mechanically safe, but it would have had to land at all 13 at
once, and 3 of them reach `entrydate` through separate lineage
(`int_powerschool__ps_adaadm_daily_ctod` and
`base_powerschool__student_enrollments`) that would each need the new component
plumbed through.

Reads `int_students__student_enrollment_union` directly, so the dedupe covers
them:

- `dim_student_enrollments`
- `dim_student_ell_status`
- `dim_student_iep_status`
- `dim_student_meal_eligibility_status`
- `dim_student_section_enrollments`
- `fct_grades_gpa`
- `fct_behavioral_incidents`
- `fct_family_communications`
- `fct_student_attendance_streaks`
- `fct_student_attendance_interventions`
- `dim_student_enrollment_status` (via the 3 status dims plus
  `dim_student_enrollments`)

Separate lineage, unaffected either way:

- `fct_student_attendance_daily` — key from `int_students__attendance_daily`,
  whose `entrydate` comes from `int_powerschool__ps_adaadm_daily_ctod`. 31 rows
  sit on the colliding keys, but they are 31 distinct calendar days and its
  primary key has 0 duplicates.
- `fct_survey_submissions` and `bridge_survey_expectations` — key from
  `int_extracts__student_enrollments`, which reads
  `base_powerschool__student_enrollments`. 0 and 3 rows on the colliding keys
  respectively, no fan-out.

Marts carrying duplicate primary keys before this change, all of which the
dedupe clears:

| Model | Duplicate primary keys |
| --- | --- |
| `dim_student_enrollments` | 6 |
| `dim_student_enrollment_status` | 6 |
| `fct_grades_gpa` | 8 (16 rows) |
| `dim_student_meal_eligibility_status` | 1 |

### Which row survives

`order by rn_year` inside the `qualify`. `rn_year` is computed upstream as
`row_number() over (partition by studentid, yearid order by yearid desc,
exitdate desc)`, so within a colliding group it is exactly `exitdate desc` and
it is never tied. The survivor is the open stint in all 6 cases, and because
`year_in_school` and `year_in_network` are set only when `rn_year = 1`, keeping
the `rn_year = 1` row keeps them populated. Ordering by `exitdate desc` alone
would tie on the Paterson pair and could leave a survivor with `rn_year = 2`
and null `year_in_school`.

### #4938 ruled a separate cause

Measured against prod on 2026-08-28. `int_powerschool__gpa_term` has 16
duplicate natural keys today, all 16 with differing GPA values. Zero of them
belong to any of the 6 enrollment-collision students. In the other direction,
all 8 duplicate `grades_gpa_key` values in `fct_grades_gpa` are fully explained
by the enrollment collision. So #4938 contributes nothing to the
`fct_grades_gpa` warning and stays open on its own cause.

</details>
