### PR TITLE
fix(adp): retry any non-JSON 404 as a gateway error

### DIFF
--- a/src/teamster/libraries/adp/workforce_now/api/resources.py
+++ b/src/teamster/libraries/adp/workforce_now/api/resources.py
@@ -90,22 +90,8 @@ class AdpWorkforceNowResource(ConfigurableResource):
             # a 504 HTML page) are not JSON, and JSONDecodeError is not in the
             # retry predicate, so parsing here would convert a retryable error
             # into a non-retryable one.
-            #
-            # ADP's gateway also returns a transient "default backend - 404" when
-            # it briefly has no healthy backend (a load-balancer signature, seen
-            # mid-pagination). That is distinct from a genuine resource 404 —
-            # treat only the gateway variant as retryable so a real 404 still
-            # fails fast.
-            body = response.text
-            is_transient_gateway_404 = (
-                response.status_code == 404 and "default backend" in body.lower()
-            )
-            if (
-                response.status_code == 429
-                or response.status_code >= 500
-                or is_transient_gateway_404
-            ):
-                self._log.warning(msg=body)
+            if response.status_code == 429 or response.status_code >= 500:
+                self._log.warning(msg=response.text)
                 raise
 
             # other 4xx are deterministic client errors — surface a specific
@@ -113,8 +99,20 @@ class AdpWorkforceNowResource(ConfigurableResource):
             # parse: a 4xx body may also be non-JSON.
             try:
                 detail = response.json()
+                is_json_body = True
             except JSONDecodeError:
                 detail = response.text
+                is_json_body = False
+
+            # ADP's API layer always answers with JSON, so a non-JSON 404 did not
+            # come from it: that is the edge gateway briefly without a healthy
+            # backend, seen mid-pagination as "default backend - 404" and as a
+            # plain openresty 404 page. Transient — re-raise the HTTPError so
+            # tenacity retries. A genuine resource 404 carries a JSON body and
+            # still fails fast.
+            if not is_json_body and response.status_code == 404:
+                self._log.warning(msg=detail)
+                raise
 
             self._log.error(msg=detail)
             raise AdpWorkforceNowError(detail) from e

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -282,7 +282,7 @@ def test_request_non_json_client_error_raises_adp_error(
 
     The deterministic-4xx branch must tolerate a non-JSON body instead of
     crashing on ``response.json()``. Uses a 400 because a non-JSON 404 is the
-    gateway signature and is retried instead (see the openresty test below).
+    gateway signature and is retried instead (see the gateway-404 test below).
     """
     monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
 
@@ -300,41 +300,22 @@ def test_request_non_json_client_error_raises_adp_error(
     assert calls["n"] == 1
 
 
-def test_request_retries_on_transient_gateway_404(monkeypatch: pytest.MonkeyPatch):
-    """ADP's gateway returns a transient ``default backend - 404`` mid-pagination.
-
-    Regression: this load-balancer 404 was classified as a deterministic 4xx and
-    raised ``AdpWorkforceNowError`` without retrying. It must be re-raised as the
-    retryable ``HTTPError`` so tenacity retries with backoff (the genuine-404
-    case above must still fail fast).
-    """
-    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
-
-    calls = {"n": 0}
-
-    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
-        calls["n"] += 1
-        if calls["n"] < 3:
-            return _FakeResponse(
-                404, {}, json_raises=True, text="default backend - 404"
-            )
-        return _FakeResponse(200, {"ok": True})
-
-    adp_wfn = _build_offline_resource(request_fn)
-
-    response = adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
-
-    assert response.status_code == 200
-    assert calls["n"] == 3
-
-
-def test_request_retries_on_openresty_gateway_404(monkeypatch: pytest.MonkeyPatch):
-    """ADP's gateway also answers with a plain openresty 404 page.
+@pytest.mark.parametrize(
+    "body",
+    ["default backend - 404", OPENRESTY_404_BODY],
+    ids=["default_backend", "openresty"],
+)
+def test_request_retries_on_transient_gateway_404(
+    body: str, monkeypatch: pytest.MonkeyPatch
+):
+    """ADP's gateway returns a transient 404 when it has no healthy backend.
 
     Regression: the retry predicate matched only the literal ``default backend``
-    body, so this variant was classified as a deterministic 4xx and failed on the
-    first attempt. The real signal is the body format -- ADP's API layer answers
-    with JSON, the gateway does not -- so any non-JSON 404 must be retried.
+    body, so the openresty variant was classified as a deterministic 4xx and
+    failed on the first attempt. The real signal is the body format -- ADP's API
+    layer answers with JSON, the gateway does not -- so any non-JSON 404 must be
+    re-raised as the retryable ``HTTPError``. The JSON-bodied 404 below must
+    still fail fast.
     """
     monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
 
@@ -343,7 +324,7 @@ def test_request_retries_on_openresty_gateway_404(monkeypatch: pytest.MonkeyPatc
     def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
         calls["n"] += 1
         if calls["n"] < 3:
-            return _FakeResponse(404, {}, json_raises=True, text=OPENRESTY_404_BODY)
+            return _FakeResponse(404, {}, json_raises=True, text=body)
         return _FakeResponse(200, {"ok": True})
 
     adp_wfn = _build_offline_resource(request_fn)
@@ -352,6 +333,30 @@ def test_request_retries_on_openresty_gateway_404(monkeypatch: pytest.MonkeyPatc
 
     assert response.status_code == 200
     assert calls["n"] == 3
+
+
+def test_request_json_404_raises_adp_error(monkeypatch: pytest.MonkeyPatch):
+    """A 404 carrying a JSON body is a genuine resource error and fails fast.
+
+    ADP's API layer answers with JSON, so a parseable 404 body did not come from
+    the gateway. It must raise ``AdpWorkforceNowError`` after one request and
+    never enter the retry path — the guard that keeps the widened gateway-404
+    predicate from swallowing real 404s.
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        return _FakeResponse(404, {"error": "not found"})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    with pytest.raises(AdpWorkforceNowError):
+        adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert calls["n"] == 1
 
 
 def test_request_persistent_gateway_404_retries_as_httperror(

--- a/tests/resources/test_resource_adp_workforce_now.py
+++ b/tests/resources/test_resource_adp_workforce_now.py
@@ -157,6 +157,14 @@ class _FakeResponse:
             raise HTTPError(f"{self.status_code} Server Error", response=self)  # pyright: ignore[reportArgumentType]
 
 
+# the body ADP's edge gateway returned on run 19266296 (issue #5076)
+OPENRESTY_404_BODY = (
+    "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n"
+    "<center><h1>404 Not Found</h1></center>\r\n<hr><center>openresty</center>\r\n"
+    "</body>\r\n</html>\r\n"
+)
+
+
 def _build_offline_resource(request_fn) -> AdpWorkforceNowResource:
     """Instantiate the resource without the network setup_for_execution path."""
     adp_wfn = AdpWorkforceNowResource(
@@ -273,7 +281,8 @@ def test_request_non_json_client_error_raises_adp_error(
     """A non-JSON 4xx surfaces ``AdpWorkforceNowError`` without retrying.
 
     The deterministic-4xx branch must tolerate a non-JSON body instead of
-    crashing on ``response.json()``.
+    crashing on ``response.json()``. Uses a 400 because a non-JSON 404 is the
+    gateway signature and is retried instead (see the openresty test below).
     """
     monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
 
@@ -281,7 +290,7 @@ def test_request_non_json_client_error_raises_adp_error(
 
     def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
         calls["n"] += 1
-        return _FakeResponse(404, {}, json_raises=True, text="404 Not Found")
+        return _FakeResponse(400, {}, json_raises=True, text="400 Bad Request")
 
     adp_wfn = _build_offline_resource(request_fn)
 
@@ -306,7 +315,35 @@ def test_request_retries_on_transient_gateway_404(monkeypatch: pytest.MonkeyPatc
     def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
         calls["n"] += 1
         if calls["n"] < 3:
-            return _FakeResponse(404, {}, text="default backend - 404")
+            return _FakeResponse(
+                404, {}, json_raises=True, text="default backend - 404"
+            )
+        return _FakeResponse(200, {"ok": True})
+
+    adp_wfn = _build_offline_resource(request_fn)
+
+    response = adp_wfn._request(method="GET", url="https://api.adp.com/hr/v2/workers")
+
+    assert response.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_request_retries_on_openresty_gateway_404(monkeypatch: pytest.MonkeyPatch):
+    """ADP's gateway also answers with a plain openresty 404 page.
+
+    Regression: the retry predicate matched only the literal ``default backend``
+    body, so this variant was classified as a deterministic 4xx and failed on the
+    first attempt. The real signal is the body format -- ADP's API layer answers
+    with JSON, the gateway does not -- so any non-JSON 404 must be retried.
+    """
+    monkeypatch.setattr(AdpWorkforceNowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _FakeResponse(404, {}, json_raises=True, text=OPENRESTY_404_BODY)
         return _FakeResponse(200, {"ok": True})
 
     adp_wfn = _build_offline_resource(request_fn)
@@ -332,7 +369,7 @@ def test_request_persistent_gateway_404_retries_as_httperror(
 
     def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
         calls["n"] += 1
-        return _FakeResponse(404, {}, text="default backend - 404")
+        return _FakeResponse(404, {}, json_raises=True, text="default backend - 404")
 
     adp_wfn = _build_offline_resource(request_fn)
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make the ADP Workforce Now resource retry a
gateway 404 instead of failing on the first request.

ADP's edge gateway answers with a 404 when it briefly has no healthy backend.
The resource decided whether a 404 was retryable by looking for the text
`default backend` in the body. On [run 19266296](https://kipptaf.dagster.cloud/prod/runs/19266296-c305-47cb-b747-7c9eb6921b42)
the gateway returned an openresty 404 page instead, so the check did not match.
The code treated it as a real client error, raised a non-retryable exception,
and the step died after one request. The auto-retry failed the same way 62
seconds later.

The fix matches on the body format instead of a substring. ADP's API answers
with JSON. The gateway does not. So a 404 whose body is not JSON came from the
gateway, and the resource now re-raises the `HTTPError` for tenacity to retry. A
genuine 404 carries a JSON body and still fails fast after one request.

Closes #5076

## Reviewer Notes

- The retry predicate widened from one substring to "any non-JSON 404". A
  genuine 404 that arrived without a JSON body would now burn 5 attempts before
  failing. It still fails.
- `test_request_non_json_client_error_raises_adp_error` moved from a 404 to a
  400. A non-JSON 404 is now the gateway case, so the old assertion contradicts
  the fix. The test still covers the JSON-parse guard.
- The two existing gateway-404 fakes now set `json_raises=True`. The real
  gateway body is not JSON, and the old fakes let `response.json()` succeed.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [x] Run `uv run dagster definitions validate` for any modified code location
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [x] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

Skipped — no dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Diagnosed with `superpowers:systematic-debugging`.

Evidence the 404 was the gateway and not a real resource 404:

- Partition `07/30/2026` materialized on the 5 nights before, most recently with
  4749 records, from the identical request URL.
- 30 adjacent partitions succeeded the next night against the same endpoint.
- The response body was an openresty HTML page. ADP's API returns a JSON error
  envelope, which is what the `response.json()` path assumes.
- Both attempts made exactly 1 request each, because the non-retryable branch
  bypassed tenacity entirely.

No data was lost. The partition kept its August 28 write. It has since aged out
of the schedule's 45-partition window (`partition_keys[-45:]` against an
`end_offset=14` daily definition), so nothing re-runs it.

One implementation trap worth knowing: a bare `raise` inside the nested
`except JSONDecodeError` re-raises the `JSONDecodeError`, which is not in the
tenacity predicate, so the retry silently does not fire. The final shape sets an
`is_json_body` flag and raises from the outer `except HTTPError` scope, which
also avoids ruff B904.

Verification:

- `uv run pytest tests/resources/test_resource_adp_workforce_now.py` — 13 pass.
  `test_get_talent_associate_memberships` fails on `main` too; it calls the live
  ADP API.
- `trunk check --force` on both changed files — no issues.
- `uv run pytest tests/test_dagster_definitions.py` and
  `dagster definitions validate -m teamster.code_locations.kipptaf.definitions`
  pass in the main checkout. In the worktree they fail on a missing dbt manifest
  and a missing `ILLUMINATE_DB_DRIVERNAME` configuration value, both unrelated
  to this change. `test_definitions_kippmiami` fails on `main` as well.

</details>
