### PR TITLE
docs(claude): distill FERPA PII definitions into a rules file with a column decision procedure

### DIFF
--- a/.claude/rules/cube-authoring.md
+++ b/.claude/rules/cube-authoring.md
@@ -189,11 +189,11 @@ comparison does not compile (Task 1 spike finding). That's why `buildGroups`
 emits one scope-specific group per enum value instead of a single group gated by
 a `conditions.if` branch.
 
-When adding a sensitive staff field, decide PII status per project CLAUDE.md
-FERPA guidance. If PII, add it to `staff_pii.yml` (not `staff_directory.yml`)
-and wire its per-field scope in `access.js`'s `STAFF_SENSITIVE_SCOPE_BY_MEMBER`.
-Student views have no PII split — any scope-specific `student-*` group sees
-every field.
+When adding a sensitive staff field, decide PII status per
+`.claude/rules/ferpa-pii.md`. If PII, add it to `staff_pii.yml` (not
+`staff_directory.yml`) and wire its per-field scope in `access.js`'s
+`STAFF_SENSITIVE_SCOPE_BY_MEMBER`. Student views have no PII split — any
+scope-specific `student-*` group sees every field.
 
 ## `cube.js` security model
 

--- a/.claude/rules/ferpa-pii.md
+++ b/.claude/rules/ferpa-pii.md
@@ -1,0 +1,173 @@
+---
+paths:
+  - "**/src/dbt/**/*.yml"
+  - "**/src/cube/**"
+---
+
+# FERPA and PII: what counts, and how this repo handles it
+
+Loads on the first read of dbt YAML or a Cube file. Distilled 2026-09-09 from
+the U.S. Department of Education's student privacy site and the regulation it
+links to. The outbound rule (never emit PII values to PR comments, issues,
+Slack, Asana, or agent output) lives in the root CLAUDE.md _Never_ block; this
+file decides what "PII" means when you apply it.
+
+Sources, in order of authority:
+
+- Regulation: 34 CFR Part 99, especially
+  [§99.3 Definitions](https://www.law.cornell.edu/cfr/text/34/99.3) and
+  [§99.31 Disclosure without consent](https://www.law.cornell.edu/cfr/text/34/99.31).
+  The eCFR blocks automated fetches; the Cornell LII mirror carries the same
+  text.
+- Department guidance:
+  [studentprivacy.ed.gov/ferpa](https://studentprivacy.ed.gov/ferpa), the
+  [PTAC glossary](https://studentprivacy.ed.gov/glossary), and PTAC's
+  [Data De-identification: An Overview of Basic Terms](https://studentprivacy.ed.gov/resources/data-de-identification-overview-basic-terms)
+  (PDF).
+
+This is a working reference for engineering decisions, not legal advice. A
+question about a specific disclosure, a data-sharing agreement, or a parent
+request goes to legal or People Operations.
+
+## Scope
+
+FERPA covers every "educational agency or institution" that receives federal
+education funds. KTAF's schools and the network office are covered.
+
+An **education record** is any record "directly related to a student" and
+"maintained by an educational agency or institution or by a party acting for the
+agency or institution" (§99.3). Nearly every student-level table in this
+warehouse qualifies. Records about staff that "relate exclusively to the
+individual in that individual's capacity as an employee" are not education
+records. Staff PII is still protected, by policy rather than FERPA; the Cube
+`staff_pii` split in `.claude/rules/cube-authoring.md` is that policy.
+
+## The definition (§99.3, verbatim)
+
+"Personally Identifiable Information. The term includes, but is not limited to:
+
+- (a) The student's name;
+- (b) The name of the student's parent or other family members;
+- (c) The address of the student or student's family;
+- (d) A personal identifier, such as the student's social security number,
+  student number, or biometric record;
+- (e) Other indirect identifiers, such as the student's date of birth, place of
+  birth, and mother's maiden name;
+- (f) Other information that, alone or in combination, is linked or linkable to
+  a specific student that would allow a reasonable person in the school
+  community, who does not have personal knowledge of the relevant circumstances,
+  to identify the student with reasonable certainty; or
+- (g) Information requested by a person who the educational agency or
+  institution reasonably believes knows the identity of the student to whom the
+  education record relates."
+
+Items (a) through (e) are direct identifiers: PII on their own. Item (f) is the
+test for everything else. PTAC's glossary names the indirect identifiers it has
+in mind: "gender, birth date, geographic indicator and descriptors." PTAC's
+de-identification paper adds that "simple removal of direct identifiers from the
+data to be released DOES NOT constitute adequate de-identification."
+
+## Directory information
+
+§99.3 lets a school designate some fields as **directory information**:
+"information contained in an education record of a student that would not
+generally be considered harmful or an invasion of privacy if disclosed."
+Examples in the regulation: name, address, telephone, email, photograph, date
+and place of birth, grade level, enrollment status, dates of attendance,
+activities and sports, honors and awards, most recent school attended. It "does
+not include a student's social security number or student identification (ID)
+number."
+
+Designation is a policy act with parent opt-out, not a property of the column.
+Do not treat a field as freely disclosable because the regulation lists it as
+directory-eligible. Unless the user confirms KTAF's directory designation and
+opt-out handling, treat every field above as PII.
+
+## De-identified data (§99.31(b))
+
+A release needs no consent "after the removal of all personally identifiable
+information provided that the educational agency or institution or other party
+has made a reasonable determination that a student's identity is not personally
+identifiable, whether through single or multiple releases, and taking into
+account other reasonably available information."
+
+Two consequences for this repo:
+
+- **Aggregates are not PII, until the cell is small.** A count by school and
+  grade is fine. A count by school, grade, race, and IEP status can be a cell
+  of 1. PTAC's answer is suppression, including complementary suppression so the
+  hidden cell cannot be recovered from totals. The repo has no automated
+  small-cell suppression
+  ([#4237](https://github.com/TEAMSchools/teamster/issues/4237)); a Cube
+  aggregate view that slices by a demographic is a decision, not a default.
+- **A record code for a de-identified release** must not be based on "a
+  student's social security number or other personal information," and the
+  releasing party may not "disclose any information about how it generates and
+  assigns a record code" (§99.31(b)(2)). An SIS primary key or `student_number`
+  fails both tests. Generate a fresh code for any de-identified extract.
+
+## Disclosure inside the network (§99.31(a)(1))
+
+Staff may see PII when they are school officials with a "legitimate educational
+interest," and the agency "must use reasonable methods to ensure that school
+officials obtain access to only those education records in which they have
+legitimate educational interests." Cube's row-level access and PII defaults are
+those reasonable methods. That is why natural-language questions go through Cube
+(root CLAUDE.md, _Tool selection_) and why a raw-warehouse answer that bypasses
+it needs a reason.
+
+## Decision procedure for a column
+
+Work down the list; stop at the first match.
+
+1. **Direct identifier: tag it.** Name and name parts (`*_name`, `lastfirst`),
+   parent or guardian or contact fields, street address or city or zip, `ssn`,
+   `student_number`, `state_id` and other state or district student numbers,
+   `local_id`, kippadb `school_specific_id`, `employee_number`, email, phone,
+   photo, `dob` or `birth_date`, place of birth, biometric data, credentials or
+   tokens.
+2. **Free text about a person: tag it.** `comment`, `note`, `entry`, `remarks`
+   on a student or staff table. Free text routinely carries names and
+   circumstances.
+3. **Student-level education content: tag it.** Grades, GPA, credits, assessment
+   scores, daily attendance, discipline, IEP or 504 or disability, EL status,
+   FRL or economic status, race or ethnicity, gender, home language, graduation
+   pathway, program enrollment. Each is item (f) information: linked to a
+   specific student and identifying in combination. Tag at the row grain it is
+   stored at; a student-level model with these columns is PII even when it
+   carries no name.
+4. **Surrogate keys: do not tag, but do not export.** `studentid`,
+   `studentsdcid`, `dcid`, `id`, `*_key`, dlt or Focus internal ids. The
+   regulation's "student number" is the number the school uses to identify the
+   student, which here is `student_number`. A database key resolves to a person
+   only through a table that is already PII, so a "reasonable person in the
+   school community" cannot identify the student from it. Repo precedent agrees:
+   no `studentid` or `studentsdcid` column carries a tag. The limits: a key is
+   still linkable, so it never leaves the warehouse in an outbound file next to
+   content, and it is never a record code for a de-identified release.
+5. **Aggregates: do not tag.** Counts, rates, and averages over a group. Watch
+   small cells (above).
+6. **Reference data: do not tag.** Courses, sections, schools, terms, calendars,
+   codesets, grade scales, plan structures such as `int_powerschool__gpnode`. No
+   student in the row.
+
+When a model mixes tiers, tag the columns, not the model. When a whole model is
+student-level content with no reference-only columns, a model-level tag is
+acceptable; both forms are `config.meta.contains_pii: true`.
+
+## Repo conventions that follow
+
+- **Tag at the column.** Precedent in `src/dbt/powerschool` staging is
+  column-level `config.meta.contains_pii: true`; follow it in new YAML. The
+  existing staging tags are narrower than tier 3 (they omit gender, race, and
+  grades). Widen them when you touch a file for another reason; do not sweep.
+- **A PII-heavy new model** gets a one-line confirmation of scope with the user
+  before tagging: direct-only, or direct plus student-level content. The default
+  when no one answers is tiers 1 through 3.
+- **Outbound surfaces** (PR comments, issue bodies, Slack, Asana, scheduled
+  agents): redact values from any tier-1 through tier-4 column to `Student A` or
+  to the column name before posting. Aggregates with no small cell may go out as
+  numbers. The row content of a query result is PII even when the query had no
+  name column.
+- **Staff data** is outside FERPA but not outside policy. `staff_pii` in Cube
+  and the root CLAUDE.md line about staff contact information govern it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,28 +167,15 @@ published page is a bug.
 
 ## PII reference
 
-`config.meta.contains_pii: true` in model YAML is authoritative but incomplete.
-Untagged columns are PII under FERPA's direct-identifier list
-([34 CFR §99.3](https://www.ecfr.gov/current/title-34/part-99/section-99.3)):
-name, SSN, student/employee ID, address, date/place of birth, mother's maiden
-name, biometric record, plus "other information... linked or linkable to a
-specific student." Schema mapping: IDs (`student_number`, `employee_number`,
-`ssn`, `state_id`, `local_id`, kippadb `school_specific_id`), names (`*_name`),
-contact (`email`, `phone`, `address`, `street`, `city`, `zip`),
-`dob`/`birth_date`, guardian/parent fields, free-text `comment`/`note` on people
-tables, credentials/tokens.
-
-Indirect identifiers (FERPA "linked or linkable"): gender, birth date,
-geographic indicators (school, zip), race/ethnicity, religion, place of birth,
-education info (grade level, EL status, IEP/504/disability), financial info (FRL
-status), activities. Each alone may be safe; combinations may not. When unsure,
-consult the [PTAC glossary](https://studentprivacy.ed.gov/glossary) or treat as
-PII. Aggregates and deidentified data are not PII.
-
-PII-tagging precedent in staging (powerschool) is narrower than this list: it
-omits gender, race/ethnicity, and internal/student ids. For a PII-heavy new
-model, confirm scope (direct-only vs direct+indirect) with the user before
-tagging.
+`config.meta.contains_pii: true` in model YAML is authoritative but incomplete;
+untagged columns can still be PII. The definition (34 CFR §99.3 verbatim), the
+column decision procedure, and the surrogate-key and small-cell rules are in
+`.claude/rules/ferpa-pii.md`, which loads on the first read of dbt YAML or a
+Cube file. Read it before tagging, before answering a raw-warehouse question,
+and before posting query rows anywhere outbound. Short form: names, contact,
+`student_number` and other school-facing ids, birth data, free text about a
+person, and student-level grades, attendance, or status flags are PII; database
+surrogate keys (`studentid`, `dcid`) and aggregates without small cells are not.
 
 ## Superpowers skill overrides
 


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will give Claude one place that says what "PII" means in this repo, grounded in the regulation instead of a paraphrase. The new `.claude/rules/ferpa-pii.md` loads on the first read of dbt YAML or a Cube file. It carries the 34 CFR §99.3 definition verbatim, the directory-information and de-identification rules from §99.3 and §99.31(b), and a 6-tier procedure for deciding whether a column gets `contains_pii`.

The question that prompted it: are PowerSchool surrogate keys like `studentid` and `studentsdcid` PII? The rule says no tag, but no export. The regulation's "student number" is the number the school uses to identify the student, which here is `student_number`. A database key resolves to a person only through a table that is already PII. The rule also says a surrogate key can never serve as a record code for a de-identified release, because §99.31(b)(2) forbids codes based on personal information.

The root CLAUDE.md "PII reference" section shrinks to a pointer and a one-sentence short form. The Cube rule's cross-reference points at the new file.

Refs #5197

## Reviewer Notes

- Tier 3 (student-level grades, attendance, IEP, race, gender) is wider than the existing staging tags, which omit gender, race, and grades. The rule says to widen when touching a file for another reason, not to sweep.
- The eCFR blocks automated fetches. The rule links the Cornell LII mirror for the regulation text. The quoted definitions came from that mirror on 2026-09-09.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

Skipped. No Dagster changes.

### dbt _(skip if no dbt changes)_

Skipped. No dbt changes.

### Docs _(skip if no schedule, sensor, or integration changes)_

Skipped. CLAUDE.md files only, no MkDocs pages.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — not triggered.
- [ ] **Dagster Cloud** — not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Sources fetched 2026-09-09: `studentprivacy.ed.gov/ferpa`, the PTAC glossary, PTAC's "Data De-identification: An Overview of Basic Terms" PDF, and `law.cornell.edu/cfr/text/34/99.3` and `/99.31`. The §99.3 PII definition, directory-information definition, and §99.31(b)(2) record-code conditions are quoted verbatim from the LII text. The PTAC paper's line that "simple removal of direct identifiers ... DOES NOT constitute adequate de-identification" is quoted verbatim.

Judgment calls, not in the sources: the surrogate-key tier (tier 4) and the "widen, do not sweep" convention. PTAC's paper lists "student IDs" among direct identifiers without distinguishing school-facing numbers from database keys. The rule reads that as `student_number`, consistent with the regulation's "student number" and the directory-information carve-out for "student identification (ID) number." Zero `studentid` or `studentsdcid` columns are tagged in `src/dbt` today.

`trunk check --force --no-fix` on the 3 changed files: no issues after `trunk fmt`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)