### PR TITLE
fix(dbt): derive Miami spedlep from the ESE Exceptionalities log

### DIFF
--- a/src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__custom_field_log__unpivot.sql
@@ -127,6 +127,7 @@ select
     unpivoted.created_at,
     unpivoted.updated_at,
     options.label as value_label,
+    options.code as value_code,
 from unpivoted
 inner join
     columns_meta

--- a/src/dbt/focus/models/intermediate/int_focus__students.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students.sql
@@ -1,29 +1,18 @@
 with
-    -- One row per ESE Exceptionalities log entry (custom_890). Focus's own
-    -- "ESE Primary Computed" field derives from this log, not from the ESE
-    -- FEFP funding code, so IEP status reads it too: placed (P or T), not
-    -- dismissed, and not gifted (L) -- Florida gifted students hold an EP,
-    -- not an IEP. The Primary checkbox is not required; it marks which
-    -- exceptionality leads, not whether a plan exists.
+    -- One row per ESE Exceptionalities log entry. Unlike Focus's own
+    -- "ESE Primary Computed" query, the Primary checkbox (log_field4) is not
+    -- required: it marks which exceptionality leads, not whether a plan exists.
     ese_entries as (
         select
             student_id,
             log_entry_id,
 
             max(
-                if(
-                    slot_column_name = 'log_field3',
-                    regexp_extract(value_label, r'^(\w+)\s*-'),
-                    null
-                )
+                if(slot_column_name = 'log_field3', value_code, null)
             ) as exceptionality_code,
 
             max(
-                if(
-                    slot_column_name = 'log_field5',
-                    regexp_extract(value_label, r'^(\w+)\s*-'),
-                    null
-                )
+                if(slot_column_name = 'log_field5', value_code, null)
             ) as placement_code,
 
             max(if(slot_column_name = 'log_field12', value, null)) as dismissal_date,

--- a/src/dbt/focus/models/intermediate/int_focus__students.sql
+++ b/src/dbt/focus/models/intermediate/int_focus__students.sql
@@ -1,4 +1,46 @@
 with
+    -- One row per ESE Exceptionalities log entry (custom_890). Focus's own
+    -- "ESE Primary Computed" field derives from this log, not from the ESE
+    -- FEFP funding code, so IEP status reads it too: placed (P or T), not
+    -- dismissed, and not gifted (L) -- Florida gifted students hold an EP,
+    -- not an IEP. The Primary checkbox is not required; it marks which
+    -- exceptionality leads, not whether a plan exists.
+    ese_entries as (
+        select
+            student_id,
+            log_entry_id,
+
+            max(
+                if(
+                    slot_column_name = 'log_field3',
+                    regexp_extract(value_label, r'^(\w+)\s*-'),
+                    null
+                )
+            ) as exceptionality_code,
+
+            max(
+                if(
+                    slot_column_name = 'log_field5',
+                    regexp_extract(value_label, r'^(\w+)\s*-'),
+                    null
+                )
+            ) as placement_code,
+
+            max(if(slot_column_name = 'log_field12', value, null)) as dismissal_date,
+        from {{ ref("int_focus__custom_field_log__unpivot") }}
+        where field_title = 'ESE Exceptionalities'
+        group by student_id, log_entry_id
+    ),
+
+    ese_students as (
+        select distinct student_id,
+        from ese_entries
+        where
+            placement_code in ('P', 'T')
+            and dismissal_date is null
+            and exceptionality_code != 'L'
+    ),
+
     labeled as (
         select
             s.*,
@@ -26,9 +68,12 @@ with
             p.label_free_reduced_meals_program as free_reduced_meals_program_label,
             p.code_idea_educational_environment as idea_educational_environment_code,
             p.label_idea_educational_environment as idea_educational_environment_label,
+
+            ese.student_id is not null as has_iep,
         from {{ ref("stg_focus__students") }} as s
         left join
             {{ ref("int_focus__students__pivot") }} as p on s.student_id = p.student_id
+        left join ese_students as ese on s.student_id = ese.student_id
     ),
 
     raced as (
@@ -72,7 +117,7 @@ with
 
             lpad(cast(disis_id as string), 7, '0') as state_studentnumber,
 
-            if(ese_fefp_code_label is not null, 'SPED', null) as spedlep,
+            if(has_iep, 'SPED', null) as spedlep,
 
             -- PowerSchool's fedethnicity: 1 = Hispanic/Latino, 0 = not. The
             -- label is the stable key for this select option.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__custom_field_log__unpivot.yml
@@ -4,8 +4,9 @@ models:
       Long reshape of Focus log-type custom fields. One row per log entry per
       populated slot: the entry keys, the slot's metadata (title/type/sort order
       from custom_field_log_columns), the stored value, and a decoded
-      value_label for select-type slots. Currently covers the two populated
-      student log fields (Immunization Compliance, ARMS Student Field Tracker).
+      value_label and value_code for select-type slots. Currently covers the
+      three populated student log fields (Immunization Compliance, ARMS Student
+      Field Tracker, ESE Exceptionalities).
     config:
       meta:
         contains_pii: true
@@ -61,3 +62,8 @@ models:
           non-select slots and for option_query-backed select slots (e.g. the
           Immunization "Vaccination" slot), where the raw value carries the
           content.
+      - name: value_code
+        description: >-
+          Focus option code for select-type slots whose options are stored — the
+          stable import/export value, as opposed to the editable label. Null in
+          the same cases as value_label.

--- a/src/dbt/focus/models/intermediate/properties/int_focus__students.yml
+++ b/src/dbt/focus/models/intermediate/properties/int_focus__students.yml
@@ -74,11 +74,18 @@ models:
         config:
           meta:
             contains_pii: true
+      - name: has_iep
+        description: >-
+          True when the student has an ESE Exceptionalities log entry that is
+          placed (P or T), not dismissed, and not gifted (L). The log is the
+          determination record Focus's own "ESE Primary Computed" field reads;
+          the ESE FEFP funding code is a downstream consequence and is not
+          consulted.
       - name: spedlep
         description: >-
-          IEP classification in the network domain. 'SPED' where an ESE FEFP
-          code is present, else null — a missing funding code does not assert
-          that the student has no IEP.
+          IEP classification in the network domain. 'SPED' where has_iep, else
+          null — a missing log entry does not assert that the student has no
+          IEP.
       - name: fedethnicity
         description: >-
           Hispanic/Latino flag in the PowerSchool domain: 1 for the "Yes"

--- a/src/dbt/focus/models/intermediate/unit_tests.yml
+++ b/src/dbt/focus/models/intermediate/unit_tests.yml
@@ -429,3 +429,78 @@ unit_tests:
           marking_period_id: 501
           marking_period_type: quarter
           marking_period_start_date: 2026-08-10
+
+  - name: test_int_focus__students_iep_from_ese_log
+    description: >-
+      has_iep and spedlep follow the ESE Exceptionalities log. Student 1 has a
+      placed disability entry (IEP). Student 2's placed entry carries a
+      dismissal date (excluded). Student 3's only placed entry is gifted, code L
+      (excluded -- an EP, not an IEP). Student 4 has no entry. The Primary
+      checkbox is absent on every row and must not be required.
+    model: int_focus__students
+    given:
+      - input: ref('stg_focus__students')
+        rows:
+          - { student_id: 1 }
+          - { student_id: 2 }
+          - { student_id: 3 }
+          - { student_id: 4 }
+      - input: ref('int_focus__students__pivot')
+        rows: []
+      - input: ref('int_focus__custom_field_log__unpivot')
+        rows:
+          - {
+              student_id: 1,
+              log_entry_id: 10,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field3,
+              value_code: K,
+            }
+          - {
+              student_id: 1,
+              log_entry_id: 10,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field5,
+              value_code: P,
+            }
+          - {
+              student_id: 2,
+              log_entry_id: 20,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field3,
+              value_code: F,
+            }
+          - {
+              student_id: 2,
+              log_entry_id: 20,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field5,
+              value_code: P,
+            }
+          - {
+              student_id: 2,
+              log_entry_id: 20,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field12,
+              value: "2025-06-01",
+            }
+          - {
+              student_id: 3,
+              log_entry_id: 30,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field3,
+              value_code: L,
+            }
+          - {
+              student_id: 3,
+              log_entry_id: 30,
+              field_title: ESE Exceptionalities,
+              slot_column_name: log_field5,
+              value_code: P,
+            }
+    expect:
+      rows:
+        - { student_id: 1, has_iep: true, spedlep: SPED }
+        - { student_id: 2, has_iep: false, spedlep: null }
+        - { student_id: 3, has_iep: false, spedlep: null }
+        - { student_id: 4, has_iep: false, spedlep: null }

--- a/src/dbt/focus/models/intermediate/unit_tests.yml
+++ b/src/dbt/focus/models/intermediate/unit_tests.yml
@@ -23,6 +23,8 @@ unit_tests:
           union all
           select 5, 791, 7261, 22, cast(null as timestamp), cast(null as numeric),
             cast(null as int64)
+      - input: ref('int_focus__custom_field_log__unpivot')
+        rows: []
       - input: ref('int_focus__students__pivot')
         format: sql
         rows: |

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__kippfwd_miami_roster.sql
@@ -54,7 +54,7 @@ with
             student_id,
             powerschool_id,
             sex_label,
-            ese_fefp_code,
+            has_iep,
             cast(disis_id as string) as mdcps_id_raw,
             cast(student_id as string) as student_id_string,
         from {{ ref("int_focus__students") }}
@@ -128,9 +128,7 @@ select
 
     regexp_extract(s.sex_label, r'\[(\w)\]') as gender,
 
-    coalesce(
-        psy.iep_status, if(s.ese_fefp_code is not null, 'Has IEP', 'No IEP')
-    ) as iep_status,
+    coalesce(psy.iep_status, if(s.has_iep, 'Has IEP', 'No IEP')) as iep_status,
 
     c1.contact_name as contact_1_name,
     c1.phone_home as contact_1_phone_home,

--- a/src/dbt/kipptaf/models/focus/intermediate/int_focus__students.sql
+++ b/src/dbt/kipptaf/models/focus/intermediate/int_focus__students.sql
@@ -2,9 +2,9 @@
 -- homeless_primary_nighttime_residence_code and lunchstatus (#4868), then
 -- idea_educational_environment_code and idea_educational_environment_label
 -- (#5041), then section_504_eligible_code, section_504_eligible_label,
--- is_504 and fedethnicity. This comment forces state:modified so CI rebuilds
--- the wrapper against the widened staging copy instead of deferring to the
--- narrower Staging environment.
+-- is_504, fedethnicity and has_iep. This comment forces state:modified so CI
+-- rebuilds the wrapper against the widened staging copy instead of deferring
+-- to the narrower Staging environment.
 with
     union_relations as (
         {{

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_core_fields.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__student_core_fields.yml
@@ -21,11 +21,10 @@ models:
     columns:
       - name: spedlep
         description: >-
-          IEP classification. For Miami, read from Focus's ESE FEFP code -- the
-          only ESE field Focus stores. Any code means the student receives ESE
-          services; its absence does not mean the student has no IEP, so it
-          reads null rather than 'No IEP'. Names 162 students against the frozen
-          archive's 419, a gap for Ops to close in Focus.
+          IEP classification. For Miami, read from the Focus ESE
+          Exceptionalities log via int_focus__students.spedlep: a placed,
+          undismissed, non-gifted entry. Its absence does not mean the student
+          has no IEP, so it reads null rather than 'No IEP'.
         data_tests:
           - not_null:
               config:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." read Miami IEP status from the Focus ESE Exceptionalities log instead of the ESE FEFP funding code.

The FEFP code is a Florida funding-matrix category set because a student has an ESE placement. It is a consequence of the determination, not the determination. Focus's own "ESE Primary Computed" field reads the ESE Exceptionalities log (`custom_890`), which records the exceptionality, placement status, placement date, and dismissal date. `int_focus__students.spedlep` now follows Focus's rule: a log entry with placement status P or T, no dismissal date, and an exceptionality other than L (gifted). Florida gifted students hold an EP, not an IEP. A new `has_iep` boolean is exposed beside it, and `rpt_gsheets__kippfwd_miami_roster` derives its `iep_status` from `has_iep` instead of the FEFP code.

Today 12 Miami students have placed, undismissed IEP entries on the log and no FEFP code, so they read as "No IEP" downstream. All 12 were flagged IEP in PowerSchool last year. The switch picks them up. It drops 13 students who have an FEFP code but no migrated log entry; those are blank on Focus's own exceptionality screen too and go to ops as data entry (#4802).

`int_focus__custom_field_log__unpivot` gains `value_code`, the option code it already joined but did not project, so consumers read codes instead of parsing labels.

## Reviewer Notes

- One source, not a union. Discussed and decided: the log is the determination record and is what Focus reads; keeping FEFP as a fallback would hide the 13 missing log entries from ops.
- The Primary checkbox is not required. It marks which exceptionality leads, not whether a plan exists, and about half the speech and language entries lack it.
- New unit test `test_int_focus__students_iep_from_ese_log` pins the placed / dismissed / gifted rule.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.) — all 6 findings addressed, verdicts posted as a comment

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models; `has_iep`, `spedlep`, and `value_code` documented
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — no exposure change
- [x] **Breaking change?** No columns renamed or removed. `spedlep` values change for 25 Miami students (12 gained, 13 lost); the KIPP Forward Miami roster sheet follows.
- [ ] If adding or modifying an external source, run `stage_external_sources` — not applicable

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Dev builds: focus package via kippmiami (`int_focus__custom_field_log__unpivot`, `int_focus__students`) 11 passed, 0 errors, both unit tests included; kipptaf (`int_focus__students`, `rpt_gsheets__kippfwd_miami_roster`) 8 passed. Both `--target dev --defer --favor-state`. The two Focus models were also built with `--target staging` so dbt Cloud CI reads the widened `zz_stg_kippmiami_focus` copies; the kipptaf passthrough comment was bumped to force `state:modified`.

Dev counts, SY2026 Miami roster: `spedlep = 'SPED'` on 145 students vs 146 in prod. Overlap with `gifted_and_talented = 'Y'`: 0. `value_code` populated on all 580 ESE select-slot rows. Cross-tab of the two sources on the SY2026 roster: log and FEFP both 133, log only 12, FEFP only 13, gifted-only log 13 (excluded), dismissed-only log 2 (excluded).

Log slot mapping, from `custom_fields.computed_query` for `PAEC_COMP_ESE_PRI`: `log_field3` exceptionality, `log_field4` Primary checkbox, `log_field5` placement status, `log_field12` dismissal date. Focus's query also requires `log_field4 = 'Y'`; this PR deliberately does not, per Reviewer Notes.

The 12 log-only students: exceptionalities K (5), F (4), G (4), T (3), V (3), W (2), X, I, D (1 each); placements dated 2020 to 2024; all SPED in PowerSchool SY2025.

Refs #4802
Refs #5148

</details>
