### PR TITLE
feat(dbt): add int_students__school_directory

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
@@ -65,7 +65,6 @@ with
             and sr.grade_level is not null
     ),
 
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     school_attributes as (
         select
             powerschool_school_id as ps_schoolid,
@@ -75,24 +74,11 @@ with
             focus_school_id,
 
         from {{ ref("stg_google_sheets__people__locations") }}
-        -- schoolid 0 is the no-school-assigned bucket; Pathways sites are not
-        -- schools students enroll into grade levels at.
         where
             powerschool_school_id is not null
+            and abbreviation is not null
             and powerschool_school_id != 0
             and not is_pathways
-    ),
-
-    -- One row per school. ps_schoolid 179901 carries two locations rows,
-    -- identical but for a null abbreviation on one, so prefer the populated one.
-    schools as (
-        {{
-            dbt_utils.deduplicate(
-                relation="school_attributes",
-                partition_by="ps_schoolid",
-                order_by="(school_short_name is null) asc",
-            )
-        }}
     )
 
 select
@@ -120,4 +106,4 @@ select
     end as school_level_alt,
 
 from directory as d
-left join schools as s on d.ps_schoolid = s.ps_schoolid
+left join school_attributes as s on d.ps_schoolid = s.ps_schoolid

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
@@ -6,40 +6,14 @@ with
             _dbt_source_project,
             academic_year,
             region,
-            schoolid,
             schoolid as ps_schoolid,
             grade_level,
 
-            'powerschool' as school_source,
+            'sis' as school_source,
 
-        from {{ ref("int_powerschool__student_enrollment_union") }}
+        from {{ ref("int_students__student_enrollment_union") }}
         -- 999999 is the graduated-students placeholder
         where schoolid != 999999 and grade_level is not null
-
-        union all
-
-        -- grain projection, not dup-masking:
-        -- academic_year/region/ps_schoolid/grade_level
-        select distinct
-            _dbt_source_project,
-            academic_year,
-            region,
-            schoolid,
-            ps_schoolid,
-            grade_level,
-
-            'focus' as school_source,
-
-        from {{ ref("int_focus__student_enrollment_roster") }}
-        -- A fixed boundary, not the current year -- do not swap for
-        -- current_academic_year. Focus reaches back to AY2018, but Miami's
-        -- PowerSchool archive owns through AY2025. Null ps_schoolid drops Focus's
-        -- non-instructional Applicants school and would break ps_schoolid's job as
-        -- the cross-SIS join key.
-        where
-            academic_year >= 2026
-            and ps_schoolid is not null
-            and grade_level is not null
 
         union all
 
@@ -49,22 +23,24 @@ with
             sr._dbt_source_project,
             sr.active_school_year_int as academic_year,
             sr.region,
-            x.location_powerschool_school_id as schoolid,
             x.location_powerschool_school_id as ps_schoolid,
             sr.grade_level,
 
             'finalsite' as school_source,
 
         from {{ ref("stg_finalsite__status_report") }} as sr
-        -- location_name is the crosswalk's unique key. Joining on
-        -- location_powerschool_school_id instead fans out, because the crosswalk
-        -- carries one row per alias name.
+        -- location_name is the crosswalk's unique key; the school id fans out
         inner join
             {{ ref("int_people__location_crosswalk") }} as x
             on sr.assigned_school = x.location_name
         where
             sr.active_school_year_int = {{ var("current_academic_year") }} + 1
+            -- a file's grade is correct only for its own cycle year
+            and cast(left(sr._dagster_partition_key, 4) as int)
+            = sr.active_school_year_int
             and x.location_powerschool_school_id is not null
+            and x.location_powerschool_school_id != 0
+            and not x.location_is_pathways
             and sr.grade_level is not null
     ),
 
@@ -88,7 +64,6 @@ select
     d._dbt_source_project,
     d.academic_year,
     d.region,
-    d.schoolid,
     d.ps_schoolid,
     d.grade_level,
     d.school_source,

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
@@ -1,5 +1,5 @@
 with
-    enrolled as (
+    directory as (
         -- grain projection, not dup-masking:
         -- academic_year/region/ps_schoolid/grade_level
         select distinct
@@ -37,22 +37,25 @@ with
         -- non-instructional Applicants school and would break ps_schoolid's job as
         -- the cross-SIS join key.
         where academic_year >= 2026 and ps_schoolid is not null
-    ),
 
-    -- grain projection, not dup-masking: academic_year/region/ps_schoolid/grade_level
-    incoming as (
+        union all
+
+        -- grain projection, not dup-masking:
+        -- academic_year/region/ps_schoolid/grade_level
         select distinct
             sr._dbt_source_project,
             sr.active_school_year_int as academic_year,
             sr.region,
-            sr.grade_level,
-
             x.location_powerschool_school_id as schoolid,
             x.location_powerschool_school_id as ps_schoolid,
+            sr.grade_level,
 
             'finalsite' as school_source,
 
         from {{ ref("stg_finalsite__status_report") }} as sr
+        -- location_name is the crosswalk's unique key. Joining on
+        -- location_powerschool_school_id instead fans out, because the crosswalk
+        -- carries one row per alias name.
         inner join
             {{ ref("int_people__location_crosswalk") }} as x
             on sr.assigned_school = x.location_name
@@ -60,28 +63,61 @@ with
             sr.active_school_year_int = {{ var("current_academic_year") }} + 1
             and x.location_powerschool_school_id is not null
             and sr.grade_level is not null
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    school_attributes as (
+        select
+            powerschool_school_id as ps_schoolid,
+            location_name as school_name,
+            abbreviation as school_short_name,
+            grade_band as school_level,
+            focus_school_id,
+
+        from {{ ref("stg_google_sheets__people__locations") }}
+        -- schoolid 0 is the no-school-assigned bucket; Pathways sites are not
+        -- schools students enroll into grade levels at.
+        where
+            powerschool_school_id is not null
+            and powerschool_school_id != 0
+            and not is_pathways
+    ),
+
+    -- One row per school. ps_schoolid 179901 carries two locations rows,
+    -- identical but for a null abbreviation on one, so prefer the populated one.
+    schools as (
+        {{
+            dbt_utils.deduplicate(
+                relation="school_attributes",
+                partition_by="ps_schoolid",
+                order_by="(school_short_name is null) asc",
+            )
+        }}
     )
 
 select
-    _dbt_source_project,
-    academic_year,
-    region,
-    schoolid,
-    ps_schoolid,
-    grade_level,
-    school_source,
+    d._dbt_source_project,
+    d.academic_year,
+    d.region,
+    d.schoolid,
+    d.ps_schoolid,
+    d.grade_level,
+    d.school_source,
 
-from enrolled
+    s.school_name,
+    s.school_short_name,
+    s.school_level,
+    s.focus_school_id,
 
-union all
+    -- TODO: figure out a better way to track these
+    case
+        when
+            d.academic_year >= 2025
+            and s.school_short_name = 'Sumner'
+            and d.grade_level >= 5
+        then 'MS'
+        else s.school_level
+    end as school_level_alt,
 
-select
-    _dbt_source_project,
-    academic_year,
-    region,
-    schoolid,
-    ps_schoolid,
-    grade_level,
-    school_source,
-
-from incoming
+from directory as d
+left join schools as s on d.ps_schoolid = s.ps_schoolid

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
@@ -36,7 +36,10 @@ with
         -- PowerSchool archive owns through AY2025. Null ps_schoolid drops Focus's
         -- non-instructional Applicants school and would break ps_schoolid's job as
         -- the cross-SIS join key.
-        where academic_year >= 2026 and ps_schoolid is not null
+        where
+            academic_year >= 2026
+            and ps_schoolid is not null
+            and grade_level is not null
 
         union all
 

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__school_directory.sql
@@ -1,0 +1,87 @@
+with
+    enrolled as (
+        -- grain projection, not dup-masking:
+        -- academic_year/region/ps_schoolid/grade_level
+        select distinct
+            _dbt_source_project,
+            academic_year,
+            region,
+            schoolid,
+            schoolid as ps_schoolid,
+            grade_level,
+
+            'powerschool' as school_source,
+
+        from {{ ref("int_powerschool__student_enrollment_union") }}
+        -- 999999 is the graduated-students placeholder
+        where schoolid != 999999 and grade_level is not null
+
+        union all
+
+        -- grain projection, not dup-masking:
+        -- academic_year/region/ps_schoolid/grade_level
+        select distinct
+            _dbt_source_project,
+            academic_year,
+            region,
+            schoolid,
+            ps_schoolid,
+            grade_level,
+
+            'focus' as school_source,
+
+        from {{ ref("int_focus__student_enrollment_roster") }}
+        -- A fixed boundary, not the current year -- do not swap for
+        -- current_academic_year. Focus reaches back to AY2018, but Miami's
+        -- PowerSchool archive owns through AY2025. Null ps_schoolid drops Focus's
+        -- non-instructional Applicants school and would break ps_schoolid's job as
+        -- the cross-SIS join key.
+        where academic_year >= 2026 and ps_schoolid is not null
+    ),
+
+    -- grain projection, not dup-masking: academic_year/region/ps_schoolid/grade_level
+    incoming as (
+        select distinct
+            sr._dbt_source_project,
+            sr.active_school_year_int as academic_year,
+            sr.region,
+            sr.grade_level,
+
+            x.location_powerschool_school_id as schoolid,
+            x.location_powerschool_school_id as ps_schoolid,
+
+            'finalsite' as school_source,
+
+        from {{ ref("stg_finalsite__status_report") }} as sr
+        inner join
+            {{ ref("int_people__location_crosswalk") }} as x
+            on sr.assigned_school = x.location_name
+        where
+            sr.active_school_year_int = {{ var("current_academic_year") }} + 1
+            and x.location_powerschool_school_id is not null
+            and sr.grade_level is not null
+    )
+
+select
+    _dbt_source_project,
+    academic_year,
+    region,
+    schoolid,
+    ps_schoolid,
+    grade_level,
+    school_source,
+
+from enrolled
+
+union all
+
+select
+    _dbt_source_project,
+    academic_year,
+    region,
+    schoolid,
+    ps_schoolid,
+    grade_level,
+    school_source,
+
+from incoming

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
@@ -77,6 +77,8 @@ models:
                   - focus
                   - finalsite
       - name: schoolid
+        data_tests:
+          - not_null
         description: >
           School id native to whichever system produced the row -- the network
           school number on PowerSchool rows, Focus's own internal school id on

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
@@ -7,12 +7,11 @@ models:
       disappearing, with no open or close date to maintain and no school that
       never enrolled anyone.
 
-      Three branches, ordered by precedence rather than by a boundary year.
-      PowerSchool owns every region-year it holds enrollment rows for, which is
-      all years for the three NJ regions and Miami through SY25-26, where its
-      frozen archive stops. Focus covers Miami from SY26-27 onward. Finalsite
-      adds next year's incoming schools and grade levels, which no student
-      information system carries yet.
+      Two branches. The sis branch reads int_students__student_enrollment_union,
+      which already resolves the PowerSchool-to-Focus handoff for Miami, so
+      every historic and current year comes from one place. The finalsite branch
+      adds next year's schools and grade levels, which no student information
+      system carries yet.
 
       A grade counts as offered if any enrollment row exists for it, active or
       not. Filtering to currently-enrolled students would blank out every
@@ -22,13 +21,20 @@ models:
       reports max_syear 2025 for KIPP Sunrise and KIPP Liberty, but the last
       students enrolled at both in 2022.
 
+      The finalsite branch has two limits inherent to its source. It sees a
+      school only once an applicant has been routed to it by name, so a new
+      school with no routed applicant is not in the directory. And a status
+      report file describes applicants in its own cycle's grade, so the branch
+      reads next year's rows only from next year's file. Until that file lands,
+      the branch is empty, which is a normal state rather than a fault.
+
       School attributes come from stg_google_sheets__people__locations, not
       int_people__location_crosswalk. The crosswalk carries one row per alias
       name -- 254 rows across 29 schools -- so joining it on a school id fans
       out. The locations sheet reaches one row per school once the
       no-school-assigned bucket, Pathways sites, and the single
       null-abbreviation row are filtered out. The crosswalk is still the right
-      lookup inside the Finalsite branch, which resolves an assigned school by
+      lookup inside the finalsite branch, which resolves an assigned school by
       name on location_name, its unique key.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
@@ -43,64 +49,47 @@ models:
         description: >
           Dagster code location owning the row -- kippnewark, kippcamden,
           kippmiami or kipppaterson. Passed through from the upstream model on
-          every branch, including Finalsite, whose union view derives it.
+          both branches.
         data_tests:
           - not_null
       - name: region
-        description: >
-          Region name -- Camden, Miami, Newark or Paterson. Matches the region
-          values on stg_google_sheets__reporting__terms, so it joins the
-          assessment calendar without translation.
+        description: Region name -- Camden, Miami, Newark or Paterson.
         data_tests:
           - not_null
       - name: academic_year
         description: >
           Academic year the school offered this grade level, as the starting
-          calendar year -- 2026 is SY26-27. The two student information system
-          branches take it from the enrollment record. The Finalsite branch
-          takes active_school_year_int, scoped to one year ahead of
-          current_academic_year.
+          calendar year -- 2026 is SY26-27. The sis branch takes it from the
+          enrollment record. The finalsite branch takes active_school_year_int,
+          scoped to one year ahead of current_academic_year.
         data_tests:
           - not_null
       - name: school_source
         description: >
-          Which system is authoritative for the row, and what separates incoming
-          rows from historic and current ones. Downstream consumers rank on it
-          -- int_tableau__fresh_enrollment_scaffold prefers a student
-          information system row over a Finalsite one when a school has both.
+          Which system produced the row. sis rows are historic and current
+          enrollment; finalsite rows are next year's applicants. A consumer that
+          needs only years with real enrollment filters to sis.
         data_tests:
           - not_null
           - accepted_values:
               arguments:
                 values:
-                  - powerschool
-                  - focus
+                  - sis
                   - finalsite
-      - name: schoolid
-        data_tests:
-          - not_null
-        description: >
-          School id native to whichever system produced the row -- the network
-          school number on PowerSchool rows, Focus's own internal school id on
-          Focus rows. Finalsite rows resolve to a network school number, so
-          schoolid and ps_schoolid match there. Join on ps_schoolid when you
-          need one key across all three branches. Excludes 999999, the
-          graduated-students placeholder, which is not a physical school.
       - name: ps_schoolid
         description: >
-          PowerSchool network school number, populated on every row including
-          Focus and Finalsite ones, and unique across regions. This is the
-          cross-system join key. It is what lets Miami's SY26-27 Focus rows line
-          up with PowerSchool-keyed models even though Miami no longer runs on
-          PowerSchool -- KIPP Courage carries schoolid 30200803 in AY2025 and
-          schoolid 15 in AY2026, with ps_schoolid 30200803 in both.
+          PowerSchool network school number, unique across regions and populated
+          on every row. Miami's Focus-era rows carry it too, because
+          int_students__student_enrollment_union resolves Focus schools to their
+          PowerSchool number, so this one key joins PowerSchool-keyed models
+          across every year. Excludes 999999, the graduated-students
+          placeholder, which is not a physical school.
       - name: focus_school_id
         description: >
           Focus's own school code, such as 2332B, from the locations sheet.
           Populated for any school the sheet maps to Focus regardless of which
-          branch produced the row. This is the key
-          int_tableau__fresh_enrollment_scaffold joins int_focus__schools on, so
-          a consumer can reach Focus-keyed models without its own crosswalk.
+          branch produced the row, so a consumer can reach Focus-keyed models
+          such as int_focus__schools without its own crosswalk.
       - name: grade_level
         description: >
           Grade level offered at the school that year, with kindergarten as 0.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
@@ -21,6 +21,12 @@ models:
       Metadata would answer this differently and wrongly. int_focus__schools
       reports max_syear 2025 for KIPP Sunrise and KIPP Liberty, but the last
       students enrolled at both in 2022.
+
+      School attributes come from a deduplicated
+      stg_google_sheets__people__locations, not int_people__location_crosswalk.
+      The crosswalk carries one row per alias name, so joining it on a school id
+      fans out. The crosswalk is still the right lookup for the Finalsite
+      branch, which resolves an assigned school by name.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -71,11 +77,10 @@ models:
         description: >
           School id native to whichever system produced the row -- the network
           school number on PowerSchool rows, Focus's own internal school id on
-          Focus rows. Finalsite rows resolve to a network school number through
-          int_people__location_crosswalk, so schoolid and ps_schoolid match
-          there. Join on ps_schoolid when you need one key across all three
-          branches. Excludes 999999, the graduated-students placeholder, which
-          is not a physical school.
+          Focus rows. Finalsite rows resolve to a network school number, so
+          schoolid and ps_schoolid match there. Join on ps_schoolid when you
+          need one key across all three branches. Excludes 999999, the
+          graduated-students placeholder, which is not a physical school.
       - name: ps_schoolid
         description: >
           PowerSchool network school number, populated on every row including
@@ -84,8 +89,31 @@ models:
           up with PowerSchool-keyed models even though Miami no longer runs on
           PowerSchool -- KIPP Courage carries schoolid 30200803 in AY2025 and
           schoolid 15 in AY2026, with ps_schoolid 30200803 in both.
+      - name: focus_school_id
+        description: >
+          Focus's own school code, such as 2332B, from the locations sheet.
+          Populated for any school the sheet maps to Focus regardless of which
+          branch produced the row. This is the key
+          int_tableau__fresh_enrollment_scaffold joins int_focus__schools on, so
+          a consumer can reach Focus-keyed models without its own crosswalk.
       - name: grade_level
         description: >
           Grade level offered at the school that year, with kindergarten as 0.
           Present only where students enrolled, so a grade a school adds or
           drops shows up as the row appearing or disappearing in that year.
+      - name: school_name
+        description: Full school name from the locations sheet.
+      - name: school_short_name
+        description:
+          School abbreviation from the locations sheet, such as Sumner.
+      - name: school_level
+        description: >
+          Grade band the locations sheet assigns the school -- ES, MS or HS. It
+          is a property of the school, so it does not vary by grade level or
+          year.
+      - name: school_level_alt
+        description: >
+          school_level with the Sumner override applied, matching the same field
+          on int_extracts__student_enrollments. From AY2025, Sumner grade 5 and
+          above reports MS while the sheet still calls the school ES. Every
+          other row equals school_level.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
@@ -22,11 +22,14 @@ models:
       reports max_syear 2025 for KIPP Sunrise and KIPP Liberty, but the last
       students enrolled at both in 2022.
 
-      School attributes come from a deduplicated
-      stg_google_sheets__people__locations, not int_people__location_crosswalk.
-      The crosswalk carries one row per alias name, so joining it on a school id
-      fans out. The crosswalk is still the right lookup for the Finalsite
-      branch, which resolves an assigned school by name.
+      School attributes come from stg_google_sheets__people__locations, not
+      int_people__location_crosswalk. The crosswalk carries one row per alias
+      name -- 254 rows across 29 schools -- so joining it on a school id fans
+      out. The locations sheet reaches one row per school once the
+      no-school-assigned bucket, Pathways sites, and the single
+      null-abbreviation row are filtered out. The crosswalk is still the right
+      lookup inside the Finalsite branch, which resolves an assigned school by
+      name on location_name, its unique key.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__school_directory.yml
@@ -1,0 +1,91 @@
+models:
+  - name: int_students__school_directory
+    description: >
+      Which schools offered which grade levels in which academic years, derived
+      from enrollment rather than school metadata -- so a school opening,
+      closing, merging or adding a grade shows up as rows appearing and
+      disappearing, with no open or close date to maintain and no school that
+      never enrolled anyone.
+
+      Three branches, ordered by precedence rather than by a boundary year.
+      PowerSchool owns every region-year it holds enrollment rows for, which is
+      all years for the three NJ regions and Miami through SY25-26, where its
+      frozen archive stops. Focus covers Miami from SY26-27 onward. Finalsite
+      adds next year's incoming schools and grade levels, which no student
+      information system carries yet.
+
+      A grade counts as offered if any enrollment row exists for it, active or
+      not. Filtering to currently-enrolled students would blank out every
+      historic year.
+
+      Metadata would answer this differently and wrongly. int_focus__schools
+      reports max_syear 2025 for KIPP Sunrise and KIPP Liberty, but the last
+      students enrolled at both in 2022.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - academic_year
+              - region
+              - ps_schoolid
+              - grade_level
+    columns:
+      - name: _dbt_source_project
+        description: >
+          Dagster code location owning the row -- kippnewark, kippcamden,
+          kippmiami or kipppaterson. Passed through from the upstream model on
+          every branch, including Finalsite, whose union view derives it.
+        data_tests:
+          - not_null
+      - name: region
+        description: >
+          Region name -- Camden, Miami, Newark or Paterson. Matches the region
+          values on stg_google_sheets__reporting__terms, so it joins the
+          assessment calendar without translation.
+        data_tests:
+          - not_null
+      - name: academic_year
+        description: >
+          Academic year the school offered this grade level, as the starting
+          calendar year -- 2026 is SY26-27. The two student information system
+          branches take it from the enrollment record. The Finalsite branch
+          takes active_school_year_int, scoped to one year ahead of
+          current_academic_year.
+        data_tests:
+          - not_null
+      - name: school_source
+        description: >
+          Which system is authoritative for the row, and what separates incoming
+          rows from historic and current ones. Downstream consumers rank on it
+          -- int_tableau__fresh_enrollment_scaffold prefers a student
+          information system row over a Finalsite one when a school has both.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - powerschool
+                  - focus
+                  - finalsite
+      - name: schoolid
+        description: >
+          School id native to whichever system produced the row -- the network
+          school number on PowerSchool rows, Focus's own internal school id on
+          Focus rows. Finalsite rows resolve to a network school number through
+          int_people__location_crosswalk, so schoolid and ps_schoolid match
+          there. Join on ps_schoolid when you need one key across all three
+          branches. Excludes 999999, the graduated-students placeholder, which
+          is not a physical school.
+      - name: ps_schoolid
+        description: >
+          PowerSchool network school number, populated on every row including
+          Focus and Finalsite ones, and unique across regions. This is the
+          cross-system join key. It is what lets Miami's SY26-27 Focus rows line
+          up with PowerSchool-keyed models even though Miami no longer runs on
+          PowerSchool -- KIPP Courage carries schoolid 30200803 in AY2025 and
+          schoolid 15 in AY2026, with ps_schoolid 30200803 in both.
+      - name: grade_level
+        description: >
+          Grade level offered at the school that year, with kindergarten as 0.
+          Present only where students enrolled, so a grade a school adds or
+          drops shows up as the row appearing or disappearing in that year.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add `int_students__school_directory`. It answers which schools offered which grade levels in which academic years, one row per `academic_year` / `region` / `ps_schoolid` / `grade_level`.

Two problems it solves. Every dashboard works out which schools and grade levels to count, and each one does it differently — the DIBELS progress monitoring models one way, `int_tableau__fresh_enrollment_scaffold` another, and the CSGF collection needs it next. We also cannot answer which schools offered which grades in a past year, because that history sits only in enrollment records.

The model derives everything from enrollment, not from school metadata. A school and grade appear in exactly the years students enrolled in them. Nobody maintains an open or close date.

Two branches, labeled by `school_source`. `sis` reads `int_students__student_enrollment_union`, which already resolves the PowerSchool-to-Focus handoff for Miami, so every historic and current year comes from one place. `finalsite` adds next year's incoming schools before any student information system carries them.

It carries school attributes alongside the keys — `school_name`, `school_short_name`, `school_level`, `focus_school_id`, `school_level_alt` — so a consumer does not need its own crosswalk join.

Nothing consumes the model yet, so it is safe to land ahead of any consumer. `int_tableau__fresh_enrollment_scaffold` is the intended first consumer; that migration is a follow-up, since the scaffold keys on `schoolid` and adds whole-school and region rollup rows this model does not carry.

## Reviewer Notes

**Two id columns.** `ps_schoolid` is the PowerSchool network school number on every row, including Miami's Focus-era rows, because the enrollment union resolves Focus schools to their PowerSchool number. `focus_school_id` carries Focus's own code for the reverse direction. An earlier revision also carried the Focus-native `schoolid`; it went away when the two SIS branches collapsed into one, because it always equaled `ps_schoolid`.

**Attributes come from the locations sheet, not `int_people__location_crosswalk`.** The crosswalk holds one row per alias name, so joining it on a school id fans out. It is still used inside the Finalsite branch, where `location_name` is its unique key.

**The grain test keys on `ps_schoolid`.** That also catches two Focus schools mapping to one PowerSchool id, which is what a school merge looks like.

**The Finalsite branch reads only the file for its own cycle year.** A status report file describes applicants in their grade for that file's cycle, so an older file's rows for next year carry last year's grade. Without the pin, the branch produced a phantom lower grade per school that the grain test cannot see. Measured on prod: 9,119 of 9,346 SY26-27 rows in the `2025_26` file are off by one against the SIS; the `2026_27` file matches on 11,486 of 11,505.

**The Finalsite branch is empty today, and that is correct.** It sees a school only once an applicant is routed to it by name, and only from the `2027_28` file, which lands when SRE opens that cycle. A new school with no routed applicant is not in the directory. That limit is inherent to the source.

**No boundary literal for the Miami handoff.** `int_students__student_enrollment_union` owns that rule (Focus carries Miami's full history back to AY2018; the frozen PowerSchool archive contributes no Miami rows). At this grain the two sources are identical sets for Miami through AY2025, so the earlier two-branch split bought nothing.

**Review history.** `claude-review` found two nullability gaps, fixed in `85ed19c7d`. An independent review then found the cycle-file grade drift and the redundant SIS split, fixed in `25f682a5b` — see the verdict comments on this PR.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — not applicable, no consumer yet
- [x] **Breaking change?** No. The model is new and nothing reads it.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — not applicable, no external source changes

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Refs #5123. Refs #4451, whose spec left the multi-year school × grade spine as an open question; this model is that follow-up. Refs #3698, which stays open: `school_level` here is still the locations sheet's single current value per school, not a grade band versioned by year.

**11 columns**: `_dbt_source_project`, `academic_year`, `region`, `ps_schoolid`, `focus_school_id`, `grade_level`, `school_source`, `school_name`, `school_short_name`, `school_level`, `school_level_alt`.

**Sources, one per branch:**

- `int_students__student_enrollment_union` — all 4 regions, all years. Its `schoolid` is already the PowerSchool number. Excludes `schoolid` 999999, the graduated-students placeholder, and null `grade_level`.
- `stg_finalsite__status_report` joined to `int_people__location_crosswalk` on `location_name`, scoped `active_school_year_int = current_academic_year + 1` and `left(_dagster_partition_key, 4) = active_school_year_int`. Excludes campus aliases (`location_powerschool_school_id = 0`) and Pathways aliases, matching the attributes CTE. Deliberately not `int_finalsite__status_report_unpivot`: the unpivot fans each applicant out per status field and the crosswalk join is the only part of it this model needs.

**Why one SIS branch, not PowerSchool plus Focus.** The first revision read `int_powerschool__student_enrollment_union` for all regions and `int_focus__student_enrollment_roster` for Miami from a hardcoded `academic_year >= 2026`. `int_students__student_enrollment_union` (13 mart consumers) already resolves that handoff and its YAML documents it. On prod, Miami PowerSchool ≤2025 and Focus ≤2025 are identical sets at this grain, so the split created a second directory of record with a conflicting rule and no extra rows.

**Why the partition pin.** `stg_finalsite__status_report` unions one file per recruitment cycle. The same `finalsite_enrollment_id` and `active_school_year_int` appear in consecutive files with a different `grade_level`, because each file reports the grade relative to its own cycle. Pinning each row to the file whose start year equals its `active_school_year_int` is the only way to read next year's grade correctly. FRESH does the same through the status crosswalk's `file_year`.

**Attribute join grain, checked before wiring it.** `int_people__location_crosswalk` is 254 rows across 29 `ps_schoolid` — one row per alias name — so joining it on a school id would have fanned the directory out roughly 1.45x and broken the grain test. `location_name` is its unique key (254 of 254), which is why the Finalsite branch still uses it. For the attributes, `stg_google_sheets__people__locations` reaches one row per school with three filters: `powerschool_school_id != 0` (the no-school-assigned bucket), `not is_pathways`, and `abbreviation is not null` — the last one because `ps_schoolid` 179901 carries two otherwise-identical rows differing only by a null abbreviation. Result is 28 rows, 28 distinct `ps_schoolid`, zero fan-out. The join is a `LEFT JOIN` so a school missing from the sheet would surface as null attributes rather than a dropped row; zero rows are unmatched today.

**`school_level_alt`** copies the CASE on `int_extracts__student_enrollments`, including its `TODO`. From AY2025, Sumner grade 5 and above reports MS while the sheet still calls the school ES. `school_level` itself is a school property, so it does not vary by grade or year.

**Why enrollment and not metadata.** `int_focus__schools.max_syear` reads 2025 for KIPP Sunrise and KIPP Liberty. Both schools last enrolled students in 2022 — confirmed in the frozen PowerSchool archive and in Focus. A `max_syear`-based directory would imply 7 Miami schools once operated when only the enrolled set is real. Paterson is the positive case: grade levels ran 0-2 and 5-6 in SY24-25, then gained grade 3 and grade 7, then grade 4 and grade 8. Only enrollment records that.

**Why not `int_students__schools`**: school-grain identity with 5 mart consumers. Adding year and grade would change its grain underneath them.

**Why not `int_extracts__student_enrollments`**: a wide denormalized extract. Carrying it for a handful of columns costs a lot for no gain.

**Nullability.** `grade_level is not null` appears on both branches, and `ps_schoolid` is filtered non-null on both, so neither carries a `not_null` test. `unique_combination_of_columns` does not reject nulls, which is why the filters matter on grain columns.

**Verified in dev at `25f682a5b`**: 1,010 rows, 1,010 distinct grain keys, zero unmatched attributes, 7 of 7 nodes pass. Camden 2014-2026, Miami 2018-2026, Newark 2004-2026, Paterson 2023-2026. The `finalsite` branch is empty; the one row it produced before the partition pin was a `2026_27`-file applicant carrying the wrong grade for SY27-28.

**Rejected workaround, recorded so it is not retried.** Having SRE enter placeholder students across every planned school and grade, then excluding those ids from the FRESH dashboard, does not work. `stg_finalsite__status_report` applies the `stg_google_sheets__finalsite__exclude_ids` filter itself, upstream of this model, so excluded ids never reach the directory. Moving that filter downstream would change FRESH's calculations on a live dashboard.

**Rejected alternative sources for the next-year branch, so they are not retried.** The Finalsite Enrollment API has no schools or programs endpoint; `assigned_school` is a per-contact track attribute there too. `int_finance__enrollment_targets` stops at AY2024 and has no Paterson rows. `stg_google_sheets__finalsite__goals` holds one recruitment year at a time and is empty for SY27-28 until SRE enters targets. `stg_google_sheets__finalsite__school_scaffold` is disabled and unmaintained since #4451. If FRESH's migration needs planned schools before applicants are routed, the goals sheet is the maintained candidate.
</details>
