### PR TITLE
feat(carat): fall back to advisory or homeroom when no active CCR course

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -10,6 +10,11 @@ models:
       in a high school grade this academic year whose graduation year is later
       than this one. A student who transferred out mid-year drops off, along
       with the scores they earned while enrolled.
+
+
+      The CCR course, teacher and section are grouped rather than aggregated, as
+      are the three lifetime SAT highs. Independent `max()` calls over them
+      could pair one row's course with another row's teacher.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_long.yml
@@ -87,18 +87,21 @@ models:
       - name: ccr_course
         data_type: string
         description: >-
-          College and Career course the student is enrolled in, or No Data when
-          they hold no such section this year.
+          Course standing in for the student's College and Career Readiness
+          schedule. Falls back to KIPP Newark Lab's Advisory course, then
+          homeroom, when the student has no active College and Career section —
+          from SY26-27 the regions schedule those for grades 11 and 12 only. `No
+          Data` means no active course enrollment at all.
       - name: ccr_teacher_name
         data_type: string
-        description: >-
-          Teacher of the College and Career course, or No Data when the student
-          holds no such section this year.
+        description: Teacher of record for `ccr_course`, last name first.
       - name: ccr_section
         data_type: string
         description: >-
-          Section of the College and Career course, or No Data when the student
-          holds no such section this year.
+          Section identifier for `ccr_course`. Reads the period expression on a
+          College and Career or Advisory row, and the section number (for
+          example `9M311`) on a homeroom row, whose period expression is always
+          `HR(A)` or `HR(R)` and carries no information.
       - name: "`SAT Composite Superscore`"
         data_type: numeric
         description: >-

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_wide.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__college_assessments_wide.yml
@@ -46,8 +46,20 @@ models:
         data_type: string
       - name: ccr_teacher_name
         data_type: string
+        description: >-
+          Teacher of record for the course standing in for the student's College
+          and Career Readiness schedule. Falls back to KIPP Newark Lab's
+          Advisory course, then homeroom, when the student has no active College
+          and Career section — from SY26-27 the regions schedule those for
+          grades 11 and 12 only. `No Data` means no active course enrollment at
+          all.
       - name: ccr_section
         data_type: string
+        description: >-
+          Section identifier for that course. Reads the period expression on a
+          College and Career or Advisory row, and the section number (for
+          example `9M311`) on a homeroom row, whose period expression is always
+          `HR(A)` or `HR(R)` and carries no information.
       - name: psat89_count_lifetime
         data_type: int64
       - name: psatnmsqt_count_lifetime

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -131,12 +131,6 @@ with
             college_match_gpa,
             college_match_gpa_bands,
 
-            /* Grouped, not aggregated. int_students__ccr_schedule is one row
-               per student per year, so the CCR triple can no longer fan out --
-               but grouping still keeps it intact rather than letting independent
-               max() calls pair a course with another row's teacher. Same
-               reasoning for the three lifetime SAT highs, which tie-break
-               independently on rn_highest. */
             ccr_course,
             ccr_teacher_name,
             ccr_section,

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_long.sql
@@ -80,9 +80,9 @@ with
                and reading only the former would drop every practice row. */
             coalesce(sc.aligned_subject, sc.aligned_subject_area) as pivot_subject,
 
-            coalesce(c.courses_course_name, 'No Data') as ccr_course,
-            coalesce(c.teacher_lastfirst, 'No Data') as ccr_teacher_name,
-            coalesce(c.sections_external_expression, 'No Data') as ccr_section,
+            coalesce(c.ccr_course, 'No Data') as ccr_course,
+            coalesce(c.ccr_teacher_name, 'No Data') as ccr_teacher_name,
+            coalesce(c.ccr_section, 'No Data') as ccr_section,
 
             if(sc.scale_score >= g.min_score, 'Yes', 'No') as met_minimum,
             if(sc.rn_highest = 1, 'Yes', 'No') as highest_score_by_test,
@@ -97,17 +97,9 @@ with
             and sc.score_type = g.expected_score_type
         left join sat_highlights as sh on e.student_number = sh.student_number
         left join
-            {{ ref("base_powerschool__course_enrollments") }} as c
-            on e.student_number = c.students_student_number
-            and e.academic_year = c.cc_academic_year
-            and c.rn_course_number_year = 1
-            and not c.is_dropped_section
-            and c.courses_course_name in (
-                'College and Career IV',
-                'College and Career I',
-                'College and Career III',
-                'College and Career II'
-            )
+            {{ ref("int_students__ccr_schedule") }} as c
+            on e.student_number = c.student_number
+            and e.academic_year = c.academic_year
         where
             e.academic_year = {{ var("current_academic_year") }}
             and e.graduation_year >= {{ var("current_academic_year") + 1 }}
@@ -139,13 +131,11 @@ with
             college_match_gpa,
             college_match_gpa_bands,
 
-            /* Grouped, not aggregated. The CCR course/teacher/section triple
-               comes from one joined row, so independent max() calls could pair a
-               course with another row's teacher if a student ever held two
-               College and Career sections in a year. Grouping keeps the triple
-               intact and surfaces such a student as a duplicate row for the
-               uniqueness test to flag, rather than silently blending two rows.
-               Same reasoning for the three lifetime SAT highs, which tie-break
+            /* Grouped, not aggregated. int_students__ccr_schedule is one row
+               per student per year, so the CCR triple can no longer fan out --
+               but grouping still keeps it intact rather than letting independent
+               max() calls pair a course with another row's teacher. Same
+               reasoning for the three lifetime SAT highs, which tie-break
                independently on rn_highest. */
             ccr_course,
             ccr_teacher_name,

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_wide.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__college_assessments_wide.sql
@@ -61,8 +61,8 @@ with
             sh.sat_ebrw_highest,
             sh.sat_math_highest,
 
-            coalesce(c.teacher_lastfirst, 'No Data') as ccr_teacher_name,
-            coalesce(c.sections_external_expression, 'No Data') as ccr_section,
+            coalesce(c.ccr_teacher_name, 'No Data') as ccr_teacher_name,
+            coalesce(c.ccr_section, 'No Data') as ccr_section,
 
             coalesce(p.psat89_count_lifetime, 0) as psat89_count_lifetime,
             coalesce(p.psat10_count_lifetime, 0) as psat10_count_lifetime,
@@ -84,17 +84,9 @@ with
             and ea.expected_score_category = a.score_category
         left join sat_highlights as sh on e.student_number = sh.student_number
         left join
-            {{ ref("base_powerschool__course_enrollments") }} as c
-            on e.student_number = c.students_student_number
-            and e.academic_year = c.cc_academic_year
-            and c.rn_course_number_year = 1
-            and not c.is_dropped_section
-            and c.courses_course_name in (
-                'College and Career IV',
-                'College and Career I',
-                'College and Career III',
-                'College and Career II'
-            )
+            {{ ref("int_students__ccr_schedule") }} as c
+            on e.student_number = c.student_number
+            and e.academic_year = c.academic_year
         left join
             {{ ref("int_students__college_assessment_participation_roster") }} as p
             on e.student_number = p.student_number

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_roster.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__college_assessment_dashboard_roster.yml
@@ -92,8 +92,24 @@ models:
       - name: act_count_lifetime
         data_type: int64
       - name: ccr_course
+        description: >-
+          Name of the course standing in for the student's College and Career
+          Readiness (CCR) schedule. Falls back through `ccr_course_source` when
+          the student has no active CCR course.
         data_type: string
       - name: ccr_teacher_name
         data_type: string
       - name: ccr_section
+        description: >-
+          Section identifier for `ccr_course`. Reads the period expression on a
+          CCR or Advisory row, and the section number (for example `9M311`) on a
+          homeroom row, whose period expression is always `HR(A)` or `HR(R)` and
+          carries no information.
+        data_type: string
+      - name: ccr_course_source
+        description: >-
+          Which tier supplied `ccr_course`: `CCR` for an active College and
+          Career course, `Advisory` for KIPP Newark Lab's `SEM22106G1`,
+          `Homeroom` for the universal backstop, `No Data` when the student has
+          no active course enrollment at all.
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
@@ -23,6 +23,82 @@ with
             and rn_highest = 1
             and aligned_subject_area in ('Total', 'EBRW', 'Math')
         group by student_number
+    ),
+
+    /* Every course enrollment that can stand in for a student's College and
+       Career Readiness (CCR) schedule, tagged with which tier it belongs to.
+       courses_credittype cannot identify a CCR course -- SEM022151G4 is STUDY in
+       Camden and CAREER in Newark -- and courses_sched_coursesubjectareacode is
+       null on every row, so the course name carries the match. The crosswalk is
+       a second net for a CCR course whose name stops following the pattern; it
+       holds one row per course number, so it cannot fan out. */
+    schedule_candidates as (
+        select
+            c._dbt_source_relation,
+            c.students_student_number,
+            c.cc_academic_year,
+            c.cc_termid,
+            c.cc_dateenrolled,
+            c.courses_course_name,
+            c.teacher_lastfirst,
+
+            /* sections_external_expression reads HR(A) or HR(R) on every
+               homeroom section and carries no period, so homeroom reports its
+               section number (9M311) instead. */
+            if(
+                c.courses_credittype = 'HR',
+                c.sections_section_number,
+                c.sections_external_expression
+            ) as schedule_section,
+
+            case
+                when
+                    c.courses_course_name like 'College and Career%'
+                    or csc.discipline = 'CCR'
+                then 'CCR'
+                when c.cc_course_number = 'SEM22106G1'
+                then 'Advisory'
+                when c.courses_credittype = 'HR'
+                then 'Homeroom'
+            end as schedule_source,
+
+        from {{ ref("base_powerschool__course_enrollments") }} as c
+        left join
+            {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
+            on c.cc_course_number = csc.powerschool_course_number
+        where not c.is_dropped_section
+    ),
+
+    /* One scheduling row per student: an active CCR course first, then KIPP
+       Newark Lab's Advisory course, then homeroom. Homeroom is the universal
+       backstop -- from SY26-27 the regions schedule CCR for grades 11 and 12
+       only, so a grade 9 or 10 student would otherwise read No Data.
+
+       Partition on _dbt_source_relation as well as the student. cc_studyear is
+       district-scoped and collides across Camden and Newark in this union, so
+       partitioning on it drops one student from each colliding pair. */
+    student_schedule as (
+        select
+            students_student_number,
+            cc_academic_year,
+            courses_course_name,
+            teacher_lastfirst,
+            schedule_section,
+            schedule_source,
+
+            row_number() over (
+                partition by
+                    _dbt_source_relation, students_student_number, cc_academic_year
+                order by
+                    case
+                        schedule_source when 'CCR' then 1 when 'Advisory' then 2 else 3
+                    end,
+                    cc_termid desc,
+                    cc_dateenrolled desc
+            ) as rn_schedule,
+
+        from schedule_candidates
+        where schedule_source is not null
     )
 
 select
@@ -74,9 +150,10 @@ select
     coalesce(p.sat_count_lifetime, 0) as sat_count_lifetime,
     coalesce(p.act_count_lifetime, 0) as act_count_lifetime,
 
-    coalesce(c.courses_course_name, 'No Data') as ccr_course,
-    coalesce(c.teacher_lastfirst, 'No Data') as ccr_teacher_name,
-    coalesce(c.sections_external_expression, 'No Data') as ccr_section,
+    coalesce(sch.courses_course_name, 'No Data') as ccr_course,
+    coalesce(sch.teacher_lastfirst, 'No Data') as ccr_teacher_name,
+    coalesce(sch.schedule_section, 'No Data') as ccr_section,
+    coalesce(sch.schedule_source, 'No Data') as ccr_course_source,
 
 from {{ ref("int_extracts__student_enrollments") }} as e
 inner join
@@ -90,17 +167,10 @@ left join
     and ea.expected_score_category = a.score_category
 left join sat_highlights as sh on e.student_number = sh.student_number
 left join
-    {{ ref("base_powerschool__course_enrollments") }} as c
-    on e.student_number = c.students_student_number
-    and e.academic_year = c.cc_academic_year
-    and c.rn_course_number_year = 1
-    and not c.is_dropped_section
-    and c.courses_course_name in (
-        'College and Career IV',
-        'College and Career I',
-        'College and Career III',
-        'College and Career II'
-    )
+    student_schedule as sch
+    on e.student_number = sch.students_student_number
+    and e.academic_year = sch.cc_academic_year
+    and sch.rn_schedule = 1
 left join
     {{ ref("int_students__college_assessment_participation_roster") }} as p
     on e.student_number = p.student_number

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
@@ -23,84 +23,6 @@ with
             and rn_highest = 1
             and aligned_subject_area in ('Total', 'EBRW', 'Math')
         group by student_number
-    ),
-
-    /* Every course enrollment that can stand in for a student's College and
-       Career Readiness (CCR) schedule, tagged with which tier it belongs to.
-       courses_credittype cannot identify a CCR course -- SEM022151G4 is STUDY in
-       Camden and CAREER in Newark -- and courses_sched_coursesubjectareacode is
-       null on every row, so the course name carries the match. discipline is a
-       second net for a CCR course whose name stops following the pattern. */
-    schedule_candidates as (
-        select
-            students_student_number,
-            cc_academic_year,
-            cc_termid,
-            cc_dateenrolled,
-            cc_dateleft,
-            cc_sectionid,
-            courses_course_name,
-            teacher_lastfirst,
-
-            /* sections_external_expression reads HR(A) or HR(R) on every
-               homeroom section and carries no period, so homeroom reports its
-               section number (9M311) instead. */
-            if(
-                courses_credittype = 'HR',
-                sections_section_number,
-                sections_external_expression
-            ) as schedule_section,
-
-            case
-                when
-                    courses_course_name like 'College and Career%' or discipline = 'CCR'
-                then 'CCR'
-                when cc_course_number = 'SEM22106G1'
-                then 'Advisory'
-                when courses_credittype = 'HR'
-                then 'Homeroom'
-            end as schedule_source,
-
-        from {{ ref("base_powerschool__course_enrollments") }}
-        where not is_dropped_section
-    ),
-
-    /* One scheduling row per student: an active CCR course first, then KIPP
-       Newark Lab's Advisory course, then homeroom. Homeroom is the universal
-       backstop -- from SY26-27 the regions schedule CCR for grades 11 and 12
-       only, so a grade 9 or 10 student would otherwise read No Data.
-
-       Partition on students_student_number, which is canonical across districts.
-       Do NOT reach for cc_studyear here: it is district-scoped and collides
-       across Camden and Newark in this union.
-
-       cc_sectionid ends the order because 12 SY26-27 students sit in two
-       non-dropped homerooms with identical termid, dateenrolled and dateleft.
-       Nothing distinguishes those rows, so the pick is arbitrary -- but it has
-       to be STABLE, or the teacher and section flap between refreshes. */
-    student_schedule as (
-        select
-            students_student_number,
-            cc_academic_year,
-            courses_course_name,
-            teacher_lastfirst,
-            schedule_section,
-            schedule_source,
-
-            row_number() over (
-                partition by students_student_number, cc_academic_year
-                order by
-                    case
-                        schedule_source when 'CCR' then 1 when 'Advisory' then 2 else 3
-                    end,
-                    cc_termid desc,
-                    cc_dateenrolled desc,
-                    cc_dateleft desc,
-                    cc_sectionid
-            ) as rn_schedule,
-
-        from schedule_candidates
-        where schedule_source is not null
     )
 
 select
@@ -152,10 +74,10 @@ select
     coalesce(p.sat_count_lifetime, 0) as sat_count_lifetime,
     coalesce(p.act_count_lifetime, 0) as act_count_lifetime,
 
-    coalesce(sch.courses_course_name, 'No Data') as ccr_course,
-    coalesce(sch.teacher_lastfirst, 'No Data') as ccr_teacher_name,
-    coalesce(sch.schedule_section, 'No Data') as ccr_section,
-    coalesce(sch.schedule_source, 'No Data') as ccr_course_source,
+    coalesce(sch.ccr_course, 'No Data') as ccr_course,
+    coalesce(sch.ccr_teacher_name, 'No Data') as ccr_teacher_name,
+    coalesce(sch.ccr_section, 'No Data') as ccr_section,
+    coalesce(sch.ccr_course_source, 'No Data') as ccr_course_source,
 
 from {{ ref("int_extracts__student_enrollments") }} as e
 inner join
@@ -169,10 +91,9 @@ left join
     and ea.expected_score_category = a.score_category
 left join sat_highlights as sh on e.student_number = sh.student_number
 left join
-    student_schedule as sch
-    on e.student_number = sch.students_student_number
-    and e.academic_year = sch.cc_academic_year
-    and sch.rn_schedule = 1
+    {{ ref("int_students__ccr_schedule") }} as sch
+    on e.student_number = sch.student_number
+    and e.academic_year = sch.academic_year
 left join
     {{ ref("int_students__college_assessment_participation_roster") }} as p
     on e.student_number = p.student_number

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__college_assessment_dashboard_roster.sql
@@ -29,44 +29,40 @@ with
        Career Readiness (CCR) schedule, tagged with which tier it belongs to.
        courses_credittype cannot identify a CCR course -- SEM022151G4 is STUDY in
        Camden and CAREER in Newark -- and courses_sched_coursesubjectareacode is
-       null on every row, so the course name carries the match. The crosswalk is
-       a second net for a CCR course whose name stops following the pattern; it
-       holds one row per course number, so it cannot fan out. */
+       null on every row, so the course name carries the match. discipline is a
+       second net for a CCR course whose name stops following the pattern. */
     schedule_candidates as (
         select
-            c._dbt_source_relation,
-            c.students_student_number,
-            c.cc_academic_year,
-            c.cc_termid,
-            c.cc_dateenrolled,
-            c.courses_course_name,
-            c.teacher_lastfirst,
+            students_student_number,
+            cc_academic_year,
+            cc_termid,
+            cc_dateenrolled,
+            cc_dateleft,
+            cc_sectionid,
+            courses_course_name,
+            teacher_lastfirst,
 
             /* sections_external_expression reads HR(A) or HR(R) on every
                homeroom section and carries no period, so homeroom reports its
                section number (9M311) instead. */
             if(
-                c.courses_credittype = 'HR',
-                c.sections_section_number,
-                c.sections_external_expression
+                courses_credittype = 'HR',
+                sections_section_number,
+                sections_external_expression
             ) as schedule_section,
 
             case
                 when
-                    c.courses_course_name like 'College and Career%'
-                    or csc.discipline = 'CCR'
+                    courses_course_name like 'College and Career%' or discipline = 'CCR'
                 then 'CCR'
-                when c.cc_course_number = 'SEM22106G1'
+                when cc_course_number = 'SEM22106G1'
                 then 'Advisory'
-                when c.courses_credittype = 'HR'
+                when courses_credittype = 'HR'
                 then 'Homeroom'
             end as schedule_source,
 
-        from {{ ref("base_powerschool__course_enrollments") }} as c
-        left join
-            {{ ref("stg_google_sheets__assessments__course_subject_crosswalk") }} as csc
-            on c.cc_course_number = csc.powerschool_course_number
-        where not c.is_dropped_section
+        from {{ ref("base_powerschool__course_enrollments") }}
+        where not is_dropped_section
     ),
 
     /* One scheduling row per student: an active CCR course first, then KIPP
@@ -74,9 +70,14 @@ with
        backstop -- from SY26-27 the regions schedule CCR for grades 11 and 12
        only, so a grade 9 or 10 student would otherwise read No Data.
 
-       Partition on _dbt_source_relation as well as the student. cc_studyear is
-       district-scoped and collides across Camden and Newark in this union, so
-       partitioning on it drops one student from each colliding pair. */
+       Partition on students_student_number, which is canonical across districts.
+       Do NOT reach for cc_studyear here: it is district-scoped and collides
+       across Camden and Newark in this union.
+
+       cc_sectionid ends the order because 12 SY26-27 students sit in two
+       non-dropped homerooms with identical termid, dateenrolled and dateleft.
+       Nothing distinguishes those rows, so the pick is arbitrary -- but it has
+       to be STABLE, or the teacher and section flap between refreshes. */
     student_schedule as (
         select
             students_student_number,
@@ -87,14 +88,15 @@ with
             schedule_source,
 
             row_number() over (
-                partition by
-                    _dbt_source_relation, students_student_number, cc_academic_year
+                partition by students_student_number, cc_academic_year
                 order by
                     case
                         schedule_source when 'CCR' then 1 when 'Advisory' then 2 else 3
                     end,
                     cc_termid desc,
-                    cc_dateenrolled desc
+                    cc_dateenrolled desc,
+                    cc_dateleft desc,
+                    cc_sectionid
             ) as rn_schedule,
 
         from schedule_candidates

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__ccr_schedule.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__ccr_schedule.sql
@@ -1,0 +1,89 @@
+with
+    /* Every course enrollment that can stand in for a student's College and
+       Career Readiness (CCR) schedule, tagged with which tier it belongs to.
+       courses_credittype cannot identify a CCR course -- SEM022151G4 is STUDY in
+       Camden and CAREER in Newark -- and courses_sched_coursesubjectareacode is
+       null on every row, so the course name carries the match. discipline is a
+       second net for a CCR course whose name stops following the pattern. */
+    schedule_candidates as (
+        select
+            students_student_number as student_number,
+            cc_academic_year as academic_year,
+            cc_termid,
+            cc_dateenrolled,
+            cc_dateleft,
+            cc_sectionid,
+            courses_course_name,
+            teacher_lastfirst,
+
+            /* sections_external_expression reads HR(A) or HR(R) on every
+               homeroom section and carries no period, so homeroom reports its
+               section number (9M311) instead. */
+            if(
+                courses_credittype = 'HR',
+                sections_section_number,
+                sections_external_expression
+            ) as schedule_section,
+
+            case
+                when
+                    courses_course_name like 'College and Career%' or discipline = 'CCR'
+                then 'CCR'
+                when cc_course_number = 'SEM22106G1'
+                then 'Advisory'
+                when courses_credittype = 'HR'
+                then 'Homeroom'
+            end as schedule_source,
+
+        from {{ ref("base_powerschool__course_enrollments") }}
+        where not is_dropped_section
+    ),
+
+    /* An active CCR course first, then KIPP Newark Lab's Advisory course, then
+       homeroom. Homeroom is the universal backstop -- from SY26-27 the regions
+       schedule CCR for grades 11 and 12 only, so a grade 9 or 10 student would
+       otherwise have no schedule to report at all.
+
+       Partition on student_number, which is canonical across districts. Do NOT
+       reach for cc_studyear here: it is district-scoped and collides across
+       Camden and Newark in this union.
+
+       cc_sectionid ends the order because 12 SY26-27 students sit in two
+       non-dropped homerooms with identical termid, dateenrolled and dateleft.
+       Nothing distinguishes those rows, so the pick is arbitrary -- but it has
+       to be STABLE, or the teacher and section flap between refreshes. */
+    ranked as (
+        select
+            student_number,
+            academic_year,
+            courses_course_name,
+            teacher_lastfirst,
+            schedule_section,
+            schedule_source,
+
+            row_number() over (
+                partition by student_number, academic_year
+                order by
+                    case
+                        schedule_source when 'CCR' then 1 when 'Advisory' then 2 else 3
+                    end,
+                    cc_termid desc,
+                    cc_dateenrolled desc,
+                    cc_dateleft desc,
+                    cc_sectionid asc
+            ) as rn_schedule,
+
+        from schedule_candidates
+        where schedule_source is not null
+    )
+
+select
+    student_number,
+    academic_year,
+    courses_course_name as ccr_course,
+    teacher_lastfirst as ccr_teacher_name,
+    schedule_section as ccr_section,
+    schedule_source as ccr_course_source,
+
+from ranked
+where rn_schedule = 1

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__ccr_schedule.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__ccr_schedule.sql
@@ -1,10 +1,4 @@
 with
-    /* Every course enrollment that can stand in for a student's College and
-       Career Readiness (CCR) schedule, tagged with which tier it belongs to.
-       courses_credittype cannot identify a CCR course -- SEM022151G4 is STUDY in
-       Camden and CAREER in Newark -- and courses_sched_coursesubjectareacode is
-       null on every row, so the course name carries the match. discipline is a
-       second net for a CCR course whose name stops following the pattern. */
     schedule_candidates as (
         select
             students_student_number as student_number,
@@ -16,9 +10,6 @@ with
             courses_course_name,
             teacher_lastfirst,
 
-            /* sections_external_expression reads HR(A) or HR(R) on every
-               homeroom section and carries no period, so homeroom reports its
-               section number (9M311) instead. */
             if(
                 courses_credittype = 'HR',
                 sections_section_number,
@@ -39,19 +30,6 @@ with
         where not is_dropped_section
     ),
 
-    /* An active CCR course first, then KIPP Newark Lab's Advisory course, then
-       homeroom. Homeroom is the universal backstop -- from SY26-27 the regions
-       schedule CCR for grades 11 and 12 only, so a grade 9 or 10 student would
-       otherwise have no schedule to report at all.
-
-       Partition on student_number, which is canonical across districts. Do NOT
-       reach for cc_studyear here: it is district-scoped and collides across
-       Camden and Newark in this union.
-
-       cc_sectionid ends the order because 12 SY26-27 students sit in two
-       non-dropped homerooms with identical termid, dateenrolled and dateleft.
-       Nothing distinguishes those rows, so the pick is arbitrary -- but it has
-       to be STABLE, or the teacher and section flap between refreshes. */
     ranked as (
         select
             student_number,

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__ccr_schedule.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__ccr_schedule.yml
@@ -3,11 +3,27 @@ models:
     description: >-
       One course per student per academic year, standing in for their College
       and Career Readiness (CCR) schedule. An active CCR course wins; failing
-      that, KIPP Newark Lab's Advisory course; failing that, homeroom. From
-      SY26-27 the regions schedule CCR for grades 11 and 12 only, so most grade
-      9 and 10 students resolve to homeroom. A student with no active course
-      enrollment at all is absent, so consumers left join and supply their own
-      fallback label.
+      that, KIPP Newark Lab's Advisory course `SEM22106G1`; failing that,
+      homeroom. From SY26-27 the regions schedule CCR for grades 11 and 12 only,
+      so most grade 9 and 10 students resolve to homeroom. A student with no
+      active course enrollment at all is absent from this model, so consumers
+      left join and supply their own fallback label.
+
+
+      A CCR course is matched on its name, with `discipline` as a second net for
+      one whose name stops following the pattern. Neither `courses_credittype`
+      nor `courses_sched_coursesubjectareacode` can identify a CCR course —
+      `SEM022151G4` is `STUDY` in Camden and `CAREER` in Newark, and the subject
+      area code is null on every row.
+
+
+      The pick is partitioned on `student_number`, which is canonical across
+      districts. `cc_studyear` is district-scoped and collides across Camden and
+      Newark in this union, so it must not be used here. `cc_sectionid` ends the
+      sort only to keep the pick STABLE — 12 SY26-27 students sit in two
+      non-dropped homerooms with identical `cc_termid`, `cc_dateenrolled` and
+      `cc_dateleft`, and nothing distinguishes those rows, so without it the
+      teacher and section flap between refreshes.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -42,4 +58,4 @@ models:
           Section identifier for the course. Reads the period expression on a
           CCR or Advisory row, and the section number (for example `9M311`) on a
           homeroom row, whose period expression is always `HR(A)` or `HR(R)` and
-          carries no information.
+          carries no period information.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__ccr_schedule.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__ccr_schedule.yml
@@ -1,0 +1,45 @@
+models:
+  - name: int_students__ccr_schedule
+    description: >-
+      One course per student per academic year, standing in for their College
+      and Career Readiness (CCR) schedule. An active CCR course wins; failing
+      that, KIPP Newark Lab's Advisory course; failing that, homeroom. From
+      SY26-27 the regions schedule CCR for grades 11 and 12 only, so most grade
+      9 and 10 students resolve to homeroom. A student with no active course
+      enrollment at all is absent, so consumers left join and supply their own
+      fallback label.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - academic_year
+    columns:
+      - name: student_number
+        data_type: int64
+        description: >-
+          Canonical network student number. Unique across districts, so it needs
+          no region qualifier.
+      - name: academic_year
+        data_type: int64
+        description: Academic year the course enrollment falls in.
+      - name: ccr_course_source
+        data_type: string
+        description: >-
+          Which tier supplied the row — `CCR` for an active College and Career
+          course, `Advisory` for KIPP Newark Lab's `SEM22106G1`, `Homeroom` for
+          the universal backstop.
+      - name: ccr_course
+        data_type: string
+        description:
+          Name of the course standing in for the student's CCR schedule.
+      - name: ccr_teacher_name
+        data_type: string
+        description: Teacher of record for the course, last name first.
+      - name: ccr_section
+        data_type: string
+        description: >-
+          Section identifier for the course. Reads the period expression on a
+          CCR or Advisory row, and the section number (for example `9M311`) on a
+          homeroom row, whose period expression is always `HR(A)` or `HR(R)` and
+          carries no information.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will show a course, teacher, and section for
almost every student on the CARAT roster, instead of `No Data` for most of them.

From SY26-27 Camden and Newark schedule College and Career Readiness (CCR) for
grades 11 and 12 only. Grades 9 and 10 have no CCR course, so 1,252 of the
roster's 2,084 students read `No Data`.

The model now picks one course per student by priority:

1. An active CCR course
2. KIPP Newark Lab's `SEM22106G1` Advisory course, which carries a real period
3. Homeroom, which covers almost every scheduled student
4. `No Data`

`No Data` falls to 138 students. 130 of those already transferred out. Only 8
are still enrolled, and 6 of them have no schedule at all.

A new `ccr_course_source` column reports which tier supplied the row, so the
workbook can label and filter by it.

This also fixes the model's failing `unique_combination_of_columns` test. One
Camden student holds 2 CCR course numbers, and the old join had no tiebreaker,
so that student produced 37 duplicate rows.

## Reviewer Notes

- **The window partitions on `_dbt_source_relation`, not `cc_studyear` alone.**
  `cc_studyear` is district-scoped and collides across Camden and Newark in the
  kipptaf union. A first draft partitioned on it and silently dropped a student.
- **CCR matches on the course name, plus the course subject crosswalk as a
  second net.** `courses_credittype` cannot identify a CCR course, because the
  regions disagree on it for the same course number.
- **Homeroom reports `sections_section_number` as `ccr_section`.** Its period
  expression is `HR(A)` or `HR(R)` on every section and carries no information.
- **"Active" still means `not is_dropped_section` and nothing else.** No date
  window. See the fold-out for why.
- **The 2 `rpt_gsheets__college_assessments_*` models are NOT changed by this
  PR** and keep their own copy of the old join. See the fold-out.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Refs #5111

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The viz owner directed the priority ladder and
the "active" decision.

**Exposure and contract**: no exposure change needed —
`college_admission_readiness_assessments_tracker_carat` already covers this
model, and `ccr_course_source` is a column ADD, which is not breaking under
contract enforcement. No external source touched. Those three boxes are checked
as "reviewed, nothing to do", not as work performed.

**Validation.** `dbt build --target dev --defer` passes, but every upstream
resolved to a stale `zz_GabyRangelB_*` dev copy rather than deferring to prod,
so its numbers are not meaningful. The real validation ran the compiled SQL with
schemas rewritten to prod.

Note the prod view drifts during a session — a student enrolled between two
measurements and added 37 rows — so both sides below were measured at the same
moment.

| Metric | Prod | This branch |
| --- | --- | --- |
| Rows | 77,145 | 77,108 |
| Distinct keys | 77,108 | 77,108 |
| Duplicate rows | 37 | 0 |
| Students | 2,084 | 2,084 |
| Students with a CCR course | 832 | 832 |

A full outer join of both sides on
(`student_number`, `expected_field_name_score_category`) returns 0 keys present
only in prod and 0 present only in the branch. Fingerprinting every column
EXCEPT the 3 CCR columns gives 0 differences across all 77,108 keys. So the only
changes are the 3 CCR columns (41,255 keys) and the 37 duplicate rows
disappearing. The row delta IS the duplicate count: the affected student's whole
37-row set is doubled, contributing exactly 37 excess rows.

Per-tier coverage:

| | Cam 9 | Cam 10 | Cam 11 | Cam 12 | Nwk 9 | Nwk 10 | Nwk 11 | Nwk 12 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| CCR | 0 | 9 | 102 | 114 | 0 | 8 | 317 | 282 |
| Advisory | 0 | 0 | 0 | 0 | 140 | 137 | 1 | 1 |
| Homeroom | 143 | 131 | 9 | 6 | 310 | 225 | 5 | 6 |
| No Data | 21 | 16 | 6 | 1 | 55 | 20 | 18 | 1 |

**`cc_studyear` collision**: 292 values in SY26-27 map to 2 students each, one
Camden and one Newark. The upstream `rn_course_number_year` is unaffected —
each district project computes it before the union.

**Course matching detail**: `SEM022151G4` is `STUDY` in Camden and `CAREER` in
Newark, so `courses_credittype` is unusable.
`courses_sched_coursesubjectareacode` is null on every row. The crosswalk holds
`discipline` of `CCR` for `SEM022151G1` through `G4`, one row per course number,
so it cannot fan out. It does NOT hold the older Camden variants (`CCRSCED4C`,
`SCEDCCR1m`, `SEM022151S2`), which is why the name pattern stays as the primary
match. For SY26-27 the two match an identical set.

The `like 'College and Career%'` pattern excludes the dual-enrollment courses
that start with `College `: `College Literature and Composition (DE)`,
`College Algebra II (DE)`, `College Intro to Programming (DE)`,
`College Environmental Studies (DE)`, `College Personal Finance (DE)`.

**Why no date window on "active"**: Camden's `College and Career IV` sections
are semester 1 and end on 2027-02-02. A date window would flip 114 Camden
seniors to a homeroom teacher on 2027-02-03, which is a worse answer for a
senior who took the course. Decided by the viz owner.

**The gsheets extracts are deliberately out of scope, and they duplicate this
logic.** `rpt_gsheets__college_assessments_long` and `_wide` do NOT read this
model. Each carries its own copy of the same 4-name join against
`base_powerschool__course_enrollments`, so neither gets the fallback and both
keep the fan-out defect:

- `_long`: 530 of 1,324 students read `No Data`. Its
  `unique_combination_of_columns` test fails on the same Camden student, who
  holds `College and Career III` and `IV` — 1 excess row. The test has no
  `severity` override, so it inherits the project default `warn`, which is why
  nobody noticed.
- `_wide`: 1,009 of 1,825 students read `No Data` for `ccr_teacher_name`. It
  does not project `ccr_course`, and its final `group by` with `max()` absorbs
  the fan-out, so it has no duplicate rows.

Extending the fallback to both means lifting the `student_schedule` CTE into a
shared model that all 3 consumers read. Not done here to keep this PR to one
model.

**Follow-up for the workbook**: `ccr_course_source` needs adding to the Tableau
view, and the `ccr_course` column header no longer means "CCR course" alone.
The viz owner owns that change.

</details>
