### PR TITLE
fix(claude): fold the verified #5230 probe results into tableau-workbook-xml

### DIFF
--- a/.claude/skills/tableau-workbook-xml/SKILL.md
+++ b/.claude/skills/tableau-workbook-xml/SKILL.md
@@ -16,16 +16,16 @@ description:
 
 Everything here was learned by editing one production workbook as `.twb` XML,
 publishing to a scratch project, and rendering. Claims are marked **Verified**
-(seen in a render or a Desktop error) or **Inferred** (consistent with a working
-file, never rendered). Two inferences in the source project were wrong, and both
-had the same shape, structural similarity treated as behavioral proof: a
-parameter token resolved in a worksheet title so it was assumed to resolve in a
-mark label (it renders blank); a tooltip form was present in the workbook so it
-was assumed to render (the copy printed its tokens literally). When you catch
-yourself reasoning "it works there, so it works here", probe: one sheet, a
-literal `PROBE ` marker, publish to scratch, render with the parameter set each
-way, read the image for the marker and the value. A hover or a click cannot be
-rendered; say so and ask a human.
+(seen in a render, a Desktop error, or a server response) or **Inferred**
+(consistent with a working file, never rendered). Two inferences in the source
+project were wrong, and both had the same shape, structural similarity treated
+as behavioral proof: a parameter token resolved in a worksheet title so it was
+assumed to resolve in a mark label (it renders blank); a tooltip form was
+present in the workbook so it was assumed to render (the copy printed its tokens
+literally). When you catch yourself reasoning "it works there, so it works
+here", probe: one sheet, a literal `PROBE ` marker, publish to scratch, render
+with the parameter set each way, read the image for the marker and the value. A
+hover or a click cannot be rendered; say so and ask a human.
 
 ## Three rules
 
@@ -68,8 +68,9 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
 3. **Edit** with `encoding="utf-8", newline=""` on both read and write. Anchor
    every substitution and assert it matched exactly once; a unique anchor can
    still land an element in the wrong content-model position, which is what step
-   4 checks. Assert the output length moved by what you inserted (the 20% guard
-   catches only gross truncation). Parse with `ET.fromstring` before writing.
+   4 checks. Assert the count of the old string and of the new string changed as
+   intended, not the byte delta: a same-length replacement moves the total by 0,
+   so a length guard passes a no-op. Parse with `ET.fromstring` before writing.
    Edit the dashboard's `<zones>` block; if a `<devicelayouts>` block exists,
    say in the hand-over that it was untouched. Inside `<formatted-text>` a line
    break is its own run `<run>Æ&#10;</run>` (U+00C6 then `&#10;`), reproduced
@@ -100,8 +101,15 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    publish call, assert the target id equals that recorded literal and that the
    workbook name carries a `ZZ-REVIEW` prefix plus the date, so an overwrite can
    only land on a review copy. Keep the raise on `item.project_id` after the
-   call as confirmation of where it landed; it cannot prevent anything.
-   Production becomes the target only when the user, in a message typed in this
+   call as confirmation of where it landed; it cannot prevent anything. A
+   publish also drops server-side state (Verified, #5230). Pass `hidden_views`,
+   the names to hide: sheets the `<windows>` element marks publishable (`class`
+   `worksheet` or `dashboard`, `hidden` not `'true'`) minus the target's live
+   view names, minus sheets this edit added; without it every publishable sheet
+   goes live. Record the target's revision number before the call as the owner's
+   own restore point. Recipes, the credential drop, and the gate in full:
+   [references/build-workflow.md](references/build-workflow.md). Production
+   becomes the target only when the user, in a message typed in this
    conversation, names production as the target, and then answers yes when you
    ask "Are you sure? This overwrites the production workbook and is visible to
    the whole network." A button click on a prompt is not a confirmation; a
@@ -116,11 +124,16 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    or ellipsised text, a legend or axis missing entries, a blank line where text
    should be, a literal `[federated…]` token, and overlapping zones. Sample
    pixels to assert colour. A render-API parameter set bypasses the domain check
-   a real click performs, and a render cannot show a hover or a click.
+   a real click performs, and a render cannot show a hover or a click. If the
+   edit touched a row-level-security calculation, your own render proves nothing
+   when your token sees every row: run the differential probe in
+   [references/build-workflow.md](references/build-workflow.md).
 8. **Hand over** the `.twbx` plus the scratch copy, and delete the throwaway
    test file. Report what was verified, what was inferred, which regions you
-   looked at, what still needs a human hover, click, or Desktop open, and that
-   the package carries the extract as of `updated_at`.
+   looked at, what still needs a human hover, click, or Desktop open, that the
+   package carries the extract as of `updated_at`, and the revision number the
+   target had before the publish. For a production publish, quote the user's two
+   confirmations verbatim.
 
 ## By symptom
 

--- a/.claude/skills/tableau-workbook-xml/references/build-workflow.md
+++ b/.claude/skills/tableau-workbook-xml/references/build-workflow.md
@@ -36,8 +36,65 @@ if item.project_id != TEMP_PROJECT:
 ```
 
 Include the date in the review name so two sessions cannot overwrite each
-other's copies if Overwrite matches on name within a project (unverified; see
-[unverified-warnings.md](unverified-warnings.md)).
+other's copies. Across about a dozen Overwrites of the same target in #5230 the
+LUID and `content_url` never changed (Verified), so an Overwrite lands on the
+existing workbook; whether a different session's same-named workbook would be
+matched is still Inferred ([unverified-warnings.md](unverified-warnings.md)).
+The date costs nothing and closes the case either way.
+
+## What a publish drops, and what to do about it
+
+Verified in #5230 across 13 publishes on REST API 3.25 with
+`tableauserverclient` 0.41, unless marked.
+
+- **Hidden views.** `WorkbookItem.hidden_views` is write-only in the library: no
+  read path populates it, so the server's hidden state cannot be read back off
+  the item and a publish without the argument makes every publishable sheet a
+  live view. In #5230 one workbook marked 20 sheets publishable against 10 live
+  views, another 12 against 2. Compute the list to hide before the call: from
+  the `.twb`'s `<windows>` element take entries whose `class` is `worksheet` or
+  `dashboard` and whose `hidden` is not `'true'`; subtract the live view names
+  of the **overwrite target** (not a scratch copy); subtract the sheets this
+  edit deliberately added. `<worksheets>` and `<dashboards>` list every sheet
+  whether publishable or not and are the wrong source. Pass the result as
+  `hidden_views` on the `WorkbookItem`.
+- **Embedded connection credentials.** A publish without a `connections=[...]`
+  list drops them. The scratch copy hides this because the packaged extract
+  still renders; the owner sees a failing refresh or a credential prompt later.
+  How to put them back is **not settled**: #5230 reports `update_connection`
+  with `oauth = True`, but in the installed library `oauth` exists only on
+  `ConnectionCredentials` and the request builder `update_connection` uses never
+  emits it; the only path that does is `publish(connections=[...])`, which #5230
+  saw report success on a live-connection workbook while leaving
+  `embed_password` false (a value the library also returns when the server omits
+  the attribute). Until a probe settles the call, say in the hand-over that
+  credentials were not carried, and treat re-embedding a service account's
+  credential as the owner's decision. Never write a key into a throwaway test
+  file; the 1Password fixture in `tests/conftest.py` supplies secrets at run
+  time.
+- **Revision number.** Every Overwrite on this site created a revision (131 to
+  132, 107 to 108, 45 to 46, 100 to 101). Call `populate_revisions` on the
+  target before publishing and record the current number in the hand-over so the
+  owner has a restore point they apply themselves from the Server UI. That is
+  the owner's action, not yours: a restore on production is a production change
+  and needs the same two confirmations as a publish.
+- **Refresh schedules and permissions.** Not established. A refresh was already
+  queued after several Overwrites, which suggests the schedule survived, but
+  nobody listed tasks before and after; the probe in
+  [unverified-warnings.md](unverified-warnings.md) is unchanged.
+
+## Proving a row-level-security change
+
+If the build touched a permissions calculation, a render as your own identity is
+worthless when your token sits in an all-access group: the gate returns true for
+every row and an applied gate looks identical to a broken one (Verified, #5230).
+Publish a **probe build** with the all-access branch removed to the
+non-production project, render it at the same crop, resolution and parameter
+value as the control, and require both halves: rows scoped to another department
+are **absent**, and rows for the render identity's own department are
+**present**. Absence alone passes a build that renders nothing. The probe build
+is a throwaway: it never becomes the hand-over, and you delete it from the
+project when the check is done.
 
 ## Pull fresh, every time
 
@@ -161,6 +218,42 @@ cp docs/tableau-xml/scripts/tsc_session.py tests/test_zz_tableau.py
 uv run pytest tests/test_zz_tableau.py -s
 rm tests/test_zz_tableau.py
 ```
+
+## Sessions and jobs
+
+Observed in #5230 on REST API 3.25 with `tableauserverclient` 0.41; library
+facts checked against the installed source.
+
+- **`401002: Invalid authentication credentials` mid-run.** Three run failures
+  in #5230. The cause is not established: #5230 read it as one active session
+  per token, while this repo's Dagster resource
+  (`src/teamster/libraries/tableau/CLAUDE.md`) attributes the same code to a
+  sign-in race and recovers with a fresh sign-in. The recovery is the same
+  either way: hold one session, sign in through the `with` block the template
+  already uses (it signs out on exit and on exception), poll a job with your own
+  loop, and re-sign-in on `401002`. `wait_for_job` is a plain sleep-and-poll
+  loop with no re-authentication and no timeout by default, so a session lost
+  mid-poll surfaces as an error from its next request; write the loop yourself.
+  Whether the Tableau MCP's token is the same one the template uses is
+  unverified; if so, an MCP call during a publish is a plausible trigger.
+- **`403180`, `Full extract refresh operation for the workbook is not allowed`,
+  is not a credential failure.** The workbook has no extract; that is normal for
+  a live connection. The two connection types need opposite proofs: a live
+  connection cannot draw without a credential, so a render proves it; an
+  extract-backed workbook renders from the `.hyper` regardless, so a render
+  proves nothing and only a refresh counts.
+- **`jobs.get_by_id` on a `create_extract` job returns server code `400031`**
+  (`REST API does not support background job type :create_extracts`). The
+  jobs-list endpoint (`jobs.get()`, `jobs.filter()`) was not tried and may poll
+  it; until then, watch the workbook's size.
+- **`jobs.get()` with no id returns a tuple** of a `BackgroundJobItem` list and
+  a `PaginationItem`. `BackgroundJobItem` has `title`, `subtitle`, `status`,
+  `ended_at`; it has no `workbook_name`, `finish_code`, or `completed_at`, so
+  filtering on `workbook_name` raises `AttributeError`.
+- **`populate_csv` on a dashboard returned 0 rows, and so did the control.**
+  Export from a worksheet, or render and read the image. The lesson is in
+  [failure-catalog.md](failure-catalog.md): the test was wrong before the
+  workbook was.
 
 ## Cross-workbook merges lose things silently
 

--- a/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
+++ b/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
@@ -99,28 +99,31 @@ not just the one that looks like the measure.**
 
 ## Tooling and process
 
-| Symptom                                          | Cause                                                                   |
-| ------------------------------------------------ | ----------------------------------------------------------------------- |
-| Workbook truncated to a fraction of its size     | Loop variable shadowed an outer regex match object                      |
-| Whole file shows as changed in a diff            | `read_text(encoding="utf-8")` flattened CRLF to LF                      |
-| Published workbook is a few hundred kilobytes    | `include_extract=False` on download                                     |
-| Download lands at `name.twbx.twbx`               | `tableauserverclient` appends the extension to `filepath`               |
-| An exit code is reported as `0` or `120` wrongly | Read through a pipeline; `$?` was `tail`'s status or a SIGPIPE artifact |
-| A commit lands on the wrong branch               | A failed command short-circuited a chained `cd`; use `git -C` always    |
+| Symptom                                             | Cause                                                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Workbook truncated to a fraction of its size        | Loop variable shadowed an outer regex match object                                       |
+| Whole file shows as changed in a diff               | `read_text(encoding="utf-8")` flattened CRLF to LF                                       |
+| Published workbook is a few hundred kilobytes       | `include_extract=False` on download                                                      |
+| Download lands at `name.twbx.twbx`                  | `tableauserverclient` appends the extension to `filepath`                                |
+| An exit code is reported as `0` or `120` wrongly    | Read through a pipeline; `$?` was `tail`'s status or a SIGPIPE artifact                  |
+| Extract refresh fails with `403180` after a publish | The workbook has no extract (live connection); not a credential failure. Verified, #5230 |
+| A commit lands on the wrong branch                  | A failed command short-circuited a chained `cd`; use `git -C` always                     |
 
 ## The tests themselves
 
 The most expensive category, because everything reports success.
 
-| Symptom                                                  | Cause                                                                       |
-| -------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Geometry checker passes the exact bug it was written for | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect  |
-| Geometry checker false-positives on production           | An absolute tolerance tight enough for one container is wrong for another   |
-| Structure assertion passes a duplicated zone             | A parent map overwritten in document order hid the stale entry              |
-| Structure assertion passes a re-parented zone            | It checked existence and type, never parentage                              |
-| Structure assertion passes a reordered zone              | No sibling-order check                                                      |
-| Structure assertion passes a card nested inside a card   | Only leaf zones were pinned; the containers never were                      |
-| Assertion checks presence, not position                  | Searching a whole block for a token, rather than asserting the run sequence |
+| Symptom                                                                             | Cause                                                                                   |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Geometry checker passes the exact bug it was written for                            | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect              |
+| Geometry checker false-positives on production                                      | An absolute tolerance tight enough for one container is wrong for another               |
+| Structure assertion passes a duplicated zone                                        | A parent map overwritten in document order hid the stale entry                          |
+| Structure assertion passes a re-parented zone                                       | It checked existence and type, never parentage                                          |
+| Structure assertion passes a reordered zone                                         | No sibling-order check                                                                  |
+| Structure assertion passes a card nested inside a card                              | Only leaf zones were pinned; the containers never were                                  |
+| Assertion checks presence, not position                                             | Searching a whole block for a token, rather than asserting the run sequence             |
+| `populate_csv` on a dashboard returned 0 rows and read as a working permission gate | The control also returned 0; a dashboard view yields no crosstab. Verified, #5230       |
+| Length guard passes an edit that changed nothing                                    | A same-length replacement moves the byte total by 0; count the strings. Verified, #5230 |
 
 Every one of those was found by building a mutant and running the assertion
 against it. Make that a step, not an afterthought:

--- a/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
+++ b/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
@@ -7,29 +7,27 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
 
 ## Publish and hand-over
 
-- **Download-then-republish may drop embedded connection credentials.** The
-  expectation is that `workbooks.download()` does not return embedded
-  credentials and `workbooks.publish()` without a `connections=[...]` list
-  republishes with none. The scratch copy hides this because the packaged
-  extract still renders; the owner would see a failing refresh or a credential
-  prompt days later. Probe: inspect the published scratch workbook's connections
-  through the REST API before and after a publish, and ask the owner whether
-  production embeds credentials. Until probed, say in the hand-over that
-  credentials were not carried deliberately.
+- **Putting embedded connection credentials back after a publish.** That a
+  publish drops them is now Verified (#5230; see
+  [build-workflow.md](build-workflow.md)). Which call restores them is not:
+  #5230 names `update_connection` with `oauth = True`, but the installed
+  library's `update_connection` request never emits `oauth`, and
+  `publish(connections=[...])` reported success on a live-connection workbook
+  while leaving `embed_password` false. Probe: on a scratch copy, try each call,
+  then read the connection back through the REST API and trigger a refresh.
+  Until then, say in the hand-over that credentials were not carried.
 - **`show_tabs=True` may change a user-visible setting.** Probe: read
   `wb.show_tabs` off the downloaded item and publish with the same value, then
   compare the two scratch copies.
 - **Extract refresh schedules and permissions may or may not survive an
   Overwrite.** Probe: list tasks and permissions for the scratch workbook before
   and after an Overwrite and print the LUID both times.
-- **Overwrite may match on name within project.** If so, an unchanged
-  `ZZ-REVIEW` name overwrites a previous session's review copy. The skill now
-  requires a date in the name; probe by publishing twice with the same name and
+- **Overwrite may match on name within project.** Verified so far (#5230): an
+  Overwrite of the same target kept its LUID and `content_url` across about a
+  dozen publishes. Still open: whether a second session's same-named workbook
+  would be matched and overwritten. The skill requires a date in the review
+  name; probe by publishing twice with the same name from two sessions and
   checking whether one workbook or two exist.
-- **Workbook revision history may be the owner's real rollback.** If the site
-  keeps revisions, an Overwrite creates one and the owner can restore from the
-  UI without a publish. Probe: check the scratch workbook's revisions after a
-  publish. Tell the owner either way.
 
 ## Dynamic text
 

--- a/docs/tableau-xml/scripts/tsc_session.py
+++ b/docs/tableau-xml/scripts/tsc_session.py
@@ -11,6 +11,15 @@ missing fixture.
 
 Adapt the credential lines for any other host. Everything below the sign-in is
 portable.
+
+One session at a time: the `with server.auth.sign_in(auth)` block IS the session
+and releases it on exit, including on an exception. Poll a job with your own
+loop and re-sign-in on `401002`; see the skill's references/build-workflow.md.
+
+A publish drops server-side state. Before publishing, set `hidden_views` on the
+WorkbookItem (the names to hide: publishable sheets from `<windows>` minus the
+target's live views minus sheets this edit added) and record the target's
+revision number via `populate_revisions`. Both recipes are in the same file.
 """
 
 import os


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will fold the parts of #5230 that survived adversarial review into the `tableau-workbook-xml` skill. #5230 reports probe results from 13 production publishes and 6 failures the skill did not cover. Two reviewers checked every claim against the skill's text and the installed `tableauserverclient` 0.41 source; the verdicts are [on the issue](https://github.com/TEAMSchools/teamster/issues/5230#issuecomment-5609699194). This PR carries what passed and states what did not.

`SKILL.md` changes by 13 lines. Verified now includes a server response. Step 3 counts the old and new strings instead of trusting a byte delta, which a same-length replacement leaves at 0. Step 6 passes `hidden_views` before the publish call, records the target's revision number, and gains the pointer to the gate reference it lacked. Step 7 runs a row-level-security differential when the edit touched a permissions calculation. Step 8 quotes the user's two production confirmations in the hand-over.

`references/build-workflow.md` gains 3 sections: what a publish drops and what to do about it, proving a row-level-security change, and sessions and jobs. `references/unverified-warnings.md` retires the revision-history entry, narrows the credential entry to the unsettled restore call, and keeps the overwrite-by-name probe. `references/failure-catalog.md` gains 3 rows. `docs/tableau-xml/scripts/tsc_session.py` changes its docstring only.

Refs #5230. Companion to #5232, which should land first.

## Reviewer Notes

- **`hidden_views` is the important change.** The library field is write-only and the template never set it, so every Overwrite through the skill so far published every publishable sheet as a live view. #5230 measured 20 marked against 10 live on one workbook. The recipe names the direction (the list is the views to hide) and subtracts sheets the edit deliberately added, which the issue's version did not.
- **The credential re-embed is left open, not adopted.** #5230 says `update_connection` with `oauth = True`; in the installed source `oauth` exists only on `ConnectionCredentials` and the request builder `update_connection` uses never emits it. The skill records the drop as Verified and the restore call as unsettled, keeps the hand-over disclosure, and forbids writing a key into a throwaway test.
- **`401002` gets no cause.** #5230 read it as one active session per token; `src/teamster/libraries/tableau/CLAUDE.md` attributes it to a sign-in race. The skill states both and the shared recovery.
- **The production gate is untouched and restated** where #5230's framing could be read as loosening it: the revision number is the owner's restore point applied from the Server UI, a restore on production is a production change with the same 2 confirmations, and the 13 publishes are cited as observations, not as the skill's loop.
- "Overwrite matches on name within project" stays Inferred. Same-target overwrites keeping their LUID does not show a second session's same-named workbook would be matched. The dated `ZZ-REVIEW` name rule stays.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

## CI checks

- [x] **Trunk** — `trunk check --force --no-fix` on all 5 files: no issues. `tsc_session.py` compiles.
- [ ] **dbt Cloud** — not applicable, no dbt changes.
- [ ] **Dagster Cloud** — not triggered, no Dagster changes.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Two Opus reviewers: one verified every library claim in #5230 against `tableauserverclient` 0.41 source with file and line; one placed each item (loop step, reference section, `unverified-warnings.md`, `.claude/context/tableau.md`, or not the skill) and named the behavior delta. Accepted: `hidden_views` in step 6, the zero-delta guard fix, the RLS differential with a two-sided completion criterion and a throwaway-build rule, revision number as hand-over artifact, `403180` asymmetry, quoting the two confirmations, retiring the revision-history warning. Rejected: the `oauth=True` recipe (source contradiction), one-session-per-token as cause (competes with the repo's diagnosis), the post-call `pub.id` guard (post-call checks prevent nothing), "Overwrite matches on name" as Verified (wrong experiment), refresh schedules as confirmed (the issue itself hedges), `.claude/context/tableau.md` "being dropped" (it was never on `main`). The MCP comment's 6 items went to #5232.

`SKILL.md` is now 263 lines. The template's Pyright `publish` overload diagnostic is the pre-existing suppressed false positive.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)