### PR TITLE
feat(dbt): list gradebook audit flag reasons in one Tableau column

### DIFF
--- a/.claude/skills/gradebook-audit/SKILL.md
+++ b/.claude/skills/gradebook-audit/SKILL.md
@@ -183,8 +183,11 @@ present it as fact.
 `stg_google_sheets__gradebook_flags` is disabled — no sheet step needed. Since
 the July 2026 teacher/student split there are no UNPIVOT lists — every flag is a
 hardcoded boolean column, and which model it lives in depends on its grain. Per
-the split's design goal, do NOT add a "reason" column explaining why a flag
-fired — flags stay aggregated booleans.
+the split's design goal, do NOT add a "reason" column to a **student-level**
+flag — those stay aggregated booleans, because they carry PII and fan out per
+student. **Assignment-level** checks are the exception: `flag_reasons` on the
+`category_summary` row already names them in plain language, so a new
+assignment-level check needs a label added there (see "Add a new flag" below).
 
 **Student-level flag** (per student × section × quarter, like
 `qt_percent_grade_greater_100`/`qt_grade_70_comment_missing`):
@@ -209,6 +212,20 @@ fired — flags stay aggregated booleans.
 4. Build in dependency order — `int_extracts__gradebook_audit_student_flags`
    first, then `rpt_gsheets__gradebook_audit_student_flags` and
    `rpt_tableau__gradebook_audit` (both read the int).
+
+**Assignment-level check** (per assignment, like `percent_graded_min_not_met`):
+
+1. Add the check to `int_powerschool__gradebook_assignment_scores_rollup.sql`
+   and fold it into `assignment_has_flags`.
+2. In `rpt_tableau__gradebook_audit.sql`'s `category_join`, add a window
+   `countif` for it over the existing partition
+   (`_dbt_source_project, sectionid, quarter, assignment_category_code`),
+   matching its 4 siblings.
+3. Add a plain-language label to the `array_to_string` array in
+   `category_summary`, keeping the array order stable — Tableau groups on the
+   string, so reordering changes existing values. Do NOT reword an existing
+   label without telling the requester; the strings are user-facing.
+4. Update the properties YAML for both models.
 
 **Category-level flag** (per section × quarter × category, like
 `not_enough_assignments`):

--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -487,8 +487,8 @@ concept, unlike the pre-July-2026 design below.
    more window `countif`s over the same partition count the assignments tripping
    each term of `assignment_has_flags`: `n_percent_graded_min_not_met`,
    `n_invalid_scores` (the `flags_sum > 0` term), `n_max_score_not_10` and
-   `n_overly_exempt`. They share the existing partition, so BigQuery computes
-   one window for all seven.
+   `n_overly_exempt`. They reuse the existing partition rather than introducing
+   a second one.
 2. `category_summary` — a grain-projection `SELECT DISTINCT` over
    `category_join` that collapses the per-assignment fan-out to one row per
    section × quarter × category, and adds `not_enough_assignments`

--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -38,7 +38,8 @@ The audit operates at several grains:
 - **Assignment** — did this assignment receive valid scores (correct point
   value, enough of the class graded, not over-exempt)? This is the
   `assignment_has_flags` rollup, surfaced on the dashboard as per-assignment
-  detail rows.
+  detail rows and, in plain language, in the `flag_reasons` column on the
+  category row.
 - **Section-category, quarter-to-date** — has this teacher entered the required
   number of assignments in this category so far this quarter? (Quarter-grain as
   of AY 2026-2027 — previously a weekly check.)
@@ -455,9 +456,13 @@ this is an internal ops artifact, unlike the Tableau-facing report below.
 
 `rpt_tableau__gradebook_audit` reads the intermediate above (aggregated, with
 PII dropped) for its section-level "any student flagged" booleans — see below.
-No per-rule "reason" is ever surfaced for either flag; the whole point of the
-July 2026 split was to move to aggregated boolean signals instead of granular
-rule-level detail.
+No per-rule "reason" is ever surfaced for either **student** flag; the whole
+point of the July 2026 split was to move to aggregated boolean signals instead
+of granular rule-level detail. That rule is scoped to the student flags, which
+carry PII and fan out per student. **Assignment** flags do carry a reason:
+`flag_reasons` names them in plain language on the category row (see below).
+Assignment flags sit at section grain, carry no PII, and come from a fixed set
+of 4 checks, so naming them adds no rows and exposes nothing.
 
 ### Final extract: `rpt_tableau__gradebook_audit`
 
@@ -478,7 +483,12 @@ concept, unlike the pre-July-2026 design below.
    rollup data. Computes `expectation`, `assignments_entered_count`, and
    `assignments_entered_count_no_flags` as **window functions** partitioned by
    `_dbt_source_project, sectionid, quarter, assignment_category_code` — not a
-   `GROUP BY` — so the per-assignment row grain survives for step 2 to use.
+   `GROUP BY` — so the per-assignment row grain survives for step 2 to use. Four
+   more window `countif`s over the same partition count the assignments tripping
+   each term of `assignment_has_flags`: `n_percent_graded_min_not_met`,
+   `n_invalid_scores` (the `flags_sum > 0` term), `n_max_score_not_10` and
+   `n_overly_exempt`. They share the existing partition, so BigQuery computes
+   one window for all seven.
 2. `category_summary` — a grain-projection `SELECT DISTINCT` over
    `category_join` that collapses the per-assignment fan-out to one row per
    section × quarter × category, and adds `not_enough_assignments`
@@ -490,14 +500,21 @@ concept, unlike the pre-July-2026 design below.
    window aggregates from step 1 over that same partition — so `DISTINCT` is a
    pure grain projection, not a mask for upstream duplicates. The
    assignment-level columns from the rollup are not projected, so they collapse
-   out.
+   out. This step also builds `flag_reasons` from the 4 window counts —
+   `array_to_string` over an array of conditional labels, wrapped in `nullif`
+   because `array_to_string` returns `''`, not NULL, when every element is NULL.
+   The labels print in a fixed order: `Under 90% graded`,
+   `Invalid scores entered`, `Not out of 10 points`, `Half the class exempt`.
+   `Under 90% graded` never appears alone, because grading below 90% of expected
+   students leaves unscored expected students, which increments
+   `n_expected_null` and so trips the `flags_sum > 0` term too.
 3. `assignment_detail` — reads `category_join` directly (the full fanned-out
    set), filtered to `assignment_has_flags`.
 4. `combined` — explicit-column `UNION ALL` of `category_summary` and
    `assignment_detail`, tagging `row_type`. `expectation`,
-   `assignments_entered_count`, and `not_enough_assignments` are null on
-   `assignment_detail` rows; the assignment-identity columns are null on
-   `category_summary` rows.
+   `assignments_entered_count`, `assignments_entered_count_no_flags`,
+   `not_enough_assignments`, and `flag_reasons` are null on `assignment_detail`
+   rows; the assignment-identity columns are null on `category_summary` rows.
 5. `student_flags_aggregate` — reads
    `int_extracts__gradebook_audit_student_flags` (see above), grouped to
    `_dbt_source_project, sectionid, quarter`, computing `has_grade_above_100` /

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
@@ -18,7 +18,10 @@ models:
       flags fired anywhere) and is_healthy_gradebook_excl_comments (same, but
       has_grade_below_70_no_comment doesn't count toward this one — it's an
       end-of-quarter item, still visible as data). A Tableau parameter picks
-      which health column to read.
+      which health column to read. flag_reasons carries a plain-language list of
+      the assignment validity checks that tripped for the category, so a teacher
+      reading assignments_entered_count against expectation can see why the
+      category is off track.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -180,6 +183,21 @@ models:
           True when the count of non-flagged assignments entered for this
           category is below expectation. Populated on row_type =
           'category_summary' rows only.
+      - name: flag_reasons
+        description: >
+          Plain-language list of the assignment validity checks that tripped for
+          this category, joined by '; ' in a fixed order: 'Under 90% graded',
+          'Invalid scores entered', 'Not out of 10 points', 'Half the class
+          exempt'. The four labels correspond 1:1 to the four terms of
+          assignment_has_flags in
+          int_powerschool__gradebook_assignment_scores_rollup
+          (percent_graded_min_not_met, flags_sum > 0, assign_max_score_not_10,
+          overly_exempt_assignment). Built as a display vector so Tableau needs
+          no calculated field. NULL when no check tripped, and NULL on row_type
+          = 'assignment_detail' rows. Populates whenever a check tripped, even
+          when not_enough_assignments is false — a category can hold flawed
+          assignments and still clear its expectation.
+        data_type: string
       - name: assignmentid
         data_type: int64
         description: >

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gradebook_audit.yml
@@ -184,6 +184,7 @@ models:
           category is below expectation. Populated on row_type =
           'category_summary' rows only.
       - name: flag_reasons
+        data_type: string
         description: >
           Plain-language list of the assignment validity checks that tripped for
           this category, joined by '; ' in a fixed order: 'Under 90% graded',
@@ -197,7 +198,6 @@ models:
           = 'assignment_detail' rows. Populates whenever a check tripped, even
           when not_enough_assignments is false — a category can hold flawed
           assignments and still clear its expectation.
-        data_type: string
       - name: assignmentid
         data_type: int64
         description: >

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -188,6 +188,11 @@ with
                 assignments_entered_count_no_flags < expectation, true, false
             ) as not_enough_assignments,
 
+            -- user-facing display vector: Tableau groups and filters on this
+            -- string, so the label order is load-bearing -- appending is safe,
+            -- reordering or rewording changes existing values. nullif is
+            -- required because array_to_string returns '' (not null) when every
+            -- element is null.
             nullif(
                 array_to_string(
                     [

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -75,6 +75,44 @@ with
                     ge.assignment_category_code
             ) as assignments_entered_count_no_flags,
 
+            countif(
+                r.duedate <= ge.week_end_sunday and r.percent_graded_min_not_met
+            ) over (
+                partition by
+                    s._dbt_source_project,
+                    s.sectionid,
+                    s.`quarter`,
+                    ge.assignment_category_code
+            ) as n_percent_graded_min_not_met,
+
+            countif(r.duedate <= ge.week_end_sunday and r.flags_sum > 0) over (
+                partition by
+                    s._dbt_source_project,
+                    s.sectionid,
+                    s.`quarter`,
+                    ge.assignment_category_code
+            ) as n_invalid_scores,
+
+            countif(
+                r.duedate <= ge.week_end_sunday and r.assign_max_score_not_10
+            ) over (
+                partition by
+                    s._dbt_source_project,
+                    s.sectionid,
+                    s.`quarter`,
+                    ge.assignment_category_code
+            ) as n_max_score_not_10,
+
+            countif(
+                r.duedate <= ge.week_end_sunday and r.overly_exempt_assignment
+            ) over (
+                partition by
+                    s._dbt_source_project,
+                    s.sectionid,
+                    s.`quarter`,
+                    ge.assignment_category_code
+            ) as n_overly_exempt,
+
         from {{ ref("int_extracts__course_schedule_by_term") }} as s
         inner join
             {{ ref("int_powerschool__u_expectations_qtd_unpivot") }} as ge
@@ -149,6 +187,19 @@ with
             if(
                 assignments_entered_count_no_flags < expectation, true, false
             ) as not_enough_assignments,
+
+            nullif(
+                array_to_string(
+                    [
+                        if(n_percent_graded_min_not_met > 0, 'Under 90% graded', null),
+                        if(n_invalid_scores > 0, 'Invalid scores entered', null),
+                        if(n_max_score_not_10 > 0, 'Not out of 10 points', null),
+                        if(n_overly_exempt > 0, 'Half the class exempt', null)
+                    ],
+                    '; '
+                ),
+                ''
+            ) as flag_reasons,
 
         from category_join
     ),
@@ -252,6 +303,7 @@ with
             assignments_entered_count,
             assignments_entered_count_no_flags,
             not_enough_assignments,
+            flag_reasons,
 
             cast(null as int64) as assignmentid,
             cast(null as string) as assignment_name,
@@ -310,6 +362,7 @@ with
             cast(null as int64) as assignments_entered_count,
             cast(null as int64) as assignments_entered_count_no_flags,
             cast(null as bool) as not_enough_assignments,
+            cast(null as string) as flag_reasons,
 
             assignmentid,
             assignment_name,
@@ -426,6 +479,7 @@ select
     w.assignments_entered_count,
     w.assignments_entered_count_no_flags,
     w.not_enough_assignments,
+    w.flag_reasons,
 
     w.assignmentid,
     w.assignment_name,


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will add `flag_reasons` to `rpt_tableau__gradebook_audit`.

The dashboard could tell a teacher a category was off track while showing they entered enough assignments. Both numbers looked right and the flag still fired. Nothing explained the gap.

Flagged assignments cause the gap. `not_enough_assignments` compares `expectation` to `assignments_entered_count_no_flags`, not to the raw entered count. `flag_reasons` names the checks that tripped, in plain language, on the `category_summary` row.

Teachers and school leaders drop the column onto a Tableau view. They write no calculated field.

The 4 labels are `Under 90% graded`, `Invalid scores entered`, `Not out of 10 points` and `Half the class exempt`. They print in a fixed order, so Tableau can group and filter on the string. The column is NULL when no check tripped.

This change adds a column and no rows. It renames nothing and removes nothing, so no downstream exposure breaks.

Refs #5119

## Reviewer Notes

- `category_summary` is a `SELECT DISTINCT`, so a new column that varied within its grain would silently add rows. The 4 labels come from window counts over the exact partition it collapses on. I measured the result: 25,480 partitions produce exactly 25,480 rows, and no partition carries more than 1 label string.
- `flag_reasons` fills in whenever a check tripped, even when `not_enough_assignments` is false. A category can hold flawed assignments and still clear its expectation. That choice goes to stakeholders separately, and reverting it is a 1-line change.
- `Under 90% graded` never prints alone. Grading below 90% of expected students leaves unscored students, which trips the invalid-scores check on the same assignment.
- Neither health boolean changed. `not_enough_assignments` already feeds both, so adding `flag_reasons` would double-count.
- `Invalid scores entered` stands in for 7 separate score checks. A teacher who sees it alone must open the assignment rows to learn which one tripped. The requester chose the 4-label set knowing this.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — the existing `rpt_tableau__gradebook_audit.yml` gains the `flag_reasons` column and an updated model description. The model has an enforced contract, so the build fails without it.
- [x] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application — the `gradebook_audit` exposure already depends on this model and needs no change, because this adds a column rather than a model.
- [x] **Breaking change?** No. This adds 1 column and renames or removes nothing, so contracted downstream consumers keep working.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** — not applicable, no external source changed.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

**Implementation**

`category_join` gains 4 window `countif`s over `(_dbt_source_project, sectionid, quarter, assignment_category_code)` — the same partition the 3 pre-existing windows use, so BigQuery computes one window for all 7. They count assignments tripping each term of `assignment_has_flags` in `int_powerschool__gradebook_assignment_scores_rollup`: `n_percent_graded_min_not_met`, `n_invalid_scores` (the `flags_sum > 0` term), `n_max_score_not_10`, `n_overly_exempt`. The due-date scope (`r.duedate <= ge.week_end_sunday`) is copied from `assignments_entered_count_no_flags`, so `flag_reasons` and `not_enough_assignments` can never disagree about which assignments are in scope.

`category_summary` builds the string with `array_to_string` over conditional labels, wrapped in `nullif(..., '')`. The wrapper is required: `array_to_string` drops NULL elements and the delimiter before them, but returns `''`, not NULL, when every element is NULL. Confirmed by direct query, not from memory.

`combined` carries `cast(null as string) as flag_reasons` on the `assignment_detail` branch, matching the existing null-placeholder pattern. `with_section_flags` picks it up through `c.*`.

**Grain safety**

Because no `OVER()` clause carries an `ORDER BY`, each window frame is the whole partition, so every new count is constant across the partition by SQL semantics rather than by luck of current data. `flag_reasons` is a deterministic scalar over those constants, so `SELECT DISTINCT` remains a pure grain projection.

**Verification against the built view**

`zz_anthonygwalters_kipptaf_tableau.rpt_tableau__gradebook_audit`, built with `--defer` against the prod manifest:

- 25,480 `category_summary` rows against 25,480 distinct partitions, so zero fan-out; 0 partitions with a multivalued `flag_reasons`
- 0 section-quarters with other than exactly 4 `category_summary` rows
- 0 `assignment_detail` rows carrying a non-NULL `flag_reasons`
- 0 rows where `flag_reasons is not null` disagrees with `assignments_entered_count > assignments_entered_count_no_flags`, across all 25,480 category rows
- all 4,975 rows in the target case (entered at or above expectation plus `not_enough_assignments`) carry a reason
- 11 distinct label combinations, every one in the fixed order
- `dbt_utils.unique_combination_of_columns` passes; 27,433 `assignment_detail` rows and 52,913 rows total

**The doc claim about `Under 90% graded`**

`is_expected_scored` and `is_expected_null` are complements given `is_expected`, so `n_expected = n_expected_null + n_expected_scored` exactly. `assign_percent_graded < 0.90` therefore forces `n_expected_null > 0`, which makes `flags_sum > 0` for that same assignment. Derived from `int_powerschool__gradebook_assignments_scores.sql` and confirmed empirically: 0 rows carry `Under 90% graded` without `Invalid scores entered`.

**Doc and skill edits**

The reference doc previously claimed no per-rule reason is ever surfaced. That rule came from the July 2026 teacher/student split, whose concern was student flags: they carry PII and fan out per student. Assignment flags sit at section grain, carry no student identifiers, and come from a fixed set of 4 checks. The rule is now scoped to student flags, and the skill gains an "Assignment-level check" procedure covering how to add a 5th label.

**Known gap, deliberately not closed**

No dbt unit test covers the `flag_reasons` derivation. A reviewer suggested one. The model carries 51 contract columns and 4 refs, and dbt requires every `expect` row to list every column, so covering the 4 conditions plus an ordering case runs to roughly 300 lines of fixture. This model gained 2 columns in the past week (`school_name`, `assignments_entered_count_no_flags`), and a column add breaks its own unit test, so the fixture would need editing on each one. The sibling `not_enough_assignments` flag has no unit test either. Left out as a cost call, not an oversight — worth revisiting if the label set stabilizes.

**AI involvement**

Claude-assisted, human-directed. Design settled through the `brainstorming` skill; reviewed by a dispatched reviewer subagent, which found no critical or important issues. Its 1 acted-on suggestion was the guardrail comment in `386c1a8a4`.

</details>
