### PR TITLE
feat(dbt): add a per-student course priority rank for the office hours roster

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__student_course_grades.yml
@@ -548,6 +548,30 @@ models:
           no letter ladder. The second case does NOT require need_60 to be null
           — a student at 95 percent has a perfectly good need_60 and still gets
           a null need_next, because there is nothing above an A to need.
+      - name: office_hours_priority_rank
+        data_type: int64
+        description: >-
+          Rank of this course among the student's courses for the same term, 1
+          being the lowest percent grade. Intended for an intervention or
+          office-hours list that caps how many teachers one student is sent to:
+          filter to rank <= N.
+
+          Null whenever quarter_course_percent_grade is null. Ungraded courses
+          are excluded from the ranking rather than sorted last, so a course
+          with nothing posted yet can never look like a student's most urgent
+          one.
+
+          Unique within the partition rather than tie-preserving. Two courses on
+          the same percent take consecutive ranks, broken by course_number so
+          the pick is reproducible across rebuilds. A tie-preserving rank would
+          let a "top 4" filter return five or more courses, which would change
+          how many sessions a student is sent to for a reason invisible to
+          whoever reads the list.
+
+          Partitioned on the term, so a Y1 row ranks the student's year-to-date
+          course grades and a quarter row ranks that quarter's. That follows
+          quarter_course_percent_grade, whose own meaning already changes with
+          the row's term.
       - name: category_name_code
         data_type: string
         description: Gradebook category code (e.g. F/S/W; NULL on Y1 rows).

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -863,9 +863,10 @@ with
     ),
 
     course_priority as (
-        /* Ungraded courses are filtered out rather than sorted last so they
-           receive no rank at all; the left join below then leaves the rank
-           null. */
+        /* No (x is null) asc guard, unlike category_ranked above — the
+           filter removes nulls before the window runs, so an ungraded course
+           takes no rank and the left join at the foot of the model is what
+           nulls the column. */
         select
             _dbt_source_project,
             studentid,

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -860,6 +860,25 @@ with
         from category_ranked
         where rn_latest_term = 1
         group by _dbt_source_project, studentid, yearid, sectionid
+    ),
+
+    course_priority as (
+        /* Ungraded courses are filtered out rather than sorted last so they
+           receive no rank at all; the left join below then leaves the rank
+           null. */
+        select
+            _dbt_source_project,
+            studentid,
+            yearid,
+            `quarter`,
+            course_number,
+
+            row_number() over (
+                partition by _dbt_source_project, studentid, yearid, `quarter`
+                order by quarter_course_percent_grade asc, course_number asc
+            ) as office_hours_priority_rank,
+        from quarter_grades
+        where quarter_course_percent_grade is not null
     )
 
 select
@@ -998,6 +1017,8 @@ select
     gsl.need_next_letter_grade,
     gsl.need_next_cutoff_percent,
 
+    cp.office_hours_priority_rank,
+
     /* signed, so negative means the projection sits below last year's actual.
        Both inputs are student-grain, so these repeat across every quarter row
        and the Y1 row for a student, which is what makes them filterable at any
@@ -1094,4 +1115,12 @@ left join
     and s._dbt_source_project = cd._dbt_source_project
     and ce.sectionid = cd.sectionid
     and ce._dbt_source_project = cd._dbt_source_project
+left join
+    course_priority as cp
+    on s.studentid = cp.studentid
+    and s.yearid = cp.yearid
+    and s.`quarter` = cp.`quarter`
+    and s._dbt_source_project = cp._dbt_source_project
+    and ce.course_number = cp.course_number
+    and ce._dbt_source_project = cp._dbt_source_project
 where s.quarter_start_date <= current_date('{{ var("local_timezone") }}')


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add one column, `office_hours_priority_rank`, to `rpt_tableau__student_course_grades`. It ranks each of a student's courses within a term, where 1 is their lowest percent grade.

The office hours strategy asks for a student list that can be handed to DeansList, and that list has to cap how many teachers one student is sent to in a week. Filtering to `rank <= N` does that in one step.

The dashboard cannot do this ranking itself. Tableau can only rank a student's courses when the course is on the sheet, and anything on the sheet also lands in the export — so a clean two-column export and a Tableau-side ranking cannot both exist. A plain column can be filtered on any sheet no matter how that sheet is laid out.

Nothing reads the column yet. The dashboard work that will use it is a separate change, so merging this on its own changes no number anyone currently sees.

## Reviewer Notes

Three judgement calls worth a look:

- **It hands out unique ranks, where the dashboard's own calculation lets ties share one.** That is deliberate. With shared ranks, a "top 4" filter can return five or six courses when grades tie, which would quietly change how many sessions a student is sent to. Ties break on course number so the choice is the same every rebuild.
- **A course with no grade posted gets no rank at all**, rather than being ranked last. This matches what the roster already does — it drops those rows today — and it stops a course with nothing graded from looking like a student's most urgent one.
- **It ranks on the marking-period grade, not the year-to-date grade.** People are already pulling their lists off the marking-period grade, and while the first quarter is the whole year so far the two are identical anyway. They separate when the second quarter opens. That decision is tracked on #5169.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

### dbt

- [x] Properties file updated — the new column is documented in
      `properties/rpt_tableau__student_course_grades.yml`.
- [x] Exposure — `academic_gradebook_health_suite` already exists and already
      depends on this model, so adding a column needs no exposure change.
- [x] **Not a breaking change** — this adds a column, removes and renames
      nothing, and this model does not enforce a contract. No rollback plan
      needed beyond reverting the commit.
- [x] No external sources added or modified, so no `stage_external_sources` run
      is required.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The column:

```sql
row_number() over (
    partition by _dbt_source_project, studentid, yearid, `quarter`
    order by quarter_course_percent_grade asc, course_number asc
)
```

computed in a `course_priority` CTE over `quarter_grades` filtered to
`quarter_course_percent_grade is not null`, then LEFT JOINed on the same keys as
the existing `qg` join, so an ungraded course-section receives a null rank from
the join rather than a rank of its own.

`_dbt_source_project` is in the partition because ids collide across districts —
the same reason commit `7407d9088` gives for putting it in the grade-scale join.
The ordering follows the `category_ranked` idiom already in this model, including
its stated reason for a final tiebreaker ("so the pick is reproducible across
rebuilds"); the `(x is null) asc` guard that idiom carries is unnecessary here
because the WHERE removes nulls before the window runs.

On why this is not a copy of the dashboard calculation. The workbook holds three
fields captioned `Teacher Priority`, all with the formula
`RANK(MIN([quarter_course_percent_grade]), 'asc')`, and they do not agree:

- `Teacher Priority (copy)` — its `<column>` says `ordering-type='Rows'`, but its
  `<column-instance>` on `Y1 - Office Hours Roster` overrides that with
  `ordering-type='Field'` over course_name / section_or_period / teacher_name.
  That makes it per-student, and it sits on Rows just above `course_name`. This
  is the one this column reproduces.
- `Teacher Priority` — `ordering-type='Rows'`, so it ranks down the whole table.
  It reaches both Office Hours sheets only as a member of the `:Measure Names`
  filter, on no shelf and no encoding, so nothing displays it.
- `Teacher Priority (label)` — the "see first" / "backup" strings. Reads the
  whole-table field and appears on no sheet at all.

Also note the sheet's visible order comes from two `<computed-sort>` entries on
`course_name` and `student_number`, both ascending by
`MIN(quarter_course_percent_grade)` — the rank dimension groups, the computed
sorts order. So this column reproduces the intent rather than any single
mechanism, and `RANK` being competition-ranked is what the `row_number` choice
above departs from.

The term partition matters because `quarter_course_percent_grade` is term-scoped
rather than fixed: the current-year quarter branch aliases
`term_percent_grade_adjusted` into it, the current-year Y1 branch aliases
`y1_percent_grade_adjusted`, and the prior-year branch takes the stored percent
for whichever storecode the row carries. So on a Y1 row this ranks year-to-date
grades and on a quarter row it ranks that quarter's, which is the behaviour the
marking-period control expects.

Verification run before committing:

- Rank shape against prod for `academic_year = 2026`: 10,576 student-term
  partitions, 0 partitions with a duplicate rank, 0 not starting at 1, 0
  non-contiguous, max 12 courses in a partition.
- `dbt build --empty --defer --favor-state` on the model: `PASS=2 WARN=0
  ERROR=0`, so BigQuery accepted the CTE, the window function and the join, and
  the existing `unique_combination_of_columns` test still runs.
- `trunk check --force --no-fix` on both changed files: no issues.

Not verified, and not verifiable from here: whether the export that will consume
this column can actually be downloaded by the roles that need it. That is the
open question in #5174 and it gates the dashboard-side work, not this column.

</details>
