### PR TITLE
test(dbt): assert the term_key grain on the terms staging table

### DIFF
--- a/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__reporting__terms.yml
+++ b/src/dbt/kipptaf/models/google/sheets/staging/properties/stg_google_sheets__reporting__terms.yml
@@ -16,6 +16,23 @@ models:
           config:
             severity: error
             where: type = 'RT'
+      # Guards the dim_terms term_key grain HERE rather than on dim_terms
+      # itself. dim_terms is a view, so sheet edits reach it instantly but its
+      # own unique test only re-runs when someone changes its SQL -- a 2026-08
+      # grade_band split tripled 60 LIT keys and sat undetected for 3 weeks.
+      # This model is a table rebuilt by the google_sheet asset on every sheet
+      # edit, so the test fires exactly when the sheet can break the key.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - type
+              - code
+              - name
+              - start_date
+              - region
+              - school_id
+          config:
+            severity: error
     columns:
       - name: type
         data_type: string


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will check that the Reporting Dates sheet holds
only one row per term, and fail the build when it holds more than one.

`dim_terms` builds a `term_key` by hashing 6 columns: `type`, `code`, `name`,
`start_date`, `region`, and `school_id`. If the sheet has two rows that match on
all 6, two terms get the same key. Fourteen other models hash the same 6 columns
to join to `dim_terms`, so a duplicate key quietly fans out every one of them.

A test for this already exists on `dim_terms`, but it cannot catch the problem
in time. `dim_terms` is a view. New sheet rows reach it the moment the sheet
saves, while its test only runs again when someone edits the model's SQL. That
check last ran on 2026-08-10.

`stg_google_sheets__reporting__terms` is a table. The `google_sheet` asset
rebuilds it on every sheet edit. Putting the same check here means it runs at
the moment the sheet can break the key.

## Reviewer Notes

**This test fails today.** Sixty duplicate rows are live in the sheet right now
-- AY2025 `LIT` rows split into 3 grade bands across all 4 regions. Someone has
to collapse those rows in the sheet before this merges green. Details in the
fold-out below.

The existing `RT`-scoped test on this model stays. It asserts a different thing
(PowerSchool joinability) and does not overlap.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory -- use your judgement, but don't ignore it.)

### dbt

- [x] No new models, so no new properties file is needed.
- [x] No exposure change -- this adds a test, not a model.
- [x] Not a breaking change -- no column is renamed or removed.
- [x] No external source change, so `stage_external_sources` is not needed.

## CI checks

- [ ] **Trunk** -- passes.
- [ ] **dbt Cloud** -- passes.
- [ ] **Dagster Cloud** -- passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

**Origin.** A Slack thread on 2026-08-31 asked whether to add `grade_band` as a
7th column to the `dim_terms` `term_key` hash, because `term_key` was failing
uniqueness. Widening the hash is the wrong fix -- 15 hash sites across 11 models
compute `term_key`, a 7th column changes every `term_key` in the warehouse (NULL
hashes to `_dbt_utils_surrogate_key_null_`), and every fact would need to resolve
a grade band to join. The duplicate rows are the actual defect.

**The duplicate rows.** All 30 duplicated groups have exactly 1 distinct
`start_date` AND 1 distinct `end_date` across their 3 band rows, so `grade_band`
carries no window information -- the 3 rows are identical on every date field.
Bands are `0,1,2` / `3,4` / `5,6,7,8` in Newark, Camden, and Miami, and
`0,1,2` / `3` / `5,6,7` in Paterson (correct -- Paterson serves grades 0-3 and
5-7 in AY2025, verified against `int_students__student_enrollments`).

Scope: 180 banded rows -- Newark 48, Camden 48, Paterson 48, Miami 36.

**Live damage.** `int_google_sheets__dibels_pm_expectations` joins
`stg_google_sheets__reporting__terms` on `academic_year` / `region` / `name` /
`code` with no band condition, so it picks up all 3. AY2025 has 60 join keys
matching 3 term rows each; AY2024 and AY2026 match 1. The model is 7,110 rows for
AY2025 against 162 for AY2024.

**Why the existing check missed it.** `dim_terms` is a view whose DDL was last
written 2026-08-10 22:19 UTC. `unique_dim_terms_term_key` last executed
2026-08-10 22:17 UTC, passing, 0 failed rows -- the same moment. The upstream
staging table rebuilt today at 20:58 UTC. Editing the sheet fires
`kipptaf__dbt_assets__google_sheets` (`select="tag:google_sheet"`, no `+`), which
rebuilds the tagged staging tables and stops. `dim_terms` sits in
`core_dbt_assets`, which excludes `tag:google_sheet`, and its automation condition
fires on a code change only, since the data-change condition skips views.

The other candidate check, the `unique_combination_of_columns` already on this
model, carries `where: type = 'RT'` and so skips every `LIT` row.

**Verification.** `dbt parse` clean. `dbt ls` registers the test. Compiled SQL is
`group by type, code, name, start_date, region, school_id having count(*) > 1`.
Run against `kipptaf_google_sheets.stg_google_sheets__reporting__terms`: 60
failing rows today, 0 across all 16 prior academic years -- so the assertion is
targeted at this defect and carries no historical debt.

**If the windows ever do diverge by band**, put the band in `code`
(`PLIT3-K2`, `PLIT3-34`, `PLIT3-58`). `code` is already in the hash, so that
costs zero code changes and keeps this test green.

</details>
