### PR TITLE
fix(dbt): add chronic_absence_status to rpt_tableau__okrts_referrals

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__okrts_referrals.yml
@@ -133,6 +133,13 @@ models:
         data_type: float64
       - name: is_chronically_absent
         data_type: boolean
+      - name: chronic_absence_status
+        data_type: string
+        description:
+          Chronic absence label for Tableau. Chronic Absence when the student's
+          unweighted year-to-date ADA is 0.90 or below, otherwise Not Chronic
+          Absence. Mirrors is_chronically_absent, including rows with no ADA
+          value, which land in Not Chronic Absence.
       - name: school_enrollment_by_week
         data_type: int64
       - name: is_week_ytd

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__okrts_referrals.sql
@@ -296,6 +296,10 @@ select
 
     if(co.unweighted_ada <= 0.90, true, false) as is_chronically_absent,
 
+    if(
+        co.unweighted_ada <= 0.90, 'Chronic Absence', 'Not Chronic Absence'
+    ) as chronic_absence_status,
+
     if(sr.incident_id is not null, true, false) as is_discrepant_incident,
 
     if(tr.student_school_id is not null, true, false) as is_tier3_4,


### PR DESCRIPTION
# Pull Request

## Summary and Motivation

When merged, this pull request will add a `chronic_absence_status` string column to `rpt_tableau__okrts_referrals`.

The OKRTS dashboard throws an error today (#5130):

```text
Error Code: 2F8B7E6C
Invalid field formula due to limitations in the data source.
Unable to properly calculate the domain for the field 'Chronic Absence?'. Displayed data may be incorrect.
```

The data was never the problem. `is_chronically_absent` is a clean BOOL with no nulls. The problem is that the workbook wraps it in a Tableau calculated field so it can attach the labels `Chronic Absence` and `Not Chronic Absence`. Tableau will not alias a database boolean, so the wrapper exists only to hold those labels. Tableau then cannot list the wrapper's distinct values, which is what the error says.

Giving the workbook a real string column removes the need for the wrapper. The labels match the current aliases exactly, so nothing on the dashboard changes visually.

`is_chronically_absent` stays. Other consumers may read it.

This change alone does not clear the error. Someone with the workbook still has to repoint `Chronic Absence?` at the new column and delete the calculated field. I wrote up what to change in #5130.

## Reviewer Notes

- The threshold is duplicated. `chronic_absence_status` repeats `unweighted_ada <= 0.90` from the line above it rather than deriving from `is_chronically_absent`, because BigQuery rejects a select-list alias referenced later in the same select list. The 2 lines sit next to each other so a future edit to one is hard to miss.
- I did not add tests. See the fold-out for why.
- The 2 models disagree on the chronic absence threshold, and I did not change that here. `rpt_tableau__okrts_referrals` treats exactly 90 percent as chronically absent; `fct_student_attendance_daily` does not. That predates this pull request and deserves its own decision.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models. The
      existing properties file gains the new column with a description.
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application. The
      `okrts_dashboard` exposure already lists `rpt_tableau__okrts_referrals`,
      so no change was needed.
- [ ] **Breaking change?** No. This adds a column and renames nothing.
- [ ] If adding or modifying an external source, run `stage_external_sources`.
      Not applicable.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Claude diagnosed the Tableau error, wrote the change, and ran the verification below.

**Verification**

`dbt build --select rpt_tableau__okrts_referrals --target dev --defer --favor-state --state src/dbt/kipptaf/target/prod` passed, so contract enforcement accepted the new column. A view build does not evaluate data, so the dev view was then queried directly:

```sql
select is_chronically_absent, chronic_absence_status, count(*) as n
from `teamster-332318.zz_anthonygwalters_kipptaf_tableau.rpt_tableau__okrts_referrals`
group by 1, 2
```

Result: exactly 2 groups. `false` maps to `Not Chronic Absence` (735,787 rows) and `true` maps to `Chronic Absence` (240,160 rows). Those counts match prod `kipptaf_tableau.rpt_tableau__okrts_referrals` exactly, so the mapping is total and produces no nulls and no third value.

`trunk check --force --no-fix` on both changed files reported no issues.

**Why no tests**

Issue #5130 proposed an `accepted_values` test. I dropped it. The column is `if(cond, 'Chronic Absence', 'Not Chronic Absence')`, so no third value is reachable and the test can never fail. `src/dbt/CLAUDE.md` bans tests that cannot fail, on the grounds that each one costs a full BigQuery scan per CI run, and this model is a view whose scan re-expands its whole upstream chain. The properties file also carries zero tests today, so adding one column-level test would have forced that column to the top of a 189-line `columns:` list, away from `is_chronically_absent`.

**Null handling**

`unweighted_ada` can be null in principle. BigQuery's `if()` returns the else branch on a null condition, so a null ADA yields `false` and `Not Chronic Absence`. That matches the existing `is_chronically_absent` behavior, which is the point — parity, not correction. Prod currently has no null `is_chronically_absent` rows.

**Root cause detail**

Full workbook evidence lives in #5130. Short version: `Chronic Absence?` is `Calculation_1138144115257987096`, formula `[is_chronically_absent]`, with aliases on `true` and `false`. Two filter cards set to "All Values in Database" and 3 filter actions passing "All Fields" both force Tableau to enumerate that calculation's domain. The 5 other aliased boolean calculations in the same datasource sit in neither context and raise no error.

</details>
