### PR TITLE
perf(dbt): put 6 eager Focus grade tables on a cron

### DIFF
--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__course_enrollments_union.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__course_enrollments_union.yml
@@ -21,7 +21,7 @@ models:
           # Same tick as int_students__course_enrollments, which is its only
           # child. That model's genuine consumers are all batch exposures --
           # ddi_suite (0 1, 0 16 Fri, 0 18), literacy_dashboard (0 5),
-          # apm_dashboard (0 6) -- and the 4 ticks sit an hour ahead of each.
+          # apm_dashboard (0 6) -- and each tick precedes its consumer.
           # Sharing the tick means ~any_deps_in_progress serializes the pass:
           # this model builds first, its child follows in the same run. The
           # pair costs about 9.4 GiB/day against 81.1 today.

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__course_enrollments_union.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__course_enrollments_union.yml
@@ -9,6 +9,29 @@ models:
       inlining `dbt_utils.union_relations`.
     config:
       materialized: table
+      meta:
+        dagster:
+          # 4x/day instead of eager. Rebuilds 24.3 times a day at 1.132 GiB a
+          # build, 27.5 GiB/day, to feed one consumer:
+          # int_students__course_enrollments, which is now on this same cron.
+          # Eager here rebuilds on any change to any of the 4 district
+          # base_powerschool__course_enrollments sources, so it fires far more
+          # often than anything downstream reads.
+          #
+          # Same tick as int_students__course_enrollments, which is its only
+          # child. That model's genuine consumers are all batch exposures --
+          # ddi_suite (0 1, 0 16 Fri, 0 18), literacy_dashboard (0 5),
+          # apm_dashboard (0 6) -- and the 4 ticks sit an hour ahead of each.
+          # Sharing the tick means ~any_deps_in_progress serializes the pass:
+          # this model builds first, its child follows in the same run. The
+          # pair costs about 9.4 GiB/day against 81.1 today.
+          #
+          # Not a view: the uniqueness test on (cc_dcid, _dbt_source_project)
+          # guards the cross-district union grain, and the data-change
+          # condition re-materializes tables only, so as a view the test would
+          # fire on code change alone. Refs #5082
+          automation_condition:
+            cron_schedule: 0 0,4,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__category_grades.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__category_grades.yml
@@ -48,7 +48,9 @@ models:
           # daily BigQuery spend. Eager buys freshness nothing reads: the only
           # downstream mart is fct_grades_category, which appears in no cube
           # file and no extract, so those rebuilds produce a table nobody
-          # queries.
+          # queries. The cube_semantic_layer exposure does list it, but no file
+          # under src/cube/model/ reads it, so that entry overstates
+          # consumption.
           #
           # Not a view, even though the intermediate layer permits it. The
           # uniqueness test here is a SIS-cutover tripwire: this model unions a

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__category_grades.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__category_grades.yml
@@ -41,6 +41,33 @@ models:
       row — Focus has no citizenship grade and no year-to-date rollup.
     config:
       materialized: table
+      meta:
+        dagster:
+          # 1x/day instead of eager. Rebuilds 85.0 times a day at 1.667 GiB a
+          # build, 141.7 GiB/day -- the largest single line in the network's
+          # daily BigQuery spend. Eager buys freshness nothing reads: the only
+          # downstream mart is fct_grades_category, which appears in no cube
+          # file and no extract, so those rebuilds produce a table nobody
+          # queries.
+          #
+          # Not a view, even though the intermediate layer permits it. The
+          # uniqueness test here is a SIS-cutover tripwire: this model unions a
+          # PowerSchool branch and a Focus branch split by a year floor from
+          # int_students__sis_cutover, and a floor that drifts makes one Miami
+          # academic year emit from both. This model inherits the split from
+          # its parents rather than declaring it, so the test guards a join
+          # fan-out rather than the seam itself -- still a live guard on the
+          # boundary the SIS migration is actively moving. As a view it would
+          # fire only on code change, because the data-change condition
+          # re-materializes tables only. A daily tick keeps it firing.
+          #
+          # 0 4 matches the gradebook_and_gpa_dashboard batch these marts feed.
+          # All 4 leaves (category_grades, gradebook_assignments_scores, gpa,
+          # final_grades) share the tick, so ~any_deps_in_progress serializes
+          # the pass -- they are direct parent-child. The group costs about
+          # 8.7 GiB/day against 228.1 today. Refs #5082
+          automation_condition:
+            cron_schedule: 0 4 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -39,7 +39,27 @@ models:
           # 15:00 for ddi's Friday 16:00, 17:00 for ddi's 18:00. This model
           # and int_powerschool__course_enrollments_union, which shares the
           # tick, cost about 9.4 GiB/day together against 81.1 today.
-          # Refs #5082
+          #
+          # Not a view, and the gap versus a view is enormous here. This model
+          # is read about 853 times a day, and its 3 window functions over a
+          # full union all corresponding block column pruning, so a view read
+          # recomputes the whole model no matter how few columns the reader
+          # selects -- the shape #5035 measured on
+          # int_assessments__all_college_assessments, where 1 column cost
+          # 1.388 GiB against a 1.390 GiB build. At 1.209 GiB a recompute that
+          # is roughly 980 GiB/day, against 53.6 eager today and 9.4 here.
+          # Same call as #4821, which moved
+          # fct_assessment_scores_enrollment_scoped the other way for the same
+          # reason.
+          #
+          # Accepted trade-off: dim_student_section_enrollments is a view over
+          # this model, and Cube reads it live -- cube-cloud@ ran 288 jobs in
+          # 14 days against it, with no refresh_key and no pre-aggregation. So
+          # the Cube class-roster, attendance, and assessment views go from
+          # roughly eager freshness to these 4 ticks, and a mid-morning
+          # schedule change is not visible until 15:00. Weighed and accepted
+          # rather than adding school-day ticks. Revisit if roster staleness
+          # draws a complaint. Refs #5082
           automation_condition:
             cron_schedule: 0 0,4,15,17 * * *
     data_tests:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -34,7 +34,7 @@ models:
           #
           # So every genuine consumer is a batch exposure, not the hourly one:
           # ddi_suite (0 1, 0 16 Fri, 0 18), literacy_dashboard (0 5), and
-          # apm_dashboard (0 6). The 4 ticks sit an hour ahead of each --
+          # apm_dashboard (0 6). Each tick precedes its consumer --
           # 00:00 for ddi's 01:00, 04:00 for literacy's 05:00 and apm's 06:00,
           # 15:00 for ddi's Friday 16:00, 17:00 for ddi's 18:00. This model
           # and int_powerschool__course_enrollments_union, which shares the

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__course_enrollments.yml
@@ -13,6 +13,35 @@ models:
       course-enrollment-grain source.
     config:
       materialized: table
+      meta:
+        dagster:
+          # 4x/day instead of eager. Rebuilds 44.3 times a day at 1.209 GiB a
+          # build, 53.6 GiB/day, on top of the churn it drives in its
+          # PowerSchool ancestors.
+          #
+          # Eager looks unavoidable from the DAG shape:
+          # base_powerschool__course_enrollments is a bare select * over this
+          # model, which puts it upstream of 184 models and 60 exposures,
+          # including the hourly ops_dashboard. Reachability is not dependency.
+          # There are only 2 routes to the intraday exposures. Route 1 runs
+          # through int_extracts__student_enrollments, which projects exactly 1
+          # spine-derived column -- is_sipps, an existence flag for course
+          # SEM01099G1 -- and rpt_tableau__ops_dashboard and
+          # rpt_tableau__attendance_dashboard both reference is_sipps zero
+          # times and carry no select * or dbt_utils.star, so neither depends
+          # on this model. Route 2 is rpt_tableau__assessment_dashboard refing
+          # the spine directly, and that one is a real dependency.
+          #
+          # So every genuine consumer is a batch exposure, not the hourly one:
+          # ddi_suite (0 1, 0 16 Fri, 0 18), literacy_dashboard (0 5), and
+          # apm_dashboard (0 6). The 4 ticks sit an hour ahead of each --
+          # 00:00 for ddi's 01:00, 04:00 for literacy's 05:00 and apm's 06:00,
+          # 15:00 for ddi's Friday 16:00, 17:00 for ddi's 18:00. This model
+          # and int_powerschool__course_enrollments_union, which shares the
+          # tick, cost about 9.4 GiB/day together against 81.1 today.
+          # Refs #5082
+          automation_condition:
+            cron_schedule: 0 0,4,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__final_grades.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__final_grades.yml
@@ -37,7 +37,9 @@ models:
           # 44/day churn in stg_powerschool__pgfinalgrades and 51.3/day in
           # base_powerschool__final_grades, both kippnewark. Eager buys
           # freshness nothing reads: the only downstream mart is
-          # fct_grades_term, which appears in no cube file and no extract.
+          # fct_grades_term, which appears in no cube file and no extract. The
+          # cube_semantic_layer exposure does list it, but no file under
+          # src/cube/model/ reads it, so that entry overstates consumption.
           #
           # Not a view, even though the intermediate layer permits it. The
           # uniqueness test here is the SIS-cutover tripwire. The PowerSchool

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__final_grades.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__final_grades.yml
@@ -30,6 +30,34 @@ models:
       `dim_student_section_enrollments`.
     config:
       materialized: table
+      meta:
+        dagster:
+          # 1x/day instead of eager. Rebuilds 79.7 times a day at 0.107 GiB a
+          # build, 8.6 GiB/day, and it is one of the models driving the
+          # 44/day churn in stg_powerschool__pgfinalgrades and 51.3/day in
+          # base_powerschool__final_grades, both kippnewark. Eager buys
+          # freshness nothing reads: the only downstream mart is
+          # fct_grades_term, which appears in no cube file and no extract.
+          #
+          # Not a view, even though the intermediate layer permits it. The
+          # uniqueness test here is the SIS-cutover tripwire. The PowerSchool
+          # and Focus branches are exact complements around
+          # focus_start_academic_year, so a >= slipping to >, the floor moving,
+          # or the not (...) guard being dropped makes one Miami academic year
+          # emit from both branches -- both carrying
+          # _dbt_source_project = 'kippmiami', which the uniqueness key
+          # catches. As a view the test would fire only on code change, because
+          # the data-change condition re-materializes tables only. A daily tick
+          # keeps it firing on the one boundary the SIS migration is actively
+          # moving.
+          #
+          # 0 4 matches the gradebook_and_gpa_dashboard batch these marts feed.
+          # All 4 leaves (category_grades, gradebook_assignments_scores, gpa,
+          # final_grades) share the tick, so ~any_deps_in_progress serializes
+          # the pass -- they are direct parent-child. The group costs about
+          # 8.7 GiB/day against 228.1 today. Refs #5082
+          automation_condition:
+            cron_schedule: 0 4 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
@@ -50,6 +50,34 @@ models:
       held no Miami row in any year.
     config:
       materialized: table
+      meta:
+        dagster:
+          # 1x/day instead of eager. Rebuilds 85.7 times a day at 0.137 GiB a
+          # build, 11.7 GiB/day, and it is one of the models driving the
+          # 69.7/day churn in snapshot_powerschool__gpa_term and 73.7/day in
+          # snapshot_powerschool__gpa_cumulative. Eager buys freshness nothing
+          # reads: the only downstream mart is fct_grades_gpa, which appears in
+          # no cube file and no extract.
+          #
+          # Not a view, even though the intermediate layer permits it. The
+          # uniqueness test here is the SIS-cutover tripwire. The PowerSchool
+          # and Focus branches are exact complements around
+          # focus_start_academic_year, so a >= slipping to >, the floor moving,
+          # or the not (...) guard being dropped makes one Miami academic year
+          # emit from both branches -- both carrying
+          # _dbt_source_project = 'kippmiami', which the uniqueness key
+          # catches. As a view the test would fire only on code change, because
+          # the data-change condition re-materializes tables only. A daily tick
+          # keeps it firing on the one boundary the SIS migration is actively
+          # moving.
+          #
+          # 0 4 matches the gradebook_and_gpa_dashboard batch these marts feed.
+          # All 4 leaves (category_grades, gradebook_assignments_scores, gpa,
+          # final_grades) share the tick, so ~any_deps_in_progress serializes
+          # the pass -- they are direct parent-child. The group costs about
+          # 8.7 GiB/day against 228.1 today. Refs #5082
+          automation_condition:
+            cron_schedule: 0 4 * * *
     data_tests:
       # Scoped to rows that resolved a student_number. int_powerschool__gpa_term
       # carries 4 Camden AY2015 rows at schoolid 0 whose student fails the

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gpa.yml
@@ -57,7 +57,9 @@ models:
           # 69.7/day churn in snapshot_powerschool__gpa_term and 73.7/day in
           # snapshot_powerschool__gpa_cumulative. Eager buys freshness nothing
           # reads: the only downstream mart is fct_grades_gpa, which appears in
-          # no cube file and no extract.
+          # no cube file and no extract. The cube_semantic_layer exposure does
+          # list it, but no file under src/cube/model/ reads it, so that entry
+          # overstates consumption.
           #
           # Not a view, even though the intermediate layer permits it. The
           # uniqueness test here is the SIS-cutover tripwire. The PowerSchool

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gradebook_assignments_scores.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gradebook_assignments_scores.yml
@@ -41,6 +41,31 @@ models:
       rather than storing them by term).
     config:
       materialized: table
+      meta:
+        dagster:
+          # 1x/day instead of eager. Rebuilds 45.3 times a day at 1.458 GiB a
+          # build, 66.1 GiB/day. Eager buys freshness nothing reads: the only
+          # downstream mart is fct_grades_assignments, which appears in no cube
+          # file and no extract.
+          #
+          # Not a view, even though the intermediate layer permits it. The
+          # uniqueness test here is a SIS-cutover tripwire: this model unions a
+          # PowerSchool branch and a Focus branch split by a year floor from
+          # int_students__sis_cutover, and a floor that drifts makes one Miami
+          # academic year emit from both. This model inherits the split from
+          # its parents rather than declaring it, so the test guards a join
+          # fan-out rather than the seam itself -- still a live guard on the
+          # boundary the SIS migration is actively moving. As a view it would
+          # fire only on code change, because the data-change condition
+          # re-materializes tables only. A daily tick keeps it firing.
+          #
+          # 0 4 matches the gradebook_and_gpa_dashboard batch these marts feed.
+          # All 4 leaves (category_grades, gradebook_assignments_scores, gpa,
+          # final_grades) share the tick, so ~any_deps_in_progress serializes
+          # the pass -- they are direct parent-child. The group costs about
+          # 8.7 GiB/day against 228.1 today. Refs #5082
+          automation_condition:
+            cron_schedule: 0 4 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gradebook_assignments_scores.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__gradebook_assignments_scores.yml
@@ -46,7 +46,9 @@ models:
           # 1x/day instead of eager. Rebuilds 45.3 times a day at 1.458 GiB a
           # build, 66.1 GiB/day. Eager buys freshness nothing reads: the only
           # downstream mart is fct_grades_assignments, which appears in no cube
-          # file and no extract.
+          # file and no extract. The cube_semantic_layer exposure does list it,
+          # but no file under src/cube/model/ reads it, so that entry
+          # overstates consumption.
           #
           # Not a view, even though the intermediate layer permits it. The
           # uniqueness test here is a SIS-cutover tripwire: this model unions a


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will put 6 Focus grade and enrollment tables on a
cron instead of rebuilding them every time anything upstream changes.

All 6 are `materialized: table` with no `cron_schedule`, so they inherit the
eager table automation condition. They rebuild 364 times a day between them and
cost about 309 GiB/day. This change is expected to bring that down to about 18
GiB/day, a 94% cut, without delaying anything a consumer reads.

The 6 are not one group, so they get 2 different crons.

The 4 leaves get `0 4 * * *`:

- `int_students__category_grades`
- `int_students__gradebook_assignments_scores`
- `int_students__gpa`
- `int_students__final_grades`

Each leaf feeds exactly one mart — `fct_grades_category`,
`fct_grades_assignments`, `fct_grades_gpa`, `fct_grades_term`. None of those 4
marts appears in a cube file or a Tableau extract, so the rebuilds produce
tables nobody queries. `0 4` matches the `gradebook_and_gpa_dashboard` batch
those marts are eventually for. All 4 share the tick, so
`~any_deps_in_progress` serializes the pass.

The 2 spine models get `0 0,4,15,17 * * *`:

- `int_students__course_enrollments`
- `int_powerschool__course_enrollments_union`

These reach much further — 184 models and 60 exposures, including the hourly
`ops_dashboard`. But reaching a model is not the same as feeding it. The hourly
dashboards project no column that comes from the spine. Every consumer that
does is a batch exposure, so the 4 ticks sit an hour ahead of each one:
`ddi_suite` at 01:00, 16:00 Friday and 18:00, `literacy_dashboard` at 05:00,
`apm_dashboard` at 06:00.

Nothing changes in BigQuery when this deploys. A properties-file change does
not alter `code_version`, which hashes the raw SQL, so the first rebuild happens
at the first cron tick.

This is the same fix as #4559, #4821, and #5035.

## Reviewer Notes

**The leaves stay tables rather than becoming views, and that is deliberate.**
Views would cost less, but each leaf's uniqueness test is the tripwire for the
Miami SIS cutover. The data-change condition only re-materializes tables, so as
views those tests would fire on code change alone. A daily tick keeps them
firing for about 8.7 GiB/day.

**The spine cron rests on a column trace, not on the DAG shape.** Worth a second
look if you disagree that `rpt_tableau__ops_dashboard` and
`rpt_tableau__attendance_dashboard` are independent of the spine. The full trace
is in #5082.

**One caveat on scope.** `int_students__category_grades` and
`int_students__gradebook_assignments_scores` inherit the PowerSchool/Focus split
from their parents rather than declaring it, so their tests guard a join
fan-out rather than the cutover seam itself. Lower value than the other 2, same
conclusion.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster code changed. The automation conditions are read from dbt model
properties by `CustomDagsterDbtTranslator`, which is unchanged.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; 6 existing properties files changed.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no
      exposure changes; consumers are unchanged.
- [x] **Breaking change?** No. No column is renamed or removed, and no model
      changes materialization. Rollback is reverting the 6 properties files,
      which restores the eager condition on the next deploy.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      no external sources changed.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor, or integration changed. These are per-model automation
conditions, not Dagster schedules, so the automations catalog does not cover
them.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The measurement set and the design come from
#5082 and were not re-derived here.

**Three decisions closed in #5082, not re-opened:** not views, not
`+enabled: false`, and the leaf tests do not move upstream. The leaf tests are
the SIS-cutover tripwire on the `focus_start_academic_year` floor from
`int_students__sis_cutover`; the PowerSchool and Focus branch predicates are
exact complements, so a `>=` slipping to `>`, the floor moving, or the
`not (...)` guard being dropped makes one Miami academic year emit from both
branches, both carrying `_dbt_source_project = 'kippmiami'`. The tests cannot
move upstream because no upstream model has both branches present.

**Discrepancy inside #5082, resolved toward the Proposed approach table.** The
issue's "Acceptance" section says "the 2 spine models still return an eager tree
with no cron," which contradicts its own Proposed approach table, its entire
"Spine column trace" section, and its headline arithmetic. 8.7 GiB/day (leaves)
+ 9.4 GiB/day (spine) = 18.1, which is the issue's stated expected result of
"about 18." The Acceptance line reads as a stale leftover from an earlier draft.
Both spine models therefore carry `0 0,4,15,17 * * *` here.

**Verification, all run against the worktree:**

1. `dbt parse --target staging` — clean, 813 models.
1. `CustomDagsterDbtTranslator.get_automation_condition()` called on each of the
   6 parsed manifest nodes. Each returns a tree containing
   `CronTickPassedCondition(cron_schedule=<intended>, cron_timezone='America/New_York')`.
   The timezone resolves from the kipptaf code location's `LOCAL_TIMEZONE`.
   Controls: `int_assessments__response_rollup` still returns its own
   `0 0,10,13,15,17 * * *`, and the view-materialized control
   `stg_focus__marking_periods` returns no cron at all.
1. `_get_dbt_meta` shadowing checked on the parsed nodes, not assumed. It is an
   or-short-circuit over the whole dict, so a top-level `meta` would be hidden
   by `config.meta`. All 6 resolve `meta_source=config` with no top-level
   `meta` key, so nothing is shadowed.
1. `dbt build --select int_students__category_grades+ int_students__gpa+ int_students__final_grades+ int_students__gradebook_assignments_scores+ --target dev --defer --favor-state --state <prod manifest>`
   — `PASS=29 WARN=0 ERROR=0 SKIP=0`.
1. Row counts identical to prod, diff 0 on all 4:
   `int_students__category_grades` 7,765,626; `int_students__final_grades`
   244,379; `int_students__gpa` 240,283;
   `int_students__gradebook_assignments_scores` 23,352,918.
1. `trunk check --force --no-fix` on the 6 changed files, run from inside the
   worktree — "Checked 6 files, No issues."

**One unrelated failure hit on the way, diagnosed and not worked around.** The
first build run failed with
`Name academic_year not found inside gg` in
`int_students__gradebook_assignments_scores`. Not caused by this branch: the
diff is 6 properties files and the SQL is byte-identical to `origin/main`.
Commit `9ef8227095` added `academic_year` to `int_focus__gradebook_grades` at
2026-08-28 22:42 UTC, and the local prod manifest was generated at
2026-08-28 17:59 UTC, 4h43m earlier. `--favor-state` therefore resolved that
`ref()` to a prod relation predating the column. Adding
`int_focus__gradebook_grades` to the selection so it builds fresh in dev
resolves it. This is the "main moved" shape from root CLAUDE.md. Anyone
re-running the verification locally against a manifest older than that commit
will hit the same thing.

**Do not extend this to the snapshots or `stg_powerschool__pgfinalgrades`.**
Their churn — `snapshot_powerschool__gpa_term` 69.7/day,
`snapshot_powerschool__gpa_cumulative` 73.7/day,
`stg_powerschool__pgfinalgrades` 44/day — is a symptom of these 6. Measure after
this lands before touching them.

**Confirming the result.** Re-run the builds/day query from #5082 24 hours after
deploy, grouping `INFORMATION_SCHEMA.JOBS_BY_PROJECT` by
`destination_table.dataset_id` AND `table_id`. Grouping by table name alone
aggregates across the 5 district projects and inflates the counts.

</details>
