### PR TITLE
feat(dbt): expose assignments_entered_count_no_flags on gradebook audit

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
@@ -164,6 +164,16 @@ models:
         description: >
           Actual count of assignments entered for this category, regardless of
           flag status. Populated on row_type = 'category_summary' rows only.
+      - name: assignments_entered_count_no_flags
+        data_type: int64
+        description: >
+          Count of assignments entered for this category that pass every
+          assignment validity check, i.e. the assignments that actually count
+          toward the category expectation. This is the number
+          not_enough_assignments compares against expectation, so it is always
+          less than or equal to assignments_entered_count. Exposed so the
+          dashboard can display a count that agrees with the flag beside it.
+          Populated on row_type = 'category_summary' rows only.
       - name: not_enough_assignments
         data_type: boolean
         description: >

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -144,6 +144,7 @@ with
             assignment_category_term,
             expectation,
             assignments_entered_count,
+            assignments_entered_count_no_flags,
 
             if(
                 assignments_entered_count_no_flags < expectation, true, false
@@ -249,6 +250,7 @@ with
             assignment_category_term,
             expectation,
             assignments_entered_count,
+            assignments_entered_count_no_flags,
             not_enough_assignments,
 
             cast(null as int64) as assignmentid,
@@ -306,6 +308,7 @@ with
             assignment_category_term,
             cast(null as int64) as expectation,
             cast(null as int64) as assignments_entered_count,
+            cast(null as int64) as assignments_entered_count_no_flags,
             cast(null as bool) as not_enough_assignments,
 
             assignmentid,
@@ -421,6 +424,7 @@ select
     w.assignment_category_term,
     w.expectation,
     w.assignments_entered_count,
+    w.assignments_entered_count_no_flags,
     w.not_enough_assignments,
 
     w.assignmentid,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add one column to `rpt_tableau__gradebook_audit`: `assignments_entered_count_no_flags`.

The gradebook health dashboard shows how many assignments a section has entered, next to the number it is supposed to have by now. A section can show 8 entered against a target of 7 and still be flagged as off track. That is correct behaviour, but on screen it looks like a bug.

The flag counts a different number. `not_enough_assignments` counts only assignments that pass every validity check. The dashboard shows every assignment entered, whether it counts or not. Roughly 35 to 40 percent of flags look contradictory for this reason.

The model already calculates the number the flag uses. It just never wrote it to the output, so Tableau could not display it. This change writes it out, so the dashboard can show a count that agrees with the flag beside it.

## Reviewer Notes

**Row count is the thing to check.** `category_summary` uses `SELECT DISTINCT`, so a column that varied inside the existing grain would have multiplied rows. This one does not — it is a window function over the same partition as `expectation` and `assignments_entered_count`, both of which are already projected the same way. Verified against prod; figures in the fold-out.

**Nothing is renamed or removed**, so no downstream consumer breaks. The model has exactly two consumers: the uniqueness test and the `gradebook_audit` exposure.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — the new
      column is documented in the existing properties file
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard — the `gradebook_audit` exposure
      already covers this model and needs no change
- [x] **Breaking change?** No. This adds a column and renames or removes
      nothing, so existing consumers are unaffected.
- [x] External sources — not applicable, no source changes

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

<details>
<summary>For Claude</summary>

Verification was run against a deferred dev build of the model
(`zz_anthonygwalters_kipptaf_tableau.rpt_tableau__gradebook_audit`) and compared
to prod (`kipptaf_tableau.rpt_tableau__gradebook_audit`).

| Check | Prod | This branch |
| --- | ---: | ---: |
| Total rows | 52,912 | 52,912 |
| `category_summary` rows | 25,480 | 25,480 |
| `assignment_detail` rows | 27,432 | 27,432 |

Additional checks, all zero:

- Section-quarters violating the four-row category floor: 0 of 6,370
- `category_summary` rows with a null in the new column: 0
- `assignment_detail` rows where the new column is populated: 0
- Rows where the new column exceeds `assignments_entered_count`: 0
- Rows where `not_enough_assignments` disagrees with
  `assignments_entered_count_no_flags < expectation`: 0

That last one is the important one. It confirms the exposed value is exactly
what already drives the flag, rather than a near-equivalent recomputation.

`dbt_utils.unique_combination_of_columns` passes. `trunk check --force` is clean
on both changed files.

**Why the column was not exposed originally:** the July 2026 teacher/student
split kept the report surface deliberately narrow. This column sat in
`category_join` purely as flag input. Exposing it is additive and does not
reintroduce any student-level data — these are section-level counts.

**Follow-up, not in this PR:** the Tableau panel still displays
`assignments_entered_count`. Switching it to the new column, or showing both, is
a dashboard change and a separate decision about which number teachers should
see. A related idea — surfacing *why* assignments fail validity, as four
category-level reason counts — was scoped and deliberately deferred.

Claude-assisted, human-directed. Change requested and approved by Anthony
Walters, who owns the decision; no further design review was sought before
implementation.

</details>
