### PR TITLE
fix(k8s): pin code servers against the autoscaler now that run pods cannot preempt them

### DIFF
--- a/.claude/skills/dagster-k8s-ops/SKILL.md
+++ b/.claude/skills/dagster-k8s-ops/SKILL.md
@@ -46,20 +46,22 @@ description:
 - `safe-to-evict: "false"` only blocks cluster autoscaler evictions — kubelet
   node-pressure evictions (exit 137, OOM) are unaffected. Scale-Out density
   makes these occasional; Dagster retries automatically.
-- **Do NOT add `safe-to-evict: "false"` to code server pods.** Tried 2026-08-18
-  to stop the 38-59 weekly autoscaler relocations, reverted the same day
-  (#4921). Because it blocks only autoscaler eviction and NOT scheduler
-  preemption, pinning a priority-0 pod removes the graceful way to free its node
-  and leaves only the violent one: capacity fragments, then run pods (then
-  priority 1000) preempted code servers to obtain it — and every preemption
-  recreates the Service with a fresh ClusterIP, which is the churn the
-  annotation was meant to reduce. Measured at matched load (~32 run/step pods
-  per 15 min): with it, 18-20 agent gRPC errors and 8-9 `Preempted` per 15 min;
-  without it, 0 and 0 across 12 hours including the nightly wave. **General
-  rule: pinning a low-priority pod against the autoscaler converts graceful
-  relocation into preemption.** The agent and run pods keep the annotation —
-  nothing outranks them the way run pods used to outrank code servers. Absence
-  is asserted in `tests/test_k8s_config.py`.
+- **`safe-to-evict: "false"` on code server pods is safe ONLY at equal priority
+  with run pods.** First tried 2026-08-18 to stop the 38-59 weekly autoscaler
+  relocations, reverted the same day (#4921). It blocks only autoscaler eviction
+  and NOT scheduler preemption, so pinning a priority-0 pod while run pods sat
+  at 1000 removed the graceful way to free its node and left the violent one:
+  capacity fragmented, run pods preempted code servers to obtain it, and every
+  preemption recreated the Service with a fresh ClusterIP. Measured at matched
+  load (~32 run/step pods per 15 min): with it, 18-20 agent gRPC errors and 8-9
+  `Preempted` per 15 min; without it, 0 and 0 across 12 hours. **General rule:
+  pinning a pod against the autoscaler is safe only when nothing outranks it on
+  the node.** #5187 put run pods at 0, so the annotation came back on code
+  servers to stop autoscaler `ScaleDown` kills (the 2026-09-09 kippmiami
+  trigger). Keep-or-revert is judged at matched load: revert if code-server
+  `Preempted` or agent gRPC errors rise above 0/0; keep if `ScaleDown` kills of
+  code servers reach 0. Presence on all three pod types is asserted in
+  `tests/test_k8s_config.py`.
 - **Judge a scheduling change only against matched run-pod load.** Code-server
   churn tracks run-pod volume, so a quiet window reads as success and a busy one
   as regression. Count `Scheduled` events on `dagster-run-` / `dagster-step-`

--- a/.k8s/CLAUDE.md
+++ b/.k8s/CLAUDE.md
@@ -70,12 +70,14 @@ skill.
 - **Do NOT use `Balanced` or `Performance`** — Balanced minimum requests (1 vCPU
   / 4 GiB) exceed ours (500m / 2 GiB). Performance has the same node-based
   pricing penalty as CCCs.
-- **`safe-to-evict: "false"` (extended-duration) is on agent and run pods.**
-  Under built-in Scale-Out it works as documented — blocks cluster autoscaler
-  eviction. Mutually exclusive with spot; do not move agent or run pods to a
-  spot tier. Run pods also have `podFailurePolicy` (`DisruptionTarget` →
-  `Ignore`) as a secondary guard for non-autoscaler disruptions; the agent does
-  not.
+- **`safe-to-evict: "false"` (extended-duration) is on agent, run, and code
+  server pods.** Under built-in Scale-Out it works as documented — blocks
+  cluster autoscaler eviction. Mutually exclusive with spot; do not move any of
+  them to a spot tier. Run pods also have `podFailurePolicy` (`DisruptionTarget`
+  → `Ignore`) as a secondary guard for non-autoscaler disruptions; the agent
+  does not. The code-server annotation depends on run pods and code servers
+  sharing priority 0: reintroducing a priority gap turns it back into the #4921
+  preemption storm. Asserted in `tests/test_k8s_config.py`.
 - **Spot + built-in Scale-Out + arch is supported under pod-priced billing** —
   set `cloud.google.com/gke-spot: "true"` alongside the compute-class + arch
   nodeSelector; Autopilot auto-injects the toleration. Mutually exclusive with

--- a/.k8s/dagster/values-override.yaml
+++ b/.k8s/dagster/values-override.yaml
@@ -158,24 +158,30 @@ workspace:
     podTemplateSpecMetadata: # raw config for the pod's metadata
       annotations:
         operator.1password.io/auto-restart: "true"
-        # Do NOT add cluster-autoscaler.kubernetes.io/safe-to-evict: "false" here.
-        # It was added 2026-08-18 to stop the 38-59 autoscaler relocations per week
-        # and reverted the same day. Measured over the hour after it went live:
-        # agent "Could not reach user code server" errors ran ~62x the four-week
-        # baseline (40/hour against ~0.65) and code-server Preempted ran ~118x
-        # (20/hour against ~0.17), while Evicted stayed flat at 0 the whole time.
+        # Blocks cluster-autoscaler relocation of code servers. Second attempt.
         #
-        # Mechanism: the annotation blocks CLUSTER-AUTOSCALER eviction but not
-        # SCHEDULER preemption. Pinning code servers to their nodes stops the
-        # autoscaler relocating them, so capacity fragments and run pods
-        # (then priority 1000) could only obtain it by preempting code servers
-        # (priority 0). It converted graceful relocations into preemptions, each
-        # of which recreates the Service and produces a fresh ClusterIP -- which
-        # is the churn the annotation was meant to reduce.
+        # First attempt 2026-08-18 (#4921) was reverted the same day: run pods
+        # sat at priority 1000 and code servers at 0, so pinning a code server
+        # to its node left preemption as the only way for a run pod to claim
+        # capacity. Agent "Could not reach user code server" errors ran ~62x
+        # baseline and code-server Preempted ~118x within the hour.
         #
-        # Evicted holding at 0 is what isolates this from the `preferred`
-        # self-anti-affinity: that change's risk shows up as kubelet eviction, and
-        # it never fired.
+        # #5187 removed the run-pod PriorityClass, so run pods and code servers
+        # are both at 0 and preemption between them is impossible. That closes
+        # the failure mode #4921 measured. What remains is the one the
+        # annotation was always meant to stop: the autoscaler killing a code
+        # server pod during a ScaleDown. On 2026-09-09 that killed kippmiami's
+        # code server while the agent was re-uploading its metadata, and one
+        # gRPC UNAVAILABLE left the location in a terminal ERROR (#5187 covers
+        # the same mechanism with preemption as the trigger).
+        #
+        # Cost: a node holding a code server cannot consolidate, so run pods
+        # that fit nowhere wait for NAP instead. Keep-or-revert rule, judged at
+        # matched run-pod load (~25+ Scheduled events per 15 min): revert if
+        # code-server Preempted or agent gRPC errors rise above the 0/0 baseline
+        # from the #4921 measurement; keep if ScaleDown kills of code servers
+        # drop to 0 and Preempted stays at 0.
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     podSpecConfig:
       # Hard-pin to built-in Scale-Out arm64 (T2A) under pod-based pricing.
       # No fallback — arm64 STOCKOUT will leave pods Pending. Code servers

--- a/tests/test_k8s_config.py
+++ b/tests/test_k8s_config.py
@@ -160,29 +160,27 @@ def test_run_pods_and_code_servers_share_default_priority():
     assert priority_classes == {"dagster-agent"}
 
 
-def test_code_servers_are_not_pinned_against_the_autoscaler():
-    """safe-to-evict: "false" was tried on code servers and reverted the same day.
+def test_every_dagster_pod_is_pinned_against_the_autoscaler():
+    """Agent, run/step, and code server pods all carry safe-to-evict: "false".
 
-    It blocks autoscaler relocation but not scheduler preemption, so it converted
-    graceful relocations into preemptions: measured ~62x the baseline gRPC error
-    rate and ~118x Preempted over one hour, with Evicted flat at 0. Asserted here
-    so it cannot be reintroduced without the reasoning resurfacing.
+    The code-server annotation is safe only while run pods and code servers share
+    a priority. It was reverted in #4921 when run pods sat at 1000: pinning a
+    code server to its node left preemption as the only way for a run pod to
+    claim capacity, and Preempted ran ~118x baseline within the hour. With both
+    at 0 (asserted above) that path is closed, and the annotation stops the
+    autoscaler ScaleDown that killed kippmiami's code server on 2026-09-09.
     """
-    server_config = _helm_values()["workspace"]["serverK8sConfig"]
+    values = _helm_values()
+    key = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 
-    annotations = server_config["podTemplateSpecMetadata"]["annotations"]
+    assert values["dagsterCloudAgent"]["annotations"][key] == "false"
 
-    assert "cluster-autoscaler.kubernetes.io/safe-to-evict" not in annotations
+    for config in ("serverK8sConfig", "runK8sConfig"):
+        annotations = values["workspace"][config]["podTemplateSpecMetadata"][
+            "annotations"
+        ]
 
-    # the agent and run pods DO carry it, and should keep it -- the agent
-    # outranks everything else in the namespace, and run pods are alone on
-    # arm64 nodes with code servers at the same priority, so neither can be
-    # preempted the way code servers were when run pods sat at 1000
-    agent_annotations = _helm_values()["dagsterCloudAgent"]["annotations"]
-
-    assert (
-        agent_annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
-    )
+        assert annotations[key] == "false"
 
 
 def test_code_server_requests_meet_scale_out_minimum():


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

"When merged, this pull request will..." add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to code server pods so the cluster autoscaler stops killing them during a `ScaleDown`.

On 2026-09-09 at 14:40 UTC the autoscaler deleted the `kippmiami` code server pod for a node scale down. The agent was re-uploading the location's metadata at that moment, got one gRPC `UNAVAILABLE`, and wrote `ERROR` to the control plane. The agent never retries that state. It is the same mechanism as the kippcamden outage in #5187, with the autoscaler as the trigger instead of a preemption.

This annotation was tried in #4921 and reverted the same day. Back then run pods sat at priority 1000, so a pinned code server could still be preempted, and that happened 118 times more often than baseline. #5187 put run pods at priority 0, so preemption between the two is impossible now and the annotation only does what it was always meant to do.

`helm upgrade` is manual. The change takes effect only after someone runs it.

## Reviewer Notes

- **Keep-or-revert rule** is written into the values file comment. Judge it at matched run-pod load, 25 or more `Scheduled` events per 15 minutes. Revert if code-server `Preempted` or agent gRPC errors rise above the 0/0 baseline from #4921. Keep if `ScaleDown` kills of code servers reach 0.
- **Cost:** a node holding a code server cannot consolidate, so a run pod that fits nowhere waits for Node Auto Provisioning instead. This is the same wait run pods already take when no node has room.
- The test that asserted the annotation's absence now asserts its presence on all 3 pod types, and its docstring carries the #4921 history so the priority dependency stays visible.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No code location changes. `uv run pytest tests/test_k8s_config.py` passes (11 tests).

## CI checks

- [x] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [x] **dbt Cloud** — passes or not triggered.
- [x] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Timeline from agent container logs and `k8s_pod` events, 2026-09-09 UTC:

- 14:36:53 control plane update trigger for kippmiami (merge of #5201). 14:38:49 `Updated successfully`.
- 14:40:06 pod `kippmiami-prod-63995e-6fc7dcfc65-jgjqt` event `ScaleDown: deleting pod for node scale down`. Replacement `...-ssjwt` scheduled the same second, container started 14:40:10, definitions import takes about 90 seconds.
- 14:40:17 agent `Fetching metadata for prod:kippmiami`, then `Unable to update prod:kippmiami ... gRPC Error code: UNAVAILABLE`, then `Updated with error`.
- 14:43:04 recovered by a `reloadRepositoryLocation` from a Dagster MCP session (audit log `authorAgentTokenId` 2951). The agent itself never re-uploaded.

Why the #4921 measurement no longer applies: `_should_trigger_recovery` and the health-check path are unchanged, but the preemption that #4921 measured needed a priority gap. Audit log confirms the `dagster-run` PriorityClass was deleted 2026-09-08 16:16 UTC and run pods created since carry no `priorityClassName`.

Alternative considered: PDB `minAvailable: 1` per location. Same effect, since the autoscaler honors PDBs, but it also blocks GKE node maintenance drains until the 1 hour override. The annotation is narrower. Both are ruled out only under a priority gap, which the test above guards.

Not in scope: the Phase 3 watchdog in `docs/superpowers/specs/2026-08-18-code-server-scheduling-resilience-design.md`, parked by the user. Upstream issue on the agent's missing retry is drafted for dagster-io/dagster.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)