### PR TITLE
docs(gradebook-audit): document the expectations rollover fill rules

### DIFF
--- a/.claude/skills/gradebook-audit/SKILL.md
+++ b/.claude/skills/gradebook-audit/SKILL.md
@@ -4,7 +4,9 @@ description: >-
   Use when any question or task touches the gradebook audit data model or its
   lineage. Triggers: explaining the model, listing refs/lineage/sources for the
   gradebook audit dashboard, adding/removing a flag, adding a region, debugging
-  a flag that isn't firing, or working on rpt_tableau__gradebook_audit or
+  a flag that isn't firing, rolling the assignment expectations over to a new
+  year (turning T&L's expectations sheet into U_EXPECTATIONS count rows to
+  upload to PowerSchool), or working on rpt_tableau__gradebook_audit or
   rpt_gsheets__gradebook_audit_student_flags and their upstream models.
 ---
 
@@ -298,6 +300,57 @@ correctly.
 
 ---
 
+## Procedure: Roll the assignment expectations over to a new year
+
+**Trigger phrases:** "we have to add gradebook audit count rows to PowerSchool",
+"we need to roll over to the new year for the PS plugin", "T&L sent the new
+year's gradebook expectations sheet", "the audit is still reporting against last
+year's expectations"
+
+This is the **academics/T&L-owned** annual update, not a dbt change — no model
+edit ships as part of it. The work is turning T&L's planning sheet into
+`U_EXPECTATIONS` upload CSVs and catching the mapping errors that would
+otherwise misreport the whole network without failing. Step 1 of the
+[reference doc's start-of-year procedure](../../../docs/models/gradebook-audit-data-model.md)
+carries the full rationale; the mechanics:
+
+1. **Get the sheet and the calendar side by side.** T&L's sheet is private, so
+   have the user share it with the Codespace, then read it with ADC — ADC has
+   Drive scope, the BigQuery MCP service account does not. Pull the target
+   year's grid from `int_students__calendar_week` for
+   `school_level in ('MS','HS')` and `_dbt_source_project != 'kippmiami'`.
+1. **Never trust the sheet's week numbers.** They run across the year rather
+   than within the quarter, they count no-school weeks that
+   `week_number_quarter` does not, and one tab often serves regions whose school
+   years start on different dates. Map every row by the **Monday of its ISO
+   week**, then compute `week_number` as that Monday's offset from each region's
+   own week 1. Don't map on the printed date range either — a Monday-holiday
+   week prints its first in-session day, not its Monday.
+1. **Emit one CSV per PowerSchool instance.** `U_EXPECTATIONS` has no region
+   column, so Camden, Newark and Paterson upload separately, and Newark MS + HS
+   share one file. Columns: `school_level`, `quarter`, `week_number`, `cnt_w`,
+   `cnt_h`, `cnt_f`, `cnt_s`, `notes`.
+1. **Fill every blank, per column, scoped to the quarter** — sheet value, else
+   carry forward the last non-null value in that quarter, else zero. A blank
+   reaching `U_EXPECTATIONS` means "no expectation", and
+   `int_powerschool__u_expectations_qtd_unpivot`'s
+   `where expectation is not null` plus `current_week`'s collapse to a single
+   week turn an all-blank week into a blank dashboard for that entire week. This
+   is what makes a quarter's all-dashes revisions week repeat the prior week's
+   counts, and a missing first week of school read as zeroes.
+1. **Check all four quarters before the user deletes the old rows.** T&L
+   frequently has only the current quarter ready. The gap is invisible until the
+   first Monday of the next quarter, and then the dashboard blanks for every
+   region at once.
+1. **Hand the upload to the user.** The data team cannot write to PowerSchool —
+   the delete-and-load happens in the plugin. Verify afterwards with the query
+   in the reference doc's Step 1: zero null counts, week counts matching
+   `int_students__calendar_week`, four rows per `region × school_level` out of
+   `int_powerschool__u_expectations_qtd_unpivot`, and the four-row
+   `category_summary` floor intact.
+
+---
+
 ## Procedure: Work on the gradebook audit dashboard after academic year rollover
 
 **Trigger phrases:** "we have swapped academic years on the database and I need
@@ -309,7 +362,8 @@ views this summer"
 **Scope — this is the data-team dbt toggle only.** Updating the assignment
 _expectations_ for the new year is a separate task owned by the academics team,
 done in PowerSchool via the `U_EXPECTATIONS` plugin — not a dbt change. For
-that, see "Start-of-year procedure" (Step 1) in the
+that, see _Procedure: Roll the assignment expectations over to a new year_ above
+and Step 1 of the start-of-year procedure in the
 [reference doc](../../../docs/models/gradebook-audit-data-model.md), which
 carries the plugin repo link and ownership. The steps below cover only the
 dbt-side year / grade-source toggle.

--- a/docs/models/gradebook-audit-data-model.md
+++ b/docs/models/gradebook-audit-data-model.md
@@ -241,6 +241,18 @@ cutoff — is the Sunday ending the most recently completed school week (the
 latest calendar week with
 `week_start_monday < date_trunc(current_date, isoweek)`).
 
+**A week carrying no expectation blanks the dashboard for that whole week.**
+This model ends in `where expectation is not null` (BigQuery `UNPIVOT` drops
+nulls regardless), and `current_week` collapses to the single most recently
+completed week per quarter. So if that one week holds no count in any of the
+four columns, this model emits nothing for it, `category_join`'s inner join
+drops every section, and the audit reports zero `category_summary` rows until
+the next week starts. A week with only _some_ columns null is the same failure
+in miniature — it yields fewer than four category rows and breaks the four-row
+floor. Neither case is guarded here, by design: both are resolved on the upload
+side, by the fill rules in Step 1 of the
+[Start-of-year procedure](#start-of-year-procedure).
+
 ### Expectations upload template: `rpt_gsheets__gradebook_audit_template`
 
 Feeds the Google Sheet the T&L team uses to build the CSV they upload back into
@@ -275,12 +287,17 @@ Three gotchas worth knowing before editing it:
   unset category produced no row at all (BigQuery `UNPIVOT` excludes nulls), so
   the gap was invisible in the sheet; wide, it surfaces as an empty cell for
   whoever is setting counts to fill in. Adding an all-null guard would hide
-  exactly what the template exists to show, and re-uploading a blank row writes
-  back the blank state it came from. Measured 2026-08-18, all 205 rows in
-  `stg_powerschool__u_expectations` carry a count in all four columns, so no
-  guard would filter anything today anyway. That 205 is the raw source count,
-  not this model's output — the template emits 202 rows, because `term_weeks`
-  keeps only weeks that have already started.
+  exactly what the template exists to show. What must _not_ happen is uploading
+  that blank straight back into `U_EXPECTATIONS`, where a blank does not read as
+  "nobody set this yet" but as "no expectation this week", and takes the
+  dashboard down with it — Step 1 of the
+  [Start-of-year procedure](#start-of-year-procedure) resolves every blank
+  before upload, which is what keeps the source table populated in all four
+  columns. Row counts on both sides track the school calendar rather than any
+  fixed number, and this model emits fewer rows than
+  `stg_powerschool__u_expectations` holds because `term_weeks` keeps only weeks
+  that have already started — so check that invariant with the query in Step 1
+  rather than against a remembered count.
 
 Coverage follows the inner join to `stg_powerschool__u_expectations` — Newark
 and Camden at MS and HS, Paterson at MS, no ES and no Miami — so it needs no
@@ -558,15 +575,16 @@ flags (`has_grade_above_100`, `has_grade_below_70_no_comment`,
 `not_enough_assignments`) are hardcoded in `rpt_tableau__gradebook_audit`'s
 `health_calc` CTE and require no annual configuration.
 
-### Step 1 — Confirm assignment expectations are updated in PowerSchool
+### Step 1 — Load the new year's assignment expectations into PowerSchool
 
-The expectations data that drives `not_enough_assignments` comes from
+Owned by the T&L team member responsible for gradebook expectations, not the
+data team — no dbt model changes as part of this step. The expectations that
+drive `not_enough_assignments` come from
 `int_powerschool__u_expectations_qtd_unpivot`, which reads the `U_EXPECTATIONS`
-table populated by the **KIPP NJ Gradebook Audit** PowerSchool plugin. The
-`U_EXPECTATIONS` table does not have an `academic_year` field — it reflects the
-current state of expectations in PowerSchool. Until the T&L team member
-responsible for gradebook expectations updates the table for the new year, the
-audit will continue to report against the prior year's expectation values.
+table populated by the **KIPP NJ Gradebook Audit** PowerSchool plugin.
+`U_EXPECTATIONS` has no `academic_year` column — it reflects whatever is
+currently live in PowerSchool — so until it is replaced for the new year, the
+audit keeps reporting against the prior year's values.
 
 `rpt_gsheets__gradebook_audit_template` (see above) exists to support this step:
 it lands every school week's current expectations in a Google Sheet, which T&L
@@ -576,6 +594,90 @@ toggle's state before reading it as the new year's grid.
 
 Plugin source and update instructions:
 [TEAMSchools/ps-plugins](https://github.com/TEAMSchools/ps-plugins)
+
+#### One upload per PowerSchool instance
+
+`U_EXPECTATIONS` carries no region column — region is implied by the instance
+the rows live in, and the kipptaf union (`stg_powerschool__u_expectations`) is
+what re-attaches `_dbt_source_project`. Camden, Newark and Paterson are separate
+PowerSchool instances and therefore separate uploads. Newark MS and Newark HS
+belong in the same Newark file even when T&L maintains them on separate sheet
+tabs.
+
+#### Renumber T&L's weeks to `week_number_quarter` before uploading
+
+`U_EXPECTATIONS.week_number` is the week's position **within its quarter**, and
+`int_powerschool__u_expectations_qtd_unpivot` joins it to
+`int_students__calendar_week.week_number_quarter`. T&L's planning sheet has not
+historically matched that, in three ways — each of which silently shifts every
+expectation onto the wrong week rather than failing loudly:
+
+- **It numbers weeks running across the year**, not within the quarter (Q2
+  starting at 11, Q3 at 23, and so on).
+- **It includes no-school weeks** — Thanksgiving, winter break, Presidents'
+  week, spring break — that `week_number_quarter` does not count.
+- **One tab often serves regions whose school years start on different dates.**
+  In AY 2026-2027 Camden opened Monday 2026-08-17 while Newark and Paterson
+  opened 2026-08-24, so Camden has 11 Q1 weeks against their 10 and the same
+  sheet row is a different `week_number` in each region.
+
+Map each sheet row by the **Monday of its ISO week**, then derive `week_number`
+per region as that Monday's offset from the region's own week 1. Do not map on
+the sheet's own week number, and do not map on its printed date range either — a
+week shortened by a Monday holiday prints its first in-session day (`9/8-9/11`
+for Labor Day week) while the calendar week's Monday is 9/7.
+
+#### Fill every blank before uploading
+
+A blank in `U_EXPECTATIONS` means "no expectation", not "unset", and it removes
+rows from the dashboard — see the expectations source section above for the
+mechanism. Resolve every blank, per count column, scoped to the quarter:
+
+1. Sheet gives a value — use it.
+2. Sheet gives `---` / `--` / blank, or the calendar week has no sheet row at
+   all — carry forward the last non-null value for that column within the same
+   quarter. This is why the last week of a quarter, which T&L marks all-dashes
+   as a revisions week, should hold the same counts as the week before it.
+3. Nothing precedes it in that quarter — use zero. A zero expectation cannot
+   raise `not_enough_assignments`, so a first week of school with no sheet row
+   reports as compliant rather than flagging every section in the region.
+
+Together these keep every calendar week populated in all four columns, which is
+what preserves the four-row category floor.
+
+#### Load every quarter, not just the current one
+
+T&L often has only the current quarter ready, with later tabs still under
+construction. Nothing breaks while those quarters are missing, because
+`current_week` filters to weeks that have already started — which is exactly why
+the gap stays invisible until the first Monday of the next quarter, when the
+dashboard goes blank for every region at once. If the later quarters ship late,
+diary that Monday and re-check before it arrives.
+
+#### Verify after the plugin load
+
+Once the `u_expectations` dlt asset has re-ingested and dbt has run:
+
+```sql
+select
+    _dbt_source_project,
+    school_level,
+    `quarter`,
+    count(*) as weeks,
+    countif(
+        cnt_w is null or cnt_h is null or cnt_f is null or cnt_s is null
+    ) as null_rows,
+from `teamster-332318`.kipptaf_powerschool.stg_powerschool__u_expectations
+group by 1, 2, 3
+order by 1, 2, 3
+```
+
+`null_rows` must be zero everywhere, and `weeks` must equal that region and
+school level's quarter length in `int_students__calendar_week` for the current
+`academic_year`. Then confirm `int_powerschool__u_expectations_qtd_unpivot`
+returns four rows per `region × school_level` for the current quarter, and that
+every section × quarter in `rpt_tableau__gradebook_audit` still has exactly four
+`category_summary` rows.
 
 ### Step 2 — Revert the summer toggle (if applied)
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will document how to roll the gradebook audit assignment expectations over to a new school year. It changes 2 files: the `gradebook-audit` skill and the published reference doc. It changes no models and no configuration.

Every year the Teaching and Learning team (T&L) replaces the count rows in the PowerSchool `U_EXPECTATIONS` table. Those counts drive the `not_enough_assignments` flag. The reference doc told the reader to confirm that the update happened, but never said how to do the update. I ran the update for the 2026-2027 school year and hit 3 problems that produce wrong numbers without producing any error. All 3 are now written down.

The first problem is that `U_EXPECTATIONS` has no region column. The region comes from which PowerSchool instance holds the row. Camden, Newark, and Paterson each need a separate upload, and Newark middle school and Newark high school share one file.

The second problem is week numbering. `U_EXPECTATIONS.week_number` counts weeks within a quarter, and `int_powerschool__u_expectations_qtd_unpivot` joins it to `int_students__calendar_week.week_number_quarter`. The T&L planning sheet numbers weeks straight through the year, counts weeks that have no school, and puts regions with different start dates on one tab. Camden started 2026-08-17 and Newark and Paterson started 2026-08-24, so Camden has 11 first-quarter weeks against 10 for Newark and Paterson. Loading the Camden numbers as the sheet writes them moves every Camden expectation 1 week early.

The third problem is blank cells. A blank count in `U_EXPECTATIONS` means "no expectation", not "nobody filled the cell in yet". `int_powerschool__u_expectations_qtd_unpivot` ends in `where expectation is not null`, and `current_week` keeps only the latest finished week of each quarter. A week that is blank in all 4 columns therefore produces no rows, the inner join in `category_join` drops every section, and the dashboard shows nothing for that entire week. T&L marks the last week of each quarter with dashes, which is exactly that case.

One fill rule answers all 3 problems, and both files now record the rule. Work one count column at a time, within one quarter: take the sheet value; if the sheet gives no value, carry forward the last real value in that quarter; if no value comes before it, use 0.

## Reviewer Notes

**The stale row count is gone.** The reference doc claimed that all 205 rows in `stg_powerschool__u_expectations` carry a count in all 4 columns, measured 2026-08-18. Replacing the rows for a new year breaks that number, and the row count follows the school calendar anyway. A verification query replaces the claim.

**One existing gotcha needed rewording rather than deleting.** The doc tells the reader not to filter blank category cells out of `rpt_gsheets__gradebook_audit_template`, because a blank cell is the signal that someone still has to fill the cell in. That guidance is still correct for the template, which is the write side. The same bullet also read as permission to upload the blank back into `U_EXPECTATIONS`, which is the case that blanks the dashboard. The bullet now states both points.

**I widened the skill description.** Asking to roll the expectations over now triggers the skill. The old description listed flags, regions, and debugging, and the rollover matched none of those 3.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

## CI checks

- [ ] **Trunk** — passes. I ran `trunk check --force` on both files before committing. The only findings were prettier line wrapping, and the pre-commit hook fixed those.
- [ ] **dbt Cloud** — passes, or selects nothing. This pull request changes no models.
- [ ] **Dagster Cloud** — not triggered. This pull request touches no Dagster path.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Written while running the SY27 expectations rollover for real, so every hazard listed came out of that load rather than out of reading the code.

**Camden week shift, measured.** `int_students__calendar_week` for `academic_year = 2026`, Q1, `_dbt_source_project = 'kippcamden'`, gives weeks 1-11 starting Monday 2026-08-17. The `NJ - Camden MS/HS - Q1` tab of the T&L sheet starts at 8/24-8/28. So:

| Camden sheet `Assigned Week #` | Correct `U_EXPECTATIONS.week_number` |
| ---: | ---: |
| (none) | 1 (Mon 2026-08-17) |
| 1 | 2 |
| 9 | 10 |
| 10 | 11 |

Newark and Paterson both open 2026-08-24 and map 1:1 with no shift. Mapping has to key on the Monday of the ISO week, not on the sheet's printed date range: Labor Day week prints `9/8-9/11` while the calendar week's Monday is 2026-09-07.

**Blank-cell cases found in the SY27 sheet.** All 3 NJ tabs mark the quarter's last week `---` in all 4 columns. Camden week 2 and Newark high school week 1 carry a value for W, H, and F but `---` for S, which yields 3 category rows instead of 4 and breaks the four-row floor. The AY 2025-2026 rows already in PowerSchool show the carry-forward precedent: Camden Q1 week 10 and week 11 both held `15/9/9/2`, with week 11 noted `Revisions Week`.

**Rollover state at the time of writing.** `U_EXPECTATIONS` held 205 rows across all 4 quarters for 5 region and school-level pairs. The AY 2026-2027 calendar disagreed with those rows in 13 places: 5 rows missing at Q3 week 9, and 8 stale rows at Q1 week 11 and Q4 week 10 that no calendar week matches. The pipeline was healthy when measured, not broken. `int_powerschool__u_expectations_qtd_unpivot` returned 20 rows, which is 4 categories for each of the 5 pairs, and all 1,565 section-quarters in `rpt_tableau__gradebook_audit` had exactly 4 `category_summary` rows.

**Two items are open and are deliberately not in this pull request.** Q2 through Q4 are still marked "under construction" on all 3 NJ tabs, so the SY27 load covers Q1 only. Nothing breaks until Monday 2026-11-02, when Q2 week 1 starts and the dashboard blanks for every region at once. Separately, the Camden tab reads `Indigenous People's DayD` with a trailing D, and that string flows into `notes`. Both belong to T&L, not to this repository.

**Verification.** I checked the fill rule against the SY27 sheet before writing it down. Applying the rule produced week grids that match `int_students__calendar_week` for all 5 region and school-level pairs, every row populated in all 4 columns, and therefore exactly 4 category rows for every week. The upload CSVs themselves stayed local and are not part of this pull request.

</details>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218270675094966