### PR TITLE
fix(dbt): null zero-filled Y1 lookback counts and two adjacent GPA gaps

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -201,7 +201,7 @@ models:
         description: Unweighted Y1 GPA as of the row's term.
       - name: gpa_total_credit_hours
         data_type: float64
-        description: Total Y1 GPA credit hours for the year. NULL on Y1 rows.
+        description: Total Y1 GPA credit hours for the year.
       - name: gpa_n_failing_y1
         data_type: int64
         description: >-
@@ -235,15 +235,19 @@ models:
           Unweighted Y1 GPA in effect 28 days ago (current-year rows only).
       - name: n_failing_y1_1_week_prior
         data_type: int64
-        description: Failing Y1 grade count 7 days ago (current-year rows only).
+        description:
+          Failing Y1 grade count 7 days ago (current-year rows only; null when
+          the student had no Y1 GPA at that point).
       - name: n_failing_y1_2_week_prior
         data_type: int64
         description:
-          Failing Y1 grade count 14 days ago (current-year rows only).
+          Failing Y1 grade count 14 days ago (current-year rows only; null when
+          the student had no Y1 GPA at that point).
       - name: n_failing_y1_4_week_prior
         data_type: int64
         description:
-          Failing Y1 grade count 28 days ago (current-year rows only).
+          Failing Y1 grade count 28 days ago (current-year rows only; null when
+          the student had no Y1 GPA at that point).
       - name: gpa_y1_prior_quarter
         data_type: float64
         description: >-

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -194,7 +194,6 @@ with
             term.semester,
 
             gtq.gpa_semester,
-            gtq.total_credit_hours_y1 as gpa_total_credit_hours,
 
             gc.cumulative_y1_gpa,
             gc.cumulative_y1_gpa_unweighted,
@@ -241,6 +240,12 @@ with
             if(
                 term.quarter = 'Y1', gty.n_failing_y1, gtq.n_failing_y1
             ) as gpa_n_failing_y1,
+
+            if(
+                term.quarter = 'Y1',
+                gty.total_credit_hours_y1,
+                gtq.total_credit_hours_y1
+            ) as gpa_total_credit_hours,
 
             /* KIPP GPA Band, the KIPP Foundation five-band unweighted scale
                documented in models/students/CLAUDE.md. Band 5 is open-ended

--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
@@ -30,3 +30,7 @@ where
        for AY2025 that was 382 of 398 grade-12 students, reporting the cohort at
        0 percent attainment. */
     and sr.is_enrolled_recent
+    /* TODO(#5171): Miami runs on Focus, so its students join no PowerSchool GPA
+       row and sit in the goal denominator unmeasurable. Drop once Miami GPA
+       data is available. */
+    and sr.region in ('Newark', 'Camden', 'Paterson')

--- a/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
+++ b/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
@@ -11,7 +11,9 @@ models:
       which is derived from enrollment dates — the enrollment ran to the end of
       its school year, or covers today. Deliberately not `enroll_status`, which
       is student-level and current-only and therefore excludes graduated seniors
-      from every completed year.
+      from every completed year. Miami is temporarily out of scope — it runs on
+      Focus rather than PowerSchool, so its students join no GPA record and
+      would sit in the goal denominator with no way to be measured.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -71,7 +73,9 @@ unit_tests:
       favor of the current-term row. Two further students pin the population
       predicate in both directions — a graduated senior whose year ran to
       completion is retained, and a mid-year withdrawal is dropped even though
-      its status is still active.
+      its status is still active. A sixth student pins the region scope — a
+      Miami enrollment is dropped even though it satisfies every other
+      predicate.
     model: int_gpa__goal_student_metrics
     given:
       - input: ref('int_extracts__student_enrollments')
@@ -156,6 +160,23 @@ unit_tests:
               false,
               'kippnewark',
               cast(3.80 as float64)
+          union all
+          /* Miami: runs on Focus, joins no PowerSchool GPA row. MUST be
+             excluded until Miami GPA data is available (#5171). */
+          select
+              2025,
+              'Miami',
+              303,
+              9,
+              90006,
+              1006,
+              35,
+              'HS',
+              1,
+              0,
+              true,
+              'kippmiami',
+              cast(3.00 as float64)
       - input: ref('int_powerschool__gpa_term')
         format: sql
         rows: |

--- a/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_lookback.sql
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/int_powerschool__gpa_term_lookback.sql
@@ -26,9 +26,12 @@ with
             gpa.yearid,
             gpa.gpa_y1,
             gpa.gpa_y1_unweighted,
-            gpa.n_failing_y1,
 
             lb.days_prior,
+
+            /* the snapshot carries n_failing_y1 = 0 on versions with no gpa_y1,
+               which reads as "failing nothing" rather than "not yet graded" */
+            if(gpa.gpa_y1 is not null, gpa.n_failing_y1, null) as n_failing_y1,
         from {{ ref("snapshot_powerschool__gpa_term") }} as gpa
         inner join
             lookbacks as lb

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_lookback.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__gpa_term_lookback.yml
@@ -10,7 +10,10 @@ models:
       close a row when it disappears from the source, so a withdrawn student's
       lookbacks return last-known values — consumers must scope by enrollment.
       Rows whose source relation is not a production district dataset are
-      excluded — the prod snapshot carries frozen dev-relation ghost rows.
+      excluded — the prod snapshot carries frozen dev-relation ghost rows. The
+      failing-count lookbacks are null wherever the version in effect carries no
+      Y1 GPA, because the snapshot writes a zero count for a student with no
+      graded courses, which would otherwise read as failing nothing.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -80,19 +83,22 @@ models:
         description:
           Count of failing Y1 grades in effect at the end of the day 7 days
           before the current day; null when that day predates the year's first
-          snapshot version.
+          snapshot version, and null when the version in effect carries no Y1
+          GPA.
       - name: n_failing_y1_2_week_prior
         data_type: int64
         description:
           Count of failing Y1 grades in effect at the end of the day 14 days
           before the current day; null when that day predates the year's first
-          snapshot version.
+          snapshot version, and null when the version in effect carries no Y1
+          GPA.
       - name: n_failing_y1_4_week_prior
         data_type: int64
         description:
           Count of failing Y1 grades in effect at the end of the day 28 days
           before the current day; null when that day predates the year's first
-          snapshot version.
+          snapshot version, and null when the version in effect carries no Y1
+          GPA.
 
 unit_tests:
   - name: unit_gpa_term_lookback_as_of_boundaries
@@ -101,7 +107,9 @@ unit_tests:
       changes between lookbacks surface distinct values per horizon, an
       intra-day change on a lookback day resolves to the end-of-day version,
       boundaries predating the first snapshot version return null, and
-      prior-year rows are excluded entirely.
+      prior-year rows are excluded entirely. A final student pins the
+      failing-count guard — the version spanning the 2- and 4-week boundaries
+      carries no Y1 GPA and a zero failing count, which must read null.
     model: int_powerschool__gpa_term_lookback
     overrides:
       vars:
@@ -248,6 +256,40 @@ unit_tests:
                   'America/New_York'
               ),
               timestamp('9999-12-31')
+          union all
+          /* student 6: the version in effect at the 2- and 4-week boundaries
+             carries no gpa_y1 but a zero n_failing_y1 — the failing count must
+             read null there, not zero, and must survive at the 1-week boundary */
+          select
+              '`teamster-332318`.`kippnewark_powerschool`.`int_powerschool__gpa_term`',
+              6,
+              101,
+              35,
+              cast(null as float64),
+              cast(null as float64),
+              0,
+              timestamp(
+                  date_sub(current_date('America/New_York'), interval 40 day),
+                  'America/New_York'
+              ),
+              timestamp(
+                  date_sub(current_date('America/New_York'), interval 10 day),
+                  'America/New_York'
+              )
+          union all
+          select
+              '`teamster-332318`.`kippnewark_powerschool`.`int_powerschool__gpa_term`',
+              6,
+              101,
+              35,
+              cast(3.4 as float64),
+              cast(3.3 as float64),
+              1,
+              timestamp(
+                  date_sub(current_date('America/New_York'), interval 10 day),
+                  'America/New_York'
+              ),
+              timestamp('9999-12-31')
     expect:
       rows:
         - {
@@ -292,6 +334,21 @@ unit_tests:
             gpa_y1_unweighted_2_week_prior: null,
             gpa_y1_unweighted_4_week_prior: null,
             n_failing_y1_1_week_prior: 4,
+            n_failing_y1_2_week_prior: null,
+            n_failing_y1_4_week_prior: null,
+          }
+        - {
+            _dbt_source_relation: "`teamster-332318`.`kippnewark_powerschool`.`int_powerschool__gpa_term`",
+            studentid: 6,
+            schoolid: 101,
+            yearid: 35,
+            gpa_y1_1_week_prior: 3.4,
+            gpa_y1_2_week_prior: null,
+            gpa_y1_4_week_prior: null,
+            gpa_y1_unweighted_1_week_prior: 3.3,
+            gpa_y1_unweighted_2_week_prior: null,
+            gpa_y1_unweighted_4_week_prior: null,
+            n_failing_y1_1_week_prior: 1,
             n_failing_y1_2_week_prior: null,
             n_failing_y1_4_week_prior: null,
           }


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will fix three gaps in the GPA models behind the Academic Health dashboards. They are grouped because they are one piece of work in adjacent files.

**The failing-count lookbacks were inventing zeros.** `int_powerschool__gpa_term_lookback` reported `0` failing grades for students who had no gradebook snapshot that far back. The matching GPA columns correctly reported nothing for those same students. On 6 September that gap covered 4,647 of 5,369 middle and high school students. Anything that read the failing count as proof a student had history was comparing real counts against zeros that never happened. The count now reports nothing when the snapshot behind it holds no GPA.

**Miami sat in the grade 9 goal denominator and could never be measured.** `int_gpa__goal_student_metrics` had no region filter. Miami runs its gradebook on Focus, not PowerSchool, so its students match no GPA record. That left 94 Miami Tech students inside the goal population with no way to ever count as meeting it. The network grade 9 goal read 610 students in the population against 507 measured, while the three school rows summed to 516. Miami comes out for now, and #5171 tracks putting it back.

**Total credit hours was empty on every Y1 row.** `rpt_tableau__student_course_grades` read that column from the quarter-level join, which matches on term name. The GPA source holds only Q1 through Q4, so the join never matched a Y1 row. The year-level columns beside it already branch to the year-level join for exactly this reason. This one now does too.

## Reviewer Notes

- **The failing-count fix is a visible change, not just a correction.** A column that used to read `0` now reads nothing for most students this early in the year. That is the intent, but anything already reading it will see the shift.
- **Miami's removal is deliberate and temporary.** The `TODO` in the model names #5171, which spells out how to reverse it and what to check first.
- **`gpa_semester` is still empty on Y1 rows.** It has the same missed join, but a Y1 row covers a whole year and has no single semester. Left alone on purpose.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

### dbt

- [x] No new models, so no new properties files. Descriptions updated on every column whose meaning changed.
- [x] No exposure change needed. No models added or removed, and no column added or removed.
- [x] Not a breaking change. The column set of all three models is identical before and after.
- [x] No external source touched.

### Dagster / Docs

Not applicable. No Dagster, schedule, sensor, or integration changes.

## CI checks

- [ ] **Trunk** — `trunk check --force --no-fix` on all six changed files reports no issues locally.
- [ ] **dbt Cloud**
- [ ] **Dagster Cloud** — should not trigger.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Found while rebuilding the Academic Health dashboards; filed as #5170.

**Fix 1 — `int_powerschool__gpa_term_lookback`.** The zeros were not produced by the pivot. They arrive because the snapshot row spanning the boundary carries `n_failing_y1 = 0` while `gpa_y1` is NULL on that same row, so the guard belongs where the measure is read. Confirmed against the snapshot for `yearid = 36`: 6,107 rows have `gpa_y1` NULL, every one of them carries `n_failing_y1 = 0`, and none carries a positive count. So `if(gpa.gpa_y1 is not null, gpa.n_failing_y1, null)` discards nothing real. The guard moved below `lb.days_prior` in the `matched` select to satisfy ST06 (plain column refs precede functions).

Post-build verification on the dev relation: 5,244 rows null on `gpa_y1_2_week_prior` and 5,244 null on `n_failing_y1_2_week_prior`, with 0 residual zero-fills on all three horizons.

**Fix 2 — `int_gpa__goal_student_metrics`.** The predicate mirrors the scope `rpt_tableau__student_course_grades` already applies. Grade 9 AY2026 enrollment splits Newark 380, Camden 136, Miami 94, so 380 + 136 = 516, which is exactly the sum of the three school rungs. Post-build the org row reads 516 in grain and 507 measured, and 238 + 133 + 136 = 507. Paterson is named in the predicate for symmetry with the report model; it has no grade 9 HS rows yet.

**Fix 3 — `rpt_tableau__student_course_grades`.** `gty` joins on `gty.is_current` with no term-name condition. Verified that `is_current` is true on exactly the 5,555 Q1 rows and no others for `yearid = 36`, so the join resolves one row per student with no fan-out risk. The expression moved from the `gtq` column-enumeration block down to the `if(...)` group, again for ST06.

Post-build parity check by student: every student with a populated Q1 value now has a populated Y1 value, and `q1_but_not_y1` is 0 in all three school levels. ES has none in either, as expected.

**Deliberately excluded: `gpa_semester`.** NULL on Y1 rows through the same missed join, but a Y1 row spans the whole year and has no single semester, the model already stamps `semester = 'S#'` there as a sentinel, and the column is empty on Q3 and Q4 rows anyway, so the second-semester value is missing even where a semester applies. Separate question, not in scope.

**Test strength was verified, not assumed.** Both unit tests gained a case. Both were then run against the reverted SQL and both failed with the right diff: the lookback returned `0` instead of `NULL` for student 6 at the 2- and 4-week boundaries, and the goal spine emitted Miami student 90006. Restored, and both pass.

**The extract's uniqueness warning is untouched.** It warns 109 duplicate groups. The same query against prod returns 109. Pre-existing, tracked under #3915.

Closes #5170. Refs #5171.

</details>
