### PR TITLE
fix(dbt): dedupe Focus contact links duplicated by a re-import

### DIFF
--- a/src/dbt/focus/models/intermediate/int_focus__student_contacts.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_contacts.sql
@@ -40,6 +40,19 @@ with
         select distinct student_id, address_id,
         from {{ ref("stg_focus__students_join_address") }}
         where residence = 'Y'
+    ),
+
+    -- TODO: a re-import can duplicate a student's whole contact set under new
+    -- person_ids, leaving 2 links per sort_order. The Focus-side merge of the
+    -- duplicate person records is the real fix.
+    students_join_people as (
+        {{
+            dbt_utils.deduplicate(
+                relation=ref("stg_focus__students_join_people"),
+                partition_by="student_id, sort_order",
+                order_by="updated_at desc",
+            )
+        }}
     )
 
 select
@@ -73,7 +86,7 @@ select
     a.home_address,
 
     if(l.address_id is null, null, sa.address_id is not null) as is_household_member,
-from {{ ref("stg_focus__students_join_people") }} as l
+from students_join_people as l
 -- intentional scoping filter to students that exist in Focus; also supplies
 -- local_student_id
 inner join {{ ref("stg_focus__students") }} as s on l.student_id = s.student_id

--- a/src/dbt/focus/models/intermediate/int_focus__student_contacts.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__student_contacts.sql
@@ -50,7 +50,7 @@ with
             dbt_utils.deduplicate(
                 relation=ref("stg_focus__students_join_people"),
                 partition_by="student_id, sort_order",
-                order_by="updated_at desc",
+                order_by="updated_at desc, id desc",
             )
         }}
     )

--- a/src/dbt/focus/models/intermediate/properties/int_focus__student_contacts.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__student_contacts.yml
@@ -14,13 +14,25 @@ models:
       (stg_focus__students_join_people is unique on id only). If it fires, Focus
       has emitted multiple link rows for one student-person pair — expected
       cause is one row per address — so collapse to the residence-flagged
-      address in this model rather than relaxing the test.
+      address in this model rather than relaxing the test. Deduped to one link
+      per (student_id, sort_order), keeping the most recently updated: a Focus
+      re-import can recreate a student's whole contact set under new person_ids,
+      which the (student_id, person_id) test cannot see. Left in place, the
+      copies consume the downstream emergency_1..4 slots and push a real contact
+      out of the feed entirely.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - student_id
               - person_id
+          config:
+            severity: error
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_id
+              - sort_order
           config:
             severity: error
     columns:

--- a/src/dbt/focus/models/staging/properties/stg_focus__students_join_people.yml
+++ b/src/dbt/focus/models/staging/properties/stg_focus__students_join_people.yml
@@ -5,6 +5,14 @@ models:
       row per join id, relating a student to a person with custody / emergency /
       pickup / relationship attributes. Soft-deleted rows are excluded. Used to
       tell whether a student already has a contact in Focus.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_id
+              - sort_order
+          config:
+            severity: warn
     columns:
       - name: id
         description: Primary key — Focus students_join_people id.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop duplicate Focus contacts from filling up a student's emergency contact slots.

A Focus re-import can recreate a student's whole contact set under new person ids. That leaves 2 link rows for each contact instead of 1. The model's existing grain test cannot see this, because the copies carry different person ids.

The effect reaches the contact feed. One Miami student's 4 emergency slots hold 2 people listed twice each, and a real third contact is pushed out of the feed entirely. The duplicate also breaks the `contact_1` uniqueness test on kipptaf `int_students__contacts`, which is how we found it.

This change keeps 1 link per student and sort order, choosing the row Focus updated most recently. It adds an error-severity test to hold that grain. It also adds a warning test at `stg_focus__students_join_people`, so the next duplicate import shows up at the source instead of 2 models downstream.

## Reviewer Notes

- **The fix drops rows, so check the blast radius.** 3902 to 3899 rows. No student loses their record: 1632 before and after.
- **Which copy wins.** The dedupe keeps the most recently updated row. The older copy has not changed since Focus created it. The newer one is still being updated.
- **This does not fix the records in Focus.** Miami Ops still needs to merge the duplicate people. The new warning test is what will flag the next one.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new
      models; both changed models already have one.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application — not
      applicable; both models are internal.
- [x] **Breaking change?** No columns renamed or removed. The column set is
      unchanged, so no contract or exposure breaks.
- [x] If adding or modifying an external source, run `stage_external_sources` —
      not applicable; the Focus source is BigQuery-native, loaded by dlt.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found while debugging Dagster run
`c0648e14-c941-415a-8a24-d74230dc833d`, which failed on
`dbt_utils_unique_combination_of_columns_int_students__contacts_student_number___dbt_source_project__contact_slot`.

**Why the fix is here and not in kipptaf.** The first proposal put a tiebreaker
on the `focus_contact_1` branch of kipptaf `int_students__contacts`, where
slotting happens. Directed to the package model instead, on the model closest to
the source. `int_focus__student_contacts` exists twice — the real model in
`src/dbt/focus/`, and a thin `union_relations` wrapper in
`src/dbt/kipptaf/models/focus/intermediate/` over
`source("kippmiami_focus", ...)`. kipptaf does not import the focus package.

**Why the existing grain test misses it.** The yml declares
`(student_id, person_id)` at error severity, and it passes. The re-import minted
new person ids for every copy, so each copy is a distinct pair. `sort_order` was
deliberately excluded, since the model is documented as unslotted and uncapped.
That documentation is still accurate — the dedupe is about duplicate link rows,
not about slotting.

**Objection raised and withdrawn.** The initial concern was that deduping on
`(student_id, sort_order)` would drop a real person from the emergency slots.
The data disproved it. All 3 of the student's contacts were duplicated by the
same re-import, pairwise identical on name and relationship. The dedupe removes
import copies and keeps their twins. Nothing real is lost, and the contact the
`emergency_rank <= 4` cap had been pushing out is restored.

**Blast radius, measured against prod.** Exactly 1 student, 3 duplicated
`(student_id, sort_order)` pairs, 3 surplus rows across the whole model.

**Verification.** `dbt build --select stg_focus__students_join_people
int_focus__student_contacts --project-dir src/dbt/kippmiami --favor-state
--defer --state <prod manifest> --target dev` gave `PASS=6 WARN=1 ERROR=0`. The
warning is the new staging test firing on its 3 known rows. Prod comparison:
3902 to 3899 rows, 1632 students unchanged. Replaying kipptaf's
`emergency_rank` window over the rebuilt model returns 3 distinct people for the
affected student, with the dropped contact restored. Trunk clean on all 3 files.

**Gotcha worth recording.** The first dev build reported 24 rows removed and 6
students lost. That was a stale personal `stg_focus__students` copy from Aug 31
(4055 rows vs prod 4060) shadowing `--defer`, not the change. `--favor-state`
corrected it to the true 3. Matches the stale-dev-shadow warning in the
`dbt-local-dev` skill.

**Not addressed here.** Two follow-ups. First, Miami Ops still has the duplicate
person records in Focus; the model now hides the effect but the records remain.
Second, the same Dagster run hit an unrelated failure — a `store_failures_as:
view` audit relation replaced by a concurrent dbt run mid-read, giving a
`notFound` on `select count(*)`. Documented in `a802dbd8bd`; no code change
here.

</details>
