### PR TITLE
feat(launch): add the Paterson GPA roster to the link catalogue

### DIFF
--- a/docs/launch/links.yml
+++ b/docs/launch/links.yml
@@ -159,6 +159,18 @@
   group: academics
   regions: [newark]
   status: verified
+- id: gpa_roster_paterson
+  name: "GPA Roster: Paterson"
+  url: https://docs.google.com/spreadsheets/d/13j1khv49eSxTFUJGxbgQKnjvmUhYTgH-SshZr5NWCbU/edit?gid=0#gid=0
+  description:
+    Provides term GPA, Y1 GPA, and cumulative GPA (unweighted, weighted, and
+    projected), along with basic identification information for students in the
+    Paterson region for grade levels 5 through 8.
+  audiences: [region, teachers]
+  system: google-sheet
+  group: academics
+  regions: [paterson]
+  status: verified
 
 - id: academic_gradebook_health_suite
   name: Academic & Gradebook Health Suite


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will put the Paterson GPA roster sheet on the launch page.

Paterson was the only region with a roster sheet and no entry. Camden, Miami and Newark all had one. The entry sits after Newark, which keeps the file alphabetical by name, and copies Newark's key order, quoting and `regions` field so the diff is one clean block.

## Reviewer Notes

**The description is not a copy of Newark's, on purpose.** Camden and Newark both say "grade levels 5 through 12". Paterson is a middle-school region, so its entry says **5 through 8**. Checked against `int_extracts__student_enrollments` for AY2026: 282 enrolled students in grades 5 to 8, 272 with a Y1 GPA and 159 with a cumulative GPA. So the sheet has real data behind it and `status: verified` is honest.

**Something to decide separately — the Miami entry.** It is `status: verified`, audiences `[region, teachers]`, and describes itself as providing term GPA and Y1 GPA. But **0 of Miami's 786 students in that roster's population resolve either measure**, because Miami runs its gradebook on Focus and the roster model reads the PowerSchool GPA chain. So that link currently hands teachers a sheet of student names with every GPA column blank.

I have not touched it here — bundling an unrequested change into this PR seemed wrong, and the right fix depends on whether you want the entry demoted to `needs-review`, delisted, or left as is until Focus is conformed. That conformance work is tracked on #5181.

## Self-review

### General

- [x] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] No dbt change — this is a docs data file only.

## CI checks

- [x] **Trunk** — passes. `trunk check --force --no-fix docs/launch/links.yml`: no issues.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The sheet link was supplied by the owner.

Validated by parsing the file before and after: entry count 43 → 44, exactly one new entry, and its key list identical to `gpa_roster_newark` — `[id, name, url, description, audiences, system, group, regions, status]`. An earlier draft omitted `regions` and the assertion caught it before anything was written.

The URL is normalised to the `/edit?gid=0#gid=0` form the other three roster entries use, rather than the `?usp=sharing` form it arrived in. Note `gpa_roster_miami` is the one roster entry already using `?usp=sharing`, so that form is not unprecedented in the file — normalising was a consistency choice, not a correction.

The same three sheets are being added as header links on the Academic Health dashboards in the `GPA-monitor-temp` Tableau project, following the `LP - Buckets - <region>` pattern from the DDI suite: one worksheet per link with a constant-string calc on Text styled to look like a link, and a URL action fired on-select with the destination as a literal. Miami is excluded there for the reason above.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)