### PR TITLE
feat(dbt): name the school on the GPA goals view and label every rung

### DIFF
--- a/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gpa_goals.yml
+++ b/src/dbt/kipptaf/models/extracts/tableau/properties/rpt_tableau__gpa_goals.yml
@@ -39,6 +39,20 @@ models:
         description:
           PowerSchool school ID when `org_level` is `school`. Null for `org`- or
           `region`-level rows.
+      - name: school_name
+        data_type: string
+        description:
+          Canonical school name when `org_level` is `school`. Null for `org`-
+          and `region`-level rows.
+      - name: aggregation_label
+        data_type: string
+        description:
+          Single label naming this row's grain, so a chart can put one field on
+          an axis at every rung — the school's short name on `school` rows, the
+          region name on `region` rows, and `Network` on the `org` row. Never
+          null. That is the point, since `schoolid` and `region` are both null
+          at the org rung, so without it a reporting tool has to carry its own
+          fallback.
       - name: grade_band
         data_type: string
         description: Human-readable grade band from the matched goal.

--- a/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_goals.sql
+++ b/src/dbt/kipptaf/models/extracts/tableau/rpt_tableau__gpa_goals.sql
@@ -5,6 +5,8 @@ select
     org_level,
     region,
     schoolid,
+    school_name,
+    aggregation_label,
     grade_band,
     goal_proportion,
     n_students_in_grain,

--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_aggregations.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_aggregations.sql
@@ -4,6 +4,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             grade_level,
             student_number,
             y1_gpa_weighted,
@@ -37,6 +39,8 @@ with
             m.academic_year,
             m.region,
             m.schoolid,
+            m.school,
+            m.school_name,
             m.student_number,
             m.is_on_pace,
             m.is_on_pace_denominator,
@@ -149,6 +153,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             org_level,
             grade_band,
             aggregation_hash,
@@ -180,6 +186,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             org_level,
             grade_band,
             aggregation_hash,
@@ -199,6 +207,9 @@ with
             metric,
             goal_proportion,
             higher_is_better,
+
+            cast(null as string) as school,
+            cast(null as string) as school_name,
 
             count(student_number) as n_students_in_grain,
 
@@ -244,6 +255,9 @@ with
             goal_proportion,
             higher_is_better,
 
+            cast(null as string) as school,
+            cast(null as string) as school_name,
+
             count(student_number) as n_students_in_grain,
 
             countif(
@@ -281,6 +295,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             org_level,
             grade_band,
             aggregation_hash,
@@ -298,6 +314,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             org_level,
             grade_band,
             aggregation_hash,
@@ -315,6 +333,8 @@ with
             academic_year,
             region,
             schoolid,
+            school,
+            school_name,
             org_level,
             grade_band,
             aggregation_hash,
@@ -335,6 +355,8 @@ with
             org_level,
             region,
             schoolid,
+            school,
+            school_name,
             grade_band,
             goal_proportion,
             higher_is_better,
@@ -358,6 +380,8 @@ with
             org_level,
             region,
             schoolid,
+            school,
+            school_name,
             grade_band,
             goal_proportion,
             n_students_in_grain,
@@ -376,6 +400,15 @@ with
                 safe_divide(metric_rate, goal_proportion),
                 safe_divide(goal_proportion, metric_rate)
             ) as progress_to_goal_raw,
+
+            case
+                org_level
+                when 'school'
+                then school
+                when 'region'
+                then region
+                else 'Network'
+            end as aggregation_label,
         from rates
     )
 
@@ -386,6 +419,8 @@ select
     org_level,
     region,
     schoolid,
+    school_name,
+    aggregation_label,
     grade_band,
     goal_proportion,
     n_students_in_grain,

--- a/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
+++ b/src/dbt/kipptaf/models/gpa/intermediate/int_gpa__goal_student_metrics.sql
@@ -2,6 +2,8 @@ select
     sr.academic_year,
     sr.region,
     sr.schoolid,
+    sr.school,
+    sr.school_name,
     sr.grade_level,
     sr.student_number,
     sr.cumulative_y1_gpa_projected_unweighted as cumulative_gpa_unweighted,

--- a/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_aggregations.yml
+++ b/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_aggregations.yml
@@ -47,6 +47,20 @@ models:
         description:
           PowerSchool school ID when `org_level` is `school`. Null for `org`- or
           `region`-level rows.
+      - name: school_name
+        data_type: string
+        description:
+          Canonical school name when `org_level` is `school`. Null for `org`-
+          and `region`-level rows.
+      - name: aggregation_label
+        data_type: string
+        description:
+          Single label naming this row's grain, so a chart can put one field on
+          an axis at every rung — the school's short name on `school` rows, the
+          region name on `region` rows, and `Network` on the `org` row. Never
+          null. That is the point, since `schoolid` and `region` are both null
+          at the org rung, so without it a reporting tool has to carry its own
+          fallback.
       - name: grade_band
         data_type: string
         description: Human-readable grade band from the matched goal.

--- a/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
+++ b/src/dbt/kipptaf/models/gpa/intermediate/properties/int_gpa__goal_student_metrics.yml
@@ -31,6 +31,13 @@ models:
       - name: schoolid
         data_type: int64
         description: The School_Number of the student's enrolling school.
+      - name: school
+        data_type: string
+        description:
+          Short school name, as the reporting layer labels a school on an axis.
+      - name: school_name
+        data_type: string
+        description: Canonical full name of the student's enrolling school.
       - name: grade_level
         data_type: int64
         description: The grade level of the enrollment record.
@@ -85,6 +92,8 @@ unit_tests:
               2025 as academic_year,
               'Newark' as region,
               101 as schoolid,
+              'NCA' as school,
+              'KIPP Newark Collegiate Academy' as school_name,
               9 as grade_level,
               90001 as student_number,
               1001 as studentid,
@@ -100,6 +109,8 @@ unit_tests:
               2025,
               'Newark',
               101,
+              'NCA',
+              'KIPP Newark Collegiate Academy',
               9,
               90002,
               1002,
@@ -115,6 +126,8 @@ unit_tests:
               2025,
               'Newark',
               101,
+              'NCA',
+              'KIPP Newark Collegiate Academy',
               9,
               90003,
               1003,
@@ -133,6 +146,8 @@ unit_tests:
               2025,
               'Newark',
               101,
+              'NCA',
+              'KIPP Newark Collegiate Academy',
               12,
               90004,
               1004,
@@ -150,6 +165,8 @@ unit_tests:
               2025,
               'Newark',
               101,
+              'NCA',
+              'KIPP Newark Collegiate Academy',
               10,
               90005,
               1005,
@@ -167,6 +184,8 @@ unit_tests:
               2025,
               'Miami',
               303,
+              'Miami Tech',
+              'KIPP Miami Technical High',
               9,
               90006,
               1006,
@@ -215,6 +234,8 @@ unit_tests:
             academic_year: 2025,
             region: Newark,
             schoolid: 101,
+            school: NCA,
+            school_name: KIPP Newark Collegiate Academy,
             grade_level: 9,
             student_number: 90001,
             cumulative_gpa_unweighted: 3.10,
@@ -227,6 +248,8 @@ unit_tests:
             academic_year: 2025,
             region: Newark,
             schoolid: 101,
+            school: NCA,
+            school_name: KIPP Newark Collegiate Academy,
             grade_level: 9,
             student_number: 90002,
             cumulative_gpa_unweighted: 2.75,
@@ -239,6 +262,8 @@ unit_tests:
             academic_year: 2025,
             region: Newark,
             schoolid: 101,
+            school: NCA,
+            school_name: KIPP Newark Collegiate Academy,
             grade_level: 9,
             student_number: 90003,
             cumulative_gpa_unweighted: 3.40,
@@ -251,6 +276,8 @@ unit_tests:
             academic_year: 2025,
             region: Newark,
             schoolid: 101,
+            school: NCA,
+            school_name: KIPP Newark Collegiate Academy,
             grade_level: 12,
             student_number: 90004,
             cumulative_gpa_unweighted: 2.90,


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will put the school's name on the GPA goals view, so the Tableau dashboard can stop deriving it from a hardcoded list of school ids.

Today `rpt_tableau__gpa_goals` exposes `schoolid` and no name at all. The dashboard fills the gap with a calc that maps three school ids to `NCA`, `NLH` and `KHS` and renders everything else as `Network`. It is commented `// MUST BE DEPRECATED`. Any school added to the goals sheet would silently read as the network total.

Two new columns replace it:

- **`school_name`** — the canonical full name, null on the org and region rungs.
- **`aggregation_label`** — one label naming this row's grain at every rung: the school's short name on school rows, the region name on region rows, and `Network` on the org row. Never null, so a chart binds a single field to its axis and carries no fallback of its own.

## Reviewer Notes

**The name is carried up through the group-by, not joined.** A join to `stg_google_sheets__people__locations` is the obvious approach and is wrong here — that model holds 42 rows across 29 school ids (11 campus placeholders on id `0`, plus Pathways programs sharing a host school's id), so it would fan the view out the moment a goal is added for one of those schools. Carrying `school` and `school_name` through the existing group-by cannot fan out, and if a school ever did carry two names the model's uniqueness test fails loudly instead.

**One behaviour change to be aware of.** Region rows will now label as `Newark` / `Camden` rather than `Network`. The current Tableau calc keys off `schoolid`, which is null on region rows, so they fall into its `ELSE 'Network'` branch today — 16 rows misreported as the network total. `Goal vs Actual by School` is unaffected because its metric, `y1_gpa_weighted`, has no region rung; the `cumulative_gpa_unweighted` metric does.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Properties files updated for all three models, with `data_type` on every new column.
- [x] No exposure change needed — no model added, renamed or removed.
- [x] **Not a breaking change.** Columns are added only; nothing is renamed or dropped, so no downstream contract breaks. The Tableau calc keeps working until someone chooses to swap it.
- [x] No external sources added or modified.

## CI checks

- [x] **Trunk** — passes. `trunk check --force --no-fix` on all six files: no issues.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Asked for whatever the GPA goals view needs so the Tableau CASE over `schoolid` can be retired.

Chain touched, three models:

1. `int_gpa__goal_student_metrics` — projects `sr.school` and `sr.school_name` off the enrollments extract.
2. `int_gpa__goal_aggregations` — carries both through `student_metrics`, `joined_school`, `agg_school` (select and group-by), the three `agg_union` branches, `rates` and `progress`. `agg_region` and `agg_org` emit `cast(null as string)`, placed after the plain refs and before the aggregates per the ST06 ordering rule. `aggregation_label` is derived in `progress` as a CASE, which is why it sits after the two `if()` logicals rather than beside the name columns.
3. `rpt_tableau__gpa_goals` — projects `school_name` and `aggregation_label`. `school` is deliberately not projected past `progress`; it exists to build the label, and on its own it would be null on two of three rungs.

Why group-by over join, with numbers. Within the goal population (`school_level = 'HS'`, `rn_year = 1`, `is_enrolled_recent`, NJ regions), `school` and `school_name` are each single-valued per `schoolid` — checked across AY2025 and AY2026 for all three goal-carrying schools. `stg_google_sheets__people__locations` is not unique on `powerschool_school_id`: 42 rows over 29 ids, max 11 rows on one id. The 11 are `is_campus` rows on `powerschool_school_id = 0`; the other three duplicates are `179901` (LSP), `73257` (Life) and `73258` (BOLD), where a Pathways program shares the host school's id. None carry GPA goals today, which is exactly why a join would look fine in review and break later.

Verified by projecting the new logic over prod `rpt_tableau__gpa_goals`: 72 rows in and 72 out, `aggregation_label` null on 0 rows, school rows missing a name on 0 rows, and the label resolving to `Network` (14 rows), `Camden` (8), `Newark` (8), `KHS` (14), `NCA` (14), `NLH` (14). `dbt parse --no-partial-parse` is clean, which covers the unit test's structure.

The unit test `unit_gpa_goal_student_metrics_grain` mocks the enrollments input with explicit SQL, so both columns were added to all six mocked rows and to all four expected rows. The Miami mock row carries `Miami Tech` / `KIPP Miami Technical High`; it is still excluded by the region predicate, so it stays absent from the expectation.

Follow-on, not done here: swapping the Tableau `School Name` calc to `aggregation_label` and deleting it. That is a workbook edit, not a repo change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)