### PR TITLE
feat(dbt): add school_name to the gradebook audit dashboard

### DIFF
--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -351,6 +351,15 @@ downstream models: the `scores` CTE here and
 — never on school name, which PowerSchool has renamed once already. This ensures
 HS-vs-non-HS flag conditions apply consistently to those students.
 
+The same caution applies to the `school_name` column that
+`int_extracts__course_schedule_by_term` and `rpt_tableau__gradebook_audit`
+carry. It reads PowerSchool `schools.name`, so it is a display label only — a
+rename changes it silently. Join and filter on `schoolid` or `school` (the
+abbreviation) instead. `schools.name` also disagrees with the canonical
+`stg_google_sheets__people__locations.location_name` for 2 schools: Hatch
+(`KIPP Hatch Academy` vs `KIPP Hatch Middle`) and Sumner (`KIPP Sumner Academy`
+vs `KIPP Sumner Elementary`).
+
 Feeds `int_powerschool__gradebook_assignment_scores_rollup`.
 
 #### `int_powerschool__gradebook_assignment_scores_rollup`

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
@@ -56,6 +56,9 @@ models:
       - name: school
         data_type: string
         description: School abbreviation.
+      - name: school_name
+        data_type: string
+        description: Full school name (e.g., 'KIPP Rise Academy').
       - name: course_number
         data_type: string
         description: PowerSchool course number.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -9,6 +9,7 @@ with
             s.school_level_alt as school_level,
             s.schoolid,
             s.school,
+            s.school_name,
 
             s.course_number,
             s.course_name,
@@ -109,6 +110,7 @@ with
             school_level,
             schoolid,
             school,
+            school_name,
 
             course_number,
             course_name,
@@ -160,6 +162,7 @@ with
             school_level,
             schoolid,
             school,
+            school_name,
 
             course_number,
             course_name,
@@ -212,6 +215,7 @@ with
             school_level,
             schoolid,
             school,
+            school_name,
 
             course_number,
             course_name,
@@ -268,6 +272,7 @@ with
             school_level,
             schoolid,
             school,
+            school_name,
 
             course_number,
             course_name,
@@ -380,6 +385,7 @@ select
     w.school_level,
     w.schoolid,
     w.school,
+    w.school_name,
 
     w.course_number,
     w.course_name,

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_schedule_by_term.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__course_schedule_by_term.sql
@@ -61,6 +61,7 @@ with
             s._dbt_source_project,
             s.terms_academic_year as academic_year,
             s.school_abbreviation as school,
+            s.school_name,
             s.sections_dcid,
             s.sections_termid as termid,
             s.sections_id as sectionid,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_schedule_by_term.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__course_schedule_by_term.yml
@@ -41,6 +41,14 @@ models:
             source_system: PowerSchool
             source_model: base_powerschool__sections
             source_column: school_abbreviation
+      - name: school_name
+        data_type: string
+        description: Full school name (e.g. 'KIPP Rise Academy').
+        config:
+          meta:
+            source_system: PowerSchool
+            source_model: base_powerschool__sections
+            source_column: school_name
       - name: school_level
         data_type: string
         description: School level (ES, MS, HS).


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add a `school_name` column to
`rpt_tableau__gradebook_audit`, holding the full school name.

The dashboard carried only the short abbreviation, for example `LSM` and `NCA`.
School leaders wanted the full name, for example `KIPP Lanning Square Middle`.

The value comes from PowerSchool `schools.name`. That column already reaches the
pipeline as `base_powerschool__sections.school_name`, so
`int_extracts__course_schedule_by_term` needs no new join — it just projects one
more column. The report then threads `school_name` through every CTE that
already carries `school`.

This change is additive. It adds a column and changes nothing else.

## Reviewer Notes

**Two schools disagree with the canonical name list.** PowerSchool calls them
`KIPP Hatch Academy` and `KIPP Sumner Academy`. The people and locations master,
`stg_google_sheets__people__locations.location_name`, calls them
`KIPP Hatch Middle` and `KIPP Sumner Elementary`. The other 10 in-scope schools
match exactly. The requester picked the PowerSchool name on purpose, because it
matches what teachers see in the system this dashboard audits.

**`school_name` is a display label, not a key.** PowerSchool has renamed a school
once already, which the reference doc already warns about for a different reason.
I extended that warning to cover the new column.

**Both changed models sit in the summer-toggle state.** I left the
`current_academic_year - 1` filters alone.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — both
      properties files carry the new column.
- [x] Include (or update) an exposure — the `gradebook_audit` exposure already
      points at `rpt_tableau__gradebook_audit`. Adding a column does not change
      it.
- [x] **Breaking change?** No. The change only adds a column. It renames and
      removes nothing.
- [x] No external sources changed.

## CI checks

- [x] **Trunk** — `trunk check --force` passes on all 5 changed files.
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — not triggered. No Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Refs #5067.

**Files changed**

- `int_extracts__course_schedule_by_term.sql` — added `s.school_name` to the
  `section_quarters` select list. The alias `s` is `base_powerschool__sections`,
  which already carries `school_name`. No new join.
- `int_extracts__course_schedule_by_term.yml` — documented the column with the
  same `meta` shape the neighbouring columns use.
- `rpt_tableau__gradebook_audit.sql` — threaded `school_name` through
  `category_join`, `category_summary`, `assignment_detail`, both branches of
  `combined`, and the final select.
- `rpt_tableau__gradebook_audit.yml` — added the column. Models under
  `models/extracts/` set `contract: enforced: true`, so the YAML must list it.
- `docs/models/gradebook-audit-data-model.md` — extended the existing KIPP Sumner
  rename caution to cover `school_name`.

**Why not read the column from `int_extracts__course_enrollments_by_term`**

That model already exposes an identical `school_name`, sourced from the same
`base_powerschool__sections.school_name`. I confirmed the values match, including
for Hatch and Sumner. But it feeds `int_extracts__gradebook_audit_student_flags`
only, not this report. The report reads
`int_extracts__course_schedule_by_term`. Pulling the name from the enrollment
model would mean joining a student-grain model into a section-grain report to
fetch a column that a section-grain model already has. Adding it to the schedule
model is 1 line and no join.

**Grain safety**

`school_name` is functionally determined by `schoolid`, so the grain-projection
`SELECT DISTINCT` in `category_summary` still collapses correctly. I verified
that no `schoolid` maps to more than 1 `school_name`.

**Verification** — built against a personal dev schema with
`--defer --favor-state --state target/prod`, then compared to the prod table:

| Check                                        | Result                       |
| -------------------------------------------- | ---------------------------- |
| `dbt build` on both models                    | PASS=4 ERROR=0               |
| Both `unique_combination_of_columns` tests    | pass                         |
| Row count, dev vs prod                        | 52,912 vs 52,912, delta 0    |
| Rows differing on any pre-existing column     | 0 in each direction          |
| Null `school_name`                            | 0 rows                       |
| Distinct `school_name`                        | 12, one per in-scope school  |
| `schoolid` values mapping to >1 `school_name` | 0                            |
| `category_summary` 4-row floor                | holds, 6,370 section-quarters |

The byte-identical check compared `to_json_string` of every row with
`school_name` excluded, in both directions with `EXCEPT DISTINCT`.

**Gotcha worth recording**

A plain `--defer` build failed with
`Name _dbt_source_project not found inside d` on the pre-existing
`stg_powerschool__schools` join. That failure was not caused by this change. A
stale copy of `stg_powerschool__schools` in my dev schema had 51 columns and no
`_dbt_source_project`, while prod has 53 and does. `--defer` prefers an existing
dev relation over the state relation, so it picked the stale one.
`--favor-state` fixes it.

</details>
