### PR TITLE
fix(powerschool): give student_enrollments dedupe a real tiebreaker

### DIFF
--- a/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
@@ -1,5 +1,7 @@
 with
     deduplicate as (
+        -- TODO(#4835): remove once Ops cleans up the PowerSchool stints that put
+        -- two enrollments on one entrydate.
         {{
             dbt_utils.deduplicate(
                 relation=ref("int_powerschool__student_enrollment_union"),

--- a/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
@@ -1,16 +1,4 @@
 with
-    deduplicate as (
-        -- TODO(#4835): remove once Ops cleans up the PowerSchool stints that put
-        -- two enrollments on one entrydate.
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_powerschool__student_enrollment_union"),
-                partition_by="student_number, academic_year, entrydate",
-                order_by="rn_year asc",
-            )
-        }}
-    ),
-
     enr_bools as (
         select
             enr.*,
@@ -26,7 +14,7 @@ with
                 then true
                 else false
             end as is_enrolled_recent,
-        from deduplicate as enr
+        from {{ ref("int_powerschool__student_enrollment_union") }} as enr
         left join
             {{ ref("int_powerschool__calendar_rollup") }} as cr
             on enr.schoolid = cr.schoolid

--- a/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
+++ b/src/dbt/powerschool/models/sis/base/base_powerschool__student_enrollments.sql
@@ -4,7 +4,7 @@ with
             dbt_utils.deduplicate(
                 relation=ref("int_powerschool__student_enrollment_union"),
                 partition_by="student_number, academic_year, entrydate",
-                order_by="student_number desc",
+                order_by="rn_year asc",
             )
         }}
     ),

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
@@ -279,8 +279,8 @@ with
         from window_calcs_2
     )
 
-    -- TODO(#4835): remove once Ops cleans up the PowerSchool stints that put two
-    -- enrollments on one entrydate.
+    -- keep one stint per entrydate; PowerSchool data entry occasionally creates two
+    -- and downstream rn_year = 1 filters assume this row survived
     {{
         dbt_utils.deduplicate(
             relation="final",

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
@@ -206,20 +206,23 @@ with
             ) as grade_level_prev,
 
             row_number() over (
-                partition by studentid order by yearid desc, exitdate desc
+                partition by studentid
+                order by yearid desc, exitdate desc, reenrollments_dcid asc
             ) as rn_all,
 
             row_number() over (
-                partition by studentid, yearid order by yearid desc, exitdate desc
+                partition by studentid, yearid
+                order by yearid desc, exitdate desc, reenrollments_dcid asc
             ) as rn_year,
 
             row_number() over (
-                partition by studentid, schoolid order by yearid desc, exitdate desc
+                partition by studentid, schoolid
+                order by yearid desc, exitdate desc, reenrollments_dcid asc
             ) as rn_school,
 
             row_number() over (
                 partition by studentid, if(grade_level = 99, true, false)
-                order by yearid desc, exitdate desc
+                order by yearid desc, exitdate desc, reenrollments_dcid asc
             ) as rn_undergrad,
         from enr_union
     ),

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__student_enrollment_union.sql
@@ -242,32 +242,46 @@ with
                 partition by studentid, rn_year order by yearid asc, exitdate asc
             ) as year_in_network,
         from window_calcs
+    ),
+
+    final as (
+        select
+            * except (rn_undergrad, year_in_school, year_in_network),
+
+            if(grade_level != 99, rn_undergrad, null) as rn_undergrad,
+            if(rn_year = 1, year_in_school, null) as year_in_school,
+            if(rn_year = 1, year_in_network, null) as year_in_network,
+            if(exitcode = 'G1', cohort_primary, null) as cohort_graduated,
+            if(exitdate is not null, true, false) as is_enrolled_y1,
+
+            if(
+                date(academic_year, 10, 1) between entrydate and exitdate, true, false
+            ) as is_enrolled_oct01,
+            if(
+                date(academic_year, 10, 15) between entrydate and exitdate, true, false
+            ) as is_enrolled_oct15,
+            if(
+                date(academic_year + 1, 3, 15) between entrydate and exitdate,
+                true,
+                false
+            ) as is_enrolled_mar15,
+
+            case
+                when yearid = yearid_prev
+                then false
+                when grade_level != 99 and grade_level <= grade_level_prev
+                then true
+                else false
+            end as is_retained_year,
+        from window_calcs_2
     )
 
-select
-    * except (rn_undergrad, year_in_school, year_in_network),
-
-    if(grade_level != 99, rn_undergrad, null) as rn_undergrad,
-    if(rn_year = 1, year_in_school, null) as year_in_school,
-    if(rn_year = 1, year_in_network, null) as year_in_network,
-    if(exitcode = 'G1', cohort_primary, null) as cohort_graduated,
-    if(exitdate is not null, true, false) as is_enrolled_y1,
-
-    if(
-        date(academic_year, 10, 1) between entrydate and exitdate, true, false
-    ) as is_enrolled_oct01,
-    if(
-        date(academic_year, 10, 15) between entrydate and exitdate, true, false
-    ) as is_enrolled_oct15,
-    if(
-        date(academic_year + 1, 3, 15) between entrydate and exitdate, true, false
-    ) as is_enrolled_mar15,
-
-    case
-        when yearid = yearid_prev
-        then false
-        when grade_level != 99 and grade_level <= grade_level_prev
-        then true
-        else false
-    end as is_retained_year,
-from window_calcs_2
+    -- TODO(#4835): remove once Ops cleans up the PowerSchool stints that put two
+    -- enrollments on one entrydate.
+    {{
+        dbt_utils.deduplicate(
+            relation="final",
+            partition_by="student_number, academic_year, entrydate",
+            order_by="rn_year asc",
+        )
+    }}

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__student_enrollment_union.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__student_enrollment_union.yml
@@ -4,7 +4,11 @@ models:
       One row per student-school enrollment event. Graduated students carry
       placeholder rows with null entry and exit dates, one row per academic year
       per student and district. Surrogate keys must include academic_year or
-      those rows collide.
+      those rows collide. One row per (student_number, academic_year,
+      entrydate): PowerSchool data entry occasionally puts two stints on one
+      entrydate, and the dedupe keeps the rn_year = 1 stint so downstream
+      rn_year = 1 filters see the row that survived. Permanent guard, not a
+      cleanup workaround.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__student_enrollment_union.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__student_enrollment_union.yml
@@ -5,6 +5,13 @@ models:
       placeholder rows with null entry and exit dates, one row per academic year
       per student and district. Surrogate keys must include academic_year or
       those rows collide.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - student_number
+              - academic_year
+              - entrydate
     columns:
       - name: studentid
         data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make the PowerSchool enrollment models keep the right row when a student has two enrollment stints with the same `entrydate`.

The dedupe in `base_powerschool__student_enrollments` ordered by `student_number`, which is also a partition key, so the sort was a no-op and BigQuery picked an arbitrary row. When it picked the wrong one, the student's live enrollment was replaced by a short transfer-out stub, and every downstream `rn_year = 1` filter dropped the student.

The dedupe now lives one step upstream in `int_powerschool__student_enrollment_union`, ordered by `rn_year asc`, so every consumer of the union gets one row per `(student_number, academic_year, entrydate)` and the surviving row is always the one `rn_year = 1` filters expect. `base_` reads the union directly. The union gains the uniqueness test that grain now earns.

Closes #5141

## Reviewer Notes

- The issue suggested `order_by="exitdate desc"`. I used `rn_year asc` instead. One of the 3 live collisions (Paterson) has both stints sharing `entrydate` and `exitdate`, so `exitdate` alone would still be arbitrary there. `rn_year` is a `row_number`, so it is unique within the group.
- The 4 `rn_*` windows in the union now end in `reenrollments_dcid asc`. Without it, two stints sharing `yearid` and `exitdate` (the Paterson pair) left `rn_year` itself unstable across builds. The students-table row has a null `reenrollments_dcid` and nulls sort first under `asc`, so the current record wins the tie.
- Moving the dedupe upstream changes the union's row count by the number of collisions (3 network-wide today, all AY2026). `base_` row counts do not change.
- kipptaf's `int_students__student_enrollment_union` reads the district union tables via `source()` and carries its own identical dedupe. It stays for now: dropping it in this PR would run kipptaf CI against stale `zz_stg_*` copies that still hold the duplicates. Removing it is a follow-up after the districts rebuild in prod.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models
- [x] Include (or update) an exposure for all models consumed by a dashboard — no new consumers
- [x] **Breaking change?** No. No columns added, removed, or renamed.
- [x] External sources — none touched

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

Diagnostic re-run on 2026-09-04 before the fix. The issue's reproduce query returned 3 collision groups, all AY2026: kippcamden (surviving `rn_year` 1, correct), kippnewark (2, wrong), kipppaterson (2, wrong). The issue reported Paterson correct and Newark 2 wrong the same morning, which confirms the pick flips between builds with no code or data change.

Blast radius query (min `rn_year` per collision group vs the current surviving row): 3 groups, 2 flip to `rn_year = 1`, 1 already correct. Paterson's group has `count(distinct exitdate) = 1`, which is why `exitdate desc` was rejected as the tiebreaker.

Related coverage already in place: `int_powerschool__ps_enrollment_all` has a warn-severity `(studentid, entrydate)` uniqueness test that fires on 63 groups today (61 Newark, 1 Camden, 1 Paterson). 60 of the Newark groups are a real stint plus a zero-length stub (`exitdate <= entrydate`) that the union filters out, so the union only sees 3. That test is the Ops cleanup list; #4835 is the tracker.

Paterson pair differs in `entrycode`, `next_school`, `sched_nextyeargrade`, and `reenrollments_dcid`. After the window tiebreaker, a kipppaterson dev build of the union passed and the surviving row is `rn_year = 1`, the students-table row, with `next_school` populated.

Local validation, kippnewark dev target with `--defer --favor-state`: `dbt build` of `int_powerschool__student_enrollment_union` and `base_powerschool__student_enrollments` passed (PASS=3 WARN=1). The warn is the pre-existing `no_shared_stint_boundary` test (60 rows, #3902). The new uniqueness test passed. Dev union rows 98,282 vs prod 98,283 (the 1 collision); dev `base_` rows 98,282 vs prod 98,282.

dbt Cloud CI is trivial for this PR: the change is confined to the powerschool package and no kipptaf column set changes, so `state:modified+` selects nothing in kipptaf.

Acceptance items still open after merge: confirm `rpt_clever__enrollments__student_id_resolves_to_students_feed` passes in production, and re-run the issue's reproduce query to confirm no `surviving_rn_year` other than 1. Follow-up: remove the dedupe from kipptaf `int_students__student_enrollment_union` once the 3 districts rebuild.

</details>
