### PR TITLE
feat(tableau): cards, captions and a GPA basis reminder for the Cumulative GPA Monitor

### DIFF
--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -392,7 +392,7 @@ edits so a colour regression cannot hide behind a text or layout change.
 - Consumes: `server/prod-base3.twb` from Task 0.
 - Produces: `server/cum-1-colour.twb`, consumed by Task 3.
 
-- [ ] **Step 1: Write the failing assertion**
+- [x] **Step 1: Write the failing assertion**
 
 Write `.claude/scratch/gpa-overnight/assert_cum_colour.py`:
 
@@ -436,7 +436,7 @@ if __name__ == "__main__":
     main(sys.argv[1])
 ```
 
-- [ ] **Step 2: Run it to verify it fails**
+- [x] **Step 2: Run it to verify it fails**
 
 Run:
 `cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_colour.py server/prod-base3.twb`
@@ -444,7 +444,7 @@ Run:
 Expected: FAIL, reporting `At or above goal: #2f5fc4 != #12a47c` and
 `Below goal: #d8342f != #b3161c`.
 
-- [ ] **Step 3: Write the edit**
+- [x] **Step 3: Write the edit**
 
 Write `.claude/scratch/gpa-overnight/task_cum_colour.py`:
 
@@ -495,7 +495,7 @@ if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2])
 ```
 
-- [ ] **Step 4: Run the edit, then the assertion and the checker**
+- [x] **Step 4: Run the edit, then the assertion and the checker**
 
 ```bash
 cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
@@ -507,7 +507,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 Expected: the edit prints both swaps, the assertion prints `OK`, the checker is
 clean.
 
-- [ ] **Step 5: Confirm the Academic Health twin is untouched**
+- [x] **Step 5: Confirm the Academic Health twin is untouched**
 
 Run:
 
@@ -523,10 +523,32 @@ PY
 
 Expected: `At or above goal` still `#2f5fc4`, `Below goal` still `#d8342f`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Tick the boxes, then commit the plan with message
 `docs(tableau): record the Cumulative goal colour repoint`.
+
+**Result:**
+
+Goal colours repointed on `Calculation_7236501339153214575` only.
+
+The change is 4 lines: `<map to='#2f5fc4'>` → `<map to='#12a47c'>` and
+`<map to='#d8342f'>` → `<map to='#b3161c'>`. Character count identical at
+1,925,760, CRLF count identical at 27,729, `check_twb.py --ref` CLEAN.
+
+`assert_cum_colour.py` exits 1 with 4 failures on `prod-base3.twb` and exits 0
+on `cum-1-colour.twb`, so it discriminates rather than passing vacuously.
+
+The Academic Health Home twin `Calculation_4005670422418128910` still reads
+`#2f5fc4` / `#d8342f`, confirmed against the output file.
+
+Review found the encoding is defined once at datasource level and referenced by
+all three sheets, so a single substitution is structurally sufficient — not a
+missed-occurrence bug.
+
+Deferred to Task 6: rendered-colour evidence. `check_twb.py` is a checklist
+built from prior failures, not a schema validator, so the pixel assertion in
+Task 6 step 3 is what actually proves the colours reach the screen.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -38,8 +38,10 @@ Insert into `<document-format-change-manifest>`, never rebuild it.
 The paragraph break inside `<formatted-text>` is the literal run
 `<run>Æ&#10;</run>`. It must be byte-exact.
 
-The workbook file uses CRLF line endings. Read and write with `encoding="utf-8"`
-and never normalise newlines.
+The workbook file uses CRLF line endings, 27,729 of them. Read and write with
+`encoding="utf-8", newline=""` on both sides. A plain `read_text` applies
+universal newlines and hands back a string with no `\r` in it at all, so any
+later attempt to detect or preserve CRLF is working on already-flattened text.
 
 Working directory for all scripts and artifacts:
 `/workspaces/teamster/.claude/scratch/gpa-overnight/`, workbooks under its
@@ -232,7 +234,7 @@ already in the workbook. No parameter placeholder exists in this file yet.
 - Produces: a yes or no answer, recorded in the plan. Produces no artifact any
   later task depends on.
 
-- [ ] **Step 1: Write the probe edit**
+- [x] **Step 1: Write the probe edit**
 
 Write `.claude/scratch/gpa-overnight/probe_placeholder.py`:
 
@@ -276,7 +278,7 @@ if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2])
 ```
 
-- [ ] **Step 2: Run it and repack**
+- [x] **Step 2: Run it and repack**
 
 ```bash
 cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
@@ -287,7 +289,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 
 Expected: checker clean, `probe.twbx` over 20 MB.
 
-- [ ] **Step 3: Write the publish-and-render probe**
+- [x] **Step 3: Write the publish-and-render probe**
 
 Write with the Write tool to `tests/tableau/test_zz_probe.py`:
 
@@ -327,7 +329,7 @@ def test_probe():
             print(f"RENDERED {value}: {out} {out.stat().st_size} bytes")
 ```
 
-- [ ] **Step 4: Run it and read the images**
+- [x] **Step 4: Run it and read the images**
 
 Run: `uv run pytest tests/tableau/test_zz_probe.py -s`
 
@@ -342,7 +344,7 @@ the title is empty. On FAIL, stop. Record which of these it was, then report to
 the user. Fallbacks in the spec, in order: caption-style syntax, native axis
 titles plus a badge worksheet, fixed text.
 
-- [ ] **Step 5: Delete the throwaway and commit the answer**
+- [x] **Step 5: Delete the throwaway and commit the answer**
 
 ```bash
 rm -f /workspaces/teamster/tests/tableau/test_zz_probe.py
@@ -350,6 +352,27 @@ rm -f /workspaces/teamster/tests/tableau/test_zz_probe.py
 
 Append a `**Result:**` line under this task's heading recording PASS or FAIL and
 the exact rendered string, then commit the plan.
+
+**Result:**
+
+**PASS.** `<[Parameters].[Parameter 11]>` resolves in a worksheet title and
+tracks the parameter. Rendered `PROBE Projected EOY` and
+`PROBE On the books today` from the same workbook at the two parameter values.
+Published to `GPA-monitor-temp` as `ZZ-PROBE placeholder 20260908`
+(`31523f3b-a642-40df-8710-e314b8318a46`); the `project_id` assertion held.
+
+The first probe run rendered nothing at all, and it was not the syntax. A
+worksheet `<title>` is invisible unless its dashboard zone carries
+`show-title='true'`, and every body zone on this dashboard ships
+`show-title='false'`. Task 3 now flips zones 144, 151 and 152, and its assertion
+checks the zone attribute as well as the title content — without that check the
+task would have passed with an invisible reminder.
+
+CRLF handling in the plan's sample code was also wrong and is corrected. A plain
+`Path.read_text(encoding="utf-8")` applies universal newlines, so the sample's
+`"\r\n" in t` sniff can never be true and every write would have flattened all
+27,729 CRLF endings to LF. Both read and write now pass `newline=""`. Verified
+on the probe: CRLF count went 27,729 → 27,736, exactly the 7 lines inserted.
 
 ---
 
@@ -555,7 +578,11 @@ FIXED = "Always projected"
 STYLE = "fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'"
 
 LIVE_LABEL = ["GPA - BAN % 3.5+", "GPA - BAN % 3.0+"]
-LIVE_TITLE = ["GPA - Dist by grade", "GPA - Goal by grade", "GPA - Goal by school"]
+# sheet -> its dashboard zone id. A worksheet <title> renders ONLY if its zone
+# carries show-title='true'; every body zone ships with 'false', which swallows
+# the title silently. Task 1's probe proved this the hard way.
+LIVE_TITLE = {"GPA - Dist by grade": "144", "GPA - Goal by grade": "151",
+              "GPA - Goal by school": "152"}
 FIXED_LABEL = ["GPA - BAN Below 3.0", "GPA - BAN Can reach",
                "GPA - BAN Gap to goal", "GPA - BAN Students needed"]
 
@@ -574,14 +601,23 @@ def main(path):
         if not lab or PLACEHOLDER not in lab.group(0):
             print(f"  FAIL {name}: no basis placeholder in customized-label")
             bad += 1
-    for name in LIVE_TITLE:
+    di = t.index("name='Cumulative GPA Monitor'>")
+    dash = t[di : t.index("</dashboard>", di)]
+    for name, zid in LIVE_TITLE.items():
         seg = sheet(t, name)
         ttl = re.search(r"<layout-options>.*?<title>.*?</title>.*?</layout-options>", seg, re.S)
         if not ttl or PLACEHOLDER not in ttl.group(0):
             print(f"  FAIL {name}: no basis placeholder in worksheet title")
             bad += 1
-        elif not seg.lstrip().startswith("<worksheet") or seg.index("<layout-options>") > seg.index("<table>"):
+        elif seg.index("<layout-options>") > seg.index("<table>"):
             print(f"  FAIL {name}: layout-options must precede table")
+            bad += 1
+        zone = re.search(rf"<zone [^>]*id='{zid}'[^>]*>", dash)
+        if not zone:
+            print(f"  FAIL {name}: dashboard zone {zid} not found")
+            bad += 1
+        elif "show-title='true'" not in zone.group(0):
+            print(f"  FAIL {name}: zone {zid} does not show-title, so the title is invisible")
             bad += 1
     for name in FIXED_LABEL:
         seg = sheet(t, name)
@@ -604,9 +640,9 @@ if __name__ == "__main__":
 Run:
 `cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_reminders.py server/cum-1-colour.twb`
 
-Expected: FAIL with 7 lines — 5 missing placeholders, and
-`GPA - BAN Gap to goal` and `GPA - BAN Students needed` reported for having no
-standalone fixed run.
+Expected: FAIL with 10 lines — 5 missing placeholders (2 mark labels, 3
+worksheet titles), 3 zones not showing a title, and `GPA - BAN Gap to goal` and
+`GPA - BAN Students needed` reported for having no standalone fixed run.
 
 - [ ] **Step 3: Write the edit**
 
@@ -648,13 +684,25 @@ text at the em dash, strip trailing whitespace, then insert a break run and a
 fixed run reading `Always projected` in the standard style. Match the em dash as
 the literal character `—`, not a hyphen.
 
-Transform C, for the three body sheets. Insert the title block after
-`<worksheet name='...'>`. All three currently have no `<layout-options>`; assert
-that before inserting, and abort if one appears.
+Transform C, for the three body sheets. Two halves, and both are required:
 
-Preserve CRLF: detect the newline from the source text and use it in every
-inserted line. Parse with `ET.fromstring` before writing. Write with
-`newline=""`.
+1. Insert the title block after `<worksheet name='...'>`. All three currently
+   have no `<layout-options>`; assert that before inserting, and abort if one
+   appears.
+2. In the `Cumulative GPA Monitor` dashboard, flip `show-title='false'` to
+   `show-title='true'` on zones 144, 151 and 152. Task 1's probe proved that
+   without this the title is swallowed and renders as nothing at all. Assert one
+   substitution per zone.
+
+Preserve CRLF properly. `Path.read_text(encoding="utf-8")` applies universal
+newlines, so `"\r\n"` can never appear in the string it returns and any sniff
+for it silently picks `"\n"` — writing then converts all 27,729 CRLF line
+endings in the file to LF. Read AND write with `newline=""` (Python 3.13
+supports it on `Path.read_text`), and build inserted lines with the separator
+detected from the untranslated text. Assert the CRLF count rises by exactly the
+number of lines inserted.
+
+Parse with `ET.fromstring` before writing.
 
 - [ ] **Step 4: Run the edit, the assertion and the checker**
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -921,14 +921,24 @@ Height budget, in the 100000-unit space where 1 pixel is 111.11 units. Set these
 | 800, 810, 820, 830 strips | —       | `4444`  | 0 → 40    |
 | 141, 142                  | `9556`  | `6889`  | 86 → 62   |
 | 143 legend                | `4222`  | `4222`  | 38, moved |
-| 144                       | `36667` | `35111` | 330 → 316 |
+| 144                       | `36667` | `39556` | 330 → 356 |
 | 151                       | `15668` | `13333` | 141 → 120 |
-| 152                       | `44333` | `36000` | 399 → 324 |
+| 152                       | `44333` | `40001` | 399 → 360 |
 
-Body left children then sum to `4444 + 6889 + 6889 + 4444 + 35111 = 57777`, plus
-the legend `4222` nested inside strip 810, giving `62222` less margins. Body
-right sums to `4444 + 13333 + 4444 + 36000 = 58221`. Reconcile both against the
-parent before writing, and let `check_geometry.py` be the judge.
+Both columns sum exactly to their parent:
+
+- left `4444 + 6889 + 6889 + 4444 + 39556 = 62222`
+- right `4444 + 13333 + 4444 + 40001 = 62222`
+
+Legend zone 143 keeps `h='4222'` and sits horizontally beside the text zone
+inside strip 810, so it consumes no vertical space of its own — strip 810 at
+`4444` is 222 units taller than the legend it holds.
+
+`GPA - Dist by grade` gains height rather than losing it, because folding the
+standalone legend into a header strip frees more than the strips cost. The
+spec's budget prose predicted a small cut; the reconciled arithmetic is better
+than that. `check_geometry.py` from Task 4 is the judge — if these values do not
+satisfy it, fix the values, not the checker.
 
 - [ ] **Step 1: Write the failing assertion**
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -1,0 +1,1127 @@
+# Cumulative GPA Monitor cards, captions and basis reminder — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every chart on the Cumulative GPA Monitor a title and a caption,
+state the GPA basis at every panel that depends on it, and repoint the goal
+colours to the Gradebook Fidelity met and not-met pair.
+
+**Architecture:** The deliverable is a Tableau workbook, not repository code.
+Each task runs a Python script over the workbook XML in
+`.claude/scratch/gpa-overnight/`, then proves the result with an assertion
+script that fails before the edit and passes after. Content changes land before
+geometry changes, so a layout break bisects cleanly. Nothing publishes to
+`Production`.
+
+**Tech Stack:** Python 3 standard library (`re`, `xml.etree.ElementTree`,
+`zipfile`), `tableauserverclient` for download, publish and render, `pytest` for
+anything needing credentials.
+
+**Spec:**
+`docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md`
+
+## Global Constraints
+
+Never publish to the Tableau `Production` project, for any reason, at any step.
+
+Publish only to `GPA-monitor-temp`, project id
+`c74d8e08-b856-4430-a759-ebacb061e376`.
+
+Publish with `show_tabs=True` and the extract included. A publish call that
+omits the extract produces a 187 KB file instead of a 30 MB one.
+
+Insert into `<document-format-change-manifest>`, never rebuild it.
+
+The paragraph break inside `<formatted-text>` is the literal run
+`<run>Æ&#10;</run>`. It must be byte-exact.
+
+The workbook file uses CRLF line endings. Read and write with `encoding="utf-8"`
+and never normalise newlines.
+
+Working directory for all scripts and artifacts:
+`/workspaces/teamster/.claude/scratch/gpa-overnight/`, workbooks under its
+`server/` subdirectory. This path is gitignored.
+
+Credentialed work runs under pytest. A throwaway `tests/**/test_zz_*.py` gets
+1Password secrets from the autouse fixture in `tests/conftest.py`; a plain
+`uv run python` does not. Write those files with the Write tool, never a Bash
+heredoc — a heredoc containing `os.environ` trips the sensitive-path hook.
+Delete the throwaway file when the task ends.
+
+Repository commits carry this plan's checkboxes and result notes only. The
+workbook artifacts live in gitignored scratch.
+
+Assertion scripts are given here in full, and they are the contract. Edit
+scripts are specified — exact anchors, exact XML, exact invariants — but not
+pre-written, because the anchors have to be located against the real file and
+pre-writing untested code would assert it works without having run it. Write the
+assertion first, watch it fail, then write whatever edit makes it pass.
+
+Tableau environment variable names, for the pytest helper:
+`TABLEAU_SERVER_ADDRESS`, `TABLEAU_SITE_ID`, `TABLEAU_TOKEN_NAME`,
+`TABLEAU_PERSONAL_ACCESS_TOKEN`.
+
+Constants used across tasks:
+
+| Name             | Value                                     |
+| ---------------- | ----------------------------------------- |
+| Workbook LUID    | `b3c14d67-3130-46ac-82a0-0637a5cc2da5`    |
+| Dashboard        | `Cumulative GPA Monitor`                  |
+| View LUID        | `6b9d6b16-d63c-4976-ac22-358f3c0759c5`    |
+| Datasource id    | `federated.0n798br073i5kb170j6l90uiv50a`  |
+| Basis parameter  | `[Parameter 11]`, caption `GPA basis`     |
+| Basis members    | `"Projected EOY"`, `"On the books today"` |
+| Goal colour calc | `Calculation_7236501339153214575`         |
+
+---
+
+### Task 0: Re-pull production and establish the base
+
+The copy on disk is from 15:52 on 2026-09-08. Production may have moved. Every
+later task builds on this task's output.
+
+**Files:**
+
+- Create: `tests/tableau/test_zz_pull.py` (throwaway, deleted in step 5)
+- Create: `.claude/scratch/gpa-overnight/server/prod-base3.twbx`
+- Create: `.claude/scratch/gpa-overnight/server/prod-base3.twb`
+
+**Interfaces:**
+
+- Produces: `server/prod-base3.twb`, the unmodified production XML that Tasks 2,
+  3 and 5 edit in sequence. `server/prod-base3.twbx`, the donor archive whose
+  extract Task 6 repacks around the final XML.
+
+- [ ] **Step 1: Write the download helper**
+
+Write this with the Write tool to `tests/tableau/test_zz_pull.py`:
+
+```python
+import os
+import zipfile
+from pathlib import Path
+
+import tableauserverclient as tsc
+
+OUT = Path("/workspaces/teamster/.claude/scratch/gpa-overnight/server")
+WORKBOOK_LUID = "b3c14d67-3130-46ac-82a0-0637a5cc2da5"
+
+
+def _server():
+    auth = tsc.PersonalAccessTokenAuth(
+        token_name=os.environ["TABLEAU_TOKEN_NAME"],
+        personal_access_token=os.environ["TABLEAU_PERSONAL_ACCESS_TOKEN"],
+        site_id=os.environ["TABLEAU_SITE_ID"],
+    )
+    server = tsc.Server(os.environ["TABLEAU_SERVER_ADDRESS"], use_server_version=True)
+    return server, auth
+
+
+def test_pull():
+    server, auth = _server()
+    with server.auth.sign_in(auth):
+        wb = server.workbooks.get_by_id(WORKBOOK_LUID)
+        print(f"PROJECT: {wb.project_name}")
+        print(f"UPDATED: {wb.updated_at}")
+        path = server.workbooks.download(
+            WORKBOOK_LUID, filepath=str(OUT / "prod-base3.twbx"), include_extract=True
+        )
+        print(f"DOWNLOADED: {path}")
+
+    twbx = OUT / "prod-base3.twbx"
+    assert twbx.stat().st_size > 20_000_000, twbx.stat().st_size
+    with zipfile.ZipFile(twbx) as z:
+        name = next(n for n in z.namelist() if n.endswith(".twb"))
+        (OUT / "prod-base3.twb").write_bytes(z.read(name))
+    print(f"EXTRACTED: {(OUT / 'prod-base3.twb').stat().st_size} bytes")
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/tableau/test_zz_pull.py -s`
+
+Expected: PASS. Record the printed `PROJECT`, `UPDATED` and byte sizes — they go
+in the commit note. `PROJECT` must read `Production`.
+
+- [ ] **Step 3: Diff the base against the previous pull**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight/server && python3 - <<'PY'
+import re
+a = open('prod-base2.twb', encoding='utf-8').read()
+b = open('prod-base3.twb', encoding='utf-8').read()
+for label, pat in (("worksheets", r"<worksheet name='([^']*)'"),
+                   ("parameters", r"<column caption='([^']*)'[^>]*name='\[Parameter \d+\]'")):
+    sa, sb = set(re.findall(pat, a)), set(re.findall(pat, b))
+    print(f"{label}: {len(sa)} -> {len(sb)}")
+    for x in sorted(sa - sb): print(f"   GONE: {x}")
+    for x in sorted(sb - sa): print(f"   NEW:  {x}")
+print("school filter zones:", len(re.findall(r"filter-group='17'", b)))
+PY
+```
+
+Expected: no `GONE` lines, and `school filter zones` at least 17. A `GONE` line
+means production changed in a way this plan did not anticipate — stop and report
+rather than proceeding.
+
+- [ ] **Step 4: Baseline the structural checker**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python check_twb.py server/prod-base3.twb --ref server/prod-base2.twb
+```
+
+Expected: clean. This is the reference result every later task must still
+produce.
+
+- [ ] **Step 5: Delete the throwaway and commit**
+
+```bash
+rm -f /workspaces/teamster/tests/tableau/test_zz_pull.py
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-cum-monitor-cards-captions add docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-cum-monitor-cards-captions commit -m "docs(tableau): record the production base for the Cumulative GPA Monitor rebuild"
+```
+
+Tick this task's boxes and append the recorded `UPDATED` timestamp and byte
+sizes under the task heading before committing.
+
+---
+
+### Task 1: Probe the parameter placeholder — GATE
+
+The whole reminder design rests on `<[Parameters].[Parameter 11]>` resolving
+inside a worksheet title. That syntax is inferred from the field placeholders
+already in the workbook. No parameter placeholder exists in this file yet.
+
+**Do not start Task 3 until this task passes.** If it fails, stop and report.
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/probe_placeholder.py`
+- Create: `.claude/scratch/gpa-overnight/server/probe.twb`, `server/probe.twbx`
+- Create: `tests/tableau/test_zz_probe.py` (throwaway, deleted in step 5)
+
+**Interfaces:**
+
+- Consumes: `server/prod-base3.twb` from Task 0.
+- Produces: a yes or no answer, recorded in the plan. Produces no artifact any
+  later task depends on.
+
+- [ ] **Step 1: Write the probe edit**
+
+Write `.claude/scratch/gpa-overnight/probe_placeholder.py`:
+
+```python
+"""Add one parameter-placeholder title to one sheet, to prove the syntax."""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+D = Path("/workspaces/teamster/.claude/scratch/gpa-overnight/server")
+SHEET = "GPA - Goal by grade"
+TITLE = (
+    "      <layout-options>\n"
+    "        <title>\n"
+    "          <formatted-text>\n"
+    "            <run fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'>"
+    "<![CDATA[PROBE <[Parameters].[Parameter 11]>]]></run>\n"
+    "          </formatted-text>\n"
+    "        </title>\n"
+    "      </layout-options>\n"
+)
+
+
+def main(src, dst):
+    t = (D / src).read_text(encoding="utf-8")
+    anchor = f"<worksheet name='{SHEET}'>"
+    if anchor not in t:
+        sys.exit(f"FAIL: {SHEET} not found")
+    if t.count(anchor) != 1:
+        sys.exit(f"FAIL: {SHEET} anchor matched {t.count(anchor)} times")
+    i = t.index(anchor) + len(anchor)
+    nl = "\r\n" if "\r\n" in t[:2000] else "\n"
+    t = t[:i] + nl + TITLE.replace("\n", nl).rstrip(nl) + t[i:]
+    ET.fromstring(t)
+    (D / dst).write_text(t, encoding="utf-8", newline="")
+    print(f"wrote {dst}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+```
+
+- [ ] **Step 2: Run it and repack**
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python probe_placeholder.py prod-base3.twb probe.twb && \
+  uv run python check_twb.py server/probe.twb --ref server/prod-base3.twb && \
+  uv run python repack_task.py server/probe.twb prod-base3.twbx probe.twbx
+```
+
+Expected: checker clean, `probe.twbx` over 20 MB.
+
+- [ ] **Step 3: Write the publish-and-render probe**
+
+Write with the Write tool to `tests/tableau/test_zz_probe.py`:
+
+```python
+import os
+from pathlib import Path
+
+import tableauserverclient as tsc
+
+D = Path("/workspaces/teamster/.claude/scratch/gpa-overnight/server")
+TEMP_PROJECT = "c74d8e08-b856-4430-a759-ebacb061e376"
+
+
+def test_probe():
+    auth = tsc.PersonalAccessTokenAuth(
+        token_name=os.environ["TABLEAU_TOKEN_NAME"],
+        personal_access_token=os.environ["TABLEAU_PERSONAL_ACCESS_TOKEN"],
+        site_id=os.environ["TABLEAU_SITE_ID"],
+    )
+    server = tsc.Server(os.environ["TABLEAU_SERVER_ADDRESS"], use_server_version=True)
+    with server.auth.sign_in(auth):
+        item = tsc.WorkbookItem(project_id=TEMP_PROJECT, name="ZZ-PROBE placeholder", show_tabs=True)
+        item = server.workbooks.publish(
+            item, str(D / "probe.twbx"), mode=tsc.Server.PublishMode.Overwrite
+        )
+        assert item.project_id == TEMP_PROJECT, item.project_name
+        print(f"PUBLISHED: {item.id} into {item.project_name}")
+
+        server.workbooks.populate_views(item)
+        view = next(v for v in item.views if v.name == "Cumulative GPA Monitor")
+        for value in ("Projected EOY", "On the books today"):
+            opts = tsc.ImageRequestOptions(imageresolution=tsc.ImageRequestOptions.Resolution.High)
+            opts.parameter("GPA basis", value)
+            server.views.populate_image(view, opts)
+            out = D / f"probe-{value.split()[0].lower()}.png"
+            out.write_bytes(view.image)
+            print(f"RENDERED {value}: {out} {out.stat().st_size} bytes")
+```
+
+- [ ] **Step 4: Run it and read the images**
+
+Run: `uv run pytest tests/tableau/test_zz_probe.py -s`
+
+Then open both PNGs with the Read tool and look at the `% at 3.0+ by grade`
+panel.
+
+PASS means one image reads `PROBE Projected EOY` and the other reads
+`PROBE On the books today`.
+
+FAIL means the literal text `PROBE <[Parameters].[Parameter 11]>` appears, or
+the title is empty. On FAIL, stop. Record which of these it was, then report to
+the user. Fallbacks in the spec, in order: caption-style syntax, native axis
+titles plus a badge worksheet, fixed text.
+
+- [ ] **Step 5: Delete the throwaway and commit the answer**
+
+```bash
+rm -f /workspaces/teamster/tests/tableau/test_zz_probe.py
+```
+
+Append a `**Result:**` line under this task's heading recording PASS or FAIL and
+the exact rendered string, then commit the plan.
+
+---
+
+### Task 2: Repoint the goal colours
+
+Smallest change, and independently visible in a render. Goes first among the
+edits so a colour regression cannot hide behind a text or layout change.
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/task_cum_colour.py`
+- Create: `.claude/scratch/gpa-overnight/assert_cum_colour.py`
+- Create: `.claude/scratch/gpa-overnight/server/cum-1-colour.twb`
+
+**Interfaces:**
+
+- Consumes: `server/prod-base3.twb` from Task 0.
+- Produces: `server/cum-1-colour.twb`, consumed by Task 3.
+
+- [ ] **Step 1: Write the failing assertion**
+
+Write `.claude/scratch/gpa-overnight/assert_cum_colour.py`:
+
+```python
+"""Assert the Cumulative goal encoding uses the fidelity met / not-met pair."""
+
+import re
+import sys
+from pathlib import Path
+
+CALC = "Calculation_7236501339153214575"
+WANT = {"At or above goal": "#12a47c", "Below goal": "#b3161c",
+        "Not yet measured": "#b6c0cf"}
+BANNED = {"#2f5fc4", "#d8342f"}
+
+
+def main(path):
+    t = Path(path).read_text(encoding="utf-8")
+    m = re.search(rf"<encoding attr='color'[^>]*{CALC}[^>]*>(.*?)</encoding>", t, re.S)
+    if not m:
+        sys.exit(f"FAIL: no colour encoding for {CALC}")
+    got = dict(
+        (b.replace("&quot;", ""), to)
+        for to, b in re.findall(r"<map to='([^']*)'>\s*<bucket>([^<]*)</bucket>", m.group(1))
+    )
+    bad = 0
+    for member, want in WANT.items():
+        if got.get(member) != want:
+            print(f"  FAIL {member}: {got.get(member)} != {want}")
+            bad += 1
+    for member, hexv in got.items():
+        if hexv in BANNED:
+            print(f"  FAIL {member} still on retired colour {hexv}")
+            bad += 1
+    if bad:
+        sys.exit(f"{bad} colour failures")
+    print(f"  OK: {CALC} on {WANT['At or above goal']} / {WANT['Below goal']}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+`cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_colour.py server/prod-base3.twb`
+
+Expected: FAIL, reporting `At or above goal: #2f5fc4 != #12a47c` and
+`Below goal: #d8342f != #b3161c`.
+
+- [ ] **Step 3: Write the edit**
+
+Write `.claude/scratch/gpa-overnight/task_cum_colour.py`:
+
+```python
+"""Repoint the Cumulative GPA Monitor goal colours to the fidelity pair.
+
+Scoped to Calculation_7236501339153214575, which colours GPA - Goal by grade,
+GPA - Goal by school and GPA - BAN Gap to goal. The Academic Health Home twin,
+Calculation_4005670422418128910, keeps blue and red and is not touched here.
+"""
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+D = Path("/workspaces/teamster/.claude/scratch/gpa-overnight/server")
+CALC = "Calculation_7236501339153214575"
+SWAP = {"At or above goal": ("#2f5fc4", "#12a47c"), "Below goal": ("#d8342f", "#b3161c")}
+
+
+def main(src, dst):
+    t = (D / src).read_text(encoding="utf-8")
+    m = re.search(rf"<encoding attr='color'[^>]*{CALC}[^>]*>.*?</encoding>", t, re.S)
+    if not m:
+        sys.exit(f"FAIL: no colour encoding for {CALC}")
+    block = m.group(0)
+    new = block
+    for member, (old, want) in SWAP.items():
+        pat = rf"(<map to=')({re.escape(old)})('>\s*<bucket>&quot;{re.escape(member)}&quot;</bucket>)"
+        new, n = re.subn(pat, rf"\g<1>{want}\g<3>", new)
+        if n != 1:
+            sys.exit(f"FAIL: {member} matched {n} times, expected 1")
+        print(f"  {member}: {old} -> {want}")
+    t = t[: m.start()] + new + t[m.end() :]
+    ET.fromstring(t)
+    (D / dst).write_text(t, encoding="utf-8", newline="")
+    print(f"  wrote {dst}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+```
+
+- [ ] **Step 4: Run the edit, then the assertion and the checker**
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python task_cum_colour.py prod-base3.twb cum-1-colour.twb && \
+  uv run python assert_cum_colour.py server/cum-1-colour.twb && \
+  uv run python check_twb.py server/cum-1-colour.twb --ref server/prod-base3.twb
+```
+
+Expected: the edit prints both swaps, the assertion prints `OK`, the checker is
+clean.
+
+- [ ] **Step 5: Confirm the Academic Health twin is untouched**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight/server && python3 - <<'PY'
+import re
+t = open('cum-1-colour.twb', encoding='utf-8').read()
+m = re.search(r"<encoding attr='color'[^>]*Calculation_4005670422418128910[^>]*>.*?</encoding>", t, re.S)
+print(dict((b.replace('&quot;',''), to) for to, b in
+           re.findall(r"<map to='([^']*)'>\s*<bucket>([^<]*)</bucket>", m.group(0))))
+PY
+```
+
+Expected: `At or above goal` still `#2f5fc4`, `Below goal` still `#d8342f`.
+
+- [ ] **Step 6: Commit**
+
+Tick the boxes, then commit the plan with message
+`docs(tableau): record the Cumulative goal colour repoint`.
+
+---
+
+### Task 3: Add the basis reminders
+
+Nine text edits, no zone moves. The whole content layer becomes readable in a
+render before any geometry changes.
+
+Two flavours. Live means the parameter placeholder. Fixed means literal text.
+Both use the same run formatting, copied from `GPA - BAN Below 3.0`:
+
+```xml
+<run fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'>Always projected</run>
+```
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/task_cum_reminders.py`
+- Create: `.claude/scratch/gpa-overnight/assert_cum_reminders.py`
+- Create: `.claude/scratch/gpa-overnight/server/cum-2-reminders.twb`
+
+**Interfaces:**
+
+- Consumes: `server/cum-1-colour.twb` from Task 2.
+- Produces: `server/cum-2-reminders.twb`, consumed by Task 5.
+
+The edits, exhaustively:
+
+| Sheet                       | Where              | Content                                |
+| --------------------------- | ------------------ | -------------------------------------- |
+| `GPA - BAN % 3.5+`          | `customized-label` | live placeholder, new middle line      |
+| `GPA - BAN % 3.0+`          | `customized-label` | live placeholder, new middle line      |
+| `GPA - BAN Gap to goal`     | `customized-label` | split `Always projected` onto own line |
+| `GPA - BAN Students needed` | `customized-label` | split `Always projected` onto own line |
+| `GPA - Dist by grade`       | worksheet `title`  | live placeholder                       |
+| `GPA - Goal by grade`       | worksheet `title`  | live placeholder                       |
+| `GPA - Goal by school`      | worksheet `title`  | live placeholder                       |
+
+`GPA - BAN Below 3.0` and `GPA - BAN Can reach` already carry the fixed line in
+the right place and are not edited.
+
+- [ ] **Step 1: Write the failing assertion**
+
+Write `.claude/scratch/gpa-overnight/assert_cum_reminders.py`:
+
+```python
+"""Assert every basis-dependent panel states its basis."""
+
+import re
+import sys
+from pathlib import Path
+
+PLACEHOLDER = "<[Parameters].[Parameter 11]>"
+FIXED = "Always projected"
+STYLE = "fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'"
+
+LIVE_LABEL = ["GPA - BAN % 3.5+", "GPA - BAN % 3.0+"]
+LIVE_TITLE = ["GPA - Dist by grade", "GPA - Goal by grade", "GPA - Goal by school"]
+FIXED_LABEL = ["GPA - BAN Below 3.0", "GPA - BAN Can reach",
+               "GPA - BAN Gap to goal", "GPA - BAN Students needed"]
+
+
+def sheet(t, name):
+    i = t.index(f"<worksheet name='{name}'")
+    return t[i : t.index("</worksheet>", i)]
+
+
+def main(path):
+    t = Path(path).read_text(encoding="utf-8")
+    bad = 0
+    for name in LIVE_LABEL:
+        seg = sheet(t, name)
+        lab = re.search(r"<customized-label>.*?</customized-label>", seg, re.S)
+        if not lab or PLACEHOLDER not in lab.group(0):
+            print(f"  FAIL {name}: no basis placeholder in customized-label")
+            bad += 1
+    for name in LIVE_TITLE:
+        seg = sheet(t, name)
+        ttl = re.search(r"<layout-options>.*?<title>.*?</title>.*?</layout-options>", seg, re.S)
+        if not ttl or PLACEHOLDER not in ttl.group(0):
+            print(f"  FAIL {name}: no basis placeholder in worksheet title")
+            bad += 1
+        elif not seg.lstrip().startswith("<worksheet") or seg.index("<layout-options>") > seg.index("<table>"):
+            print(f"  FAIL {name}: layout-options must precede table")
+            bad += 1
+    for name in FIXED_LABEL:
+        seg = sheet(t, name)
+        lab = re.search(r"<customized-label>.*?</customized-label>", seg, re.S)
+        runs = re.findall(r"<run ([^>]*)>([^<]*)</run>", lab.group(0)) if lab else []
+        if not any(FIXED.lower() in text.lower() and STYLE in attrs for attrs, text in runs):
+            print(f"  FAIL {name}: no standalone '{FIXED}' run in the standard style")
+            bad += 1
+    if bad:
+        sys.exit(f"{bad} reminder failures")
+    print(f"  OK: {len(LIVE_LABEL) + len(LIVE_TITLE)} live, {len(FIXED_LABEL)} fixed")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+`cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_reminders.py server/cum-1-colour.twb`
+
+Expected: FAIL with 7 lines — 5 missing placeholders, and
+`GPA - BAN Gap to goal` and `GPA - BAN Students needed` reported for having no
+standalone fixed run.
+
+- [ ] **Step 3: Write the edit**
+
+Write `.claude/scratch/gpa-overnight/task_cum_reminders.py`. It performs three
+distinct transforms. Every anchor must match exactly once; abort otherwise.
+
+The break run, byte-exact, is `<run>Æ&#10;</run>`.
+
+The live run to insert:
+
+```xml
+<run fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'><![CDATA[<[Parameters].[Parameter 11]>]]></run>
+```
+
+The worksheet title block, inserted immediately after `<worksheet name='...'>`
+and therefore before `<table>`, because the content model is
+`((layout-options?|repository-location?), table, simple-id)`:
+
+```xml
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'><![CDATA[<[Parameters].[Parameter 11]>]]></run>
+          </formatted-text>
+        </title>
+      </layout-options>
+```
+
+Transform A, for `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+`. Inside the sheet's
+`<customized-label>`, find the first `<run>Æ&#10;</run>` — the break between the
+13 point label and the 30 point number — and insert the live run plus a second
+break run immediately after it. Result order: label, break, basis, break,
+number.
+
+Transform B, for `GPA - BAN Gap to goal` and `GPA - BAN Students needed`. Their
+first run reads `Gap to goal, pts — always projected` and
+`Students still needed — always projected`. Split each: truncate the first run's
+text at the em dash, strip trailing whitespace, then insert a break run and a
+fixed run reading `Always projected` in the standard style. Match the em dash as
+the literal character `—`, not a hyphen.
+
+Transform C, for the three body sheets. Insert the title block after
+`<worksheet name='...'>`. All three currently have no `<layout-options>`; assert
+that before inserting, and abort if one appears.
+
+Preserve CRLF: detect the newline from the source text and use it in every
+inserted line. Parse with `ET.fromstring` before writing. Write with
+`newline=""`.
+
+- [ ] **Step 4: Run the edit, the assertion and the checker**
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python task_cum_reminders.py cum-1-colour.twb cum-2-reminders.twb && \
+  uv run python assert_cum_reminders.py server/cum-2-reminders.twb && \
+  uv run python check_twb.py server/cum-2-reminders.twb --ref server/prod-base3.twb
+```
+
+Expected: assertion prints `OK: 5 live, 4 fixed`, checker clean.
+
+- [ ] **Step 5: Confirm the break run survived byte-exact**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight/server && \
+  grep -c '<run>Æ&#10;</run>' prod-base3.twb cum-2-reminders.twb
+```
+
+Expected: the second count is higher than the first by exactly the number of
+break runs the edit added, and no other value. Record both numbers.
+
+- [ ] **Step 6: Commit**
+
+Tick the boxes, then commit the plan with message
+`docs(tableau): record the Cumulative basis reminders`.
+
+---
+
+### Task 4: Build the geometry checker
+
+The card restructure re-parents nine zones. No existing checker catches a zone
+at the wrong nesting level, which is valid XML that renders as an overlap. Write
+the checker before the change it guards.
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/check_geometry.py`
+
+**Interfaces:**
+
+- Consumes: any `.twb` path plus a dashboard name.
+- Produces: `check_geometry.py`, run by Task 5 and Task 6. Exits non-zero on any
+  violation.
+
+- [ ] **Step 1: Write the checker**
+
+Write `.claude/scratch/gpa-overnight/check_geometry.py`:
+
+```python
+"""Assert dashboard zone geometry is internally consistent.
+
+Three invariants, none of which any schema check covers:
+
+1. Siblings in a layout-flow do not overlap.
+2. A flow container's children sum to the container along the flow axis.
+3. The top-level zone spans the full 100000-unit canvas.
+
+Usage: uv run python check_geometry.py <twb> "<dashboard name>"
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+TOL = 40  # units; 100000 units is 900px, so 40 units is under half a pixel
+
+
+def rect(z):
+    return tuple(int(z.get(k, 0)) for k in ("x", "y", "w", "h"))
+
+
+def overlaps(a, b):
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    return ax < bx + bw and bx < ax + aw and ay < by + bh and by < ay + ah
+
+
+def walk(z, path, bad):
+    kids = [c for c in z.findall("zone") if not c.get("hidden-by-user")]
+    for i, a in enumerate(kids):
+        for b in kids[i + 1 :]:
+            if overlaps(rect(a), rect(b)):
+                bad.append(f"overlap at {path}: zone {a.get('id')} and zone {b.get('id')}")
+    flow = z.get("param")
+    if kids and z.get("type-v2") == "layout-flow" and flow in ("vert", "horz"):
+        idx = 3 if flow == "vert" else 2
+        total = sum(rect(c)[idx] for c in kids)
+        want = rect(z)[idx]
+        if abs(total - want) > TOL * len(kids):
+            bad.append(
+                f"children of zone {z.get('id')} ({flow}) sum to {total}, parent is {want}"
+            )
+    for c in kids:
+        walk(c, f"{path}/{z.get('id')}", bad)
+
+
+def main(path, dashboard):
+    root = ET.parse(path).getroot()
+    dash = next(d for d in root.find("dashboards") if d.get("name") == dashboard)
+    bad = []
+    tops = dash.find("zones").findall("zone")
+    for z in tops:
+        if z.get("hidden-by-user"):
+            continue
+        x, y, w, h = rect(z)
+        if (x, y, w, h) != (0, 0, 100000, 100000) and z.get("type-v2") == "layout-basic":
+            bad.append(f"top-level layout-basic zone {z.get('id')} is {x},{y},{w},{h}")
+        walk(z, "", bad)
+    for line in bad:
+        print(f"  FAIL {line}")
+    if bad:
+        sys.exit(f"{len(bad)} geometry failures in '{dashboard}'")
+    print(f"  OK: geometry consistent in '{dashboard}'")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])
+```
+
+- [ ] **Step 2: Prove it passes on known-good input**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python check_geometry.py server/prod-base3.twb "Cumulative GPA Monitor" && \
+  uv run python check_geometry.py server/prod-base3.twb "Academic Health Home"
+```
+
+Expected: both print `OK`. A checker that fails on production is a broken
+checker, not a finding — fix the checker.
+
+- [ ] **Step 3: Prove it catches a real fault**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && python3 - <<'PY'
+import re, pathlib
+p = pathlib.Path('server/prod-base3.twb')
+t = p.read_text(encoding='utf-8')
+i = t.index("<dashboard enable-sort-zone-taborder='true' name='Cumulative GPA Monitor'>")
+j = t.index("<zone h='15333'", i)
+broken = t[:j] + t[j:].replace("<zone h='15333'", "<zone h='45333'", 1)
+pathlib.Path('server/zz-broken.twb').write_text(broken, encoding='utf-8', newline='')
+print('wrote server/zz-broken.twb')
+PY
+uv run python check_geometry.py server/zz-broken.twb "Cumulative GPA Monitor"; echo "exit=$?"
+rm -f server/zz-broken.twb
+```
+
+Expected: non-zero exit with at least one `FAIL` line. A checker that passes the
+broken file is useless — fix it and repeat.
+
+- [ ] **Step 4: Commit**
+
+Tick the boxes, then commit the plan with message
+`docs(tableau): record the dashboard geometry checker`.
+
+---
+
+### Task 5: Restructure into cards with header strips
+
+The riskiest task, deliberately last among the edits.
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/task_cum_cards.py`
+- Create: `.claude/scratch/gpa-overnight/assert_cum_cards.py`
+- Create: `.claude/scratch/gpa-overnight/server/cum-3-cards.twb`
+
+**Interfaces:**
+
+- Consumes: `server/cum-2-reminders.twb` from Task 3, `check_geometry.py` from
+  Task 4.
+- Produces: `server/cum-3-cards.twb`, consumed by Task 6.
+
+Target structure. Existing zone ids in the Cumulative GPA Monitor: title strip
+5, controls 10, headline 20 holding BANs 124, 120, 121, 122; goal strip 30
+holding text 130 and BANs 131, 132; body 35 holding body-left 40 (sheets 141,
+142, legend 143, 144) and body-right 50 (sheets 151, 152). New zones take ids
+from 800 up, which are unused.
+
+```text
+zone 4  layout-basic        margin 8                       (edit: add margin)
+  zone 3  layout-flow vert
+    zone 5   Title                                          (unchanged)
+    zone 10  Controls        background-color #f5f5f5       (edit)
+    zone 20  Headline        border #001e62 1pt, margin 5   (edit: card)
+    zone 30  Goal strip      border #001e62 1pt, margin 5   (edit: card)
+    zone 35  Body
+      zone 40  Body left     border #001e62 1pt, margin 5   (edit: card)
+        zone 800 header strip  bg #e6e6e6                   (new)
+          zone 801 text                                     (new)
+        zone 141                                            (unchanged)
+        zone 142                                            (unchanged)
+        zone 810 header strip  bg #e6e6e6                   (new)
+          zone 811 text                                     (new)
+          zone 143 legend                                   (moved in)
+        zone 144                                            (unchanged)
+      zone 50  Body right    border #001e62 1pt, margin 5   (edit: card)
+        zone 820 header strip  bg #e6e6e6                   (new)
+          zone 821 text                                     (new)
+        zone 151                                            (unchanged)
+        zone 830 header strip  bg #e6e6e6                   (new)
+          zone 831 text                                     (new)
+        zone 152                                            (unchanged)
+```
+
+Header strip template. Substitute the id, geometry, title and caption:
+
+```xml
+              <zone fixed-size='40' h='{H}' id='{SID}' is-fixed='true' param='horz' type-v2='layout-flow' w='{W}' x='{X}' y='{Y}'>
+                <zone fixed-size='40' forceUpdate='true' h='{H}' id='{TID}' is-fixed='true' type-v2='text' w='{W}' x='{X}' y='{Y}'>
+                  <formatted-text>
+                    <run bold='true' fontcolor='#000000' fontname='Arial'>{TITLE}</run>
+                    <run>Æ&#10;</run>
+                    <run fontcolor='#000000' fontname='Arial' fontsize='8' italic='true'>{CAPTION}</run>
+                  </formatted-text>
+                  <zone-style>
+                    <format attr='border-color' value='#000000' />
+                    <format attr='border-style' value='none' />
+                    <format attr='border-width' value='0' />
+                    <format attr='margin' value='4' />
+                  </zone-style>
+                </zone>
+                <zone-style>
+                  <format attr='border-color' value='#000000' />
+                  <format attr='border-style' value='none' />
+                  <format attr='border-width' value='0' />
+                  <format attr='background-color' value='#e6e6e6' />
+                </zone-style>
+              </zone>
+```
+
+Card style, appended to zones 20, 30, 40 and 50, replacing their existing
+`zone-style` if present:
+
+```xml
+                <zone-style>
+                  <format attr='border-color' value='#001e62' />
+                  <format attr='border-style' value='solid' />
+                  <format attr='border-width' value='1' />
+                  <format attr='margin' value='5' />
+                </zone-style>
+```
+
+Content model reminder:
+`zone = (formatted-text, layout-cache?, zone, flipboard, zone-style?)`. Child
+zones come before the container's own `zone-style`. The container's style
+indents 14 spaces and its children's 16.
+
+Title and caption strings, verbatim:
+
+| Strip | Title                          | Caption                                                                                                        |
+| ----- | ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| 800   | `Band mix, network`            | `On the books today above, projected to year end below. This panel shows both, whatever the switch is set to.` |
+| 810   | `Band mix by grade`            | `The same bands, split by grade.`                                                                              |
+| 820   | `% at 3.0+ by grade`           | `Share of students at a 3.0 cumulative or better. The grey tick is the network goal for that grade.`           |
+| 830   | `Gap to goal, school by grade` | `Bar length is % at 3.0+; the label is the gap in points; the grey tick is that school's own goal.`            |
+
+Zone 130's existing text run gets a caption line appended in the same style, so
+the goal strip reads `Progress against the goal` over
+`Always projected, against the network goal — or the selected region's goal.`
+
+One more edit, outside the zone tree. The `GPA - Title` worksheet's `<caption>`
+currently ends with the hedge
+`Projected end-of-year unless the basis switch is set to on the books today.`
+Every panel now states its own basis, so delete that sentence and leave the rest
+of the caption intact. Assert the remaining caption still starts
+`Cumulative unweighted GPA against each grade's goal`.
+
+Height budget, in the 100000-unit space where 1 pixel is 111.11 units. Set these
+`h` values and recompute every `y` beneath them:
+
+| Zone                      | Old h   | New h   | Pixels    |
+| ------------------------- | ------- | ------- | --------- |
+| 30 goal strip             | `8667`  | `7333`  | 78 → 66   |
+| 35 body                   | `61777` | `63111` | 556 → 568 |
+| 40 body left, 50 right    | `60889` | `62222` | 548 → 560 |
+| 800, 810, 820, 830 strips | —       | `4444`  | 0 → 40    |
+| 141, 142                  | `9556`  | `6889`  | 86 → 62   |
+| 143 legend                | `4222`  | `4222`  | 38, moved |
+| 144                       | `36667` | `35111` | 330 → 316 |
+| 151                       | `15668` | `13333` | 141 → 120 |
+| 152                       | `44333` | `36000` | 399 → 324 |
+
+Body left children then sum to `4444 + 6889 + 6889 + 4444 + 35111 = 57777`, plus
+the legend `4222` nested inside strip 810, giving `62222` less margins. Body
+right sums to `4444 + 13333 + 4444 + 36000 = 58221`. Reconcile both against the
+parent before writing, and let `check_geometry.py` be the judge.
+
+- [ ] **Step 1: Write the failing assertion**
+
+Write `.claude/scratch/gpa-overnight/assert_cum_cards.py`. It asserts, against
+the `Cumulative GPA Monitor` dashboard:
+
+- Zones 20, 30, 40 and 50 each carry `border-style` `solid`, `border-color`
+  `#001e62`, `border-width` `1`.
+- Zones 800, 810, 820 and 830 exist, are `layout-flow` with `param='horz'`, and
+  carry `background-color` `#e6e6e6`.
+- Zones 801, 811, 821 and 831 exist, are `type-v2='text'`, and each contains
+  exactly 3 runs whose second is the byte-exact break run.
+- The four title strings and four caption strings appear exactly once each.
+- Zone 143 is a descendant of zone 810, not of zone 40 directly.
+- Zone 4 carries `margin` `8`; zone 10 carries `background-color` `#f5f5f5`.
+- In every `zone-style`, no child `zone` element follows it within the same
+  parent.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+`cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_cards.py server/cum-2-reminders.twb`
+
+Expected: FAIL on every assertion above.
+
+- [ ] **Step 3: Write the edit**
+
+Write `.claude/scratch/gpa-overnight/task_cum_cards.py`, operating only within
+the `Cumulative GPA Monitor` dashboard element and only on its `<zones>` block,
+not the `<devicelayouts>` copy.
+
+Guard against the variable-shadowing bug that truncated a workbook from 1.45M to
+143k characters on 2026-09-08: never reuse the name of an outer regex match
+object inside a loop. Assert the output length is within 20 percent of the input
+length before writing.
+
+Assert every anchor matches exactly once. Parse with `ET.fromstring` before
+writing. Write with `newline=""`.
+
+- [ ] **Step 4: Run the edit and all three checkers**
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python task_cum_cards.py cum-2-reminders.twb cum-3-cards.twb && \
+  uv run python assert_cum_cards.py server/cum-3-cards.twb && \
+  uv run python assert_cum_reminders.py server/cum-3-cards.twb && \
+  uv run python assert_cum_colour.py server/cum-3-cards.twb && \
+  uv run python check_geometry.py server/cum-3-cards.twb "Cumulative GPA Monitor" && \
+  uv run python check_geometry.py server/cum-3-cards.twb "Academic Health Home" && \
+  uv run python check_twb.py server/cum-3-cards.twb --ref server/prod-base3.twb
+```
+
+Expected: all seven clean. The two earlier assertions re-run here to prove the
+restructure did not undo them.
+
+- [ ] **Step 5: Confirm nothing else moved**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight/server && python3 - <<'PY'
+import re
+a = open('prod-base3.twb', encoding='utf-8').read()
+b = open('cum-3-cards.twb', encoding='utf-8').read()
+print(f"length: {len(a)} -> {len(b)}")
+for label, pat in (("worksheets", r"<worksheet name='([^']*)'"),
+                   ("parameters", r"name='(\[Parameter \d+\])'")):
+    sa, sb = set(re.findall(pat, a)), set(re.findall(pat, b))
+    print(f"{label}: {len(sa)} -> {len(sb)}  gone={sorted(sa-sb)}  new={sorted(sb-sa)}")
+print("school filter zones:", len(re.findall(r"filter-group='17'", a)), "->",
+      len(re.findall(r"filter-group='17'", b)))
+for name in ("Academic Health Home", "Academic Health Schools", "Gradebook School Rollup"):
+    ia = a.index(f"name='{name}'>"); ib = b.index(f"name='{name}'>")
+    ja = a.index("</dashboard>", ia); jb = b.index("</dashboard>", ib)
+    print(f"{name}: {'UNCHANGED' if a[ia:ja] == b[ib:jb] else 'CHANGED'}")
+PY
+```
+
+Expected: no worksheets or parameters gone, `filter-group='17'` count unchanged,
+and all three other dashboards `UNCHANGED`.
+
+- [ ] **Step 6: Commit**
+
+Tick the boxes, then commit the plan with message
+`docs(tableau): record the Cumulative card restructure`.
+
+---
+
+### Task 6: Repack, render and hand over
+
+**Files:**
+
+- Create: `.claude/scratch/gpa-overnight/server/cum-final.twbx`
+- Create: `tests/tableau/test_zz_review.py` (throwaway, deleted in step 5)
+
+**Interfaces:**
+
+- Consumes: `server/cum-3-cards.twb` from Task 5, `server/prod-base3.twbx` from
+  Task 0.
+- Produces: `server/cum-final.twbx`, the handover package, and a review copy in
+  `GPA-monitor-temp`.
+
+- [ ] **Step 1: Repack around the production extract**
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
+  uv run python repack_task.py server/cum-3-cards.twb prod-base3.twbx cum-final.twbx && \
+  ls -l server/cum-final.twbx
+```
+
+Expected: over 20 MB. A file in the hundreds of kilobytes means the extract was
+dropped — stop.
+
+- [ ] **Step 2: Publish the review copy and render both bases**
+
+Write with the Write tool to `tests/tableau/test_zz_review.py`, copying the
+structure of the Task 1 probe but publishing `cum-final.twbx` as
+`ZZ-REVIEW cum cards 20260908` and rendering `Cumulative GPA Monitor` at both
+`GPA basis` values plus `Academic Health Home` once.
+
+Write the renders to exactly these paths, which later steps read by name:
+`server/review-projected.png`, `server/review-onthebooks.png`,
+`server/review-acadhealth.png`.
+
+Assert `item.project_id` equals `c74d8e08-b856-4430-a759-ebacb061e376` after
+publish, before rendering. Print the project name.
+
+Run: `uv run pytest tests/tableau/test_zz_review.py -s`
+
+- [ ] **Step 3: Assert the rendered colours by pixel, not by eye**
+
+Run:
+
+```bash
+cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run --with pillow python - <<'PY'
+from collections import Counter
+from PIL import Image
+img = Image.open('server/review-projected.png').convert('RGB')
+w, h = img.size
+crop = img.crop((int(w * 0.60), int(h * 0.55), w, h))          # goal-by-school panel
+counts = Counter(crop.getdata())
+def near(target, tol=12):
+    r0, g0, b0 = tuple(int(target[i:i+2], 16) for i in (1, 3, 5))
+    return sum(n for (r, g, b), n in counts.items()
+               if abs(r-r0) <= tol and abs(g-g0) <= tol and abs(b-b0) <= tol)
+for name, hexv in (("green #12a47c", "#12a47c"), ("red #b3161c", "#b3161c"),
+                   ("OLD blue #2f5fc4", "#2f5fc4"), ("OLD red #d8342f", "#d8342f")):
+    print(f"  {name}: {near(hexv)} px")
+PY
+```
+
+Expected: the two new colours have thousands of pixels each; the two retired
+colours have none, or a negligible count from anti-aliasing against the band
+chart. If a retired colour shows thousands, the edit missed a sheet.
+
+- [ ] **Step 4: Read both renders and check the text**
+
+Open `server/review-projected.png` and `server/review-onthebooks.png` with the
+Read tool. Confirm, in both:
+
+- Four card borders are visible, and each header strip shows its title and
+  caption.
+- The four headline numbers each show a basis line.
+- The three body charts each show a basis line, and it differs between the two
+  images.
+- The goal strip shows `Always projected` on both numbers in both images.
+- No text is clipped, no panel overlaps another, and the dashboard title is not
+  cut off at the top.
+
+Also open the Academic Health Home render and confirm it is unchanged, including
+its blue and red goal bars.
+
+- [ ] **Step 5: Delete the throwaway, record and hand over**
+
+```bash
+rm -f /workspaces/teamster/tests/tableau/test_zz_review.py
+```
+
+Append a `**Result:**` block under this task recording the review workbook URL,
+the pixel counts, and anything the renders showed that the checkers did not.
+
+Commit the plan with message
+`docs(tableau): record the Cumulative monitor rebuild verification`.
+
+Then report to the user, in the terminal:
+
+- The path to `server/cum-final.twbx` and its size.
+- The review copy's URL in `GPA-monitor-temp`.
+- An explicit statement that nothing was published to `Production` and that the
+  production publish is theirs to run.
+
+- [ ] **Step 6: Open the pull request**
+
+Push the branch and open a PR from `.github/pull_request_template.md`, with
+`Closes #5190` in the body. The PR carries the spec and the plan; the workbook
+itself is not in the repository, so say so in the body and link the review copy.

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -810,7 +810,7 @@ the checker before the change it guards.
 - Produces: `check_geometry.py`, run by Task 5 and Task 6. Exits non-zero on any
   violation.
 
-- [ ] **Step 1: Write the checker**
+- [x] **Step 1: Write the checker**
 
 Write `.claude/scratch/gpa-overnight/check_geometry.py`:
 
@@ -884,7 +884,7 @@ if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2])
 ```
 
-- [ ] **Step 2: Prove it passes on known-good input**
+- [x] **Step 2: Prove it passes on known-good input**
 
 Run:
 
@@ -897,7 +897,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 Expected: both print `OK`. A checker that fails on production is a broken
 checker, not a finding — fix the checker.
 
-- [ ] **Step 3: Prove it catches a real fault**
+- [x] **Step 3: Prove it catches a real fault**
 
 Run:
 
@@ -919,10 +919,52 @@ rm -f server/zz-broken.twb
 Expected: non-zero exit with at least one `FAIL` line. A checker that passes the
 broken file is useless — fix it and repeat.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 Tick the boxes, then commit the plan with message
 `docs(tableau): record the dashboard geometry checker`.
+
+**Result:**
+
+`check_geometry.py` asserts three invariants no schema check covers: siblings do
+not overlap, a flow container's children account for the container, and the
+top-level zone spans the canvas. It took two fix rounds, and both misses were
+the same shape — a rule that looked like it was checking something while having
+a hole exactly where the real defect lives.
+
+**Round 1, Critical.** The delivered checker used a tolerance of 900 units per
+child. With five children that is 4,500 units of slack against the 4,445-unit
+shortfall the pre-flight scan had already found in this plan's own height table,
+so the checker passed the exact defect it exists to catch. Proven rather than
+argued: `body-left` at `h='62222'` with five children summing to 57,777,
+sequential `y`, no overlap, returned `OK: geometry consistent`.
+
+Tightening the tolerance was not the fix either — at 40 it false-positived on
+six legitimate production containers. The real parent-minus-children gaps in
+`prod-base3.twb` are stable per-container constants with no relation to child
+count: 0, 0, 1, 586, 586, 587, 587, 888, 888, 2636. A per-child multiplier is
+unsound in both directions.
+
+The checker now compares each zone's gap against the same zone in a `--baseline`
+workbook and requires it to be identical, falling back to an absolute 0–3000
+bound only for zones the baseline does not contain, which is what Task 5's new
+header strips will be. It prints which mode it ran in, so the weaker check
+cannot be mistaken for the stronger one.
+
+**Round 2, two Important.** Top-level sibling zones were never compared to each
+other, so a visible top-level zone covering the whole body passed. That is not
+hypothetical — the rollup-overlay incident earlier today was a zone lifted out
+of the flow to top level, which is precisely the case this missed. And an
+unrecognised argument such as `--baselien` silently degraded to the weak mode
+and exited 0, handing a pass to any caller gating on exit code.
+
+Verified independently at every step, with exit codes read directly rather than
+through a pipeline: known-good files pass in both modes across both dashboards;
+the fabricated top-level overlap fails; the 4,445 gap fails naming zone 40 and
+its expected 888; and all four misuse paths exit 1 with a readable one-line
+message. Non-vacuity confirmed both ways — the hidden pop-out panels 220 and 224
+genuinely do overlap the body and are excluded only by the `hidden-by-user`
+skip, not by an absence of overlap to find.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -590,7 +590,7 @@ The edits, exhaustively:
 `GPA - BAN Below 3.0` and `GPA - BAN Can reach` already carry the fixed line in
 the right place and are not edited.
 
-- [ ] **Step 1: Write the failing assertion**
+- [x] **Step 1: Write the failing assertion**
 
 Write `.claude/scratch/gpa-overnight/assert_cum_reminders.py`:
 
@@ -663,7 +663,7 @@ if __name__ == "__main__":
     main(sys.argv[1])
 ```
 
-- [ ] **Step 2: Run it to verify it fails**
+- [x] **Step 2: Run it to verify it fails**
 
 Run:
 `cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_reminders.py server/cum-1-colour.twb`
@@ -672,7 +672,7 @@ Expected: FAIL with 10 lines — 5 missing placeholders (2 mark labels, 3
 worksheet titles), 3 zones not showing a title, and `GPA - BAN Gap to goal` and
 `GPA - BAN Students needed` reported for having no standalone fixed run.
 
-- [ ] **Step 3: Write the edit**
+- [x] **Step 3: Write the edit**
 
 Write `.claude/scratch/gpa-overnight/task_cum_reminders.py`. It performs three
 distinct transforms. Every anchor must match exactly once; abort otherwise.
@@ -732,7 +732,7 @@ number of lines inserted.
 
 Parse with `ET.fromstring` before writing.
 
-- [ ] **Step 4: Run the edit, the assertion and the checker**
+- [x] **Step 4: Run the edit, the assertion and the checker**
 
 ```bash
 cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
@@ -743,7 +743,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 
 Expected: assertion prints `OK: 5 live, 4 fixed`, checker clean.
 
-- [ ] **Step 5: Confirm the break run survived byte-exact**
+- [x] **Step 5: Confirm the break run survived byte-exact**
 
 Run:
 
@@ -755,10 +755,42 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight/server && \
 Expected: the second count is higher than the first by exactly the number of
 break runs the edit added, and no other value. Record both numbers.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Tick the boxes, then commit the plan with message
 `docs(tableau): record the Cumulative basis reminders`.
+
+**Result:**
+
+Nine edits, no zones moved. 34 lines added, 5 removed, CRLF 27,729 → 27,758
+(+29, matching the lines inserted), `Æ` break runs 229 → 233 (+4).
+
+All four headline numbers now share one structure — label, basis, number. The
+two that follow the switch carry the live placeholder; the two that do not carry
+`Always projected`, split out of the 13pt label where it used to run inline.
+`GPA - BAN Below 3.0` and `GPA - BAN Can reach` were not touched: they already
+had the fixed line in that exact slot, and they are what the other four now
+match.
+
+The three body sheets carry the placeholder as a worksheet title, and zones 144,
+151 and 152 were flipped to `show-title='true'`. Without that flip the title is
+swallowed — Task 1's probe rendered a perfect title and showed nothing at all.
+
+Task 2's colours and the structural checker both still pass on the output.
+
+**Fix round 1/5.** Review found the assertion checked presence, not position: it
+searched the whole label for a placeholder _somewhere_, so a run in the wrong
+slot would have passed. The finding was against the plan's own text rather than
+the implementation, and I ruled it worth fixing now — Task 5 re-runs this
+assertion to prove that re-parenting nine zones did not scramble the labels,
+which is exactly the failure a positional check catches.
+
+The assertion now requires the exact 5-run sequence and prints the actual
+sequence on failure. Proved independently: a copy of the workbook with the basis
+run moved ahead of the label run fails the new check with
+`run 0 is not the expected 'label' run`, and the old presence-only logic returns
+`True` on the same file. Re-review verdicted the finding ADDRESSED with no new
+breakage.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -410,7 +410,7 @@ BANNED = {"#2f5fc4", "#d8342f"}
 
 
 def main(path):
-    t = Path(path).read_text(encoding="utf-8")
+    t = Path(path).read_text(encoding="utf-8", newline="")
     m = re.search(rf"<encoding attr='color'[^>]*{CALC}[^>]*>(.*?)</encoding>", t, re.S)
     if not m:
         sys.exit(f"FAIL: no colour encoding for {CALC}")
@@ -467,7 +467,10 @@ SWAP = {"At or above goal": ("#2f5fc4", "#12a47c"), "Below goal": ("#d8342f", "#
 
 
 def main(src, dst):
-    t = (D / src).read_text(encoding="utf-8")
+    # newline="" on BOTH sides: a plain read_text applies universal newlines and
+    # the write then flattens all 27,729 CRLF endings to LF.
+    t = (D / src).read_text(encoding="utf-8", newline="")
+    crlf_in = t.count("\r\n")
     m = re.search(rf"<encoding attr='color'[^>]*{CALC}[^>]*>.*?</encoding>", t, re.S)
     if not m:
         sys.exit(f"FAIL: no colour encoding for {CALC}")
@@ -481,7 +484,10 @@ def main(src, dst):
         print(f"  {member}: {old} -> {want}")
     t = t[: m.start()] + new + t[m.end() :]
     ET.fromstring(t)
+    if t.count("\r\n") != crlf_in:
+        sys.exit(f"FAIL: CRLF count moved {crlf_in} -> {t.count(chr(13) + chr(10))}")
     (D / dst).write_text(t, encoding="utf-8", newline="")
+    print(f"  CRLF lines unchanged at {crlf_in}")
     print(f"  wrote {dst}")
 
 
@@ -593,7 +599,7 @@ def sheet(t, name):
 
 
 def main(path):
-    t = Path(path).read_text(encoding="utf-8")
+    t = Path(path).read_text(encoding="utf-8", newline="")
     bad = 0
     for name in LIVE_LABEL:
         seg = sheet(t, name)

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -1267,7 +1267,7 @@ against the source before each use.
 - Produces: `server/cum-final.twbx`, the handover package, and a review copy in
   `GPA-monitor-temp`.
 
-- [ ] **Step 1: Repack around the production extract**
+- [x] **Step 1: Repack around the production extract**
 
 ```bash
 cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
@@ -1278,7 +1278,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 Expected: over 20 MB. A file in the hundreds of kilobytes means the extract was
 dropped — stop.
 
-- [ ] **Step 2: Publish the review copy and render both bases**
+- [x] **Step 2: Publish the review copy and render both bases**
 
 Write with the Write tool to `tests/tableau/test_zz_review.py`, copying the
 structure of the Task 1 probe but publishing `cum-final.twbx` as
@@ -1294,7 +1294,7 @@ publish, before rendering. Print the project name.
 
 Run: `uv run pytest tests/tableau/test_zz_review.py -s`
 
-- [ ] **Step 3: Assert the rendered colours by pixel, not by eye**
+- [x] **Step 3: Assert the rendered colours by pixel, not by eye**
 
 Run:
 
@@ -1320,7 +1320,7 @@ Expected: the two new colours have thousands of pixels each; the two retired
 colours have none, or a negligible count from anti-aliasing against the band
 chart. If a retired colour shows thousands, the edit missed a sheet.
 
-- [ ] **Step 4: Read both renders and check the text**
+- [x] **Step 4: Read both renders and check the text**
 
 Open `server/review-projected.png` and `server/review-onthebooks.png` with the
 Read tool. Confirm, in both:
@@ -1337,7 +1337,7 @@ Read tool. Confirm, in both:
 Also open the Academic Health Home render and confirm it is unchanged, including
 its blue and red goal bars.
 
-- [ ] **Step 5: Delete the throwaway, record and hand over**
+- [x] **Step 5: Delete the throwaway, record and hand over**
 
 ```bash
 rm -f /workspaces/teamster/tests/tableau/test_zz_review.py
@@ -1356,8 +1356,54 @@ Then report to the user, in the terminal:
 - An explicit statement that nothing was published to `Production` and that the
   production publish is theirs to run.
 
-- [ ] **Step 6: Open the pull request**
+- [x] **Step 6: Open the pull request**
 
 Push the branch and open a PR from `.github/pull_request_template.md`, with
 `Closes #5190` in the body. The PR carries the spec and the plan; the workbook
 itself is not in the repository, so say so in the body and link the review copy.
+
+**Result:**
+
+`server/cum-final.twbx`, 29,436,163 bytes, repacked around the production
+extract — all three `.hyper` files intact at 60.1, 3.4 and 3.4 MB. Review copy
+published to `GPA-monitor-temp` as `ZZ-REVIEW cum cards 20260908`
+(`06e50e42-74a8-41c4-9a8e-5690b6824896`), tabs visible. The `project_id`
+assertion ran before any render on every one of the six publishes. Nothing went
+near `Production`.
+
+**Colour, asserted by pixel rather than by eye.** In the goal-by-school panel:
+`#12a47c` 120,106 px and `#b3161c` 40,062 px projected, 82,975 and 32,159 on the
+books. The retired `#2f5fc4` is down to 2 anti-aliasing pixels and `#d8342f` to
+zero. Academic Health Home holds 84,248 blue and 35,320 red with zero green, and
+its render is byte-identical across all six publishes.
+
+**Live basis, confirmed to track the parameter.** The same workbook renders
+`Projected EOY` and `On the books today` on the three body charts at the two
+parameter values.
+
+**The render found four defects that every structural checker passed.** This is
+the task's main result.
+
+1. Both goal-strip numbers rendered as `####`. Task 3 had split
+   `— always projected` onto its own line for visual consistency, and three
+   lines do not fit that box at 66px, 78px or 88px. Reverted to production's
+   inline form, which is live today and renders `+4.4pp` cleanly.
+2. The GPA band legend showed 3 of 5 entries, then 4 of 5. Height was the lever,
+   not width: at 70px the strip fits a title plus two item rows, which also
+   explains the 3-then-4 progression at 40px and 50px.
+3. Row labels clipped to `al Un / ghted`, then wrapped mid-word. Shortened the
+   two constant-string calcs to `Actual` and `Projected`; the card caption
+   directly above already carries the explanation.
+4. The live basis line was **blank** on both headline BANs. My error: Task 1's
+   probe proved the parameter placeholder resolves in a worksheet title, and I
+   wrote "proven live in this workbook" into the plan and applied the same token
+   to mark labels. Mark labels carry FIELD placeholders; a field reference is
+   not a parameter reference. Routing the parameter through a calc on the Text
+   shelf was worse — it blanked the entire label, title and number included.
+   Both attempts passed every assertion.
+
+   Settled with static text, `Follows the GPA basis`, in the same run style and
+   position. All four headline numbers now read uniformly. The live value stays
+   where it was asked for and where it works: the three switch-driven cards.
+
+The reminders assertion records both failed mechanisms so neither is retried.

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -1109,7 +1109,7 @@ spec's budget prose predicted a small cut; the reconciled arithmetic is better
 than that. `check_geometry.py` from Task 4 is the judge — if these values do not
 satisfy it, fix the values, not the checker.
 
-- [ ] **Step 1: Write the failing assertion**
+- [x] **Step 1: Write the failing assertion**
 
 Write `.claude/scratch/gpa-overnight/assert_cum_cards.py`. It asserts, against
 the `Cumulative GPA Monitor` dashboard:
@@ -1126,14 +1126,14 @@ the `Cumulative GPA Monitor` dashboard:
 - In every `zone-style`, no child `zone` element follows it within the same
   parent.
 
-- [ ] **Step 2: Run it to verify it fails**
+- [x] **Step 2: Run it to verify it fails**
 
 Run:
 `cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python assert_cum_cards.py server/cum-2-reminders.twb`
 
 Expected: FAIL on every assertion above.
 
-- [ ] **Step 3: Write the edit**
+- [x] **Step 3: Write the edit**
 
 Write `.claude/scratch/gpa-overnight/task_cum_cards.py`, operating only within
 the `Cumulative GPA Monitor` dashboard element and only on its `<zones>` block,
@@ -1147,7 +1147,7 @@ length before writing.
 Assert every anchor matches exactly once. Parse with `ET.fromstring` before
 writing. Write with `newline=""`.
 
-- [ ] **Step 4: Run the edit and all three checkers**
+- [x] **Step 4: Run the edit and all three checkers**
 
 ```bash
 cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
@@ -1163,7 +1163,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && \
 Expected: all seven clean. The two earlier assertions re-run here to prove the
 restructure did not undo them.
 
-- [ ] **Step 5: Confirm nothing else moved**
+- [x] **Step 5: Confirm nothing else moved**
 
 Run:
 
@@ -1189,10 +1189,67 @@ PY
 Expected: no worksheets or parameters gone, `filter-group='17'` count unchanged,
 and all three other dashboards `UNCHANGED`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Tick the boxes, then commit the plan with message
 `docs(tableau): record the Cumulative card restructure`.
+
+**Result:**
+
+Four cards, four header strips, nine zones re-parented. The workbook came out
+right on the first delivery and never changed after it — md5
+`ec34ccaff8d4f40de47de04d25e2b876` through both fix rounds. Everything the two
+rounds fixed was in the test.
+
+Structure: cards 20, 30, 40 and 50 bordered `#001e62` 1pt margin 5; strips 800
+and 810 under card 40, 820 and 830 under card 50; the standalone GPA band legend
+143 relocated inside strip 810, where Academic Health docks its own legends;
+`GPA - Title`'s caption shortened now that every panel states its own basis.
+
+Verified: 68 worksheets and 14 parameters unchanged with none added or removed,
+`filter-group='17'` still on 17 zones, and all four sibling dashboards
+byte-identical. CRLF 27,758 → 27,848 with zero bare LF. Length +0.4%. The
+manifest is byte-identical to production. Content-model ordering clean in all
+ten touched containers.
+
+**Two arithmetic errors of mine, both caught by `check_geometry.py`.** The
+plan's original height table left both body columns short of their parent by
+4,445 and 4,001 units. My corrected table then made the children sum to the
+parent exactly, ignoring the 888-unit margin each column carries. The
+implementer fixed the values rather than weakening the checker, exactly as
+instructed: zone 144 to 38,668 and zone 152 to 39,113. Both columns now show gap
+888, matching the baseline.
+
+A third error of mine: I told the implementer to pin zones 40 and 50 to zone 3.
+They are children of zone 35. Following that literally would have made the
+assertion reject the correct workbook. The implementer pinned 40 and 50 to 35,
+added 35 to 3 to close the chain, and said so rather than quietly complying.
+
+**Fix round 1.** `assert_cum_cards.py` was discriminating — 33 failures on the
+input — but did not pin the tree. Three mutants of the shipped file all passed:
+a stale duplicate legend left as a sibling of 144, strip 820 re-parented under
+the wrong card, and strip 800 moved out of order. The first is exactly the
+failure the brief singled out; it passed because the parent map was overwritten
+in document order. Also fixed: stale `fixed-size` on five zones this task
+resized. The implementer derived the rule from production before applying it and
+declared the scope widening from three zones to five. An independent audit of
+all 66 `is-fixed` zones confirms the production invariant holds — `fixed-size`
+is never larger than the stored size, zero violations before and zero after.
+
+**Fix round 2.** The hardened assertion still did not pin the four card zones. A
+card nested inside a sibling card, placed before its `zone-style` so the content
+model stayed valid, passed cleanly. Pinned zones 20, 30, 35, 40 and 50 and the
+top-level child lists: 22 ids unique, 14 parents pinned, 8 sequences pinned.
+
+The assertion now catches all four original mutants and five further ones a
+reviewer invented afterwards — changed border colour, `zone-style` before
+children, a text zone lifted out of its strip, a strip deleted, and two cards
+swapped. It generalizes rather than being fitted to the cases it was shown.
+
+Mutants were built by text surgery, not ElementTree. An ET round-trip changes
+attribute quoting and line endings enough that the unmutated control failed, so
+ET-built mutants would have proved nothing. The harness is checked lossless
+against the source before each use.
 
 ---
 

--- a/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
+++ b/docs/superpowers/plans/2026-09-08-cumulative-monitor-cards-captions.md
@@ -95,7 +95,7 @@ later task builds on this task's output.
   3 and 5 edit in sequence. `server/prod-base3.twbx`, the donor archive whose
   extract Task 6 repacks around the final XML.
 
-- [ ] **Step 1: Write the download helper**
+- [x] **Step 1: Write the download helper**
 
 Write this with the Write tool to `tests/tableau/test_zz_pull.py`:
 
@@ -139,14 +139,14 @@ def test_pull():
     print(f"EXTRACTED: {(OUT / 'prod-base3.twb').stat().st_size} bytes")
 ```
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 Run: `uv run pytest tests/tableau/test_zz_pull.py -s`
 
 Expected: PASS. Record the printed `PROJECT`, `UPDATED` and byte sizes — they go
 in the commit note. `PROJECT` must read `Production`.
 
-- [ ] **Step 3: Diff the base against the previous pull**
+- [x] **Step 3: Diff the base against the previous pull**
 
 Run:
 
@@ -169,7 +169,7 @@ Expected: no `GONE` lines, and `school filter zones` at least 17. A `GONE` line
 means production changed in a way this plan did not anticipate — stop and report
 rather than proceeding.
 
-- [ ] **Step 4: Baseline the structural checker**
+- [x] **Step 4: Baseline the structural checker**
 
 Run:
 
@@ -180,7 +180,7 @@ cd /workspaces/teamster/.claude/scratch/gpa-overnight && uv run python check_twb
 Expected: clean. This is the reference result every later task must still
 produce.
 
-- [ ] **Step 5: Delete the throwaway and commit**
+- [x] **Step 5: Delete the throwaway and commit**
 
 ```bash
 rm -f /workspaces/teamster/tests/tableau/test_zz_pull.py
@@ -190,6 +190,25 @@ git -C /workspaces/teamster/.worktrees/anthonygwalters/feat/claude-cum-monitor-c
 
 Tick this task's boxes and append the recorded `UPDATED` timestamp and byte
 sizes under the task heading before committing.
+
+**Result:**
+
+Pulled 2026-09-08. `PROJECT: Production`,
+`NAME: Academic & Gradebook Health Suite`, `UPDATED: 2026-09-08 16:04:16+00:00`
+— later than the 14:39 revision the earlier base came from. `prod-base3.twbx` is
+30,913,759 bytes; `prod-base3.twb` is 1,926,339 bytes.
+
+`tableauserverclient` appends the extension to whatever `filepath` it is given,
+so `filepath="…/prod-base3"` is what produces `prod-base3.twbx`. Passing the
+full name yields `prod-base3.twbx.twbx`.
+
+Diff against the 15:52 base: 68 worksheets, 5 dashboards and 11 parameters
+unchanged with no additions or removals; `filter-group='17'` still on 17 zones;
+all 5 dashboard elements byte-identical. The entire 29,657-character growth sits
+in `<datasources>`, which is the 16:04 extract refresh writing new extract
+metadata. No design change to rebase onto.
+
+`check_twb.py server/prod-base3.twb --ref server/prod-base2.twb` → `CLEAN`.
 
 ---
 

--- a/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
+++ b/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
@@ -1,0 +1,267 @@
+# Cumulative GPA Monitor cards, captions and basis reminder
+
+Refs [#5190](https://github.com/TEAMSchools/teamster/issues/5190).
+
+## Problem
+
+The Cumulative GPA Monitor is the only tab in the
+`Academic & Gradebook Health Suite` with no titles and no captions. Every body
+zone sets `show-title='false'`. A reader gets two rotated row labels, the words
+`Grade Level`, and nothing else.
+
+`GPA - Goal by school` is the worst case. It encodes four things and explains
+none of them: bar length is the share of students at a 3.0 cumulative GPA or
+above, the mark label is the gap to goal in percentage points, colour is at or
+below goal, and the grey tick is that school's own goal.
+
+The dashboard also hides which GPA basis a reader is looking at, and that is the
+more dangerous gap. The `GPA basis` control switches between `Projected EOY` and
+`On the books today`. Some panels follow it and some ignore it, with nothing on
+screen marking the difference.
+
+## The three-way split
+
+Tracing `[Parameter 11]` through the calculations gives three groups, not two.
+The reminder design follows from this split, so it is recorded here in full.
+
+**Follows the switch.** `GPA - Dist by grade`, `GPA - Goal by grade`,
+`GPA - Goal by school`, `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+`. Each resolves
+through `Calculation_0141679102236570168` (`Cum GPA (unweighted)`), which
+branches on `[Parameters].[Parameter 11]`.
+
+**Ignores the switch, always projected.** `GPA - BAN Below 3.0`,
+`GPA - BAN Can reach`, `GPA - BAN Gap to goal` and `GPA - BAN Students needed`.
+The first two read `cumulative_y1_gpa_unweighted` directly. The last two also
+compare against `gpa_goal_proportion_org`, or `gpa_goal_proportion_region` when
+`[Parameter 3]` is not `"All"`.
+
+**Ignores the switch, shows both.** `GPA - Dist on the books` and
+`GPA - Dist projected` render on-the-books and projected figures as two rows of
+one panel, whatever the switch is set to.
+
+A reader who sets the basis to `On the books today` therefore sees four numbers
+and one panel that did not change, and the dashboard says nothing about it.
+
+## The pattern being copied
+
+Academic Health Home and Academic Health Schools already solve the titling
+problem, and they solve it the same way. Three reusable pieces:
+
+- **Card.** A container with `border-style` `solid`, `border-color` `#001e62`,
+  `border-width` 1 and `margin` 5.
+- **Header strip.** The card's first child: a horizontal `layout-flow` with
+  `background-color` `#e6e6e6`, holding a text zone plus whichever legend or
+  parameter control belongs to that chart.
+- **Section label.** Bare text in `Tableau Semibold` `#001e62`, sitting above a
+  card rather than inside it.
+
+The text zone pairs a bold title with an 8 point italic caption:
+
+```xml
+<run bold='true' fontcolor='#000000' fontname='Arial'>Y1 Weighted GPA by School</run>
+<run>Æ&#10;</run>
+<run fontcolor='#000000' fontname='Arial' fontsize='8' italic='true'>What % of students have a GPA of ≥ 3.0?</run>
+```
+
+One card can hold several header-and-chart pairs. Academic Health Home zone 63
+holds two. Copying that nesting, rather than giving every chart its own border,
+is what makes the pixel budget work.
+
+## Design
+
+### Structure
+
+Four cards:
+
+1. **Headline.** The four big numbers, in one bordered card.
+2. **Goal strip.** The `Progress against the goal` label and its two numbers.
+3. **Body left.** Header strip, then `GPA - Dist on the books` and
+   `GPA - Dist projected`; header strip carrying the GPA band legend, then
+   `GPA - Dist by grade`.
+4. **Body right.** Header strip, then `GPA - Goal by grade`; header strip, then
+   `GPA - Goal by school`.
+
+The standalone GPA band legend zone is absorbed into card 3's second header
+strip, where Academic Health docks its own legends. That removes a floating
+element and frees 38 pixels.
+
+Two fixes ride along. The dashboard's outer `layout-basic` zone has no margin,
+unlike Academic Health Home's `margin` of 8, which is why the title clips
+against the top edge. The controls strip gets `background-color` `#f5f5f5` to
+match Academic Health Home.
+
+### The basis reminder
+
+A dashboard text zone is dead text and cannot resolve a parameter. Live basis
+text has to come from a parameter control, a worksheet title or caption, or a
+mark label. This design uses the last two.
+
+The six big-number sheets already build their text in `<customized-label>` with
+a CDATA-wrapped placeholder, so the mechanism is proven live in this workbook:
+
+```xml
+<run fontcolor='#001e62' fontname='Tableau Semibold' fontsize='30'><![CDATA[<[federated.0n798br073i5kb170j6l90uiv50a].[usr:Calculation_4645249709926099321:qk]>]]></run>
+```
+
+Two of them already carry a fixed basis line between the label and the number:
+
+```xml
+<run fontcolor='#8c8c8c' fontname='Tableau Light' fontsize='10'>Always projected</run>
+```
+
+Every basis line in this design reuses that exact formatting, so `Tableau Light`
+10 in `#8c8c8c` means "which basis you are looking at" everywhere on the
+dashboard, whether a mark label or a sheet title renders it.
+
+**Live.** `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+` gain the placeholder as
+their middle line, in the slot the other two BANs already use. All four then
+share one structure: label, basis, number. `GPA - Dist by grade`,
+`GPA - Goal by grade` and `GPA - Goal by school` carry the same line as a
+worksheet title, top left, under the header strip.
+
+**Fixed.** `GPA - BAN Gap to goal` and `GPA - BAN Students needed` already say
+`— always projected`, but inline in the 13 point label where it runs long. Split
+it onto its own line in the standard grey. Card 3's first header strip states in
+its caption that the panel shows both bases.
+
+`GPA - Dist by grade` cannot use a native axis title, because its value axis
+sets `display='false'`. The other two charts do render a default `% at 3.0+`
+axis title, but one runs up the left edge and the other along the bottom.
+Worksheet titles put the reminder in the same place on all three, which is what
+makes it read as a convention rather than three separate notes.
+
+### Caption copy
+
+Each row below is one header strip, named by its card and its position in that
+card.
+
+| Header strip   | Title                        | Caption                                                                                                      |
+| -------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Card 2 label   | Progress against the goal    | Always projected, against the network goal — or the selected region's goal.                                  |
+| Card 3, first  | Band mix, network            | On the books today above, projected to year end below. This panel shows both, whatever the switch is set to. |
+| Card 3, second | Band mix by grade            | The same bands, split by grade.                                                                              |
+| Card 4, first  | % at 3.0+ by grade           | Share of students at a 3.0 cumulative or better. The grey tick is the network goal for that grade.           |
+| Card 4, second | Gap to goal, school by grade | Bar length is % at 3.0+; the label is the gap in points; the grey tick is that school's own goal.            |
+
+`GPA - Title`'s caption currently hedges with "Projected end-of-year unless the
+basis switch is set to on the books today". Once every panel states its own
+basis, that sentence can go.
+
+### Colour
+
+A reviewer asked for the met and not-met colours to match the Gradebook Fidelity
+dashboard. Doing that also fixes a collision. The goal bars currently use
+`#2f5fc4` and `#d8342f`, which are also the `3.0-3.49` and `below 2.0` band
+colours in the stacked charts directly above them, so blue and red each carry
+two meanings on one screen.
+
+Edit the map on `Calculation_7236501339153214575` only:
+
+| Member           | Now       | New       |
+| ---------------- | --------- | --------- |
+| At or above goal | `#2f5fc4` | `#12a47c` |
+| Below goal       | `#d8342f` | `#b3161c` |
+| Not yet measured | `#b6c0cf` | unchanged |
+| null             | `#edc948` | unchanged |
+
+The new pair matches `Calculation_1052997927364395018` (`Cell state`) on the
+fidelity dashboard. `#b6c0cf` stays even though it is also the `2.5-2.99` band
+grey, because a neutral meaning "no data" reads the same in both places.
+
+That encoding colours three sheets, not two: `GPA - Goal by grade`,
+`GPA - Goal by school` and `GPA - BAN Gap to goal`. The goal strip's headline
+number therefore turns green at goal and red when short, which was not part of
+the original request but keeps the strip consistent with the panels below it.
+
+Academic Health Home's twin calculation, `Calculation_4005670422418128910`,
+stays on blue and red. The two tabs will show the same concept in different
+colours until someone decides otherwise.
+
+Green and red separate mainly by hue, so they are the harder pair for red-green
+colour blindness, where the current blue and red are safer. `#12a47c` leans teal
+enough to survive most simulations, and the bars carry signed point labels
+either way. The owner chose this pair knowing that.
+
+## Pixel budget
+
+The canvas is 1366 by 900 with `sizing-mode="fixed"`, and it is allocated to the
+last pixel today: title 60, controls 68, headline 138, goal strip 78, body 556.
+Body left holds 86, 86, 38 and 330. Body right holds 141 and 399.
+
+Four header strips and three worksheet titles have to come from somewhere:
+
+- The band legend zone folds into a header strip: 38 pixels.
+- The two single-row bars go from 86 to 62 pixels each. They are single bars.
+- Goal strip goes from 78 to 66 pixels.
+- `GPA - Goal by school` goes from 399 to about 324 pixels. Twelve rows at 27
+  pixels each; the Academic Health equivalent runs nine rows at 20 and reads
+  fine.
+- `GPA - Goal by grade` goes from 141 to about 120 pixels.
+- `GPA - Dist by grade` barely moves, 330 to about 316 pixels.
+
+The visible cost concentrates in the school panel. Final values are set during
+the build, where the check is that each flow container's children sum to the
+parent and the whole dashboard sums to 100000 units.
+
+## Build order
+
+The order is deliberate: the unproven thing first, then content, then geometry.
+
+**Step 0. Re-pull production.** Not the copy on disk. The owner published
+revision 3.0 at 14:39 on 2026-09-08, adding a cross-datasource School filter
+(`filter-group='17'`) to 17 sheets. Building on an older base destroys it.
+Record the revision and diff the worksheet and parameter lists against the base.
+
+**Step 1. Probe the placeholder.** The parameter token
+`<![CDATA[<[Parameters].[Parameter 11]>]]>` is inferred from the field and
+built-in placeholder syntax already in the file. No parameter placeholder exists
+in this workbook yet. Change one title, publish to `GPA-monitor-temp`, render at
+both parameter values through the render API, and read the text back. If it does
+not resolve, stop and report. Fallbacks, in order: the caption-style syntax,
+then native axis titles for the two goal panels with a badge worksheet for the
+third, then fixed text.
+
+**Step 2. Colour.** Four values in one encoding map.
+
+**Step 3. Reminders.** Six `<customized-label>` edits and three worksheet
+titles. No zone moves yet, so the whole content layer is renderable and readable
+before any geometry changes.
+
+**Step 4. Structure.** The re-parenting, last, so a layout break bisects cleanly
+instead of hiding behind a text bug.
+
+## Verification
+
+- `check_twb.py` and an XML parse after every script. It covers worksheet
+  `simple-id`, `<view>` and `<aggregation>`, element-versus-manifest feature
+  declarations, and manifest entries dropped against `--ref`.
+- Colour: sample pixels from the render and assert `#12a47c` and `#b3161c` are
+  present and `#2f5fc4` and `#d8342f` are absent from that panel. Not by eye.
+- Reminders: render at both parameter values, assert both strings appear and
+  that they differ.
+- Structure: assert geometry programmatically. No sibling overlap, every flow
+  container's children summing to the parent, total 100000. No existing checker
+  does this, and it is what would have caught the rollup overlay on 2026-09-08.
+- Merge check: worksheet list and parameter list diffed against the step 0 pull,
+  and the School filter confirmed on all 17 sheets.
+
+## Constraints
+
+Never publish to the `Production` project. The deliverable is a `.twbx` plus a
+review copy in `GPA-monitor-temp` (`c74d8e08-b856-4430-a759-ebacb061e376`) for
+the owner to publish. Publish with the extract included and tabs visible.
+
+Insert into `<document-format-change-manifest>`, never rebuild it. A regex
+rebuild on 2026-09-08 silently dropped a dotted entry and broke the extract.
+
+The paragraph break inside `<formatted-text>` is the literal run
+`<run>Æ&#10;</run>`, 235 of them in the file, and it must be byte-exact. The
+file uses CRLF line endings.
+
+A zone at the wrong nesting level is valid XML that renders overlapping, and no
+schema check catches it.
+
+## Out of scope
+
+Academic Health Home's goal colours. The dashed cumulative reference line, which
+the owner is doing by hand. Any change to the underlying dbt models.

--- a/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
+++ b/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
@@ -193,14 +193,16 @@ Four header strips and three worksheet titles have to come from somewhere:
 - The band legend zone folds into a header strip: 38 pixels.
 - The two single-row bars go from 86 to 62 pixels each. They are single bars.
 - Goal strip goes from 78 to 66 pixels.
-- `GPA - Goal by school` goes from 399 to about 324 pixels. Twelve rows at 27
-  pixels each; the Academic Health equivalent runs nine rows at 20 and reads
-  fine.
-- `GPA - Goal by grade` goes from 141 to about 120 pixels.
-- `GPA - Dist by grade` barely moves, 330 to about 316 pixels.
+- `GPA - Goal by school` goes from 399 to 360 pixels. Twelve rows at 30 pixels
+  each; the Academic Health equivalent runs nine rows at 20 and reads fine.
+- `GPA - Goal by grade` goes from 141 to 120 pixels.
+- `GPA - Dist by grade` gains, 330 to 356 pixels.
 
-The visible cost concentrates in the school panel. Final values are set during
-the build, where the check is that each flow container's children sum to the
+The visible cost concentrates in the school panel, and it is smaller than it
+first looked. Reconciling each flow container's children against its parent
+during planning showed that folding the standalone legend into a header strip
+frees more than the four strips cost, so the by-grade chart grows rather than
+shrinking. The build's check is that each flow container's children sum to the
 parent and the whole dashboard sums to 100000 units.
 
 ## Build order

--- a/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
+++ b/docs/superpowers/specs/2026-09-08-cumulative-monitor-cards-captions-design.md
@@ -24,10 +24,25 @@ screen marking the difference.
 Tracing `[Parameter 11]` through the calculations gives three groups, not two.
 The reminder design follows from this split, so it is recorded here in full.
 
-**Follows the switch.** `GPA - Dist by grade`, `GPA - Goal by grade`,
-`GPA - Goal by school`, `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+`. Each resolves
-through `Calculation_0141679102236570168` (`Cum GPA (unweighted)`), which
-branches on `[Parameters].[Parameter 11]`.
+**Follows the switch, wholly.** `GPA - Dist by grade` — bars, mark labels and
+the `GPA band` colour encoding all resolve through
+`Calculation_0141679102236570168` (`Cum GPA (unweighted)`), which branches on
+`[Parameters].[Parameter 11]`. `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+` do the
+same.
+
+**Follows the switch in part.** `GPA - Goal by grade` and `GPA - Goal by school`
+each encode three things — bar length, mark label, colour — and not every
+encoding is parameter-aware. On `GPA - Goal by grade`, bar length and the mark
+label both resolve through `Calculation_0141679102236570168`; only the colour,
+`Calculation_7236501339153214575` (`Goal status`), is built on
+`Calculation_9485136151529756033` / `Calculation_4693780698737655073`, a
+projected-only pair. On `GPA - Goal by school`, only the bar length,
+`Calculation_9335003396903351453` (`% at 3.0+`), is parameter-aware. Both the
+mark label, `Calculation_3466859908724272046` (`Gap to goal (pts)`), and the
+colour — the same `Goal status` calc — are built on that same projected-only
+pair. Setting the basis to `On the books today` therefore moves the bars on both
+panels while their gap labels and colours stay projected, which is what produces
+a near-zero-length bar carrying a label like `+11.4pp` in green.
 
 **Ignores the switch, always projected.** `GPA - BAN Below 3.0`,
 `GPA - BAN Can reach`, `GPA - BAN Gap to goal` and `GPA - BAN Students needed`.
@@ -40,7 +55,8 @@ compare against `gpa_goal_proportion_org`, or `gpa_goal_proportion_region` when
 one panel, whatever the switch is set to.
 
 A reader who sets the basis to `On the books today` therefore sees four numbers
-and one panel that did not change, and the dashboard says nothing about it.
+and one panel that do not change, two panels whose bars move while their labels
+and colour stay projected, and the dashboard says nothing about any of it.
 
 ## The pattern being copied
 
@@ -113,16 +129,32 @@ Every basis line in this design reuses that exact formatting, so `Tableau Light`
 10 in `#8c8c8c` means "which basis you are looking at" everywhere on the
 dashboard, whether a mark label or a sheet title renders it.
 
-**Live.** `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+` gain the placeholder as
-their middle line, in the slot the other two BANs already use. All four then
-share one structure: label, basis, number. `GPA - Dist by grade`,
-`GPA - Goal by grade` and `GPA - Goal by school` carry the same line as a
-worksheet title, top left, under the header strip.
+**Live.** The plan was for `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+` to gain the
+placeholder as their middle line, in the slot the other two BANs already use, so
+all four would share one structure: label, basis, number. That failed twice. A
+`<[Parameters].…>` token renders blank inside a mark label. Routing the
+parameter through a calculation on the Text shelf was worse — it blanked the
+whole label, title and number included, not just the basis line. The
+worksheet-title route is the only one that resolves a parameter in this
+workbook. `GPA - BAN % 3.5+` and `GPA - BAN % 3.0+` ship with static text,
+`Follows the GPA basis`, in the same run style and position instead.
+`GPA - Dist by grade`, `GPA - Goal by grade` and `GPA - Goal by school` carry
+the live placeholder as a worksheet title, top left, under the header strip —
+that route works, which is why those three keep it.
 
 **Fixed.** `GPA - BAN Gap to goal` and `GPA - BAN Students needed` already say
-`— always projected`, but inline in the 13 point label where it runs long. Split
-it onto its own line in the standard grey. Card 3's first header strip states in
-its caption that the panel shows both bases.
+`— always projected`, inline in the 13 point label where it runs long. The plan
+called for splitting it onto its own line in the standard grey; that rendered
+the number as `####` in both BANs — three lines do not fit the box at this size
+— so the build reverted to production's inline form, which is what ships. Card
+3's first header strip states in its caption that the panel shows both bases.
+
+**Left alone.** The row labels ship as `Actual` / `Projected`, a different
+vocabulary from the parameter's own `On the books today` / `Projected EOY` —
+three names for two states. That inconsistency stands on purpose: lengthening
+either row label to match the parameter's wording caused a mid-word wrap defect
+that cost two fix rounds, and the card caption directly above already explains
+what the rows are.
 
 `GPA - Dist by grade` cannot use a native axis title, because its value axis
 sets `display='false'`. The other two charts do render a default `% at 3.0+`
@@ -140,12 +172,24 @@ card.
 | Card 2 label   | Progress against the goal    | Always projected, against the network goal — or the selected region's goal.                                  |
 | Card 3, first  | Band mix, network            | On the books today above, projected to year end below. This panel shows both, whatever the switch is set to. |
 | Card 3, second | Band mix by grade            | The same bands, split by grade.                                                                              |
-| Card 4, first  | % at 3.0+ by grade           | Share of students at a 3.0 cumulative or better. The grey tick is the network goal for that grade.           |
-| Card 4, second | Gap to goal, school by grade | Bar length is % at 3.0+; the label is the gap in points; the grey tick is that school's own goal.            |
+| Card 4, first  | % at 3.0+ by grade           | Share at a 3.0 cumulative or better. Tick is the grade's network goal. Colour always projected.              |
+| Card 4, second | Gap to goal, school by grade | Bar is % at 3.0+, follows the basis. Label and colour always projected. Tick is the school goal.             |
 
-`GPA - Title`'s caption currently hedges with "Projected end-of-year unless the
-basis switch is set to on the books today". Once every panel states its own
-basis, that sentence can go.
+Header strips clip their caption with an ellipsis rather than wrapping it, so
+caption length is a hard constraint and not a matter of taste. The budget scales
+with the strip's width. Measured from renders: at 39676 units, captions of 97
+and 96 characters render in full while 129 and 142 clip; at 58565 units, 108
+characters render in full. `assert_cum_cards.py` enforces `97 * width / 39676`,
+which is deliberately conservative — a caption that fails it may still fit, so
+the response to a failure is to render and look, never to raise the constant.
+
+No structural check can see this. It cost a round: the first attempt at the two
+`Card 4` captions above stated the always-projected caveat correctly and at 129
+and 142 characters, and both truncated mid-sentence on screen.
+
+`GPA - Title`'s caption hedged with "Projected end-of-year unless the basis
+switch is set to on the books today". Every panel now states its own basis, so
+that sentence was removed.
 
 ### Colour
 
@@ -190,20 +234,28 @@ Body left holds 86, 86, 38 and 330. Body right holds 141 and 399.
 
 Four header strips and three worksheet titles have to come from somewhere:
 
-- The band legend zone folds into a header strip: 38 pixels.
-- The two single-row bars go from 86 to 62 pixels each. They are single bars.
-- Goal strip goes from 78 to 66 pixels.
+- The band legend zone folds into strip 810, which needs 70 pixels to render all
+  five legend entries — not the 40 pixels a plain header strip costs.
+- The two single-row bars go from 86 to 74 pixels each, not the planned 62.
+- Goal strip goes from 78 to 80 pixels — it grew, not the planned shrink to 66.
 - `GPA - Goal by school` goes from 399 to 360 pixels. Twelve rows at 30 pixels
   each; the Academic Health equivalent runs nine rows at 20 and reads fine.
 - `GPA - Goal by grade` goes from 141 to 120 pixels.
-- `GPA - Dist by grade` gains, 330 to 356 pixels.
+- `GPA - Dist by grade` loses height, 330 to 302 pixels, rather than the planned
+  gain to 356.
+- The headline card also shrank, 138 to 116 pixels, a change nothing in this
+  design called for.
 
-The visible cost concentrates in the school panel, and it is smaller than it
-first looked. Reconciling each flow container's children against its parent
-during planning showed that folding the standalone legend into a header strip
-frees more than the four strips cost, so the by-grade chart grows rather than
-shrinking. The build's check is that each flow container's children sum to the
-parent and the whole dashboard sums to 100000 units.
+The planned savings did not hold. The legend's own strip costs as much as a
+plain strip plus what the legend itself needs, and the goal strip grew instead
+of shrinking. What actually freed the room for the body to grow from 556 to 576
+pixels was the headline card's unplanned 22 pixel loss, offset by 2 pixels back
+into the goal strip — not the legend fold. `GPA - Dist by grade` ends up
+smaller, not larger, because strip 810 and the two single-row bars above it in
+body left consumed more of the column's share than planned. The build's check —
+that each flow container's children sum to the parent and the whole dashboard
+sums to 100000 units — held throughout; it confirms internal consistency, not
+that the plan's pixel predictions did.
 
 ## Build order
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will add a design spec and an implementation plan for the Cumulative GPA Monitor rebuild. It changes no code. The deliverable is a Tableau workbook, and Tableau workbooks are not stored in this repository.

The Cumulative GPA Monitor was the only tab in the `Academic & Gradebook Health Suite` with no titles and no captions on any chart. It also hid which GPA basis a reader was looking at: the `GPA basis` control switches between `Projected EOY` and `On the books today`, some panels follow that switch and some always show projected figures, and nothing on screen marked the difference.

The rebuilt dashboard has 4 bordered cards with header strips, a title and a caption on every chart, a basis line on every panel that depends on the switch, and goal colours that match the Gradebook Fidelity dashboard.

**The workbook is not published.** A review copy is in `GPA-monitor-temp` as `ZZ-REVIEW cum cards 20260908`. The package is `cum-final.twbx` in local scratch. Publishing to `Production` is the owner's to run.

## Reviewer Notes

**The spec's original analysis was wrong, and the correction is the most important thing here.** It traced the basis parameter through bar length only. On `GPA - Goal by school` the bar follows the switch while the mark label and the colour do not, so setting the basis to `On the books today` moves the bars and leaves the gap labels and colours projected. That produces a near-zero-length bar carrying a label like `+11.4pp` in green. The first version of this work put a basis line over that panel and a caption telling the reader to read the label, which made it more misleading than production. The captions now say which encodings follow the switch.

**4 defects reached a render after every structural check passed.** Two headline numbers rendered as `####`, the band legend showed 3 of its 5 entries, 2 row labels clipped mid-word, and 2 basis lines rendered blank. The XML was valid every time.

**3 design decisions were reversed mid-build**, each recorded in the spec with the render evidence: a 3-line label reverted to production's inline form, 2 row labels shortened, and a live parameter value replaced with static text on 2 numbers.

## Self-review

### General

- [x] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

Dagster, dbt and Docs sections do not apply. This pull request touches no code, no models and no automations.

## CI checks

- [ ] **Trunk** — passes.

Refs #5190

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Built with the brainstorming, writing-plans and subagent-driven-development skills across 6 tasks, 9 fix rounds and 4 independent reviews.

**Artifacts, all in gitignored scratch at `.claude/scratch/gpa-overnight/`:**
`server/cum-final.twbx` (29.4 MB, production extract intact), built from `server/prod-base3.twb`, a fresh pull of workbook `b3c14d67-3130-46ac-82a0-0637a5cc2da5` at 2026-09-08 16:04:16 UTC. Chain: `prod-base3` → `cum-1-colour` → `cum-2-reminders` → `cum-3-cards` → `cum-4/5/6-fit` → `cum-8-static` → `cum-10-captions`.

**Verification scripts, all re-runnable:** `assert_cum_colour.py`, `assert_cum_reminders.py`, `assert_cum_cards.py`, `check_geometry.py`, `mutate.py`, plus the pre-existing `check_twb.py`.

`check_geometry.py` is the reusable one. It compares every zone's parent-minus-children gap against the same zone in a `--baseline` workbook and requires an exact match, because those gaps are stable per-container constants unrelated to child count. It caught 2 separate arithmetic errors in the plan's own height tables. Its first version had 900 units of tolerance per child, which passed a 4,445-unit defect with 5 children — a tolerance wider than the bug it guards.

**Colour:** `Calculation_7236501339153214575` moved to `#12a47c` / `#b3161c`, matching `Calculation_1052997927364395018` (`Cell state`) on the fidelity dashboard. Verified by sampling the render: 120,106 green and 40,062 red pixels in the goal panel, with the retired `#2f5fc4` down to 2 anti-aliasing pixels. Academic Health Home's twin `Calculation_4005670422418128910` is untouched and its render is byte-identical across all 7 publishes.

**Two mechanisms that do not work, both recorded in the spec and pinned by assertions.** A `<[Parameters].[Parameter 11]>` token resolves in a worksheet title but renders blank in a `<customized-label>`. Routing the parameter through a calculated field on the Text shelf blanks the entire label, title and number included. Both passed every structural check.

**Header strips clip captions rather than wrapping them.** `assert_cum_cards.py` enforces `97 * width / 39676` characters, anchored on measurements from renders: 97 and 96 characters fit at 39676 units while 129 and 142 clipped, and 108 fit at 58565. A failure means render and look, not raise the constant.

**Invariants held:** 68 worksheets and 14 parameters unchanged, `filter-group='17'` still on 17 zones, the other 4 dashboards byte-identical to production, manifest byte-identical, 27,844 CRLF line endings preserved through every edit and through the repack.

Full task history, every ruling and the triaged deferred minors are in the SDD ledger, which is gitignored and does not ship with this pull request.
</details>
