### PR TITLE
fix(dbt): join rpt_tableau__gradebook_gpa terms on academic_year, not yearid

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_gpa.yml
@@ -1,12 +1,11 @@
 models:
   - name: rpt_tableau__gradebook_gpa
     description: >-
-      Network-wide, Miami included by decision, though it returned no Miami rows
-      in any year in prod as of 2026-08-27 — not even AY2024 or AY2025, when
-      Miami was still on PowerSchool. The block is `not enr.is_out_of_district`,
-      null for Miami until #5038. Miami's GPA columns stay null after that,
-      because `int_powerschool__gpa_term` is PowerSchool-only; the Focus GPA
-      branch is #5021. Ratified on #4996.
+      Network-wide, Miami included by decision and ratified on #4996. Miami's
+      GPA columns stay null, because `int_powerschool__gpa_term` is
+      PowerSchool-only; the Focus GPA branch is #5021. Miami's course, section
+      and gradebook-category columns stay null for the same reason, so a Miami
+      row carries roster and term attributes only.
     # TODO(#3900): residual warn-level violations trace to the known
     # base_powerschool__course_enrollments double-write duplicates.
     data_tests:
@@ -14,7 +13,8 @@ models:
           arguments:
             combination_of_columns:
               - _dbt_source_relation
-              - studentid
+              - student_number
+              - academic_year
               - sectionid
               - quarter
               - category_name_code

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
@@ -4,7 +4,7 @@ with
             _dbt_source_relation,
             _dbt_source_project,
             schoolid,
-            yearid,
+            academic_year,
 
             term as `quarter`,
 
@@ -24,7 +24,7 @@ with
             _dbt_source_relation,
             _dbt_source_project,
             schoolid,
-            yearid,
+            academic_year,
 
             'Y1' as `quarter`,
 
@@ -113,7 +113,11 @@ with
         inner join
             term
             on enr.schoolid = term.schoolid
-            and enr.yearid = term.yearid
+            -- academic_year, not yearid: yearid is null on every Miami row of
+            -- int_extracts__student_enrollments, so this inner join dropped all
+            -- of them. Identity for NJ, where yearid = academic_year - 1990
+            -- holds on every row of both sides, so no NJ row moves.
+            and enr.academic_year = term.academic_year
             and enr._dbt_source_project = term._dbt_source_project
         left join
             {{ ref("int_powerschool__gpa_term") }} as gtq

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_gpa.sql
@@ -114,9 +114,7 @@ with
             term
             on enr.schoolid = term.schoolid
             -- academic_year, not yearid: yearid is null on every Miami row of
-            -- int_extracts__student_enrollments, so this inner join dropped all
-            -- of them. Identity for NJ, where yearid = academic_year - 1990
-            -- holds on every row of both sides, so no NJ row moves.
+            -- int_extracts__student_enrollments, so this join dropped them all
             and enr.academic_year = term.academic_year
             and enr._dbt_source_project = term._dbt_source_project
         left join


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put Miami students back into the
`rpt_tableau__gradebook_gpa` Tableau extract, in every year from 2018 to 2026.

Miami has no PowerSchool `yearid` anywhere in the enrollment chain since the
Focus cutover, so `int_extracts__student_enrollments` carries a null `yearid` on
all 10,078 Miami rows. The extract joined enrollments to the term spine on
`yearid`. Null never matches anything, so every Miami row fell out. Nothing
errored and no test failed. The rows just quietly disappeared — 0 Miami rows
against 2,405,211 total.

The fix joins on `academic_year` instead, on both sides. No New Jersey row
moves.

Miami rows carry roster and term attributes only. Their GPA, course, section and
gradebook-category columns stay null, because the models behind those columns
read PowerSchool. The Focus GPA branch is tracked in #5021.

Refs #5061

## Reviewer Notes

**The uniqueness key changed too, and it had to.** The old key used `studentid`,
which is null on every Miami row. Left alone, it would have collapsed 29,571
restored rows into 6 groups. The new key uses `student_number` and adds
`academic_year`. This is a net win for New Jersey as well — the known #3900
double-write violations drop from 19,332 to 169.

**Two models named in issue #5061 are not fixed here, on purpose.** Details in
the fold-out below.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models. No new
      models — the existing `rpt_tableau__gradebook_gpa.yml` is updated.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application. Two
      already exist in `models/exposures/tableau.yml` and need no change.
- [x] **Breaking change?** No columns renamed or removed. The contract column
      list is unchanged.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`**. Not applicable — no external sources touched.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

## The New Jersey swap is an identity, not a measured 1 to 1

`yearid = academic_year - 1990` holds on every row of both join sides for all
three NJ regions, verified against prod:

| Relation | NJ rows | Rows where `yearid != academic_year - 1990` |
| --- | --- | --- |
| `int_extracts__student_enrollments` | 124,285 | 0 |
| `int_students__terms` | 2,011 | 0 |

So the swap cannot move an NJ row. A local `dbt build` against prod upstreams
(`--target dev --defer --favor-state`) confirms it:

| Region | Prod rows | Built rows | Delta |
| --- | --- | --- | --- |
| Camden | 517,810 | 517,810 | 0 |
| Newark | 1,854,413 | 1,854,413 | 0 |
| Paterson | 32,981 | 32,981 | 0 |
| Miami | 0 | 29,571 | +29,571 |

## Why the term CTE now projects academic_year instead of yearid

`term.yearid` had exactly one reference — the join predicate this change
rewrites. Projecting both would leave a dead column, so the two UNION branches
project `academic_year` in its place.

## The uniqueness key

Old key — `_dbt_source_relation`, `studentid`, `sectionid`, `quarter`,
`category_name_code`.

New key — `_dbt_source_relation`, `student_number`, `academic_year`,
`sectionid`, `quarter`, `category_name_code`.

`studentid` is null on all 10,078 Miami enrollment rows, and `sectionid` and
`category_name_code` are null on every Miami row of this extract, because the
joins producing them are PowerSchool-only. The old key therefore yields 6
distinct values for 29,571 Miami rows.

`studentid` and `student_number` are exactly 1 to 1 within a source relation for
NJ — 24,825 distinct values each way, and 24,825 for the pair — so the swap
moves nothing there. Adding `academic_year` strictly narrows the key.

Measured against prod, the new key raises distinct-key coverage from 2,385,879
to 2,405,042 out of 2,405,211 rows. The test run on the local build warns at
169, split Camden 34, Newark 51, Paterson 84, and zero Miami. Those 169 are the
pre-existing #3900 `base_powerschool__course_enrollments` double-write
duplicates, which the `TODO(#3900)` note above the test still describes
correctly.

## Two models issue #5061 lists that this PR does not touch

`rpt_tableau__student_course_grades` — not a bug. It already carries
`and enr.region in ('Newark', 'Camden', 'Paterson')`, with the model description
stating that Miami is hard-excluded because the region is unsupported in the
rebuilt dashboard, ratified on #4340 and #4996. The null `yearid` is a second,
redundant reason it holds 0 Miami rows. Swapping the join key there would add no
Miami row, so the change was made and then reverted.

`rpt_gsheets__absence_streak_roster` — has the same null-key join and also holds
0 Miami rows, but its properties set `config: enabled: false`. The model never
builds, and its 7,417-row prod relation is frozen. The change was made and then
reverted for the same reason.

## Audit of the other consumers

`int_extracts__student_enrollments` has 113 consumers. 34 reference the
enrollment alias's `yearid` or `studentid`. Only an inner join can silently
exclude Miami, so those were separated out. Every remaining inner join is one of
three cases, none of them a live Miami bug:

- The other side is PowerSchool-only, so there is no Miami data to recover —
  `int_tableau__gradebook_audit_student_scaffold`,
  `rpt_tableau__ap_assessment_dashboard`, `rpt_tableau__crdc_roster`,
  `rpt_tableau__gpa_cumulative_year`, `rpt_tableau__gradebook_assignments`,
  `rpt_gsheets__csgf_hs_ap_offerings`, `rpt_deanslist__student_misc`.
- Miami is filtered out explicitly — `rpt_tableau__nj_school_register` carries
  `where co.region != 'Miami'`.
- The model is disabled — `rpt_gsheets__absence_streak_roster`, above.

`int_students__attendance_daily` is confirmed unaffected, matching the issue.

</details>
