### PR TITLE
fix(grow): retry a body truncated mid-stream on idempotent requests

### DIFF
--- a/src/teamster/libraries/level_data/grow/resources.py
+++ b/src/teamster/libraries/level_data/grow/resources.py
@@ -6,6 +6,7 @@ from dagster_shared import check
 from oauthlib.oauth2 import BackendApplicationClient
 from pydantic import PrivateAttr
 from requests import Response, Session
+from requests.exceptions import ChunkedEncodingError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError, Timeout
 from requests_oauthlib import OAuth2Session
@@ -37,9 +38,10 @@ class GrowServerError(GrowAPIError):
     """Raised when a request to the Grow API fails transiently.
 
     Covers a 5xx response and a connection-level failure (refused, reset, DNS,
-    timeout) on an idempotent request. An upstream flake, not an application
-    bug, so it is recoverable via retry. POST is excluded: the create may have
-    landed server-side, so retrying it risks a duplicate record.
+    timeout, body truncated mid-stream) on an idempotent request. An upstream
+    flake, not an application bug, so it is recoverable via retry. POST is
+    excluded: the create may have landed server-side, so retrying it risks a
+    duplicate record.
     """
 
 
@@ -94,7 +96,7 @@ class GrowResource(ConfigurableResource):
     def _request(self, method: str, url: str, **kwargs) -> Response:
         try:
             response = self._session.request(method=method, url=url, **kwargs)
-        except (RequestsConnectionError, Timeout) as e:
+        except (RequestsConnectionError, Timeout, ChunkedEncodingError) as e:
             self._raise_request_error(
                 message=str(e), cause=e, transient=method != "POST"
             )

--- a/tests/resources/test_resource_grow_retry.py
+++ b/tests/resources/test_resource_grow_retry.py
@@ -7,6 +7,7 @@ import logging
 import types
 
 import pytest
+from requests.exceptions import ChunkedEncodingError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 from tenacity import wait_none
@@ -136,6 +137,30 @@ def test_connection_error_retries_then_surfaces_as_grow_api_error(
         calls["n"] += 1
 
         raise RequestsConnectionError("connection reset by peer")
+
+    grow = _build_offline_resource(request_fn)
+
+    with pytest.raises(GrowAPIError):
+        grow.put("users", "abc", json={"name": "x"})
+
+    assert calls["n"] == 3
+
+
+def test_chunked_encoding_error_retries(monkeypatch: pytest.MonkeyPatch):
+    """A body truncated mid-stream retries like a reset connection.
+
+    Regression: Grow dropped the ``observations`` page 1771 bytes short and
+    ``requests`` raised ``ChunkedEncodingError``, which is not a
+    ``ConnectionError``, so the step failed on the first attempt.
+    """
+    monkeypatch.setattr(GrowResource._request.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"n": 0}
+
+    def request_fn(method: str, url: str, **kwargs) -> _FakeResponse:
+        calls["n"] += 1
+
+        raise ChunkedEncodingError("Connection broken: IncompleteRead")
 
     grow = _build_offline_resource(request_fn)
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will retry a Grow API request whose response body is cut off mid-stream, the same way it already retries a reset connection or a timeout.

Dagster run `2f03caff-dd90-4ea8-8d21-e4d8b25ee40b` failed on the `observations` step because Grow dropped the connection 1771 bytes before the end of a page. `requests` raised `ChunkedEncodingError`. That class is not a `ConnectionError` or `Timeout`, so `GrowResource._request` did not mark it transient and the tenacity retry never fired. Dagster's run-level auto-retry recovered the partition 1 minute later, so no data was lost.

The fix adds `ChunkedEncodingError` to the transient tuple in `_request`. POST stays excluded by the existing `transient=method != "POST"` guard. One regression test asserts 3 attempts on a truncated body.

## Reviewer Notes

The other `requests`-based resources (coupa, tableau, finalsite, zendesk, adp, knowbe4) have the same gap. Left for a separate change.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [x] Ran `uv run pytest tests/resources/test_resource_grow_retry.py` — 9 passed

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes or not triggered.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Diagnosed via `get_run_logs` error chain bottom: `urllib3.exceptions.IncompleteRead: IncompleteRead(545846 bytes read, 1771 more expected)` raised from `requests/models.py` `content` → `ChunkedEncodingError`, caught nowhere in `_request`. Auto-retry run `2658a290-e6ab-43cb-ad07-ca1cf827ce20` succeeded. `ChunkedEncodingError` inherits directly from `RequestException`, not from `ConnectionError`.

</details>