### PR TITLE
fix(deanslist): capture and expose the NonDisciplinary incident flag

### DIFF
--- a/src/dbt/deanslist/models/intermediate/properties/int_deanslist__incidents.yml
+++ b/src/dbt/deanslist/models/intermediate/properties/int_deanslist__incidents.yml
@@ -7,6 +7,8 @@ models:
         data_type: boolean
       - name: is_referral
         data_type: boolean
+      - name: non_disciplinary
+        data_type: boolean
       - name: send_alert
         data_type: boolean
       - name: close_ts_timezone_type

--- a/src/dbt/deanslist/models/staging/properties/stg_deanslist__incidents.yml
+++ b/src/dbt/deanslist/models/staging/properties/stg_deanslist__incidents.yml
@@ -15,6 +15,8 @@ models:
         data_type: boolean
       - name: is_referral
         data_type: boolean
+      - name: non_disciplinary
+        data_type: boolean
       - name: send_alert
         data_type: boolean
       - name: close_ts_timezone_type

--- a/src/dbt/deanslist/models/staging/stg_deanslist__incidents.sql
+++ b/src/dbt/deanslist/models/staging/stg_deanslist__incidents.sql
@@ -14,6 +14,7 @@ with
             hearingflag as hearing_flag,
             isactive as is_active,
             isreferral as is_referral,
+            nondisciplinary as non_disciplinary,
             sendalert as send_alert,
 
             /* records */

--- a/src/teamster/libraries/deanslist/schema.py
+++ b/src/teamster/libraries/deanslist/schema.py
@@ -256,6 +256,7 @@ class Incident(BaseModel):
     IsReferral: bool | None = None
     Location: str | None = None
     LocationID: str | None = None
+    NonDisciplinary: bool | None = None
     ReportedDetails: str | None = None
     ReportingIncidentID: str | None = None
     ReturnPeriod: str | None = None

--- a/src/teamster/libraries/deanslist/schema.py
+++ b/src/teamster/libraries/deanslist/schema.py
@@ -252,6 +252,7 @@ class Incident(BaseModel):
     IncidentID: str | None = None
     Infraction: str | None = None
     InfractionTypeID: str | None = None
+    is_deleted: bool | None = None
     IsActive: bool | None = None
     IsReferral: bool | None = None
     Location: str | None = None


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the `avro_schema_valid` asset check from
failing on every DeansList `incidents` partition, and expose the new
`NonDisciplinary` flag as `non_disciplinary` in `stg_deanslist__incidents`.

DeansList added a boolean `NonDisciplinary` field to the `/api/v1/incidents`
response. The shared `Incident` model did not declare it. `check_avro_schema_valid`
compares the response fields to the Avro schema fields, so every `incidents`
partition failed the check and fired an alert on an otherwise successful run.
The field was also dropped when the Avro file was written, so the value never
reached the warehouse.

This pull request also declares `is_deleted` on `Incident`. `DeansListResource.get`
merges `deleted_data` into the asset output after stamping that flag, so deleted
incidents are written to the same Avro file as live ones. `Behavior` and
`Homework` declare the flag; `Incident` did not, so it was dropped at write time
and a deleted incident would reach the warehouse indistinguishable from a live
one. Declaring it now rides the re-encode this change already needs.

All 4 districts import the same `Incident` model, so both 1-line schema changes
cover kippcamden, kippmiami, kippnewark, and kipppaterson.

**This pull request is a draft on purpose. Do not merge it yet.** The dbt commit
is safe to merge only after every `incidents` Avro file in Cloud Storage carries
the new schema. Reviewer Notes explains the order.

## Reviewer Notes

**Merge order is load-bearing.** `stg_deanslist__incidents` reads the source with
no partition filter, so each build scans all 2,330 Avro files (2016-07 onward).
A scan across files with different Avro writer schemas drops the field that only
the newer files declare — for the whole scan, including the newer files that
hold real values. Issue #4151 reproduces this. So merging the dbt commit before
the files are homogeneous gives a column that builds clean and reads NULL on
every row.

The order is:

1. Merge this pull request only after steps 2 and 3, or split it and merge the
   Avro commit first.
1. Run `scripts/reencode_avro_partitions.py` with `--execute` for each district
   `incidents` asset, after the Avro fix deploys.
1. Re-stage the external source so the `zz_stg_*` table declares the new column.
1. Follow up in `kipptaf`. `int_deanslist__incidents` there unions the 4 district
   copies with `dbt_utils.union_relations`, which builds a column superset, so it
   emits `non_disciplinary` once at least 1 district prod copy carries it — but
   only after that wrapper rebuilds. Until then
   `fct_behavioral_incidents`, `fct_behavioral_consequences`, and the Tableau
   extracts reading them stay without the column. This is the two-PR pattern in
   `src/dbt/CLAUDE.md` under "kipptaf source consumers of district columns".

**The green dbt Cloud check on this pull request is not validation.** The dbt
Cloud CI job builds `kipptaf` only. These changes live in the `deanslist` source
package, so `state:modified+` selects 0 models and the check passes in about 30
seconds without building anything.

**Local Dagster validation: 4 of 6 tests pass.** `test_definitions_kippmiami`
and `test_definitions_all` fail on missing `FOCUS_DB` dlt credentials. The
identical failure reproduces on `main`, so it predates this pull request and is
a local credential gap, not a code problem.

**`is_deleted` never lost data, as far as we can measure.** The incidents
endpoint returns no deleted rows today, no Avro file declares the flag across
all 2,330 blobs, and 50 consecutive check executions never reported it as an
extra. A fresh pull with `UpdatedSince` backdated to 2016-07-01 returns exactly
the `IncidentID` set the warehouse holds — 803 incidents across 4 windows, 2
schools, and 2 fiscal years, 0 orphaned. So this is closing a latent gap, not
recovering lost rows. `is_deleted` will read NULL until DeansList starts
returning deleted rows.

**Historical rows keep `non_disciplinary` as NULL.** Re-encoding fills the field
with null for old files, because those files never carried a value. Populating
history instead needs a full re-materialization of 2,330 partitions, which we
decided against.

## Self-review

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [x] Run `uv run dagster definitions validate` for any modified code location
- [x] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager — not applicable, no new
      integration

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
      — no new models. Both existing properties files declare the new column.
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — not
      applicable, no new consumer
- [x] **Breaking change?** Not breaking. This pull request adds a column and
      renames or removes nothing. Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped. This pull request changes no schedule, sensor, or integration.

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [x] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Started from a `systematic-debugging` pass on
run `d805b02c-9afb-4463-8b8f-12eeb6458823` (kippnewark `deanslist/incidents`,
partition `2026-08-01|122`), which reported SUCCESS while carrying
`dagster-cloud/triggered_alert: true`.

Root cause chain: `check_avro_schema_valid` (`src/teamster/core/asset_checks.py:27`)
computes `extras = record_fields - schema_fields` and returns
`passed=len(extras) == 0` at WARN severity. 20 consecutive check executions
recorded `extras: NonDisciplinary`.

Verification of the Avro fix: a live `GET /api/v1/incidents` for school 122 with
`UpdatedSince=2026-08-01`, `StartDate=2026-07-01`, `EndDate=2026-08-31`,
`IncludeDeleted=Y`, `cf=Y`, `attachments=Y` returned 22 records. Against the
patched model the check returned `passed=True`, `extras=''`, and
`py_avro_schema` generated
`{'name': 'NonDisciplinary', 'type': ['null', 'boolean'], 'default': None}`.
No other extra fields, and no model field missing from the response. The
throwaway test was deleted.

Field-coverage audit of `stg_deanslist__incidents`: of the 59 `Incident` model
fields, only `NonDisciplinary` and `URI` were unreferenced. `URI` stays
unexposed — nobody asked for it. The remaining external-table columns are the 5
`_dagster_partition_*` hive keys and `_file_name`, which the dedupe uses and the
model deliberately does not project.

Contract detail: `deanslist` enforces contracts on `staging` only
(`dbt_project.yml`). The staging properties file therefore had to declare
`non_disciplinary` or the build fails. `int_deanslist__incidents.yml` is not
contract-enforced, but it mirrors the staging column list, so it gets the entry
for consistency. `int_deanslist__incidents.sql` selects `i.*`, so the column
propagates with no SQL change there.

Re-encode sizing, from `reencode_avro_partitions.py` dry runs (no writes):
kippnewark 1,482, kippcamden 616, kippmiami 202, kipppaterson 30 — 2,330 blobs,
`skipped=0`, `errors=0`. `skipped=0` is expected, because no file carries the
field yet. These counts exceed a BigQuery `INFORMATION_SCHEMA` estimate of
1,139 / 434 / 124 / 24; the gap is almost certainly zero-record files for
school-months with no incidents, which a row-based count cannot see. That is
inferred, not verified — the Codespace service account
`codespaces@teamster-332318.iam.gserviceaccount.com` holds no object
permissions on any `teamster-<district>` bucket (`testIamPermissions` reports
`storage.objects.list`, `get`, `create`, `delete`, and `buckets.get` all
missing; `teamster-test` is fully permitted). So the re-encode cannot run from a
Codespace under the default credentials, and the dry runs above ran under user
credentials with `GOOGLE_APPLICATION_CREDENTIALS` cleared.

`is_deleted` is now declared on `Incident` (commit 3). Evidence gathered before
adding it, in increasing strength:

1. Live probe: `deleted_data` empty and `deleted_rowcount` absent across 12
   school-months spanning 2024 to 2026.
1. Check history: 50 consecutive `avro_schema_valid` executions report `extras`
   of `""` or `"NonDisciplinary"` only.
1. Full GCS scan: no file among all 2,330 blobs declares `is_deleted`, so the
   3-minute window on 2024-09-04 when `Incident` briefly declared it
   (`20f92c9e65`, reverted by `4dfeee8499` 3 minutes later) never materialized a
   partition. That also means the flag is unrecoverable for history — it was
   destroyed at write time, so no file sample can separate a historical deleted
   incident from a live one.
1. Orphan test: a fresh pull with `UpdatedSince` backdated to 2016-07-01 returns
   exactly the `IncidentID` set the warehouse holds. 803 incidents across
   school 122 and 124 for 2024-02 and 2025-10, with 0 in the warehouse but
   absent from the API, and 0 the reverse.

Placement follows the `Behavior` precedent in the same file, which sorts
case-insensitively (`ExpireTime`, `is_deleted`, `Notes`), so it sits between
`InfractionTypeID` and `IsActive`. The reverted 2024 commit put it at the end of
the scalar block instead; the shipped `Behavior` convention won.

`py_avro_schema` now generates 60 fields, with `is_deleted` and
`NonDisciplinary` both as `['null', 'boolean']`.

Deliberately not done: a deleted-row filter on `stg_deanslist__incidents`.
`stg_deanslist__behavior` filters `where not is_deleted or is_deleted is null`;
adding the equivalent here changes a production model's semantics and wants its
own decision. `non_disciplinary` is projected in dbt but `is_deleted` is not —
it would be an always-NULL column, and its useful form is a filter, not a
projection.

Unexplained and unrelated to this change: `rowcount` exceeds `len(data)` for
school 124 under a narrow `UpdatedSince` — 187 vs 178, 348 vs 336, 205 vs 199 —
while the backdated pull above matched exactly. The `records` materialization
metadata reports `rowcount + deleted_rowcount`, not rows written, so it
overstates in those cases. `get()` does not paginate. Worth its own issue.

</details>
