### PR TITLE
chore(dbt): point every Miami GPA and gradebook exclusion at one tracking issue

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gradebook_audit.sql
@@ -131,6 +131,9 @@ with
             /* summer toggle: see skill */
             s.academic_year = {{ var("current_academic_year") }}
             and s.school_level_alt != 'ES'
+            /* TODO(#5181): Miami runs on Focus, whose gradebook assignment
+               data is not yet conformed to the PowerSchool vocabulary this
+               audit reads. Temporary. */
             and s._dbt_source_project != 'kippmiami'
             and s.exclude_from_gpa = 0
     ),

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__student_course_grades.sql
@@ -361,8 +361,10 @@ with
                2-year window */
             and enr.academic_year >= {{ var("current_academic_year") - 1 }}
             and enr.academic_year <= {{ var("current_academic_year") }}
-            /* Miami hard-excluded: region unsupported in the rebuilt
-               dashboard (#4340) */
+            /* TODO(#5181): Miami runs on Focus, whose GPA and grades are not
+               yet conformed to the PowerSchool metric vocabulary, so its
+               students resolve no term or year-to-date GPA. Temporary; the
+               dashboard rebuild (#4340) shipped without the region. */
             and enr.region in ('Newark', 'Camden', 'Paterson')
     ),
 

--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
@@ -30,7 +30,8 @@ where
        for AY2025 that was 382 of 398 grade-12 students, reporting the cohort at
        0 percent attainment. */
     and sr.is_enrolled_recent
-    /* TODO(#5171): Miami runs on Focus, so its students join no PowerSchool GPA
-       row and sit in the goal denominator unmeasurable. Drop once Miami GPA
-       data is available. */
+    /* TODO(#5171, #5181): Miami runs on Focus, so its students join no
+       PowerSchool GPA row and sit in the goal denominator unmeasurable.
+       #5181 tracks the Focus conformance this depends on; drop both once
+       Miami GPA data is available. */
     and sr.region in ('Newark', 'Camden', 'Paterson')


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will make the three Miami exclusions on the GPA and gradebook surface read the same way, and point all three at one tracking issue.

Miami runs its gradebook on Focus. Focus GPA and grades are not conformed to the PowerSchool metric vocabulary yet, so Miami students resolve no term GPA and no year-to-date GPA. Excluding them is deliberate and temporary.

The problem was that the three sites did not look alike. One named #4340, which is the closed dashboard rebuild issue and not a tracker. One had no comment at all. Only one named a real tracking issue. A reader could not tell which exclusions were temporary and which were permanent.

All three now carry a `TODO` naming #5181, which tracks the Focus conformance work they all wait on. #5171 stays on the goal-denominator site, since it is that site's specific unwind.

This is a comment-only change. No filter, no logic, and no output moves.

## Reviewer Notes

Nothing here changes what any model returns. If you want one thing to check, check that: the three added comments sit next to filters that are byte-identical to before.

Worth knowing for CI: an inline SQL comment marks a model `state:modified`, so dbt Cloud CI will rebuild these three and everything downstream of them. That is expected for a comment-only PR and is the cost of the repo's rule that TODOs live at the derivation site rather than in the properties file.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] No new models, so no new properties files are needed.
- [x] No exposure changes: no model is added, renamed, or removed.
- [x] Not a breaking change. No column is renamed or removed, and no contracted model's shape changes.
- [x] No external sources added or modified.

## CI checks

- [x] **Trunk** — passes. Ran `trunk check --force --no-fix` on all three files: no issues.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The owner's instruction was that Miami is a blanket temporary exclusion until the Focus data model is onboarded and typed to the PowerSchool metric vocabulary, and that in every case the exclusion should carry a TODO and a tracking issue.

The three sites, all scoped to the GPA and gradebook surface:

1. `models/gpa/intermediate/int_gpa__goal_student_metrics.sql` — `sr.region in ('Newark', 'Camden', 'Paterson')`. Already had `TODO(#5171)`; now reads `TODO(#5171, #5181)`.
2. `models/extracts/tableau/rpt_tableau__student_course_grades.sql` — `enr.region in ('Newark', 'Camden', 'Paterson')`. Was `Miami hard-excluded: region unsupported in the rebuilt dashboard (#4340)`. "hard-excluded" read permanent; #4340 is closed and is the rebuild issue, not a tracker. The #4340 reference is kept as context.
3. `models/extracts/tableau/rpt_tableau__gradebook_audit.sql` — `s._dbt_source_project != 'kippmiami'`. Had no comment.

Miami exclusions elsewhere (NJ state testing, NJSMART, Illuminate, athletic eligibility, DeansList) were checked and left alone. Those are permanent domain rules, not Focus-onboarding ones.

Verification that this is comment-only: for each file, comments (`/* */`, `--`, `{# #}`) were stripped from the before and after text and the remaining tokens whitespace-collapsed and compared. Identical in all three. That is the check `.claude/rules/dbt-sql.md` prescribes for a comment-only SQL change, and it holds where a dev build cannot. Jinja expression tokens such as `{{ var("current_academic_year") }}` are preserved by that comparison, so templating is covered too.

Supporting measurements, AY2026 grade 9-12, taken while scoping #5181:

| Region | Enrolled | Have `gpa_y1` | Have cumulative unweighted GPA |
| --- | --- | --- | --- |
| Newark | 1,568 | 1,330 | 1,402 |
| Camden | 576 | 497 | 547 |
| Miami | 115 | 0 | 0 |

Two things a future unwind needs to know, both recorded on #5181. Focus's `student_gpa_calculated` carries `marking_period_id = -1` on every row, so there is no term-grained row and no year-to-date analog exists to conform. And `int_gpa__goal_student_metrics` reads `cumulative_gpa_unweighted` from `int_extracts__student_enrollments.cumulative_y1_gpa_projected_unweighted`, which is null for all 115 Miami students because it is a projected measure and Focus projects nothing — so the cumulative metric is not a cheaper first step than the Y1 one.

Refs #5181

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)