### PR TITLE
docs: publish a guide for adding a tool to the launch page

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,7 +18,7 @@ docs/
     groups.yml              # Topical groups, families, promo cards, threshold
     build.py               # load -> select -> validate -> render
     template.html           # The published page's shell
-    README.md              # Field reference: what "verified" requires
+    README.md              # This directory + state of the catalog
     RUNBOOK.md              # Verification task sequence
     PROJECT.md              # Why this exists, where it stands
   reference/               # Architectural patterns and operational guides
@@ -43,6 +43,7 @@ docs/
     dagster.md
     dbt-development.md
     google-sheets.md
+    launch-page-guide.md   # Field reference for links.yml (published)
     local-development.md
     sftp-integration.md
     superpowers.md
@@ -89,8 +90,11 @@ Regenerate only in a full environment where all locations load.
 ## `launch/` Directory
 
 The staff tool catalog and the pipeline that publishes it — see
-`docs/launch/README.md` (field reference) and `docs/launch/PROJECT.md` (why and
-where it stands) before touching anything here.
+`docs/guides/launch-page-guide.md` (the published field reference: every
+`links.yml` field, legal values, and validation errors), `docs/launch/README.md`
+(this directory and the state of the catalog) and `docs/launch/PROJECT.md` (why
+and where it stands) before touching anything here. `build.py` is authoritative
+if the guide and the code disagree.
 
 - **`docs/launch/*.{yml,py}` and `template.html` are source, not docs** —
   `mkdocs.yml` `exclude_docs` keeps `links.yml`, `groups.yml`, `build.py`,

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -48,6 +48,7 @@ Cloud:
 | [Local Development](local-development.md)   | Installing dependencies, running Dagster locally, linting, and testing      |
 | [Dagster](dagster.md)                       | Tableau scheduling, backfills, branch deployments, monitoring runs          |
 | [Google Sheets & Forms](google-sheets.md)   | Adding and updating Google Sheets and Forms sources                         |
+| [Launch Page](launch-page-guide.md)         | Adding, changing, or removing a tool on the staff launch page               |
 | [dbt Development](dbt-development.md)       | Targets, defer, staging external sources, cross-project workflows           |
 | [SFTP Integration](sftp-integration.md)     | Adding a new SFTP file drop using `init_sftp_integration.py`                |
 | [Claude Code & Superpowers](superpowers.md) | Using Claude Code's structured workflows for features, fixes, and refactors |

--- a/docs/guides/launch-page-guide.md
+++ b/docs/guides/launch-page-guide.md
@@ -1,0 +1,336 @@
+# Adding a tool to the launch page
+
+The launch page is the page staff open to find a dashboard. It is built from one
+file in this repository: `docs/launch/links.yml`. Add an entry there, open a
+pull request, and the tool appears on the page when the pull request merges.
+
+This guide covers adding a tool, changing one, and taking one down.
+
+**Who this is for.** Anyone on the data team with push access. You do not need
+Zendesk editing rights, and you never edit the page's HTML — only the catalog
+file.
+
+## Before you start
+
+You need three things:
+
+- **A Codespace on this repository**, and push access to open a pull request.
+- **Access to the tool itself**, so you can open it and confirm what it is
+  called and what it does. Most entries are Tableau, at `tableau.kipp.org`.
+- **For anything Google-hosted or AppSheet: the ability to open the file's Share
+  dialog.** This is not optional. See [The sharing check](#the-sharing-check).
+
+## Where the catalog lives
+
+Everything is under `docs/launch/`:
+
+| File            | What it is                                                      |
+| --------------- | --------------------------------------------------------------- |
+| `links.yml`     | **The catalog.** One entry per tool. This is the file you edit  |
+| `groups.yml`    | The page's sections, region families, promo cards, publish gate |
+| `build.py`      | Validates the catalog and renders the page                      |
+| `template.html` | The page shell                                                  |
+
+`build.py` runs during the docs site build and generates `launch/index.html`.
+You never edit the HTML.
+
+Two things to know about how this publishes:
+
+- **Only `status: verified` entries appear on the page.** An entry left at
+  `needs-review` is excluded from the build. Setting `verified` is what puts the
+  tool in front of staff — it is a release switch, not a quality note.
+- **This repository is public, and so is the catalog file.** Tool names,
+  descriptions, and URLs are fine; they are already public today, and the
+  destinations all require sign-in. Do not add phone numbers, email addresses,
+  individual staff names, or anything about how to authenticate to a system.
+
+## Step 1 — Decide it belongs
+
+A catalog entry is a claim that a staff member might need to find this tool. Ask
+two questions:
+
+1. **Is this staff-facing?** Machine plumbing — a sheet a pipeline writes to
+   that nobody opens — does not belong here, even though it is a real artifact
+   with a real URL.
+
+1. **Is it already here under a different name?** Search `links.yml` for the
+   tool and for words in its name. The catalog was assembled from five separate
+   pages that had drifted apart, so near-duplicates are a real risk.
+
+If you find a duplicate, a dead tool, or a tool missing from the list entirely,
+**open an issue** rather than fixing it inside an unrelated pull request.
+
+## The sharing check
+
+**Do this before you write the entry, not after.**
+
+A Tableau link is safe to publish because Tableau requires sign-in — the URL is
+useless to anyone outside the network.
+
+**A Google Drive link is not automatically safe.** If a Sheet is shared "anyone
+with the link," then the URL _is_ the access control, and publishing it in a
+public repository hands it to the internet.
+
+So for anything with a `google-*` system:
+
+1. Open the file.
+1. Click **Share**.
+1. Confirm **General access is _not_ "Anyone with the link."** It must be
+   restricted to named people or Workspace groups.
+
+**If you find one that is link-shared, do not add it.** Flag it instead. That is
+a live exposure to fix at the source, not something to document.
+
+**AppSheet apps need this twice.** An AppSheet app has its own access setting,
+_and_ it reads from a backing Google Sheet with separate sharing. Both have to
+require sign-in. Open the app, then open the Sheet behind it, and check each.
+
+**Check the Share dialog, not a script.** For a file you do not administer, the
+Drive API returns only the owner — not the groups it is actually shared with. An
+empty group list from a script is inconclusive, not evidence of a problem. The
+Share dialog shows the real picture.
+
+## Step 2 — Write the entry
+
+Add a block to `links.yml`. Entries run roughly alphabetically by name; put
+yours where it reads naturally.
+
+```yaml
+- id: attendance_dashboard
+  name: Attendance Dashboard
+  url: https://tableau.kipp.org/#/views/...
+  description:
+    Monitor ADA, chronic absenteeism, completion status of chronic absenteeism
+    interventions, and daily attendance calls.
+  audiences: [leaders, ops, region]
+  system: tableau
+  group: attendance
+  status: verified
+```
+
+### Fields checked on every entry
+
+Validated whether the entry publishes or not. A missing or wrong value fails the
+build.
+
+| Field    | Rule                                                                      |
+| -------- | ------------------------------------------------------------------------- |
+| `id`     | Lowercase letters, digits, and underscores only. Must be unique           |
+| `name`   | Non-empty. Use what the tool calls itself when you open it                |
+| `url`    | Must start with `https://`                                                |
+| `system` | One of the nine values in [Systems](#systems)                             |
+| `group`  | One of the seven ids in [Groups](#groups). Required — there is no default |
+| `status` | `needs-review` or `verified`                                              |
+
+For `id`, use the name in `snake_case`: `attendance_dashboard`,
+`coaching_conversation_tool`, `gpa_roster_camden`.
+
+### Fields required to publish
+
+Checked only once `status: verified` — which is also the only time they matter,
+because that is when the entry reaches staff.
+
+| Field         | Rule                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| `description` | Non-empty. **One sentence**: what the tool is for, not how it works |
+| `audiences`   | Non-empty list from `teachers`, `leaders`, `ops`, `region`          |
+
+`audiences` controls **relevance, not access.** Tagging a tool for one role does
+not hide it from anyone — the All view always lists everything, and the
+destination system enforces who can actually see the data. So the question is
+"who needs this in their day-to-day," and a tool can be in several.
+
+### Optional fields
+
+| Field             | What it does                                                              |
+| ----------------- | ------------------------------------------------------------------------- |
+| `guide`           | URL of the Zendesk help article for this tool. Must be `https://`         |
+| `access: limited` | Badge for tools most staff cannot open. `limited` is the only legal value |
+| `regions`         | Geography: any of `newark`, `camden`, `miami`, `paterson`, or `[all]`     |
+
+**`regions` is not `audiences`.** `regions` is geography — which regions a tool
+covers. `audiences: [region]` is the _Regional & CMO role view_, an entirely
+different thing. A tool can be `audiences: [region]` with no `regions:` at all,
+or scoped to one region and used by teachers.
+
+Use `regions` when a tool exists once per region, like the GPA Rosters or the
+Student Contact Info Feeds.
+
+### The one YAML rule that bites
+
+**Quote a string only when YAML needs it.** A value containing `: ` (colon then
+space) needs quotes. Most values do not, and adding them anyway fails the
+linter.
+
+```yaml
+name: "GPA Roster: Camden" # quoted -- contains a colon-space
+name: Attendance Dashboard # not quoted -- does not need it
+```
+
+## Step 3 — Check it before you push
+
+From the repository root:
+
+```sh
+# Validate the catalog and render the page
+uv run --group docs pytest tests/launch -v
+
+# Build the whole site and look at the real page
+uv run --group docs mkdocs build --site-dir site
+# then open site/launch/index.html
+```
+
+The tests are the same check CI runs. If validation fails you get **every**
+problem at once, not just the first, each naming the entry:
+
+```text
+3 problem(s) in the launch catalog:
+  - Attendance Dashboard: `id` 'Attendance-Dashboard' must match ^[a-z0-9_]+$
+  - Seat Tracker: unknown `group` 'enrollment'
+  - Stipend App: needs a non-empty `audiences` list
+```
+
+Also run the linter, because the YAML rules fire at push time rather than at
+commit time:
+
+```sh
+.trunk/tools/trunk check --force --no-fix docs/launch/links.yml
+```
+
+## Step 4 — Open a pull request
+
+Branch off `main`, commit, push, and open a pull request. Branch naming follows
+the convention in the root `CLAUDE.md`.
+
+CI runs the `launch` job on any change under `docs/launch/`. It validates the
+catalog, builds the site, and **attaches the rendered page as a downloadable
+artifact named `launch-page-preview`** — so a reviewer can open the real page as
+your change would publish it.
+
+**Work in batches, and merge as you go.** A twenty-entry diff gets reviewed
+badly. Two or three related tools per pull request is about right.
+
+**A blocked entry never blocks its batch.** If one tool needs a decision, leave
+it at `status: needs-review`, note the question, and ship the rest. It simply
+does not appear on the page until someone resolves it.
+
+## Other changes you might be making
+
+### Updating a URL, name, or description
+
+Edit the entry in place. Leave `status: verified`. Nothing else is needed.
+
+### Taking a tool off the page
+
+Change `status: verified` to `status: needs-review`. The entry stays in the file
+with its history intact and drops off the page on the next build. Prefer this to
+deleting the block — a deletion loses the record that the tool existed.
+
+Delete the entry only when the tool is genuinely gone.
+
+### Adding a help guide link
+
+Add `guide:` with the Zendesk article URL. It must be `https://`.
+
+### Adding a region-variant tool
+
+Tools that exist once per region collapse into a single row on the page with
+per-region sub-links. That grouping is a **family**, defined in `groups.yml`.
+
+To add a member to an existing family:
+
+1. Add a normal entry to `links.yml` with **exactly one** value in `regions:` —
+   one of `newark`, `camden`, `miami`, `paterson`. `[all]` is not legal for a
+   family member.
+
+1. Add the entry's **`name`** to that family's `members:` list in `groups.yml`.
+   Families match on `name`, not on `id`, so the two must agree exactly.
+
+A new family, or a new `group`, is a `groups.yml` conversation with the catalog
+owner — not something to add unilaterally.
+
+## Two things that will surprise you
+
+**The page can refuse to publish.** `groups.yml` carries `minimum_verified: 25`.
+If fewer than that many entries are verified, **no page is generated at all**
+and the URL returns a 404, rather than serving a near-empty page. The build
+still passes. This is deliberate.
+
+**A broken catalog on `main` freezes all documentation publishing**, not just
+the launch page — the docs deploy runs the same code path. That is why the pull
+request check exists. Do not merge a catalog change with a failing `launch` job.
+
+## Reference
+
+### Groups
+
+The section of the page a tool sorts into. Required on every entry.
+
+| Id            | Section on the page               |
+| ------------- | --------------------------------- |
+| `attendance`  | Attendance & behavior             |
+| `academics`   | Academics & assessment            |
+| `college`     | College readiness & pathways      |
+| `performance` | Performance management & coaching |
+| `staff`       | Staff, hiring & pay               |
+| `operations`  | Enrollment & operations           |
+| `surveys`     | Surveys                           |
+
+Pick the one the tool most belongs under. If none fits, raise it — do not guess.
+
+### Systems
+
+| Value           | Display label |
+| --------------- | ------------- |
+| `tableau`       | Tableau       |
+| `appsheet`      | AppSheet      |
+| `zendesk`       | Zendesk       |
+| `google-sheet`  | Google Sheet  |
+| `google-slides` | Google Slides |
+| `google-form`   | Google Form   |
+| `google-doc`    | Google Doc    |
+| `apps-script`   | Apps Script   |
+| `other`         | Other         |
+
+Anything `google-*` or `appsheet` triggers
+[the sharing check](#the-sharing-check).
+
+### Audiences
+
+| Value      | Role view on the page |
+| ---------- | --------------------- |
+| `teachers` | Teachers              |
+| `leaders`  | Leaders               |
+| `ops`      | Operations            |
+| `region`   | Regional & CMO        |
+
+There is always an **All tools** view listing every published entry regardless
+of audience.
+
+### Validation errors and what they mean
+
+| Error                                       | Fix                                                                       |
+| ------------------------------------------- | ------------------------------------------------------------------------- |
+| ``missing `id` ``                           | Add one, in `snake_case`                                                  |
+| `` `id` ... must match ^[a-z0-9_]+$ ``      | Lowercase letters, digits, underscores only                               |
+| ``duplicate `id` ``                         | Another entry already uses it — the tool may already be listed            |
+| `` `url` must be https ``                   | Use the `https://` form                                                   |
+| ``unknown `system` ``                       | Use a value from [Systems](#systems)                                      |
+| ``missing `group` `` / ``unknown `group` `` | Use an id from [Groups](#groups)                                          |
+| `` `status` must be one of ... ``           | `needs-review` or `verified`                                              |
+| ``verified entries need a `description` ``  | Write one sentence, or drop back to `needs-review`                        |
+| ``needs a non-empty `audiences` list ``     | Decide who this is for                                                    |
+| `unknown audience `                         | Use a value from [Audiences](#audiences)                                  |
+| `` `access` may only be 'limited' ``        | Remove the field or set it to `limited`                                   |
+| `a family member needs exactly one region`  | One of the four regions in `regions:`, not `[all]`, not several           |
+| `family ... names missing tool `            | The `members:` name in `groups.yml` must match the entry's `name` exactly |
+
+### Where to ask
+
+Every judgment call here is one somebody else can answer in two minutes.
+Guessing costs more than asking.
+
+- **Does this tool belong in the catalog?** Ask the catalog owner.
+- **Which group does it go in?** Ask, if none of the seven obviously fits.
+- **I found a link-shared Google Sheet.** Flag it immediately. Do not add it.
+- **A new group or family.** Needs a `groups.yml` decision, not a guess.

--- a/docs/launch/PROJECT.md
+++ b/docs/launch/PROJECT.md
@@ -1,8 +1,10 @@
 # Data launch page — project overview
 
-Orientation for anyone picking up this work. [README.md](README.md) is the field
-reference and [RUNBOOK.md](RUNBOOK.md) is the task sequence; this is the why,
-the scope, and where it stands.
+Orientation for anyone picking up this work.
+[Adding a tool to the launch page](../guides/launch-page-guide.md) is the
+published field reference, [README.md](README.md) covers this directory and the
+state of the catalog, and [RUNBOOK.md](RUNBOOK.md) is the task sequence; this is
+the why, the scope, and where it stands.
 
 Last updated 2026-08-11.
 
@@ -133,7 +135,8 @@ not wire the build into the deploy before the gate exists.
 | Path                                                                 | What                                         |
 | -------------------------------------------------------------------- | -------------------------------------------- |
 | `docs/launch/links.yml`                                              | The catalog. Source of truth                 |
-| `docs/launch/README.md`                                              | Field reference and what "verified" requires |
+| `docs/launch/README.md`                                              | This directory, and the state of the catalog |
+| `docs/guides/launch-page-guide.md`                                   | Published field reference: how to add a tool |
 | `docs/launch/RUNBOOK.md`                                             | The verification task sequence               |
 | `docs/superpowers/specs/2026-08-06-launch-page-design.md`            | What the page is (on #4762)                  |
 | `docs/superpowers/specs/2026-08-11-launch-page-build-gate-design.md` | How it gets built (on #4819)                 |

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -25,6 +25,21 @@ what puts the tool in front of staff. The page starts empty and fills up.
 `template.html` into the published page. See PROJECT.md for how the pieces fit
 together and what's left to decide.
 
+## The field reference lives in the published guide
+
+**[Adding a tool to the launch page](../guides/launch-page-guide.md)** is the
+reference for every field: what is required, what the legal values are, the
+Google Drive sharing check, how to preview the page locally, and what each
+validation error means. It is published in the docs site nav, so it is reachable
+without cloning the repository.
+
+Keep it as the single home for those rules. This file covers what the directory
+is and the state of this particular catalog; it deliberately does not restate
+the field table.
+
+`build.py` is the authority if the two ever disagree — `_tier_one` validates
+every entry, `_tier_two` only the verified subset.
+
 ## Current state
 
 `links.yml` was **scraped from the existing Google Site** and merged. It is a
@@ -40,10 +55,10 @@ The scrape found several kinds of problem, which is a good sign — these are
 exactly the failures that come from maintaining the same list on five separate
 pages by hand.
 
-## The work
+## What "verified" means here
 
 Review every entry and change its `status` to `verified`. An entry is verified
-when all five of these are true:
+when all of these are true:
 
 1. **The tool still exists** and the URL loads. You will need Tableau access for
    most of them; ask if you do not have it.
@@ -54,82 +69,33 @@ when all five of these are true:
 1. **`audiences` is right.** Who actually needs this in their day-to-day? A tool
    can be in several. A tool in none still appears in the All view, so an empty
    list is a real answer — but it should be a decision, not an accident.
-1. **`system` is right** — `tableau`, `appsheet`, `zendesk`, `google-sheet`,
-   `google-slides`, `google-form`, `google-doc`, `apps-script`, or `other`.
-1. **For anything Google-hosted, the sharing is group-based.** See below. This
-   one is not optional.
+1. **`system` and `group` are right.** Legal values are in the guide.
+1. **For anything Google-hosted, the sharing is group-based.** The procedure is
+   in the guide. This one is not optional — see below for what we already know
+   about the files in this catalog.
 
-### `group`
+## What we already know about the Google-hosted entries
 
-**Every entry needs a `group`.** It is what section of the published page the
-tool sorts into, and it is required — an entry with a missing or unknown `group`
-fails validation. The legal ids come from `groups.yml`:
+The guide explains how to run the sharing check. These are the findings specific
+to the files already in this catalog, which are worth keeping as a record:
 
-- `attendance` — Attendance & behavior
-- `academics` — Academics & assessment
-- `college` — College readiness & pathways
-- `performance` — Performance management & coaching
-- `staff` — Staff, hiring & pay
-- `operations` — Enrollment & operations
-- `surveys` — Surveys
+- **The three GPA Rosters** in `links.yml` were checked and are group-shared
+  correctly. Anything you add is on you to check.
+- **The four Student Contact Info Feeds** are the case in point for why the
+  check has to happen in the Share dialog: automated reads show only an owner,
+  but the data team confirmed each is shared to its region's group with CMO
+  staff holding access to all four, and none is link-shared. They carry student
+  and guardian contact information, so treat them as the most sensitive entries
+  here and re-confirm rather than assume if anything about them changes.
 
-Pick whichever one the tool most belongs under. If none fits, that is a
-`groups.yml` conversation, not a reason to guess.
-
-### The other fields
-
-- **`guide:`** — optional. The Zendesk help article for this tool, if one
-  exists.
-- **`access: limited`** — optional badge for tools most staff cannot open.
-- **`regions:`** — optional, and **not the same thing as `audiences`**. This is
-  geography: which of `newark`, `camden`, `miami`, `paterson` a tool covers, or
-  `[all]`. Use it when a tool exists once per region, like the Student Contact
-  Info Feeds. `audiences: [region]` means something entirely different — it is
-  the _Regional and CMO_ role view. A tool can be `audiences: [region]` with no
-  `regions:` at all, or scoped to one region and used by teachers.
-
-Add `guide:` with the Zendesk article URL if the tool has a help article and the
-entry is missing it.
-
-### Google-hosted tools need one extra check
-
-A Tableau link is safe to publish because Tableau requires sign-in — the URL is
-useless to anyone outside. **A Google Drive link is not automatically safe.** If
-a Sheet is shared "anyone with the link," then the URL _is_ the access control,
-and publishing it here — in a public repository — hands it to the internet.
-
-So for every entry with a `google-*` system, open the file, click **Share**, and
-confirm **General access is _not_** "Anyone with the link." It should be
-restricted to named people or Workspace groups.
-
-If you find one that is link-shared: **do not add it to this file.** Flag it
+If you find a file that is link-shared: **do not add it to this file.** Flag it
 instead. That is a live exposure to fix at the source, not something to
 document.
 
-The three GPA Rosters currently in `links.yml` were checked and are group-shared
-correctly. Anything you add is on you to check.
-
-**A tooling caveat you will hit.** For a file you do not administer, the Drive
-API returns only the owner — not the groups it is actually shared with. An empty
-group list from a script is therefore inconclusive, not evidence of a problem.
-Check the Share dialog in the UI, which shows the real picture.
-
-The four Student Contact Info Feeds are the case in point: automated reads show
-only an owner, but the data team confirmed each is shared to its region's group
-with CMO staff holding access to all four, and none is link-shared. They carry
-student and guardian contact information, so treat them as the most sensitive
-entries here and re-confirm rather than assume if anything about them changes.
-
-**AppSheet apps need this twice over.** An AppSheet app has its own access
-setting, _and_ it reads from a backing Google Sheet with its own separate
-sharing. Both have to require sign-in. There is no API shortcut here — open the
-app, then open the Sheet behind it, and check each.
-
-### What order to do it in, and which entries need a decision
+## What order to do it in, and which entries need a decision
 
 See [RUNBOOK.md](RUNBOOK.md). That file owns the sequence, the entries that need
-a judgment call rather than a lookup, and what to flag as you go. This file
-stays the field reference so the two cannot drift apart.
+a judgment call rather than a lookup, and what to flag as you go.
 
 ## Out of scope
 

--- a/docs/launch/RUNBOOK.md
+++ b/docs/launch/RUNBOOK.md
@@ -3,9 +3,10 @@
 The task sequence for getting `links.yml` from a scraped starting point to a
 catalog we would put in front of staff.
 
-[README.md](README.md) is the reference: what the directory is, what each field
-means, and what "verified" requires. This file is the order to do things in and
-who owns what.
+[Adding a tool to the launch page](../guides/launch-page-guide.md) is the field
+reference: what each field means and what the legal values are.
+[README.md](README.md) covers what this directory is and what "verified"
+requires. This file is the order to do things in and who owns what.
 
 The design for how this catalog gets served is tracked separately in #4762 — a
 static page built from `links.yml` and published to GitHub Pages. You do not
@@ -43,17 +44,18 @@ a `guide:` link points at a real article.
 
 ## Step 1 — Verify the catalog entries
 
-The week's work. For each entry, apply the five checks in
-[README.md](README.md#the-work) and change `status: needs-review` to
-`status: verified`.
+The week's work. For each entry, apply the checks in
+[README.md](README.md#what-verified-means-here) and change
+`status: needs-review` to `status: verified`.
 
 Suggested order:
 
 1. **The tools you already know**, to confirm the pattern before scaling up.
 1. **The rest alphabetically.** Most are quick — open it, confirm the name,
    tighten the description, decide the audiences.
-1. **Anything Google-hosted gets the sharing check** described in README.md.
-   Non-optional, and it is the one check with a real consequence if skipped.
+1. **Anything Google-hosted gets the sharing check** described in
+   [the guide](../guides/launch-page-guide.md#the-sharing-check). Non-optional,
+   and it is the one check with a real consequence if skipped.
 
 Roughly 44 entries at ten to fifteen minutes each is about a day and a half of
 focused time. The rest of the week is the judgment calls and what you turn up

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Local Development: guides/local-development.md
       - Dagster: guides/dagster.md
       - Google Sheets & Forms: guides/google-sheets.md
+      - Launch Page: guides/launch-page-guide.md
       - ADP Location Renames: guides/adp-location-renames.md
       - dbt Development: guides/dbt-development.md
       - SFTP Integration: guides/sftp-integration.md


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will publish a guide that explains how to add a tool to the staff launch page.

The launch page is built from one file, `docs/launch/links.yml`. Nothing in the repository explained how to add an entry to it. The three files in `docs/launch/` each cover adjacent ground: `README.md` is a field reference written for verifying the scraped entries, `RUNBOOK.md` is the sequence for the one-time verification sprint, and `PROJECT.md` is orientation. All three are excluded from the published docs site, so none was reachable without cloning the repo.

The new guide is `docs/guides/launch-page-guide.md`. It covers what each field means, which fields are required to publish, the Google Drive sharing check, how to preview the page locally, and what each validation error means. It also covers changing a tool and taking one off the page.

`docs/launch/README.md` is trimmed to what the directory is and the state of this catalog. Its field reference now points at the published guide, so there is one home for those rules instead of two that drift.

Closes #5222

## Reviewer Notes

**Placement.** The guide sits in `docs/guides/`, not `docs/launch/`. `exclude_docs` treats `docs/launch/` as build source and excludes every markdown file in it, that directory has its own CODEOWNERS entry, and any change under it triggers the `launch` pytest job. A guide that lives there would be unpublishable and would run catalog validation on a typo fix.

**The rules come from `build.py`, not from the old prose.** I took the field rules from `_tier_one` and `_tier_two` rather than from `README.md`, so the guide distinguishes what is validated on every entry from what is validated only once an entry is `verified`. The guide says `build.py` wins if the two ever disagree.

**What the README trim keeps.** I kept the findings specific to this catalog's Google-hosted entries, because they are a record rather than a procedure: the three GPA Rosters were checked and are group-shared, and the four Student Contact Info Feeds are confirmed group-shared despite automated reads showing only an owner. The generic procedure moved to the guide.

**Cross-references.** Renaming the README's "The work" section broke an anchor in `RUNBOOK.md`. That is fixed, along with the pointers in `PROJECT.md`, the `launch/` section and structure tree in `docs/CLAUDE.md`, and the routing table in `docs/guides/index.md`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

No Dagster or dbt changes, so those sections are skipped. No schedule, sensor, or integration changes either, so the automations catalog does not need regenerating.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The user asked whether a doc explaining the `links.yml` process already existed, found it did not, and chose the published-docs route over a Zendesk help article.

Verified locally in the worktree before pushing:

- `uv run --group docs pytest tests/launch -v` — 59 passed.
- `uv run --group docs mkdocs build` — builds with no errors. The guide renders at `guides/launch-page-guide/index.html`, the generated `launch/index.html` still builds, and the nav label "Launch Page" appears on sibling pages.
- All four in-page anchor targets the guide links to resolve in the built HTML: `the-sharing-check`, `systems`, `groups`, `audiences`.
- `trunk check --force --no-fix` clean on all seven changed files. Table padding needed `trunk fmt` to settle MD060.

The README anchor now referenced from `RUNBOOK.md` is `#what-verified-means-here`, matching the renamed heading `## What "verified" means here`.

Two facts worth carrying forward, both stated in the guide because they are easy to miss and expensive to rediscover: `groups.yml` carries `minimum_verified: 25`, below which `render()` returns `None` and no page is generated while the build still passes; and a catalog that fails validation on `main` freezes the whole docs deploy, since both run the same code path.

The docs-site deploy fires on `docs/**`, so this merge republishes the site including the launch page itself. No catalog entries changed, so the rendered page content is unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
