### PR TITLE
fix(dbt): resolve staff org units from the location crosswalk

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__admin_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__admin_import.sql
@@ -5,73 +5,17 @@ with
 
             u.id as user_id,
 
-            case
-                sr.home_work_location_dagster_code_location
-                when 'kippnewark'
-                then '/Students/TEAM/'
-                when 'kippcamden'
-                then '/Students/KCNA/'
-                when 'kippmiami'
-                then '/Students/Miami/'
-                when 'kipppaterson'
-                then '/Students/KIPP Paterson/'
-            end || case
-                sr.home_work_location_powerschool_school_id
-                /* TEAM */
-                when 133570965
-                then 'TEAM Academy'
-                when 73252
-                then 'Rise'
-                when 73253
-                then 'NCA'
-                when 73254
-                then 'SPARK'
-                when 73255
-                then 'THRIVE'
-                when 73256
-                then 'Seek'
-                when 73257
-                then 'Life'
-                when 73258
-                then 'BOLD'
-                when 73259
-                then 'Upper Roseville'
-                when 732511
-                then 'Newark Lab'
-                when 732513
-                then 'KJA'
-                when 732514
-                then 'KPA'
-                /* KCNA */
-                when 179901
-                then 'LSP'
-                when 179902
-                then 'LSM'
-                when 179903
-                then 'KHM'
-                when 179904
-                then 'KCNHS'
-                when 179905
-                then 'KSE'
-                /* KMS */
-                when 30200803
-                then 'Courage Academy'
-                when 30200804
-                then 'Royalty Academy'
-                /* Paterson */
-                when 2
-                then 'Paterson Prep Middle'
-                when 1234
-                then 'Paterson Prep Elementary'
-            end as org_unit_path,
+            x.location_google_student_org_unit_path as org_unit_path,
         from {{ ref("int_people__staff_roster") }} as sr
         inner join
             {{ ref("stg_google_directory__users") }} as u
             on sr.google_email = u.primary_email
+        inner join
+            {{ ref("int_people__location_crosswalk") }} as x
+            on sr.home_work_location_name = x.location_name
         where
             sr.user_principal_name is not null
             and sr.assignment_status not in ('Terminated', 'Deceased')
-            and sr.home_work_location_powerschool_school_id != 0
     ),
 
     with_ids as (

--- a/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__admin_import.sql
+++ b/src/dbt/kipptaf/models/extracts/google/directory/rpt_google_directory__admin_import.sql
@@ -13,6 +13,8 @@ with
                 then '/Students/KCNA/'
                 when 'kippmiami'
                 then '/Students/Miami/'
+                when 'kipppaterson'
+                then '/Students/KIPP Paterson/'
             end || case
                 sr.home_work_location_powerschool_school_id
                 /* TEAM */
@@ -56,6 +58,11 @@ with
                 then 'Courage Academy'
                 when 30200804
                 then 'Royalty Academy'
+                /* Paterson */
+                when 2
+                then 'Paterson Prep Middle'
+                when 1234
+                then 'Paterson Prep Elementary'
             end as org_unit_path,
         from {{ ref("int_people__staff_roster") }} as sr
         inner join


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." give staff at 5 schools the "Reset Student PW" role in Google Workspace, including all of KIPP Paterson.

The model that builds the role-assignment import, `rpt_google_directory__admin_import`, mapped a staff member's home work location to a student org unit path with a hardcoded `case` statement. That `case` was wrong or incomplete for 5 schools. When it produced no match, or a path that does not exist in Google, the join to the org unit list dropped the row, so those staff never reached the Google API call and never got the role.

This replaces the `case` with a join to `int_people__location_crosswalk`, the Ops-maintained lookup that the sibling model `rpt_google_directory__users_import` already uses for the same purpose. Adding a school is now a spreadsheet edit, not a code change.

## Reviewer Notes

The bug the Slack request reported was Paterson, which the `case` never mentioned. Checking the other regions against Google's real org units turned up 4 more schools with the same failure:

| school | hardcoded path | real path |
| --- | --- | --- |
| KIPP Hatch Middle (179903) | `/Students/KCNA/KHM` — does not exist | `/Students/KCNA/KHA` |
| KIPP Sumner (179905) | `/Students/KCNA/KSE` — does not exist | `/Students/KCNA/KSA` |
| Miami MTH, Legacy Elementary, Legacy Middle | absent from the `case` | valid paths in the crosswalk |

The diff also drops the `home_work_location_powerschool_school_id != 0` filter. It was standing in for "this location is not a school"; the crosswalk answers that directly with a null org unit path, which the join already discards.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

Same-day request — flagged in Slack by Laszlo de Simon; it blocks the Paterson student account rollout and i-Ready testing.

### dbt

- [x] Properties file — no new model, existing `.yml` unchanged.
- [x] Exposure — unchanged; this model feeds the Dagster `role_assignments_create` asset, not a dashboard.
- [x] Not a breaking change — no columns renamed or removed.
- [x] No external source changes.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Root cause found with `superpowers:systematic-debugging`. The first commit was a 7-line patch adding Paterson to the `case`; `claude-review` flagged the reinvented lookup, the finding was verified against prod data, and the second commit replaces the `case` entirely.

Verification, run against prod tables (the local dev build resolved upstreams to stale `zz_cbini_*` schemas and returned 0 rows, so the compiled SQL was re-run with the schemas repointed at prod):

- The crosswalk join on `home_work_location_name` is 1:1 — 1,581 roster rows, 1,581 distinct staff, no fan-out.
- 285 roster rows across 6 locations resolve to a null org unit path (regional and central office locations). The org-unit join discards them, matching the old `school_id != 0` behavior.
- Pending assignments now total 137: Paterson Prep Elementary 55, Paterson Prep Middle 34, Legacy Elementary 20, KSA 17, Legacy Middle 6, KHA 3, TEAM Academy 1, Rise 1.
- The old `case` yielded 91 (89 Paterson after the first commit, plus 2 Newark). The extra 46 are the KHA / KSA / Miami staff the `case` was silently dropping.
- Miami MTH (30200805) is in the crosswalk but has 0 pending rows — its 8 staff already hold the role, presumably granted by hand.

`claude-review` ran against the first commit only; it does not re-fire on `synchronize`. A draft toggle would re-run it, at the cost of cancelling and restarting the dbt Cloud check.

After merge, the fix takes effect when `rpt_google_directory__admin_import` rebuilds and the `kipptaf/google/directory/role_assignments_create` asset materializes. For the rush timeline, materialize that asset manually rather than waiting for the schedule.

</details>
