### PR TITLE
fix(dbt): match Newark/Camden ops directors by title keyword

### DIFF
--- a/src/dbt/kipptaf/models/extracts/lattice/README.md
+++ b/src/dbt/kipptaf/models/extracts/lattice/README.md
@@ -11,8 +11,9 @@ Keep this doc in sync with the model whenever the criteria change.
 ### High level summary
 
 - **KTAF central and Paterson include everyone** — no role filter.
-- **Newark and Camden are treated identically** — operations leaders and two
-  departments (**Technology** or **Marketing, Comms, and Enrollment**) included.
+- **Newark and Camden are treated identically** — director-level Operations
+  staff (excluding Associate Directors) and two departments (**Technology** or
+  **Marketing, Comms, and Enrollment**) included.
 - **Miami includes additional leader roles** — gated on a title keyword match
   plus one hardcoded location ("Room 11"), rather than an explicit title or
   department list.
@@ -48,12 +49,14 @@ Any one of these qualifies:
 - **KIPP Miami** — only school/team leaders: job title contains "Director,"
   "Head," "Leader," or "Dean," **or** their work location is "Room 11."
 - **Newark (TEAM Academy Charter School) or Camden (KIPP Cooper Norcross
-  Academy)** — only these operations roles:
-  - Director School Operations
-  - Director Campus Operations
-  - Managing Director of School Operations
-  - Managing Director of Operations
-  - Fellow School Operations Director
+  Academy)** — anyone in the **Operations** department whose job title contains
+  "Director" but not "Associate." This covers `Director`,
+  `Director School Operations`, `Director Campus Operations`,
+  `Managing Director of School Operations`, `Managing Director of Operations`,
+  and `Fellow School Operations Director`. **Associate Directors of School
+  Operations are excluded** — confirmed with Ops. The keyword match replaced an
+  exact title list that silently dropped Operations staff carrying the bare ADP
+  title `Director`.
 - **Newark or Camden** — anyone in the **Technology** or **Marketing, Comms, and
   Enrollment** department.
 - **Any entity** — job title contains "Head of School." The ADP title is "Head

--- a/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
+++ b/src/dbt/kipptaf/models/extracts/lattice/properties/rpt_lattice__users.yml
@@ -4,14 +4,14 @@ models:
       Daily staff roster for Lattice SFTP import. Includes all KIPP TEAM and
       Family Schools Inc. employees, all KIPP Paterson employees,
       Director/Head/Leader/Dean-tier (or Room 11) staff in Miami, and Newark and
-      Camden staff in select Operations director roles or in the Technology or
-      Marketing, Comms, and Enrollment departments. Regardless of business unit,
-      also includes Heads of School, Managing Directors in the School Support
-      department, and everyone in the Teaching and Learning department. Interns
-      are excluded. Covers staff who are Active or on Leave, plus any staff who
-      met those same criteria and were terminated within the past 30 days.
-      Includes staff gender identity and race/ethnicity reporting category for
-      Lattice.
+      Camden staff in the Operations department whose job title contains
+      "Director" but not "Associate", or in the Technology or Marketing, Comms,
+      and Enrollment departments. Regardless of business unit, also includes
+      Heads of School, Managing Directors in the School Support department, and
+      everyone in the Teaching and Learning department. Interns are excluded.
+      Covers staff who are Active or on Leave, plus any staff who met those same
+      criteria and were terminated within the past 30 days. Includes staff
+      gender identity and race/ethnicity reporting category for Lattice.
     columns:
       - name: external_user_id
         description: ADP employee number used as the Lattice external user ID.

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -31,12 +31,10 @@ with
                 or (
                     home_business_unit_name
                     in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
-                    -- director-level operations roles, matched on the title
-                    -- keyword rather than an exact list so new ADP title
-                    -- variants (e.g. a bare 'Director') don't silently drop
-                    -- out. Associate Directors are intentionally excluded.
                     and home_department_name = 'Operations'
                     and contains_substr(job_title, 'Director')
+                    -- Associate Directors of School Operations are excluded by
+                    -- decision, not by oversight
                     and not contains_substr(job_title, 'Associate')
                 )
                 or (

--- a/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
+++ b/src/dbt/kipptaf/models/extracts/lattice/rpt_lattice__users.sql
@@ -31,13 +31,13 @@ with
                 or (
                     home_business_unit_name
                     in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
-                    and job_title in (
-                        'Director School Operations',
-                        'Director Campus Operations',
-                        'Managing Director of School Operations',
-                        'Managing Director of Operations',
-                        'Fellow School Operations Director'
-                    )
+                    -- director-level operations roles, matched on the title
+                    -- keyword rather than an exact list so new ADP title
+                    -- variants (e.g. a bare 'Director') don't silently drop
+                    -- out. Associate Directors are intentionally excluded.
+                    and home_department_name = 'Operations'
+                    and contains_substr(job_title, 'Director')
+                    and not contains_substr(job_title, 'Associate')
                 )
                 or (
                     home_business_unit_name


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add director-level Operations staff in
Newark and Camden to the Lattice user extract, even when their ADP job title is
just "Director."

The extract picked Newark and Camden staff by matching their job title against
an exact list of five Operations titles. Three active Operations staff carry the
plain title "Director" in ADP, so they matched nothing and never reached
Lattice. Two of them are school-operations directors who were added to Lattice
by hand instead.

The fix matches on a keyword rather than a list. In Newark and Camden, anyone in
the Operations department whose title contains "Director" is now included,
unless the title also contains "Associate." Associate Directors of School
Operations stay out of the feed, which Ops confirmed is correct.

The README in the same folder is updated to match.

## Reviewer Notes

- **Nobody is dropped.** All 25 Newark and Camden Operations staff currently in
  the extract still qualify under the keyword match. Net change is 3 people
  added, 0 removed.
- **The rule is now scoped to the Operations department.** The old title list
  had no department condition. That did not matter, because no one outside
  Operations held any of the five listed titles. It matters now, because
  "Director" on its own is a common title in Special Education, KIPP Forward,
  and School Support — those staff are not swept in.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] No new models, so no new properties file is needed.
- [x] No column renames or removals, so no breaking change for downstream
      exposures.

## CI checks

- [x] **Trunk** — `trunk check --force` clean on both changed files.
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — not triggered, no Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Started from a report that a Camden Operations
director was missing from the feed while a Newark counterpart was present.

Old predicate, `rpt_lattice__users.sql`:

```sql
or (
    home_business_unit_name
    in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
    and job_title in (
        'Director School Operations',
        'Director Campus Operations',
        'Managing Director of School Operations',
        'Managing Director of Operations',
        'Fellow School Operations Director'
    )
)
```

New predicate:

```sql
or (
    home_business_unit_name
    in ('TEAM Academy Charter School', 'KIPP Cooper Norcross Academy')
    and home_department_name = 'Operations'
    and contains_substr(job_title, 'Director')
    and not contains_substr(job_title, 'Associate')
)
```

Verification, all against the prod roster
(`teamster-332318.kipptaf_people.int_people__staff_roster`) and the prod extract
(`kipptaf_extracts.rpt_lattice__users`, 345 rows):

1. Applied the full new gate set (intern / part-time / temp / status filters
   included) to the prod roster and left-joined the prod extract. Result: 28
   qualifying Newark and Camden Operations staff — 25 already in the extract, 3
   newly added. Zero dropped.
2. Confirmed no Newark or Camden staff holds one of the five old titles outside
   the Operations department, so adding the department condition removes nobody.
3. The 3 newly included staff all carry the exact title `Director` in the
   Operations department: one in Camden, two in Newark. Two of them sit at the
   regional office locations, one of whom was the originally reported gap.
4. The 2 Associate Directors of School Operations (one per region) remain
   excluded, per the Ops decision.
5. `dbt build --select rpt_lattice__users --target dev` passes, including the
   `unique_external_user_id` test. Note the dev build is a compile and
   materialize proof only, not a data proof — the dev roster snapshot is stale
   and predates one of the three hires. The prod-roster queries above are the
   data proof.

Why keyword matching over extending the list: the same gap will recur every time
ADP grows a new Operations director title variant, and the list gives no signal
when that happens — the person just quietly never appears in Lattice. Miami's
branch in the same model already matches on title keywords, so this makes the
two consistent. The `not ... 'Associate'` term is the one subtractive piece; it
exists because Ops wants Associate Directors out, and the keyword match would
otherwise pull them in.

Follow-up for whoever administers Lattice: at least one of the newly included
staff already has a hand-created Lattice account. Confirm the external user ID
on that account matches their ADP employee number, or the feed will create a
duplicate rather than adopt the existing user.

</details>
