### PR TITLE
fix(claude): make the output scanner redact and name the rule in every denial

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -113,10 +113,10 @@ evidence in `.claude/scratch/` and reference it. For non-Bash tools only Section
 `content`/`new_string` is content-exempt, so editing docs is unaffected.)
 
 **Non-Bash tool inputs are path-scanned too:** `TodoWrite` / `AskUserQuestion`
-text containing a bare `env` (or other sensitive-path token) trips "Cannot
-access sensitive path". Reword (`environment variable`; avoid cred-suffix tokens
-like `_KIPPMIAMI`). Also fires on `mcp__github__*` PR / issue bodies — prose
-like "staging env" / "dev env" is denied; write "environment".
+text containing a bare `env` (or other sensitive-path token) trips Rule 1 or 3c.
+Reword (`environment variable`; avoid cred-suffix tokens like `_KIPPMIAMI`).
+Also fires on `mcp__github__*` PR / issue bodies — prose like "staging env" /
+"dev env" is denied; write "environment".
 
 **Your own ad-hoc Bash self-blocks on `$UPPER_CASE`:** Rule 7 denies any Bash
 command expanding a non-allowlisted uppercase var — including one you define in
@@ -126,8 +126,11 @@ that same command (`sc=$(...); echo "${SC}"`). Use lowercase names
 **BigQuery MCP** — queries must start with SELECT/SHOW/DESCRIBE/WITH; embedded
 DML/DDL (INSERT, UPDATE, DELETE, CREATE, DROP, etc.) is blocked. The block
 matches the keyword as a substring — including inside a string literal
-(`where type = 'Drop'`), which is denied with the misleading "Cannot access
-sensitive path" message. Reword to avoid the literal (`like 'Dr%'`).
+(`where type = 'Drop'`). Reword to avoid the literal (`like 'Dr%'`).
+
+**Deny messages name the rule.** Every `check-sensitive.sh` denial reads
+`❌ check-sensitive.sh Rule N: <what matched>. <what to do instead>.` Follow the
+instruction in the message before consulting this file; the two agree.
 
 **Output scanning** (PostToolUse) — redacts tool results containing secret
 material (keys, tokens, connection strings, high-entropy strings): every string
@@ -137,9 +140,8 @@ and MCP tools. Does NOT fire for Edit.
 
 **MCP spill files are Bash-unreadable:** a large MCP result that overflows the
 context budget dumps to `~/.claude/projects/.../tool-results/`; Bash
-(`jq`/`cat`) on that path is denied ("Cannot access sensitive path"). Use a
-subagent (as the spill message suggests) or reconstruct the data from prior tool
-output instead.
+(`jq`/`cat`) on that path is denied by the hook. Use a subagent (as the spill
+message suggests) or reconstruct the data from prior tool output instead.
 
 ## Context injection (`tool-gotchas.sh`)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,26 +19,37 @@ behavior.
 Claude Code hooks communicate decisions via **stdout JSON + exit code 0**:
 
 - **Allow**: exit 0 with no output (or empty stdout)
-- **Deny**: exit 0 with
+- **PreToolUse deny**: exit 0 with
   `{"hookSpecificOutput": {"permissionDecision": "deny", ...}}` on stdout
+- **PostToolUse redact**: exit 0 with
+  `{"hookSpecificOutput": {"updatedToolOutput": <redacted tool_response>, ...}}`.
+  PostToolUse cannot deny: the tool already ran, and `permissionDecision` is
+  silently ignored on this event (the scanner emitted it for months with no
+  effect). `updatedToolOutput` must keep the tool's output shape or the harness
+  drops it and shows the original. `{"decision": "block", "reason": ...}` ends
+  the turn with a warning and is used only when there is nothing to redact.
 
 **Exit 1 is a non-blocking error** — Claude Code logs it but executes the tool
 anyway. Never use `exit 1` to deny. Never write deny JSON to stderr (`>&2`). The
 regression test suite (`expect_deny_exit0`) enforces both invariants.
+
+Auto mode does not replace either hook: `permissions.deny` and PreToolUse hooks
+run before the classifier, and the classifier never sees tool results.
 
 ## What is blocked
 
 **Outbound secret-value egress scan** (PreToolUse, Section 4) — write-capable
 MCP tools (tool name contains
 `create`/`update`/`write`/`add`/`comment`/`upload`/
-`send`/`post`/`put`/`delete`/`append`/`insert`/`merge`/`push`/`reply`) and
-WebFetch URLs are scanned for secret VALUES (`op://` refs, private-key headers,
-cloud tokens, connection strings — the same pattern set as `check-output.sh`). A
-match is blocked to stop exfiltration. Practical effect: a GitHub issue/PR write
-or an Asana/Drive write whose body contains a real-looking secret is denied —
-redact it (e.g. `op://…` → `op-uri`). Read-only MCP tools (bigquery / dagster /
-dbt `get_`/`list_`/`search_`) are not scanned. There is no keyword-based URL
-scanner — only secret-value shapes match.
+`send`/`post`/`put`/`delete`/`append`/`insert`/`merge`/`push`/`reply`/
+`share`/`forward`/`schedule`/`launch`/`trigger`), WebFetch URLs, and WebSearch
+queries are scanned for secret VALUES (`op://` refs, private-key headers, cloud
+tokens, connection strings — the same pattern set as `check-output.sh`). A match
+is blocked to stop exfiltration. Practical effect: a GitHub issue/PR write or an
+Asana/Drive write whose body contains a real-looking secret is denied — redact
+it (e.g. `op://…` → `op-uri`). Read-only MCP tools (bigquery / dagster / dbt
+`get_`/`list_`/`search_`) are not scanned. There is no keyword-based URL scanner
+— only secret-value shapes match.
 
 **Secret paths** (all tools blocked) — dotenv files, private key/cert files, SSH
 directory, secret-volume, credentials JSON files, devcontainer template
@@ -118,10 +129,11 @@ matches the keyword as a substring — including inside a string literal
 (`where type = 'Drop'`), which is denied with the misleading "Cannot access
 sensitive path" message. Reword to avoid the literal (`like 'Dr%'`).
 
-**Output scanning** (PostToolUse) — blocks tool results containing secret
-material (keys, tokens, connection strings, high-entropy strings). Fires for
-Bash, Read, Grep, NotebookEdit, WebFetch, WebSearch, and MCP tools. Does NOT
-fire for Edit.
+**Output scanning** (PostToolUse) — redacts tool results containing secret
+material (keys, tokens, connection strings, high-entropy strings): every string
+in the result becomes `[redacted: secret material]` and an `additionalContext`
+note says why. Fires for Bash, Read, Grep, NotebookEdit, WebFetch, WebSearch,
+and MCP tools. Does NOT fire for Edit.
 
 **MCP spill files are Bash-unreadable:** a large MCP result that overflows the
 context budget dumps to `~/.claude/projects/.../tool-results/`; Bash

--- a/.claude/hooks/check-output.sh
+++ b/.claude/hooks/check-output.sh
@@ -11,6 +11,12 @@ input=$(cat)
 # replacement that fails its output schema is silently ignored and the original
 # output is shown. additionalContext tells Claude what happened.
 emit_redacted() {
+	# Payload-key drift (#20): the scan below reads the whole payload when
+	# .tool_response is absent, but a replacement built from {} fails the tool's
+	# output schema and the harness shows the ORIGINAL. Nothing to redact safely,
+	# so fail closed and end the turn instead.
+	jq -e 'has("tool_response")' >/dev/null 2>&1 <<<"${input}" || deny_output
+
 	jq -c --arg r "$1" '
     def redact: if type == "object" then with_entries(if (.key | IN("type", "filePath")) then . else .value |= redact end)
       elif type == "array" then map(redact)

--- a/.claude/hooks/check-output.sh
+++ b/.claude/hooks/check-output.sh
@@ -4,16 +4,33 @@
 
 input=$(cat)
 
+# PostToolUse ignores hookSpecificOutput.permissionDecision (PreToolUse-only).
+# The only way to keep secret material out of the model's context here is
+# updatedToolOutput, which REPLACES the tool result. Redact every string leaf of
+# tool_response but keep the shape keys `type` and `filePath`: a built-in tool's
+# replacement that fails its output schema is silently ignored and the original
+# output is shown. additionalContext tells Claude what happened.
+emit_redacted() {
+	jq -c --arg r "$1" '
+    def redact: if type == "object" then with_entries(if (.key | IN("type", "filePath")) then . else .value |= redact end)
+      elif type == "array" then map(redact)
+      elif type == "string" then "[redacted: secret material]" else . end;
+    {hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $r,
+      updatedToolOutput: ((.tool_response // {}) | redact)}}' <<<"${input}"
+	exit 0
+}
+
 deny_output() {
-  echo '{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "deny", "permissionDecisionReason": "⛔ Output blocked — unscannable input or secret material"}}'
-  exit 0
+	# Nothing parsable to redact: end the turn with a visible warning instead.
+	echo '{"decision": "block", "reason": "⛔ Output blocked — unscannable input or secret material"}'
+	exit 0
 }
 
 # Fail closed on input this hook cannot understand (empty stdin, unparseable
 # JSON, non-object frame, or missing/empty tool_name) — otherwise a nonstandard
 # envelope skips scanning entirely and re-opens full passthrough.
 if [[ -z ${input} ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"${input}"; then
-  deny_output
+	deny_output
 fi
 tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 # Normalize once: lowercase + strip all whitespace so a re-cased name cannot
@@ -21,7 +38,7 @@ tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 tool_name=${tool_name,,}
 tool_name=${tool_name//[[:space:]]/}
 if [[ -z ${tool_name} ]]; then
-  deny_output
+	deny_output
 fi
 
 # Scan output from tools that can return sensitive content (names normalized)
@@ -41,17 +58,17 @@ combined=$(jq -r '[(.tool_response // .) | .. | strings] | join(" ")' <<<"${inpu
 std_blobs=$(echo "${combined}" | grep -oE '[A-Za-z0-9+/]{24,}={0,2}' || true)
 url_blobs=$(echo "${combined}" | grep -oE '[A-Za-z0-9_-]{24,}' || true)
 if [[ -n ${std_blobs} || -n ${url_blobs} ]]; then
-  # tr '_-' '/+' is a no-op on standard blobs and normalizes url-safe ones.
-  # trunk-ignore(shellcheck/SC2312): read returns 1 at EOF to terminate the loop — expected
-  decoded=$(printf '%s\n%s\n' "${std_blobs}" "${url_blobs}" | while read -r blob; do
-    printf '%s' "${blob}" | tr '_-' '/+' | base64 -d 2>/dev/null || true
-  done | tr -d '\0')
-  [[ -n ${decoded} ]] && combined="${combined} ${decoded}"
-  # trunk-ignore(shellcheck/SC2312): read returns 1 at EOF to terminate the loop — expected
-  inflated=$(printf '%s\n%s\n' "${std_blobs}" "${url_blobs}" | while read -r blob; do
-    printf '%s' "${blob}" | tr '_-' '/+' | base64 -d 2>/dev/null | gunzip -c 2>/dev/null | head -c 65536 || true
-  done | tr -d '\0')
-  [[ -n ${inflated} ]] && combined="${combined} ${inflated}"
+	# tr '_-' '/+' is a no-op on standard blobs and normalizes url-safe ones.
+	# trunk-ignore(shellcheck/SC2312): read returns 1 at EOF to terminate the loop — expected
+	decoded=$(printf '%s\n%s\n' "${std_blobs}" "${url_blobs}" | while read -r blob; do
+		printf '%s' "${blob}" | tr '_-' '/+' | base64 -d 2>/dev/null || true
+	done | tr -d '\0')
+	[[ -n ${decoded} ]] && combined="${combined} ${decoded}"
+	# trunk-ignore(shellcheck/SC2312): read returns 1 at EOF to terminate the loop — expected
+	inflated=$(printf '%s\n%s\n' "${std_blobs}" "${url_blobs}" | while read -r blob; do
+		printf '%s' "${blob}" | tr '_-' '/+' | base64 -d 2>/dev/null | gunzip -c 2>/dev/null | head -c 65536 || true
+	done | tr -d '\0')
+	[[ -n ${inflated} ]] && combined="${combined} ${inflated}"
 fi
 
 # Whitespace-stripped copy catches a token split across newlines/spaces (#30).
@@ -71,8 +88,7 @@ secret_re='op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIz
 # Slack/Stripe token split across a newline is not reassembled here.
 jwt_re='eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}'
 if echo "${combined}" | grep -qiE "${secret_re}" || echo "${stripped}" | grep -qiE "${jwt_re}"; then
-  echo '{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "deny", "permissionDecisionReason": "⛔ Output contains secret material — blocked"}}'
-  exit 0
+	emit_redacted "⛔ Tool output contained secret material — redacted by check-output.sh"
 fi
 
 # Heuristic: long high-entropy strings not already matched. Strip base64 image
@@ -81,6 +97,5 @@ fi
 entropy_input=$(echo "${combined}" | sed -E 's#data:[^,[:space:]]*;base64,[A-Za-z0-9+/=]+##g')
 long_runs=$(echo "${entropy_input}" | grep -oE '[A-Za-z0-9+/=_-]{120,}' || true)
 if [[ -n ${long_runs} ]] && echo "${long_runs}" | grep -qvE '^[0-9a-fA-F]+$'; then
-  echo '{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "deny", "permissionDecisionReason": "⛔ Output contains high-entropy string — possible encoded secret"}}'
-  exit 0
+	emit_redacted "⛔ Tool output contained a high-entropy string (possible encoded secret) — redacted by check-output.sh"
 fi

--- a/.claude/hooks/check-sensitive.sh
+++ b/.claude/hooks/check-sensitive.sh
@@ -9,8 +9,8 @@
 # chmod 700) and 1Password authentication.
 
 deny() {
-  echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "❌ Cannot access sensitive path"}}'
-  exit 0
+	echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "❌ Cannot access sensitive path"}}'
+	exit 0
 }
 
 input=$(cat)
@@ -19,7 +19,7 @@ input=$(cat)
 # cannot understand rather than silently allow. Empty stdin, unparseable JSON,
 # a non-object frame, or a missing/empty tool_name all fall through to deny.
 if [[ -z ${input} ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"${input}"; then
-  deny
+	deny
 fi
 tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 # Normalize once: lowercase + strip all whitespace so a re-cased or padded
@@ -28,7 +28,7 @@ tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 tool_name=${tool_name,,}
 tool_name=${tool_name//[[:space:]]/}
 if [[ -z ${tool_name} ]]; then
-  deny
+	deny
 fi
 
 # Normalize path strings: collapse //, /./, resolve ../
@@ -36,11 +36,11 @@ _normalize() { sed -E ':a; s#//+#/#g; s#/\./#/#g; s#/[^/]+/\.\./#/#g; ta'; }
 
 # Collect ALL string values from tool_input (covers MCP, NotebookEdit, any tool schema)
 if [[ ${tool_name} == "agent" ]]; then
-  path=$(jq -r '
+	path=$(jq -r '
     [.tool_input | to_entries[] | select(.key != "description") | .value | .. | strings] | join(" ")
   ' <<<"${input}")
 else
-  path=$(jq -r '
+	path=$(jq -r '
     [.tool_input | to_entries[] | .value | .. | strings] | join(" ")
   ' <<<"${input}")
 fi
@@ -57,9 +57,9 @@ _cands=$(jq -r '
   [.tool_input | to_entries[] | select(.key | test("^(content|new_string|old_string)$") | not) | .value | .. | strings] | .[]
 ' <<<"${input}")
 while IFS= read -r _cand; do
-  [[ -n ${_cand} && -e ${_cand} ]] || continue
-  _r=$(readlink -f "${_cand}" 2>/dev/null) || continue
-  [[ -n ${_r} ]] && resolved+=" ${_r}"
+	[[ -n ${_cand} && -e ${_cand} ]] || continue
+	_r=$(readlink -f "${_cand}" 2>/dev/null) || continue
+	[[ -n ${_r} ]] && resolved+=" ${_r}"
 done <<<"${_cands}"
 [[ -n ${resolved} ]] && normalized="${normalized} ${resolved}"
 
@@ -80,14 +80,14 @@ path_only=${path_only//[\"\'\\]/}
 # All fields except Write/Edit body content (content, new_string, old_string)
 # Used by Rules 1/1c: catches MCP sql/nested fields but skips doc content
 if [[ ${tool_name} == "write" || ${tool_name} == "edit" ]]; then
-  no_content=$(jq -r '
+	no_content=$(jq -r '
     [.tool_input | to_entries[] | select(.key | test("^(content|new_string|old_string)$") | not) | .value | .. | strings] | join(" ")
   ' <<<"${input}")
-  no_content=$(echo "${no_content}" | _normalize)
-  [[ -n ${resolved} ]] && no_content="${no_content} ${resolved}"
-  no_content=${no_content//[\"\'\\]/}
+	no_content=$(echo "${no_content}" | _normalize)
+	[[ -n ${resolved} ]] && no_content="${no_content} ${resolved}"
+	no_content=${no_content//[\"\'\\]/}
 else
-  no_content=${sanitized}
+	no_content=${sanitized}
 fi
 
 # ═══════════════════════════════════════════════════════════════════
@@ -102,8 +102,8 @@ fi
 #    the full corpus.
 _env_scan=$(echo "${no_content}" | sed -E 's/\.env\.(example|sample|template|dist)([^a-zA-Z]|$)/\2/g')
 if echo "${_env_scan}" | grep -qiE '\.env[.a-z]*' ||
-  echo "${no_content}" | grep -qiE '(^|[ /])(\.ssh|\.kube|\.pem|\.key|\.cer|secrets\.json|credentials\.json|application_default_credentials\.json|\.git-credentials|\.netrc|secret-volume)([ /]|$)|(^|[ /])(\.?/)?env(/|[ ]|$)|\.config/op([ /]|$)|\.devcontainer/tpl/'; then
-  deny
+	echo "${no_content}" | grep -qiE '(^|[ /])(\.ssh|\.kube|\.pem|\.key|\.cer|secrets\.json|credentials\.json|application_default_credentials\.json|\.git-credentials|\.netrc|secret-volume)([ /]|$)|(^|[ /])(\.?/)?env(/|[ ]|$)|\.config/op([ /]|$)|\.devcontainer/tpl/'; then
+	deny
 fi
 
 # 1b. File-extension patterns scoped to path_only (named path keys incl. MCP
@@ -111,13 +111,13 @@ fi
 #     keys without scanning free-text fields like a SQL `sql` parameter, where a
 #     dot-attribute such as record.key would otherwise false-positive.
 if echo "${path_only}" | grep -qiE '\*?\.(cer|key|pem)([ /]|$)'; then
-  deny
+	deny
 fi
 
 # 1c. High-risk proc/dev paths — kept in all-tools scope (sandbox is ineffective
 #     in Codespaces; hooks are the sole enforcement layer)
 if echo "${no_content}" | grep -qE '/proc/[^[:space:]]*/environ|/proc/[^[:space:]]*/cmdline|/dev/fd/'; then
-  deny
+	deny
 fi
 
 # ═══════════════════════════════════════════════════════════════════
@@ -132,12 +132,12 @@ fi
 # fields (content/edits) are excluded so a file body that mentions one of
 # these paths does not false-positive. Pattern mirrors Rule 2.
 if [[ ${tool_name} =~ ^mcp__filesystem__(write_file|edit_file|move_file|create_directory)$ ]]; then
-  fs_target=$(jq -r '[.tool_input | (.path?, .source?, .destination?) | strings] | join(" ")' <<<"${input}")
-  fs_target=$(echo "${fs_target}" | _normalize)
-  fs_target=${fs_target//[\"\'\\]/}
-  if echo "${fs_target}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
-    deny
-  fi
+	fs_target=$(jq -r '[.tool_input | (.path?, .source?, .destination?) | strings] | join(" ")' <<<"${input}")
+	fs_target=$(echo "${fs_target}" | _normalize)
+	fs_target=${fs_target//[\"\'\\]/}
+	if echo "${fs_target}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
+		deny
+	fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════
@@ -145,112 +145,112 @@ fi
 # ═══════════════════════════════════════════════════════════════════
 if [[ ${tool_name} == "bash" ]]; then
 
-  # 2. Protected paths — Edit/Write handled by permissions.deny; Bash blocked here
-  if echo "${path_only}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
-    deny
-  fi
+	# 2. Protected paths — Edit/Write handled by permissions.deny; Bash blocked here
+	if echo "${path_only}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
+		deny
+	fi
 
-  # 3. Environment variable / process memory leakage
-  # declare: -x already listed; also block any -flag cluster containing p
-  # (-p/-px/-xp dump variable definitions, equivalent to printenv/set)
-  if echo "${sanitized}" | grep -qiE '\bprintenv\b|\bdeclare -x\b|\bdeclare[[:space:]]+-[a-zA-Z]*p[a-zA-Z]*\b|\bexport -p\b|\bcompgen\b|\btypeset([[:space:]]+-x|\b)|/proc/[^[:space:]]*/environ|/proc/[^[:space:]]*/cmdline|OP_SERVICE_ACCOUNT_TOKEN|OP_CONNECT_TOKEN|OP_SERVICE|ACCOUNT_TOKEN|\benviron\b|\bgetenv\b'; then
-    deny
-  fi
+	# 3. Environment variable / process memory leakage
+	# declare: -x already listed; also block any -flag cluster containing p
+	# (-p/-px/-xp dump variable definitions, equivalent to printenv/set)
+	if echo "${sanitized}" | grep -qiE '\bprintenv\b|\bdeclare -x\b|\bdeclare[[:space:]]+-[a-zA-Z]*p[a-zA-Z]*\b|\bexport -p\b|\bcompgen\b|\btypeset([[:space:]]+-x|\b)|/proc/[^[:space:]]*/environ|/proc/[^[:space:]]*/cmdline|OP_SERVICE_ACCOUNT_TOKEN|OP_CONNECT_TOKEN|OP_SERVICE|ACCOUNT_TOKEN|\benviron\b|\bgetenv\b'; then
+		deny
+	fi
 
-  # 3d. Catch bare `declare` (dumps all vars), but not `declare VAR=val` or `declare -flags`
-  # trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(declare), not a command substitution
-  if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)declare([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(declare([[:space:]]|$|\))'; then
-    deny
-  fi
+	# 3d. Catch bare `declare` (dumps all vars), but not `declare VAR=val` or `declare -flags`
+	# trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(declare), not a command substitution
+	if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)declare([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(declare([[:space:]]|$|\))'; then
+		deny
+	fi
 
-  # 3b. Catch `set` as a standalone command (dumps all vars), but not `set -flags`
-  # trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(set), not a command substitution
-  if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)set([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(set([[:space:]]|$|\))'; then
-    deny
-  fi
+	# 3b. Catch `set` as a standalone command (dumps all vars), but not `set -flags`
+	# trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(set), not a command substitution
+	if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)set([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(set([[:space:]]|$|\))'; then
+		deny
+	fi
 
-  # 3c. Standalone `env` shell command — scoped to path/command only (not file content)
-  if echo "${path_only}" | grep -qiE '\benv\b'; then
-    deny
-  fi
+	# 3c. Standalone `env` shell command — scoped to path/command only (not file content)
+	if echo "${path_only}" | grep -qiE '\benv\b'; then
+		deny
+	fi
 
-  # 4. 1Password CLI escalation — prevent using a leaked token to access the vault
-  #    or mint new credentials. Verbs extended (#14): signin/account/user/
-  #    service-account/connect and plural items.
-  if echo "${sanitized}" | grep -qE '\bop\b.*\b(vault|item|items|read|run|document|inject|signin|account|user|service-account|connect)\b'; then
-    deny
-  fi
+	# 4. 1Password CLI escalation — prevent using a leaked token to access the vault
+	#    or mint new credentials. Verbs extended (#14): signin/account/user/
+	#    service-account/connect and plural items.
+	if echo "${sanitized}" | grep -qE '\bop\b.*\b(vault|item|items|read|run|document|inject|signin|account|user|service-account|connect)\b'; then
+		deny
+	fi
 
-  # 5. Encoding-based bypass: a base64/hex decode feeding a shell interpreter.
-  #    Newlines flattened to ; so a decode and the consuming interpreter on
-  #    separate lines are caught (a pipe/`;` split across a newline previously
-  #    evaded the line-oriented grep). Consumers now include eval (#15).
-  _flat=${normalized//$'\n'/;}
-  if echo "${_flat}" | grep -qiE '(base64[[:space:]]+(-d|--decode)|\bxxd\b|\bprintf[[:space:]]+[^|;&]*\\x).*(\||[;&]+).*(bash|sh|source|eval)'; then
-    deny
-  fi
+	# 5. Encoding-based bypass: a base64/hex decode feeding a shell interpreter.
+	#    Newlines flattened to ; so a decode and the consuming interpreter on
+	#    separate lines are caught (a pipe/`;` split across a newline previously
+	#    evaded the line-oriented grep). Consumers now include eval (#15).
+	_flat=${normalized//$'\n'/;}
+	if echo "${_flat}" | grep -qiE '(base64[[:space:]]+(-d|--decode)|\bxxd\b|\bprintf[[:space:]]+[^|;&]*\\x).*(\||[;&]+).*(bash|sh|source|eval)'; then
+		deny
+	fi
 
-  # 5a. Reverse order: a shell interpreter (bash/sh/source/eval, or the `.` dot
-  #     builtin) consuming a process substitution <(...), here-string <<<, or
-  #     command substitution $(...) that runs a decode (#15). Scans `sanitized`
-  #     (quote/backslash-stripped) to keep the quote-split defense; these forms
-  #     are same-line, so the newline-flattening (Rule 5) is not needed here.
-  if echo "${sanitized}" | grep -qiE '\b(bash|sh|source|eval)\b.*(<\(|<<<|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)|(^|[;&|][[:space:]]*)\.[[:space:]]+(<\(|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)'; then
-    deny
-  fi
+	# 5a. Reverse order: a shell interpreter (bash/sh/source/eval, or the `.` dot
+	#     builtin) consuming a process substitution <(...), here-string <<<, or
+	#     command substitution $(...) that runs a decode (#15). Scans `sanitized`
+	#     (quote/backslash-stripped) to keep the quote-split defense; these forms
+	#     are same-line, so the newline-flattening (Rule 5) is not needed here.
+	if echo "${sanitized}" | grep -qiE '\b(bash|sh|source|eval)\b.*(<\(|<<<|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)|(^|[;&|][[:space:]]*)\.[[:space:]]+(<\(|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)'; then
+		deny
+	fi
 
-  # 5b. Python runtime string construction (exec/eval with chr/join/bytes/base64/codecs)
-  if echo "${sanitized}" | grep -qiE '\b(exec|eval)[[:space:]]*\(.*\bchr[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\.join[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\bbytes[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*base64\.b64decode|\b(exec|eval)[[:space:]]*\(.*codecs\.decode|\b(exec|eval)[[:space:]]*\(.*\.fromhex'; then
-    deny
-  fi
+	# 5b. Python runtime string construction (exec/eval with chr/join/bytes/base64/codecs)
+	if echo "${sanitized}" | grep -qiE '\b(exec|eval)[[:space:]]*\(.*\bchr[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\.join[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\bbytes[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*base64\.b64decode|\b(exec|eval)[[:space:]]*\(.*codecs\.decode|\b(exec|eval)[[:space:]]*\(.*\.fromhex'; then
+		deny
+	fi
 
-  # 5c. Python __import__ with sensitive modules (bypasses exec() requirement)
-  if echo "${sanitized}" | grep -qiE '\b__import__[[:space:]]*\(.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
-    deny
-  fi
+	# 5c. Python __import__ with sensitive modules (bypasses exec() requirement)
+	if echo "${sanitized}" | grep -qiE '\b__import__[[:space:]]*\(.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
+		deny
+	fi
 
-  # 5d. Python importlib bypass (avoids __import__ check)
-  if echo "${sanitized}" | grep -qiE '\bimportlib\b.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
-    deny
-  fi
+	# 5d. Python importlib bypass (avoids __import__ check)
+	if echo "${sanitized}" | grep -qiE '\bimportlib\b.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
+		deny
+	fi
 
-  # 7. Shell variable expansion — block $UPPER_CASE broadly, allowlist known-safe vars
-  # Block ${!prefix*} (indirect expansion that enumerates variable names)
-  if echo "${sanitized}" | grep -qE '\$\{![^}]*\}'; then
-    deny
-  fi
-  # Strip allowed variable references, then deny if any $VAR remain
-  safe='HOME|PATH|PWD|OLDPWD|USER|SHELL|TERM|LANG|LANGUAGE'
-  # LC_* enumerated explicitly (not LC_[A-Z]+) so a secret-bearing name like
-  # $LC_SECRET / $LC_CREDENTIALS is not swallowed by a wildcard (Finding 1).
-  safe+='|LC_ALL|LC_CTYPE|LC_NUMERIC|LC_TIME|LC_COLLATE|LC_MONETARY|LC_MESSAGES|LC_PAPER|LC_NAME|LC_ADDRESS|LC_TELEPHONE|LC_MEASUREMENT|LC_IDENTIFICATION'
-  safe+='|HOSTNAME|SHLVL|LOGNAME|TZ|TMPDIR|EDITOR|VISUAL|PAGER|DISPLAY'
-  # XDG_* enumerated explicitly (not XDG_[A-Z_]+) so $XDG_SESSION_SECRET et al.
-  # are not swallowed by a wildcard (Finding 1).
-  safe+='|XDG_CONFIG_HOME|XDG_DATA_HOME|XDG_CACHE_HOME|XDG_STATE_HOME|XDG_RUNTIME_DIR|XDG_CONFIG_DIRS|XDG_DATA_DIRS|XDG_SESSION_ID|XDG_SESSION_TYPE|XDG_SESSION_CLASS'
-  safe+='|PS[0-4]|IFS|PPID|UID|EUID|RANDOM|SECONDS|LINENO|_'
-  safe+='|OSTYPE|MACHTYPE|HOSTTYPE|BASH_SOURCE|BASH_LINENO|BASH_REMATCH|BASHPID|BASH_VERSION|HISTSIZE|HISTCONTROL'
-  # COMP_* enumerated explicitly (not COMP[A-Z_]*) so $COMP_TOKEN / $COMP_API_SECRET
-  # are not swallowed by a wildcard (Finding 1).
-  safe+='|COMPREPLY|COMP_WORDS|COMP_CWORD|COMP_LINE|COMP_POINT|COMP_KEY|COMP_TYPE|COMP_WORDBREAKS'
-  safe+='|SHELLOPTS|BASHOPTS|DIRSTACK|PIPESTATUS|FUNCNAME|REPLY'
-  safe+='|DAGSTER_HOME|DBT_PROFILES_DIR|DBT_PROJECT_DIR|DBT_CLOUD_ENVIRONMENT_TYPE|DBT_SEND_ANONYMOUS_USAGE_STATS'
-  safe+='|GOOGLE_CLOUD_PROJECT|PYTHONDONTWRITEBYTECODE|PYTHONPATH|PYTHONHASHSEED'
-  safe+='|TRUNK_TELEMETRY|UV_LINK_MODE|UV_RESOLUTION|UV_CACHE_DIR|VIRTUAL_ENV|NVM_DIR'
-  safe+='|JAVA_HOME|GOPATH|GOROOT|CARGO_HOME|RUSTUP_HOME|NODE_PATH'
-  safe+='|CI|GITHUB_WORKSPACE|GITHUB_REPOSITORY|GITHUB_REF|GITHUB_SHA|GITHUB_ACTIONS|GITHUB_ACTOR|GITHUB_OUTPUT|GITHUB_EVENT_NAME'
-  safe+='|CODESPACES|CODESPACE_NAME|REMOTE_CONTAINERS'
-  # Anchor the strip with a captured-and-re-emitted trailing non-identifier
-  # boundary so a safe PREFIX cannot consume a longer secret var name
-  # (e.g. $CI must strip, but $CI_SECRET / $USER_PASSWORD must not).
-  stripped=$(echo "${sanitized}" | sed -E "s/\\$\\{?(${safe})\\}?([^A-Z0-9_]|\$)/\\2/g")
-  # Match single-char uppercase too ($X), not just multi-char ($AWS_SECRET) — the
-  # `*` quantifier instead of `+` (#27). Lowercase vars ($i / $file) stay ignored:
-  # env-secret names are uppercase by convention and matching loop vars would
-  # false-positive broadly. ($_ is on the safe list, so the `*` does not snag it.)
-  if echo "${stripped}" | grep -qE '\$\{?[A-Z_][A-Z0-9_]*\}?'; then
-    deny
-  fi
+	# 7. Shell variable expansion — block $UPPER_CASE broadly, allowlist known-safe vars
+	# Block ${!prefix*} (indirect expansion that enumerates variable names)
+	if echo "${sanitized}" | grep -qE '\$\{![^}]*\}'; then
+		deny
+	fi
+	# Strip allowed variable references, then deny if any $VAR remain
+	safe='HOME|PATH|PWD|OLDPWD|USER|SHELL|TERM|LANG|LANGUAGE'
+	# LC_* enumerated explicitly (not LC_[A-Z]+) so a secret-bearing name like
+	# $LC_SECRET / $LC_CREDENTIALS is not swallowed by a wildcard (Finding 1).
+	safe+='|LC_ALL|LC_CTYPE|LC_NUMERIC|LC_TIME|LC_COLLATE|LC_MONETARY|LC_MESSAGES|LC_PAPER|LC_NAME|LC_ADDRESS|LC_TELEPHONE|LC_MEASUREMENT|LC_IDENTIFICATION'
+	safe+='|HOSTNAME|SHLVL|LOGNAME|TZ|TMPDIR|EDITOR|VISUAL|PAGER|DISPLAY'
+	# XDG_* enumerated explicitly (not XDG_[A-Z_]+) so $XDG_SESSION_SECRET et al.
+	# are not swallowed by a wildcard (Finding 1).
+	safe+='|XDG_CONFIG_HOME|XDG_DATA_HOME|XDG_CACHE_HOME|XDG_STATE_HOME|XDG_RUNTIME_DIR|XDG_CONFIG_DIRS|XDG_DATA_DIRS|XDG_SESSION_ID|XDG_SESSION_TYPE|XDG_SESSION_CLASS'
+	safe+='|PS[0-4]|IFS|PPID|UID|EUID|RANDOM|SECONDS|LINENO|_'
+	safe+='|OSTYPE|MACHTYPE|HOSTTYPE|BASH_SOURCE|BASH_LINENO|BASH_REMATCH|BASHPID|BASH_VERSION|HISTSIZE|HISTCONTROL'
+	# COMP_* enumerated explicitly (not COMP[A-Z_]*) so $COMP_TOKEN / $COMP_API_SECRET
+	# are not swallowed by a wildcard (Finding 1).
+	safe+='|COMPREPLY|COMP_WORDS|COMP_CWORD|COMP_LINE|COMP_POINT|COMP_KEY|COMP_TYPE|COMP_WORDBREAKS'
+	safe+='|SHELLOPTS|BASHOPTS|DIRSTACK|PIPESTATUS|FUNCNAME|REPLY'
+	safe+='|DAGSTER_HOME|DBT_PROFILES_DIR|DBT_PROJECT_DIR|DBT_CLOUD_ENVIRONMENT_TYPE|DBT_SEND_ANONYMOUS_USAGE_STATS'
+	safe+='|GOOGLE_CLOUD_PROJECT|PYTHONDONTWRITEBYTECODE|PYTHONPATH|PYTHONHASHSEED'
+	safe+='|TRUNK_TELEMETRY|UV_LINK_MODE|UV_RESOLUTION|UV_CACHE_DIR|VIRTUAL_ENV|NVM_DIR'
+	safe+='|JAVA_HOME|GOPATH|GOROOT|CARGO_HOME|RUSTUP_HOME|NODE_PATH'
+	safe+='|CI|GITHUB_WORKSPACE|GITHUB_REPOSITORY|GITHUB_REF|GITHUB_SHA|GITHUB_ACTIONS|GITHUB_ACTOR|GITHUB_OUTPUT|GITHUB_EVENT_NAME'
+	safe+='|CODESPACES|CODESPACE_NAME|REMOTE_CONTAINERS'
+	# Anchor the strip with a captured-and-re-emitted trailing non-identifier
+	# boundary so a safe PREFIX cannot consume a longer secret var name
+	# (e.g. $CI must strip, but $CI_SECRET / $USER_PASSWORD must not).
+	stripped=$(echo "${sanitized}" | sed -E "s/\\$\\{?(${safe})\\}?([^A-Z0-9_]|\$)/\\2/g")
+	# Match single-char uppercase too ($X), not just multi-char ($AWS_SECRET) — the
+	# `*` quantifier instead of `+` (#27). Lowercase vars ($i / $file) stay ignored:
+	# env-secret names are uppercase by convention and matching loop vars would
+	# false-positive broadly. ($_ is on the safe list, so the `*` does not snag it.)
+	if echo "${stripped}" | grep -qE '\$\{?[A-Z_][A-Z0-9_]*\}?'; then
+		deny
+	fi
 
 fi
 
@@ -262,53 +262,53 @@ fi
 #    every SQL-capable tool is covered (execute_sql, forecast,
 #    analyze_contribution, and any future tool), not just two named ones.
 if [[ ${tool_name} == mcp__bigquery__* ]]; then
-  # Write-statement denylist. Newlines flattened so UPDATE..SET split across
-  # lines is caught (#12); INSERT no longer requires INTO (#11); TRUNCATE and
-  # LOAD DATA added (#10). Verbs require a trailing space so column names like
-  # delete_flag / merge_count do not false-positive.
-  _bq_has_write() {
-    # Newlines flattened to spaces via parameter expansion (no tr subshell).
-    # Match each write verb on a word boundary (\b…\b) instead of requiring a
-    # secondary keyword or a trailing space: GoogleSQL makes DELETE's FROM and
-    # MERGE's INTO optional and lets /* */ comments replace the whitespace, so
-    # `DELETE ds.t`, `MERGE ds.t …` and `DROP/**/TABLE t` must all still match.
-    # \b…\b keeps read-query identifiers like delete_flag / merge_count /
-    # create_ts from false-positiving (no boundary before the trailing _).
-    echo "${1//$'\n'/ }" | grep -qiE '\bINSERT\b|\bUPDATE\b.*\bSET\b|\bDELETE\b|\bMERGE\b|\bEXPORT\b.*\bDATA\b|\bLOAD\b.*\bDATA\b|\bTRUNCATE\b|\bCREATE\b|\bDROP\b|\bALTER\b|\bGRANT\b|\bREVOKE\b|\bCALL\b'
-  }
-  case ${tool_name} in
-  mcp__bigquery__execute_sql)
-    # Whole arg is SQL: require a read statement at the start (allowlist) ...
-    if ! echo "${sanitized}" | grep -qiE '^[[:space:]]*(SELECT|SHOW|DESCRIBE|WITH)\b'; then
-      deny
-    fi
-    # ... and reject any embedded write statement.
-    if _bq_has_write "${sanitized}"; then
-      deny
-    fi
-    ;;
-  mcp__bigquery__forecast | mcp__bigquery__analyze_contribution)
-    # history_data / input_data accept a bare table-id OR a query, so requiring
-    # a read prefix would wrongly deny a legitimate table-id (#28); reject only
-    # embedded write statements.
-    if _bq_has_write "${sanitized}"; then
-      deny
-    fi
-    ;;
-  mcp__bigquery__ask_data_insights)
-    # Natural-language question + structured table refs; no raw-SQL field for a
-    # caller to inject (server performs read-only NL->SQL). Intentionally not
-    # SQL-gated — a denylist on prose would block words like "drop"/"deleted".
-    : # no-op
-    ;;
-  *)
-    # Unknown bigquery tool: conservatively reject obvious write statements
-    # anywhere in its arguments.
-    if _bq_has_write "${sanitized}"; then
-      deny
-    fi
-    ;;
-  esac
+	# Write-statement denylist. Newlines flattened so UPDATE..SET split across
+	# lines is caught (#12); INSERT no longer requires INTO (#11); TRUNCATE and
+	# LOAD DATA added (#10). Verbs require a trailing space so column names like
+	# delete_flag / merge_count do not false-positive.
+	_bq_has_write() {
+		# Newlines flattened to spaces via parameter expansion (no tr subshell).
+		# Match each write verb on a word boundary (\b…\b) instead of requiring a
+		# secondary keyword or a trailing space: GoogleSQL makes DELETE's FROM and
+		# MERGE's INTO optional and lets /* */ comments replace the whitespace, so
+		# `DELETE ds.t`, `MERGE ds.t …` and `DROP/**/TABLE t` must all still match.
+		# \b…\b keeps read-query identifiers like delete_flag / merge_count /
+		# create_ts from false-positiving (no boundary before the trailing _).
+		echo "${1//$'\n'/ }" | grep -qiE '\bINSERT\b|\bUPDATE\b.*\bSET\b|\bDELETE\b|\bMERGE\b|\bEXPORT\b.*\bDATA\b|\bLOAD\b.*\bDATA\b|\bTRUNCATE\b|\bCREATE\b|\bDROP\b|\bALTER\b|\bGRANT\b|\bREVOKE\b|\bCALL\b'
+	}
+	case ${tool_name} in
+	mcp__bigquery__execute_sql)
+		# Whole arg is SQL: require a read statement at the start (allowlist) ...
+		if ! echo "${sanitized}" | grep -qiE '^[[:space:]]*(SELECT|SHOW|DESCRIBE|WITH)\b'; then
+			deny
+		fi
+		# ... and reject any embedded write statement.
+		if _bq_has_write "${sanitized}"; then
+			deny
+		fi
+		;;
+	mcp__bigquery__forecast | mcp__bigquery__analyze_contribution)
+		# history_data / input_data accept a bare table-id OR a query, so requiring
+		# a read prefix would wrongly deny a legitimate table-id (#28); reject only
+		# embedded write statements.
+		if _bq_has_write "${sanitized}"; then
+			deny
+		fi
+		;;
+	mcp__bigquery__ask_data_insights)
+		# Natural-language question + structured table refs; no raw-SQL field for a
+		# caller to inject (server performs read-only NL->SQL). Intentionally not
+		# SQL-gated — a denylist on prose would block words like "drop"/"deleted".
+		: # no-op
+		;;
+	*)
+		# Unknown bigquery tool: conservatively reject obvious write statements
+		# anywhere in its arguments.
+		if _bq_has_write "${sanitized}"; then
+			deny
+		fi
+		;;
+	esac
 fi
 
 # ═══════════════════════════════════════════════════════════════════
@@ -321,9 +321,12 @@ fi
 # untouched. Scans the raw value corpus (${path}, before quote-strip/normalize)
 # so op:// and "service_account" JSON survive. Regex mirrors check-output.sh —
 # update BOTH if adding a token type.
-if [[ ${tool_name} == webfetch ]] ||
-  [[ ${tool_name} =~ ^mcp__.*(create|update|write|add|comment|upload|send|post|put|delete|append|insert|merge|push|reply) ]]; then
-  if echo "${path}" | grep -qiE 'op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIza[0-9A-Za-z_-]{35}|ya29\.[0-9A-Za-z_-]+|goog_[a-zA-Z0-9_-]+|eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}|ops_eyJ[A-Za-z0-9_-]{50,}|AKIA[0-9A-Z]{16}|(postgres(ql)?|mysql|mongodb(\+srv)?)://[^[:space:]]+:[^[:space:]]+@|"type"[[:space:]]*:[[:space:]]*"service_account"|gh[pusor]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[0-9A-Za-z-]{10,}|\b(sk|rk)_(live|test)_[0-9A-Za-z]{16,}|hooks\.slack\.com/services/[A-Za-z0-9/]+|aws_secret_access_key["[:space:]:=]+[A-Za-z0-9/+]{40}'; then
-    deny
-  fi
+# websearch: the query string leaves the machine too. share/forward/schedule/
+# launch/trigger: Drive share_file, Outlook forward_mail, Slack schedule_message,
+# and Dagster/dbt run launches carry free text outbound but matched no verb.
+if [[ ${tool_name} == webfetch || ${tool_name} == websearch ]] ||
+	[[ ${tool_name} =~ ^mcp__.*(create|update|write|add|comment|upload|send|post|put|delete|append|insert|merge|push|reply|share|forward|schedule|launch|trigger) ]]; then
+	if echo "${path}" | grep -qiE 'op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIza[0-9A-Za-z_-]{35}|ya29\.[0-9A-Za-z_-]+|goog_[a-zA-Z0-9_-]+|eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}|ops_eyJ[A-Za-z0-9_-]{50,}|AKIA[0-9A-Z]{16}|(postgres(ql)?|mysql|mongodb(\+srv)?)://[^[:space:]]+:[^[:space:]]+@|"type"[[:space:]]*:[[:space:]]*"service_account"|gh[pusor]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[0-9A-Za-z-]{10,}|\b(sk|rk)_(live|test)_[0-9A-Za-z]{16,}|hooks\.slack\.com/services/[A-Za-z0-9/]+|aws_secret_access_key["[:space:]:=]+[A-Za-z0-9/+]{40}'; then
+		deny
+	fi
 fi

--- a/.claude/hooks/check-sensitive.sh
+++ b/.claude/hooks/check-sensitive.sh
@@ -9,7 +9,10 @@
 # chmod 700) and 1Password authentication.
 
 deny() {
-	echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "❌ Cannot access sensitive path"}}'
+	# Reason is shown to Claude verbatim as permissionDecisionReason, so name the
+	# rule and the way out. Keep it free of tokens the hooks themselves deny.
+	local reason=${1:-Cannot access sensitive path}
+	jq -cn --arg r "❌ ${reason}" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
 	exit 0
 }
 
@@ -19,7 +22,7 @@ input=$(cat)
 # cannot understand rather than silently allow. Empty stdin, unparseable JSON,
 # a non-object frame, or a missing/empty tool_name all fall through to deny.
 if [[ -z ${input} ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"${input}"; then
-	deny
+	deny "check-sensitive.sh: hook input was empty or not a JSON object; failing closed. Retry the call as-is once; if it repeats, tell the user."
 fi
 tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 # Normalize once: lowercase + strip all whitespace so a re-cased or padded
@@ -28,7 +31,7 @@ tool_name=$(jq -r '.tool_name // ""' <<<"${input}")
 tool_name=${tool_name,,}
 tool_name=${tool_name//[[:space:]]/}
 if [[ -z ${tool_name} ]]; then
-	deny
+	deny "check-sensitive.sh: tool_name was missing from the hook input; failing closed. Retry once; if it repeats, tell the user."
 fi
 
 # Normalize path strings: collapse //, /./, resolve ../
@@ -103,7 +106,7 @@ fi
 _env_scan=$(echo "${no_content}" | sed -E 's/\.env\.(example|sample|template|dist)([^a-zA-Z]|$)/\2/g')
 if echo "${_env_scan}" | grep -qiE '\.env[.a-z]*' ||
 	echo "${no_content}" | grep -qiE '(^|[ /])(\.ssh|\.kube|\.pem|\.key|\.cer|secrets\.json|credentials\.json|application_default_credentials\.json|\.git-credentials|\.netrc|secret-volume)([ /]|$)|(^|[ /])(\.?/)?env(/|[ ]|$)|\.config/op([ /]|$)|\.devcontainer/tpl/'; then
-	deny
+	deny "check-sensitive.sh Rule 1: an argument matches a secret-file pattern (dotenv, .ssh or .kube dirs, key/cert files, credentials or secrets JSON, netrc, secret-volume, devcontainer tpl, or the bare word env). If it is a real secret file, do not read or name it; ask the user. If it is prose, write 'environment variable' and 'dotenv'."
 fi
 
 # 1b. File-extension patterns scoped to path_only (named path keys incl. MCP
@@ -111,13 +114,13 @@ fi
 #     keys without scanning free-text fields like a SQL `sql` parameter, where a
 #     dot-attribute such as record.key would otherwise false-positive.
 if echo "${path_only}" | grep -qiE '\*?\.(cer|key|pem)([ /]|$)'; then
-	deny
+	deny "check-sensitive.sh Rule 1b: a path argument ends in .cer, .key, or .pem (certificate or private key). Do not open it; ask the user."
 fi
 
 # 1c. High-risk proc/dev paths — kept in all-tools scope (sandbox is ineffective
 #     in Codespaces; hooks are the sole enforcement layer)
 if echo "${no_content}" | grep -qE '/proc/[^[:space:]]*/environ|/proc/[^[:space:]]*/cmdline|/dev/fd/'; then
-	deny
+	deny "check-sensitive.sh Rule 1c: /proc/*/environ, /proc/*/cmdline, and /dev/fd/ expose process memory. There is no approved bypass; ask the user."
 fi
 
 # ═══════════════════════════════════════════════════════════════════
@@ -136,7 +139,7 @@ if [[ ${tool_name} =~ ^mcp__filesystem__(write_file|edit_file|move_file|create_d
 	fs_target=$(echo "${fs_target}" | _normalize)
 	fs_target=${fs_target//[\"\'\\]/}
 	if echo "${fs_target}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
-		deny
+		deny "check-sensitive.sh Rule 1d: the filesystem MCP may not write a protected config path (.claude hooks or settings, .devcontainer/scripts, .git/hooks, .trunk config). Draft the change and hand it to the user to apply."
 	fi
 fi
 
@@ -147,38 +150,38 @@ if [[ ${tool_name} == "bash" ]]; then
 
 	# 2. Protected paths — Edit/Write handled by permissions.deny; Bash blocked here
 	if echo "${path_only}" | grep -qE '\.claude/(settings\.json|settings\.local\.json|hooks/[^[:space:]]*\.sh|shell-snapshots/)|\.devcontainer/scripts/|\.git/hooks/|\.trunk/(trunk\.yaml|config/)'; then
-		deny
+		deny "check-sensitive.sh Rule 2: Bash may not name a protected file (.claude/hooks/*.sh, settings.json, shell-snapshots, .devcontainer/scripts, .git/hooks, .trunk config). Use the Read tool, or run a script from .claude/scratch/ that holds the path. Stage with git add -u, never by name."
 	fi
 
 	# 3. Environment variable / process memory leakage
 	# declare: -x already listed; also block any -flag cluster containing p
 	# (-p/-px/-xp dump variable definitions, equivalent to printenv/set)
 	if echo "${sanitized}" | grep -qiE '\bprintenv\b|\bdeclare -x\b|\bdeclare[[:space:]]+-[a-zA-Z]*p[a-zA-Z]*\b|\bexport -p\b|\bcompgen\b|\btypeset([[:space:]]+-x|\b)|/proc/[^[:space:]]*/environ|/proc/[^[:space:]]*/cmdline|OP_SERVICE_ACCOUNT_TOKEN|OP_CONNECT_TOKEN|OP_SERVICE|ACCOUNT_TOKEN|\benviron\b|\bgetenv\b'; then
-		deny
+		deny "check-sensitive.sh Rule 3: the command dumps process variables (printenv, declare -x/-p, export -p, compgen, typeset, getenv, environ, or an OP_ token name). Credentials exist only inside uv run pytest (see tests/CLAUDE.md); do not read them from the shell."
 	fi
 
 	# 3d. Catch bare `declare` (dumps all vars), but not `declare VAR=val` or `declare -flags`
 	# trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(declare), not a command substitution
 	if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)declare([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(declare([[:space:]]|$|\))'; then
-		deny
+		deny "check-sensitive.sh Rule 3d: a bare declare dumps every shell variable. Remove it; declare NAME=value and declare -f are fine."
 	fi
 
 	# 3b. Catch `set` as a standalone command (dumps all vars), but not `set -flags`
 	# trunk-ignore(shellcheck/SC2016): regex contains literal $\( for matching $(set), not a command substitution
 	if echo "${sanitized}" | grep -qE '(^|[;&|(`][[:space:]]*)set([[:space:]]*$|[[:space:]]*[|>&;)`])|\$\(set([[:space:]]|$|\))'; then
-		deny
+		deny "check-sensitive.sh Rule 3b: a bare set dumps every shell variable. Remove it; set -flags are fine."
 	fi
 
 	# 3c. Standalone `env` shell command — scoped to path/command only (not file content)
 	if echo "${path_only}" | grep -qiE '\benv\b'; then
-		deny
+		deny "check-sensitive.sh Rule 3c: the bare word 'env' appears in the command or a path. Spell it 'environment variable' in prose, and run programs directly rather than through the env command."
 	fi
 
 	# 4. 1Password CLI escalation — prevent using a leaked token to access the vault
 	#    or mint new credentials. Verbs extended (#14): signin/account/user/
 	#    service-account/connect and plural items.
 	if echo "${sanitized}" | grep -qE '\bop\b.*\b(vault|item|items|read|run|document|inject|signin|account|user|service-account|connect)\b'; then
-		deny
+		deny "check-sensitive.sh Rule 4: the 1Password CLI (op vault/item/read/run/inject/signin/...) is off limits from Bash. Credentialed work runs under uv run pytest, which bootstraps 1Password itself (tests/CLAUDE.md)."
 	fi
 
 	# 5. Encoding-based bypass: a base64/hex decode feeding a shell interpreter.
@@ -187,7 +190,7 @@ if [[ ${tool_name} == "bash" ]]; then
 	#    evaded the line-oriented grep). Consumers now include eval (#15).
 	_flat=${normalized//$'\n'/;}
 	if echo "${_flat}" | grep -qiE '(base64[[:space:]]+(-d|--decode)|\bxxd\b|\bprintf[[:space:]]+[^|;&]*\\x).*(\||[;&]+).*(bash|sh|source|eval)'; then
-		deny
+		deny "check-sensitive.sh Rule 5: a base64/xxd/printf decode feeding a shell interpreter. Write the decoded content to .claude/scratch/ with the Write tool and run that file instead."
 	fi
 
 	# 5a. Reverse order: a shell interpreter (bash/sh/source/eval, or the `.` dot
@@ -196,28 +199,28 @@ if [[ ${tool_name} == "bash" ]]; then
 	#     (quote/backslash-stripped) to keep the quote-split defense; these forms
 	#     are same-line, so the newline-flattening (Rule 5) is not needed here.
 	if echo "${sanitized}" | grep -qiE '\b(bash|sh|source|eval)\b.*(<\(|<<<|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)|(^|[;&|][[:space:]]*)\.[[:space:]]+(<\(|\$\().*(base64[[:space:]]+(-d|--decode)|\bxxd\b)'; then
-		deny
+		deny "check-sensitive.sh Rule 5a: a base64/xxd/printf decode feeding a shell interpreter. Write the decoded content to .claude/scratch/ with the Write tool and run that file instead."
 	fi
 
 	# 5b. Python runtime string construction (exec/eval with chr/join/bytes/base64/codecs)
 	if echo "${sanitized}" | grep -qiE '\b(exec|eval)[[:space:]]*\(.*\bchr[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\.join[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*\bbytes[[:space:]]*\(|\b(exec|eval)[[:space:]]*\(.*base64\.b64decode|\b(exec|eval)[[:space:]]*\(.*codecs\.decode|\b(exec|eval)[[:space:]]*\(.*\.fromhex'; then
-		deny
+		deny "check-sensitive.sh Rule 5b: Python exec/eval over a constructed string (chr/join/bytes/base64/codecs/fromhex). Put the code in a file under .claude/scratch/ and run it with uv run python."
 	fi
 
 	# 5c. Python __import__ with sensitive modules (bypasses exec() requirement)
 	if echo "${sanitized}" | grep -qiE '\b__import__[[:space:]]*\(.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
-		deny
+		deny "check-sensitive.sh Rule 5c: Python __import__ of an OS/process/network module from the command line. Put the code in a file under .claude/scratch/ with normal import statements and run it with uv run python."
 	fi
 
 	# 5d. Python importlib bypass (avoids __import__ check)
 	if echo "${sanitized}" | grep -qiE '\bimportlib\b.*\b(os|subprocess|shutil|pty|ctypes|socket|http|urllib|multiprocessing|signal)\b'; then
-		deny
+		deny "check-sensitive.sh Rule 5d: Python importlib of an OS/process/network module from the command line. Put the code in a file under .claude/scratch/ with normal import statements and run it with uv run python."
 	fi
 
 	# 7. Shell variable expansion — block $UPPER_CASE broadly, allowlist known-safe vars
 	# Block ${!prefix*} (indirect expansion that enumerates variable names)
 	if echo "${sanitized}" | grep -qE '\$\{![^}]*\}'; then
-		deny
+		deny "check-sensitive.sh Rule 7: ${!prefix*} enumerates variable names. Remove it."
 	fi
 	# Strip allowed variable references, then deny if any $VAR remain
 	safe='HOME|PATH|PWD|OLDPWD|USER|SHELL|TERM|LANG|LANGUAGE'
@@ -249,7 +252,7 @@ if [[ ${tool_name} == "bash" ]]; then
 	# env-secret names are uppercase by convention and matching loop vars would
 	# false-positive broadly. ($_ is on the safe list, so the `*` does not snag it.)
 	if echo "${stripped}" | grep -qE '\$\{?[A-Z_][A-Z0-9_]*\}?'; then
-		deny
+		deny "check-sensitive.sh Rule 7: the command expands an uppercase shell variable not on the safe list; uppercase names may hold credentials. Use lowercase names for ad-hoc variables (sc=value, then reference sc) and get credentials through uv run pytest."
 	fi
 
 fi
@@ -280,11 +283,11 @@ if [[ ${tool_name} == mcp__bigquery__* ]]; then
 	mcp__bigquery__execute_sql)
 		# Whole arg is SQL: require a read statement at the start (allowlist) ...
 		if ! echo "${sanitized}" | grep -qiE '^[[:space:]]*(SELECT|SHOW|DESCRIBE|WITH)\b'; then
-			deny
+			deny "check-sensitive.sh Rule 8: BigQuery MCP is read-only; the SQL must start with SELECT, SHOW, DESCRIBE, or WITH. DML/DDL goes to the user's terminal."
 		fi
 		# ... and reject any embedded write statement.
 		if _bq_has_write "${sanitized}"; then
-			deny
+			deny "check-sensitive.sh Rule 8: BigQuery MCP is read-only and the SQL contains a write verb (INSERT, UPDATE..SET, DELETE, MERGE, CREATE, DROP, ALTER, TRUNCATE, EXPORT/LOAD DATA, GRANT, REVOKE, CALL), matched even inside a string literal. Reword the literal (like 'Dr%') or hand DML/DDL to the user's terminal."
 		fi
 		;;
 	mcp__bigquery__forecast | mcp__bigquery__analyze_contribution)
@@ -292,7 +295,7 @@ if [[ ${tool_name} == mcp__bigquery__* ]]; then
 		# a read prefix would wrongly deny a legitimate table-id (#28); reject only
 		# embedded write statements.
 		if _bq_has_write "${sanitized}"; then
-			deny
+			deny "check-sensitive.sh Rule 8: BigQuery MCP is read-only and the SQL contains a write verb (INSERT, UPDATE..SET, DELETE, MERGE, CREATE, DROP, ALTER, TRUNCATE, EXPORT/LOAD DATA, GRANT, REVOKE, CALL), matched even inside a string literal. Reword the literal (like 'Dr%') or hand DML/DDL to the user's terminal."
 		fi
 		;;
 	mcp__bigquery__ask_data_insights)
@@ -305,7 +308,7 @@ if [[ ${tool_name} == mcp__bigquery__* ]]; then
 		# Unknown bigquery tool: conservatively reject obvious write statements
 		# anywhere in its arguments.
 		if _bq_has_write "${sanitized}"; then
-			deny
+			deny "check-sensitive.sh Rule 8: BigQuery MCP is read-only and the SQL contains a write verb (INSERT, UPDATE..SET, DELETE, MERGE, CREATE, DROP, ALTER, TRUNCATE, EXPORT/LOAD DATA, GRANT, REVOKE, CALL), matched even inside a string literal. Reword the literal (like 'Dr%') or hand DML/DDL to the user's terminal."
 		fi
 		;;
 	esac
@@ -327,6 +330,6 @@ fi
 if [[ ${tool_name} == webfetch || ${tool_name} == websearch ]] ||
 	[[ ${tool_name} =~ ^mcp__.*(create|update|write|add|comment|upload|send|post|put|delete|append|insert|merge|push|reply|share|forward|schedule|launch|trigger) ]]; then
 	if echo "${path}" | grep -qiE 'op://|-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|PRIVATE KEY-----|AIza[0-9A-Za-z_-]{35}|ya29\.[0-9A-Za-z_-]+|goog_[a-zA-Z0-9_-]+|eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}|ops_eyJ[A-Za-z0-9_-]{50,}|AKIA[0-9A-Z]{16}|(postgres(ql)?|mysql|mongodb(\+srv)?)://[^[:space:]]+:[^[:space:]]+@|"type"[[:space:]]*:[[:space:]]*"service_account"|gh[pusor]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[0-9A-Za-z-]{10,}|\b(sk|rk)_(live|test)_[0-9A-Za-z]{16,}|hooks\.slack\.com/services/[A-Za-z0-9/]+|aws_secret_access_key["[:space:]:=]+[A-Za-z0-9/+]{40}'; then
-		deny
+		deny "check-sensitive.sh Section 4: this outbound write carries a secret-shaped value (1Password reference, private-key header, cloud token, JWT, connection string, service-account JSON). Redact it (write op-uri) before sending."
 	fi
 fi

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -116,8 +116,9 @@ runs all of them; each `test_*.sh` covers one rule area; `helpers.sh` provides
   / `OUTPUT_HOOK` env overrides:
   `HOOK=/abs/scratch/check-sensitive-x.sh OUTPUT_HOOK=/abs/scratch/check-output-x.sh bash tests/hooks/run_all.sh`.
 - Reading a `test_*.sh` range that contains secret-shaped fixtures (`op://`, key
-  headers, cloud tokens) trips `check-output.sh` on the Read result. Read clean
-  ranges only, or anchor Edits on a non-fixture line (e.g. `print_summary`).
+  headers, cloud tokens) gets the whole Read result redacted by
+  `check-output.sh`. Read clean ranges only, or anchor Edits on a non-fixture
+  line (e.g. `print_summary`).
 - Synthetic secret fixtures: split the literal (`"sk_live""_..."`,
   `'-----BEGIN ''PRIVATE KEY-----'`) so gitleaks' source scan misses it but bash
   rebuilds the value at run time — cleaner than a `trunk-ignore`, which trips

--- a/tests/hooks/helpers.sh
+++ b/tests/hooks/helpers.sh
@@ -172,6 +172,40 @@ expect_allow() {
 	fi
 }
 
+# Assert the PostToolUse hook REDACTED the content: stdout carries
+# updatedToolOutput, the redaction literal is present, and the secret is gone.
+# Presence of the key alone is not enough — an empty {} replacement is ignored
+# by the harness for built-in tools and the original output is shown.
+# Usage: expect_redacted <description> <json_input> <secret_literal>
+expect_redacted() {
+	local desc="$1" input="$2" secret="$3" output
+	output=$(printf '%s' "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
+	if grep -q '"updatedToolOutput"' <<<"${output}" &&
+		grep -qF '[redacted: secret material]' <<<"${output}" &&
+		! grep -qF -- "${secret}" <<<"${output}"; then
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [redacted]: ${desc}"
+	else
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [redacted]: ${desc} (secret survived or no redaction literal)"
+	fi
+}
+
+# Assert the PostToolUse hook ended the turn (decision:block) — the fail-closed
+# path for payloads it cannot redact (unparseable, or no .tool_response key).
+# Usage: expect_block <description> <json_input>
+expect_block() {
+	local desc="$1" input="$2" output
+	output=$(printf '%s' "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
+	if grep -q '"decision"' <<<"${output}" && grep -q '"block"' <<<"${output}"; then
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [block]: ${desc}"
+	else
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [block]: ${desc} (expected decision:block)"
+	fi
+}
+
 # PostToolUse helper
 # check_output <desc> <expect> [tool] <content>
 # 3-arg form: check_output "desc" deny|clean "output"        (defaults to Bash)

--- a/tests/hooks/helpers.sh
+++ b/tests/hooks/helpers.sh
@@ -21,80 +21,85 @@ NC='\033[0m'
 
 # Helper: check if hook stdout contains a deny decision
 _is_deny() {
-  grep -q '"permissionDecision"' <<<"$1" && grep -q '"deny"' <<<"$1"
+	# PreToolUse denies via permissionDecision; PostToolUse cannot deny — it
+	# redacts via updatedToolOutput, or ends the turn with decision:block when the
+	# payload is unparseable. All three count as "blocked".
+	{ grep -q '"permissionDecision"' <<<"$1" && grep -q '"deny"' <<<"$1"; } ||
+		grep -q '"updatedToolOutput"' <<<"$1" ||
+		{ grep -q '"decision"' <<<"$1" && grep -q '"block"' <<<"$1"; }
 }
 
 # Assert that a hook deny exits 0 with deny JSON on stdout (not exit 1/stderr).
 # Claude Code treats exit 1 as a non-blocking error — only exit 0 + JSON is honored.
 # Usage: expect_deny_exit0 <description> <hook_script> <json_input>
 expect_deny_exit0() {
-  local desc="$1" hook="$2" input="$3"
-  local stdout stderr exit_code tmpfile
-  # Per-invocation temp file (mktemp) — a fixed /tmp path races under parallel runs.
-  tmpfile=$(mktemp)
-  stdout=$(printf '%s' "${input}" | bash "${hook}" 2>"${tmpfile}")
-  exit_code=$?
-  stderr=$(cat "${tmpfile}")
-  rm -f "${tmpfile}"
-  local ok=true
-  if [[ ${exit_code} -ne 0 ]]; then
-    ok=false
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [exit 0]: ${desc} (got exit ${exit_code} — Claude Code ignores non-zero)"
-  elif ! _is_deny "${stdout}"; then
-    ok=false
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [deny JSON on stdout]: ${desc} (stdout empty or missing deny)"
-  elif echo "${stderr}" | grep -q 'permissionDecision'; then
-    ok=false
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [no deny on stderr]: ${desc} (deny JSON leaked to stderr)"
-  fi
-  if [[ ${ok} == "true" ]]; then
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [exit 0 + deny on stdout]: ${desc}"
-  fi
+	local desc="$1" hook="$2" input="$3"
+	local stdout stderr exit_code tmpfile
+	# Per-invocation temp file (mktemp) — a fixed /tmp path races under parallel runs.
+	tmpfile=$(mktemp)
+	stdout=$(printf '%s' "${input}" | bash "${hook}" 2>"${tmpfile}")
+	exit_code=$?
+	stderr=$(cat "${tmpfile}")
+	rm -f "${tmpfile}"
+	local ok=true
+	if [[ ${exit_code} -ne 0 ]]; then
+		ok=false
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [exit 0]: ${desc} (got exit ${exit_code} — Claude Code ignores non-zero)"
+	elif ! _is_deny "${stdout}"; then
+		ok=false
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [deny JSON on stdout]: ${desc} (stdout empty or missing deny)"
+	elif echo "${stderr}" | grep -qE 'permissionDecision|updatedToolOutput|"decision"'; then
+		ok=false
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [no deny on stderr]: ${desc} (deny JSON leaked to stderr)"
+	fi
+	if [[ ${ok} == "true" ]]; then
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [exit 0 + deny on stdout]: ${desc}"
+	fi
 }
 
 # Helper: build JSON input for the hook
 make_input() {
-  local tool_name="$1"
-  local field="$2"
-  local value="$3"
-  jq -n --arg tn "${tool_name}" --arg fld "${field}" --arg val "${value}" \
-    '{tool_name: $tn, tool_input: {($fld): $val}}'
+	local tool_name="$1"
+	local field="$2"
+	local value="$3"
+	jq -n --arg tn "${tool_name}" --arg fld "${field}" --arg val "${value}" \
+		'{tool_name: $tn, tool_input: {($fld): $val}}'
 }
 
 # Helper: build JSON input with two fields (for Write/Edit tools)
 make_input2() {
-  local tool_name="$1"
-  local field1="$2" value1="$3"
-  local field2="$4" value2="$5"
-  jq -n --arg tn "${tool_name}" \
-    --arg f1 "${field1}" --arg v1 "${value1}" \
-    --arg f2 "${field2}" --arg v2 "${value2}" \
-    '{tool_name: $tn, tool_input: {($f1): $v1, ($f2): $v2}}'
+	local tool_name="$1"
+	local field1="$2" value1="$3"
+	local field2="$4" value2="$5"
+	jq -n --arg tn "${tool_name}" \
+		--arg f1 "${field1}" --arg v1 "${value1}" \
+		--arg f2 "${field2}" --arg v2 "${value2}" \
+		'{tool_name: $tn, tool_input: {($f1): $v1, ($f2): $v2}}'
 }
 
 # Run hook with pre-built JSON and check result
 # expect_deny_json <description> <json>
 expect_deny_json() {
-  local desc="$1" input="$2"
-  # Validate the full protocol (exit 0 + deny on stdout + not on stderr).
-  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
+	local desc="$1" input="$2"
+	# Validate the full protocol (exit 0 + deny on stdout + not on stderr).
+	expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow_json() {
-  local desc="$1" input="$2"
-  local output
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
-  else
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
-  fi
+	local desc="$1" input="$2"
+	local output
+	output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
+	if _is_deny "${output}"; then
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
+	else
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
+	fi
 }
 
 # Pipe an arbitrary raw string to a named hook and assert it denies.
@@ -102,69 +107,69 @@ expect_allow_json() {
 # and tool_name normalization that the JSON-builder helpers can't express.
 # Usage: expect_deny_raw <description> <hook_script> <raw_input>
 expect_deny_raw() {
-  local desc="$1" hook="$2" input="$3"
-  expect_deny_exit0 "${desc}" "${hook}" "${input}"
+	local desc="$1" hook="$2" input="$3"
+	expect_deny_exit0 "${desc}" "${hook}" "${input}"
 }
 
 # Pipe an arbitrary raw string to a named hook and assert it allows.
 # Usage: expect_allow_raw <description> <hook_script> <raw_input>
 expect_allow_raw() {
-  local desc="$1" hook="$2" input="$3"
-  local output
-  output=$(printf '%s' "${input}" | bash "${hook}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
-  else
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
-  fi
+	local desc="$1" hook="$2" input="$3"
+	local output
+	output=$(printf '%s' "${input}" | bash "${hook}" 2>/dev/null)
+	if _is_deny "${output}"; then
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
+	else
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
+	fi
 }
 
 # Run hook with two-field input and check result
 expect_deny2() {
-  local desc="$1" tool="$2" f1="$3" v1="$4" f2="$5" v2="$6"
-  local input
-  input=$(make_input2 "${tool}" "${f1}" "${v1}" "${f2}" "${v2}")
-  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
+	local desc="$1" tool="$2" f1="$3" v1="$4" f2="$5" v2="$6"
+	local input
+	input=$(make_input2 "${tool}" "${f1}" "${v1}" "${f2}" "${v2}")
+	expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow2() {
-  local desc="$1" tool="$2" f1="$3" v1="$4" f2="$5" v2="$6"
-  local input output
-  input=$(make_input2 "${tool}" "${f1}" "${v1}" "${f2}" "${v2}")
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
-  else
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
-  fi
+	local desc="$1" tool="$2" f1="$3" v1="$4" f2="$5" v2="$6"
+	local input output
+	input=$(make_input2 "${tool}" "${f1}" "${v1}" "${f2}" "${v2}")
+	output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
+	if _is_deny "${output}"; then
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
+	else
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
+	fi
 }
 
 # Run hook and check result
 # expect_deny <description> <tool_name> <field> <value>
 expect_deny() {
-  local desc="$1" tool="$2" field="$3" value="$4"
-  local input
-  input=$(make_input "${tool}" "${field}" "${value}")
-  expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
+	local desc="$1" tool="$2" field="$3" value="$4"
+	local input
+	input=$(make_input "${tool}" "${field}" "${value}")
+	expect_deny_exit0 "${desc}" "${HOOK}" "${input}"
 }
 
 expect_allow() {
-  local desc="$1" tool="$2" field="$3" value="$4"
-  local input output
-  input=$(make_input "${tool}" "${field}" "${value}")
-  output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
-  if _is_deny "${output}"; then
-    FAIL=$((FAIL + 1))
-    ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
-    ERRORS+="\n       tool=${tool} ${field}=$(echo "${value}" | head -c 80)"
-  else
-    PASS=$((PASS + 1))
-    echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
-  fi
+	local desc="$1" tool="$2" field="$3" value="$4"
+	local input output
+	input=$(make_input "${tool}" "${field}" "${value}")
+	output=$(echo "${input}" | bash "${HOOK}" 2>/dev/null)
+	if _is_deny "${output}"; then
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [should allow]: ${desc}"
+		ERRORS+="\n       tool=${tool} ${field}=$(echo "${value}" | head -c 80)"
+	else
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [allow]: ${desc}"
+	fi
 }
 
 # PostToolUse helper
@@ -172,49 +177,49 @@ expect_allow() {
 # 3-arg form: check_output "desc" deny|clean "output"        (defaults to Bash)
 # 4-arg form: check_output "desc" deny|clean Tool "output"
 check_output() {
-  local desc="$1" expect="$2" tool content_val
-  if [[ $# -eq 3 ]]; then
-    tool="Bash"
-    content_val="$3"
-  else
-    tool="$3"
-    content_val="$4"
-  fi
-  local input
-  input=$(jq -n --arg tn "${tool}" --arg c "${content_val}" \
-    '{tool_name: $tn, tool_response: {content: $c, stdout: $c, stderr: ""}}')
+	local desc="$1" expect="$2" tool content_val
+	if [[ $# -eq 3 ]]; then
+		tool="Bash"
+		content_val="$3"
+	else
+		tool="$3"
+		content_val="$4"
+	fi
+	local input
+	input=$(jq -n --arg tn "${tool}" --arg c "${content_val}" \
+		'{tool_name: $tn, tool_response: {content: $c, stdout: $c, stderr: ""}}')
 
-  if [[ ${expect} == "deny" ]]; then
-    # Full protocol: exit 0 + deny on stdout + not on stderr.
-    expect_deny_exit0 "${desc}" "${OUTPUT_HOOK}" "${input}"
-  else
-    local output
-    output=$(printf '%s' "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
-    if _is_deny "${output}"; then
-      FAIL=$((FAIL + 1))
-      ERRORS+="\n  ${RED}FAIL${NC} [expected clean]: ${desc}"
-    else
-      PASS=$((PASS + 1))
-      echo -e "  ${GREEN}PASS${NC} [clean]: ${desc}"
-    fi
-  fi
+	if [[ ${expect} == "deny" ]]; then
+		# Full protocol: exit 0 + deny on stdout + not on stderr.
+		expect_deny_exit0 "${desc}" "${OUTPUT_HOOK}" "${input}"
+	else
+		local output
+		output=$(printf '%s' "${input}" | bash "${OUTPUT_HOOK}" 2>/dev/null)
+		if _is_deny "${output}"; then
+			FAIL=$((FAIL + 1))
+			ERRORS+="\n  ${RED}FAIL${NC} [expected clean]: ${desc}"
+		else
+			PASS=$((PASS + 1))
+			echo -e "  ${GREEN}PASS${NC} [clean]: ${desc}"
+		fi
+	fi
 }
 
 # Print summary and exit with appropriate code
 print_summary() {
-  local label="${1:-Hook Security Tests}"
-  echo ""
-  echo "========================================="
-  echo -e " ${label}: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
-  echo "========================================="
+	local label="${1:-Hook Security Tests}"
+	echo ""
+	echo "========================================="
+	echo -e " ${label}: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+	echo "========================================="
 
-  if [[ ${FAIL} -gt 0 ]]; then
-    echo -e "\nFailures:${ERRORS}"
-    echo ""
-    exit 1
-  else
-    echo -e "\n${GREEN}All tests passed.${NC}"
-    echo ""
-    exit 0
-  fi
+	if [[ ${FAIL} -gt 0 ]]; then
+		echo -e "\nFailures:${ERRORS}"
+		echo ""
+		exit 1
+	else
+		echo -e "\n${GREEN}All tests passed.${NC}"
+		echo ""
+		exit 0
+	fi
 }

--- a/tests/hooks/test_deny_reasons.sh
+++ b/tests/hooks/test_deny_reasons.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Every check-sensitive.sh denial names the rule that fired and the way out.
+# permissionDecisionReason is shown to Claude verbatim, so a generic message
+# ("Cannot access sensitive path") sends it hunting through CLAUDE.md instead
+# of fixing the call.
+#
+# Usage: bash tests/hooks/test_deny_reasons.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/hooks/helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+echo ""
+echo "========================================="
+echo " Deny reasons (check-sensitive.sh)"
+echo "========================================="
+
+# expect_reason <desc> <json_input> <substring the reason must contain>
+expect_reason() {
+	local desc="$1" input="$2" want="$3" output reason
+	output=$(printf '%s' "${input}" | bash "${HOOK}" 2>/dev/null)
+	reason=$(jq -r '.hookSpecificOutput.permissionDecisionReason // ""' <<<"${output}" 2>/dev/null)
+	if [[ ${reason} == *"${want}"* ]]; then
+		PASS=$((PASS + 1))
+		echo -e "  ${GREEN}PASS${NC} [reason]: ${desc}"
+	else
+		FAIL=$((FAIL + 1))
+		ERRORS+="\n  ${RED}FAIL${NC} [reason]: ${desc} (wanted '${want}' in: ${reason:0:80})"
+	fi
+}
+
+echo ""
+echo -e "${YELLOW}Each rule names itself and an alternative${NC}"
+
+# trunk-ignore-begin(shellcheck/SC2312): jq -n static JSON, return value irrelevant
+expect_reason "fail-closed: empty stdin" "" "failing closed"
+expect_reason "Rule 1: dotenv path" "$(make_input Read file_path /repo/.env)" "Rule 1:"
+expect_reason "Rule 1b: pem under a path key" "$(make_input Read file_path /repo/server.pem)" "Rule 1b:"
+expect_reason "Rule 1c: proc environ" "$(make_input Bash command 'cat /proc/1/environ')" "Rule 1c:"
+expect_reason "Rule 2: Bash names a hook script" "$(make_input Bash command 'cat .claude/hooks/check-sensitive.sh')" "Rule 2:"
+expect_reason "Rule 3: printenv" "$(make_input Bash command printenv)" "Rule 3:"
+expect_reason "Rule 3b: bare set" "$(make_input Bash command 'set | head')" "Rule 3b:"
+# A bare `env` command is Rule 1's (all-tools) match; 3c only sees forms Rule 1
+# lets through, such as a word-bounded env inside a file name.
+expect_reason "Rule 1: bare env command" "$(make_input Bash command 'env')" "Rule 1:"
+expect_reason "Rule 3c: env word in a path" "$(make_input Bash command 'cat ./env.txt')" "Rule 3c:"
+expect_reason "Rule 4: op read" "$(make_input Bash command 'op read x')" "Rule 4:"
+expect_reason "Rule 5: base64 decode into bash" "$(make_input Bash command 'echo x | base64 -d | bash')" "Rule 5:"
+# trunk-ignore(shellcheck/SC2016): the literal $VAR is the fixture; it must reach the hook unexpanded
+expect_reason "Rule 7: uppercase var" "$(make_input Bash command 'echo $AWS_SECRET')" "Rule 7:"
+expect_reason "Rule 8: BQ write verb" "$(make_input mcp__bigquery__execute_sql sql 'select 1; drop table t')" "Rule 8:"
+expect_reason "Section 4: egress with token" \
+	"$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{body:"AKIAIOSFODNN7EXAMPLE"}}')" "Section 4:"
+# every reason tells Claude what to do instead, not only what matched
+expect_reason "Rule 2 reason offers the Read tool" "$(make_input Bash command 'cat .claude/hooks/check-sensitive.sh')" "Read tool"
+expect_reason "Rule 8 reason offers a rewrite" "$(make_input mcp__bigquery__execute_sql sql "select 1 where t = 'Drop'")" "Dr%"
+# trunk-ignore-end(shellcheck/SC2312)
+
+print_summary "Deny reasons"

--- a/tests/hooks/test_egress.sh
+++ b/tests/hooks/test_egress.sh
@@ -19,26 +19,43 @@ echo -e "${YELLOW}#22: write-capable MCP tools must not send secret values${NC}"
 
 # trunk-ignore-begin(shellcheck/SC2312): jq -n produces static JSON, return value irrelevant
 expect_deny_json "github issue_write body w/ 1pw reference" \
-  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"see op://vault/item/field"}}')"
+	"$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"see op://vault/item/field"}}')"
 expect_deny_json "github add_issue_comment w/ priv-key header" \
-  "$(jq -n '{tool_name:"mcp__github__add_issue_comment", tool_input:{body:"-----BEGIN PRIVATE KEY-----"}}')"
+	"$(jq -n '{tool_name:"mcp__github__add_issue_comment", tool_input:{body:"-----BEGIN PRIVATE KEY-----"}}')"
 expect_deny_json "drive create_file w/ google oauth token" \
-  "$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__create_file", tool_input:{content:"ya29.a0AfH6SMBexampletokenvalue"}}')"
+	"$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__create_file", tool_input:{content:"ya29.a0AfH6SMBexampletokenvalue"}}')"
 expect_deny_json "asana create_tasks w/ gh token" \
-  "$(jq -n '{tool_name:"mcp__claude_ai_Asana__create_tasks", tool_input:{html_notes:"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"}}')"
+	"$(jq -n '{tool_name:"mcp__claude_ai_Asana__create_tasks", tool_input:{html_notes:"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"}}')"
 expect_deny_json "WebFetch url carrying a 1pw reference" \
-  "$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://x.example/?u=op://vault/i/f"}}')"
+	"$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://x.example/?u=op://vault/i/f"}}')"
+
+# Egress verbs share/forward/schedule/launch/trigger and the WebSearch query.
+expect_deny_json "drive share_file message w/ 1pw reference (share verb)" \
+	"$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__share_file", tool_input:{message:"op://vault/item/field"}}')"
+expect_deny_json "outlook forward_mail comment w/ 1pw reference (forward verb)" \
+	"$(jq -n '{tool_name:"mcp__claude_ai_Microsoft_365__outlook_forward_mail", tool_input:{comment:"op://vault/item/field"}}')"
+expect_deny_json "slack schedule_message w/ 1pw reference (schedule verb)" \
+	"$(jq -n '{tool_name:"mcp__claude_ai_Slack__slack_schedule_message", tool_input:{text:"op://vault/item/field"}}')"
+expect_deny_json "dagster launch_run config w/ AWS key (launch verb)" \
+	"$(jq -n '{tool_name:"mcp__dagster__launch_run", tool_input:{runConfigData:"AKIAIOSFODNN7EXAMPLE"}}')"
+expect_deny_json "WebSearch query carrying an AWS key" \
+	"$(jq -n '{tool_name:"WebSearch", tool_input:{query:"what is AKIAIOSFODNN7EXAMPLE"}}')"
 
 echo ""
 echo -e "${YELLOW}#22: read-capable tools and benign writes still allowed${NC}"
 
+expect_allow_json "WebSearch benign query" \
+	"$(jq -n '{tool_name:"WebSearch", tool_input:{query:"dagster asset checks docs"}}')"
+expect_allow_json "slack schedule_message benign text" \
+	"$(jq -n '{tool_name:"mcp__claude_ai_Slack__slack_schedule_message", tool_input:{text:"standup moved to 10"}}')"
+
 # read-capable MCP tool: a reference passed in is not exfiltration → allow
 expect_allow_json "dagster get_run arg w/ 1pw reference (read tool)" \
-  "$(jq -n '{tool_name:"mcp__dagster__get_run", tool_input:{runId:"op://vault/i/f"}}')"
+	"$(jq -n '{tool_name:"mcp__dagster__get_run", tool_input:{runId:"op://vault/i/f"}}')"
 expect_allow_json "github issue_write benign body" \
-  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"normal description text"}}')"
+	"$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"normal description text"}}')"
 expect_allow_json "WebFetch benign url" \
-  "$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://example.com/docs/guide"}}')"
+	"$(jq -n '{tool_name:"WebFetch", tool_input:{url:"https://example.com/docs/guide"}}')"
 # trunk-ignore-end(shellcheck/SC2312)
 
 echo ""
@@ -46,26 +63,26 @@ echo -e "${YELLOW}#3/I6: more secret shapes + merge/delete write verbs${NC}"
 
 # trunk-ignore-begin(shellcheck/SC2312): jq -n static JSON, return value irrelevant
 expect_deny_json "issue_write body w/ postgres conn string" \
-  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"postgres://admin:s3cret@db.example.com:5432/prod"}}')"
+	"$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{title:"t", body:"postgres://admin:s3cret@db.example.com:5432/prod"}}')"
 expect_deny_json "drive create_file w/ service_account JSON" \
-  "$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__create_file", tool_input:{content:"{\"type\": \"service_account\", \"project_id\": \"x\"}"}}')"
+	"$(jq -n '{tool_name:"mcp__claude_ai_Google_Drive__create_file", tool_input:{content:"{\"type\": \"service_account\", \"project_id\": \"x\"}"}}')"
 expect_deny_json "asana create_tasks w/ AWS access key id" \
-  "$(jq -n '{tool_name:"mcp__claude_ai_Asana__create_tasks", tool_input:{html_notes:"AKIAIOSFODNN7EXAMPLE"}}')"
+	"$(jq -n '{tool_name:"mcp__claude_ai_Asana__create_tasks", tool_input:{html_notes:"AKIAIOSFODNN7EXAMPLE"}}')"
 # newly-synced patterns (#5/I6): Slack / Stripe / Slack-webhook / contextual AWS secret.
 # Split string literals so gitleaks' source scan doesn't flag the synthetic tokens.
 expect_deny_json "issue_write w/ Slack bot token" \
-  "$(jq -n --arg b "xoxb-2401234567-""2409876543210-AbCdEfGhIjKlMnOpQrStUvWx" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
+	"$(jq -n --arg b "xoxb-2401234567-""2409876543210-AbCdEfGhIjKlMnOpQrStUvWx" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
 expect_deny_json "issue_write w/ Stripe live key" \
-  "$(jq -n --arg b "sk_live""_4eC39HqLyjWDarjtT1zdp7dc0000abcd" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
+	"$(jq -n --arg b "sk_live""_4eC39HqLyjWDarjtT1zdp7dc0000abcd" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
 expect_deny_json "issue_write w/ Slack webhook URL" \
-  "$(jq -n --arg b "https://hooks.slack.com/services/""T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
+	"$(jq -n --arg b "https://hooks.slack.com/services/""T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" '{tool_name:"mcp__github__issue_write", tool_input:{body:$b}}')"
 expect_deny_json "issue_write w/ aws_secret_access_key assignment" \
-  "$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{body:"aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEYAB"}}')"
+	"$(jq -n '{tool_name:"mcp__github__issue_write", tool_input:{body:"aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEYAB"}}')"
 # write-verb name coverage: merge / delete are gated too
 expect_deny_json "merge_pull_request w/ 1pw reference (merge verb)" \
-  "$(jq -n '{tool_name:"mcp__github__merge_pull_request", tool_input:{commit_message:"see op://vault/item/field"}}')"
+	"$(jq -n '{tool_name:"mcp__github__merge_pull_request", tool_input:{commit_message:"see op://vault/item/field"}}')"
 expect_deny_json "asana delete_task w/ 1pw reference (delete verb)" \
-  "$(jq -n '{tool_name:"mcp__claude_ai_Asana__delete_task", tool_input:{note:"op://vault/item/field"}}')"
+	"$(jq -n '{tool_name:"mcp__claude_ai_Asana__delete_task", tool_input:{note:"op://vault/item/field"}}')"
 # trunk-ignore-end(shellcheck/SC2312)
 
 print_summary "Egress value-scan"

--- a/tests/hooks/test_output_scanner.sh
+++ b/tests/hooks/test_output_scanner.sh
@@ -14,8 +14,8 @@ echo " Output Scanner (check-output.sh)"
 echo "========================================="
 
 if [[ ! -f ${OUTPUT_HOOK} ]]; then
-  echo -e "  ${YELLOW}SKIP${NC}: ${OUTPUT_HOOK} not found"
-  exit 0
+	echo -e "  ${YELLOW}SKIP${NC}: ${OUTPUT_HOOK} not found"
+	exit 0
 fi
 
 # ─── Secret pattern detection ────────────────────────────────────────────────
@@ -106,14 +106,14 @@ echo -e "${YELLOW}PostToolUse: Exit code regression (must exit 0 on deny)${NC}"
 
 # trunk-ignore-begin(shellcheck/SC2312): command substitution in function args is intentional
 expect_deny_exit0 "PostToolUse JWT deny exits 0" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0' \
-    '{tool_name: "Read", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
+	"$(jq -n --arg c 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0' \
+		'{tool_name: "Read", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
 expect_deny_exit0 "PostToolUse op:// deny exits 0" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c 'config: op://vault/item/field' \
-    '{tool_name: "Bash", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
+	"$(jq -n --arg c 'config: op://vault/item/field' \
+		'{tool_name: "Bash", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
 expect_deny_exit0 "PostToolUse high-entropy deny exits 0" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c "$(printf 'g%.0s' {1..120})" \
-    '{tool_name: "Bash", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
+	"$(jq -n --arg c "$(printf 'g%.0s' {1..120})" \
+		'{tool_name: "Bash", tool_response: {content: $c, stdout: $c, stderr: ""}}')"
 # trunk-ignore-end(shellcheck/SC2312)
 
 # ─── Schema regression: hook must read .tool_response (Claude Code's payload key) ──
@@ -125,16 +125,16 @@ echo -e "${YELLOW}PostToolUse: Schema regression (.tool_response is the real key
 
 # trunk-ignore-begin(shellcheck/SC2312)
 expect_deny_exit0 "scans .tool_response high-entropy string" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c "$(printf 'g%.0s' {1..200})" \
-    '{tool_name: "Bash", tool_response: {stdout: $c, stderr: ""}}')"
+	"$(jq -n --arg c "$(printf 'g%.0s' {1..200})" \
+		'{tool_name: "Bash", tool_response: {stdout: $c, stderr: ""}}')"
 expect_deny_exit0 "scans .tool_response named pattern (op://)" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c "leaked: op://vault/item/field" \
-    '{tool_name: "Bash", tool_response: {stdout: $c, stderr: ""}}')"
+	"$(jq -n --arg c "leaked: op://vault/item/field" \
+		'{tool_name: "Bash", tool_response: {stdout: $c, stderr: ""}}')"
 # trunk-ignore(gitleaks/generic-api-key): synthetic ops_ token fixture
 _fake_op_trace='+ token=ops_eyJzaWduSW5BZGRyZXNzIjoiZXhhbXBsZS4xcGFzc3dvcmQuY29tIiwidXNlckF1dGgiOnsibWV0aG9kIjoiU1JQZy00MDk2In19'
 expect_deny_exit0 "scans .tool_response stderr (bash -x trace path)" "${OUTPUT_HOOK}" \
-  "$(jq -n --arg c "${_fake_op_trace}" \
-    '{tool_name: "Bash", tool_response: {stdout: "", stderr: $c}}')"
+	"$(jq -n --arg c "${_fake_op_trace}" \
+		'{tool_name: "Bash", tool_response: {stdout: "", stderr: $c}}')"
 # trunk-ignore-end(shellcheck/SC2312)
 
 # ─── Schema fallback (#6e/#20): payload under a non-tool_response key ────────
@@ -143,14 +143,42 @@ expect_deny_exit0 "scans .tool_response stderr (bash -x trace path)" "${OUTPUT_H
 echo ""
 echo -e "${YELLOW}PostToolUse: payload-key drift fallback (#20)${NC}"
 
+# With no .tool_response there is nothing to redact in the tool's own shape, so
+# the hook must end the turn (decision:block), not emit an empty replacement
+# that the harness ignores.
 # trunk-ignore-begin(shellcheck/SC2312)
-expect_deny_exit0 "secret under .output (not .tool_response)" "${OUTPUT_HOOK}" \
-  "$(jq -n '{tool_name:"Bash", output:{stdout:"leaked op://vault/item/field"}}')"
-expect_deny_exit0 "secret at top level (no tool_response)" "${OUTPUT_HOOK}" \
-  "$(jq -n '{tool_name:"mcp__github__issue_read", result:"op://vault/item/field"}')"
+expect_block "secret under .output (not .tool_response) ends the turn" \
+	"$(jq -n '{tool_name:"Bash", output:{stdout:"leaked op://vault/item/field"}}')"
+expect_block "secret at top level (no tool_response) ends the turn" \
+	"$(jq -n '{tool_name:"mcp__github__issue_read", result:"op://vault/item/field"}')"
 # trunk-ignore-end(shellcheck/SC2312)
 # control: clean .tool_response output still passes (fallback no overreach)
 check_output "clean .tool_response still clean" clean "rows: 5"
+
+# ─── Redaction content: the secret must be GONE from updatedToolOutput ────────
+echo ""
+echo -e "${YELLOW}PostToolUse: redaction replaces the secret, keeps the shape${NC}"
+
+# trunk-ignore-begin(shellcheck/SC2312)
+expect_redacted "Bash stdout secret replaced" \
+	"$(jq -n '{tool_name:"Bash", tool_response:{stdout:"x op://vault/item/field y", stderr:"", interrupted:false, isImage:false}}')" \
+	"op://vault/item/field"
+expect_redacted "Read file.content secret replaced" \
+	"$(jq -n '{tool_name:"Read", tool_response:{type:"text", file:{filePath:"/repo/a.sh", content:"op://vault/item/field", numLines:1}}}')" \
+	"op://vault/item/field"
+expect_redacted "MCP array-of-content secret replaced" \
+	"$(jq -n '{tool_name:"mcp__github__issue_read", tool_response:[{type:"text", text:"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"}]}')" \
+	"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
+# shape keys survive so built-in tools accept the replacement
+_shape=$(jq -n '{tool_name:"Read", tool_response:{type:"text", file:{filePath:"/repo/a.sh", content:"op://vault/item/field"}}}' | bash "${OUTPUT_HOOK}" 2>/dev/null)
+if jq -e '.hookSpecificOutput.updatedToolOutput | .type == "text" and .file.filePath == "/repo/a.sh"' <<<"${_shape}" >/dev/null 2>&1; then
+	PASS=$((PASS + 1))
+	echo -e "  ${GREEN}PASS${NC} [shape]: type and filePath preserved"
+else
+	FAIL=$((FAIL + 1))
+	ERRORS+="\n  ${RED}FAIL${NC} [shape]: type/filePath not preserved"
+fi
+# trunk-ignore-end(shellcheck/SC2312)
 
 # ─── Batch 6: new detections (#16 base64url, #18 gzip, #19 patterns, #30 split) ─
 echo ""


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." make `check-output.sh` redact tool results that contain secret material, which it has never actually done, and make every `check-sensitive.sh` denial tell Claude which rule fired and what to do instead.

The output hook returned `permissionDecision: deny`. Claude Code honors that field only on PreToolUse. On PostToolUse it is ignored, so every scanned result reached the model unredacted. The regression suite passed the whole time because it checked the hook's stdout, not what the harness did with it. Proof from this session: a Read of a test fixture line returned the fixture in full before the change and `[redacted: secret material]` after.

The hook now returns `updatedToolOutput`, the documented replace-the-result field, with every string in the result redacted and a note to Claude saying why. When the payload has no `tool_response` to redact, it returns `decision: block` and ends the turn rather than emitting an empty replacement the harness would ignore.

The egress gate in `check-sensitive.sh` gains WebSearch queries and the MCP verbs `share`, `forward`, `schedule`, `launch`, `trigger`, which let Drive share, Outlook forward, Slack schedule, and Dagster launch calls carry a 1Password reference outbound unscanned.

Every one of the 24 denials in `check-sensitive.sh` used to read "Cannot access sensitive path". Each now reads `check-sensitive.sh Rule N: <what matched>. <what to do instead>.` so Claude fixes the call instead of searching CLAUDE.md for the workaround.

## Reviewer Notes

- The redaction keeps the keys `type` and `filePath` unredacted. Built-in tools validate the replacement against their output schema and silently fall back to the original output when it fails.
- `decision: block` on PostToolUse is documented in the hooks reference decision-control table; it ends the turn with the reason as a warning line.
- `deny()` builds its JSON with `jq --arg` so reason text with quotes or `$` cannot break the envelope. The default reason is unchanged for a caller that passes nothing.
- A bare `env` command is caught by Rule 1 (all tools), never Rule 3c. Rule 1's message mentions the bare word so the fix reads the same either way.
- `check-sensitive.sh` and `helpers.sh` diffs are mostly tab reindentation from the commit hook's shfmt. Review with `git diff -w`.
- Docs updated in `.claude/CLAUDE.md` and `tests/CLAUDE.md`: redaction instead of denial, the new egress verbs, rule-named denials, and a note that Auto mode does not replace either hook because the classifier never sees tool results.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.) Per-finding verdicts posted as a PR comment; finding 1 fixed in the second commit.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes trivially (no dbt changes).
- [ ] **Dagster Cloud** — not triggered (no code location changes).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Claude reviewed both hooks against the hooks reference (PostToolUse decision control table: `decision`, `reason`, `additionalContext`, `updatedToolOutput`; `permissionDecision` listed for PreToolUse only), probed each hook with scratch harnesses, and drafted the edits in `.claude/scratch/`. The user transcribed or copied the protected hook files; Claude wrote the tests and CLAUDE.md edits. `bash tests/hooks/run_all.sh`: 10 suites, 0 failures on the committed files. New suites and helpers: `expect_redacted` (redaction literal present, secret gone), `expect_block` (drift payload ends the turn), `tests/hooks/test_deny_reasons.sh` (each rule names itself and offers an alternative). Probe results that motivated the egress change: `Google_Drive__share_file`, `outlook_forward_mail`, `slack_schedule_message`, and a `WebSearch` query each passed the old gate carrying a 1Password reference. Known gaps left as-is because only Auto mode covers them: glob-obfuscated dotfile reads (`cat .en?`), `curl` exfiltration from Bash, and Python `getattr`/`chr` construction of the process variable mapping. Reading `check-sensitive.sh` with the Read tool now gets redacted by `check-output.sh` because the file holds the secret regexes; snapshot it into `.claude/scratch/` and patch by script (`.claude/scratch/patch-deny.py` pattern) instead.

</details>
