### PR TITLE
feat(dbt): add an exposure for the Academic and Gradebook Health Suite

### DIFF
--- a/src/dbt/kipptaf/models/exposures/tableau.yml
+++ b/src/dbt/kipptaf/models/exposures/tableau.yml
@@ -352,6 +352,24 @@ exposures:
                 - 0 12 * * *
                 - 30 14 * * *
                 - 15 16 * * *
+  - name: academic_gradebook_health_suite
+    label: Academic & Gradebook Health Suite
+    type: dashboard
+    owner:
+      name: Data Team - awalters
+    depends_on:
+      - ref("rpt_tableau__gpa_goals")
+      - ref("rpt_tableau__gpa_cumulative_year")
+      - ref("rpt_tableau__student_course_grades")
+    config:
+      meta:
+        dagster:
+          kinds:
+            - tableau
+          asset:
+            metadata:
+              id: b3c14d67-3130-46ac-82a0-0637a5cc2da5
+              cron_schedule: 0 4 * * *
   - name: gradebook_and_gpa_dashboard
     label: Gradebook and GPA Dashboard
     type: dashboard


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

> "When merged, this pull request will..."

...add a dbt exposure for the Academic and Gradebook Health Suite, so the
workbook's lineage is recorded and Dagster drives its extract refresh.

Companion to the catalog swap in the launch page. Neither PR depends on the
other.

### Sourced from Tableau, not inferred

The workbook reports its own upstream datasources, and they name the models
directly:

```text
rpt_tableau__gpa_goals (kipptaf_tableau)
rpt_tableau__gpa_cumulative_year (kipptaf_tableau)
rpt_tableau__student_course_grades+ (kipptaf_tableau)
```

All three exist under `models/extracts/tableau/`. A fourth datasource,
`GPA Goals - Y1`, is embedded and Tableau-side rather than a dbt model, so it is
not in `depends_on`.

The LUID `b3c14d67-3130-46ac-82a0-0637a5cc2da5` came from the API rather than
being read off a URL.

### One thing to confirm before merging

The cron matches `gradebook_and_gpa_dashboard` at `0 4 * * *`. Because
`src/teamster/code_locations/kipptaf/tableau/schedules.py` builds real
`ScheduleDefinition` objects straight from this metadata, adding it **creates a
Dagster schedule that will refresh this workbook at 4am Eastern**.

Worth checking nothing already refreshes it on a Tableau-native schedule, or it
gets two independent refreshers. Dropping the `asset` block records lineage
without Dagster touching the refresh, if that turns out to be the case.

### What stays

`gradebook_and_gpa_dashboard` is untouched. That workbook still exists and still
sees roughly 330 views a month, so its lineage is still true even though the
launch page now points at the suite. This adds; it does not replace.

Refs #4761

## AI Assistance

> If Claude Code authored or co-authored this PR, briefly note what was
> AI-assisted vs. human-directed in the summary above

Claude wrote the exposure. The request and the choice of refresh schedule were
the author's; the dependency list and LUID came from querying Tableau.

## Self-review

> Complete only the sections relevant to your changes.

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

No Dagster code changes, but note the behavioural one above: this exposure's
`cron_schedule` causes a new `..._extract_refresh_schedule` to be created on the
`kipptaf` code location.

### dbt _(skip if no dbt changes)_

- [ ] Properties file — N/A, no new models.
- [ ] Exposure — this is the exposure, for a dashboard consuming three existing
      `rpt_tableau__` models.
- [ ] Breaking change — no. Additive only; no model, column or contract changes.
- [ ] External sources — N/A.

### Docs _(skip if no schedule, sensor, or integration changes)_

A schedule is created indirectly, from exposure metadata rather than a schedule
definition. `reference/automations.md` is generated by a script that must run
where every code location imports cleanly, which the codespace is not — flagging
rather than regenerating it here from a partial catalog.

## CI checks

- [ ] **Trunk** — verified locally with `trunk check --force`; no issues.
- [ ] **dbt Cloud** — expected to run; this touches `src/dbt/`.
- [ ] **Dagster Cloud** — expected to trigger for `kipptaf`.

## Reviewer notes

One judgement call worth a second look: I set `owner.name` to
`Data Team - awalters`, following the `Data Team - grangel` form used on ten
exposures, because Tableau lists Anthony Walters as the workbook owner. The
other 39 use plain `Data Team` and there is no `awalters` precedent, so if that
suffix is meant to be person-specific to one maintainer, say and I will drop it.
