### PR TITLE
fix: widen unbounded numeric on the Focus gradebook_grades table

### DIFF
--- a/src/dbt/focus/models/staging/stg_focus__gradebook_grades.sql
+++ b/src/dbt/focus/models/staging/stg_focus__gradebook_grades.sql
@@ -3,8 +3,6 @@ select
     student_id,
     assignment_id,
     standard_id,
-    points,
-    possible_points,
     letter_grade,
     exclude_from_average,
     late,
@@ -19,4 +17,7 @@ select
     uuid,
     created_at,
     updated_at,
+
+    cast(points as numeric) as points,
+    cast(possible_points as numeric) as possible_points,
 from {{ source("focus", "gradebook_grades") }}

--- a/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
+++ b/src/teamster/code_locations/kippmiami/dlt/focus/config/focus.yaml
@@ -110,6 +110,9 @@ assets:
     cursor_column: updated_at
   - table_name: gradebook_grades
     cursor_column: updated_at
+    # points is an unbounded Postgres numeric holding more than 9 decimal
+    # places, which the default decimal128(38, 9) cannot represent.
+    widen_unbounded_numeric: true
   - table_name: gradebook_assignments
     cursor_column: updated_at
   - table_name: gradebook_assignment_types


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will restart the KIPP Miami Focus sync, which has failed every run since 2026-08-29 12:19 UTC.

`gradebook_grades.points` is an unbounded Postgres `numeric`. dlt renders that as `decimal128(38, 9)`, and a value now carries more than 9 decimal places, so pyarrow refuses to convert it and the extract dies. All 20 Focus tables share the step `kippmiami__dlt__focus`, so the one column took down the whole sync.

This is the same failure as #5021 on `student_gpa_calculated.weighted_gpa`, and it takes the same fix: set `widen_unbounded_numeric: true` on the table in `focus.yaml`.

Widening retypes `points` and `possible_points` to BigQuery BIGNUMERIC, so `stg_focus__gradebook_grades` casts both back to `numeric`. The staging contract declares `data_type: numeric`, and `src/dbt/focus/dbt_project.yml` enforces contracts. This mirrors `stg_focus__student_gpa_calculated`.

Closes #5074

## Reviewer Notes

One thing may need a follow-up run after merge. `points` and `possible_points` are `NUMERIC` in BigQuery today, and the adapter's docstring says the `replace` disposition cannot retype a column in place. If the first post-merge load fails on the type change, someone launches one manual Focus run selecting only `gradebook_grades` with run config `refresh: drop_resources`. That path already exists, from #4740.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

Neither Dagster box is checked, and both need a reason. `kippmiami.definitions`
cannot load in a Codespace: it resolves the Focus database credential at module
import, and that credential is unset here. So `definitions validate` and
`tests/test_dagster_definitions.py` both fail for a reason unrelated to this
change. I checked the config the way the code location does instead — parsed
`focus.yaml` and rebuilt the `widen_numeric_tables` set, which now holds exactly
`gradebook_grades` and `student_gpa_calculated`. The change adds one key to a
YAML file and edits no Python. The third box holds: the asset key and the
Library plus Config pattern are untouched.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

Every dbt box is checked because nothing triggers it. This PR adds no model, so
there is no new properties file and no new exposure. It renames and removes no
column, so it is not a breaking change — `points` and `possible_points` keep
their names and their declared `numeric` type. It touches no external source.

### Docs

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Diagnosed from run `1a7b7d07-4a91-4ee3-9896-035e2617f5c3` with `superpowers:systematic-debugging`.

Root cause is read from the bottom of the run's error chain, not inferred:

```text
pyarrow.lib.ArrowInvalid: Rescaling Decimal value would cause data loss
```

wrapped by

```text
PyToArrowConversionException: Conversion to arrow failed for field `points`
with dlt hint `data_type=decimal` and `inferred_arrow_type=decimal128(38, 9)`
```

**What I verified**

- Last successful `kippmiami/dlt/focus/gradebook_grades` materialization: 2026-08-29 12:19:31 UTC, 5327 rows.
- The 10 most recent `kippmiami__dlt__focus__intraday_sensor` retries all end `STEP_FAILURE`, roughly 15 minutes apart.
- `dagster_kippmiami_dlt_focus.gradebook_grades.points` and `.possible_points` are `NUMERIC`. `student_gpa_calculated`'s 16 widened columns are `BIGNUMERIC`. Both read from `INFORMATION_SCHEMA.COLUMNS`.
- `tests/libraries/test_dlt_focus_type_adapter.py` — 14 passed.
- Parsing `focus.yaml` yields `widen_unbounded_numeric` for exactly `gradebook_grades` and `student_gpa_calculated`, out of 79 tables.
- `dbt build --select stg_focus__gradebook_grades` in the `kippmiami` project — PASS=5 WARN=2 ERROR=0. The contract holds.
- `trunk check --force` on both changed files — no issues.

**What I did not verify**

- I could not reach the Focus Postgres database from the Codespace, so I did not read the offending `points` value or measure its real scale. `(76, 38)` stays the destination ceiling, as set in #5021.
- I did not test whether a `replace` load can retype `NUMERIC` to `BIGNUMERIC` in place. The pipeline runs `autodetect_schema=True` with `loader_file_format="parquet"`, so a `WRITE_TRUNCATE` load may handle it. The `refresh: drop_resources` fallback in Reviewer Notes covers the other case.
- `dagster definitions validate -m teamster.code_locations.kippmiami.definitions` cannot run in the Codespace — `kippmiami.definitions` resolves the Focus database credential eagerly at module load, and that credential is unset here. I checked the config the same way the code location does instead, by parsing `focus.yaml` and rebuilding the `widen_numeric_tables` set. The change adds one key to a YAML file and touches no Python.

**Separate, pre-existing, not from this change**

The build warned on 2 relationships tests: 3 orphan `student_id` values and 4289 orphan `assignment_id` values. My change casts 2 numeric columns and cannot affect either column. Worth a look on its own, but it is not this PR.

</details>
