### PR TITLE
docs(claude): add the Tableau MCP context file with a pointer into the workbook skill

### DIFF
--- a/.claude/context/tableau.md
+++ b/.claude/context/tableau.md
@@ -1,0 +1,60 @@
+# Tableau MCP gotchas
+
+Injected on the first `mcp__tableau__*` call. Everything here is about the MCP
+server's own tools. Editing or publishing a workbook is a different job with its
+own gate: **invoke the `tableau-workbook-xml` skill before writing any
+`tableauserverclient` code**, and do not attempt a publish from memory. That
+skill carries the checkers, the repack script, the non-production review-copy
+publish, and the two typed confirmations a production publish requires.
+
+Marks: **Verified** = observed against this server on the date given.
+**Inferred** = reported by one project (#5230) without a controlled probe.
+
+- **The MCP is read-only.** Verified 2026-09-09: all 19 tools in this deployment
+  are `get-`, `list-`, `query-`, `search-` or `generate-pulse-*`. There is no
+  publish, no workbook edit, no group mutation. Do not look for one. Workbook
+  content can still be edited and republished from this Codespace with
+  `tableauserverclient`; that is the skill's job, not the MCP's.
+- **No tool returns calculated-field text.** Inferred (#5230). `get-workbook`
+  and `list-workbooks` return workbook, view and datasource metadata, never the
+  formula, and there is no Metadata API GraphQL passthrough. Row-level-security
+  calculations cannot be audited from the MCP: checking which workbooks carry a
+  branch, or searching for `USERNAME()` against a literal, happens outside it,
+  by downloading the workbook through the skill.
+- **Both metadata paths fail on an embedded extract.** Verified 2026-09-04
+  against one embedded-extract luid; do not re-test that case:
+
+  | Tool                      | Result                                        |
+  | ------------------------- | --------------------------------------------- |
+  | `get-datasource-metadata` | HTTP 500                                      |
+  | `query-datasource`        | `Unable to retrieve data source information.` |
+
+  `get-datasource-metadata` reaches the Metadata API only for published
+  datasources, and even then returns field names, types and roles, not formulas.
+  `query-datasource`'s inline `calculation` parameter is not a way round it.
+
+- **`get-workbook` gives the workbook-to-table mapping.** Inferred (#5230). Its
+  `upstreamDatasources` array returns each datasource's name, luid and type, and
+  it worked for embedded extracts. That maps a workbook to its dbt model in one
+  call, and it surfaced a second, stale datasource left attached by an
+  incomplete repoint that is otherwise invisible without Desktop. Use it before
+  asking the user to read the Data pane.
+- **The MCP cannot test a persona.** `scripts/tableau-mcp-launch.sh`
+  authenticates with one fixed personal access token from 1Password, with no
+  per-user credential, so `get-view-data` and `query-datasource` return that
+  identity's rows for every user of the MCP. A render or query through it cannot
+  distinguish an applied row-level-security gate from a broken one. The probe
+  that can is in the skill's `references/build-workflow.md`.
+- **`search-content` ranks, `list-*` enumerates.** Inferred (#5230).
+  `search-content` returns one ranked page of top matches, not every match. When
+  completeness matters, use `list-workbooks` with a filter.
+- **`401002: Invalid authentication credentials` on a Tableau session.** The
+  cause is not established. #5230 saw it three times during scripted publishes
+  and read it as one-active-session-per-token; this repo's Dagster resource
+  (`src/teamster/libraries/tableau/CLAUDE.md`) attributes the same code to a
+  sign-in race and recovers with a fresh sign-in. Both agree on the recovery.
+  Two facts worth knowing before a scripted publish runs alongside MCP calls:
+  the MCP holds a session on its token for the life of the server process, and
+  the skill's publish template signs in through a `with` block that releases its
+  session on exit. Whether the two use the same token is unverified here; if
+  they do, an MCP call mid-publish is a plausible trigger.


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will add `.claude/context/tableau.md`, the file the `tool-gotchas.sh` hook injects on the first `mcp__tableau__*` call in a session. It carries the 6 Tableau MCP behaviors reported in #5230 (read-only tool set, no calculated-field text, metadata paths failing on embedded extracts, `get-workbook` upstream mapping, one fixed identity so no persona testing, `search-content` ranks rather than enumerates), each marked Verified or Inferred, and one entry on `401002` that records both candidate causes and the shared recovery.

It also carries the sentence that routes an MCP-first agent into `tableau-workbook-xml` before it writes any `tableauserverclient` code. Today nothing does that: the skill's description fires on XML-level symptoms, not on "which workbooks carry this branch", and an agent that discovers the MCP is read-only and reaches for the library on its own never sees the skill's publish gate.

Refs #5230. A companion PR folds the verified probe results into the skill itself; this one is independent and should land first.

## Reviewer Notes

- The draft this is adapted from lived only on `cristinabaldor/docs/claude-tableau-permissions-guide` and was deleted there in f556180d3; it was never on `main`. Two wording changes from that draft: the read-only claim names the two `generate-pulse-*` tools that fall outside the four prefixes, and "row-level security is invisible to the MCP" became "the MCP cannot test a persona", which is what was observed.
- The `401002` entry does not pick a cause. #5230 read it as one active session per token; `src/teamster/libraries/tableau/CLAUDE.md` attributes the same code to a sign-in race. The recovery is the same either way and the entry says so.
- Whether the MCP's token is the same one the skill's publish template uses is stated as unverified. If it is, an MCP call during a scripted publish is a plausible trigger for the `401002`s in #5230.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

## CI checks

- [x] **Trunk** — `trunk check --force --no-fix` on the file: no issues.
- [ ] **dbt Cloud** — not applicable, no dbt changes.
- [ ] **Dagster Cloud** — not triggered, no Dagster changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)