### PR TITLE
fix(dbt): align is_transfer_grade position across the gpprogress_grades union branches

### DIFF
--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__gpprogress_grades.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__gpprogress_grades.sql
@@ -75,13 +75,13 @@ with
             fg.courses_credit_hours as official_potential_credits,
             sub.enrolledcredits as potential_credits,
 
-            false as is_transfer_grade,
-
             'Enrolled' as credit_status,
 
             if(
                 fg.y1_letter_grade not like 'F%', sub.enrolledcredits, 0.0
             ) as earned_credits,
+
+            false as is_transfer_grade,
 
         from {{ ref("int_powerschool__gpnode") }} as gpn
         inner join


### PR DESCRIPTION
# Pull Request

> **Write this whole PR in plain language.** Read `.github/PLAIN_LANGUAGE.md`
> and follow it: every sentence does a job, one idea per sentence, active voice,
> common words. Only the "For Claude" fold-out at the bottom is exempt.

## Summary & Motivation

> What changed and why. A reviewer skimming just this section should understand
> the change. Save tradeoffs, edge cases, and verification detail for "Reviewer
> Notes" below.

When merged, this pull request will fix the package model `int_powerschool__gpprogress_grades`, which fails in prod with `Column 23 in UNION ALL has incompatible types: STRING, BOOL`.

#5201 moved `is_transfer_grade` to the end of the select list in the stored-grades branch only. `UNION ALL` matches columns by position, so the Enrolled branch's `false as is_transfer_grade` lined up against `credit_status`. This PR moves the Enrolled branch's column to the same slot. Camden's automation run failed on it and retried once; Newark's would fail the same way.

Refs #5012.

## Reviewer Notes

> Optional. Name what's worth a second look and why, in a line or two each. Full
> technical detail, exact values, and edge cases belong in "For Claude" below.
> Delete if there's nothing here.

- 1 file, 2 lines moved. dbt Cloud CI builds kipptaf only and does not cover this package model; the evidence is the Newark dev build in "For Claude".

## Self-review

> Complete only the sections relevant to your changes.

### General

> If this is a same-day request, please flag that in the #data-team Slack

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

- [ ] Run `uv run dagster definitions validate` for any modified code location
- [ ] Run `uv run pytest tests/test_dagster_definitions.py` for any modified
      code location
- [ ] New integrations follow the
      [Library + Config pattern](https://teamschools.github.io/teamster/reference/adding-an-integration/)
      with the correct asset key format and IO manager

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [ ] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** Renaming or removing columns in a contracted model
      (`stg_`, `rpt_`, mart) will break downstream exposures. Coordinate with
      affected teams before merging and document your rollback plan in the
      summary above.
- [ ] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      See
      [Staging external sources](https://teamschools.github.io/teamster/guides/dbt-development/#staging-external-sources)

No new models, no contracted column changes, no external source changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

- [ ] If adding or changing a schedule or sensor, regenerate the automations
      catalog: `uv run scripts/gen-automations-doc.py`
- [ ] If adding a new integration to a code location, update that location's
      `CLAUDE.md` by running `/claude-md-management:revise-claude-md`

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

> Full technical detail behind the Reviewer Notes flags above — exact values,
> edge cases, full reasoning — plus anything else simplified or cut from Summary
> for plain-language readability, AI involvement, and anything a future
> `@claude` invocation needs. Delete if there's nothing to add.

Claude-assisted, human-directed. Failing prod run: kippcamden `__ASSET_JOB` `98316104-d84e-4865-b976-a9d389abc260` (retry of `d1eef0be`). The defect came from `589bd6cb94` on #5201, a post-review ST06 reorder that touched one branch of the union; the dev builds on that PR ran before that commit, and dbt Cloud CI builds kipptaf only.

Verification: `dbt build --select int_powerschool__gpprogress_grades --target dev --favor-state --defer` for kippnewark: `PASS=2 WARN=0 ERROR=0` (model plus uniqueness test), 88,946 rows, `countif(is_transfer_grade)` = 8,509 and `credit_status` split 80,490 Earned / 8,456 Enrolled, matching the pre-reorder figures from #5201.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)