### PR TITLE
fix(k8s): drop the dagster-run PriorityClass so run pods stop preempting code servers

### DIFF
--- a/.claude/skills/dagster-day2/SKILL.md
+++ b/.claude/skills/dagster-day2/SKILL.md
@@ -165,13 +165,13 @@ Step 8 churn: at replicas=1 with maxSurge=200%, normal Helm upgrade = 2 creates.
 3-4 creates = a rollout retry; >>4 = sustained storm.
 
 In this codebase, agent pods run at priority 1000 (`dagster-agent`
-PriorityClass) — same tier as run/step pods, so they CANNOT be preempted by
-them. If you see "no agents have recently heartbeated" AND the agent pod shows
-Preempted events, the preemption would have to come from a pod at priority >1000
-(system-cluster-critical, etc.) — which is rare and worth investigating. If
-agents are RUNNING with heartbeats but there's agent-level ReadTimeout to
-`*.agent.dagster.cloud`, that's a control-plane connectivity issue, not
-pod-level preemption.
+PriorityClass) — above run/step and code server pods (0), so they CANNOT be
+preempted by them. If you see "no agents have recently heartbeated" AND the
+agent pod shows Preempted events, the preemption would have to come from a pod
+at priority >1000 (system-cluster-critical, etc.) — which is rare and worth
+investigating. If agents are RUNNING with heartbeats but there's agent-level
+ReadTimeout to `*.agent.dagster.cloud`, that's a control-plane connectivity
+issue, not pod-level preemption.
 
 **Timeline table** (ET): run failures, tick failures, terminal schedule tick
 failures, location load failures, agent errors, code server failures, unhealthy

--- a/.claude/skills/dagster-day2/references/tick-failure-analysis.md
+++ b/.claude/skills/dagster-day2/references/tick-failure-analysis.md
@@ -26,16 +26,17 @@ disambiguated before attributing root cause, because they imply different fixes.
    the failure window (`mcp__gke__query_logs`, reason includes Preempted,
    Evicted, OOMKilling, Killing).
 5. Classify by GKE event type:
-   - **Preempted** "by pod `<uuid>`": priority preemption by run/step pods. In
-     this codebase, code server pods run at priority 0 and run/step pods run at
-     priority 1000 (`dagster-run` PriorityClass in
-     `.k8s/dagster/values-override.yaml`) BY DESIGN — preempting code servers to
-     free capacity for runs is intentional. Routine preemption is expected, not
-     an escalation. Only escalate if: (a) preemption rate is
-     sustained >>1/location/hour, (b) no correlation with run/step pod
-     scheduling, or (c) code server pods are being preempted while run/step pods
-     are idle. Check for hourly pattern (>50% in first 5 min of hour =
-     schedule-triggered bursts). PDB is bypassed for priority preemption.
+   - **Preempted** "by pod `<uuid>`": priority preemption. Since 2026-09-08 code
+     server pods and run/step pods both run at priority 0 (the `dagster-run`
+     PriorityClass was removed in #5187), so a run pod can no longer preempt a
+     code server. A code server `Preempted` event now means a GKE
+     system-critical pod (priority 2,000,000,000) landed on its node, or the
+     priority gap was reintroduced — check `.k8s/dagster/values-override.yaml`.
+     Escalate if: (a) preemption rate is sustained >>1/location/hour, (b) the
+     preempting pod is a `dagster-run-` or `dagster-step-` pod, or (c) code
+     server pods are being preempted while run/step pods are idle. Check for
+     hourly pattern (>50% in first 5 min of hour = schedule-triggered bursts).
+     PDB is bypassed for priority preemption.
    - **Evicted** "low on resource: memory": node memory pressure. Monitor.
    - **OOMKilling**: container OOM (pod survives, container restarts).
      Investigate memory requests.

--- a/.claude/skills/dagster-k8s-ops/SKILL.md
+++ b/.claude/skills/dagster-k8s-ops/SKILL.md
@@ -51,7 +51,7 @@ description:
   (#4921). Because it blocks only autoscaler eviction and NOT scheduler
   preemption, pinning a priority-0 pod removes the graceful way to free its node
   and leaves only the violent one: capacity fragments, then run pods (then
-  priority 1000) preempt code servers to obtain it — and every preemption
+  priority 1000) preempted code servers to obtain it — and every preemption
   recreates the Service with a fresh ClusterIP, which is the churn the
   annotation was meant to reduce. Measured at matched load (~32 run/step pods
   per 15 min): with it, 18-20 agent gRPC errors and 8-9 `Preempted` per 15 min;

--- a/.claude/skills/dagster-k8s-ops/SKILL.md
+++ b/.claude/skills/dagster-k8s-ops/SKILL.md
@@ -50,27 +50,34 @@ description:
   to stop the 38-59 weekly autoscaler relocations, reverted the same day
   (#4921). Because it blocks only autoscaler eviction and NOT scheduler
   preemption, pinning a priority-0 pod removes the graceful way to free its node
-  and leaves only the violent one: capacity fragments, then run pods
-  (priority 1000) preempt code servers to obtain it — and every preemption
+  and leaves only the violent one: capacity fragments, then run pods (then
+  priority 1000) preempt code servers to obtain it — and every preemption
   recreates the Service with a fresh ClusterIP, which is the churn the
   annotation was meant to reduce. Measured at matched load (~32 run/step pods
   per 15 min): with it, 18-20 agent gRPC errors and 8-9 `Preempted` per 15 min;
   without it, 0 and 0 across 12 hours including the nightly wave. **General
   rule: pinning a low-priority pod against the autoscaler converts graceful
   relocation into preemption.** The agent and run pods keep the annotation —
-  nothing outranks them the way run pods outrank code servers. Absence is
-  asserted in `tests/test_k8s_config.py`.
+  nothing outranks them the way run pods used to outrank code servers. Absence
+  is asserted in `tests/test_k8s_config.py`.
 - **Judge a scheduling change only against matched run-pod load.** Code-server
   churn tracks run-pod volume, so a quiet window reads as success and a busy one
   as regression. Count `Scheduled` events on `dagster-run-` / `dagster-step-`
   pods for the same window and discard readings below ~25 per 15 min. Two zero
   readings during the #4921 investigation were load artifacts, not fixes.
-- **PriorityClass `dagster-run`** (value 1000) on run/step pods makes kubelet
-  evict code server pods (default priority 0) first during node memory pressure.
-- **PriorityClass `dagster-agent`** (value 1000) on agent pods — same tier as
-  run/step pods, preventing mutual preemption. Does not protect against OOM
-  kills of the pod itself — only eviction ordering. Code servers tolerate
-  eviction: they are stateless and PDB-protected (`maxUnavailable: 1`).
+- **Run/step pods and code servers both run at priority 0** (no PriorityClass).
+  Run pods carried `dagster-run` (1000) until 2026-09-08. A run pod preempted
+  the kippcamden code server while the agent re-uploaded its metadata; the
+  single gRPC UNAVAILABLE wrote `ERROR` to the control plane and the location
+  stayed down for four days (#5187). Equal priority means a run pod that fits
+  nowhere waits for NAP instead of preempting. A `Preempted` event on a code
+  server now points at a GKE system-critical pod, not a run pod.
+- **PriorityClass `dagster-agent`** (value 1000) on agent pods — above run/step
+  and code server pods, so nothing in the namespace preempts the agent. The
+  agent pins to amd64 and the others to arm64, so it never preempts them either.
+  Does not protect against OOM kills of the pod itself — only eviction ordering.
+  Code servers tolerate eviction: they are stateless and PDB-protected
+  (`maxUnavailable: 1`).
 - **PDB for code servers** uses `maxUnavailable: 1`. Do not switch to
   `minAvailable: 1` — GKE Recommender flags single-replica + `minAvailable: 1`
   as blocking voluntary evictions (node maintenance). The known
@@ -80,7 +87,7 @@ description:
 - **PDBs do NOT block spot reclaim** — spot reclaim is involuntary.
 - **GKE Autopilot system-critical preemption** — `system-cluster-critical` and
   `system-node-critical` pods (priority 2,000,000,000) preempt dagster-run pods
-  (priority 1000) cluster-wide whenever GKE needs to land kube-dns, fluent-bit,
+  (priority 0) cluster-wide whenever GKE needs to land kube-dns, fluent-bit,
   metrics-agent, etc. on a node. Unpreventable at our layer. Observable
   signature in pod events: "Preempted in order to admit critical pod". Mitigated
   by `runK8sConfig.jobSpecConfig.podFailurePolicy` with `action: Ignore` on the
@@ -99,11 +106,12 @@ description:
   query — check the auto-retry; if it succeeded, this was infra disruption, no
   fix needed.
 - **`required` antiAffinity authorizes scheduler preemption** of the target pods
-  when no other node fits. `runK8sConfig.affinity.podAntiAffinity` is `required`
-  against code-server labels, with run pods at priority 1000 vs code-server 0 —
-  so the scheduler CAN evict code servers at schedule time, not just kubelet at
-  eviction time. Do not describe this anti-affinity as "isolating" code servers
-  from runs or "preventing co-location."
+  when no other node fits, but only of pods at LOWER priority. While run pods
+  sat at 1000 and code servers at 0, `runK8sConfig.affinity.podAntiAffinity` let
+  the scheduler evict code servers at schedule time. With both at 0 the
+  anti-affinity is a pure placement constraint: a run pod that fits nowhere goes
+  `Pending` until NAP adds a node. Any change that reintroduces a priority gap
+  reopens the preemption path.
 - `ttlSecondsAfterFinished` is etcd/apiserver hygiene only — terminated
   containers already released cgroup RSS, so TTL does NOT free node memory. Do
   not propose it as a lever for node memory pressure or eviction issues.

--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -82,6 +82,12 @@ skill.
   `safe-to-evict: "false"`. Code-server spot reclaim triggers full agent
   reconciliation cascade (cold start + ClusterIP churn) — factor into cost
   analysis.
+- **Run/step pods and code servers both run at priority 0.** Do not add a
+  `priorityClassName` to either. Run pods sat at 1000 (`dagster-run`) until
+  2026-09-08, when one preempted the kippcamden code server mid-upload and left
+  the location in a terminal `ERROR` for four days (#5187). Only the agent
+  carries a PriorityClass (`dagster-agent`, 1000), and it lives on amd64 nodes
+  where it competes with nothing. Asserted in `tests/test_k8s_config.py`.
 - **Code server topology spread** uses `ScheduleAnyway` across
   `topology.kubernetes.io/zone` via `serverK8sConfig.podSpecConfig` — prefers
   cross-zone but allows same-zone during capacity exhaustion (do not switch to

--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -144,9 +144,7 @@ workspace:
           # the control plane, but code servers still serve sensor
           # evaluations, workspace snapshots, and gRPC health checks —
           # kipptaf's large definitions module (every integration) bursts
-          # above 750m during sensor eval waves. Priority tier (0) is
-          # unchanged, so topology preferences and dagster-run preemption
-          # behavior are unaffected.
+          # above 750m during sensor eval waves.
           cpu: 1000m
           memory: 2.5Gi
       securityContext:
@@ -170,7 +168,7 @@ workspace:
         # Mechanism: the annotation blocks CLUSTER-AUTOSCALER eviction but not
         # SCHEDULER preemption. Pinning code servers to their nodes stops the
         # autoscaler relocating them, so capacity fragments and run pods
-        # (priority 1000) can only obtain it by preempting code servers
+        # (then priority 1000) could only obtain it by preempting code servers
         # (priority 0). It converted graceful relocations into preemptions, each
         # of which recreates the Service and produces a fresh ClusterIP -- which
         # is the churn the annotation was meant to reduce.
@@ -215,8 +213,8 @@ workspace:
       # K8s sets the DisruptionTarget pod condition when a pod is terminated by
       # priority-class preemption, eviction API (node drain), graceful node
       # shutdown, or taint-based eviction. On Autopilot, GKE system-critical
-      # pods (priority > 1000) routinely preempt our dagster-run pods
-      # (priority 1000) to land kube-dns, fluent-bit, metrics-agent, etc. —
+      # pods (priority 2,000,000,000) routinely preempt our dagster-run pods
+      # (priority 0) to land kube-dns, fluent-bit, metrics-agent, etc. —
       # this is unavoidable cluster-wide behavior. podFailurePolicy with
       # action=Ignore makes the Job controller treat those disruptions as
       # not-a-failure: the Job transparently replaces the pod without counting
@@ -255,7 +253,18 @@ workspace:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     podSpecConfig:
-      priorityClassName: dagster-run
+      # No priorityClassName: run pods stay at default priority 0, the same tier
+      # as code servers. The `dagster-run` PriorityClass (value 1000) was removed
+      # 2026-09-08 after a run pod preempted the kippcamden code server while
+      # the agent was re-uploading its metadata (#5187). A single gRPC
+      # UNAVAILABLE in that window writes ERROR to the control plane, and the
+      # agent never retries a location the control plane already marks as
+      # errored -- so the location stayed down for four days. Equal priority
+      # means a run pod that finds no room waits for Node Auto Provisioning
+      # instead of preempting a code server. The kubelet eviction-order
+      # argument for 1000 never applied: the required anti-affinity below keeps
+      # run pods and code servers off the same node.
+      #
       # Hard-pin to built-in Scale-Out arm64 (T2A) under pod-based pricing.
       # No fallback — arm64 STOCKOUT will leave run pods Pending until
       # capacity returns. `podFailurePolicy` (`DisruptionTarget` → `Ignore`)
@@ -266,7 +275,8 @@ workspace:
         kubernetes.io/arch: arm64
       affinity:
         # Hard-block run/step pods from sharing a node with code servers
-        # (eliminates preemption-driven code server evictions) or with the
+        # (with both at priority 0, a run pod that fits nowhere waits for a
+        # new node rather than preempting a code server) or with the
         # agent (protects the single-replica agent from kubelet node-pressure
         # eviction by bursty run workloads). Each term is evaluated
         # independently — a candidate node is rejected if EITHER selector
@@ -372,23 +382,14 @@ extraManifests:
   - apiVersion: scheduling.k8s.io/v1
     kind: PriorityClass
     metadata:
-      name: dagster-run
-    value: 1000
-    globalDefault: false
-    preemptionPolicy: PreemptLowerPriority
-    description: >-
-      Elevates run/step pods above default priority (0) so kubelet evicts code
-      server pods first during node memory pressure.
-  - apiVersion: scheduling.k8s.io/v1
-    kind: PriorityClass
-    metadata:
       name: dagster-agent
     value: 1000
     globalDefault: false
     preemptionPolicy: PreemptLowerPriority
     description: >-
-      Elevates agent pods to the same priority as run/step pods so the scheduler
-      cannot preempt them to fit run workloads.
+      Elevates agent pods above run/step and code server pods (priority 0) so
+      nothing in this namespace can preempt the single-replica agent. The agent
+      pins to amd64 nodes and the others to arm64, so it never preempts them.
   - apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:

--- a/tests/test_k8s_config.py
+++ b/tests/test_k8s_config.py
@@ -144,14 +144,16 @@ def test_run_pods_and_code_servers_share_default_priority():
     The location stayed down for four days (#5187). Equal priority makes a run
     pod that fits nowhere wait for a new node instead.
     """
-    workspace = _helm_values()["workspace"]
+    values = _helm_values()
 
     for key in ("serverK8sConfig", "runK8sConfig"):
-        assert "priorityClassName" not in workspace[key].get("podSpecConfig", {})
+        assert "priorityClassName" not in values["workspace"][key].get(
+            "podSpecConfig", {}
+        )
 
     priority_classes = {
         m["metadata"]["name"]
-        for m in _helm_values()["extraManifests"]
+        for m in values["extraManifests"]
         if m["kind"] == "PriorityClass"
     }
 

--- a/tests/test_k8s_config.py
+++ b/tests/test_k8s_config.py
@@ -133,13 +133,29 @@ def test_run_pod_isolation_from_code_servers_stays_required():
     assert {"app.kubernetes.io/name": "dagster-cloud-agent"} in selectors
 
 
-def test_code_servers_keep_default_priority():
-    """Code servers stay at priority 0 by decision: promoting them above
-    dagster-run would make run pods queue instead.
-    """
-    server_config = _helm_values()["workspace"]["serverK8sConfig"]
+def test_run_pods_and_code_servers_share_default_priority():
+    """Run/step pods and code servers both stay at priority 0 so neither can
+    preempt the other.
 
-    assert "priorityClassName" not in server_config.get("podSpecConfig", {})
+    Run pods carried a `dagster-run` PriorityClass (1000) until 2026-09-08. A run
+    pod preempted the kippcamden code server while the agent was uploading its
+    metadata; the one gRPC UNAVAILABLE wrote ERROR to the control plane, and the
+    agent never retries a location the control plane already marks as errored.
+    The location stayed down for four days (#5187). Equal priority makes a run
+    pod that fits nowhere wait for a new node instead.
+    """
+    workspace = _helm_values()["workspace"]
+
+    for key in ("serverK8sConfig", "runK8sConfig"):
+        assert "priorityClassName" not in workspace[key].get("podSpecConfig", {})
+
+    priority_classes = {
+        m["metadata"]["name"]
+        for m in _helm_values()["extraManifests"]
+        if m["kind"] == "PriorityClass"
+    }
+
+    assert priority_classes == {"dagster-agent"}
 
 
 def test_code_servers_are_not_pinned_against_the_autoscaler():
@@ -156,8 +172,10 @@ def test_code_servers_are_not_pinned_against_the_autoscaler():
 
     assert "cluster-autoscaler.kubernetes.io/safe-to-evict" not in annotations
 
-    # the agent and run pods DO carry it, and should keep it -- they are not
-    # preemptible by run pods the way priority-0 code servers are
+    # the agent and run pods DO carry it, and should keep it -- the agent
+    # outranks everything else in the namespace, and run pods are alone on
+    # arm64 nodes with code servers at the same priority, so neither can be
+    # preempted the way code servers were when run pods sat at 1000
     agent_annotations = _helm_values()["dagsterCloudAgent"]["annotations"]
 
     assert (


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." remove the `dagster-run` PriorityClass so run and step pods sit at the same priority as code servers and can no longer preempt them.

On Friday 2026-09-04 a run pod preempted the `kippcamden` code server 2 minutes after it loaded. The agent re-uploaded the location's metadata while the replacement pod was still pending. That one gRPC `UNAVAILABLE` wrote `ERROR` to the Dagster+ control plane. The agent never retries a location the control plane already marks as errored, so `kippcamden` stayed down until a manual redeploy on Tuesday.

With both pod types at priority 0, a run pod that finds no room waits for a new node instead of killing a code server. The original reason for priority 1000 was kubelet eviction order under memory pressure. That never applied: the `required` anti-affinity already keeps run pods and code servers off the same node.

`helm upgrade` is manual. The change takes effect only after someone runs it.

## Reviewer Notes

- The `dagster-agent` PriorityClass stays at 1000. The agent is pinned to amd64 nodes and everything else to arm64, so it never competes with run pods. Its description text is updated to say so.
- The test in `tests/test_k8s_config.py` now asserts that neither `serverK8sConfig` nor `runK8sConfig` sets a `priorityClassName`, and that `dagster-agent` is the only PriorityClass manifest.
- Skill and CLAUDE.md text that described run-pod preemption of code servers as by design is rewritten. A code server `Preempted` event now means a GKE system-critical pod, or a reintroduced priority gap.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No code location changes. `uv run pytest tests/test_k8s_config.py` passes (11 tests).

## CI checks

- [x] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [x] **dbt Cloud** — passes or not triggered.
- [x] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Timeline from agent container logs and `k8s_pod` events, all 2026-09-04 UTC:

- 17:10:49 `kippcamden-prod-18ff21` loaded, "Updated successfully".
- 17:12:43 pod `kippcamden-prod-18ff21-8575cbccc9-bbpkt` `Preempted by pod 4a1636f9-...` on node `...-x242`. Replacement pod `...-9dmr2` hit `FailedScheduling` (Insufficient cpu/memory) until 17:13:56.
- 17:13:50 agent reconcile had `kippcamden` in its "To upload" set, called `list_repositories`, got `DagsterUserCodeUnreachableError: gRPC Error code: UNAVAILABLE`, and wrote error data to the control plane. `_update_location_data` in `dagster_cloud/workspace/user_code_launcher/user_code_launcher.py` has no retry around that call.
- 17:13:53 health check warning: "If it continues failing for more than 300 seconds, a replacement code server will be deployed." Pod was back at 17:14:03, so the replacement path never fired.
- `_should_trigger_recovery` returns `False` when the location is in `control_plane_error_locations`, so the agent never re-uploaded. Recovered only at the 2026-09-08 14:22 UTC redeploy.

Not changed: `podFailurePolicy`, `safe-to-evict` annotations, anti-affinity, the agent PriorityClass. Specs under `docs/superpowers/specs/` that describe the old priority scheme are left as history. The Phase 3 watchdog in `2026-08-18-code-server-scheduling-resilience-design.md` is still the durable fix for the terminal `ERROR` state; its error-signature filter needs widening to include `DagsterUserCodeUnreachableError` when built.

</details>