### PR TITLE
fix(grow): keep coaches off the Teachers fallback observation group

### DIFF
--- a/src/dbt/kipptaf/models/extracts/schoolmint/properties/rpt_schoolmint_grow__users.yml
+++ b/src/dbt/kipptaf/models/extracts/schoolmint/properties/rpt_schoolmint_grow__users.yml
@@ -159,12 +159,13 @@ models:
         data_type: string
         description: >
           Observation-group membership directive consumed by `grow_user_sync`.
-          Observee and observer are independent: `observees` covers `Teacher`,
-          `School Admin` and `School Assistant Admin`, `observers` covers any
-          admin role plus `Regional Observer` and `Coach`, and a user who
-          matches both gets `observees;observers`. A New Teacher Network
-          Coordinator is usually a teacher too, so they get both. Empty string
-          when the user matches neither.
+          Observee and observer are independent: `observees` covers `Teacher`
+          only, `observers` covers any admin role plus `Regional Observer` and
+          `Coach`, and a user who matches both gets `observees;observers`. A New
+          Teacher Network Coordinator is usually a teacher too, so they get
+          both. A school admin or assistant admin observes without being
+          observed -- they hold a leadership role rather than a coached teaching
+          assignment. Empty string when the user matches neither.
       - name: surrogate_key_source
         data_type: string
         description: >
@@ -711,10 +712,9 @@ unit_tests:
 
   - name: unit_grow_users_group_type_additive
     description:
-      Pins observee and observer membership as two independent predicates. A
-      School Assistant Admin who coaches is now both, where the old first-match
-      CASE made every admin an observer only. A Regional Admin is an observer
-      but never an observee. A plain teacher stays an observee.
+      Pins observee and observer membership as two independent predicates. Only
+      a teacher is an observee -- a School Assistant Admin who coaches observes
+      and is never observed, and neither is a Regional Admin.
     model: rpt_schoolmint_grow__users
     given:
       - input: ref('int_people__staff_roster')
@@ -820,7 +820,7 @@ unit_tests:
     expect:
       rows:
         - { user_internal_id: 200, group_type: observers }
-        - { user_internal_id: 201, group_type: observees;observers }
+        - { user_internal_id: 201, group_type: observers }
         - { user_internal_id: 202, group_type: observees }
 
   - name: unit_grow_users_region_scope
@@ -1089,7 +1089,7 @@ unit_tests:
             role_names: [Regional Observer, School Assistant Admin],
             regional_admin_school_ids: [sch-courage],
             readonly: 0,
-            group_type: observees;observers,
+            group_type: observers,
           }
         - {
             user_internal_id: 402,

--- a/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
+++ b/src/dbt/kipptaf/models/extracts/schoolmint/rpt_schoolmint_grow__users.sql
@@ -230,16 +230,10 @@ with
                 select role._id from unnest(u.roles) as role order by role._id
             ) as role_ids_ws,
 
-            /* observee and observer are independent; a coaching admin is both */
+            /* observee and observer are independent; only teachers are observed */
             array_to_string(
                 [
-                    if(
-                        p.is_teacher
-                        or p.is_school_admin
-                        or p.is_school_assistant_admin,
-                        'observees',
-                        null
-                    ),
+                    if(p.is_teacher, 'observees', null),
                     if(
                         p.is_regional_admin
                         or p.is_regional_observer

--- a/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
+++ b/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
@@ -144,6 +144,18 @@ def _observes_fallback(user: dict[str, Any]) -> bool:
     )
 
 
+def _fallback_group(uncoached: list[str], observers: list[str]) -> dict[str, list[str]]:
+    """Membership of a school's Teachers fallback group.
+
+    Its observers go with its observees: an empty fallback that still carries
+    observers shows up as a group in each of their pickers, holding nobody.
+    """
+    return {
+        "observees": uncoached,
+        "observers": observers if uncoached else [],
+    }
+
+
 @asset(
     key=[*key_prefix, "user_sync"],
     deps=[AssetKey(["kipptaf", "extracts", "rpt_schoolmint_grow__users"])],
@@ -330,12 +342,7 @@ def grow_user_sync(
 
         wanted: dict[str, dict[str, Any]] = {
             # Teachers survives as the fallback for observees with no coach.
-            # Its observers go with its observees: an empty fallback with
-            # observers still shows up as a group in each of their pickers.
-            "Teachers": {
-                "observees": uncoached,
-                "observers": school_observers if uncoached else [],
-            }
+            "Teachers": _fallback_group(uncoached, school_observers)
         }
         # Parenthesised employee number, so a display-name change relabels
         # the group without breaking its identity. None (e.g. Teachers) gets

--- a/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
+++ b/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
@@ -1,5 +1,5 @@
 import pathlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 from dagster import (
@@ -70,6 +70,11 @@ observations = build_grow_asset(
     schema=OBSERVATION_SCHEMA,
 )
 
+# Grow school payload key -> role name. Also the roles that observe a school's
+# Teachers fallback group: a coach reaches their own reports through their own
+# group, so listing them on the fallback too duplicates it in their picker.
+ADMIN_ROLES = {"admins": "School Admin", "assistantAdmins": "School Assistant Admin"}
+
 
 def _match_observation_group(
     name: str,
@@ -77,51 +82,22 @@ def _match_observation_group(
     existing_by_id: dict[str, str],
     claimed: set[str],
 ) -> str | None:
-    """Find an unclaimed existing group id for this wanted group.
+    """Unclaimed existing group id for this wanted group, or None.
 
-    Prefers an exact name match. Falls back to ``match_key``, a stable
-    substring that survives a display-name change -- for a coach group that is
-    the parenthesised employee number.
-
-    The fallback is a suffix match and nothing more: any existing group whose
-    name ends in ``(<employee number>)`` is claimed, and the school PUT then
-    replaces its membership. A group with no ``match_key``, such as Teachers,
-    gets no fallback at all and so can never be claimed this way.
-
-    That leaves a hand-made group named ``... (<a live employee number>)``
-    theoretically claimable. Measured 2026-09-02: zero of the 585 existing
-    groups end in parenthesised digits, and every active employee number is
-    six digits in 100001-402082 -- so no group name carrying a year or a small
-    cohort number can collide. Revisit if employee numbering ever narrows to
-    four digits.
+    Exact name first, then a suffix match on ``match_key`` (the parenthesised
+    employee number, which survives a coach rename). None means no fallback.
     """
-    for group_id, group_name in existing_by_id.items():
-        if group_id not in claimed and group_name == name:
-            return group_id
+    unclaimed = [(i, n) for i, n in existing_by_id.items() if i not in claimed]
 
-    if match_key is None:
-        return None
-
-    return next(
-        (
-            group_id
-            for group_id, group_name in existing_by_id.items()
-            if group_id not in claimed and group_name.endswith(match_key)
-        ),
-        None,
+    return next((i for i, n in unclaimed if n == name), None) or (
+        next((i for i, n in unclaimed if n.endswith(match_key)), None)
+        if match_key is not None
+        else None
     )
 
 
-FALLBACK_OBSERVER_ROLE_NAMES = ("School Admin", "School Assistant Admin")
-
-
 def _can_anchor_group(user: dict[str, Any]) -> bool:
-    """Whether this user can be the sole observer of a coaching group.
-
-    A coach who is inactive, readonly, or no longer carries an observer role
-    cannot actually observe, so their reports fall back to the school's
-    Teachers group rather than into a group nobody can act in.
-    """
+    """Active, writable, and observer-capable: can be a group's sole observer."""
     return (
         user["inactive"] == 0
         and not user["readonly"]
@@ -130,30 +106,28 @@ def _can_anchor_group(user: dict[str, Any]) -> bool:
 
 
 def _observes_fallback(user: dict[str, Any]) -> bool:
-    """Whether this user observes a school's Teachers fallback group.
-
-    The fallback holds only the observees whose own manager cannot anchor a
-    group, which makes it a leadership backstop rather than a coaching
-    assignment. Every coach already reaches their own reports through their own
-    group, so listing them here too puts a second, wider group in their picker
-    for teachers they do not coach. Only a school's admins and assistant admins
-    observe it.
-    """
-    return _can_anchor_group(user) and any(
-        role in user["role_names"] for role in FALLBACK_OBSERVER_ROLE_NAMES
+    """A school admin or assistant admin who can anchor a group."""
+    return _can_anchor_group(user) and not set(ADMIN_ROLES.values()).isdisjoint(
+        user["role_names"]
     )
 
 
-def _fallback_group(uncoached: list[str], observers: list[str]) -> dict[str, list[str]]:
-    """Membership of a school's Teachers fallback group.
+def _at_school(
+    school_users: list[dict[str, Any]],
+    users_by_grow_id: dict[str, dict[str, Any]],
+    pred: Callable[[dict[str, Any]], bool],
+) -> list[str]:
+    """Home-school users matching pred, plus managers of reports here who match.
 
-    Its observers go with its observees: an empty fallback that still carries
-    observers shows up as a group in each of their pickers, holding nobody.
+    A leader covering a satellite campus reaches its users through their
+    reports, not their own school_id.
     """
-    return {
-        "observees": uncoached,
-        "observers": observers if uncoached else [],
-    }
+    managers = (users_by_grow_id.get(u["coach_id"]) for u in school_users)
+
+    return sorted(
+        {u["user_id"] for u in school_users if pred(u)}
+        | {m["user_id"] for m in managers if m is not None and pred(m)}
+    )
 
 
 @asset(
@@ -176,10 +150,8 @@ def grow_user_sync(
     with db_bigquery.get_client() as bq:
         query_job = bq.query(query=query, project=db_bigquery.project)
 
-    arrow = query_job.to_arrow()
-
-    context.log.info(f"Retrieved {arrow.num_rows} rows")
-    users = arrow.to_pylist()
+    users = query_job.to_arrow().to_pylist()
+    context.log.info(f"Retrieved {len(users)} rows")
 
     # create/update users
     for u in users:
@@ -228,7 +200,6 @@ def grow_user_sync(
             "readonly": bool(u["readonly"]),
         }
 
-        # reset request_args after the restore branch may have mutated it
         request_args = ["users"]
 
         try:
@@ -267,11 +238,6 @@ def grow_user_sync(
             continue
 
     # update school observation groups
-    admin_roles = {
-        "admins": "School Admin",
-        "assistantAdmins": "School Assistant Admin",
-    }
-
     schools = grow.get("schools")["data"]
 
     # A coach's home school often differs from their reports', so resolve
@@ -301,21 +267,9 @@ def grow_user_sync(
             g["_id"]: g["name"] for g in school["observationGroups"]
         }
 
-        # Home-school membership, plus any manager of a report at this school
-        # who observes the fallback -- mirrors the admin lists' reach so a
-        # leader covering a satellite campus can observe its coachless teachers
-        # there too.
-        school_observers_set = {
-            u["user_id"] for u in school_users if _observes_fallback(u)
-        }
-
-        for u in school_users:
-            manager = users_by_grow_id.get(u["coach_id"])
-
-            if manager is not None and _observes_fallback(manager):
-                school_observers_set.add(manager["user_id"])
-
-        school_observers = sorted(school_observers_set)
+        school_observers = _at_school(
+            school_users, users_by_grow_id, _observes_fallback
+        )
 
         # Route every observee to their coach's group, or to the fallback.
         by_coach: dict[str, list[str]] = {}
@@ -337,12 +291,14 @@ def grow_user_sync(
             else:
                 by_coach.setdefault(coach_id, []).append(u["user_id"])
 
-        def coach_group_name(coach: dict[str, Any]) -> str:
-            return f"{coach['user_name']} ({coach['user_internal_id']})"
-
         wanted: dict[str, dict[str, Any]] = {
-            # Teachers survives as the fallback for observees with no coach.
-            "Teachers": _fallback_group(uncoached, school_observers)
+            # Teachers survives as the fallback for observees with no coach. An
+            # empty fallback drops its observers too, or it still shows up in
+            # each of their pickers holding nobody.
+            "Teachers": {
+                "observees": uncoached,
+                "observers": school_observers if uncoached else [],
+            }
         }
         # Parenthesised employee number, so a display-name change relabels
         # the group without breaking its identity. None (e.g. Teachers) gets
@@ -352,7 +308,7 @@ def grow_user_sync(
 
         for coach_id, observee_ids in by_coach.items():
             coach = users_by_grow_id[coach_id]
-            name = coach_group_name(coach)
+            name = f"{coach['user_name']} ({coach['user_internal_id']})"
 
             wanted[name] = {
                 "observees": observee_ids,
@@ -381,44 +337,22 @@ def grow_user_sync(
         # The school PUT REPLACES this array, so a group left out is deleted.
         # Emit every surviving group emptied rather than dropping it, so no
         # observation history is ever orphaned by a coach moving on.
-        for group_id, group_name in existing_by_id.items():
-            if group_id in claimed:
-                continue
-
-            observation_groups.append(
-                {
-                    "_id": group_id,
-                    "name": group_name,
-                    "observees": [],
-                    "observers": [],
-                }
-            )
+        observation_groups += [
+            {"_id": i, "name": n, "observees": [], "observers": []}
+            for i, n in existing_by_id.items()
+            if i not in claimed
+        ]
 
         payload["observationGroups"] = observation_groups
 
-        for key, role_name in admin_roles.items():
-            # Home-school membership, plus anyone whose reports sit at this
-            # school -- a leader covering two campuses belongs to both.
-            admins_here = {
-                u["user_id"] for u in school_users if role_name in u["role_names"]
-            }
-
-            for u in school_users:
-                manager = users_by_grow_id.get(u["coach_id"])
-
-                if (
-                    manager is not None
-                    and manager["inactive"] == 0
-                    and role_name in manager["role_names"]
-                ):
-                    admins_here.add(manager["user_id"])
-
+        for key, role_name in ADMIN_ROLES.items():
             payload[key] = [
-                {
-                    "_id": user_id,
-                    "name": users_by_grow_id[user_id]["user_name"],
-                }
-                for user_id in sorted(admins_here)
+                {"_id": i, "name": users_by_grow_id[i]["user_name"]}
+                for i in _at_school(
+                    school_users,
+                    users_by_grow_id,
+                    lambda u, r=role_name: u["inactive"] == 0 and r in u["role_names"],
+                )
             ]
 
         try:
@@ -445,10 +379,7 @@ def grow_user_sync(
     )
 
 
-grow_multi_partitions_assets = [
-    assignments,
-    observations,
-]
+grow_multi_partitions_assets = [assignments, observations]
 
 assets = [
     *grow_multi_partitions_assets,

--- a/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
+++ b/src/teamster/code_locations/kipptaf/level_data/grow/assets.py
@@ -112,6 +112,9 @@ def _match_observation_group(
     )
 
 
+FALLBACK_OBSERVER_ROLE_NAMES = ("School Admin", "School Assistant Admin")
+
+
 def _can_anchor_group(user: dict[str, Any]) -> bool:
     """Whether this user can be the sole observer of a coaching group.
 
@@ -123,6 +126,21 @@ def _can_anchor_group(user: dict[str, Any]) -> bool:
         user["inactive"] == 0
         and not user["readonly"]
         and "observers" in user["group_type"]
+    )
+
+
+def _observes_fallback(user: dict[str, Any]) -> bool:
+    """Whether this user observes a school's Teachers fallback group.
+
+    The fallback holds only the observees whose own manager cannot anchor a
+    group, which makes it a leadership backstop rather than a coaching
+    assignment. Every coach already reaches their own reports through their own
+    group, so listing them here too puts a second, wider group in their picker
+    for teachers they do not coach. Only a school's admins and assistant admins
+    observe it.
+    """
+    return _can_anchor_group(user) and any(
+        role in user["role_names"] for role in FALLBACK_OBSERVER_ROLE_NAMES
     )
 
 
@@ -272,17 +290,17 @@ def grow_user_sync(
         }
 
         # Home-school membership, plus any manager of a report at this school
-        # who is themselves observer-capable -- mirrors the admin lists' reach
-        # so a leader covering a satellite campus can observe its coachless
-        # teachers there too.
+        # who observes the fallback -- mirrors the admin lists' reach so a
+        # leader covering a satellite campus can observe its coachless teachers
+        # there too.
         school_observers_set = {
-            u["user_id"] for u in school_users if "observers" in u["group_type"]
+            u["user_id"] for u in school_users if _observes_fallback(u)
         }
 
         for u in school_users:
             manager = users_by_grow_id.get(u["coach_id"])
 
-            if manager is not None and _can_anchor_group(manager):
+            if manager is not None and _observes_fallback(manager):
                 school_observers_set.add(manager["user_id"])
 
         school_observers = sorted(school_observers_set)
@@ -312,7 +330,12 @@ def grow_user_sync(
 
         wanted: dict[str, dict[str, Any]] = {
             # Teachers survives as the fallback for observees with no coach.
-            "Teachers": {"observees": uncoached, "observers": school_observers}
+            # Its observers go with its observees: an empty fallback with
+            # observers still shows up as a group in each of their pickers.
+            "Teachers": {
+                "observees": uncoached,
+                "observers": school_observers if uncoached else [],
+            }
         }
         # Parenthesised employee number, so a display-name change relabels
         # the group without breaking its identity. None (e.g. Teachers) gets

--- a/tests/assets/test_grow_observation_groups.py
+++ b/tests/assets/test_grow_observation_groups.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from teamster.code_locations.kipptaf.level_data.grow.assets import (
     _can_anchor_group,
-    _fallback_group,
     _match_observation_group,
     _observes_fallback,
 )
@@ -87,7 +86,10 @@ def test_match_observation_group_claims_any_group_with_the_key_suffix() -> None:
     Pins the residual risk rather than asserting it away: a hand-made group
     whose name ends in a live employee number IS claimed, and the school PUT
     replaces its membership. Accepted because no real group name can collide
-    -- see the docstring on ``_match_observation_group`` for the measurement.
+    Measured 2026-09-02: zero of the 585 existing groups end in parenthesised
+    digits, and every active employee number is six digits in 100001-402082,
+    so no name carrying a year or a small cohort number can match. Revisit if
+    employee numbering ever narrows to four digits.
     If a shape gate is ever added, this test is the one that must change.
     """
     existing_by_id = {"g1": "New Hires (123456)"}
@@ -154,19 +156,3 @@ def test_observes_fallback_false_for_regional_observer() -> None:
 
 def test_observes_fallback_false_when_admin_cannot_anchor() -> None:
     assert _observes_fallback(_user(role_names=["School Admin"], readonly=1)) is False
-
-
-def test_fallback_group_keeps_observers_while_it_holds_observees() -> None:
-    assert _fallback_group(["u1", "u2"], ["a1"]) == {
-        "observees": ["u1", "u2"],
-        "observers": ["a1"],
-    }
-
-
-def test_fallback_group_drops_observers_when_it_holds_nobody() -> None:
-    """An empty fallback with observers still shows up in each of their pickers.
-
-    24 of the 28 schools have an empty fallback, so this is what actually
-    clears the duplicate group for a coach who is also an assistant admin.
-    """
-    assert _fallback_group([], ["a1", "a2"]) == {"observees": [], "observers": []}

--- a/tests/assets/test_grow_observation_groups.py
+++ b/tests/assets/test_grow_observation_groups.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from teamster.code_locations.kipptaf.level_data.grow.assets import (
     _can_anchor_group,
+    _fallback_group,
     _match_observation_group,
     _observes_fallback,
 )
@@ -153,3 +154,19 @@ def test_observes_fallback_false_for_regional_observer() -> None:
 
 def test_observes_fallback_false_when_admin_cannot_anchor() -> None:
     assert _observes_fallback(_user(role_names=["School Admin"], readonly=1)) is False
+
+
+def test_fallback_group_keeps_observers_while_it_holds_observees() -> None:
+    assert _fallback_group(["u1", "u2"], ["a1"]) == {
+        "observees": ["u1", "u2"],
+        "observers": ["a1"],
+    }
+
+
+def test_fallback_group_drops_observers_when_it_holds_nobody() -> None:
+    """An empty fallback with observers still shows up in each of their pickers.
+
+    24 of the 28 schools have an empty fallback, so this is what actually
+    clears the duplicate group for a coach who is also an assistant admin.
+    """
+    assert _fallback_group([], ["a1", "a2"]) == {"observees": [], "observers": []}

--- a/tests/assets/test_grow_observation_groups.py
+++ b/tests/assets/test_grow_observation_groups.py
@@ -1,7 +1,8 @@
 """Pure-helper coverage for Grow observation-group matching and anchoring.
 
-`_match_observation_group` and `_can_anchor_group` are plain functions over
-small dicts -- no Dagster execution, no Grow API, no fixtures beyond literals.
+`_match_observation_group`, `_can_anchor_group` and `_observes_fallback` are
+plain functions over small dicts -- no Dagster execution, no Grow API, no
+fixtures beyond literals.
 """
 
 from typing import Any
@@ -9,6 +10,7 @@ from typing import Any
 from teamster.code_locations.kipptaf.level_data.grow.assets import (
     _can_anchor_group,
     _match_observation_group,
+    _observes_fallback,
 )
 
 
@@ -101,6 +103,7 @@ def _user(**overrides: Any) -> dict[str, Any]:
         "inactive": 0,
         "readonly": 0,
         "group_type": ["observers", "observees"],
+        "role_names": ["School Admin"],
     }
     user.update(overrides)
 
@@ -121,3 +124,32 @@ def test_can_anchor_group_false_when_missing_observers_role() -> None:
 
 def test_can_anchor_group_true_when_active_not_readonly_and_observer() -> None:
     assert _can_anchor_group(_user()) is True
+
+
+def test_observes_fallback_true_for_school_admin() -> None:
+    assert _observes_fallback(_user(role_names=["School Admin"])) is True
+
+
+def test_observes_fallback_true_for_school_assistant_admin() -> None:
+    assert (
+        _observes_fallback(_user(role_names=["Coach", "School Assistant Admin"]))
+        is True
+    )
+
+
+def test_observes_fallback_false_for_coach_without_an_admin_role() -> None:
+    """A coach reaches their own reports through their own group, not the fallback.
+
+    Pins the fix for the duplicate group: before this, every observer-capable
+    user at a school observed the fallback too, so a coach was listed against
+    the coachless teachers they do not coach.
+    """
+    assert _observes_fallback(_user(role_names=["Coach"])) is False
+
+
+def test_observes_fallback_false_for_regional_observer() -> None:
+    assert _observes_fallback(_user(role_names=["Regional Observer"])) is False
+
+
+def test_observes_fallback_false_when_admin_cannot_anchor() -> None:
+    assert _observes_fallback(_user(role_names=["School Admin"], readonly=1)) is False


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop every coach from also observing their school's `Teachers` fallback group, and stop school leaders from being observed at all.

PR #5078 gave each coach their own observation group. It left the `Teachers` group in place as the fallback for teachers whose own manager cannot anchor a group, and it left every observer-capable person at the school on that group as an observer. So a coach saw two groups: their own reports, plus a wider group holding teachers they do not coach.

Three changes ship together.

**Only a teacher is an observee.** A school admin or assistant admin holds a leadership role, not a coached teaching assignment. 171 of them stop being observed.

**Only a school's admins and assistant admins observe the fallback.** That drops the fallback's observers from 235 to 165. Every other coach reaches their own reports through their own group.

**The fallback's observers are emptied when it holds no observees.** An empty group with observers still shows up as a group in each of their pickers. 24 of the 28 schools now have an empty fallback.

The fallback itself survives. It holds the 9 teachers whose own manager cannot anchor a group, down from 26.

## Reviewer Notes

**Leaders who coach only other leaders now anchor no group.** Coach groups drop from 174 to 150, because 24 coaches had no reports left once admins and assistant admins stopped being observees. A principal who coaches only their assistant principals can no longer observe them in Grow. That follows directly from the decision that leaders are not observees, but it is worth an eyeball before the first sync run.

**165 people still observe a fallback, and 122 of them also anchor their own coach group.** Restricting the fallback to admins and assistant admins does not remove every duplicate group — most coaches hold `School Assistant Admin`. Where their school's fallback is empty the group carries nobody, which is the case at 24 of 28 schools. The four exceptions are Room 9, KIPP Newark Collegiate Academy, KIPP Cooper Norcross High and KIPP Newark Lab High School.

**Nobody observes an empty fallback, so a newly-uncoached teacher is invisible until the next sync.** The sync runs daily, and the group is re-populated with its observers the moment it has an observee again.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the TEAMster Asana Project
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why.

### Dagster

- [ ] Run `uv run dagster definitions validate` for any modified code location

`dagster definitions validate` cannot run in this Codespace — the `kipptaf` location fails to import on unset Illuminate dlt settings, which is documented behaviour. Verified instead with `py_compile` plus the pure-helper unit tests. Needs a real check in CI.

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models; `group_type`'s description and two unit tests are updated in place.
- [x] **Breaking change?** No. No column is renamed, removed, or retyped. `group_type` changes values, not its shape.

## CI checks

- [ ] **Trunk** — `trunk check --force` passes locally on all four changed files.
- [ ] **dbt Cloud** — `dbt build --select rpt_schoolmint_grow__users` passes locally: 14 nodes, 0 errors, 0 warnings. All 7 unit tests pass.
- [ ] **Dagster Cloud** — expected to run, since a code location changed.

<details>
<summary>For Claude</summary>

Reported by a school assistant admin at KIPP Royalty Academy who saw two groups in her picker: her own coach group, and the school's `Teachers` group with her listed as a `Coach` on it.

The original report was that the second group let her see everyone. It did not: measured against the extract, KIPP Royalty Academy's fallback held 1 observee, not 42. The duplicate group was real; its width was not. The live group membership could not be read back to confirm — the 1Password token in the working session was expired, and the `schools` ingest snapshot in BigQuery predates the last sync by an hour.

The fallback observer rule was chosen over two alternatives, both rejected by the requester: `School Admin` only (27 observers network-wide, about one per school), and dropping only the coaches who anchor a group. The chosen rule leaves 122 anchoring coaches on a fallback that is empty at 24 of 28 schools, which is why the third change — emptying the observers with the observees — carries most of the fix.

`is_teacher` and the two admin flags are mutually exclusive by construction: `is_teacher` reads `job_function in ('Teacher', 'Teacher in Residence')` while both admin flags read `tier`, which is derived from the same `job_function`. Confirmed against production: zero active staff hold both the `Teacher` role and an admin role, so no teacher loses observee status from this change.

Before-and-after counts, both measured over active users with a resolved Grow account and school, production versus a local dev build of the model:

| measure                | before | after |
| ---------------------- | -----: | ----: |
| observees              |    873 |   702 |
| fallback observees     |     26 |     9 |
| fallback observers     |    235 |   165 |
| coach groups           |    174 |   150 |

Claude-assisted, human-directed.

</details>
