### PR TITLE
fix(iready): guard string-to-int casts against decimal-formatted values

### DIFF
--- a/.claude/rules/dbt-sql.md
+++ b/.claude/rules/dbt-sql.md
@@ -151,6 +151,12 @@ validation/profiling goes through BigQuery MCP, not `dbt show`.
   where the raw value first appears, as a named column. Downstream expressions
   operate on already-typed columns — never nest `cast()` inside another
   function.
+- **`select * replace (...)` only for simple conversions.** A column that is
+  excepted from `*` and re-added under its own name as a plain `cast`,
+  `safe_cast`, or `parse_date` goes in `replace`. Anything that branches or
+  merges — `coalesce`, `if`, `case` — stays as `except` plus an explicit re-add,
+  so the logic reads in the select list rather than inside the star. Renamed or
+  merged-away columns stay in `except`; both clauses can sit on one `*`.
 - **`cast(col as type)` needs an explicit alias** — unaliased, BigQuery names
   the column `f0_`, not `col`, so a contracted / explicitly-projected `select`
   gets the wrong column name and fails. Write `cast(col as type) as col`; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ accept a subagent's self-report without the checks there.
 
 ## Pull requests and CI
 
+- On a feature branch, commit, push, and open the PR yourself once the work is
+  verified. The _Never_ block covers `main` only: a feature-branch push and
+  `create_pull_request` run on the same credentials as every other `git` and
+  `gh` call in the session, so never hand them to the user as needing theirs.
 - Squash merge. PR body from `.github/pull_request_template.md`.
 - Issue refs (`Refs #N`, `Closes #N`) in the body put the PR on project boards.
   Never `gh project item-add` a PR.

--- a/src/dbt/iready/models/staging/properties/stg_iready__instruction_by_lesson_pro.yml
+++ b/src/dbt/iready/models/staging/properties/stg_iready__instruction_by_lesson_pro.yml
@@ -43,3 +43,103 @@ models:
         data_type: numeric
       - name: passed_or_not_passed_numeric
         data_type: float64
+
+unit_tests:
+  - name: unit_iready_instruction_by_lesson_pro_decimal_formatted_ints
+    description:
+      Verifies the integer columns survive a source value formatted with two
+      decimal places. Every column in the i-Ready Avro external is STRING, and
+      the vendor export intermittently writes whole numbers as 9.00, which a
+      bare cast to int64 rejects with Bad int64 value. The first row supplies
+      that formatting for all five integer columns; the second supplies plain
+      integers to prove the numeric round trip leaves clean values unchanged.
+    model: stg_iready__instruction_by_lesson_pro
+    given:
+      - input: source('iready', 'src_iready__instruction_by_lesson_pro')
+        format: sql
+        rows: |
+          select
+              2026 as _dagster_partition_academic_year,
+              'KIPP Miami' as school,
+              '9' as student_grade,
+              'Math' as `subject`,
+              'Level 9' as `level`,
+              'Rational Numbers' as topic,
+              'Completed' as lesson_status,
+              'Passed' as lesson_result,
+              'English' as lesson_language,
+              'Compare Rational Numbers' as lesson_title,
+              '12.00' as lesson_time_on_task_min,
+              '9.00' as skills_completed,
+              '8.00' as skills_successful,
+              '88.50' as percent_skills_successful,
+              '10.00' as items_completed,
+              '9.00' as items_correct,
+              '90.00' as percent_items_correct,
+              '900001' as student_id,
+              '09/02/2026' as completion_date
+
+          union all
+
+          select
+              2026 as _dagster_partition_academic_year,
+              'KIPP Miami' as school,
+              '8' as student_grade,
+              'Reading' as `subject`,
+              'Level 8' as `level`,
+              'Vocabulary' as topic,
+              'Completed' as lesson_status,
+              'Not Passed' as lesson_result,
+              'English' as lesson_language,
+              'Context Clues' as lesson_title,
+              '7' as lesson_time_on_task_min,
+              '4' as skills_completed,
+              '2' as skills_successful,
+              '50' as percent_skills_successful,
+              '6' as items_completed,
+              '3' as items_correct,
+              '50' as percent_items_correct,
+              '900002' as student_id,
+              '09/02/2026' as completion_date
+    expect:
+      rows:
+        - student_id: 900001
+          academic_year_int: 2026
+          school: KIPP Miami
+          subject: Math
+          level: Level 9
+          topic: Rational Numbers
+          lesson_title: Compare Rational Numbers
+          lesson_status: Completed
+          lesson_result: Passed
+          lesson_time_on_task_min: 12
+          lesson_language: English
+          skills_completed: 9
+          skills_successful: 8
+          items_completed: 10
+          items_correct: 9
+          percent_items_correct: 90.00
+          completion_date: 2026-09-02
+          student_grade: "9"
+          percent_skills_successful: 88.50
+          passed_or_not_passed_numeric: 1.0
+        - student_id: 900002
+          academic_year_int: 2026
+          school: KIPP Miami
+          subject: Reading
+          level: Level 8
+          topic: Vocabulary
+          lesson_title: Context Clues
+          lesson_status: Completed
+          lesson_result: Not Passed
+          lesson_time_on_task_min: 7
+          lesson_language: English
+          skills_completed: 4
+          skills_successful: 2
+          items_completed: 6
+          items_correct: 3
+          percent_items_correct: 50
+          completion_date: 2026-09-02
+          student_grade: "8"
+          percent_skills_successful: 50
+          passed_or_not_passed_numeric: 0.0

--- a/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
+++ b/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
@@ -40,8 +40,8 @@ with
 
             _dagster_partition_academic_year as academic_year_int,
 
-            cast(overall_scale_score as int) as overall_scale_score,
-            cast(duration_min as int) as duration_min,
+            cast(cast(overall_scale_score as numeric) as int) as overall_scale_score,
+            cast(cast(duration_min as numeric) as int) as duration_min,
 
             cast(
                 percent_progress_to_annual_stretch_growth_percent as numeric
@@ -158,7 +158,9 @@ with
                 percent_progress_to_annual_stretch_growth_percent >= 100, true, false
             ) as is_met_stretch,
 
-            if(student_grade = 'K', 0, cast(student_grade as int)) as student_grade_int,
+            if(
+                student_grade = 'K', 0, cast(cast(student_grade as numeric) as int)
+            ) as student_grade_int,
 
             case
                 _dagster_partition_subject when 'ela' then 'ELA' when 'math' then 'Math'

--- a/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
+++ b/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
@@ -1,8 +1,14 @@
 with
+    source_grade_normalized as (
+        select *, if(student_grade = 'K', '0', student_grade) as student_grade_numeric,
+        from {{ source("iready", "src_iready__diagnostic_results") }}
+    ),
+
     diagnostic_results as (
         select
             * except (
                 `grouping`,
+                student_grade_numeric,
                 `start_date`,
                 `subject`,
                 algebra_and_algebraic_thinking_scale_score,
@@ -42,6 +48,7 @@ with
 
             cast(cast(overall_scale_score as numeric) as int) as overall_scale_score,
             cast(cast(duration_min as numeric) as int) as duration_min,
+            cast(cast(student_grade_numeric as numeric) as int) as student_grade_int,
 
             cast(
                 percent_progress_to_annual_stretch_growth_percent as numeric
@@ -119,7 +126,7 @@ with
 
             parse_date('%m/%d/%Y', `start_date`) as `start_date`,
             parse_date('%m/%d/%Y', completion_date) as completion_date,
-        from {{ source("iready", "src_iready__diagnostic_results") }}
+        from source_grade_normalized
     ),
 
     hs_goals as (
@@ -157,10 +164,6 @@ with
             if(
                 percent_progress_to_annual_stretch_growth_percent >= 100, true, false
             ) as is_met_stretch,
-
-            if(
-                student_grade = 'K', 0, cast(cast(student_grade as numeric) as int)
-            ) as student_grade_int,
 
             case
                 _dagster_partition_subject when 'ela' then 'ELA' when 'math' then 'Math'

--- a/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
+++ b/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
@@ -9,129 +9,190 @@ with
             * except (
                 `grouping`,
                 student_grade_numeric,
-                `start_date`,
                 `subject`,
-                algebra_and_algebraic_thinking_scale_score,
-                annual_stretch_growth_measure,
-                annual_typical_growth_measure,
                 assessment_gain,
                 baseline_assessment_y_n,
-                baseline_diagnostic_y_n,
-                completion_date,
-                comprehension_informational_text_scale_score,
-                comprehension_literature_scale_score,
-                comprehension_overall_scale_score,
-                diagnostic_gain,
-                duration_min,
-                geometry_scale_score,
-                high_frequency_words_scale_score,
-                measurement_and_data_scale_score,
-                mid_on_grade_level_scale_score,
                 most_recent_assessment_ytd_y_n,
-                most_recent_diagnostic_y_n,
-                most_recent_diagnostic_ytd_y_n,
-                number_and_operations_scale_score,
-                overall_scale_score,
-                percent_progress_to_annual_stretch_growth_percent,
-                percent_progress_to_annual_typical_growth_percent,
-                percentile,
-                phonics_scale_score,
-                phonological_awareness_scale_score,
-                reading_comprehension_informational_text_scale_score,
-                reading_comprehension_literature_scale_score,
-                reading_comprehension_overall_scale_score,
-                student_id,
-                vocabulary_scale_score
+                most_recent_diagnostic_y_n
+            ) replace (
+                cast(
+                    cast(overall_scale_score as numeric) as int
+                ) as overall_scale_score,
+                cast(cast(duration_min as numeric) as int) as duration_min,
+                cast(
+                    percent_progress_to_annual_stretch_growth_percent as numeric
+                ) as percent_progress_to_annual_stretch_growth_percent,
+                cast(
+                    percent_progress_to_annual_typical_growth_percent as numeric
+                ) as percent_progress_to_annual_typical_growth_percent,
+                cast(
+                    cast(coalesce(diagnostic_gain, assessment_gain) as numeric) as int
+                ) as diagnostic_gain,
+                cast(
+                    cast(annual_stretch_growth_measure as numeric) as int
+                ) as annual_stretch_growth_measure,
+                cast(
+                    cast(annual_typical_growth_measure as numeric) as int
+                ) as annual_typical_growth_measure,
+                cast(cast(percentile as numeric) as int) as percentile,
+                cast(
+                    cast(algebra_and_algebraic_thinking_scale_score as numeric) as int
+                ) as algebra_and_algebraic_thinking_scale_score,
+                cast(
+                    cast(comprehension_informational_text_scale_score as numeric) as int
+                ) as comprehension_informational_text_scale_score,
+                cast(
+                    cast(comprehension_literature_scale_score as numeric) as int
+                ) as comprehension_literature_scale_score,
+                cast(
+                    cast(comprehension_overall_scale_score as numeric) as int
+                ) as comprehension_overall_scale_score,
+                cast(
+                    cast(geometry_scale_score as numeric) as int
+                ) as geometry_scale_score,
+                cast(
+                    cast(high_frequency_words_scale_score as numeric) as int
+                ) as high_frequency_words_scale_score,
+                cast(
+                    cast(measurement_and_data_scale_score as numeric) as int
+                ) as measurement_and_data_scale_score,
+                cast(
+                    cast(mid_on_grade_level_scale_score as numeric) as int
+                ) as mid_on_grade_level_scale_score,
+                cast(
+                    cast(number_and_operations_scale_score as numeric) as int
+                ) as number_and_operations_scale_score,
+                cast(
+                    cast(phonics_scale_score as numeric) as int
+                ) as phonics_scale_score,
+                cast(
+                    cast(phonological_awareness_scale_score as numeric) as int
+                ) as phonological_awareness_scale_score,
+                cast(
+                    cast(
+                        reading_comprehension_informational_text_scale_score as numeric
+                    ) as int
+                ) as reading_comprehension_informational_text_scale_score,
+                cast(
+                    cast(reading_comprehension_literature_scale_score as numeric) as int
+                ) as reading_comprehension_literature_scale_score,
+                cast(
+                    cast(reading_comprehension_overall_scale_score as numeric) as int
+                ) as reading_comprehension_overall_scale_score,
+                cast(
+                    cast(vocabulary_scale_score as numeric) as int
+                ) as vocabulary_scale_score,
+                coalesce(
+                    most_recent_diagnostic_y_n,
+                    most_recent_diagnostic_ytd_y_n,
+                    most_recent_assessment_ytd_y_n
+                ) as most_recent_diagnostic_ytd_y_n,
+                coalesce(
+                    baseline_diagnostic_y_n, baseline_assessment_y_n
+                ) as baseline_diagnostic_y_n,
+                safe_cast(student_id as int) as student_id,
+                parse_date('%m/%d/%Y', `start_date`) as `start_date`,
+                parse_date('%m/%d/%Y', completion_date) as completion_date
             ),
 
             _dagster_partition_academic_year as academic_year_int,
-
-            cast(cast(overall_scale_score as numeric) as int) as overall_scale_score,
-            cast(cast(duration_min as numeric) as int) as duration_min,
             cast(cast(student_grade_numeric as numeric) as int) as student_grade_int,
-
-            cast(
-                percent_progress_to_annual_stretch_growth_percent as numeric
-            ) as percent_progress_to_annual_stretch_growth_percent,
-            cast(
-                percent_progress_to_annual_typical_growth_percent as numeric
-            ) as percent_progress_to_annual_typical_growth_percent,
-
-            cast(
-                cast(coalesce(diagnostic_gain, assessment_gain) as numeric) as int
-            ) as diagnostic_gain,
-            cast(
-                cast(annual_stretch_growth_measure as numeric) as int
-            ) as annual_stretch_growth_measure,
-            cast(
-                cast(annual_typical_growth_measure as numeric) as int
-            ) as annual_typical_growth_measure,
             cast(cast(`grouping` as numeric) as int) as _grouping,
-            cast(cast(percentile as numeric) as int) as percentile,
-            cast(
-                cast(algebra_and_algebraic_thinking_scale_score as numeric) as int
-            ) as algebra_and_algebraic_thinking_scale_score,
-            cast(
-                cast(comprehension_informational_text_scale_score as numeric) as int
-            ) as comprehension_informational_text_scale_score,
-            cast(
-                cast(comprehension_literature_scale_score as numeric) as int
-            ) as comprehension_literature_scale_score,
-            cast(
-                cast(comprehension_overall_scale_score as numeric) as int
-            ) as comprehension_overall_scale_score,
-            cast(cast(geometry_scale_score as numeric) as int) as geometry_scale_score,
-            cast(
-                cast(high_frequency_words_scale_score as numeric) as int
-            ) as high_frequency_words_scale_score,
-            cast(
-                cast(measurement_and_data_scale_score as numeric) as int
-            ) as measurement_and_data_scale_score,
-            cast(
-                cast(mid_on_grade_level_scale_score as numeric) as int
-            ) as mid_on_grade_level_scale_score,
-            cast(
-                cast(number_and_operations_scale_score as numeric) as int
-            ) as number_and_operations_scale_score,
-            cast(cast(phonics_scale_score as numeric) as int) as phonics_scale_score,
-            cast(
-                cast(phonological_awareness_scale_score as numeric) as int
-            ) as phonological_awareness_scale_score,
-            cast(
-                cast(
-                    reading_comprehension_informational_text_scale_score as numeric
-                ) as int
-            ) as reading_comprehension_informational_text_scale_score,
-            cast(
-                cast(reading_comprehension_literature_scale_score as numeric) as int
-            ) as reading_comprehension_literature_scale_score,
-            cast(
-                cast(reading_comprehension_overall_scale_score as numeric) as int
-            ) as reading_comprehension_overall_scale_score,
-            cast(
-                cast(vocabulary_scale_score as numeric) as int
-            ) as vocabulary_scale_score,
-
-            coalesce(
-                most_recent_diagnostic_y_n,
-                most_recent_diagnostic_ytd_y_n,
-                most_recent_assessment_ytd_y_n
-            ) as most_recent_diagnostic_ytd_y_n,
-
-            coalesce(
-                baseline_diagnostic_y_n, baseline_assessment_y_n
-            ) as baseline_diagnostic_y_n,
-
-            safe_cast(student_id as int) as student_id,
-
-            parse_date('%m/%d/%Y', `start_date`) as `start_date`,
-            parse_date('%m/%d/%Y', completion_date) as completion_date,
         from source_grade_normalized
     ),
 
     hs_goals as (
         select
-            * except (annual_typical_growth_measure, annual_stretch_growth_measure),
+            * replace (
+                case
+                    when student_grade not in ('9', '10', '11', '12')
+                    then annual_typical_growth_measure
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = 'Mid or Above Grade Level'
+                    then 9
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = 'Early On Grade Level'
+                    then 9
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '1 Grade Level Below'
+                    then 9
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '2 Grade Levels Below'
+                    then 10
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '3 or More Grade Levels Below'
+                    then 12
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = 'Mid or Above Grade Level'
+                    then 4
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = 'Early On Grade Level'
+                    then 4
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '1 Grade Level Below'
+                    then 9
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '2 Grade Levels Below'
+                    then 12
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '3 or More Grade Levels Below'
+                    then 18
+                end as annual_typical_growth_measure,
+                case
+                    when student_grade not in ('9', '10', '11', '12')
+                    then annual_stretch_growth_measure
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = 'Mid or Above Grade Level'
+                    then 12
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = 'Early On Grade Level'
+                    then 21
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '1 Grade Level Below'
+                    then 22
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '2 Grade Levels Below'
+                    then 23
+                    when
+                        _dagster_partition_subject = 'math'
+                        and overall_relative_placement = '3 or More Grade Levels Below'
+                    then 31
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = 'Mid or Above Grade Level'
+                    then 13
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = 'Early On Grade Level'
+                    then 22
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '1 Grade Level Below'
+                    then 25
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '2 Grade Levels Below'
+                    then 36
+                    when
+                        _dagster_partition_subject = 'ela'
+                        and overall_relative_placement = '3 or More Grade Levels Below'
+                    then 50
+                end as annual_stretch_growth_measure
+            ),
 
             if(
                 most_recent_diagnostic_ytd_y_n = 'Y', overall_scale_score, null
@@ -204,95 +265,6 @@ with
                 then 'Two or More Grade Levels Below'
             end as placement_3_level,
 
-            case
-                when student_grade not in ('9', '10', '11', '12')
-                then annual_typical_growth_measure
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = 'Mid or Above Grade Level'
-                then 9
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = 'Early On Grade Level'
-                then 9
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '1 Grade Level Below'
-                then 9
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '2 Grade Levels Below'
-                then 10
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '3 or More Grade Levels Below'
-                then 12
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = 'Mid or Above Grade Level'
-                then 4
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = 'Early On Grade Level'
-                then 4
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '1 Grade Level Below'
-                then 9
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '2 Grade Levels Below'
-                then 12
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '3 or More Grade Levels Below'
-                then 18
-            end as annual_typical_growth_measure,
-
-            case
-                when student_grade not in ('9', '10', '11', '12')
-                then annual_stretch_growth_measure
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = 'Mid or Above Grade Level'
-                then 12
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = 'Early On Grade Level'
-                then 21
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '1 Grade Level Below'
-                then 22
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '2 Grade Levels Below'
-                then 23
-                when
-                    _dagster_partition_subject = 'math'
-                    and overall_relative_placement = '3 or More Grade Levels Below'
-                then 31
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = 'Mid or Above Grade Level'
-                then 13
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = 'Early On Grade Level'
-                then 22
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '1 Grade Level Below'
-                then 25
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '2 Grade Levels Below'
-                then 36
-                when
-                    _dagster_partition_subject = 'ela'
-                    and overall_relative_placement = '3 or More Grade Levels Below'
-                then 50
-            end as annual_stretch_growth_measure,
         from diagnostic_results
     ),
 
@@ -309,10 +281,10 @@ with
 
     calcs as (
         select
-            * except (typical_growth, stretch_growth),
-
-            if(typical_growth > 0, typical_growth, 0) as typical_growth,
-            if(stretch_growth > 0, stretch_growth, 0) as stretch_growth,
+            * replace (
+                if(typical_growth > 0, typical_growth, 0) as typical_growth,
+                if(stretch_growth > 0, stretch_growth, 0) as stretch_growth
+            ),
         from growth_measures
     )
 

--- a/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
+++ b/src/dbt/iready/models/staging/stg_iready__diagnostic_results.sql
@@ -13,7 +13,10 @@ with
                 assessment_gain,
                 baseline_assessment_y_n,
                 most_recent_assessment_ytd_y_n,
-                most_recent_diagnostic_y_n
+                most_recent_diagnostic_y_n,
+                diagnostic_gain,
+                most_recent_diagnostic_ytd_y_n,
+                baseline_diagnostic_y_n
             ) replace (
                 cast(
                     cast(overall_scale_score as numeric) as int
@@ -25,9 +28,6 @@ with
                 cast(
                     percent_progress_to_annual_typical_growth_percent as numeric
                 ) as percent_progress_to_annual_typical_growth_percent,
-                cast(
-                    cast(coalesce(diagnostic_gain, assessment_gain) as numeric) as int
-                ) as diagnostic_gain,
                 cast(
                     cast(annual_stretch_growth_measure as numeric) as int
                 ) as annual_stretch_growth_measure,
@@ -82,14 +82,6 @@ with
                 cast(
                     cast(vocabulary_scale_score as numeric) as int
                 ) as vocabulary_scale_score,
-                coalesce(
-                    most_recent_diagnostic_y_n,
-                    most_recent_diagnostic_ytd_y_n,
-                    most_recent_assessment_ytd_y_n
-                ) as most_recent_diagnostic_ytd_y_n,
-                coalesce(
-                    baseline_diagnostic_y_n, baseline_assessment_y_n
-                ) as baseline_diagnostic_y_n,
                 safe_cast(student_id as int) as student_id,
                 parse_date('%m/%d/%Y', `start_date`) as `start_date`,
                 parse_date('%m/%d/%Y', completion_date) as completion_date
@@ -97,102 +89,24 @@ with
 
             _dagster_partition_academic_year as academic_year_int,
             cast(cast(student_grade_numeric as numeric) as int) as student_grade_int,
+            cast(
+                cast(coalesce(diagnostic_gain, assessment_gain) as numeric) as int
+            ) as diagnostic_gain,
             cast(cast(`grouping` as numeric) as int) as _grouping,
+            coalesce(
+                most_recent_diagnostic_y_n,
+                most_recent_diagnostic_ytd_y_n,
+                most_recent_assessment_ytd_y_n
+            ) as most_recent_diagnostic_ytd_y_n,
+            coalesce(
+                baseline_diagnostic_y_n, baseline_assessment_y_n
+            ) as baseline_diagnostic_y_n,
         from source_grade_normalized
     ),
 
     hs_goals as (
         select
-            * replace (
-                case
-                    when student_grade not in ('9', '10', '11', '12')
-                    then annual_typical_growth_measure
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = 'Mid or Above Grade Level'
-                    then 9
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = 'Early On Grade Level'
-                    then 9
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '1 Grade Level Below'
-                    then 9
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '2 Grade Levels Below'
-                    then 10
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '3 or More Grade Levels Below'
-                    then 12
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = 'Mid or Above Grade Level'
-                    then 4
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = 'Early On Grade Level'
-                    then 4
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '1 Grade Level Below'
-                    then 9
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '2 Grade Levels Below'
-                    then 12
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '3 or More Grade Levels Below'
-                    then 18
-                end as annual_typical_growth_measure,
-                case
-                    when student_grade not in ('9', '10', '11', '12')
-                    then annual_stretch_growth_measure
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = 'Mid or Above Grade Level'
-                    then 12
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = 'Early On Grade Level'
-                    then 21
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '1 Grade Level Below'
-                    then 22
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '2 Grade Levels Below'
-                    then 23
-                    when
-                        _dagster_partition_subject = 'math'
-                        and overall_relative_placement = '3 or More Grade Levels Below'
-                    then 31
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = 'Mid or Above Grade Level'
-                    then 13
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = 'Early On Grade Level'
-                    then 22
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '1 Grade Level Below'
-                    then 25
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '2 Grade Levels Below'
-                    then 36
-                    when
-                        _dagster_partition_subject = 'ela'
-                        and overall_relative_placement = '3 or More Grade Levels Below'
-                    then 50
-                end as annual_stretch_growth_measure
-            ),
+            * except (annual_typical_growth_measure, annual_stretch_growth_measure),
 
             if(
                 most_recent_diagnostic_ytd_y_n = 'Y', overall_scale_score, null
@@ -265,6 +179,95 @@ with
                 then 'Two or More Grade Levels Below'
             end as placement_3_level,
 
+            case
+                when student_grade not in ('9', '10', '11', '12')
+                then annual_typical_growth_measure
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = 'Mid or Above Grade Level'
+                then 9
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = 'Early On Grade Level'
+                then 9
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '1 Grade Level Below'
+                then 9
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '2 Grade Levels Below'
+                then 10
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '3 or More Grade Levels Below'
+                then 12
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = 'Mid or Above Grade Level'
+                then 4
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = 'Early On Grade Level'
+                then 4
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '1 Grade Level Below'
+                then 9
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '2 Grade Levels Below'
+                then 12
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '3 or More Grade Levels Below'
+                then 18
+            end as annual_typical_growth_measure,
+
+            case
+                when student_grade not in ('9', '10', '11', '12')
+                then annual_stretch_growth_measure
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = 'Mid or Above Grade Level'
+                then 12
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = 'Early On Grade Level'
+                then 21
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '1 Grade Level Below'
+                then 22
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '2 Grade Levels Below'
+                then 23
+                when
+                    _dagster_partition_subject = 'math'
+                    and overall_relative_placement = '3 or More Grade Levels Below'
+                then 31
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = 'Mid or Above Grade Level'
+                then 13
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = 'Early On Grade Level'
+                then 22
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '1 Grade Level Below'
+                then 25
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '2 Grade Levels Below'
+                then 36
+                when
+                    _dagster_partition_subject = 'ela'
+                    and overall_relative_placement = '3 or More Grade Levels Below'
+                then 50
+            end as annual_stretch_growth_measure,
         from diagnostic_results
     ),
 
@@ -281,10 +284,10 @@ with
 
     calcs as (
         select
-            * replace (
-                if(typical_growth > 0, typical_growth, 0) as typical_growth,
-                if(stretch_growth > 0, stretch_growth, 0) as stretch_growth
-            ),
+            * except (typical_growth, stretch_growth),
+
+            if(typical_growth > 0, typical_growth, 0) as typical_growth,
+            if(stretch_growth > 0, stretch_growth, 0) as stretch_growth,
         from growth_measures
     )
 

--- a/src/dbt/iready/models/staging/stg_iready__instruction_by_lesson_pro.sql
+++ b/src/dbt/iready/models/staging/stg_iready__instruction_by_lesson_pro.sql
@@ -10,12 +10,12 @@ select
     lesson_language,
     lesson_title,
 
-    cast(lesson_time_on_task_min as int) as lesson_time_on_task_min,
-    cast(skills_completed as int) as skills_completed,
-    cast(skills_successful as int) as skills_successful,
+    cast(cast(lesson_time_on_task_min as numeric) as int) as lesson_time_on_task_min,
+    cast(cast(skills_completed as numeric) as int) as skills_completed,
+    cast(cast(skills_successful as numeric) as int) as skills_successful,
     cast(percent_skills_successful as numeric) as percent_skills_successful,
-    cast(items_completed as int) as items_completed,
-    cast(items_correct as int) as items_correct,
+    cast(cast(items_completed as numeric) as int) as items_completed,
+    cast(cast(items_correct as numeric) as int) as items_correct,
     cast(percent_items_correct as numeric) as percent_items_correct,
 
     safe_cast(student_id as int) as student_id,

--- a/src/dbt/iready/models/staging/stg_iready__instructional_usage_data.sql
+++ b/src/dbt/iready/models/staging/stg_iready__instructional_usage_data.sql
@@ -116,133 +116,181 @@ select
         year_to_date_vocabulary_percent_lessons_passed as numeric
     ) as year_to_date_vocabulary_percent_lessons_passed,
     cast(_dagster_partition_academic_year as int) as _dagster_partition_academic_year,
-    cast(april_lessons_completed as int) as april_lessons_completed,
-    cast(april_total_time_on_task_min as int) as april_total_time_on_task_min,
+    cast(cast(april_lessons_completed as numeric) as int) as april_lessons_completed,
     cast(
-        april_weekly_average_time_on_task_min as int
+        cast(april_total_time_on_task_min as numeric) as int
+    ) as april_total_time_on_task_min,
+    cast(
+        cast(april_weekly_average_time_on_task_min as numeric) as int
     ) as april_weekly_average_time_on_task_min,
-    cast(august_lessons_completed as int) as august_lessons_completed,
-    cast(august_total_time_on_task_min as int) as august_total_time_on_task_min,
+    cast(cast(august_lessons_completed as numeric) as int) as august_lessons_completed,
     cast(
-        august_weekly_average_time_on_task_min as int
+        cast(august_total_time_on_task_min as numeric) as int
+    ) as august_total_time_on_task_min,
+    cast(
+        cast(august_weekly_average_time_on_task_min as numeric) as int
     ) as august_weekly_average_time_on_task_min,
-    cast(december_lessons_completed as int) as december_lessons_completed,
-    cast(december_total_time_on_task_min as int) as december_total_time_on_task_min,
     cast(
-        december_weekly_average_time_on_task_min as int
+        cast(december_lessons_completed as numeric) as int
+    ) as december_lessons_completed,
+    cast(
+        cast(december_total_time_on_task_min as numeric) as int
+    ) as december_total_time_on_task_min,
+    cast(
+        cast(december_weekly_average_time_on_task_min as numeric) as int
     ) as december_weekly_average_time_on_task_min,
-    cast(february_lessons_completed as int) as february_lessons_completed,
-    cast(february_total_time_on_task_min as int) as february_total_time_on_task_min,
     cast(
-        february_weekly_average_time_on_task_min as int
+        cast(february_lessons_completed as numeric) as int
+    ) as february_lessons_completed,
+    cast(
+        cast(february_total_time_on_task_min as numeric) as int
+    ) as february_total_time_on_task_min,
+    cast(
+        cast(february_weekly_average_time_on_task_min as numeric) as int
     ) as february_weekly_average_time_on_task_min,
-    cast(january_lessons_completed as int) as january_lessons_completed,
-    cast(january_total_time_on_task_min as int) as january_total_time_on_task_min,
     cast(
-        january_weekly_average_time_on_task_min as int
+        cast(january_lessons_completed as numeric) as int
+    ) as january_lessons_completed,
+    cast(
+        cast(january_total_time_on_task_min as numeric) as int
+    ) as january_total_time_on_task_min,
+    cast(
+        cast(january_weekly_average_time_on_task_min as numeric) as int
     ) as january_weekly_average_time_on_task_min,
-    cast(july_lessons_completed as int) as july_lessons_completed,
-    cast(july_total_time_on_task_min as int) as july_total_time_on_task_min,
+    cast(cast(july_lessons_completed as numeric) as int) as july_lessons_completed,
     cast(
-        july_weekly_average_time_on_task_min as int
+        cast(july_total_time_on_task_min as numeric) as int
+    ) as july_total_time_on_task_min,
+    cast(
+        cast(july_weekly_average_time_on_task_min as numeric) as int
     ) as july_weekly_average_time_on_task_min,
-    cast(june_lessons_completed as int) as june_lessons_completed,
-    cast(june_total_time_on_task_min as int) as june_total_time_on_task_min,
+    cast(cast(june_lessons_completed as numeric) as int) as june_lessons_completed,
     cast(
-        june_weekly_average_time_on_task_min as int
+        cast(june_total_time_on_task_min as numeric) as int
+    ) as june_total_time_on_task_min,
+    cast(
+        cast(june_weekly_average_time_on_task_min as numeric) as int
     ) as june_weekly_average_time_on_task_min,
-    cast(last_week_lessons_completed as int) as last_week_lessons_completed,
-    cast(last_week_time_on_task_min as int) as last_week_time_on_task_min,
-    cast(march_lessons_completed as int) as march_lessons_completed,
-    cast(march_total_time_on_task_min as int) as march_total_time_on_task_min,
     cast(
-        march_weekly_average_time_on_task_min as int
+        cast(last_week_lessons_completed as numeric) as int
+    ) as last_week_lessons_completed,
+    cast(
+        cast(last_week_time_on_task_min as numeric) as int
+    ) as last_week_time_on_task_min,
+    cast(cast(march_lessons_completed as numeric) as int) as march_lessons_completed,
+    cast(
+        cast(march_total_time_on_task_min as numeric) as int
+    ) as march_total_time_on_task_min,
+    cast(
+        cast(march_weekly_average_time_on_task_min as numeric) as int
     ) as march_weekly_average_time_on_task_min,
-    cast(may_lessons_completed as int) as may_lessons_completed,
-    cast(may_total_time_on_task_min as int) as may_total_time_on_task_min,
+    cast(cast(may_lessons_completed as numeric) as int) as may_lessons_completed,
     cast(
-        may_weekly_average_time_on_task_min as int
+        cast(may_total_time_on_task_min as numeric) as int
+    ) as may_total_time_on_task_min,
+    cast(
+        cast(may_weekly_average_time_on_task_min as numeric) as int
     ) as may_weekly_average_time_on_task_min,
-    cast(november_lessons_completed as int) as november_lessons_completed,
-    cast(november_total_time_on_task_min as int) as november_total_time_on_task_min,
     cast(
-        november_weekly_average_time_on_task_min as int
+        cast(november_lessons_completed as numeric) as int
+    ) as november_lessons_completed,
+    cast(
+        cast(november_total_time_on_task_min as numeric) as int
+    ) as november_total_time_on_task_min,
+    cast(
+        cast(november_weekly_average_time_on_task_min as numeric) as int
     ) as november_weekly_average_time_on_task_min,
-    cast(october_lessons_completed as int) as october_lessons_completed,
-    cast(october_total_time_on_task_min as int) as october_total_time_on_task_min,
     cast(
-        october_weekly_average_time_on_task_min as int
+        cast(october_lessons_completed as numeric) as int
+    ) as october_lessons_completed,
+    cast(
+        cast(october_total_time_on_task_min as numeric) as int
+    ) as october_total_time_on_task_min,
+    cast(
+        cast(october_weekly_average_time_on_task_min as numeric) as int
     ) as october_weekly_average_time_on_task_min,
-    cast(september_lessons_completed as int) as september_lessons_completed,
-    cast(september_total_time_on_task_min as int) as september_total_time_on_task_min,
     cast(
-        september_weekly_average_time_on_task_min as int
+        cast(september_lessons_completed as numeric) as int
+    ) as september_lessons_completed,
+    cast(
+        cast(september_total_time_on_task_min as numeric) as int
+    ) as september_total_time_on_task_min,
+    cast(
+        cast(september_weekly_average_time_on_task_min as numeric) as int
     ) as september_weekly_average_time_on_task_min,
     cast(
-        year_to_date_algebra_and_algebraic_thinking_lessons_completed as int
+        cast(
+            year_to_date_algebra_and_algebraic_thinking_lessons_completed as numeric
+        ) as int
     ) as year_to_date_algebra_and_algebraic_thinking_lessons_completed,
     cast(
-        year_to_date_algebra_and_algebraic_thinking_time_on_task_min as int
+        cast(
+            year_to_date_algebra_and_algebraic_thinking_time_on_task_min as numeric
+        ) as int
     ) as year_to_date_algebra_and_algebraic_thinking_time_on_task_min,
     cast(
-        year_to_date_comprehension_close_reading_lessons_completed as int
+        cast(
+            year_to_date_comprehension_close_reading_lessons_completed as numeric
+        ) as int
     ) as year_to_date_comprehension_close_reading_lessons_completed,
     cast(
-        year_to_date_comprehension_close_reading_time_on_task_min as int
+        cast(
+            year_to_date_comprehension_close_reading_time_on_task_min as numeric
+        ) as int
     ) as year_to_date_comprehension_close_reading_time_on_task_min,
     cast(
-        year_to_date_comprehension_lessons_completed as int
+        cast(year_to_date_comprehension_lessons_completed as numeric) as int
     ) as year_to_date_comprehension_lessons_completed,
     cast(
-        year_to_date_comprehension_time_on_task_min as int
+        cast(year_to_date_comprehension_time_on_task_min as numeric) as int
     ) as year_to_date_comprehension_time_on_task_min,
     cast(
-        year_to_date_geometry_lessons_completed as int
+        cast(year_to_date_geometry_lessons_completed as numeric) as int
     ) as year_to_date_geometry_lessons_completed,
     cast(
-        year_to_date_geometry_time_on_task_min as int
+        cast(year_to_date_geometry_time_on_task_min as numeric) as int
     ) as year_to_date_geometry_time_on_task_min,
     cast(
-        year_to_date_high_frequency_words_lessons_completed as int
+        cast(year_to_date_high_frequency_words_lessons_completed as numeric) as int
     ) as year_to_date_high_frequency_words_lessons_completed,
     cast(
-        year_to_date_high_frequency_words_time_on_task_min as int
+        cast(year_to_date_high_frequency_words_time_on_task_min as numeric) as int
     ) as year_to_date_high_frequency_words_time_on_task_min,
     cast(
-        year_to_date_measurement_and_data_lessons_completed as int
+        cast(year_to_date_measurement_and_data_lessons_completed as numeric) as int
     ) as year_to_date_measurement_and_data_lessons_completed,
     cast(
-        year_to_date_measurement_and_data_time_on_task_min as int
+        cast(year_to_date_measurement_and_data_time_on_task_min as numeric) as int
     ) as year_to_date_measurement_and_data_time_on_task_min,
     cast(
-        year_to_date_number_and_operations_lessons_completed as int
+        cast(year_to_date_number_and_operations_lessons_completed as numeric) as int
     ) as year_to_date_number_and_operations_lessons_completed,
     cast(
-        year_to_date_number_and_operations_time_on_task_min as int
+        cast(year_to_date_number_and_operations_time_on_task_min as numeric) as int
     ) as year_to_date_number_and_operations_time_on_task_min,
     cast(
-        year_to_date_overall_lessons_completed as int
+        cast(year_to_date_overall_lessons_completed as numeric) as int
     ) as year_to_date_overall_lessons_completed,
     cast(
-        year_to_date_overall_time_on_task_min as int
+        cast(year_to_date_overall_time_on_task_min as numeric) as int
     ) as year_to_date_overall_time_on_task_min,
     cast(
-        year_to_date_phonics_lessons_completed as int
+        cast(year_to_date_phonics_lessons_completed as numeric) as int
     ) as year_to_date_phonics_lessons_completed,
     cast(
-        year_to_date_phonics_time_on_task_min as int
+        cast(year_to_date_phonics_time_on_task_min as numeric) as int
     ) as year_to_date_phonics_time_on_task_min,
     cast(
-        year_to_date_phonological_awareness_lessons_completed as int
+        cast(year_to_date_phonological_awareness_lessons_completed as numeric) as int
     ) as year_to_date_phonological_awareness_lessons_completed,
     cast(
-        year_to_date_phonological_awareness_time_on_task_min as int
+        cast(year_to_date_phonological_awareness_time_on_task_min as numeric) as int
     ) as year_to_date_phonological_awareness_time_on_task_min,
     cast(
-        year_to_date_vocabulary_lessons_completed as int
+        cast(year_to_date_vocabulary_lessons_completed as numeric) as int
     ) as year_to_date_vocabulary_lessons_completed,
     cast(
-        year_to_date_vocabulary_time_on_task_min as int
+        cast(year_to_date_vocabulary_time_on_task_min as numeric) as int
     ) as year_to_date_vocabulary_time_on_task_min,
 
     safe_cast(student_id as int) as student_id,

--- a/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
+++ b/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
@@ -132,9 +132,11 @@ select
         ) as int
     ) as geometric_measurement_and_figures_skills_successful,
     cast(
-        -- trunk-ignore(sqlfluff/LT05): vendor column name exceeds 88 chars
-        i_ready_pro_number_relationships_and_operation_concepts_percent_k_2_skills_successful
-        as int
+        cast(
+            -- trunk-ignore(sqlfluff/LT05): vendor column name exceeds 88 chars
+            i_ready_pro_number_relationships_and_operation_concepts_percent_k_2_skills_successful
+            as numeric
+        ) as int
     ) as number_relationships_and_operation_concepts_percent_k_2_skills_successful,
     cast(
         cast(

--- a/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
+++ b/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
@@ -21,87 +21,115 @@ select
     user_name,
 
     cast(_dagster_partition_academic_year as int) as academic_year_int,
-    cast(all_lessons_completed as int) as all_lessons_completed,
-    cast(all_lessons_passed as int) as all_lessons_passed,
-    cast(total_lesson_time_on_task_min as int) as total_lesson_time_on_task_min,
+    cast(cast(all_lessons_completed as numeric) as int) as all_lessons_completed,
+    cast(cast(all_lessons_passed as numeric) as int) as all_lessons_passed,
+    cast(
+        cast(total_lesson_time_on_task_min as numeric) as int
+    ) as total_lesson_time_on_task_min,
     cast(percent_all_lessons_passed as numeric) as percent_all_lessons_passed,
 
     cast(
-        i_ready_algebra_and_algebraic_thinking_lessons_completed as int
+        cast(i_ready_algebra_and_algebraic_thinking_lessons_completed as numeric) as int
     ) as algebra_and_algebraic_thinking_lessons_completed,
     cast(
-        i_ready_algebra_and_algebraic_thinking_lessons_passed as int
+        cast(i_ready_algebra_and_algebraic_thinking_lessons_passed as numeric) as int
     ) as algebra_and_algebraic_thinking_lessons_passed,
     cast(
-        i_ready_algebra_and_algebraic_thinking_percent_lessons_passed as int
+        cast(
+            i_ready_algebra_and_algebraic_thinking_percent_lessons_passed as numeric
+        ) as int
     ) as algebra_and_algebraic_thinking_percent_lessons_passed,
-    cast(i_ready_geometry_lessons_completed as int) as geometry_lessons_completed,
-    cast(i_ready_geometry_lessons_passed as int) as geometry_lessons_passed,
     cast(
-        i_ready_geometry_percent_lessons_passed as int
+        cast(i_ready_geometry_lessons_completed as numeric) as int
+    ) as geometry_lessons_completed,
+    cast(
+        cast(i_ready_geometry_lessons_passed as numeric) as int
+    ) as geometry_lessons_passed,
+    cast(
+        cast(i_ready_geometry_percent_lessons_passed as numeric) as int
     ) as geometry_percent_lessons_passed,
     cast(
-        i_ready_measurement_and_data_lessons_completed as int
+        cast(i_ready_measurement_and_data_lessons_completed as numeric) as int
     ) as measurement_and_data_lessons_completed,
     cast(
-        i_ready_measurement_and_data_lessons_passed as int
+        cast(i_ready_measurement_and_data_lessons_passed as numeric) as int
     ) as measurement_and_data_lessons_passed,
     cast(
-        i_ready_measurement_and_data_percent_lessons_passed as int
+        cast(i_ready_measurement_and_data_percent_lessons_passed as numeric) as int
     ) as measurement_and_data_percent_lessons_passed,
     cast(
-        i_ready_number_and_operations_lessons_completed as int
+        cast(i_ready_number_and_operations_lessons_completed as numeric) as int
     ) as number_and_operations_lessons_completed,
     cast(
-        i_ready_number_and_operations_lessons_passed as int
+        cast(i_ready_number_and_operations_lessons_passed as numeric) as int
     ) as number_and_operations_lessons_passed,
     cast(
-        i_ready_number_and_operations_percent_lessons_passed as int
+        cast(i_ready_number_and_operations_percent_lessons_passed as numeric) as int
     ) as number_and_operations_percent_lessons_passed,
     cast(
-        i_ready_pro_data_statistics_and_probability_percent_skills_successful as int
+        cast(
+            i_ready_pro_data_statistics_and_probability_percent_skills_successful
+            as numeric
+        ) as int
     ) as data_statistics_and_probability_percent_skills_successful,
     cast(
-        i_ready_pro_data_statistics_and_probability_skills_completed as int
+        cast(
+            i_ready_pro_data_statistics_and_probability_skills_completed as numeric
+        ) as int
     ) as data_statistics_and_probability_skills_completed,
     cast(
-        i_ready_pro_data_statistics_and_probability_skills_successful as int
+        cast(
+            i_ready_pro_data_statistics_and_probability_skills_successful as numeric
+        ) as int
     ) as data_statistics_and_probability_skills_successful,
     cast(
-        i_ready_pro_decimals_and_operations_percent_skills_successful as int
+        cast(
+            i_ready_pro_decimals_and_operations_percent_skills_successful as numeric
+        ) as int
     ) as decimals_and_operations_percent_skills_successful,
     cast(
-        i_ready_pro_decimals_and_operations_skills_completed as int
+        cast(i_ready_pro_decimals_and_operations_skills_completed as numeric) as int
     ) as decimals_and_operations_skills_completed,
     cast(
-        i_ready_pro_decimals_and_operations_skills_successful as int
+        cast(i_ready_pro_decimals_and_operations_skills_successful as numeric) as int
     ) as decimals_and_operations_skills_successful,
     cast(
-        i_ready_pro_equations_and_functions_percent_skills_successful as int
+        cast(
+            i_ready_pro_equations_and_functions_percent_skills_successful as numeric
+        ) as int
     ) as equations_and_functions_percent_skills_successful,
     cast(
-        i_ready_pro_equations_and_functions_skills_completed as int
+        cast(i_ready_pro_equations_and_functions_skills_completed as numeric) as int
     ) as equations_and_functions_skills_completed,
     cast(
-        i_ready_pro_equations_and_functions_skills_successful as int
+        cast(i_ready_pro_equations_and_functions_skills_successful as numeric) as int
     ) as equations_and_functions_skills_successful,
     cast(
-        i_ready_pro_fractions_and_operations_percent_skills_successful as int
+        cast(
+            i_ready_pro_fractions_and_operations_percent_skills_successful as numeric
+        ) as int
     ) as fractions_and_operations_percent_skills_successful,
     cast(
-        i_ready_pro_fractions_and_operations_skills_completed as int
+        cast(i_ready_pro_fractions_and_operations_skills_completed as numeric) as int
     ) as fractions_and_operations_skills_completed,
     cast(
-        i_ready_pro_fractions_and_operations_skills_successful as int
+        cast(i_ready_pro_fractions_and_operations_skills_successful as numeric) as int
     ) as fractions_and_operations_skills_successful,
     cast(
-        i_ready_pro_geometric_measurement_and_figures_percent_skills_successful as int
+        cast(
+            i_ready_pro_geometric_measurement_and_figures_percent_skills_successful
+            as numeric
+        ) as int
     ) as geometric_measurement_and_figures_percent_skills_successful,
     cast(
-        i_ready_pro_geometric_measurement_and_figures_skills_completed as int
+        cast(
+            i_ready_pro_geometric_measurement_and_figures_skills_completed as numeric
+        ) as int
     ) as geometric_measurement_and_figures_skills_completed,
     cast(
-        i_ready_pro_geometric_measurement_and_figures_skills_successful as int
+        cast(
+            i_ready_pro_geometric_measurement_and_figures_skills_successful as numeric
+        ) as int
     ) as geometric_measurement_and_figures_skills_successful,
     cast(
         -- trunk-ignore(sqlfluff/LT05): vendor column name exceeds 88 chars
@@ -109,155 +137,184 @@ select
         as int
     ) as number_relationships_and_operation_concepts_percent_k_2_skills_successful,
     cast(
-        i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_completed
-        as int
+        cast(
+            i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_completed
+            as numeric
+        ) as int
     ) as number_relationships_and_operation_concepts_k_2_skills_completed,
     cast(
-        i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_successful
-        as int
+        cast(
+            -- trunk-ignore(sqlfluff/LT05): 77-char column name, can't wrap
+            i_ready_pro_number_relationships_and_operation_concepts_k_2_skills_successful
+            as numeric
+        ) as int
     ) as number_relationships_and_operation_concepts_k_2_skills_successful,
     cast(
-        i_ready_pro_number_sense_percent_k_2_skills_successful as int
+        cast(i_ready_pro_number_sense_percent_k_2_skills_successful as numeric) as int
     ) as number_sense_percent_k_2_skills_successful,
     cast(
-        i_ready_pro_number_sense_k_2_skills_completed as int
+        cast(i_ready_pro_number_sense_k_2_skills_completed as numeric) as int
     ) as number_sense_k_2_skills_completed,
     cast(
-        i_ready_pro_number_sense_k_2_skills_successful as int
+        cast(i_ready_pro_number_sense_k_2_skills_successful as numeric) as int
     ) as number_sense_k_2_skills_successful,
     cast(
-        i_ready_pro_rational_numbers_and_operations_percent_skills_successful as int
+        cast(
+            i_ready_pro_rational_numbers_and_operations_percent_skills_successful
+            as numeric
+        ) as int
     ) as rational_numbers_and_operations_percent_skills_successful,
     cast(
-        i_ready_pro_rational_numbers_and_operations_skills_completed as int
+        cast(
+            i_ready_pro_rational_numbers_and_operations_skills_completed as numeric
+        ) as int
     ) as rational_numbers_and_operations_skills_completed,
     cast(
-        i_ready_pro_rational_numbers_and_operations_skills_successful as int
+        cast(
+            i_ready_pro_rational_numbers_and_operations_skills_successful as numeric
+        ) as int
     ) as rational_numbers_and_operations_skills_successful,
     cast(
-        i_ready_pro_ratios_and_proportions_percent_skills_successful as int
+        cast(
+            i_ready_pro_ratios_and_proportions_percent_skills_successful as numeric
+        ) as int
     ) as ratios_and_proportions_percent_skills_successful,
     cast(
-        i_ready_pro_ratios_and_proportions_skills_completed as int
+        cast(i_ready_pro_ratios_and_proportions_skills_completed as numeric) as int
     ) as ratios_and_proportions_skills_completed,
     cast(
-        i_ready_pro_ratios_and_proportions_skills_successful as int
+        cast(i_ready_pro_ratios_and_proportions_skills_successful as numeric) as int
     ) as ratios_and_proportions_skills_successful,
     cast(
-        i_ready_pro_whole_numbers_and_operations_percent_skills_successful as int
+        cast(
+            i_ready_pro_whole_numbers_and_operations_percent_skills_successful
+            as numeric
+        ) as int
     ) as whole_numbers_and_operations_percent_skills_successful,
     cast(
-        i_ready_pro_whole_numbers_and_operations_skills_completed as int
+        cast(
+            i_ready_pro_whole_numbers_and_operations_skills_completed as numeric
+        ) as int
     ) as whole_numbers_and_operations_skills_completed,
     cast(
-        i_ready_pro_whole_numbers_and_operations_skills_successful as int
+        cast(
+            i_ready_pro_whole_numbers_and_operations_skills_successful as numeric
+        ) as int
     ) as whole_numbers_and_operations_skills_successful,
 
     cast(
-        i_ready_comprehension_close_reading_lessons_completed as int
+        cast(i_ready_comprehension_close_reading_lessons_completed as numeric) as int
     ) as comprehension_close_reading_lessons_completed,
     cast(
-        i_ready_comprehension_close_reading_lessons_passed as int
+        cast(i_ready_comprehension_close_reading_lessons_passed as numeric) as int
     ) as comprehension_close_reading_lessons_passed,
     cast(
-        i_ready_comprehension_close_reading_percent_lessons_passed as int
+        cast(
+            i_ready_comprehension_close_reading_percent_lessons_passed as numeric
+        ) as int
     ) as comprehension_close_reading_percent_lessons_passed,
     cast(
-        i_ready_high_frequency_words_lessons_completed as int
+        cast(i_ready_high_frequency_words_lessons_completed as numeric) as int
     ) as high_frequency_words_lessons_completed,
     cast(
-        i_ready_high_frequency_words_lessons_passed as int
+        cast(i_ready_high_frequency_words_lessons_passed as numeric) as int
     ) as high_frequency_words_lessons_passed,
     cast(
-        i_ready_high_frequency_words_percent_lessons_passed as int
+        cast(i_ready_high_frequency_words_percent_lessons_passed as numeric) as int
     ) as high_frequency_words_percent_lessons_passed,
-    cast(i_ready_phonics_lessons_completed as int) as phonics_lessons_completed,
-    cast(i_ready_phonics_lessons_passed as int) as phonics_lessons_passed,
     cast(
-        i_ready_phonics_percent_lessons_passed as int
+        cast(i_ready_phonics_lessons_completed as numeric) as int
+    ) as phonics_lessons_completed,
+    cast(
+        cast(i_ready_phonics_lessons_passed as numeric) as int
+    ) as phonics_lessons_passed,
+    cast(
+        cast(i_ready_phonics_percent_lessons_passed as numeric) as int
     ) as phonics_percent_lessons_passed,
     cast(
-        i_ready_phonological_awareness_lessons_completed as int
+        cast(i_ready_phonological_awareness_lessons_completed as numeric) as int
     ) as phonological_awareness_lessons_completed,
     cast(
-        i_ready_phonological_awareness_lessons_passed as int
+        cast(i_ready_phonological_awareness_lessons_passed as numeric) as int
     ) as phonological_awareness_lessons_passed,
     cast(
-        i_ready_phonological_awareness_percent_lessons_passed as int
+        cast(i_ready_phonological_awareness_percent_lessons_passed as numeric) as int
     ) as phonological_awareness_percent_lessons_passed,
     cast(
-        i_ready_pro_endings_affixes_percent_skills_successful as int
+        cast(i_ready_pro_endings_affixes_percent_skills_successful as numeric) as int
     ) as endings_affixes_percent_skills_successful,
     cast(
-        i_ready_pro_endings_affixes_skills_completed as int
+        cast(i_ready_pro_endings_affixes_skills_completed as numeric) as int
     ) as endings_affixes_skills_completed,
     cast(
-        i_ready_pro_endings_affixes_skills_successful as int
+        cast(i_ready_pro_endings_affixes_skills_successful as numeric) as int
     ) as endings_affixes_skills_successful,
     cast(
-        i_ready_pro_high_frequency_words_percent_skills_successful as int
+        cast(
+            i_ready_pro_high_frequency_words_percent_skills_successful as numeric
+        ) as int
     ) as high_frequency_words_percent_skills_successful,
     cast(
-        i_ready_pro_high_frequency_words_skills_completed as int
+        cast(i_ready_pro_high_frequency_words_skills_completed as numeric) as int
     ) as high_frequency_words_skills_completed,
     cast(
-        i_ready_pro_high_frequency_words_skills_successful as int
+        cast(i_ready_pro_high_frequency_words_skills_successful as numeric) as int
     ) as high_frequency_words_skills_successful,
     cast(
-        i_ready_pro_language_structures_lessons_completed as int
+        cast(i_ready_pro_language_structures_lessons_completed as numeric) as int
     ) as language_structures_lessons_completed,
     cast(
-        i_ready_pro_language_structures_lessons_passed as int
+        cast(i_ready_pro_language_structures_lessons_passed as numeric) as int
     ) as language_structures_lessons_passed,
     cast(
-        i_ready_pro_language_structures_percent_lessons_passed as int
+        cast(i_ready_pro_language_structures_percent_lessons_passed as numeric) as int
     ) as language_structures_percent_lessons_passed,
     cast(
-        i_ready_pro_multi_syllable_percent_skills_successful as int
+        cast(i_ready_pro_multi_syllable_percent_skills_successful as numeric) as int
     ) as multi_syllable_percent_skills_successful,
     cast(
-        i_ready_pro_multi_syllable_skills_completed as int
+        cast(i_ready_pro_multi_syllable_skills_completed as numeric) as int
     ) as multi_syllable_skills_completed,
     cast(
-        i_ready_pro_multi_syllable_skills_successful as int
+        cast(i_ready_pro_multi_syllable_skills_successful as numeric) as int
     ) as multi_syllable_skills_successful,
     cast(
-        i_ready_pro_single_syllable_percent_skills_successful as int
+        cast(i_ready_pro_single_syllable_percent_skills_successful as numeric) as int
     ) as single_syllable_percent_skills_successful,
     cast(
-        i_ready_pro_single_syllable_skills_completed as int
+        cast(i_ready_pro_single_syllable_skills_completed as numeric) as int
     ) as single_syllable_skills_completed,
     cast(
-        i_ready_pro_single_syllable_skills_successful as int
+        cast(i_ready_pro_single_syllable_skills_successful as numeric) as int
     ) as single_syllable_skills_successful,
 
     coalesce(
-        cast(i_ready_comprehension_lessons_completed as int),
-        cast(i_ready_pro_comprehension_lessons_completed as int)
+        cast(cast(i_ready_comprehension_lessons_completed as numeric) as int),
+        cast(cast(i_ready_pro_comprehension_lessons_completed as numeric) as int)
     ) as comprehension_lessons_completed,
 
     coalesce(
-        cast(i_ready_comprehension_lessons_passed as int),
-        cast(i_ready_pro_comprehension_lessons_passed as int)
+        cast(cast(i_ready_comprehension_lessons_passed as numeric) as int),
+        cast(cast(i_ready_pro_comprehension_lessons_passed as numeric) as int)
     ) as comprehension_lessons_passed,
 
     coalesce(
-        cast(i_ready_comprehension_percent_lessons_passed as int),
-        cast(i_ready_pro_comprehension_percent_lessons_passed as int)
+        cast(cast(i_ready_comprehension_percent_lessons_passed as numeric) as int),
+        cast(cast(i_ready_pro_comprehension_percent_lessons_passed as numeric) as int)
     ) as comprehension_percent_lessons_passed,
     coalesce(
-        cast(i_ready_vocabulary_lessons_completed as int),
-        cast(i_ready_pro_vocabulary_lessons_completed as int)
+        cast(cast(i_ready_vocabulary_lessons_completed as numeric) as int),
+        cast(cast(i_ready_pro_vocabulary_lessons_completed as numeric) as int)
     ) as vocabulary_lessons_completed,
 
     coalesce(
-        cast(i_ready_vocabulary_lessons_passed as int),
-        cast(i_ready_pro_vocabulary_lessons_passed as int)
+        cast(cast(i_ready_vocabulary_lessons_passed as numeric) as int),
+        cast(cast(i_ready_pro_vocabulary_lessons_passed as numeric) as int)
     ) as vocabulary_lessons_passed,
 
     coalesce(
-        cast(i_ready_vocabulary_percent_lessons_passed as int),
-        cast(i_ready_pro_vocabulary_percent_lessons_passed as int)
+        cast(cast(i_ready_vocabulary_percent_lessons_passed as numeric) as int),
+        cast(cast(i_ready_pro_vocabulary_percent_lessons_passed as numeric) as int)
     ) as vocabulary_percent_lessons_passed,
 
     safe_cast(student_id as int) as student_id,

--- a/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
+++ b/src/dbt/iready/models/staging/stg_iready__personalized_instruction_summary.sql
@@ -1,3 +1,46 @@
+with
+    typed as (
+        select
+            *,
+            cast(
+                cast(i_ready_comprehension_lessons_completed as numeric) as int
+            ) as comprehension_lessons_completed_i_ready,
+            cast(
+                cast(i_ready_pro_comprehension_lessons_completed as numeric) as int
+            ) as comprehension_lessons_completed_i_ready_pro,
+            cast(
+                cast(i_ready_comprehension_lessons_passed as numeric) as int
+            ) as comprehension_lessons_passed_i_ready,
+            cast(
+                cast(i_ready_pro_comprehension_lessons_passed as numeric) as int
+            ) as comprehension_lessons_passed_i_ready_pro,
+            cast(
+                cast(i_ready_comprehension_percent_lessons_passed as numeric) as int
+            ) as comprehension_percent_lessons_passed_i_ready,
+            cast(
+                cast(i_ready_pro_comprehension_percent_lessons_passed as numeric) as int
+            ) as comprehension_percent_lessons_passed_i_ready_pro,
+            cast(
+                cast(i_ready_vocabulary_lessons_completed as numeric) as int
+            ) as vocabulary_lessons_completed_i_ready,
+            cast(
+                cast(i_ready_pro_vocabulary_lessons_completed as numeric) as int
+            ) as vocabulary_lessons_completed_i_ready_pro,
+            cast(
+                cast(i_ready_vocabulary_lessons_passed as numeric) as int
+            ) as vocabulary_lessons_passed_i_ready,
+            cast(
+                cast(i_ready_pro_vocabulary_lessons_passed as numeric) as int
+            ) as vocabulary_lessons_passed_i_ready_pro,
+            cast(
+                cast(i_ready_vocabulary_percent_lessons_passed as numeric) as int
+            ) as vocabulary_percent_lessons_passed_i_ready,
+            cast(
+                cast(i_ready_pro_vocabulary_percent_lessons_passed as numeric) as int
+            ) as vocabulary_percent_lessons_passed_i_ready_pro,
+        from {{ source("iready", "src_iready__personalized_instruction_summary") }}
+    )
+
 select
     _dagster_partition_subject,
     academic_year,
@@ -291,36 +334,33 @@ select
     ) as single_syllable_skills_successful,
 
     coalesce(
-        cast(cast(i_ready_comprehension_lessons_completed as numeric) as int),
-        cast(cast(i_ready_pro_comprehension_lessons_completed as numeric) as int)
+        comprehension_lessons_completed_i_ready,
+        comprehension_lessons_completed_i_ready_pro
     ) as comprehension_lessons_completed,
 
     coalesce(
-        cast(cast(i_ready_comprehension_lessons_passed as numeric) as int),
-        cast(cast(i_ready_pro_comprehension_lessons_passed as numeric) as int)
+        comprehension_lessons_passed_i_ready, comprehension_lessons_passed_i_ready_pro
     ) as comprehension_lessons_passed,
 
     coalesce(
-        cast(cast(i_ready_comprehension_percent_lessons_passed as numeric) as int),
-        cast(cast(i_ready_pro_comprehension_percent_lessons_passed as numeric) as int)
+        comprehension_percent_lessons_passed_i_ready,
+        comprehension_percent_lessons_passed_i_ready_pro
     ) as comprehension_percent_lessons_passed,
     coalesce(
-        cast(cast(i_ready_vocabulary_lessons_completed as numeric) as int),
-        cast(cast(i_ready_pro_vocabulary_lessons_completed as numeric) as int)
+        vocabulary_lessons_completed_i_ready, vocabulary_lessons_completed_i_ready_pro
     ) as vocabulary_lessons_completed,
 
     coalesce(
-        cast(cast(i_ready_vocabulary_lessons_passed as numeric) as int),
-        cast(cast(i_ready_pro_vocabulary_lessons_passed as numeric) as int)
+        vocabulary_lessons_passed_i_ready, vocabulary_lessons_passed_i_ready_pro
     ) as vocabulary_lessons_passed,
 
     coalesce(
-        cast(cast(i_ready_vocabulary_percent_lessons_passed as numeric) as int),
-        cast(cast(i_ready_pro_vocabulary_percent_lessons_passed as numeric) as int)
+        vocabulary_percent_lessons_passed_i_ready,
+        vocabulary_percent_lessons_passed_i_ready_pro
     ) as vocabulary_percent_lessons_passed,
 
     safe_cast(student_id as int) as student_id,
 
     parse_date('%m/%d/%Y', date_range_start) as date_range_start,
     parse_date('%m/%d/%Y', date_range_end) as date_range_end,
-from {{ source("iready", "src_iready__personalized_instruction_summary") }}
+from typed


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop the kippmiami `stg_iready__instruction_by_lesson_pro` build from failing when i-Ready sends a whole number written with two decimal places.

Every column in the i-Ready Avro external tables is typed STRING. The vendor export sometimes writes a whole number as `9.00`. BigQuery rejects that with `Bad int64 value: 9.00` when the model casts the string straight to an integer. That failed the Miami build on 3 days in a row: September 1, 2, and 3.

This change wraps 152 integer casts in a numeric cast first, across the 4 i-Ready staging models that had bare casts. It copies the pattern `stg_iready__instruction_by_lesson` already uses. It also adds a unit test that feeds decimal-formatted strings to all 5 integer columns of the model that broke.

Three smaller changes ride along. In `stg_iready__diagnostic_results`, columns that were excepted from `select *` and re-added as a plain cast, `safe_cast`, or `parse_date` now use `select * replace (...)`. Anything with branching or merging — `coalesce`, `if`, `case` — stays as `except` plus re-add; that boundary is now written into `.claude/rules/dbt-sql.md`. In `stg_iready__diagnostic_results` and `stg_iready__personalized_instruction_summary`, 7 casts that sat inside `if()` or `coalesce()` now happen once in a leading CTE, and the `if`/`coalesce` reads the typed column — the shape `.claude/rules/dbt-sql.md` asks for. And one line is added to the root `CLAUDE.md` under "Pull requests and CI": a feature-branch commit, push, and PR are Claude's to do; only `main` is off limits. During this work Claude committed the fix and then told the user the push and PR needed the user's credentials, which was false.

Refs #5128 — the separate data-loss bug this investigation surfaced.

## Reviewer Notes

- The 2 `_dagster_partition_academic_year` casts are deliberately left alone. That column is already INT64, so a numeric round trip would be noise.
- `stg_iready__instructional_usage_data` is disabled in both Newark and Miami, so it builds nowhere. 60 of the 152 edits are in that file. I checked them by turning the model on in Miami, building it, and turning it back off.
- Two `trunk-ignore(sqlfluff/LT05)` lines in `stg_iready__personalized_instruction_summary`, one pre-existing and one new. The extra nesting pushes a 77-character column name to 89 characters and there is nowhere to wrap it.
- `claude-review` caught one cast the sweep missed. A pre-existing `-- trunk-ignore` comment sat between `cast(` and the column name, and the sweep's regex did not span it. Fixed in the second commit.
- The `except` → `replace` change is behavior-neutral: an A/B rebuild of both versions against the same dev source returns identical aggregates. A first dev-vs-prod comparison disagreed on 4 coalesce columns; that was the dev external flickering between two reads of the old-name vendor columns 3 minutes apart with no re-stage — the #4151 pattern, noted on #5128.
- The CTE refactor is behavior-neutral: dev-vs-prod parity on 41,509 and 283,225 rows with identical sums and distinct keys. In `diagnostic_results` the `'K' → 0` grade rule is now a string normalization (`'K' → '0'`) in a leading CTE, then one cast in the existing cast layer.
- A second, separate problem turned up while debugging. `items_correct`, `items_completed`, and `percent_items_correct` are NULL for all 21,162 rows in the prod Miami external table right now, even though the same GCS files return 934 populated values through a freshly staged copy. That is a data-loss bug, not a build failure, and it is not fixed here. It is filed as #5128. See the fold-out.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.) — per-finding verdicts posted as a PR comment

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models; the unit test goes in the existing properties file
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — no exposure change; no columns added or removed
- [x] **Breaking change?** No. No column is renamed or removed. Output types are unchanged: every wrapped cast still returns `int64`, and the enforced contracts pass.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** — no external source changed

## CI checks

- [ ] **Trunk** — passes
- [ ] **dbt Cloud** — passes
- [ ] **Dagster Cloud** — passes or not triggered

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Investigated with `superpowers:systematic-debugging` from Dagster run `0933a4ad-952f-4548-8de4-232fad2f3a26`.

## Root cause

`INFORMATION_SCHEMA.JOBS_BY_PROJECT` shows 3 failed BigQuery jobs in 10 days for `stg_iready__instruction_by_lesson_pro`, all with `error_result.message = "Bad int64 value: 9.00"`, one each on 2026-09-01, -02, -03. The compiled SQL at deploy commit `d3441680` matches HEAD, so there was no code drift.

All 46 columns of `src_iready__instruction_by_lesson_pro` are STRING. The offending column is `items_correct` in partition `2026|math`: all 934 of its values are decimal-formatted, confirmed against a freshly staged external.

`cast('9.00' as int64)` fails. `cast(cast('9.00' as numeric) as int64)` returns `9`. Halves round away from zero, matching the behavior `stg_iready__instruction_by_lesson` already ships.

## The regex sweep

Applied by script with per-file assertions, not by hand:

```
(?<![a-z_])cast\(\s*([a-z_0-9]+)\s+as\s+int\s*\)
```

The lookbehind keeps it off `safe_cast(`. The inner group is a bare identifier, so `cast(cast(... as numeric) as int)` and `cast(coalesce(...) as int)` do not match and are not double-wrapped. Counts: `instruction_by_lesson_pro` 5, `instructional_usage_data` 60, `personalized_instruction_summary` 83 + 1 by hand, `diagnostic_results` 3. Total 152, with 2 skipped by the `_dagster_partition_academic_year` allowlist.

The one by hand: `\s*` does not span a `-- trunk-ignore` comment, so the regex skipped `i_ready_pro_number_relationships_and_operation_concepts_percent_k_2_skills_successful`. The post-sweep "anything left?" check was single-line, so it missed the same multi-line block. `claude-review` caught it. A `perl -0777` multi-line rescan of all 4 files now returns 0 bare casts outside the allowlist.

## Verification

| Check | Result |
| --- | --- |
| Unit test against old SQL | ERROR `Bad int64 value: 12.00` — reproduces prod |
| Unit test against new SQL | PASS |
| `dbt build` real data, `package:iready`, kippmiami dev | PASS=11 ERROR=0 |
| `dbt build --empty` — the enforced-contract gate | PASS=11 ERROR=0, re-run PASS=2 after the second commit |
| `stg_iready__instructional_usage_data`, temporarily enabled | PASS, then reverted |
| `trunk check --force --no-fix` on every changed file | No issues |
| Dev vs prod parity, `stg_iready__instruction_by_lesson_pro` | 21,162 rows both; identical distinct keys and column sums |
| Dev vs prod parity after the CTE refactor, `stg_iready__diagnostic_results` | 41,509 rows both; identical `sum(student_grade_int)`, `countif(student_grade_int = 0)` (4,970 K rows), `sum(overall_scale_score)`, `sum(duration_min)`, `sum(diagnostic_gain)`, 41,208 distinct keys |
| Dev vs prod parity after the CTE refactor, `stg_iready__personalized_instruction_summary` | 283,225 rows both; identical sums on all 6 coalesced columns and `all_lessons_completed`, 275,103 distinct keys |
| `student_id` decimal or uncastable values, all 6 i-Ready sources, 1.47M rows | 0 — `safe_cast(student_id)` is not a live silent-NULL risk (review finding 5) |

The dev source copies were stale and missing the newer vendor columns, so `stage_external_sources` ran with `ext_full_refresh: true` against `zz_cbini_kippmiami_iready` before the builds.

## Review findings, final state

- Finding 1 (missed cast): fixed, see above.
- Finding 2 (nesting depth): first declined, then done in the fourth commit at the user's direction. The `diagnostic_results` version needs two steps because `cast('K' as numeric)` errors: a leading CTE normalizes `'K'` to `'0'` as a string, and the existing cast layer casts it once as `student_grade_int`; the `if()` in `hs_goals` is gone. The `personalized_instruction_summary` version is a `typed` CTE with 12 named `cast(cast(...))` columns, suffixed `_i_ready` / `_i_ready_pro`, and the 6 `coalesce` blocks read those.
- Finding 3 (unit test `format: sql` vs `dict`): declined. The fixture's whole point is a STRING that looks like a float. In dict format `"9.00"` must be quoted to stay a string, and yamllint `quoted-strings` fires on quoted scalars at CI (`.claude/rules/dbt-yaml.md`). `format: sql` makes the string type explicit.
- Finding 4 (uniqueness test): pre-existing, follow-up. 21,162 rows collapse to 20,138 distinct on `(student_id, completion_date, lesson_title)` and to 21,118 distinct on all 20 columns, so 44 rows are exact duplicates. They are within-file: 42 in `2024|ela`, 2 in `2025|math`, none across partitions — vendor export duplicates, not pull overlap. Whether to `distinct` them in staging is a data-team call before any test can pass.
- Finding 5 (`safe_cast(student_id)`): checked, not a live risk, see the table.

## The second bug, filed as #5128

```sql
select
  (select countif(items_correct is not null)
   from `teamster-332318.kippmiami_iready.src_iready__instruction_by_lesson_pro`) as prod_external,
  (select countif(items_correct is not null)
   from `teamster-332318.zz_cbini_kippmiami_iready.src_iready__instruction_by_lesson_pro`) as fresh_external
-- prod_external = 0, fresh_external = 934
```

Both externals have the identical 46-column schema in the same order and read the same 5 files under `gs://teamster-kippmiami/dagster/kippmiami/iready/instruction_by_lesson/`, verified by `INFORMATION_SCHEMA.COLUMNS` and `_FILE_NAME`. So this is not autodetect sampling a different file. It matches the failure modes `.claude/rules/dbt-yaml.md` documents from #4151 — schema heterogeneity (4 of 5 files lack the field) and/or metadata-cache staleness. Which one is not settled; the decisive check is `bq --nouse_cache` on prod. No dashboard reads the 3 columns today. Full evidence and the fix path are in #5128.

This fix is correct either way: the data genuinely contains `9.00` and the model has to handle it. It does remove the only alarm on #5128 — the crash was what made the NULLs visible.

## The CLAUDE.md line

Resolves two tensions the session exposed. First, the _Never_ block's push prohibition names `main` only, `.claude/rules/worktrees.md` hands Claude the exact feature-branch push command, and the PR section assumes Claude opens PRs — but nothing said so outright, and Claude over-generalized the prohibition into "pushing is the user's job" and invented a credentials reason. Second, the harness's own Bash guidance says commit or push only when asked; Claude committed unasked and then declined to push, applying that rule to one step and not the other. The new line states the repo policy once so the harness default no longer decides it.
</details>


