### PR TITLE
feat(fresh): flag SIS-enrolled students missing from Finalsite on the QC worklist

### DIFF
--- a/.claude/skills/fresh-dashboard/SKILL.md
+++ b/.claude/skills/fresh-dashboard/SKILL.md
@@ -994,11 +994,27 @@ regression, not a cleanup — the same trap that produced a wrong doc claim abou
 `is_grade_level_mismatch` / `is_school_mismatch`, which DO collapse NULL to
 `false` because they are wrapped.
 
-**The worklist has four flags, not five.** `is_same_day_status_tie` was deleted
-at the AY2026 review and replaced by the pending-status set inside
-`is_enroll_status_mismatch`. The same-day tie still happens in the data and the
-Reset Protocol is still the fix — it just no longer gets its own worklist row,
-so don't re-add the flag when someone reports a wrong `latest_status`.
+**The worklist has five flags, and `is_same_day_status_tie` is not one of
+them.** It was deleted at the AY2026 review and replaced by the pending-status
+set inside `is_enroll_status_mismatch`. The same-day tie still happens in the
+data and the Reset Protocol is still the fix — it just no longer gets its own
+worklist row, so don't re-add the flag when someone reports a wrong
+`latest_status`. The fifth flag is `is_missing_finalsite_record`, added in
+#5167, which is a different thing entirely.
+
+**`is_missing_finalsite_record` is the only flag sourced from the SIS side.** It
+fires when a student is currently enrolled in
+`int_extracts__student_enrollments` but no Finalsite record exists for them
+under any cycle, and it is `UNION ALL`ed onto the worklist rather than unpivoted
+— a student Finalsite never knew about cannot appear in a Finalsite-sourced
+roster. Miami reaches it through `int_finalsite__contact_id_attributes`, because
+Miami rows carry no `infosnap_id`. Do NOT "fix" the unscoped anti-join by adding
+a `finalsite_recruitment_year` filter: that was measured and rejected, because
+it also flags students whose Finalsite record merely sits in an adjacent cycle
+or has no status dates to unpivot. Those rows are also the students who are
+missing from the Progress to Goals count, so this flag is what a "PowerSchool
+says N, the dashboard says N-1" question should be answered with now, instead of
+tracing one student by hand.
 
 **`is_enroll_status_mismatch` has TWO directions in the docs, not three.** The
 "left" and "not finished enrolling" statuses were presented separately until the

--- a/.claude/skills/fresh-dashboard/SKILL.md
+++ b/.claude/skills/fresh-dashboard/SKILL.md
@@ -938,6 +938,22 @@ it with:
 uv run dbt parse --target prod --project-dir src/dbt/kipptaf --target-path target/prod
 ```
 
+**Deferred cleanup — rename the shadowed `focus_student_id` alias.** Do this at
+the AY2027-2028 rollover, not before; it was raised on #5168 and explicitly
+deferred as not worth its own PR. Both
+`int_tableau__finalsite_student_scaffold.sql` and
+`rpt_tableau__fresh_dashboard_qc.sql` open a `finalsite_contact_ids` CTE with
+`cast(focus_student_id_prefixed as int) as focus_student_id`. That alias shadows
+a real, differently-valued column on `int_finalsite__contact_id_attributes` —
+the genuinely unprefixed `focus_student_id` — so a reader diffing either CTE
+against its upstream model can take the prefixed value for the bare one. The
+prefixed value IS the student number (`concat('8400', focus_student_id)`), and
+the better-named precedent is `stg_people__student_logins.sql`, which calls it
+`student_number` and reserves `student_number_bare` for the unprefixed id.
+**Rename in BOTH models in one change** — doing one leaves the pair divergent,
+which is worse for the reader than the shared bad name. It is a CTE-internal
+alias in both places, so nothing outside those two models sees it.
+
 **When to make the change:** whenever SRE says the recruitment cycle has rolled
 over — not on a fixed schedule. There is no "revert" step the way
 gradebook-audit's summer toggle has; this is a one-directional bump forward each

--- a/docs/models/fresh-dashboard-data-model.md
+++ b/docs/models/fresh-dashboard-data-model.md
@@ -904,6 +904,15 @@ whole pipeline at the new cycle, and several models `inner join` against sheets
 scoped to that year. Flipping the var before those sheets carry the new year's
 rows does not error — it silently returns zero rows.
 
+One cleanup is parked against this rollover rather than done on its own.
+`int_tableau__finalsite_student_scaffold` and `rpt_tableau__fresh_dashboard_qc`
+both alias `cast(focus_student_id_prefixed as int)` to `focus_student_id`, which
+is the name of a different, genuinely unprefixed column on
+`int_finalsite__contact_id_attributes`. The value is correct and nothing is
+broken; the name misleads. Rename it in both models together at the AY2027-2028
+rollover — renaming one alone leaves the two CTEs divergent, which reads worse
+than the shared bad name. Raised on #5168 and deferred there.
+
 ### Steps, in order
 
 | #   | Step                                                              | Owner           |

--- a/docs/models/fresh-dashboard-data-model.md
+++ b/docs/models/fresh-dashboard-data-model.md
@@ -744,17 +744,33 @@ through untouched.
 
 ### The QC worklist: `rpt_tableau__fresh_dashboard_qc`
 
-`is_enroll_status_mismatch` is one of the worklist's four flags. Three of them —
+`is_enroll_status_mismatch` is one of the worklist's five flags. Three of them —
 this one, `is_grade_level_mismatch` and `is_school_mismatch` — are computed in
-`int_tableau__finalsite_student_scaffold`; `is_missing_sis_record` is derived in
-`rpt_tableau__fresh_dashboard_qc` itself. `rpt_tableau__fresh_dashboard_qc` is
-the SRE-facing surface for all four: it takes the roster at
-`grouped_status_timeframe = 'Current'`, `UNPIVOT`s the flags into
-`(flag_name, flag_value)`, and keeps only the rows where a flag actually fired
-(`where flag_value`). So it is a **worklist, not a report** — one row per
-student per problem, and an empty result is the good outcome.
+`int_tableau__finalsite_student_scaffold`; `is_missing_sis_record` and
+`is_missing_finalsite_record` are derived in `rpt_tableau__fresh_dashboard_qc`
+itself. `rpt_tableau__fresh_dashboard_qc` is the SRE-facing surface for all
+five: it takes the roster at `grouped_status_timeframe = 'Current'`, `UNPIVOT`s
+the first four flags into `(flag_name, flag_value)`, keeps only the rows where a
+flag actually fired (`where flag_value`), then `UNION ALL`s the
+`is_missing_finalsite_record` rows on. So it is a **worklist, not a report** —
+one row per student per problem, and an empty result is the good outcome.
 
-#### The four flags, in plain language
+**`is_missing_finalsite_record` is unioned on, not unpivoted, and that is
+structural.** Every other flag describes a Finalsite record, so it can be
+computed on a Finalsite-sourced roster. This one describes a student Finalsite
+has never heard of, and no such student can appear in that roster at all — the
+model therefore reads `int_extracts__student_enrollments` directly, resolves
+each student's Finalsite identity (`infosnap_id`, falling back to
+`int_finalsite__contact_id_attributes` for Miami, whose rows carry no
+`infosnap_id`), and anti-joins against `stg_finalsite__status_report`. The
+anti-join is deliberately unscoped by year: a record filed under an adjacent
+cycle, or one with no status dates for `int_finalsite__status_report_unpivot` to
+unpivot, still means Finalsite knows the student. Scoping it to
+`finalsite_recruitment_year` instead was measured and rejected — it took
+Newark's count from 2 to 8, and all 6 additions were records that exist but sit
+in the 2025 or 2027 cycle, which is a different and murkier problem.
+
+#### The five flags, in plain language
 
 For explaining the worklist to a non-technical audience. Each row is one student
 with one problem; a student with several problems appears once per problem, and
@@ -763,12 +779,13 @@ a student with none does not appear at all.
 Listed in the triage order SRE reviews them in, most urgent first — which is not
 the order the flags are declared in the SQL.
 
-| #   | flag                        | what it means                                                                                                                                                                                                                                                                                                                    | how it gets fixed                                                                                                          |
-| --- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `is_missing_sis_record`     | Not a disagreement but an absence — Finalsite says the student is enrolled and the SIS has no enrollment record at all to compare against.                                                                                                                                                                                       | Someone has to create or link the SIS record. A different fix from the disagreement case, which is why it is its own flag. |
-| 2   | `is_school_mismatch`        | Finalsite's assigned school is not the school the SIS has them at, so the student is counted against the wrong school's targets until it is fixed.                                                                                                                                                                               | Confirm the true school, then fix whichever system is wrong.                                                               |
-| 3   | `is_enroll_status_mismatch` | Finalsite and the SIS disagree about whether the student is enrolled — Finalsite says enrolled while the SIS says withdrawn or graduated, or Finalsite says the student left or has not finished enrolling while the SIS still has them active. Documented below as two directions, one per comparison the check actually makes. | Decide which system is right, then correct the other one.                                                                  |
-| 4   | `is_grade_level_mismatch`   | Finalsite's grade for the student is not the grade the SIS has them in.                                                                                                                                                                                                                                                          | Confirm the true grade, then fix whichever system is wrong.                                                                |
+| #   | flag                          | what it means                                                                                                                                                                                                                                                                                                                    | how it gets fixed                                                                                                          |
+| --- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `is_missing_sis_record`       | Not a disagreement but an absence — Finalsite says the student is enrolled and the SIS has no enrollment record at all to compare against.                                                                                                                                                                                       | Someone has to create or link the SIS record. A different fix from the disagreement case, which is why it is its own flag. |
+| 2   | `is_school_mismatch`          | Finalsite's assigned school is not the school the SIS has them at, so the student is counted against the wrong school's targets until it is fixed.                                                                                                                                                                               | Confirm the true school, then fix whichever system is wrong.                                                               |
+| 3   | `is_enroll_status_mismatch`   | Finalsite and the SIS disagree about whether the student is enrolled — Finalsite says enrolled while the SIS says withdrawn or graduated, or Finalsite says the student left or has not finished enrolling while the SIS still has them active. Documented below as two directions, one per comparison the check actually makes. | Decide which system is right, then correct the other one.                                                                  |
+| 4   | `is_grade_level_mismatch`     | Finalsite's grade for the student is not the grade the SIS has them in.                                                                                                                                                                                                                                                          | Confirm the true grade, then fix whichever system is wrong.                                                                |
+| 5   | `is_missing_finalsite_record` | The student is enrolled in the SIS right now, but Finalsite has no record for them at all. These are the students who make the dashboard's count come out lower than the SIS's.                                                                                                                                                  | Someone has to create or restore the Finalsite record. Until they do, the student stays invisible on Progress to Goals.    |
 
 #### Which Finalsite statuses drive these checks
 
@@ -850,10 +867,18 @@ resolve these, then update this section and the flag definitions to match.
 
 Two properties worth knowing before reading it:
 
-- **`is_missing_sis_record` is derived in this model, not upstream.** The other
-  three come through from `int_tableau__finalsite_student_scaffold`; this one is
-  computed here as
-  `finalsite_expected_enroll_status = 0 and enroll_status is null`.
+- **Two flags are derived in this model, not upstream.** The three comparison
+  flags come through from `int_tableau__finalsite_student_scaffold`;
+  `is_missing_sis_record` is computed here as
+  `finalsite_expected_enroll_status = 0 and enroll_status is null`, and
+  `is_missing_finalsite_record` is computed here from the SIS side.
+- **The two absence flags are mirror images, and neither subsumes the other.**
+  `is_missing_sis_record` starts from a Finalsite record and finds no SIS
+  enrollment; `is_missing_finalsite_record` starts from an SIS enrollment and
+  finds no Finalsite record. They cannot both fire for one student, because
+  neither student exists on the other flag's side. Only
+  `is_missing_finalsite_record` rows are invisible in Progress to Goals, since
+  that view counts Finalsite records.
 - **The two comparison flags read `false`, not `true`, when the SIS side is
   missing — and `false`, not NULL.** `is_grade_level_mismatch` and
   `is_school_mismatch` wrap their `!=` in `if(<cmp>, true, false)`. The bare

--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__fresh_dashboard_qc.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__fresh_dashboard_qc.yml
@@ -7,7 +7,10 @@ models:
       keeps only the rows where a flag is true -- so a student appears once for
       each thing needing a fix, up to four times, and not at all when clean.
       Each row pairs the Finalsite values with the SIS values they were compared
-      against so the fix is actionable without a second lookup. See
+      against so the fix is actionable without a second lookup. A fifth flag,
+      is_missing_finalsite_record, is unioned on from the SIS side rather than
+      unpivoted, because a student the SIS knows and Finalsite does not cannot
+      appear in a Finalsite-sourced roster at all. See
       docs/models/fresh-dashboard-data-model.md.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
@@ -15,6 +18,7 @@ models:
             combination_of_columns:
               - enrollment_academic_year
               - finalsite_id
+              - powerschool_student_number
               - flag_name
           config:
             severity: error
@@ -23,14 +27,21 @@ models:
         data_type: string
         description: >
           Which problem fired -- is_enroll_status_mismatch,
-          is_grade_level_mismatch, is_school_mismatch, or is_missing_sis_record.
-          The first three are computed on
-          int_tableau__finalsite_student_scaffold; is_missing_sis_record is
-          derived here, and fires when Finalsite says a student is Enrolled but
-          no SIS enrollment record matched at all -- distinct from
+          is_grade_level_mismatch, is_school_mismatch, is_missing_sis_record, or
+          is_missing_finalsite_record. The first three are computed on
+          int_tableau__finalsite_student_scaffold; the last two are derived
+          here. is_missing_sis_record fires when Finalsite says a student is
+          Enrolled but no SIS enrollment record matched at all -- distinct from
           is_enroll_status_mismatch, which compares a status against a record
-          that does exist. The two need different fixes: create or link the
-          record, versus correct a status.
+          that does exist. The two need different fixes -- create or link the
+          record, versus correct a status. is_missing_finalsite_record is the
+          mirror image, and fires when a student is currently enrolled in the
+          SIS but no Finalsite record exists for them under any cycle. Its rows
+          are the ones missing from the Progress to Goals student count, since
+          that view counts Finalsite records rather than SIS enrollments. The
+          anti-join is deliberately unscoped by year -- a record filed under an
+          adjacent cycle, or one with no status dates to unpivot, means
+          Finalsite does know the student and is not this problem.
       - name: flag_value
         data_type: bool
         description: >
@@ -55,17 +66,26 @@ models:
         description: >
           PowerSchool-space school id the student is assigned to in Finalsite. 0
           when Finalsite has no school assigned. Compare against sis_schoolid.
+          On is_missing_finalsite_record rows there is no Finalsite record to
+          read, so this carries the SIS school id and always equals
+          sis_schoolid.
       - name: school
         data_type: string
         description: >
           Short school abbreviation for schoolid, or "No School Assigned" when
-          Finalsite has none.
+          Finalsite has none. On is_missing_finalsite_record rows it is the SIS
+          school abbreviation, so the worklist stays filterable by school for
+          every flag.
       - name: finalsite_id
         data_type: string
         description: >
-          Finalsite enrollment id. Together with enrollment_academic_year and
-          flag_name this is the grain of the worklist, and it is the id SRE uses
-          to find the record in Finalsite.
+          Finalsite enrollment id, and the id SRE uses to find the record in
+          Finalsite. Null on is_missing_finalsite_record rows, which is the
+          finding itself -- there is no record to point at, so SRE works from
+          last_name and powerschool_student_number instead. Because of those
+          nulls the grain is enrollment_academic_year plus flag_name plus
+          whichever of finalsite_id and powerschool_student_number is populated,
+          and the uniqueness test lists all four columns.
         config:
           meta:
             contains_pii: true
@@ -73,7 +93,9 @@ models:
         data_type: int64
         description: >
           Student number as reported by Finalsite. Null for applicants with no
-          SIS identity yet, which is expected on is_missing_sis_record rows.
+          SIS identity yet, which is expected on is_missing_sis_record rows. On
+          is_missing_finalsite_record rows it comes from the SIS instead and is
+          always populated, so it carries the grain where finalsite_id is null.
         config:
           meta:
             contains_pii: true
@@ -94,7 +116,9 @@ models:
         data_type: int64
         description: >
           Grade level as reported by Finalsite (PK = -1, K = 0, 1-12 as
-          themselves). Compare against sis_grade_level.
+          themselves). Compare against sis_grade_level. On
+          is_missing_finalsite_record rows it carries the SIS grade level and
+          always equals sis_grade_level.
       - name: self_contained
         data_type: string
         description: >
@@ -111,7 +135,10 @@ models:
         description: >
           The student's most recent Finalsite status for this cycle. This is
           what the expected enrollment status is derived from, so it is usually
-          the field to check first when a flag looks wrong.
+          the field to check first when a flag looks wrong. Null on
+          is_missing_finalsite_record rows, along with enrollment_type,
+          self_contained and finalsite_expected_enroll_status -- all four read
+          only from Finalsite, and those rows have no Finalsite record.
       - name: sis_enroll_status
         data_type: int64
         description: >
@@ -130,7 +157,14 @@ models:
         description: School id from the matched SIS enrollment record.
       - name: sis_school
         data_type: string
-        description: School name from the matched SIS enrollment record.
+        description: >
+          School from the matched SIS enrollment record. Beware an upstream
+          inconsistency this column inherits -- on the four unpivoted flags it
+          reads whatever int_tableau__finalsite_student_scaffold matched, which
+          is an abbreviation for New Jersey but Focus's full school name for
+          Miami. On is_missing_finalsite_record rows it is the abbreviation in
+          every region, because those rows read
+          int_extracts__student_enrollments directly.
       - name: finalsite_expected_enroll_status
         data_type: int64
         description: >

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_qc.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__fresh_dashboard_qc.sql
@@ -36,6 +36,83 @@ with
 
         from {{ ref("int_tableau__finalsite_student_scaffold") }}
         where grouped_status_timeframe = 'Current'
+    ),
+
+    -- grain projection onto finalsite_enrollment_id, which the source repeats
+    -- across Dagster partitions. Deliberately unscoped by year: a record filed
+    -- under any cycle still means Finalsite knows the student.
+    finalsite_records as (
+        select distinct finalsite_enrollment_id,
+        from {{ ref("stg_finalsite__status_report") }}
+    ),
+
+    finalsite_contact_ids as (
+        select
+            _dbt_source_project,
+            finalsite_enrollment_id,
+
+            cast(focus_student_id_prefixed as int) as focus_student_id,
+        from {{ ref("int_finalsite__contact_id_attributes") }}
+    ),
+
+    sis_enrollments as (
+        select
+            e.academic_year,
+            e.academic_year_display,
+            e.region,
+            e.schoolid,
+            e.school,
+            e.student_number,
+            e.student_first_name,
+            e.student_last_name,
+            e.grade_level,
+            e.enroll_status,
+
+            -- Miami rows carry no infosnap_id, so their Finalsite identity
+            -- comes from the contact-id crosswalk instead.
+            coalesce(e.infosnap_id, c.finalsite_enrollment_id) as sis_finalsite_id,
+
+        from {{ ref("int_extracts__student_enrollments") }} as e
+        left join
+            finalsite_contact_ids as c
+            on e.student_number = c.focus_student_id
+            and e._dbt_source_project = c._dbt_source_project
+        where
+            e.rn_year = 1
+            and e.enroll_status = 0
+            and e.academic_year = {{ var("finalsite_recruitment_year") }}
+    ),
+
+    sis_only as (
+        select
+            e.academic_year as enrollment_academic_year,
+            e.academic_year_display as enrollment_academic_year_display,
+            e.region,
+            e.schoolid,
+            e.school,
+            e.student_number as powerschool_student_number,
+            e.student_first_name as first_name,
+            e.student_last_name as last_name,
+            e.grade_level,
+            e.enroll_status as sis_enroll_status,
+            e.grade_level as sis_grade_level,
+            e.schoolid as sis_schoolid,
+            e.school as sis_school,
+
+            'KTAF' as org,
+            'is_missing_finalsite_record' as flag_name,
+            true as flag_value,
+
+            cast(null as string) as finalsite_id,
+            cast(null as string) as self_contained,
+            cast(null as string) as enrollment_type,
+            cast(null as string) as latest_status,
+            cast(null as int64) as finalsite_expected_enroll_status,
+
+        from sis_enrollments as e
+        left join
+            finalsite_records as f on e.sis_finalsite_id = f.finalsite_enrollment_id
+        where f.finalsite_enrollment_id is null
     )
 
 select
@@ -72,3 +149,31 @@ from
         )
     )
 where flag_value
+
+union all
+
+select
+    enrollment_academic_year,
+    enrollment_academic_year_display,
+    org,
+    region,
+    schoolid,
+    school,
+    finalsite_id,
+    powerschool_student_number,
+    first_name,
+    last_name,
+    grade_level,
+    self_contained,
+    enrollment_type,
+    latest_status,
+    sis_enroll_status,
+    sis_grade_level,
+    sis_schoolid,
+    sis_school,
+    finalsite_expected_enroll_status,
+
+    flag_name,
+    flag_value,
+
+from sis_only

--- a/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_id_attributes.yml
+++ b/src/dbt/kipptaf/models/finalsite/intermediate/properties/int_finalsite__contact_id_attributes.yml
@@ -6,6 +6,15 @@ models:
       `id_attributes` identifiers pivoted to columns). Enabled only where the
       Finalsite API layer is wired — today KIPP Miami, Newark, Camden and
       Paterson; carries `_dbt_source_relation`.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - focus_student_id_prefixed
+              - _dbt_source_project
+          config:
+            where: focus_student_id_prefixed is not null
+            severity: warn
     columns:
       - name: finalsite_enrollment_id
         data_type: string
@@ -19,4 +28,11 @@ models:
           The 8400-prefixed Focus student id the `rpt_focus__*` extracts
           consume, produced by the per-region package model. Null outside Miami,
           which is what limits those extracts to Miami rows when they filter on
-          it being non-null.
+          it being non-null. Where it is non-null it is one row per student per
+          district, which is what lets consumers join it to a student roster
+          without deduplicating first -- `rpt_tableau__fresh_dashboard_qc`
+          relies on that, and the model-level test above is what keeps the
+          assumption honest. The test warns rather than errors because a second
+          contact record for one student is a plausible Finalsite state (a
+          re-application, say) rather than corruption -- it should surface for a
+          human, not break every build downstream of this model.


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will add a fifth flag to the FRESH QC worklist, `is_missing_finalsite_record`, so the enrollment team can find students the dashboard cannot count.

The Progress to Goals tab counts Finalsite records, not SIS enrollments. A student who is enrolled in the SIS but has no Finalsite record is therefore missing from the count, with nothing to explain the gap. Paterson Prep Middle School grade 5 showed 55 students against PowerSchool's 56 for exactly this reason.

The QC worklist could not show that student either. It reads `int_tableau__finalsite_student_scaffold`, which starts from Finalsite, so a student with no Finalsite record produces no row and no flag can fire. The existing `is_missing_sis_record` flag covers only the opposite direction.

Today someone has to notice that 2 counts disagree and then ask the data team to trace a single student by hand. After this change they filter the worklist by the new flag instead.

9 students fire the new flag right now. Newark has 2, Camden has 2, Paterson has 1, and Miami has 4.

## Reviewer Notes

**The new rows are unioned on, not unpivoted.** Every other flag describes a Finalsite record, so it can be computed on a Finalsite-sourced roster. This one describes a student Finalsite has never heard of, who cannot appear in that roster at all. The model reads `int_extracts__student_enrollments` directly and anti-joins Finalsite.

**The anti-join ignores the recruitment year on purpose.** I measured the year-scoped version and rejected it. Details in the fold-out.

**Miami needs a different id path.** Every Miami row carries a null `infosnap_id`, so the Finalsite identity comes from `int_finalsite__contact_id_attributes` instead.

**`finalsite_id` is null on the new rows, and the uniqueness test changed because of it.** The test now also keys on `powerschool_student_number`.

**`sis_school` is inconsistent upstream, and this change does not hide that.** Worth a look if you disagree with the call. Details in the fold-out.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster changes.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

No column was added, renamed or removed, so the contract is unchanged and no exposure edit was needed. `rpt_tableau__fresh_dashboard_qc` is already listed under the `fresh_dashboard` exposure. Tableau does see new rows, and on those rows `finalsite_id` is null for the first time. No external source changed.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule, sensor or integration changes. `docs/models/fresh-dashboard-data-model.md` and the `fresh-dashboard` skill both said the worklist has 4 flags, so this updates both.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Started from a count discrepancy the user reported (PPMS grade 5, 56 in PowerSchool vs 55 on Progress to Goals) and traced it to a single student whose PowerSchool record carries a Finalsite ID that exists nowhere in `stg_finalsite__status_report`, at either the kipptaf union or the `kipppaterson_finalsite` source. That student is not on `stg_google_sheets__finalsite__exclude_ids`, and no Finalsite record matches their last name under a different id, so it is a genuinely absent record rather than a stale link. Paterson's `2026_27` partition holds 1635 records, so ingestion was healthy.

**Why the anti-join is unscoped by year.** Scoping to `var("finalsite_recruitment_year")` via `int_finalsite__status_report_unpivot` was measured against prod. It took Newark from 2 flagged students to 8. All 6 additions were records that exist but sit in the 2025 or 2027 cycle, or that have no status dates for the `UNPIVOT` to produce rows from (BigQuery `UNPIVOT` drops all-null rows). None of those is "Finalsite has no record for this student", and each needs a different conversation with SRE, so folding them into this flag would make it noisy and ambiguous. Camden and Paterson were unchanged between the two definitions. If SRE later wants "enrolled but not in the current cycle", that is a separate flag.

**Why one branch instead of two.** The approved design called for a second branch reading `int_focus__student_enrollment_roster` for Miami, mirroring `int_tableau__finalsite_student_scaffold`. That turned out to be unnecessary. `int_extracts__student_enrollments` already carries all 1507 currently-enrolled Miami students at `academic_year = 2026`, `rn_year = 1`, `enroll_status = 0`, and its `student_number` domain matches the Focus roster exactly (1507 of 1507 join). The single branch plus a `coalesce` onto the contact-id crosswalk reproduces the identical 9 students, so the Focus ref and the `UNION ALL` were dropped. Verified by running both shapes.

**Fan-out was checked, not assumed.** `int_finalsite__contact_id_attributes` has 4608 rows and 4608 distinct `(focus_student_id, _dbt_source_project)` pairs, and `int_extracts__student_enrollments` at those filters has 11024 rows and 11024 distinct `(student_number, academic_year)` pairs. So the crosswalk left join cannot duplicate a student, and `sis_only` emits at most one row per student. That is what makes the widened uniqueness test safe.

**Why `powerschool_student_number` joined the uniqueness test.** The test was `(enrollment_academic_year, finalsite_id, flag_name)` at `severity: error`. New rows have a null `finalsite_id`, and BigQuery groups nulls together in `GROUP BY`, so all 9 would collide on one key and fail. Adding `powerschool_student_number` can only refine the existing key, so the 4 original flags keep passing — confirmed by the dev build, where all 4 return byte-identical counts to prod.

**The `sis_school` wart.** `sis_school` is already inconsistent in prod. On the 4 unpivoted flags it comes from `int_tableau__finalsite_student_scaffold`, which reads the PowerSchool branch for New Jersey (an abbreviation, e.g. `PPMS`) and the Focus branch for Miami (a full name, e.g. `KIPP Courage Academy`). The new rows read `int_extracts__student_enrollments.school`, which is the abbreviation in every region including Miami (`Courage`, `Royalty`). I chose not to reproduce the full-name form for Miami, because the abbreviation matches the `school` column's documented meaning and matches every New Jersey row. The result is that Miami `sis_school` differs by flag. This is documented on the column, and the underlying inconsistency is arguably the thing to fix, separately.

**Verification.** Built with `uv run dbt build --select rpt_tableau__fresh_dashboard_qc --target dev --defer --favor-state --state <main repo>/src/dbt/kipptaf/target/prod` from the worktree. `PASS=2 WARN=0 ERROR=0`, both before and after `trunk fmt` reformatted the SQL. Against the built dev view, the new flag returns 9 rows (Newark 2, Camden 2, Paterson 1, Miami 4), including the PPMS grade 5 student, whose row carries `schoolid = 2`, `school = 'PPMS'`, `grade_level = 5`, `sis_enroll_status = 0` and a null `finalsite_id`. The 4 existing flags return 19, 18, 31 and 7 rows in both dev and prod. `trunk check --force --no-fix` over all 4 changed files reports no issues.

One of the 9 rows (Miami, grade 7) has a null `schoolid` and `school`. That is the single Focus enrollment with no school assigned, not a join failure.

**Not covered.** A student whose Finalsite record exists but is dropped by the status crosswalk inner join still produces no worklist row. That is a pre-existing gap in a different place and is out of scope here.

Closes #5167

</details>



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218210363748280