### PR TITLE
feat(dbt): warn on overlapping PowerSchool stints and dedupe ps_membership_reg student-days

### DIFF
--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_enrollment_all.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_enrollment_all.sql
@@ -37,32 +37,45 @@ with
             {{ ref("stg_powerschool__students") }} as s
             on r.studentid = s.id
             and s.enroll_status != 1
+    ),
+
+    enrollments as (
+        select
+            sr.id as studentid,
+            sr.student_number,
+            sr.schoolid,
+            sr.entrydate,
+            sr.entrycode,
+            sr.exitdate,
+            sr.exitcode,
+            sr.grade_level,
+            sr.fteid,
+            sr.membershipshare,
+            sr.track,
+
+            t.yearid,
+
+            -1 as programid,
+
+            coalesce(f.dflt_att_mode_code, '-1') as dflt_att_mode_code,
+            coalesce(f.dflt_conversion_mode_code, '-1') as dflt_conversion_mode_code,
+
+            lead(sr.entrydate) over (
+                partition by sr.id, sr.schoolid order by sr.entrydate, sr.exitdate
+            ) as next_entrydate,
+        from union_relations as sr
+        left join {{ ref("stg_powerschool__fte") }} as f on sr.fteid = f.id
+        left join
+            {{ ref("stg_powerschool__terms") }} as t
+            on sr.schoolid = t.schoolid
+            and t.isyearrec = 1
+            and sr.entrydate between t.firstday and t.lastday
     )
 
 select
-    sr.id as studentid,
-    sr.student_number,
-    sr.schoolid,
-    sr.entrydate,
-    sr.entrycode,
-    sr.exitdate,
-    sr.exitcode,
-    sr.grade_level,
-    sr.fteid,
-    sr.membershipshare,
-    sr.track,
+    * except (next_entrydate),
 
-    t.yearid,
-
-    -1 as programid,
-
-    coalesce(f.dflt_att_mode_code, '-1') as dflt_att_mode_code,
-    coalesce(f.dflt_conversion_mode_code, '-1') as dflt_conversion_mode_code,
-
-from union_relations as sr
-left join {{ ref("stg_powerschool__fte") }} as f on sr.fteid = f.id
-left join
-    {{ ref("stg_powerschool__terms") }} as t
-    on sr.schoolid = t.schoolid
-    and t.isyearrec = 1
-    and sr.entrydate between t.firstday and t.lastday
+    -- overlapping stints at one school: the later stint owns the shared days
+    -- (see test_int_powerschool__ps_enrollment_all__no_overlapping_stints)
+    if(next_entrydate < exitdate, next_entrydate, exitdate) as exitdate_clipped,
+from enrollments

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_enrollment_all.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_enrollment_all.sql
@@ -61,7 +61,7 @@ with
             coalesce(f.dflt_conversion_mode_code, '-1') as dflt_conversion_mode_code,
 
             lead(sr.entrydate) over (
-                partition by sr.id, sr.schoolid order by sr.entrydate, sr.exitdate
+                partition by sr.id order by sr.entrydate, sr.exitdate
             ) as next_entrydate,
         from union_relations as sr
         left join {{ ref("stg_powerschool__fte") }} as f on sr.fteid = f.id
@@ -75,7 +75,7 @@ with
 select
     * except (next_entrydate),
 
-    -- overlapping stints at one school: the later stint owns the shared days
+    -- overlapping stints: the later stint owns the shared days
     -- (see test_int_powerschool__ps_enrollment_all__no_overlapping_stints)
     if(next_entrydate < exitdate, next_entrydate, exitdate) as exitdate_clipped,
 from enrollments

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
@@ -88,9 +88,7 @@ with
         where cd.insession = 1
     )
 
-    -- overlapping stints (see
-    -- test_int_powerschool__ps_enrollment_all__no_overlapping_stints)
-    -- emit one row per stint for each shared day; keep the later stint
+    -- see test_int_powerschool__ps_enrollment_all__no_overlapping_stints
     {{
         dbt_utils.deduplicate(
             relation="membership",

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
@@ -1,84 +1,100 @@
-select
-    ev.studentid,
-    ev.student_number,
-    ev.schoolid,
-    ev.entrydate,
-    ev.track as student_track,
-    ev.fteid,
-    ev.dflt_att_mode_code,
-    ev.dflt_conversion_mode_code,
-    ev.grade_level,
-    ev.yearid,
+with
+    membership as (
+        select
+            ev.studentid,
+            ev.student_number,
+            ev.schoolid,
+            ev.entrydate,
+            ev.track as student_track,
+            ev.fteid,
+            ev.dflt_att_mode_code,
+            ev.dflt_conversion_mode_code,
+            ev.grade_level,
+            ev.yearid,
 
-    cd.date_value as calendardate,
-    cd.a,
-    cd.b,
-    cd.c,
-    cd.d,
-    cd.e,
-    cd.f,
-    cd.bell_schedule_id,
-    cd.cycle_day_id,
+            cd.date_value as calendardate,
+            cd.a,
+            cd.b,
+            cd.c,
+            cd.d,
+            cd.e,
+            cd.f,
+            cd.bell_schedule_id,
+            cd.cycle_day_id,
 
-    bs.attendance_conversion_id,
+            bs.attendance_conversion_id,
 
-    case
-        when
-            (ev.track = 'A' and cd.a = 1)
-            or (ev.track = 'B' and cd.b = 1)
-            or (ev.track = 'C' and cd.c = 1)
-            or (ev.track = 'D' and cd.d = 1)
-            or (ev.track = 'E' and cd.e = 1)
-            or (ev.track = 'F' and cd.f = 1)
-        then ev.membershipshare
-        when ev.track is null
-        then ev.membershipshare
-        else 0
-    end as studentmembership,
-    case
-        when
-            (ev.track = 'A' and cd.a = 1)
-            or (ev.track = 'B' and cd.b = 1)
-            or (ev.track = 'C' and cd.c = 1)
-            or (ev.track = 'D' and cd.d = 1)
-            or (ev.track = 'E' and cd.e = 1)
-            or (ev.track = 'F' and cd.f = 1)
-        then cd.membershipvalue
-        when ev.track is null
-        then cd.membershipvalue
-        else 0
-    end as calendarmembership,
-    case
-        when
-            (ev.track = 'A' and cd.a = 1)
-            or (ev.track = 'B' and cd.b = 1)
-            or (ev.track = 'C' and cd.c = 1)
-            or (ev.track = 'D' and cd.d = 1)
-            or (ev.track = 'E' and cd.e = 1)
-            or (ev.track = 'F' and cd.f = 1)
-        then 1
-        when (ev.track is null)
-        then 1
-        else 0
-    end as ontrack,
-    case
-        when
-            (ev.track = 'A' and cd.a = 1)
-            or (ev.track = 'B' and cd.b = 1)
-            or (ev.track = 'C' and cd.c = 1)
-            or (ev.track = 'D' and cd.d = 1)
-            or (ev.track = 'E' and cd.e = 1)
-            or (ev.track = 'F' and cd.f = 1)
-        then 0
-        when ev.track is null
-        then 0
-        else 1
-    end as offtrack,
-from {{ ref("int_powerschool__ps_enrollment_all") }} as ev
-inner join
-    {{ ref("stg_powerschool__calendar_day") }} as cd
-    on ev.schoolid = cd.schoolid
-    and cd.date_value between ev.entrydate and date_sub(ev.exitdate, interval 1 day)
-inner join
-    {{ ref("stg_powerschool__bell_schedule") }} as bs on cd.bell_schedule_id = bs.id
-where cd.insession = 1
+            case
+                when
+                    (ev.track = 'A' and cd.a = 1)
+                    or (ev.track = 'B' and cd.b = 1)
+                    or (ev.track = 'C' and cd.c = 1)
+                    or (ev.track = 'D' and cd.d = 1)
+                    or (ev.track = 'E' and cd.e = 1)
+                    or (ev.track = 'F' and cd.f = 1)
+                then ev.membershipshare
+                when ev.track is null
+                then ev.membershipshare
+                else 0
+            end as studentmembership,
+            case
+                when
+                    (ev.track = 'A' and cd.a = 1)
+                    or (ev.track = 'B' and cd.b = 1)
+                    or (ev.track = 'C' and cd.c = 1)
+                    or (ev.track = 'D' and cd.d = 1)
+                    or (ev.track = 'E' and cd.e = 1)
+                    or (ev.track = 'F' and cd.f = 1)
+                then cd.membershipvalue
+                when ev.track is null
+                then cd.membershipvalue
+                else 0
+            end as calendarmembership,
+            case
+                when
+                    (ev.track = 'A' and cd.a = 1)
+                    or (ev.track = 'B' and cd.b = 1)
+                    or (ev.track = 'C' and cd.c = 1)
+                    or (ev.track = 'D' and cd.d = 1)
+                    or (ev.track = 'E' and cd.e = 1)
+                    or (ev.track = 'F' and cd.f = 1)
+                then 1
+                when (ev.track is null)
+                then 1
+                else 0
+            end as ontrack,
+            case
+                when
+                    (ev.track = 'A' and cd.a = 1)
+                    or (ev.track = 'B' and cd.b = 1)
+                    or (ev.track = 'C' and cd.c = 1)
+                    or (ev.track = 'D' and cd.d = 1)
+                    or (ev.track = 'E' and cd.e = 1)
+                    or (ev.track = 'F' and cd.f = 1)
+                then 0
+                when ev.track is null
+                then 0
+                else 1
+            end as offtrack,
+        from {{ ref("int_powerschool__ps_enrollment_all") }} as ev
+        inner join
+            {{ ref("stg_powerschool__calendar_day") }} as cd
+            on ev.schoolid = cd.schoolid
+            and cd.date_value
+            between ev.entrydate and date_sub(ev.exitdate, interval 1 day)
+        inner join
+            {{ ref("stg_powerschool__bell_schedule") }} as bs
+            on cd.bell_schedule_id = bs.id
+        where cd.insession = 1
+    )
+
+    -- overlapping stints (see
+    -- test_int_powerschool__ps_enrollment_all__no_overlapping_stints)
+    -- emit one row per stint for each shared day; keep the later stint
+    {{
+        dbt_utils.deduplicate(
+            relation="membership",
+            partition_by="studentid, calendardate",
+            order_by="entrydate desc",
+        )
+    }}

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_membership_reg.sql
@@ -1,98 +1,85 @@
-with
-    membership as (
-        select
-            ev.studentid,
-            ev.student_number,
-            ev.schoolid,
-            ev.entrydate,
-            ev.track as student_track,
-            ev.fteid,
-            ev.dflt_att_mode_code,
-            ev.dflt_conversion_mode_code,
-            ev.grade_level,
-            ev.yearid,
+select
+    ev.studentid,
+    ev.student_number,
+    ev.schoolid,
+    ev.entrydate,
+    ev.track as student_track,
+    ev.fteid,
+    ev.dflt_att_mode_code,
+    ev.dflt_conversion_mode_code,
+    ev.grade_level,
+    ev.yearid,
 
-            cd.date_value as calendardate,
-            cd.a,
-            cd.b,
-            cd.c,
-            cd.d,
-            cd.e,
-            cd.f,
-            cd.bell_schedule_id,
-            cd.cycle_day_id,
+    cd.date_value as calendardate,
+    cd.a,
+    cd.b,
+    cd.c,
+    cd.d,
+    cd.e,
+    cd.f,
+    cd.bell_schedule_id,
+    cd.cycle_day_id,
 
-            bs.attendance_conversion_id,
+    bs.attendance_conversion_id,
 
-            case
-                when
-                    (ev.track = 'A' and cd.a = 1)
-                    or (ev.track = 'B' and cd.b = 1)
-                    or (ev.track = 'C' and cd.c = 1)
-                    or (ev.track = 'D' and cd.d = 1)
-                    or (ev.track = 'E' and cd.e = 1)
-                    or (ev.track = 'F' and cd.f = 1)
-                then ev.membershipshare
-                when ev.track is null
-                then ev.membershipshare
-                else 0
-            end as studentmembership,
-            case
-                when
-                    (ev.track = 'A' and cd.a = 1)
-                    or (ev.track = 'B' and cd.b = 1)
-                    or (ev.track = 'C' and cd.c = 1)
-                    or (ev.track = 'D' and cd.d = 1)
-                    or (ev.track = 'E' and cd.e = 1)
-                    or (ev.track = 'F' and cd.f = 1)
-                then cd.membershipvalue
-                when ev.track is null
-                then cd.membershipvalue
-                else 0
-            end as calendarmembership,
-            case
-                when
-                    (ev.track = 'A' and cd.a = 1)
-                    or (ev.track = 'B' and cd.b = 1)
-                    or (ev.track = 'C' and cd.c = 1)
-                    or (ev.track = 'D' and cd.d = 1)
-                    or (ev.track = 'E' and cd.e = 1)
-                    or (ev.track = 'F' and cd.f = 1)
-                then 1
-                when (ev.track is null)
-                then 1
-                else 0
-            end as ontrack,
-            case
-                when
-                    (ev.track = 'A' and cd.a = 1)
-                    or (ev.track = 'B' and cd.b = 1)
-                    or (ev.track = 'C' and cd.c = 1)
-                    or (ev.track = 'D' and cd.d = 1)
-                    or (ev.track = 'E' and cd.e = 1)
-                    or (ev.track = 'F' and cd.f = 1)
-                then 0
-                when ev.track is null
-                then 0
-                else 1
-            end as offtrack,
-        from {{ ref("int_powerschool__ps_enrollment_all") }} as ev
-        inner join
-            {{ ref("stg_powerschool__calendar_day") }} as cd
-            on ev.schoolid = cd.schoolid
-            and cd.date_value
-            between ev.entrydate and date_sub(ev.exitdate, interval 1 day)
-        inner join
-            {{ ref("stg_powerschool__bell_schedule") }} as bs
-            on cd.bell_schedule_id = bs.id
-        where cd.insession = 1
-    )
-
-    -- see test_int_powerschool__ps_enrollment_all__no_overlapping_stints
-    {{
-        dbt_utils.deduplicate(
-            relation="membership",
-            partition_by="studentid, calendardate",
-            order_by="entrydate desc",
-        )
-    }}
+    case
+        when
+            (ev.track = 'A' and cd.a = 1)
+            or (ev.track = 'B' and cd.b = 1)
+            or (ev.track = 'C' and cd.c = 1)
+            or (ev.track = 'D' and cd.d = 1)
+            or (ev.track = 'E' and cd.e = 1)
+            or (ev.track = 'F' and cd.f = 1)
+        then ev.membershipshare
+        when ev.track is null
+        then ev.membershipshare
+        else 0
+    end as studentmembership,
+    case
+        when
+            (ev.track = 'A' and cd.a = 1)
+            or (ev.track = 'B' and cd.b = 1)
+            or (ev.track = 'C' and cd.c = 1)
+            or (ev.track = 'D' and cd.d = 1)
+            or (ev.track = 'E' and cd.e = 1)
+            or (ev.track = 'F' and cd.f = 1)
+        then cd.membershipvalue
+        when ev.track is null
+        then cd.membershipvalue
+        else 0
+    end as calendarmembership,
+    case
+        when
+            (ev.track = 'A' and cd.a = 1)
+            or (ev.track = 'B' and cd.b = 1)
+            or (ev.track = 'C' and cd.c = 1)
+            or (ev.track = 'D' and cd.d = 1)
+            or (ev.track = 'E' and cd.e = 1)
+            or (ev.track = 'F' and cd.f = 1)
+        then 1
+        when (ev.track is null)
+        then 1
+        else 0
+    end as ontrack,
+    case
+        when
+            (ev.track = 'A' and cd.a = 1)
+            or (ev.track = 'B' and cd.b = 1)
+            or (ev.track = 'C' and cd.c = 1)
+            or (ev.track = 'D' and cd.d = 1)
+            or (ev.track = 'E' and cd.e = 1)
+            or (ev.track = 'F' and cd.f = 1)
+        then 0
+        when ev.track is null
+        then 0
+        else 1
+    end as offtrack,
+from {{ ref("int_powerschool__ps_enrollment_all") }} as ev
+inner join
+    {{ ref("stg_powerschool__calendar_day") }} as cd
+    on ev.schoolid = cd.schoolid
+    and ev.entrydate <= cd.date_value
+    and ev.exitdate_clipped > cd.date_value
+inner join
+    {{ ref("stg_powerschool__bell_schedule") }} as bs on cd.bell_schedule_id = bs.id
+where cd.insession = 1

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_enrollment_all.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_enrollment_all.yml
@@ -48,8 +48,9 @@ models:
         data_type: date
         description: >-
           `exitdate`, cut back to the next stint's `entrydate` when a later
-          stint at the same school starts before this one ends. Date-range joins
-          that must stay one row per student-day
-          (int_powerschool__ps_membership_reg) use this instead of `exitdate`;
-          overlapping stints are a source defect surfaced by
+          stint at any school starts before this one ends. PowerSchool holds one
+          enrollment at a time, so a transfer whose old stint was left open is
+          cut at the new school's start. Date-range joins that must stay one row
+          per student-day (int_powerschool__ps_membership_reg) use this instead
+          of `exitdate`; overlapping stints are a source defect surfaced by
           test_int_powerschool__ps_enrollment_all__no_overlapping_stints.

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_enrollment_all.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_enrollment_all.yml
@@ -44,3 +44,12 @@ models:
         data_type: string
       - name: dflt_conversion_mode_code
         data_type: string
+      - name: exitdate_clipped
+        data_type: date
+        description: >-
+          `exitdate`, cut back to the next stint's `entrydate` when a later
+          stint at the same school starts before this one ends. Date-range joins
+          that must stay one row per student-day
+          (int_powerschool__ps_membership_reg) use this instead of `exitdate`;
+          overlapping stints are a source defect surfaced by
+          test_int_powerschool__ps_enrollment_all__no_overlapping_stints.

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
@@ -1,5 +1,20 @@
 models:
   - name: int_powerschool__ps_membership_reg
+    description: >-
+      One row per student per in-session calendar day, from each enrollment
+      stint in int_powerschool__ps_enrollment_all joined to the school's
+      calendar over the half-open `[entrydate, exitdate)`. Two stints that
+      overlap at the same school would emit 2 rows for every shared day, so the
+      model dedupes on `(studentid, calendardate)` and keeps the stint with the
+      later `entrydate`. The dedupe is a permanent guard so one bad stint pair
+      does not double-count attendance network-wide; the source defect surfaces
+      in `test_int_powerschool__ps_enrollment_all__no_overlapping_stints`.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - studentid
+              - calendardate
     columns:
       - name: studentid
         data_type: int64

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
@@ -3,12 +3,11 @@ models:
     description: >-
       One row per student per in-session calendar day, from each enrollment
       stint in int_powerschool__ps_enrollment_all joined to the school's
-      calendar over the half-open `[entrydate, exitdate)`. Two stints that
-      overlap at the same school would emit 2 rows for every shared day, so the
-      model dedupes on `(studentid, calendardate)` and keeps the stint with the
-      later `entrydate`. The dedupe is a permanent guard so one bad stint pair
-      does not double-count attendance network-wide; the source defect surfaces
-      in `test_int_powerschool__ps_enrollment_all__no_overlapping_stints`.
+      calendar over the half-open `[entrydate, exitdate_clipped)`. The clipped
+      exit comes from int_powerschool__ps_enrollment_all, which cuts a stint off
+      where the next stint at the same school begins, so overlapping stints
+      cannot emit 2 rows for one student-day here. The `(studentid,
+      calendardate)` grain test guards that.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
@@ -5,7 +5,7 @@ models:
       stint in int_powerschool__ps_enrollment_all joined to the school's
       calendar over the half-open `[entrydate, exitdate_clipped)`. The clipped
       exit comes from int_powerschool__ps_enrollment_all, which cuts a stint off
-      where the next stint at the same school begins, so overlapping stints
+      where the student's next stint begins at any school, so overlapping stints
       cannot emit 2 rows for one student-day here. The grain is guarded
       upstream, where a defect would originate: the overlap test on
       int_powerschool__ps_enrollment_all, the `(schoolid, date_value)`

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_membership_reg.yml
@@ -6,14 +6,11 @@ models:
       calendar over the half-open `[entrydate, exitdate_clipped)`. The clipped
       exit comes from int_powerschool__ps_enrollment_all, which cuts a stint off
       where the next stint at the same school begins, so overlapping stints
-      cannot emit 2 rows for one student-day here. The `(studentid,
-      calendardate)` grain test guards that.
-    data_tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - studentid
-              - calendardate
+      cannot emit 2 rows for one student-day here. The grain is guarded
+      upstream, where a defect would originate: the overlap test on
+      int_powerschool__ps_enrollment_all, the `(schoolid, date_value)`
+      uniqueness test on stg_powerschool__calendar_day, and the `id` uniqueness
+      test on stg_powerschool__bell_schedule.
     columns:
       - name: studentid
         data_type: int64

--- a/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__calendar_day.yml
+++ b/src/dbt/powerschool/models/sis/staging/properties/stg_powerschool__calendar_day.yml
@@ -4,7 +4,15 @@ models:
       School year calendar is maintained is this table. It's used for Bell
       Schedules, ADM/ADA reports and overall attendance by showing which days
       are in-session withindifferent tracks or overall. This used to be named
-      DailySchedules.
+      DailySchedules. One row per `(schoolid, date_value)`. Date-range joins
+      such as int_powerschool__ps_membership_reg rely on that grain to stay at
+      one row per student-day.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - schoolid
+              - date_value
     columns:
       - name: id
         data_type: int64

--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -18,6 +18,29 @@ data_tests:
             name: int_powerschool__ps_enrollment_all
             package: powerschool
 
+  - name: test_int_powerschool__ps_enrollment_all__no_overlapping_stints
+    description: >-
+      Within a `(studentid, schoolid)` partition, no stint's `entrydate` may
+      fall inside an earlier stint's half-open `[entrydate, exitdate)`. An
+      overlapping pair makes `int_powerschool__ps_membership_reg` emit 2 rows
+      for every in-session day in the overlap, and every attendance model
+      downstream double-counts those student-days. `ps_membership_reg` dedupes
+      defensively on `(studentid, calendardate)` so one bad pair does not skew
+      network attendance while Ops fixes the stints, but the source defect is
+      only visible here. The existing `(studentid, entrydate)` and `(studentid,
+      exitdate)` uniqueness tests miss overlaps whose dates differ. Runs at the
+      consuming district's default warn severity. Failing with 22 stints as of
+      2026-09-08 (kippnewark 2, kippcamden 3, kipppaterson 17), none of which
+      reach an in-session calendar day, so the dedupe removes 0 rows today. The
+      2026-08-20 Newark incident (#5160) produced 558 duplicate student-days
+      before Ops corrected the stints.
+    config:
+      meta:
+        dagster:
+          ref:
+            name: int_powerschool__ps_enrollment_all
+            package: powerschool
+
   - name: int_powerschool__student_enrollment_union_no_shared_stint_boundary
     description: >-
       Within a `student_number` partition, consecutive enrollment stints must

--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -24,16 +24,17 @@ data_tests:
       fall inside an earlier stint's half-open `[entrydate, exitdate)`. An
       overlapping pair makes `int_powerschool__ps_membership_reg` emit 2 rows
       for every in-session day in the overlap, and every attendance model
-      downstream double-counts those student-days. `ps_membership_reg` dedupes
-      defensively on `(studentid, calendardate)` so one bad pair does not skew
-      network attendance while Ops fixes the stints, but the source defect is
-      only visible here. The existing `(studentid, entrydate)` and `(studentid,
-      exitdate)` uniqueness tests miss overlaps whose dates differ. Runs at the
-      consuming district's default warn severity. Failing with 22 stints as of
-      2026-09-08 (kippnewark 2, kippcamden 3, kipppaterson 17), none of which
-      reach an in-session calendar day, so the dedupe removes 0 rows today. The
-      2026-08-20 Newark incident (#5160) produced 558 duplicate student-days
-      before Ops corrected the stints.
+      downstream double-counts those student-days. `exitdate_clipped` on this
+      model cuts the earlier stint off at the later stint's `entrydate` so
+      `ps_membership_reg` stays at one row per student-day while Ops fixes the
+      stints, but the source defect is only visible here. The existing
+      `(studentid, entrydate)` and `(studentid, exitdate)` uniqueness tests miss
+      overlaps whose dates differ. Runs at the consuming district's default warn
+      severity. Failing with 22 stints as of 2026-09-08 (kippnewark 2,
+      kippcamden 3, kipppaterson 17), none of which reach an in-session calendar
+      day, so the clip changes 0 rows today. The 2026-08-20 Newark incident
+      (#5160) produced 558 duplicate student-days before Ops corrected the
+      stints.
     config:
       meta:
         dagster:

--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -20,8 +20,8 @@ data_tests:
 
   - name: test_int_powerschool__ps_enrollment_all__no_overlapping_stints
     description: >-
-      Within a `(studentid, schoolid)` partition, no stint's `entrydate` may
-      fall inside an earlier stint's half-open `[entrydate, exitdate)`. An
+      For each `studentid`, at any school, no stint's `entrydate` may fall
+      inside an earlier stint's half-open `[entrydate, exitdate)`. An
       overlapping pair makes `int_powerschool__ps_membership_reg` emit 2 rows
       for every in-session day in the overlap, and every attendance model
       downstream double-counts those student-days. `exitdate_clipped` on this
@@ -30,11 +30,11 @@ data_tests:
       stints, but the source defect is only visible here. The existing
       `(studentid, entrydate)` and `(studentid, exitdate)` uniqueness tests miss
       overlaps whose dates differ. Runs at the consuming district's default warn
-      severity. Failing with 21 stints as of 2026-09-08 (kippnewark 1,
-      kippcamden 3, kipppaterson 17), none of which reach an in-session calendar
-      day, so the clip changes 0 rows today. The 2026-08-20 Newark incident
-      (#5160) produced 558 duplicate student-days before Ops corrected the
-      stints.
+      severity. Failing with 56 stints as of 2026-09-08 (kippnewark 36,
+      kippcamden 3, kipppaterson 17), most of them cross-school stints from
+      yearid 26. None reach an in-session calendar day, so the clip changes 0
+      rows today. The 2026-08-20 Newark incident (#5160) produced 558 duplicate
+      student-days before Ops corrected the stints.
     config:
       meta:
         dagster:

--- a/src/dbt/powerschool/tests/properties.yml
+++ b/src/dbt/powerschool/tests/properties.yml
@@ -30,7 +30,7 @@ data_tests:
       stints, but the source defect is only visible here. The existing
       `(studentid, entrydate)` and `(studentid, exitdate)` uniqueness tests miss
       overlaps whose dates differ. Runs at the consuming district's default warn
-      severity. Failing with 22 stints as of 2026-09-08 (kippnewark 2,
+      severity. Failing with 21 stints as of 2026-09-08 (kippnewark 1,
       kippcamden 3, kipppaterson 17), none of which reach an in-session calendar
       day, so the clip changes 0 rows today. The 2026-08-20 Newark incident
       (#5160) produced 558 duplicate student-days before Ops corrected the

--- a/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
+++ b/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
@@ -1,0 +1,20 @@
+with
+    stints as (
+        select
+            studentid,
+            student_number,
+            schoolid,
+            entrydate,
+            exitdate,
+            max(exitdate) over (
+                partition by studentid, schoolid
+                order by entrydate
+                rows between unbounded preceding and 1 preceding
+            ) as prior_max_exitdate,
+        from {{ ref("int_powerschool__ps_enrollment_all") }}
+        where entrydate is not null
+    )
+
+select studentid, student_number, schoolid, entrydate, exitdate, prior_max_exitdate,
+from stints
+where entrydate < prior_max_exitdate

--- a/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
+++ b/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
@@ -8,7 +8,7 @@ with
             exitdate,
             max(exitdate) over (
                 partition by studentid, schoolid
-                order by entrydate
+                order by entrydate, exitdate
                 rows between unbounded preceding and 1 preceding
             ) as prior_max_exitdate,
         from {{ ref("int_powerschool__ps_enrollment_all") }}

--- a/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
+++ b/src/dbt/powerschool/tests/test_int_powerschool__ps_enrollment_all__no_overlapping_stints.sql
@@ -7,7 +7,7 @@ with
             entrydate,
             exitdate,
             max(exitdate) over (
-                partition by studentid, schoolid
+                partition by studentid
                 order by entrydate, exitdate
                 rows between unbounded preceding and 1 preceding
             ) as prior_max_exitdate,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will catch overlapping PowerSchool enrollment stints where they first appear and stop them from double-counting attendance.

When a student has 2 stints at the same school whose dates overlap, `int_powerschool__ps_membership_reg` emits 2 rows for every shared school day. Every attendance model downstream inherits the duplicates. On 2026-08-20 this produced 558 duplicate Newark student-days. #5188 removed the dedupe that hid the problem 4 models downstream. This PR puts the guard at the source instead:

- A new warn test on `int_powerschool__ps_enrollment_all` flags any stint whose `entrydate` falls inside an earlier stint for the same student, at any school.
- `int_powerschool__ps_enrollment_all` gains `exitdate_clipped`: the stint's `exitdate`, cut back to the student's next stint's `entrydate`, at any school. `int_powerschool__ps_membership_reg` joins the calendar on that clipped range, so overlapping stints cannot produce 2 rows for one student-day.
- `stg_powerschool__calendar_day` gains a uniqueness test on `(schoolid, date_value)`, the other join key that could fan out student-days. Every guard now sits on the small table where a defect would originate, and nothing scans the 13.9M-row `ps_membership_reg`.

## Reviewer Notes

- The clip replaces an earlier draft of this PR that deduped `ps_membership_reg` with `dbt_utils.deduplicate`. Clipping 110k stint rows is cheaper than an `array_agg` over 13.9M student-day rows: the Newark dev build of `ps_membership_reg` dropped from 123s to 21s.
- Stints that share an `entrydate` sort by `exitdate` in both the clip window and the test window, so the shorter stint is the one clipped. Without that tiebreak the first build clipped 2 students' full 2026-27 year.
- Both windows partition by `studentid` only. PowerSchool holds one enrollment at a time, so a transfer whose old stint was left open is cut at the new school's start. Newark has 32 such pairs from yearid 26; none reach an in-session day today.
- The `ps_membership_reg` join changed from `between entrydate and date_sub(exitdate, 1 day)` to the half-open form. Same days, different spelling.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Verdicts posted in a PR comment.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models. `exitdate_clipped` is documented in `int_powerschool__ps_enrollment_all.yml`; `int_powerschool__ps_membership_reg.yml` gained a description; `stg_powerschool__calendar_day.yml` gained the composite uniqueness test; `tests/properties.yml` gained the new test's entry.
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — no exposure change.
- [x] **Breaking change?** No. One column added to `ps_enrollment_all`; `ps_membership_reg` row set is identical to prod today.
- [x] External sources — none touched.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Closes #5189. Refs #5160, #5188, #5045.

Verification on 2026-09-08, `--target dev --defer --favor-state` against each district's prod manifest:

| district | overlap test | calendar_day `(schoolid, date_value)` | ps_membership_reg rows vs prod |
| --- | --- | --- | --- |
| kippnewark | WARN 36 | PASS | 13,916,780 = 13,916,780 (13,916,780 distinct keys) |
| kippcamden | WARN 3 | PASS | not built |
| kipppaterson | WARN 17 | PASS | not built |

In Newark 36 stints are clipped today: 32 cross-school pairs from yearid 26, 2 from yearid 25 involving `schoolid = 999999`, 1 same-school 2-day stint in yearid 36, and 1 with no matching term. None of the clipped days are in session, so the row set is unchanged. The kipptaf ctod wrapper's grain test was not rerun; the district tables it reads are byte-identical to prod under this change.

dbt Cloud CI is a no-op for this PR (package-only, no kipptaf model modified). The local builds above are the validation.

Test shape: `max(exitdate) over (partition by studentid order by entrydate, exitdate rows between unbounded preceding and 1 preceding)`, flag `entrydate < prior_max_exitdate`. One row per offending later stint. Includes `schoolid = 999999`, unlike the two existing uniqueness tests on this model. A zero-length stint sharing an `entrydate` with a real one is not flagged here (it overlaps nothing) but is caught by the existing `(studentid, entrydate)` uniqueness test.

Clip shape: `lead(entrydate) over (partition by studentid order by entrydate, exitdate)` in a CTE, then `if(next_entrydate < exitdate, next_entrydate, exitdate) as exitdate_clipped`. `exitdate` is never null in this model (0 rows across 3 districts), so no coalesce. 212 stints have `exitdate < entrydate`; they produce no membership rows before or after this change and are out of scope.

</details>
