### PR TITLE
feat(dbt): pivot college assessments long extract by subject and relabel its columns

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -4,60 +4,111 @@ models:
       **Excludes Miami by design.** SAT and ACT results for students in testing
       grades. Miami's high school starts at grade 9 and has no college-testing
       cohort yet, so there is nothing for Miami to report. Revisit when Miami
-      reaches grade 11. Ratified on #4996.
+      reaches grade 11. Ratified on #4996. One row per student per sitting, with
+      the Composite, EBRW and Math results for that sitting pivoted into columns
+      rather than split across three rows.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - test_type
+              - administration_type
+              - test_date
     columns:
       - name: region
         data_type: string
+        description: Region the student's school belongs to.
       - name: schoolid
         data_type: int64
+        description: PowerSchool identifier for the student's school.
       - name: school
         data_type: string
+        description: Abbreviated name of the student's school.
       - name: student_number
         data_type: int64
+        description: PowerSchool student number.
       - name: salesforce_id
         data_type: string
+        description: Salesforce contact identifier for the student.
       - name: student_name
         data_type: string
+        description: Student's full name, last name first.
       - name: student_first_name
         data_type: string
+        description: Student's first name.
       - name: student_last_name
         data_type: string
+        description: Student's last name.
       - name: grade_level
         data_type: int64
+        description: Grade the student is enrolled in this academic year.
       - name: student_email
         data_type: string
+        description: Student's network email address.
       - name: enroll_status
         data_type: string
+        description: Enrollment status of the student, spelled out.
       - name: ktc_cohort
         data_type: int64
+        description: KIPP Through College cohort the student belongs to.
       - name: graduation_year
         data_type: int64
+        description: Year the student is expected to graduate high school.
       - name: year_in_network
         data_type: int64
+        description: Count of years the student has attended a network school.
       - name: iep_status
         data_type: string
+        description: Whether the student has an IEP.
       - name: grad_iep_exempt_status_overall
         data_type: string
+        description: >-
+          Whether the student is exempt from graduation testing requirements
+          because of an IEP.
       - name: cumulative_y1_gpa
         data_type: float64
+        description: Cumulative year-one GPA earned to date.
       - name: cumulative_y1_gpa_projected
         data_type: float64
+        description: Projected cumulative year-one GPA for the full year.
       - name: college_match_gpa
         data_type: numeric
+        description: GPA used to match the student to colleges.
       - name: college_match_gpa_bands
         data_type: string
+        description: Band the college match GPA falls into.
       - name: ccr_course
         data_type: string
+        description: >-
+          College and Career course the student is enrolled in, or No Data when
+          they hold no such section this year.
       - name: ccr_teacher_name
         data_type: string
+        description: >-
+          Teacher of the College and Career course, or No Data when the student
+          holds no such section this year.
       - name: ccr_section
         data_type: string
-      - name: sat_total_superscore
+        description: >-
+          Section of the College and Career course, or No Data when the student
+          holds no such section this year.
+      - name: "`SAT Composite Superscore`"
         data_type: numeric
-      - name: sat_ebrw_highest
+        description: >-
+          Best SAT composite the student has assembled across all sittings.
+          Official SAT only, and repeated on every row for the student, so it
+          does not describe the sitting the row reports.
+      - name: "`SAT Highest EBRW Score`"
         data_type: numeric
-      - name: sat_math_highest
+        description: >-
+          Highest SAT EBRW section score across all sittings. Official SAT only,
+          and repeated on every row for the student.
+      - name: "`SAT Highest Math Score`"
         data_type: numeric
+        description: >-
+          Highest SAT Math section score across all sittings. Official SAT only,
+          and repeated on every row for the student.
       - name: test_type
         data_type: string
         description: >-
@@ -73,13 +124,61 @@ models:
           Official.
       - name: test_date
         data_type: date
-      - name: test_subject
-        data_type: string
-      - name: scale_score
+        description: Date the student sat the test.
+      - name: "`Composite Score`"
         data_type: numeric
-      - name: highest_score_by_test
+        description: Composite scale score for this sitting.
+      - name: total_highest_score_by_test
         data_type: string
-      - name: hs_grad_ready
+        description: >-
+          Whether this sitting is the student's highest composite for this test
+          type.
+      - name: "`Meeting High School Grad Benchmark - Composite`"
         data_type: string
-      - name: college_ready
+        description: >-
+          Whether the composite score meets the high school graduation
+          benchmark. NA means no benchmark is defined for this score type, which
+          is distinct from a No that missed one.
+      - name: "`Meeting College Ready Benchmark - Composite`"
         data_type: string
+        description: >-
+          Whether the composite score meets the college-ready benchmark. NA
+          means no benchmark is defined for this score type.
+      - name: "`EBRW Score`"
+        data_type: numeric
+        description: >-
+          EBRW scale score for this sitting. On the ACT this column carries the
+          Reading score, which shares the same aligned subject bucket.
+      - name: ebrw_reading_highest_score_by_test
+        data_type: string
+        description: >-
+          Whether this sitting is the student's highest EBRW or Reading score
+          for this test type.
+      - name: "`Meeting HS Grad Benchmark - EBRW`"
+        data_type: string
+        description: >-
+          Whether the EBRW score meets the high school graduation benchmark. NA
+          means no benchmark is defined for this score type.
+      - name: "`Meeting College Ready Benchmark - EBRW`"
+        data_type: string
+        description: >-
+          Whether the EBRW score meets the college-ready benchmark. NA means no
+          benchmark is defined for this score type.
+      - name: "`Math Score`"
+        data_type: numeric
+        description: Math scale score for this sitting.
+      - name: math_highest_score_by_test
+        data_type: string
+        description: >-
+          Whether this sitting is the student's highest Math score for this test
+          type.
+      - name: "`Meeting High School Grad Benchmark - Math`"
+        data_type: string
+        description: >-
+          Whether the Math score meets the high school graduation benchmark. NA
+          means no benchmark is defined for this score type.
+      - name: "`Meeting College Ready Benchmark - Math`"
+        data_type: string
+        description: >-
+          Whether the Math score meets the college-ready benchmark. NA means no
+          benchmark is defined for this score type.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -6,7 +6,10 @@ models:
       cohort yet, so there is nothing for Miami to report. Revisit when Miami
       reaches grade 11. Ratified on #4996. One row per student per sitting, with
       the Composite, EBRW and Math results for that sitting pivoted into columns
-      rather than split across three rows.
+      rather than split across three rows. Scoped to students currently enrolled
+      in a high school grade this academic year whose graduation year is later
+      than this one. A student who transferred out mid-year drops off, along
+      with the scores they earned while enrolled.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -48,7 +51,10 @@ models:
         description: Student's network email address.
       - name: enroll_status
         data_type: string
-        description: Enrollment status of the student, spelled out.
+        description: >-
+          Enrollment status of the student, spelled out. Always reads Currently
+          Enrolled, because the model filters to that status. Retained so a
+          reader of the sheet can see the scope without consulting the model.
       - name: ktc_cohort
         data_type: int64
         description: KIPP Through College cohort the student belongs to.

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -113,6 +113,7 @@ with
             and e.graduation_year >= {{ var("current_academic_year") + 1 }}
             and e.school_level = 'HS'
             and e.rn_year = 1
+            and e.enroll_status = 0
     ),
 
     pivoted as (

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -59,9 +59,7 @@ with
             e.college_match_gpa_bands,
 
             sc.scope,
-            sc.subject_area,
             sc.test_date,
-            sc.score_type,
             sc.scale_score,
 
             /* Official or Practice. The test_type column below already carries the
@@ -73,6 +71,14 @@ with
             sh.sat_total_superscore,
             sh.sat_ebrw_highest,
             sh.sat_math_highest,
+
+            /* The bucket the three subject blocks below pivot on. Official rows
+               carry it in aligned_subject, which folds SAT EBRW and ACT Reading
+               into one EBRW/Reading value; practice rows leave that column null
+               and carry the same vocabulary in aligned_subject_area. Reading
+               only the latter would split official EBRW from official Reading,
+               and reading only the former would drop every practice row. */
+            coalesce(sc.aligned_subject, sc.aligned_subject_area) as pivot_subject,
 
             coalesce(c.courses_course_name, 'No Data') as ccr_course,
             coalesce(c.teacher_lastfirst, 'No Data') as ccr_teacher_name,
@@ -107,6 +113,174 @@ with
             and e.graduation_year >= {{ var("current_academic_year") + 1 }}
             and e.school_level = 'HS'
             and e.rn_year = 1
+    ),
+
+    pivoted as (
+        select
+            region,
+            schoolid,
+            school,
+            student_number,
+            salesforce_id,
+            student_name,
+            student_first_name,
+            student_last_name,
+            grade_level,
+            student_email,
+            enroll_status,
+            ktc_cohort,
+            graduation_year,
+            year_in_network,
+            iep_status,
+            grad_iep_exempt_status_overall,
+            cumulative_y1_gpa,
+            cumulative_y1_gpa_projected,
+            college_match_gpa,
+            college_match_gpa_bands,
+
+            /* Grouped, not aggregated. The CCR course/teacher/section triple
+               comes from one joined row, so independent max() calls could pair a
+               course with another row's teacher if a student ever held two
+               College and Career sections in a year. Grouping keeps the triple
+               intact and surfaces such a student as a duplicate row for the
+               uniqueness test to flag, rather than silently blending two rows.
+               Same reasoning for the three lifetime SAT highs, which tie-break
+               independently on rn_highest. */
+            ccr_course,
+            ccr_teacher_name,
+            ccr_section,
+            sat_total_superscore,
+            sat_ebrw_highest,
+            sat_math_highest,
+            scope as test_type,
+            administration_type,
+            test_date,
+
+            /* max() over 'Yes'/'No' resolves to 'Yes', which is correct for both
+               flags: the sitting is the student's highest, or meets the
+               benchmark, if any duplicate upstream row says so. Duplicate
+               kippadb records are tracked in #4871. 'NA' means no benchmark
+               exists for that score type, distinct from a 'No' that missed one. */
+            max(if(pivot_subject = 'Total', scale_score, null)) as total_scale_score,
+            max(
+                if(pivot_subject = 'Total', highest_score_by_test, null)
+            ) as total_highest_score_by_test,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'Total'
+                        and expected_metric_name = 'HS Grad-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as total_hs_grad_ready,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'Total'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as total_college_ready,
+
+            max(
+                if(pivot_subject = 'EBRW/Reading', scale_score, null)
+            ) as ebrw_reading_scale_score,
+            max(
+                if(pivot_subject = 'EBRW/Reading', highest_score_by_test, null)
+            ) as ebrw_reading_highest_score_by_test,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'EBRW/Reading'
+                        and expected_metric_name = 'HS Grad-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as ebrw_reading_hs_grad_ready,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'EBRW/Reading'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as ebrw_reading_college_ready,
+
+            max(if(pivot_subject = 'Math', scale_score, null)) as math_scale_score,
+            max(
+                if(pivot_subject = 'Math', highest_score_by_test, null)
+            ) as math_highest_score_by_test,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'Math'
+                        and expected_metric_name = 'HS Grad-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as math_hs_grad_ready,
+            coalesce(
+                max(
+                    if(
+                        pivot_subject = 'Math'
+                        and expected_metric_name = 'College-Ready',
+                        met_minimum,
+                        null
+                    )
+                ),
+                'NA'
+            ) as math_college_ready,
+
+        from final
+        /* The three subjects pivoted above. Equivalent to the prior score_type
+           exclusion list: every excluded score_type maps to Reading, Math Test,
+           Reading Test, English or Science. Being a positive filter, it also
+           excludes students with no qualifying score, which the prior list did
+           implicitly -- a null score_type never satisfied `not in`. */
+        where pivot_subject in ('Total', 'EBRW/Reading', 'Math')
+        group by
+            region,
+            schoolid,
+            school,
+            student_number,
+            salesforce_id,
+            student_name,
+            student_first_name,
+            student_last_name,
+            grade_level,
+            student_email,
+            enroll_status,
+            ktc_cohort,
+            graduation_year,
+            year_in_network,
+            iep_status,
+            grad_iep_exempt_status_overall,
+            cumulative_y1_gpa,
+            cumulative_y1_gpa_projected,
+            college_match_gpa,
+            college_match_gpa_bands,
+            ccr_course,
+            ccr_teacher_name,
+            ccr_section,
+            sat_total_superscore,
+            sat_ebrw_highest,
+            sat_math_highest,
+            scope,
+            administration_type,
+            test_date
     )
 
 select
@@ -134,31 +308,27 @@ select
     ccr_teacher_name,
     ccr_section,
 
-    sat_total_superscore,
-    sat_ebrw_highest,
-    sat_math_highest,
+    sat_total_superscore as `SAT Composite Superscore`,
+    sat_ebrw_highest as `SAT Highest EBRW Score`,
+    sat_math_highest as `SAT Highest Math Score`,
 
-    scope as test_type,
+    test_type,
     administration_type,
     test_date,
-    subject_area as test_subject,
-    scale_score,
-    highest_score_by_test,
 
-    coalesce(hs_grad_ready, 'NA') as hs_grad_ready,
-    coalesce(college_ready, 'NA') as college_ready,
+    total_scale_score as `Composite Score`,
+    total_highest_score_by_test,
+    total_hs_grad_ready as `Meeting High School Grad Benchmark - Composite`,
+    total_college_ready as `Meeting College Ready Benchmark - Composite`,
 
-from
-    final pivot (
-        any_value(met_minimum) for expected_metric_name
-        in ('HS Grad-Ready' as hs_grad_ready, 'College-Ready' as college_ready)
-    )
-where
-    score_type not in (
-        'act_science',
-        'act_english',
-        'psat10_reading',
-        'psat10_math_test',
-        'sat_reading_test_score',
-        'sat_math_test_score'
-    )
+    ebrw_reading_scale_score as `EBRW Score`,
+    ebrw_reading_highest_score_by_test,
+    ebrw_reading_hs_grad_ready as `Meeting HS Grad Benchmark - EBRW`,
+    ebrw_reading_college_ready as `Meeting College Ready Benchmark - EBRW`,
+
+    math_scale_score as `Math Score`,
+    math_highest_score_by_test,
+    math_hs_grad_ready as `Meeting High School Grad Benchmark - Math`,
+    math_college_ready as `Meeting College Ready Benchmark - Math`,
+
+from pivoted


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make three changes to `rpt_gsheets__college_assessments_long`.

**It puts one student sitting on one row.** Today the extract writes one row per score type, so a student who sat one test appears on 3 rows — Composite, EBRW and Math. KIPP Forward reads the sheet one sitting at a time, so they compare 3 rows to answer one question. This pivots the 3 subjects into columns.

**It renames 12 columns to plain labels.** Kyla Kenny left 17 comments on a mockup asking for these. The sheet will read `Meeting College Ready Benchmark - Math` instead of `math_college_ready`.

**It scopes the roster to currently enrolled students.** The model had no enrollment-status filter, so 92 students who transferred out mid-year stayed on the roster with the scores they earned while enrolled. That drops 133 rows and 92 students.

Together, prod's 7,627 rows become 2,412.

This supersedes #4876, which cannot merge. That branch predates the practice-assessment work, so it reads the official-only hub and its goals CTE names 6 columns that no longer exist. Close #4876 when this lands.

## Reviewer Notes

**This renames columns on a contracted model that feeds a live sheet.** The Google Sheet reads the view directly, so its headers are these column names. Any formula pointing at an old header breaks. Rollback is a straight revert, which restores every old name. Please confirm with KIPP Forward that nothing downstream keys on the old headers before merging.

**It also removes 92 students from that sheet.** Anyone who has been tracking a transferred-out student will see them disappear. This was a deliberate call, not a side effect of the pivot, and it is a separate commit if you want to take one without the other.

**The subject predicate reads two columns on purpose.** `coalesce(aligned_subject, aligned_subject_area)` is the pivot key. Reading either alone silently loses a whole pipeline. Detail below.

**The uniqueness test warns on 1 row, and the condition is pre-existing.** One student holds 2 College and Career sections in the same year, so the CCR course, teacher and section triple splits their sitting. Prod emits 6 rows for that sitting today; this emits 2. The test is new, so the warning is new, but the data condition is not.

**3 columns keep their names deliberately.** Kyla commented that she is not sure what the `*_highest_score_by_test` columns are. Anthony Walters is settling that naming separately. Her column-reordering request is also not here, because it is ambiguous about which GPA column she means.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — updated, with a description on every column and a new uniqueness test
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the existing exposure still points at the right sheet and needs no change
- [x] **Breaking change?** Yes, twice over — 12 renamed columns and 92 fewer students. See Reviewer Notes for the rollback plan and the coordination this needs.
- [ ] If adding or modifying an external source, run `stage_external_sources` — not applicable, no external source changed

## CI checks

- [x] **Trunk** — passed on the first commit; re-running on the second.
- [x] **dbt Cloud** — passed on the first commit; re-running on the second.
- [ ] **Dagster Cloud** — not triggered, no Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Refs #5069.

**Why the subject key is a coalesce.** The 2 columns carry transposed vocabularies across the 2 pipelines:

| Row | `aligned_subject` | `aligned_subject_area` |
| --- | --- | --- |
| Official SAT EBRW | `EBRW/Reading` | `EBRW` |
| Official ACT Reading | `EBRW/Reading` | `Reading` |
| Official PSAT10 Reading, legacy | `Reading` | `Reading` |
| Practice PSAT 8/9 EBRW | null | `EBRW/Reading` |

Official rows carry the unified bucket in `aligned_subject`, which folds SAT EBRW and ACT Reading together. Practice rows leave that column null and carry the same vocabulary in `aligned_subject_area`. So `aligned_subject` alone drops every practice sitting, and `aligned_subject_area` alone splits official EBRW from official Reading and stops excluding the legacy PSAT10 Reading subscore. The coalesce reproduces the old `score_type not in (...)` exclusion exactly, including its implicit drop of students with no qualifying score, because a null never satisfied `not in`.

#4876 filtered on `aligned_subject` and would have shipped the practice-dropping version.

**Why `administration_type` is in the group by.** Measured 2026-08-30, no `(student_number, scope, test_date)` group holds both an Official and a Practice sitting, so the added grain column changes no row count. It is a guard, and it is what lets a reader tell a practice sitting from an official one. #4876 dropped the column entirely.

**Metric name strings.** `int_google_sheets__kippfwd__goals_unpivot` uses `HS Grad-Ready` and `College-Ready`. #4876 tested for `HS-Ready`, which matches nothing and would have resolved every grad-ready flag to `NA`.

**Backticked column names.** `rpt_illuminate__studemo` is the in-repo precedent for spaced column names in a contract-enforced `kipptaf_extracts` model. A `trunk-ignore` for `sqlfluff/RF05` is NOT needed here — trunk reports `ignore-does-nothing` for it, unlike on studemo.

**SAT qualifier kept on 3 labels.** Kyla asked for `Composite Superscore`, `Highest EBRW Score` and `Highest Math Score`. Those 3 columns hold SAT-only lifetime highs and repeat on every row of the student, including PSAT and ACT rows, so the unqualified labels would read as the score for the row's own test.

**Enrollment scope.** The filter is `enroll_status = 0`, matching `rpt_gsheets__gpa_roster`, `rpt_gsheets__athletic_eligibility` and `rpt_gsheets__mtss_rti`. The `enroll_status` output column is now constant at `Currently Enrolled`. Repo convention says to omit a column whose value the WHERE clause predetermines, but it is retained here so a sheet reader can see the scope without opening the model — say the word and it comes out.

**Verification, in two stages.** The pivot alone was proven behavior-preserving first — 2,545 rows over the same 2,544 distinct sittings as prod's 7,627 rows, with an identical test-type and administration-type distribution. The enrollment filter then deliberately reduced that to 2,412 rows over 2,411 sittings and 1,330 students. Practice rows go from 115 to 114; the single ACT practice sitting belonged to a transferred-out student. The contract passed with the backticked names in both builds, and `trunk check --force` is clean on both files.

</details>
