### PR TITLE
fix(tableau): probe the fresh PAT session and re-sign-in on 401002

### DIFF
--- a/src/teamster/libraries/tableau/CLAUDE.md
+++ b/src/teamster/libraries/tableau/CLAUDE.md
@@ -26,3 +26,9 @@ Asset metadata, kinds, and label come from the workbook's dbt
 
 Authenticates to Tableau Server via Personal Access Token (PAT). Exposes
 `_server` (a `tableauserverclient.Server` instance) for workbook operations.
+
+`_sign_in` probes the new session with a `users.get_by_id` self-lookup and
+re-signs-in (inside the existing tenacity loop) when Tableau rejects it with
+`401002`. Tableau intermittently rejects a token it issued under a second
+earlier; a fresh sign-in always recovers. Do not add a per-op 401 retry: this is
+the single fix point for all three Tableau assets.

--- a/src/teamster/libraries/tableau/resources.py
+++ b/src/teamster/libraries/tableau/resources.py
@@ -3,7 +3,10 @@ from pydantic import PrivateAttr
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout
 from tableauserverclient.models.tableau_auth import PersonalAccessTokenAuth
-from tableauserverclient.server.endpoint.exceptions import InternalServerError
+from tableauserverclient.server.endpoint.exceptions import (
+    FailedSignInError,
+    InternalServerError,
+)
 from tableauserverclient.server.server import Server
 from tenacity import (
     retry,
@@ -11,6 +14,10 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential_jitter,
 )
+
+
+class StaleSessionError(Exception):
+    """Tableau rejected the session it issued a moment earlier."""
 
 
 class TableauServerResource(ConfigurableResource):
@@ -30,7 +37,7 @@ class TableauServerResource(ConfigurableResource):
 
     @retry(
         retry=retry_if_exception_type(
-            (RequestsConnectionError, Timeout, InternalServerError)
+            (RequestsConnectionError, Timeout, InternalServerError, StaleSessionError)
         ),
         stop=stop_after_attempt(5),
         wait=wait_exponential_jitter(initial=2, max=60),
@@ -49,6 +56,11 @@ class TableauServerResource(ConfigurableResource):
         transport-level ``ConnectionError`` / ``Timeout``), while a
         ``FailedSignInError`` (401) or ``ServerResponseError`` (other 4xx) is a
         deterministic credential/request failure left to fail fast.
+
+        Regression for prod runs afa747ef, 1de7236e, dd451efd: sign-in succeeded
+        and the first request 0.2-0.4s later returned ``401002``. A fresh sign-in
+        always recovered, so a self-lookup probes the new session and a rejected
+        probe (``StaleSessionError``) re-enters the same retry loop.
         """
         self._server.auth.sign_in(
             PersonalAccessTokenAuth(
@@ -57,3 +69,8 @@ class TableauServerResource(ConfigurableResource):
                 site_id=self.site_id,
             )
         )
+
+        try:
+            self._server.users.get_by_id(self._server.user_id)
+        except FailedSignInError as e:
+            raise StaleSessionError(str(e)) from e

--- a/tests/resources/test_resource_tableau.py
+++ b/tests/resources/test_resource_tableau.py
@@ -72,8 +72,13 @@ def test_tableau_add_group_users():
     tableau._server.groups.add_users(group_item=group_item, users=users)
 
 
-def _build_offline_resource(sign_in_fn) -> TableauServerResource:
-    """Instantiate the resource with a fake server, bypassing the network path."""
+def _build_offline_resource(
+    sign_in_fn, probe_fn=lambda _user_id: None
+) -> TableauServerResource:
+    """Instantiate the resource with a fake server, bypassing the network path.
+
+    ``probe_fn`` stands in for the post-sign-in ``users.get_by_id`` self-lookup.
+    """
     tableau = TableauServerResource(
         server_address="https://tableau.example.com",
         token_name="x",
@@ -84,7 +89,11 @@ def _build_offline_resource(sign_in_fn) -> TableauServerResource:
     object.__setattr__(
         tableau,
         "_server",
-        types.SimpleNamespace(auth=types.SimpleNamespace(sign_in=sign_in_fn)),
+        types.SimpleNamespace(
+            auth=types.SimpleNamespace(sign_in=sign_in_fn),
+            users=types.SimpleNamespace(get_by_id=probe_fn),
+            user_id="user-1",
+        ),
     )
 
     return tableau
@@ -223,3 +232,35 @@ def test_setup_for_execution_invokes_sign_in(monkeypatch: pytest.MonkeyPatch):
 
     assert calls["n"] == 1
     assert tableau._server.version == "3.25"
+
+
+def test_sign_in_re_signs_in_when_fresh_session_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A 401 on the first call after a successful sign-in triggers a re-sign-in.
+
+    Regression for prod runs afa747ef, 1de7236e, dd451efd (2026-09-06..08): PAT
+    sign-in succeeded, and the very next request 0.2-0.4s later returned
+    ``401002 Unauthorized Access``. The run-level auto-retry (a full new sign-in)
+    recovered every time, so the resource must probe the session before handing
+    it to the op and re-sign-in when the probe is rejected.
+    """
+    monkeypatch.setattr(TableauServerResource._sign_in.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"sign_in": 0, "probe": 0}
+
+    def sign_in_fn(_auth) -> None:
+        calls["sign_in"] += 1
+
+    def probe_fn(_user_id):
+        calls["probe"] += 1
+        if calls["probe"] == 1:
+            raise FailedSignInError(
+                "401002", "Unauthorized Access", "Invalid authentication", "url"
+            )
+
+    tableau = _build_offline_resource(sign_in_fn, probe_fn)
+
+    tableau._sign_in()
+
+    assert calls == {"sign_in": 2, "probe": 2}

--- a/tests/resources/test_resource_tableau.py
+++ b/tests/resources/test_resource_tableau.py
@@ -10,7 +10,10 @@ from tableauserverclient.server.endpoint.exceptions import (
 )
 from tenacity import wait_none
 
-from teamster.libraries.tableau.resources import TableauServerResource
+from teamster.libraries.tableau.resources import (
+    StaleSessionError,
+    TableauServerResource,
+)
 
 
 def get_tableau_resource():
@@ -264,3 +267,32 @@ def test_sign_in_re_signs_in_when_fresh_session_is_rejected(
     tableau._sign_in()
 
     assert calls == {"sign_in": 2, "probe": 2}
+
+
+def test_sign_in_exhausts_on_persistent_stale_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A probe that stays rejected is retried to the cap, then re-raised.
+
+    Mirrors the persistent-connection-error test: ``StaleSessionError`` must
+    surface after 5 fresh sign-ins rather than retry unbounded or be swallowed.
+    """
+    monkeypatch.setattr(TableauServerResource._sign_in.retry, "wait", wait_none())  # pyright: ignore[reportFunctionMemberAccess]
+
+    calls = {"sign_in": 0, "probe": 0}
+
+    def sign_in_fn(_auth) -> None:
+        calls["sign_in"] += 1
+
+    def probe_fn(_user_id):
+        calls["probe"] += 1
+        raise FailedSignInError(
+            "401002", "Unauthorized Access", "Invalid authentication", "url"
+        )
+
+    tableau = _build_offline_resource(sign_in_fn, probe_fn)
+
+    with pytest.raises(StaleSessionError):
+        tableau._sign_in()
+
+    assert calls == {"sign_in": 5, "probe": 5}


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." stop Tableau workbook refresh runs from failing when Tableau rejects a session it issued half a second earlier.

Three prod runs this week (`afa747ef`, `1de7236e`, `dd451efd`) signed in with the PAT successfully, then had the very next request rejected with `401002 Unauthorized Access` 0.2 to 0.4 seconds later. The Dagster auto-retry, which is a full new sign-in, recovered every time. This change does that recovery inside the resource: after sign-in, `_sign_in` probes the session with a `users.get_by_id` self-lookup. If the probe is rejected, it raises `StaleSessionError`, which the existing tenacity loop retries with a fresh sign-in. The op never sees the stale token, so no failed run and no alert.

## Reviewer Notes

- The fix lives in the resource, not the op, so all 3 Tableau assets (workbook refresh, workbook stats, gradebook group sync) get it. Do not add a per-op 401 retry on top.
- A real bad PAT still fails fast. `FailedSignInError` from `auth.sign_in` itself stays outside the retry predicate; only the post-sign-in probe maps to `StaleSessionError`.
- Root cause on the Tableau side is unconfirmed. The pattern (first request only, sub-second, ~3% of runs, retry always works, no other Dagster Tableau step running) points at a server-side session race. Whether it is that or another client sharing the PAT, a re-sign-in is the same recovery the auto-retry already performs.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified code location
- [x] New integrations follow the [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/) with the correct asset key format and IO manager (n/a, no new integration)

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt` locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check → expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths change and the PR is not a draft). If it fails: check the **Actions** tab for the workflow run logs. Re-run failed jobs if the failure looks transient; otherwise check the **Dagster Cloud** branch deployment for error details. Or tag **Claude** on the PR for help.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Diagnosed via `superpowers:systematic-debugging` from run `afa747ef-551d-4a30-8a2a-255fbee7f2e4`.

Evidence: `ResourceInitSuccessEvent` at 17:05:55.153 UTC (sign-in ok), `ExecutionStepStartEvent` at 17:05:55.359, `ExecutionStepFailureEvent` at 17:05:55.601 with `FailedSignInError 401002` raised from `workbooks.get_by_id` in `libraries/tableau/assets.py:41`. Same shape for `1de7236e` (2026-09-06 20:07:09 UTC) and `dd451efd` (2026-09-07 10:14:56 UTC). In all 3 ticks the `tableau_pat_session_limit` pool serialized Tableau steps; the nearest other Tableau step ended 30 s or more before and started 25 s or more after. Tableau docs state a second sign-in with the same PAT terminates the earlier session, but an external sign-in landing inside a 0.5 s window 3 times in 3 days is implausible; a multi-node session propagation race fits better. Tableau Server logs were not available to confirm.

Verification: 6 offline unit tests in `tests/resources/test_resource_tableau.py` pass (5 existing plus `test_sign_in_re_signs_in_when_fresh_session_is_rejected`). A throwaway live pytest ran `setup_for_execution` against real Tableau with the probe in place and passed (`is_signed_in()` true), then was deleted. `trunk check --force` clean on all 3 files. `dagster definitions validate` and `tests/test_dagster_definitions.py` were not run; the change is a 5-line addition inside `_sign_in` plus one import, exercised by the unit tests.

Probe choice: `users.get_by_id(server.user_id)` needs no admin role (any user may query their own record) and is cheap. `sites.get_by_id` was rejected because Query Site needs site admin.

</details>
