### PR TITLE
fix(dagster): serialize role assignment inserts per org unit

### DIFF
--- a/src/teamster/libraries/google/CLAUDE.md
+++ b/src/teamster/libraries/google/CLAUDE.md
@@ -38,11 +38,21 @@ failed emails to skip group membership for uncreated users (via
 includes the password hash) out of logs and asset-check metadata.
 
 **409 conflict handling**: 409 is deliberately excluded from
-`_TRANSIENT_HTTP_CODES` because its meaning is method-specific: for
-`batch_insert_role_assignments` it means "entity already exists" (not
-retryable), but for `batch_update_users` it means "conflicting request, please
-try again" (retryable). User update 409s are retried individually via
-`_retry_update_user()` after a 1-second cooldown.
+`_TRANSIENT_HTTP_CODES`, so no batch method retries one. Read the `reason` code
+before assuming what a 409 means — `duplicate` ("entity already exists") is
+permanent, `conflict` ("conflicting requests, please try again") is Google
+serializing two writes against one resource and is transient. User update 409s
+are retried individually via `_retry_update_user()` after a 1-second cooldown.
+
+**Role assignment batches are serialized per org unit**: the Directory API
+serializes writes against a single org unit, so two `roleAssignments.insert`
+sub-requests scoped to the same org unit inside one batch race and one returns
+409 `conflict` — which nothing retries, so it fails the `zero_api_errors` check.
+`_batch_by_distinct_org_unit` deals at most one item per org unit into each
+batch, and batches run sequentially, so two writes to one org unit are never in
+flight together. The batch count therefore equals the largest single org unit's
+row count, NOT `len(rows) / size` — a payload of 135 rows across 6 org units
+(largest 56) yields 56 batches, not 14.
 
 **Batch callback signature**: Google's batch executor calls
 `callback(id, response, exception)` with exactly one of `response`/`exception`

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -1,5 +1,6 @@
 import time
-from collections.abc import Callable
+from collections import defaultdict, deque
+from collections.abc import Callable, Iterator
 
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster._utils.backoff import backoff, exponential_delay_generator
@@ -54,6 +55,51 @@ def _retryable_execute(request) -> Callable[[], dict]:
             raise
 
     return execute
+
+
+def _batch_by_distinct_org_unit(
+    role_assignments: list[dict], size: int
+) -> Iterator[list[dict]]:
+    """Yield batches in which no two role assignments share an ``orgUnitId``.
+
+    The Directory API serializes writes against a single org unit, so two
+    inserts scoped to the same org unit inside one ``BatchHttpRequest`` race each
+    other and one comes back ``409 Conflicting requests. Please try again``.
+    Dealing at most one item per org unit into each batch removes that
+    contention: batches execute sequentially, so no two writes to the same org
+    unit are ever in flight together.
+
+    A batch therefore holds at most ``size`` items AND at most one per distinct
+    org unit, so a payload targeting few org units yields more, smaller batches.
+    An item without an ``orgUnitId`` (a customer-scoped assignment) is keyed on
+    its position instead, so those still pack to ``size``.
+
+    Args:
+        role_assignments: Role assignment resource dicts.
+        size: Maximum items per batch.
+
+    Yields:
+        Batches of role assignment dicts, preserving input order within each
+        org unit.
+    """
+    by_org_unit = defaultdict[str | int, deque[dict]](deque)
+
+    for i, role_assignment in enumerate(role_assignments):
+        by_org_unit[role_assignment.get("orgUnitId") or i].append(role_assignment)
+
+    while by_org_unit:
+        batch = []
+
+        for org_unit_id in list(by_org_unit):
+            batch.append(by_org_unit[org_unit_id].popleft())
+
+            if not by_org_unit[org_unit_id]:
+                del by_org_unit[org_unit_id]
+
+            if len(batch) == size:
+                break
+
+        yield batch
 
 
 class GoogleDirectoryResource(ConfigurableResource):
@@ -660,7 +706,12 @@ class GoogleDirectoryResource(ConfigurableResource):
     def batch_insert_role_assignments(
         self, role_assignments: list[dict], customer: str | None = None
     ) -> list[str]:
-        """Create multiple role assignments in batches of 10.
+        """Create multiple role assignments in batches of at most 10.
+
+        Batches are built so that no two assignments in one batch target the
+        same org unit — see :func:`_batch_by_distinct_org_unit`, which exists
+        because concurrent writes to one org unit return ``409 Conflicting
+        requests``, a status the batch retry layer does not treat as transient.
 
         Each batch — and each individual sub-request within it — is retried on
         transient errors (5xx, 429) with exponential backoff to handle quota
@@ -675,7 +726,9 @@ class GoogleDirectoryResource(ConfigurableResource):
         """
         exceptions = []
 
-        batches = list(chunk(obj=role_assignments, size=10))
+        batches = list(
+            _batch_by_distinct_org_unit(role_assignments=role_assignments, size=10)
+        )
 
         for i, batch in enumerate(batches):
             self._log.info(msg=f"Processing batch {i + 1}")

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -1,6 +1,7 @@
 import time
-from collections import defaultdict, deque
+from collections import defaultdict
 from collections.abc import Callable, Iterator
+from itertools import zip_longest
 
 from dagster import ConfigurableResource, DagsterLogManager, InitResourceContext
 from dagster._utils.backoff import backoff, exponential_delay_generator
@@ -70,9 +71,10 @@ def _batch_by_distinct_org_unit(
     unit are ever in flight together.
 
     A batch therefore holds at most ``size`` items AND at most one per distinct
-    org unit, so a payload targeting few org units yields more, smaller batches.
-    An item without an ``orgUnitId`` (a customer-scoped assignment) is keyed on
-    its position instead, so those still pack to ``size``.
+    org unit, so a payload targeting few org units yields more, smaller batches:
+    the batch count equals the largest single org unit's row count. An item
+    without an ``orgUnitId`` (a customer-scoped assignment) is keyed on its
+    position instead, so those still pack to ``size``.
 
     Args:
         role_assignments: Role assignment resource dicts.
@@ -82,24 +84,16 @@ def _batch_by_distinct_org_unit(
         Batches of role assignment dicts, preserving input order within each
         org unit.
     """
-    by_org_unit = defaultdict[str | int, deque[dict]](deque)
+    by_org_unit = defaultdict[str | int, list[dict]](list)
 
     for i, role_assignment in enumerate(role_assignments):
         by_org_unit[role_assignment.get("orgUnitId") or i].append(role_assignment)
 
-    while by_org_unit:
-        batch = []
-
-        for org_unit_id in list(by_org_unit):
-            batch.append(by_org_unit[org_unit_id].popleft())
-
-            if not by_org_unit[org_unit_id]:
-                del by_org_unit[org_unit_id]
-
-            if len(batch) == size:
-                break
-
-        yield batch
+    # One "round" takes at most one item per org unit, so a round already
+    # satisfies the distinctness rule; chunk() only caps it at ``size`` for the
+    # case where the org units outnumber a single batch.
+    for round_ in zip_longest(*by_org_unit.values()):
+        yield from chunk(obj=[item for item in round_ if item is not None], size=size)
 
 
 class GoogleDirectoryResource(ConfigurableResource):

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -8,6 +8,7 @@ from googleapiclient.errors import HttpError
 
 from teamster.libraries.google.directory.resources import (
     GoogleDirectoryResource,
+    _batch_by_distinct_org_unit,
     _retryable_execute,
     _TransientHttpError,
     members_for_created_users,
@@ -439,6 +440,76 @@ def test_batch_insert_role_assignments_retries_transient_subrequest_and_succeeds
         )
     assert exceptions == []
     assert mock_api.new_batch_http_request.call_count == 2
+
+
+# ── _batch_by_distinct_org_unit ───────────────────────────────────────────────
+
+
+def test_batch_by_distinct_org_unit_never_repeats_an_org_unit_in_a_batch():
+    role_assignments = [
+        {"assignedTo": f"uid{i}", "orgUnitId": org_unit_id}
+        for org_unit_id, count in [("ou_a", 56), ("ou_b", 33), ("ou_c", 3)]
+        for i in range(count)
+    ]
+
+    batches = list(
+        _batch_by_distinct_org_unit(role_assignments=role_assignments, size=10)
+    )
+
+    for batch in batches:
+        org_unit_ids = [ra["orgUnitId"] for ra in batch]
+        assert len(org_unit_ids) == len(set(org_unit_ids))
+        assert len(batch) <= 10
+
+    flat = [ra for batch in batches for ra in batch]
+    assert len(flat) == len(role_assignments)
+
+    for org_unit_id in ("ou_a", "ou_b", "ou_c"):
+        assert [ra for ra in flat if ra["orgUnitId"] == org_unit_id] == [
+            ra for ra in role_assignments if ra["orgUnitId"] == org_unit_id
+        ]
+
+
+def test_batch_by_distinct_org_unit_yields_every_item_exactly_once():
+    role_assignments = [
+        {"assignedTo": f"uid{i}", "orgUnitId": "ou_a"} for i in range(5)
+    ]
+
+    batches = list(
+        _batch_by_distinct_org_unit(role_assignments=role_assignments, size=10)
+    )
+
+    assert batches == [[ra] for ra in role_assignments]
+
+
+def test_batch_by_distinct_org_unit_packs_customer_scoped_items_to_size():
+    role_assignments = [
+        {"assignedTo": f"uid{i}", "scopeType": "CUSTOMER"} for i in range(25)
+    ]
+
+    batches = list(
+        _batch_by_distinct_org_unit(role_assignments=role_assignments, size=10)
+    )
+
+    assert [len(batch) for batch in batches] == [10, 10, 5]
+
+
+def test_batch_insert_role_assignments_splits_same_org_unit_across_batches():
+    resource, mock_api = _make_resource()
+    mock_api.new_batch_http_request.side_effect = _make_batch_side_effect(
+        [[({"roleAssignmentId": f"ra{i}"}, None)] for i in range(3)]
+    )
+
+    with patch("teamster.libraries.google.directory.resources.time.sleep"):
+        exceptions = resource.batch_insert_role_assignments(
+            [
+                {"assignedTo": f"uid{i}", "roleId": "rid", "orgUnitId": "ou_a"}
+                for i in range(3)
+            ]
+        )
+
+    assert exceptions == []
+    assert mock_api.new_batch_http_request.call_count == 3
 
 
 # ── list_roles / list_role_assignments default params ─────────────────────────


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the "Reset Student PW" role assignment
job from reporting a false failure when it grants many staff the same role on the
same student org unit.

Google's Directory API handles one write at a time per org unit. The job sends
role assignments 10 at a time in a single batch. When two of those 10 target the
same org unit, they race, and one comes back with `409 Conflicting requests.
Please try again`. The job does not retry that response, so it records the
assignment as failed and the `zero_api_errors` check fires an alert.

This is what happened in
[run d5145d79](https://kipptaf.dagster.cloud/prod/runs/d5145d79-1b25-4fd1-9971-66862bf10ae7)
on 8/31. The run itself succeeded, but 1 of 135 role assignments failed this way,
and one staff member did not get their password reset role.

The fix changes how batches are built. Each batch now takes at most one
assignment per org unit. Batches run one after another, so two writes to the same
org unit are never in flight at the same time.

## Reviewer Notes

- The new batching makes batches smaller when the work targets few org units.
  The batch count equals the largest single org unit's row count, not the row
  total divided by the batch size. The 8/31 payload of 135 rows spanned 6 org
  units, the largest holding 56, so it goes from 14 batches of 10 to 56 batches
  that taper from 6 down to 1. Each batch is followed by a 1 second pause, so the
  job takes roughly 42 seconds longer. The job has no runtime pressure.
- This fix prevents the conflict rather than retrying it. A 409 from some other
  source would still fail the check. See the fold-out for why we chose prevention.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] Run `uv run dagster definitions validate` for any modified code location
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location — `test_definitions_kipptaf` passes. 4 of 6 pass locally;
      `kippmiami` and `all` fail on a missing dlt config value that also fails on
      `main`, so it is pre-existing and unrelated. Details in the fold-out.
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager _(no new integration)_

### dbt _(no dbt changes)_

### Docs _(no schedule, sensor, or integration changes)_

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found via `superpowers:systematic-debugging` on
Dagster prod run `d5145d79-1b25-4fd1-9971-66862bf10ae7`.

**Evidence.** The run status was `SUCCESS`; the alert came from the
`zero_api_errors` asset check on
`kipptaf/google/directory/role_assignments_create`, which failed WARN with one
error:

```text
HttpError 409 when requesting .../roleassignments returned
"Conflicting requests. Please try again".
Details: [{'message': 'Conflicting requests. Please try again',
           'domain': 'global', 'reason': 'conflict'}]
```

The 4 prior check executions all recorded `errors: []`.

**Why it surfaced now.** PR #5095 (merge `494847107e`) added the Paterson org
unit mapping to `rpt_google_directory__admin_import`, which took the extract from
roughly 0-3 pending rows a day to 135. Row counts by org unit at the time:

| org_unit_path                                    | rows |
| ------------------------------------------------ | ---- |
| /Students/KIPP Paterson/Paterson Prep Elementary | 56   |
| /Students/KIPP Paterson/Paterson Prep Middle     | 33   |
| /Students/Miami/Legacy Elementary                | 20   |
| /Students/KCNA/KSA                               | 17   |
| /Students/Miami/Legacy Middle                    | 6    |
| /Students/KCNA/KHA                               | 3    |

With `chunk(size=10)` over that input, essentially every batch held multiple
inserts against one org unit.

**Root cause.** `_TRANSIENT_HTTP_CODES` is `{429, 500, 502, 503, 504}`.
`_execute_batch_with_retry` retries a sub-request only when its status is in that
set, so a 409 lands in `failures` on the first attempt and reaches the check.
The reason code was `conflict`, not `duplicate` — Google's concurrency
serialization, not "entity already exists". The extract already anti-joins
`stg_google_directory__role_assignments`, so a true duplicate is unlikely anyway.

**Options considered.** Three were put to the author: add 409 to
`_TRANSIENT_HTTP_CODES`; retry 409 only when `error_details` carries
`reason == 'conflict'`; or serialize per org unit. The author chose
serialization, which removes the contention instead of absorbing it.

**Known limits, stated plainly.** Serialization only helps if the org unit is the
contended resource. That is an inference from the error shape and the row
distribution, not something confirmed against Google's implementation. If 409s
persist, the retry-based options above are still on the table.

**Not changed.** `_TRANSIENT_HTTP_CODES` still omits 409 for the other batch
methods, and `batch_update_users` still carries a hand-rolled 409 retry
(`_retry_update_user`) to compensate. That inconsistency is real but out of scope
here.

**Verification.** 4 new tests in
`tests/resources/test_resource_google_directory.py` cover no-repeated-org-unit
within a batch, every item yielded once, customer-scoped items still packing to
`size`, and `batch_insert_role_assignments` splitting 3 same-org-unit items into 3
batches. Selected run: 12 passed, 46 deselected; 58 collected clean. The live-API
tests in that file were deliberately not run — they mutate the real Google
directory. `trunk check --force` on both changed files: no issues.

**Definitions validation.** `uv run pytest tests/test_dagster_definitions.py` in
the worktree: 4 passed, 2 failed. `test_definitions_kipptaf` — the only location
that imports the changed module — passes. `test_definitions_kippmiami` and
`test_definitions_all` fail on a dlt `ConfigFieldMissingException`, and
`test_definitions_kippmiami` fails identically on `main` in the same Codespace, so
it is a local config gap and not this branch. A fresh worktree also has no
compiled dbt manifest, which fails every location until you copy or regenerate
`src/dbt/*/target/manifest.json` — worth knowing before chasing that error.

</details>
