### PR TITLE
fix(launch): give the font stacks a real face on Windows

### DIFF
--- a/docs/launch/groups.yml
+++ b/docs/launch/groups.yml
@@ -43,6 +43,9 @@ families:
 
 # "From the data team" cards, pointing at prose that lives in Zendesk.
 promos:
+  - label: Meet the data team
+    blurb: Who's on the team, and who to ask.
+    url: https://teamschools.zendesk.com/hc/en-us/articles/43201228776855-Meet-the-data-team
   - label: All help guides
     blurb: Every written guide in one list.
     url: https://teamschools.zendesk.com/hc/en-us/categories/204269047-Data-Launch

--- a/docs/launch/template.html
+++ b/docs/launch/template.html
@@ -6,8 +6,20 @@
     <title>Data tools — KIPP NJ | Miami</title>
     <style>
       /* Tokens lifted from the KIPP NJ | Miami design system.
-   --font-brand tries licensed Whitney first, then falls back to Calibri
-   and system fonts for anyone without it installed. */
+
+   Both stacks name a real face for every platform rather than relying on
+   a generic keyword. `ui-monospace` resolves only on Apple platforms, and
+   Menlo is macOS-only, so a stack ending there falls through to the
+   generic `monospace` on Windows -- which is Courier New, a thin serifed
+   typewriter face that looks broken at the 11-12px this design uses it at.
+   Cascadia Mono and Consolas both ship with Windows and cover it.
+
+   Same reasoning for the brand stack: licensed Whitney first, then the
+   native UI face per platform (San Francisco, Segoe UI, Roboto), then
+   Calibri. Segoe UI precedes Calibri deliberately -- both are Microsoft
+   faces, but Segoe UI is drawn for screen chrome at small sizes while
+   Calibri is a document face, and this page is almost entirely small
+   uppercase labels and letter-spaced chrome. */
       :root {
         --kipp-indigo: #001e62;
         --kipp-red: #ee3c37;
@@ -38,9 +50,11 @@
         --border-default: var(--neutral-300);
         --focus-ring: var(--kipp-blue);
         --font-brand:
-          "Whitney SSm A", "Whitney", Calibri, "Segoe UI", system-ui,
-          -apple-system, "Helvetica Neue", Arial, sans-serif;
-        --font-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+          "Whitney SSm A", "Whitney", -apple-system, BlinkMacSystemFont,
+          "Segoe UI", Roboto, Calibri, "Helvetica Neue", Arial, sans-serif;
+        --font-mono:
+          "JetBrains Mono", "Cascadia Mono", Consolas, ui-monospace, "SF Mono",
+          Menlo, "Roboto Mono", monospace;
       }
       *,
       *::before,
@@ -174,7 +188,10 @@
       /* promo cards */
       .promos {
         display: grid;
-        grid-template-columns: repeat(5, 1fr);
+        /* auto-fill, not a fixed 5, so cards keep a consistent width
+           whatever the card count is -- the list grows and shrinks as
+           prose lands in Zendesk. */
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
         gap: 10px;
         margin-bottom: 18px;
       }


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...make the launch page render correctly on Windows. The page is live at
`teamschools.github.io/teamster/launch/` but has not been rolled out to staff
yet, so this is a pre-rollout correction rather than a production fix.

### The bug

The monospace stack has no Windows face in it:

```css
--font-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
```

On Windows every entry falls through. JetBrains Mono is a developer font
nobody has installed, `ui-monospace` is an Apple system keyword that Chrome and
Edge on Windows do not resolve, and Menlo is macOS-only. So it lands on generic
`monospace`, which Windows maps to **Courier New** — a thin serifed typewriter
face, rendering the tab counts, filter-chip counts, group counts and system
badges at 11-12px next to an otherwise clean sans.

Now:

```css
--font-mono:
  "JetBrains Mono", "Cascadia Mono", Consolas, ui-monospace,
  "SF Mono", Menlo, "Roboto Mono", monospace;
```

Consolas ships with every Windows since Vista and holds up at small sizes;
Cascadia Mono covers Windows 11. Apple and Android keep the faces they had.

### Second, smaller problem

The brand stack had `Calibri` ahead of `Segoe UI`, so Windows got Calibri — a
document face with a small x-height, asked to render a page that is almost
entirely 11px letter-spaced uppercase chrome. Reordered so each platform gets
its native UI face:

```css
--font-brand:
  "Whitney SSm A", "Whitney", -apple-system, BlinkMacSystemFont,
  "Segoe UI", Roboto, Calibri, "Helvetica Neue", Arial, sans-serif;
```

Licensed Whitney still wins where it is installed. Calibri is retained, just
behind Segoe UI. Both are Microsoft faces; the difference is that one is drawn
for screen chrome and the other for documents. Happy to flip them if the
brand guidance should win over the rendering.

### Not the webfont

The reported suspect was Hanken Grotesk. That was already removed when the
Google Fonts CDN call was dropped — the live page has no reference to it. The
mono fallback chain is the actual cause.

### Also in here

`Meet the data team` returns as a promo card. It was dropped during the build
because it pointed at `#`, which tier 1 validation rejects; it now has a real
Zendesk destination.

The promo grid moves from a hard-coded five columns to
`repeat(auto-fill, minmax(200px, 1fr))`, so cards keep a consistent width as
the count changes rather than stretching. That count will keep moving as prose
lands in Zendesk.

Refs #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude diagnosed and wrote the change. The report — that the page renders badly
on Windows — was human, and correct; the attributed cause was not, and the
diagnosis corrected it.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

N/A — no Dagster changes.

### dbt _(skip if no dbt changes)_

N/A — no dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — verified locally with `trunk check --force` on both changed
      files; no issues.
- [ ] **pytest / launch** — 59 tests pass. Catalog still validates at 39
      verified of 44 with zero errors, and the rendered page carries the new
      stacks and both promo cards.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — not triggered; no watched paths change.

## Reviewer notes

No test asserts a font stack, so nothing here is covered by CI beyond the page
still building. The check that matters is opening the preview artifact this
PR's gate uploads — ideally on Windows, which is the platform the change is
for.

One judgement call worth a second opinion: `Segoe UI` now precedes `Calibri`,
and Calibri is named in the KTAF writing defaults. My reasoning is that those
defaults describe documents while this is application chrome, but that is a
brand call rather than a technical one.
