### PR TITLE
fix(people): resolve school leader and DSO managers without a job-title filter

### DIFF
--- a/src/dbt/kipptaf/models/people/intermediate/int_people__leadership_crosswalk.sql
+++ b/src/dbt/kipptaf/models/people/intermediate/int_people__leadership_crosswalk.sql
@@ -1,5 +1,11 @@
 with
-    staff_roster as (
+    active_roster as (
+        /* every non-terminated employee, no title filter. The manager
+           self-joins below (head of school, MDSO) read this CTE: a School
+           Leader's manager holds titles such as Head of Schools, Managing
+           Director, or Chief Academic Officer, and a title list can never be
+           complete. Filtering the manager lookup by title nulled `hos` for
+           every MS/HS student (#5164). */
         select
             employee_number,
             formatted_name,
@@ -14,6 +20,13 @@ with
             home_work_location_campus_name,
             reports_to_employee_number,
         from {{ ref("int_people__staff_roster") }}
+        where assignment_status != 'Terminated'
+    ),
+
+    staff_roster as (
+        /* the school-based leadership roles this crosswalk is keyed on */
+        select *,
+        from active_roster
         where
             job_title in (
                 'Director School Operations',
@@ -22,7 +35,6 @@ with
                 'School Leader',
                 'School Leader in Residence'
             )
-            and assignment_status != 'Terminated'
             and home_work_location_powerschool_school_id != 0
     ),
 
@@ -109,8 +121,8 @@ select
     mdo.sam_account_name as mdo_sam_account_name,
 from school_leadership as l
 left join staff_roster as sl on l.sl_employee_number = sl.employee_number
-left join staff_roster as hos on sl.reports_to_employee_number = hos.employee_number
+left join active_roster as hos on sl.reports_to_employee_number = hos.employee_number
 left join staff_roster as dso on l.dso_employee_number = dso.employee_number
-left join staff_roster as mdso on dso.reports_to_employee_number = mdso.employee_number
+left join active_roster as mdso on dso.reports_to_employee_number = mdso.employee_number
 left join mdo as m on l.home_work_location_region = m.home_work_location_region
 left join staff_roster as mdo on m.mdo_employee_number = mdo.employee_number

--- a/src/dbt/kipptaf/models/people/intermediate/properties/int_people__leadership_crosswalk.yml
+++ b/src/dbt/kipptaf/models/people/intermediate/properties/int_people__leadership_crosswalk.yml
@@ -5,9 +5,13 @@ models:
       employee numbers and contact attributes of the school leader, head of
       school, director of school operations (DSO), managing director of school
       operations (MDSO), and regional managing director of operations (MDO).
-      Derived from `int_people__staff_roster` after filtering to the relevant
-      leadership job titles. Grouped on `home_work_location_reporting_name` so
-      an ADP rename does not split a school into two rows.
+      The school leader, DSO, and MDO are picked from `int_people__staff_roster`
+      by job title. Their managers (head of school, MDSO) are resolved through
+      `reports_to_employee_number` against every non-terminated employee, with
+      no title filter, because those managers hold varied titles (Head of
+      Schools, Managing Director, Chief Academic Officer). Grouped on
+      `home_work_location_reporting_name` so an ADP rename does not split a
+      school into two rows.
     config:
       materialized: table
     columns:
@@ -55,8 +59,11 @@ models:
         data_type: string
       - name: head_of_school_employee_number
         description: |
-          Employee number of the Head of School (the School Leader's
-          supervisor).
+          Employee number of the School Leader's manager, taken from the School
+          Leader's `reports_to_employee_number` with no job-title filter. Today
+          that is a Head of Schools, Managing Director, or Chief Academic
+          Officer; check `head_of_school_job_title` before treating the name as
+          a Head of Schools. NULL only when the school has no School Leader.
         data_type: int64
       - name: head_of_school_preferred_name_lastfirst
         description: Head of School's preferred name in `Last, First` format.
@@ -93,8 +100,10 @@ models:
         data_type: string
       - name: mdso_employee_number
         description: |
-          Employee number of the Managing Director of School Operations (the
-          DSO's supervisor).
+          Employee number of the DSO's manager, taken from the DSO's
+          `reports_to_employee_number` with no job-title filter. Usually the
+          Managing Director of School Operations; see `mdso_job_title`. NULL
+          when the school has no DSO.
         data_type: int64
       - name: mdso_preferred_name_lastfirst
         description: MDSO's preferred name in `Last, First` format.


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make `int_people__leadership_crosswalk` resolve each School Leader's manager and each DSO's manager against every non-terminated employee, with no job-title filter.

Today the `hos` and `mdso` self-joins read a roster CTE filtered to 5 leadership titles. School Leaders report to people titled Head of Schools, Managing Director, or Chief Academic Officer, and none of those titles is in the list, so the join matches nobody. `head_of_school_*` is NULL on 23 of 24 schools, `hos` is NULL for every MS and HS student in `rpt_tableau__student_course_grades`, and the HoS filter card on the Academic Health Home tab offers only Null.

The change splits the CTE. `active_roster` holds every non-terminated employee and feeds the two manager joins. `staff_roster` keeps the 5-title filter and still picks the School Leader, DSO, and MDO. The model's grain and its `unique` test are unchanged.

Closes #5164

## Reviewer Notes

`head_of_school_*` now reflects whoever the School Leader reports to in ADP, whatever that person's title. On 2 schools that is another School Leader or an Assistant School Leader. The yml says to check `head_of_school_job_title` before reading the name as a Head of Schools. If the business wants a strict Head of Schools, that is a different source (`int_people__location_crosswalk.location_head_of_schools_employee_number`) and a different PR.

`active_roster` keeps the existing `assignment_status != 'Terminated'` test, which also keeps the 5 `Deceased` rows. I left that as it was to keep this change narrow.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties file updated (`int_people__leadership_crosswalk.yml`: model, `head_of_school_employee_number`, and `mdso_employee_number` descriptions)
- [x] No new exposure needed; the model is upstream of existing Tableau exposures
- [x] Not a breaking change: no column added, renamed, or removed
- [x] No external source touched

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Verified locally: `uv run dbt build --select int_people__leadership_crosswalk --target dev --defer --favor-state` built 24 rows and passed the `unique` test on `home_work_location_powerschool_school_id`. In the dev table `head_of_school_employee_number` is populated on 23 of 24 rows; the 24th (KIPP TEAM Academy, 133570965) has no School Leader in the roster, which is a separate data gap. `mdso_*` is populated on every school with a DSO (21 of 24; the 3 Miami schools without a DSO stay NULL). `mdo_*` stays NULL everywhere because no active employee holds the title Managing Director of Operations; not changed here.

Downstream simulation, joining the dev crosswalk to prod `int_extracts__student_enrollments` on `schoolid` for AY2026 MS/HS: every region's students gain a non-null `hos` except about 510 Newark MS students at TEAM Academy. Prod today has 0.

Root-cause commit: 45bea1db3 (2025-11-25) moved these joins from `{{ ref("int_people__staff_roster") }}` to the filtered CTE. Trunk check on both files: no issues. `select *,` in `staff_roster` follows the repo's trailing-comma convention (90 precedent files).

</details>
