### PR TITLE
fix(launch): noindex the page, and keep desktop Whitney off the small UI text

### DIFF
--- a/docs/launch/template.html
+++ b/docs/launch/template.html
@@ -11,19 +11,24 @@
     <style>
       /* Tokens lifted from the KIPP NJ | Miami design system.
 
-   Both stacks name a real face for every platform rather than relying on
-   a generic keyword. `ui-monospace` resolves only on Apple platforms, and
-   Menlo is macOS-only, so a stack ending there falls through to the
-   generic `monospace` on Windows -- which is Courier New, a thin serifed
-   typewriter face that looks broken at the 11-12px this design uses it at.
-   Cascadia Mono and Consolas both ship with Windows and cover it.
+   Three type stacks, split by size rather than by role, because what
+   renders well at 26px and what renders well at 11px are different fonts.
+   Each names a real face for every platform instead of trusting a generic
+   keyword to resolve. Per-stack reasoning sits with each one below.
 
-   Same reasoning for the brand stack: licensed Whitney first, then the
-   native UI face per platform (San Francisco, Segoe UI, Roboto), then
-   Calibri. Segoe UI precedes Calibri deliberately -- both are Microsoft
-   faces, but Segoe UI is drawn for screen chrome at small sizes while
-   Calibri is a document face, and this page is almost entirely small
-   uppercase labels and letter-spaced chrome. */
+   Two Windows notes that drove the current shape, since both are invisible
+   on a Mac and neither is obvious from reading the CSS:
+
+   - `ui-monospace` resolves only on Apple platforms and Menlo is macOS-only,
+     so a mono stack ending there falls through to generic `monospace`, which
+     Windows maps to Courier New.
+   - Windows rasterization depends on font hinting in a way macOS does not.
+     A face that is unhinted at small sizes looks fine on one and poor on the
+     other, from identical CSS.
+
+   Segoe UI precedes Calibri throughout: both are Microsoft faces, but Segoe
+   UI is drawn for screen chrome at small sizes and Calibri is a document
+   face. */
       :root {
         --kipp-indigo: #001e62;
         --kipp-red: #ee3c37;
@@ -53,9 +58,21 @@
         --border-subtle: var(--neutral-200);
         --border-default: var(--neutral-300);
         --focus-ring: var(--kipp-blue);
-        --font-brand:
+        /* Display sizes only -- the logotype at 17px and the page heading at
+           26px. Desktop Whitney is cut for sizes like these and holds up. */
+        --font-display:
           "Whitney SSm A", "Whitney", -apple-system, BlinkMacSystemFont,
           "Segoe UI", Roboto, Calibri, "Helvetica Neue", Arial, sans-serif;
+        /* Everything else, which is 17 rules between 11px and 16px. Note the
+           absence of plain "Whitney": staff Windows machines carry the DESKTOP
+           cut, not ScreenSmart, and it is not hinted for these sizes. macOS
+           rasterizes outlines and mostly ignores hinting, so it looks fine
+           there and poor on Windows -- the same file, the same CSS. Whitney
+           SSm stays first because ScreenSmart is cut for exactly this range;
+           anyone who has it should get it. */
+        --font-brand:
+          "Whitney SSm A", -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, Calibri, "Helvetica Neue", Arial, sans-serif;
         --font-mono:
           "JetBrains Mono", "Cascadia Mono", Consolas, ui-monospace, "SF Mono",
           Menlo, "Roboto Mono", monospace;
@@ -106,7 +123,7 @@
         gap: 16px;
       }
       .wordmark {
-        font: 800 17px/1 var(--font-brand);
+        font: 800 17px/1 var(--font-display);
         letter-spacing: 0.02em;
         color: #fff;
       }
@@ -145,7 +162,7 @@
         flex-wrap: wrap;
       }
       .head h1 {
-        font: 700 26px/1.2 var(--font-brand);
+        font: 700 26px/1.2 var(--font-display);
         color: var(--kipp-indigo);
         margin: 0 0 4px;
       }

--- a/docs/launch/template.html
+++ b/docs/launch/template.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Reachable by link, but not surfaced in search. A robots.txt is not an
+         option: this site is served from an org-root domain the repo does not
+         control, and teamschools.github.io/robots.txt already 404s. -->
+    <meta name="robots" content="noindex, nofollow" />
     <title>Data tools — KIPP NJ | Miami</title>
     <style>
       /* Tokens lifted from the KIPP NJ | Miami design system.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...do two things found while auditing the live page: keep it out of search
results, and stop desktop Whitney rendering the small UI text on Windows.

## 1. Keep the page out of search

```html
<meta name="robots" content="noindex, nofollow" />
```

A `noindex` tag was chosen during the design discussion and recorded in the
spec's open-questions section as settled. It never made it into the
implementation plan, so no task built it and no review caught the omission. The
page has been indexable since it went live.

Nothing on it is secret — the catalog is public by design. But "reachable by
link" and "surfaces when a parent searches for KIPP Newark dashboards" are
different postures, and the second was not the one chosen.

Not urgent today: the page is absent from `sitemap.xml` and nothing links to it,
so crawlers have no path in. That changes the moment it is linked from Zendesk
or an email, which is the point at which this becomes hard to undo — search
engines are slow to forget.

A `robots.txt` cannot do this job. The site is served from
`teamschools.github.io`, an org-root domain this repo does not control, and
`teamschools.github.io/robots.txt` already returns 404.

## 2. Stop desktop Whitney rendering the small UI text

A Windows user reported the page rendering badly. Two earlier guesses were
wrong. DevTools on the affected machine settles it:

```text
Family name:     Whitney
PostScript name: Whitney-Bold
Font origin:     Local file
```

That is the **desktop** cut, not Whitney SSm. The stack asks for SSm first and
falls through to it, so the brand font has been resolving correctly the whole
time — it is simply not the cut for the sizes this page uses.

Hoefler ships ScreenSmart as a separate family precisely because desktop cuts
are not hinted for small on-screen sizes, and Windows rasterization depends on
hinting where macOS largely ignores it. Identical file, identical CSS, fine on a
Mac and poor on Windows. That is exactly the reported asymmetry.

Where the design actually uses the brand font:

| Size | Rules |
| --- | --- |
| 26px and 17px | 2 |
| 11px to 16px | **17** |

So the token splits by size rather than by role:

```css
/* .wordmark (17px) and .head h1 (26px) — desktop Whitney holds up here */
--font-display: "Whitney SSm A", "Whitney", -apple-system, …

/* the other 17 rules, 11-16px — ScreenSmart if present, never the desktop cut */
--font-brand:   "Whitney SSm A", -apple-system, …
```

No configuration ends up worse. Machines with ScreenSmart are unchanged.
Machines with only desktop Whitney keep it on the logotype and headline and get
Segoe UI on the chrome, which is hinted for exactly that range. Machines with
neither are unchanged.

Refs #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude wrote both changes. The `noindex` decision was the author's, made during
design and recorded in the spec; losing it between the spec and the plan was
Claude's error, caught by auditing the live page.

The Windows report was the author's and was correct. Claude's first two
diagnoses were not: a monospace fallback that genuinely had no Windows face
(real defect, wrong culprit), then a CSS shorthand theory the author's own
DevTools reading disproved. The third diagnosis came from evidence rather than
inference — a rendered-font reading from the affected machine — and the split
between display and UI sizes was the author's call.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

N/A — no Dagster changes.

### dbt _(skip if no dbt changes)_

N/A — no dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

N/A — no schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — verified locally with `trunk check --force`; no issues.
- [ ] **pytest / launch** — 59 tests pass; the rendered page carries the tag and
      still emits its catalog payload.
- [ ] **dbt Cloud** — no dbt changes.
- [ ] **Dagster Cloud** — not triggered; no watched paths change.

## Reviewer notes

The typography change is a brand call as much as a technical one: Whitney stays
on the logotype and the page heading, and steps back everywhere else. Worth a
second opinion if you would rather it appear throughout even at a legibility
cost, or not at all for consistency.

The `noindex` half is one line plus a comment explaining why `robots.txt` is not
the mechanism, so nobody reaches for it later.

Neither change is covered by a test — no test asserts a font stack or a meta
tag. Verification is opening the preview artifact this PR's gate uploads,
ideally on a Windows machine with Whitney installed, which is the configuration
this fixes.

Worth knowing that this does not retroactively remove anything — no crawler has
indexed the page yet, since nothing links to it and it is not in the sitemap.
The tag is what keeps that true once the page starts being shared.
