### PR TITLE
chore(dbt): revert gradebook audit summer toggle to the live academic year

### DIFF
--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
@@ -19,7 +19,7 @@ with
         from {{ ref("int_students__calendar_week") }}
         where
             -- summer toggle: see skill
-            academic_year = {{ var("current_academic_year") - 1 }}
+            academic_year = {{ var("current_academic_year") }}
             and week_start_monday
             < date_trunc(current_date('{{ var("local_timezone") }}'), isoweek)
         group by
@@ -68,6 +68,6 @@ select
     cnt_f as `F`,
     cnt_s as `S`,
 
-    {{ var("current_academic_year") - 1 }} as academic_year,  /* summer toggle: see skill */
+    {{ var("current_academic_year") }} as academic_year,  /* summer toggle: see skill */
 
 from week_expectations

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__gradebook_audit_template.sql
@@ -63,9 +63,13 @@ select
     week_start_monday,
     school_week_end_date as week_end_friday,
     notes,
+    -- trunk-ignore(sqlfluff/RF06): keeps the uppercase header T&L uploads
     cnt_w as `W`,
+    -- trunk-ignore(sqlfluff/RF06): keeps the uppercase header T&L uploads
     cnt_h as `H`,
+    -- trunk-ignore(sqlfluff/RF06): keeps the uppercase header T&L uploads
     cnt_f as `F`,
+    -- trunk-ignore(sqlfluff/RF06): keeps the uppercase header T&L uploads
     cnt_s as `S`,
 
     {{ var("current_academic_year") }} as academic_year,  /* summer toggle: see skill */

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -128,7 +128,8 @@ with
             and r.duedate between s.quarter_start_date and s.quarter_end_date
             and r.scoretype in ('POINTS', 'PERCENT')
         where
-            s.academic_year = {{ var("current_academic_year") - 1 }}  /* summer toggle: see skill */
+            /* summer toggle: see skill */
+            s.academic_year = {{ var("current_academic_year") }}
             and s.school_level_alt != 'ES'
             and s._dbt_source_project != 'kippmiami'
             and s.exclude_from_gpa = 0

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_es_comments.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_es_comments.sql
@@ -54,7 +54,7 @@ left join
     and qg.termbin_start_date <= current_date('{{ var("local_timezone") }}')
 where
     -- summer toggle: see skill (no storedgrades fallback here -- see skill)
-    s.academic_year = {{ var("current_academic_year") - 1 }}
+    s.academic_year = {{ var("current_academic_year") }}
     /* alt so Sumner G5 (treated as MS) stays in the audit, not the ES view */
     and s.region_school_level_alt in ('CamdenES', 'NewarkES', 'PatersonES')
     and s.credit_type in ('HR', 'MATH', 'ENG')

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__u_expectations_qtd_unpivot.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__u_expectations_qtd_unpivot.sql
@@ -14,7 +14,7 @@ with
         from {{ ref("int_students__calendar_week") }}
         where
             -- summer toggle: see skill
-            academic_year = {{ var("current_academic_year") - 1 }}
+            academic_year = {{ var("current_academic_year") }}
             and week_start_monday
             < date_trunc(current_date('{{ var("local_timezone") }}'), isoweek)
     ),
@@ -65,7 +65,7 @@ select
     assignment_category_code,
     expectation,
 
-    {{ var("current_academic_year") - 1 }} as academic_year,  /* summer toggle: see skill */
+    {{ var("current_academic_year") }} as academic_year,  /* summer toggle: see skill */
 
     concat(assignment_category_code, right(`quarter`, 1)) as assignment_category_term,
 

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__gradebook_audit_student_flags.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__gradebook_audit_student_flags.sql
@@ -93,9 +93,9 @@ left join
     and s.sectionid = qg.sectionid
     and s._dbt_source_project = qg._dbt_source_project
     and s.`quarter` = qg.storecode
-    and qg.grades_type = 'last_year'  /* summer toggle: see skill */
+    and qg.grades_type = 'current_year'  /* summer toggle: see skill */
 where
-    s.academic_year = {{ var("current_academic_year") - 1 }}  /* summer toggle: see skill */
+    s.academic_year = {{ var("current_academic_year") }}  /* summer toggle: see skill */
     and s.quarter_start_date <= current_date('{{ var("local_timezone") }}')
     and s.rn_year = 1
     and s.enroll_status = 0


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will point the gradebook audit back at the current school year.

Every July the data team bumps the academic year variable before PowerSchool holds any data for the new year. To keep school leaders seeing data over the summer, we flip five gradebook audit models to read the prior year instead. That toggle went in on 24 July. The new school year has now started, so this reverts it.

The new year is ready. PowerSchool holds 2,532 sections for 2026-2027. Q1 is the current quarter. Teachers have already entered a percent grade on 26,854 Q1 records.

This also repairs a model that is broken right now. `rpt_tableau__gradebook_es_comments` is still pinned to last year, but last year's grades have since been cleared out of `base_powerschool__final_grades`. Its join matches nothing, so the elementary comments view reports every single comment as missing. After this change the join matches 12,112 of the 12,216 elementary records.

## Reviewer Notes

All five files must ship together. I proved this by accident: building the Tableau model on its own, against the current production expectations model, returned zero rows. The two models join on academic year, and they disagreed about which year it was.

I did not add a fallback to archived grades in the elementary comments model. The gradebook audit skill records that someone tried this before and reverted it, because the archive holds no elementary data for the years we would need. A fallback there would report every comment as missing rather than fall back to anything real.

The second commit suppresses four `RF06` lint findings in `rpt_gsheets__gradebook_audit_template.sql`. These are pre-existing and sit on lines this branch does not otherwise change, but CI lints every line of a changed file, so they failed the first run. The backticks around `W`, `H`, `F` and `S` are load-bearing: removing them trips `CP02` instead, and sqlfmt then rewrites the aliases to lowercase. That would silently rename the header row T&L uploads into PowerSchool. I rebuilt the model and confirmed the output columns are still uppercase.

One line in `rpt_tableau__gradebook_audit` has its marker comment moved onto its own line, to stay under the 88 character limit. I rebuilt and the output is unchanged: 9,985 rows, 1,565 section-quarters, zero floor violations.

Elementary comments still read 100% missing today. That is correct, not a bug. These are end-of-quarter comments and we are in week 2 of Q1. The whole network has exactly one comment entered so far.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### dbt

This change adds no models, changes no properties files, touches no exposures, renames no columns, and adds no external sources. It changes filter values inside five existing models, plus four lint suppression comments.

- [x] **Breaking change?** No. No columns are renamed or removed, so no downstream exposure breaks.

## CI checks

- [x] **Trunk** — passes locally on all five changed files after the `RF06` suppression. The first CI run failed on those four findings; see Reviewer Notes.
- [x] **dbt Cloud** — passed on the first run.
- [x] **Dagster Cloud** — not triggered, no Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Anthony asked to run the summer turnover process; Claude found the toggle already applied and recommended the revert direction instead, which Anthony confirmed.

Reverts `2d16e2a80`. Eight marked sites across five models flip `{{ var("current_academic_year") - 1 }}` back to `{{ var("current_academic_year") }}`:

- `rpt_tableau__gradebook_audit.sql` — `category_join` WHERE (1)
- `int_extracts__gradebook_audit_student_flags.sql` — outer `academic_year` filter, plus `grades_type` `'last_year'` to `'current_year'` (2)
- `int_powerschool__u_expectations_qtd_unpivot.sql` — `int_students__calendar_week` filter and the stamped output column (2)
- `rpt_tableau__gradebook_es_comments.sql` — year filter (1)
- `rpt_gsheets__gradebook_audit_template.sql` — `term_weeks` filter and the stamped output column (2)

Deliberately NOT changed: the `academic_year = {{ var("current_academic_year") - 1 }}` filter inside the `stg_powerschool__storedgrades` union branch of `int_extracts__gradebook_audit_student_flags` (around line 31). That branch must always read the prior year. It carries no `summer toggle` marker and is not a toggle point.

Evidence gathered before the change:

- `current_academic_year` var is 2026.
- `int_extracts__course_schedule_by_term`: 2,532 sections for academic_year 2026 across all four quarters.
- Q1 runs 2026-07-01 to 2026-11-02 and is flagged current on 2,493 sections. School weeks began 2026-08-17; two are complete.
- `base_powerschool__final_grades` holds only academic_year 2026, total 242,814 rows. AY2025 is entirely gone, which is what broke the elementary comments model.
- AY2026 Q1: 61,315 rows, 26,854 with a percent grade, exactly 1 with a comment.
- `stg_powerschool__u_expectations` is populated for Newark, Camden and Paterson across all four quarters, week 2 present, so the QTD join finds a current week.

Verification after the change, dev build of all six models with `--defer --favor-state` against the prod manifest, `PASS=12 WARN=0 ERROR=0 SKIP=0 NO-OP=2 TOTAL=14`:

- `rpt_tableau__gradebook_audit`: 9,985 rows, academic_year 2026 only. 6,260 `category_summary` and 3,725 `assignment_detail`. All 1,565 section-quarters have exactly 4 category rows (min 4, max 4, zero violations), so the 4-row floor holds.
- `int_extracts__gradebook_audit_student_flags`: 35,229 Q1 rows, 26,632 with a grade, 25 above 100, 3,082 below 70 with no comment.
- `rpt_tableau__gradebook_es_comments`: 12,216 rows, join matches 12,112.
- `int_powerschool__u_expectations_qtd_unpivot`: Q1 only, 5 region and level combinations, 4 categories each, week 2 for Camden and week 1 for Newark and Paterson, week ending 2026-08-30.
- `rpt_gsheets__gradebook_audit_template`: 7 rows, grain unique, weeks 2026-08-17 to 2026-08-28. Output columns confirmed as `W`, `H`, `F`, `S` after the suppression commit.

Two gotchas worth recording:

1. Re-running the build with a narrower `--select` of just `rpt_tableau__gradebook_audit` returned **zero rows**. `--favor-state` re-pointed the unselected `int_powerschool__u_expectations_qtd_unpivot` to prod, which still stamps 2025, breaking the `academic_year` join key. This is the exact failure the gradebook audit skill predicts for a partial toggle, and it confirms the five files are not independently shippable. Re-running the full six-model selection restored the numbers above.
1. `trunk-action` in CI lints every line of a **changed file**, not only the changed lines. An earlier draft of this PR body claimed CI scopes lint to the diff; that was wrong, and the first CI run failed on four pre-existing `RF06` findings in a file whose toggle lines alone were edited. Assume any pre-existing finding in a file you touch will fail CI.

The gradebook audit skill and `docs/models/gradebook-audit-data-model.md` both still assert that `base_powerschool__final_grades` retains prior-year rows after the academic year variable rolls over. That is no longer true and is what broke the elementary comments model. Worth correcting in a follow-up so next July's run does not rely on it.

Follow-up for the academics and T&L team, not part of this PR: `rpt_gsheets__gradebook_audit_template` now shows the new year's grid, but it only emits weeks that have already started, so it currently holds 7 rows rather than a full-year grid. That is the model's documented design, not a regression. Separately, `stg_powerschool__u_expectations` carries no academic year column, so I cannot tell from the warehouse whether the counts now loaded are the new year's expectations or last year's leftovers. Someone should confirm T&L has uploaded the 2026-2027 expectations.

</details>
