### PR TITLE
fix(dbt): prefix pre-Focus Miami vendor student ids in the kipptaf union wrappers

### DIFF
--- a/src/dbt/kipptaf/macros/utils.sql
+++ b/src/dbt/kipptaf/macros/utils.sql
@@ -17,3 +17,12 @@
     {%- set locations = var("frozen_powerschool_code_locations") -%}
     {{ column }} not in ('{{ locations | join("', '") }}')
 {%- endmacro %}
+
+{# Miami vendor files through SY2025 carry the bare pre-Focus student number; the
+   Focus student_number, and so the network student_number, is that number with an
+   8400 prefix (#5149). `year` is the row's academic year and `project` the code
+   location: extract_source_project() inside a union_relations CTE, or the
+   _dbt_source_project column once it exists. #}
+{% macro focus_student_number(id, year, project) -%}
+    {{ id }} + if({{ project }} = 'kippmiami' and {{ year }} <= 2025, 8400000000, 0)
+{%- endmacro %}

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__benchmark_student_summary.sql
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__benchmark_student_summary.sql
@@ -33,6 +33,7 @@ with
 
 select
     * except (
+        student_primary_id,
         basic_comprehension_maze_local_percentile,
         enrollment_teacher_staff_id,
         official_teacher_staff_id,
@@ -60,6 +61,12 @@ select
 
     basic_comprehension_maze_local_percentile
     as reading_comprehension_maze_local_percentile,
+
+    {{
+        focus_student_number(
+            "student_primary_id", "academic_year", "_dbt_source_project"
+        )
+    }} as student_primary_id,
 
     coalesce(
         enrollment_teacher_staff_id, official_teacher_staff_id

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__pm_student_summary.sql
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/int_amplify__mclass__pm_student_summary.sql
@@ -19,6 +19,10 @@ with
             x.location_powerschool_school_id as schoolid,
             x.location_dagster_code_location as _dbt_source_project,
 
+            coalesce(
+                ur.student_primary_id, ur.student_primary_id_studentnumber
+            ) as student_primary_id_keyed,
+
             initcap(
                 regexp_extract(x.location_dagster_code_location, r'kipp(\w+)')
             ) as region,
@@ -42,6 +46,7 @@ select
         school_primary_id,
         student_primary_id,
         student_primary_id_studentnumber,
+        student_primary_id_keyed,
         student_id_state_id,
         secondary_student_id_stateid,
         primary_school_id
@@ -54,9 +59,11 @@ select
     coalesce(device_date, client_date) as client_date,
     coalesce(account_name, district_name) as district_name,
     coalesce(schoolid, school_primary_id) as school_primary_id,
-    coalesce(
-        student_primary_id, student_primary_id_studentnumber
-    ) as student_primary_id,
+    {{
+        focus_student_number(
+            "student_primary_id_keyed", "academic_year", "_dbt_source_project"
+        )
+    }} as student_primary_id,
     coalesce(student_id_state_id, secondary_student_id_stateid) as student_id_state_id,
 
 from location_xref

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__benchmark_student_summary.yml
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__benchmark_student_summary.yml
@@ -233,7 +233,11 @@ models:
         data_type: string
       - name: student_primary_id
         data_type: int64
-        description: Student primary identifier (student number).
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here, after the crosswalk resolves
+          the region.
         config:
           meta:
             source_system: Amplify

--- a/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__pm_student_summary.yml
+++ b/src/dbt/kipptaf/models/amplify/mclass/intermediate/properties/int_amplify__mclass__pm_student_summary.yml
@@ -244,7 +244,11 @@ models:
         data_type: string
       - name: student_primary_id
         data_type: int64
-        description: Student primary identifier (student number).
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here, after the crosswalk resolves
+          the region.
         config:
           meta:
             source_system: Amplify

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__diagnostic_results.sql
@@ -10,6 +10,18 @@ with
         }}
     ),
 
+    sourced as (
+        select
+            * except (student_id),
+
+            {{
+                focus_student_number(
+                    "student_id", "academic_year_int", extract_source_project()
+                )
+            }} as student_id,
+        from union_relations
+    ),
+
     transformations as (
         select
             dr.* except (_dbt_source_relation),
@@ -35,7 +47,7 @@ with
                 when 'kippmiami'
                 then 'FL'
             end as state_assessment_type,
-        from union_relations as dr
+        from sourced as dr
         left join
             {{ ref("int_people__location_crosswalk") }} as lc
             on dr.school = lc.location_name

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson.sql
@@ -8,6 +8,18 @@ with
                 ]
             )
         }}
+    ),
+
+    sourced as (
+        select
+            * except (student_id),
+
+            {{
+                focus_student_number(
+                    "student_id", "academic_year_int", extract_source_project()
+                )
+            }} as student_id,
+        from union_relations
     )
 
 select
@@ -18,6 +30,6 @@ select
         r'kipp[a-z]+_',
         lc.location_dagster_code_location || '_'
     ) as _dbt_source_relation,
-from union_relations as ur
+from sourced as ur
 left join
     {{ ref("int_people__location_crosswalk") }} as lc on ur.school = lc.location_name

--- a/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson_pro.sql
+++ b/src/dbt/kipptaf/models/iready/intermediate/int_iready__instruction_by_lesson_pro.sql
@@ -10,6 +10,18 @@ with
                 ]
             )
         }}
+    ),
+
+    sourced as (
+        select
+            * except (student_id),
+
+            {{
+                focus_student_number(
+                    "student_id", "academic_year_int", extract_source_project()
+                )
+            }} as student_id,
+        from union_relations
     )
 
 select
@@ -20,6 +32,6 @@ select
         r'kipp[a-z]+_',
         lc.location_dagster_code_location || '_'
     ) as _dbt_source_relation,
-from union_relations as ur
+from sourced as ur
 left join
     {{ ref("int_people__location_crosswalk") }} as lc on ur.school = lc.location_name

--- a/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__diagnostic_results.yml
+++ b/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__diagnostic_results.yml
@@ -12,6 +12,10 @@ models:
                 field: name
       - name: student_id
         data_type: int64
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here.
       - name: _dbt_source_relation
         data_type: string
       - name: academic_year

--- a/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__instruction_by_lesson.yml
+++ b/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__instruction_by_lesson.yml
@@ -17,6 +17,10 @@ models:
         data_type: int64
       - name: student_id
         data_type: int64
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here.
       - name: academic_year
         data_type: string
       - name: subject

--- a/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__instruction_by_lesson_pro.yml
+++ b/src/dbt/kipptaf/models/iready/intermediate/properties/int_iready__instruction_by_lesson_pro.yml
@@ -17,6 +17,10 @@ models:
         data_type: int64
       - name: student_id
         data_type: int64
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here.
       - name: subject
         data_type: string
       - name: level

--- a/src/dbt/kipptaf/models/iready/staging/stg_iready__personalized_instruction_summary.sql
+++ b/src/dbt/kipptaf/models/iready/staging/stg_iready__personalized_instruction_summary.sql
@@ -1,10 +1,32 @@
-{{
-    dbt_utils.union_relations(
-        relations=[
-            source("kippnj_iready", "stg_iready__personalized_instruction_summary"),
-            source(
-                "kippmiami_iready", "stg_iready__personalized_instruction_summary"
-            ),
-        ]
+with
+    union_relations as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    source(
+                        "kippnj_iready",
+                        "stg_iready__personalized_instruction_summary",
+                    ),
+                    source(
+                        "kippmiami_iready",
+                        "stg_iready__personalized_instruction_summary",
+                    ),
+                ]
+            )
+        }}
+    ),
+
+    sourced as (
+        select
+            * except (student_id),
+
+            {{
+                focus_student_number(
+                    "student_id", "academic_year_int", extract_source_project()
+                )
+            }} as student_id,
+        from union_relations
     )
-}}
+
+select *,
+from sourced

--- a/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml
+++ b/src/dbt/kipptaf/models/renlearn/staging/properties/stg_renlearn__star.yml
@@ -271,8 +271,13 @@ models:
         data_type: int64
       - name: student_display_id
         data_type: int64
+        description: >-
+          Network student number. Miami rows through SY2025 carry the bare
+          pre-Focus number in the source; they are brought onto the
+          8400-prefixed Focus student number here.
       - name: student_identifier
         data_type: int64
+        description: Same value as student_display_id in every row.
       - name: student_sourced_id
         data_type: int64
       - name: student_user_id

--- a/src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql
+++ b/src/dbt/kipptaf/models/renlearn/staging/stg_renlearn__star.sql
@@ -9,8 +9,28 @@ with
         }}
     ),
 
+    sourced as (
+        select
+            * except (student_display_id, student_identifier),
+
+            {{
+                focus_student_number(
+                    "student_display_id",
+                    "_dagster_partition_fiscal_year - 1",
+                    extract_source_project(),
+                )
+            }} as student_display_id,
+            {{
+                focus_student_number(
+                    "student_identifier",
+                    "_dagster_partition_fiscal_year - 1",
+                    extract_source_project(),
+                )
+            }} as student_identifier,
+        from union_relations
+    ),
+
     derived as (
-        -- trunk-ignore(sqlfluff/AM04)
         select
             *,
 
@@ -94,7 +114,7 @@ with
                     student_identifier
                 order by completed_date desc
             ) as rn_subject_year,
-        from union_relations
+        from sourced
         where deactivation_reason is null
     )
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." let historical Miami vendor data join to Miami students again.

After #5148, Miami's `student_number` is the 8400-prefixed Focus id. iReady, STAR and DIBELS rows through SY2025 still carry the bare pre-migration number, so those rows stopped matching Miami students.

This PR fixes the id in the kipptaf `union_relations` wrappers, where the source project is known. One macro, `focus_student_number`, holds the rule: add 8400000000 to the id when the code location is kippmiami and the academic year is SY2025 or earlier. Each iReady wrapper and the STAR wrapper call it in a `sourced` CTE right after `union_relations`, reading the code location from the raw source relation. Every bare Miami number is 6 digits, so adding the offset is the same as prepending `8400`. New Jersey rows never match the guard.

DIBELS has no district source. Both Amplify tables come from one network account and the region only resolves at the crosswalk join in the 2 mClass intermediates, so the same macro runs there on `_dbt_source_project` once the region is known.

Source packages and district projects are untouched. Consumers keep joining on `student_number`. No column is added and nothing joins to Focus.

Closes #5149

## Reviewer Notes

- The boundary is the same in every source: SY2025 and earlier bare, SY2026 prefixed. STAR keys on fiscal year, so its guard reads `<= 2026`.
- The guard runs on the raw `_dbt_source_relation` before the wrappers rewrite it to a per-district code location, so it reads `kippmiami` directly and never depends on the crosswalk match.
- One Miami student has a Focus id with no `8400` prefix at all. Their pre-SY2026 vendor rows will not join under this rule. That id is an Ops correction in Focus.
- `int_iready__instructional_usage_data` is disabled and has no consumers, so it is left alone.
- The 2 Amplify files were CRLF. `git-diff-check` rejects CR on added lines, so they are now LF and their diffs read as whole-file. The substantive change in each is under 15 lines.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No columns added, renamed or removed. Values change for pre-SY2026 Miami vendor ids only.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      No external source changed.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. This PR went through 3 shapes. v1 added `student_number_legacy` to the Focus and student models and joined the vendor intermediates to Focus. v2 added a `student_number_offset` var to the iReady and STAR source packages. Charlie redirected both: source-specific intermediates are not the place to join Focus, and package models are not the place for a district-specific shim, which belongs in the kippmiami project or the kipptaf `union_relations` wrapper. This is the wrapper version. The earlier PR comments refer to v1.

Prod diagnostic, 2026-09-04: Miami vendor rows matching the bare vs prefixed id. iReady diagnostic SY2020 to SY2025 38,531 bare / 0 prefixed, SY2026 0 / 2,896. iReady personalized instruction, instruction by lesson and by lesson pro: all Miami rows bare through SY2025, prefixed from SY2026. STAR SY2023 to SY2025 all bare (7,539), SY2026 0 / 743. DIBELS benchmark and PM SY2023 to SY2024 all bare. Every partition-year column is INT64. All 4,061 Focus ids are numeric, and every bare legacy number is 6 digits, so `+ 8400000000` equals the literal prefix.

Dev verification (`--target dev --defer --favor-state`, kippmiami dev source copies rebuilt from main first): kipptaf build of the 7 touched models passed with only the 3 pre-existing crosswalk `relationships` warns (124, 1,488 and 5 orphans, identical in prod). Value check on the dev tables, Miami rows through SY2025: iReady diagnostic 45,194 rows all prefixed, 45,007 join a Miami enrollment; personalized instruction 259,113 / 259,109; by lesson 681,320 / 680,909; by lesson pro 18,240 / 18,240; STAR 7,539 / 7,539; DIBELS benchmark 8,802 / 8,802; DIBELS PM 8,363 / 8,363. Unmatched rows are students who left before the Focus migration. SY2026 Miami rows and all New Jersey rows are unchanged.

The dbt Cloud PR schemas held v1-built views referencing `student_number_legacy`, and dbt Cloud reuses PR-schema relations over deferred ones, so Charlie dropped the `dbt_cloud_pr_70403104388001_5154_*` datasets before this version was pushed.

</details>
