### PR TITLE
feat(dbt): include Paterson MS in athletic eligibility

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
@@ -50,4 +50,3 @@ where
     and e.enroll_status = 0
     and not e.is_out_of_district
     and e.region != 'Miami'
-    and (e.region != 'Paterson' or e.school_level = 'MS')

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__athletic_eligibility.sql
@@ -49,4 +49,5 @@ where
     and e.rn_year = 1
     and e.enroll_status = 0
     and not e.is_out_of_district
-    and e.region not in ('Miami', 'Paterson')
+    and e.region != 'Miami'
+    and (e.region != 'Paterson' or e.school_level = 'MS')

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
@@ -102,7 +102,10 @@ with
             and e.rn_year = 1
             and e.enroll_status = 0
             and e.grade_level >= 5
-            and e.region not in ('Paterson', 'Miami')
+            and e.region != 'Miami'
+            -- Paterson is MS-only; gate so future HS grades do not silently
+            -- enter the credits-based rules below untested
+            and (e.region != 'Paterson' or e.school_level = 'MS')
     )
 
 select

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__athletic_eligibility.sql
@@ -103,9 +103,6 @@ with
             and e.enroll_status = 0
             and e.grade_level >= 5
             and e.region != 'Miami'
-            -- Paterson is MS-only; gate so future HS grades do not silently
-            -- enter the credits-based rules below untested
-            and (e.region != 'Paterson' or e.school_level = 'MS')
     )
 
 select


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add Paterson middle school students to the
athletic eligibility Google Sheet.

Paterson was filtered out of both athletic eligibility models last year, in
commits `a2de93807` and `611d62a2b`. Since then none of its students have
appeared in the sheet. This change drops Paterson from the exclusion and leaves
Miami excluded.

One line changes in each model:

```sql
-- was
and e.region not in ('Paterson', 'Miami')
-- now
and e.region != 'Miami'
```

This adds 280 Paterson students for the 2025-26 year, in grades 5 through 8.
Newark and Camden row counts do not change.

## Reviewer Notes

- **Nobody has confirmed the eligibility thresholds for Paterson.** The model
  applies the same GPA cuts of 2.2 and 2.5 and the same 90% attendance rule that
  Newark and Camden use. Someone who owns athletics should confirm those are
  right for Paterson before this sheet goes out to schools.
- **66 of the 280 Paterson students get a blank Q1 status.** That is an upstream
  GPA gap, not something this change causes. Numbers are in the fold-out below.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models and no new columns, so both properties files are unchanged.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — the
      `rpt_gsheets__athletic_eligibility` exposure already exists and is
      unchanged.
- [x] **Breaking change?** No. No columns are renamed or removed, so the
      enforced contract on the extract is untouched. The change is row-scope
      only.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      not applicable, no external sources touched.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes, zero warnings.
- [x] **Dagster Cloud** — not triggered, no Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

## Verification

Built in a worktree against deferred prod upstreams:

```text
uv run dbt build --select int_students__athletic_eligibility+ \
  --target dev --defer --favor-state \
  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
  --project-dir <worktree>/src/dbt/kipptaf
```

`PASS=3 WARN=0 ERROR=0` across `int_students__athletic_eligibility`,
`rpt_gsheets__athletic_eligibility`, and the downstream
`rpt_deanslist__promo_status`, which also consumes the intermediate.

Row counts from the dev extract view, versus prod:

| region   | prod rows | dev rows | grades |
| -------- | --------- | -------- | ------ |
| Newark   | 3,796     | 3,796    | 5-12   |
| Camden   | 1,303     | 1,303    | 5-12   |
| Paterson | 0         | 280      | 5-8    |

Newark and Camden counts are unchanged, which is the regression check that
matters here. Paterson breaks down as 55 / 81 / 88 / 56 across grades 5 / 6 / 7
/ 8, matching `int_extracts__student_enrollments` exactly, so there is no
fan-out. Distinct-key check on the intermediate: 5,381 rows, 5,381 distinct
`(student_number, _dbt_source_project)`.

Paterson Q1 status distribution:

| q1_ae_status            | n   |
| ----------------------- | --- |
| Eligible                | 191 |
| null                    | 66  |
| Probation - ADA         | 18  |
| Probation - ADA and GPA | 2   |
| Ineligible - GPA        | 2   |
| Probation - GPA         | 1   |

## The 66 null statuses

Not caused by this change. `int_powerschool__gpa_term_pivot` has 276 rows for
`_dbt_source_project = 'kipppaterson'` at `yearid = 36`, of which 60 have a null
`gpa_y1_cur`. Those students fall through every `case` branch and land on the
implicit null.

The same shape exists in the regions already in the sheet, so this is a
pre-existing upstream gap rather than a Paterson-specific defect, though
Paterson grade 6 is the worst affected:

| project      | grade | n   | `cy_y1_gpa` null | share |
| ------------ | ----- | --- | ---------------- | ----- |
| kipppaterson | 6     | 81  | 53               | 65%   |
| kippnewark   | 5     | 637 | 151              | 24%   |
| kippnewark   | 8     | 583 | 111              | 19%   |
| kippcamden   | 6     | 194 | 11               | 6%    |

Grade 5 null `py_y1_gpa` is 100% in all three regions and is expected, since
grade 5 students have no prior middle school GPA. The Q1 `case` handles it
explicitly with `when is_first_time_ninth or grade_level = 5 then 'Eligible'`.

Worth a separate issue against `int_powerschool__gpa_term_pivot` for the
Paterson grade 6 gap if athletics cares about those 53 students.

## Separate pre-existing defects found while reading the model

Neither is touched by this PR. Both are worth their own issue.

1. `q3_ae_status` and `q4_ae_status` are byte-identical `case` blocks, 39 lines
   each, both reading `cy_s1_gpa` and `cy_weighted_s1_ada`. The year-end status
   is therefore computed from first-semester inputs. Confirmed empirically: 0 of
   5,381 rows have `q3_ae_status is distinct from q4_ae_status`.
1. All four `q*_ae_status` columns in
   `int_students__athletic_eligibility.yml` carry a copy-pasted `grade_level`
   description.

Checked and **not** a defect: `cy_credits` filters `storecode = 'Q2'` with no
academic-year predicate and joins on `studentid` + `_dbt_source_project`
without `yearid`, which looks like a fan-out risk. It is latent only —
`base_powerschool__final_grades` currently holds a single `yearid` (36).

## Lint

`trunk check --force --no-fix` on both changed files: `No issues`.

</details>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218031042086602