### PR TITLE
docs(claude): add band roster panel lessons to tableau-workbook-xml

### DIFF
--- a/.claude/skills/tableau-workbook-xml/SKILL.md
+++ b/.claude/skills/tableau-workbook-xml/SKILL.md
@@ -5,11 +5,12 @@ description:
   Desktop refuses to open a file Server published (`no declaration found for
   element`, `missing elements in content model`, `not allowed for content
   model`, `D2E8DA72`); a render shows `####`, blank or literal placeholder text,
-  a clipped caption, a 200% percent-of-total axis, or overlapping zones; a
-  hand-edited .twb or .twbx is about to be repacked, published, republished or
-  rolled back with tableauserverclient; or you are hand-editing tooltips,
-  titles, captions, mark-label text, dashboard zones, number formats, or copying
-  an element between workbooks."
+  a clipped caption, a 200% percent-of-total axis, overlapping zones, or a sheet
+  inside a panel that stays empty until a click; a hand-edited .twb or .twbx is
+  about to be repacked, published, republished or rolled back with
+  tableauserverclient; or you are hand-editing tooltips, titles, captions,
+  mark-label text, dashboard zones, filter cards, floating panels, parameter
+  actions, number formats, or copying an element between workbooks."
 ---
 
 # tableau-workbook-xml
@@ -42,7 +43,10 @@ hover or a click cannot be rendered; say so and ask a human.
    review finding in the source project was against a test that would have
    passed something broken: a geometry checker with 4,500 units of tolerance
    against a 4,445-unit bug, a structure assertion that passed a duplicated, a
-   re-parented, and a reordered zone.
+   re-parented, and a reordered zone. The other direction happens too: an
+   assertion that demanded an order Tableau never writes (alphabetical
+   `<encodings>` children, a floating zone under the `layout-basic` root) failed
+   a correct file. An assertion that fails on the untouched base is wrong.
 
 ## The loop
 
@@ -56,9 +60,12 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    If you have a previous base, diff the worksheet and parameter lists against
    it; anything outside `<datasources>` is a design change to understand before
    building on it. The owner republished mid-project with a 17-sheet change
-   buried in a routine save. Run both checkers against the untouched base: a
-   failure there is a checker bug, not a workbook bug. Code:
-   [references/build-workflow.md](references/build-workflow.md).
+   buried in a routine save, and again between two pulls a day apart. Derive
+   free `[Parameter N]` numbers, zone ids and `filter-group` values from this
+   base, never from an earlier script: `[Parameter 14]` was free one day and
+   taken the next after a review copy was promoted. Run both checkers against
+   the untouched base: a failure there is a checker bug, not a workbook bug.
+   Code: [references/build-workflow.md](references/build-workflow.md).
 2. **Write the assertion before the edit.** Run it against the unedited file and
    confirm it fails. Once it passes, break your own output and confirm the
    assertion catches it. For a dashboard-zone change use `mutate.py`, running
@@ -77,8 +84,10 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    byte-exactly; the tooltips in this corpus used bare `&#10;` instead. Traps:
    [references/formatting.md](references/formatting.md).
 4. **Check.** `--ref` and `--baseline` are the untouched base from step 1, never
-   an earlier edit of your own. Run `check_geometry.py` once per dashboard that
-   contains an edited zone; it checks only the one you name.
+   an earlier edit of your own and never an older pull: against last week's
+   base, Tableau's own new elements (`preference`, `refresh`, `refresh-event`)
+   read as unknown. Run `check_geometry.py` once per dashboard that contains an
+   edited zone; it checks only the one you name.
 
    ```bash
    uv run python docs/tableau-xml/scripts/check_twb.py out.twb --ref base.twb >/tmp/o1 2>&1; rc1=$?
@@ -124,7 +133,10 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    or ellipsised text, a legend or axis missing entries, a blank line where text
    should be, a literal `[federated…]` token, and overlapping zones. Sample
    pixels to assert colour. A render-API parameter set bypasses the domain check
-   a real click performs, and a render cannot show a hover or a click. If the
+   a real click performs, and a render cannot show a hover or a click. It can
+   show a panel's default state: for a sheet inside a parameter-driven panel,
+   render the open state and require the sheet's rows, not just the panel
+   chrome; a stored action-filter state can leave it empty (By symptom). If the
    edit touched a row-level-security calculation, your own render proves nothing
    when your token sees every row: run the differential probe in
    [references/build-workflow.md](references/build-workflow.md).
@@ -154,7 +166,11 @@ table: [references/content-models.md](references/content-models.md).
   Publishing and rendering cannot verify this fix; the owner opening the `.twbx`
   in Desktop can.
 - **`no declaration found for element 'x'`.** The feature manifest does not
-  declare `x`. Insert the entry; never rebuild the manifest.
+  declare `x`. Insert the entry; never rebuild the manifest. The refusal is per
+  workbook, not per Desktop build: before ruling a feature out because one
+  workbook refused it, grep the target's own manifest. A merged or promoted base
+  may already declare it (Verified: the merged Academic Health workbook declared
+  all four dynamic-zone-visibility features its predecessor lacked).
 - **`missing elements in content model`.** A hand-built worksheet lacks
   `<simple-id>`, or its `<view>` lacks `<aggregation>`. Clone the skeleton from
   a working sheet.
@@ -182,6 +198,14 @@ Renders blank or literal. Matrix, examples, and the open question:
   `[datasource].[instance]` strings. Ask a human to hover.
 - **Text in a dashboard text zone does not resolve.** It never does (Verified).
   Move it to a worksheet title or caption.
+- **A sheet inside a panel is empty with nothing selected.** A stored
+  action-filter state on that sheet excludes every row until another action
+  fires: a `<filter>` carrying `user:ui-action-filter` with
+  `user:ui-enumeration='inclusive'` over `empty-level` members (Verified).
+  Rewrite that block to the unrestricted `level-members` form the workbook's
+  other stored action states use. Before wiring an action to any sheet, grep it
+  for `user:ui-action-filter` and read the state; a sheet that has been a sliver
+  or a hidden zone can carry a state nobody has seen.
 
 Layout. Numbers, their measurement conditions, and the card idiom:
 [references/layout-and-zones.md](references/layout-and-zones.md).
@@ -199,6 +223,14 @@ Layout. Numbers, their measurement conditions, and the card idiom:
   `check_geometry.py --baseline`.
 - **Percent-of-total axis reads 200%.** A `<lod>` on Detail changed the mark
   grain (Verified). The shipped fix put the field on Tooltip (Inferred safe).
+- **Adding a floating panel, or removing a zone from a flow.** A floating
+  container is a top-level child of `<zones>`, a sibling of the `layout-basic`
+  root; a dynamic-zone-visibility subtree carries `hidden-by-user='true'` on
+  every zone. Removing a fixed-width sibling from a flow is a cascade across the
+  surviving column, written as a table and asserted row by row.
+- **Adding a filter card.** Three elements per filtered sheet plus one zone,
+  `filter-group` from the fresh base's max plus one, and a `distribute-evenly`
+  strip's stored `w`/`x` re-tiled by hand.
 
 Formats and edits: [references/formatting.md](references/formatting.md).
 
@@ -207,6 +239,10 @@ Formats and edits: [references/formatting.md](references/formatting.md).
   Desktop.
 - **Parameter action fires, nothing changes.** A blanket replace rewrote the
   `<member>` domain. Every substitution asserts one match.
+- **Inserting a `<lod>` or a filter.** `<encodings>` children are in shelf
+  order, not alphabetical; `<filter>` and `<column-instance>` elements are
+  sorted by column string. Anchor on the neighbour, assert the position:
+  [references/content-models.md](references/content-models.md).
 
 Process: [references/build-workflow.md](references/build-workflow.md) and
 [references/failure-catalog.md](references/failure-catalog.md).
@@ -216,6 +252,8 @@ Process: [references/build-workflow.md](references/build-workflow.md) and
 - **Whole-file diff, `.twbx.twbx`, tiny download, wrong exit code.** CRLF
   flattened by `read_text`; `filepath` gets an extension appended;
   `include_extract=False`; status read through a pipe.
+- **Restore point reported as revision 9 of 24.** `populate_revisions` returns
+  `revision_number` as strings; cast to `int` before `max()`.
 
 Everything observed, with exact error strings and numbers:
 [references/failure-catalog.md](references/failure-catalog.md). Risks a Tableau

--- a/.claude/skills/tableau-workbook-xml/SKILL.md
+++ b/.claude/skills/tableau-workbook-xml/SKILL.md
@@ -5,12 +5,12 @@ description:
   Desktop refuses to open a file Server published (`no declaration found for
   element`, `missing elements in content model`, `not allowed for content
   model`, `D2E8DA72`); a render shows `####`, blank or literal placeholder text,
-  a clipped caption, a 200% percent-of-total axis, overlapping zones, or a sheet
-  inside a panel that stays empty until a click; a hand-edited .twb or .twbx is
-  about to be repacked, published, republished or rolled back with
-  tableauserverclient; or you are hand-editing tooltips, titles, captions,
-  mark-label text, dashboard zones, filter cards, floating panels, parameter
-  actions, number formats, or copying an element between workbooks."
+  a clipped caption, a 200% percent-of-total axis, overlapping zones, or a panel
+  sheet empty with nothing selected; a hand-edited .twb or .twbx is about to be
+  repacked, published, republished or rolled back with tableauserverclient; or
+  you are hand-editing tooltips, titles, captions, mark-label text, dashboard
+  zones, parameter actions, number formats, or copying an element between
+  workbooks."
 ---
 
 # tableau-workbook-xml
@@ -44,9 +44,10 @@ hover or a click cannot be rendered; say so and ask a human.
    passed something broken: a geometry checker with 4,500 units of tolerance
    against a 4,445-unit bug, a structure assertion that passed a duplicated, a
    re-parented, and a reordered zone. The other direction happens too: an
-   assertion that demanded an order Tableau never writes (alphabetical
-   `<encodings>` children, a floating zone under the `layout-basic` root) failed
-   a correct file. An assertion that fails on the untouched base is wrong.
+   assertion that demanded an order or a nesting Tableau does not keep failed a
+   correct file. A checker or an invariant that fails on the untouched base is
+   wrong; only the step-2 assertion of the finished state is meant to fail
+   there.
 
 ## The loop
 
@@ -84,10 +85,11 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    byte-exactly; the tooltips in this corpus used bare `&#10;` instead. Traps:
    [references/formatting.md](references/formatting.md).
 4. **Check.** `--ref` and `--baseline` are the untouched base from step 1, never
-   an earlier edit of your own and never an older pull: against last week's
-   base, Tableau's own new elements (`preference`, `refresh`, `refresh-event`)
-   read as unknown. Run `check_geometry.py` once per dashboard that contains an
-   edited zone; it checks only the one you name.
+   an earlier edit of your own and never an older pull. Run `check_geometry.py`
+   once per dashboard that contains an edited zone. It checks only the one you
+   name, and it skips every `hidden-by-user` zone, so a panel driven by dynamic
+   zone visibility is covered only by your own assertion and the open-state
+   render.
 
    ```bash
    uv run python docs/tableau-xml/scripts/check_twb.py out.twb --ref base.twb >/tmp/o1 2>&1; rc1=$?
@@ -133,12 +135,11 @@ gets no secrets). Read exit codes with a redirect, never through a pipe.
    or ellipsised text, a legend or axis missing entries, a blank line where text
    should be, a literal `[federated…]` token, and overlapping zones. Sample
    pixels to assert colour. A render-API parameter set bypasses the domain check
-   a real click performs, and a render cannot show a hover or a click. It can
-   show a panel's default state: for a sheet inside a parameter-driven panel,
-   render the open state and require the sheet's rows, not just the panel
-   chrome; a stored action-filter state can leave it empty (By symptom). If the
-   edit touched a row-level-security calculation, your own render proves nothing
-   when your token sees every row: run the differential probe in
+   a real click performs, and a render cannot show a hover or a click. For a
+   sheet inside a parameter-driven panel, render the open state and require
+   rows, not just the panel chrome. If the edit touched a row-level-security
+   calculation, your own render proves nothing when your token sees every row:
+   run the differential probe in
    [references/build-workflow.md](references/build-workflow.md).
 8. **Hand over** the `.twbx` plus the scratch copy, and delete the throwaway
    test file. Report what was verified, what was inferred, which regions you
@@ -169,8 +170,7 @@ table: [references/content-models.md](references/content-models.md).
   declare `x`. Insert the entry; never rebuild the manifest. The refusal is per
   workbook, not per Desktop build: before ruling a feature out because one
   workbook refused it, grep the target's own manifest. A merged or promoted base
-  may already declare it (Verified: the merged Academic Health workbook declared
-  all four dynamic-zone-visibility features its predecessor lacked).
+  may already declare it.
 - **`missing elements in content model`.** A hand-built worksheet lacks
   `<simple-id>`, or its `<view>` lacks `<aggregation>`. Clone the skeleton from
   a working sheet.
@@ -198,14 +198,14 @@ Renders blank or literal. Matrix, examples, and the open question:
   `[datasource].[instance]` strings. Ask a human to hover.
 - **Text in a dashboard text zone does not resolve.** It never does (Verified).
   Move it to a worksheet title or caption.
-- **A sheet inside a panel is empty with nothing selected.** A stored
-  action-filter state on that sheet excludes every row until another action
-  fires: a `<filter>` carrying `user:ui-action-filter` with
-  `user:ui-enumeration='inclusive'` over `empty-level` members (Verified).
-  Rewrite that block to the unrestricted `level-members` form the workbook's
-  other stored action states use. Before wiring an action to any sheet, grep it
-  for `user:ui-action-filter` and read the state; a sheet that has been a sliver
-  or a hidden zone can carry a state nobody has seen.
+- **A panel sheet is empty with nothing selected.** A stored action-filter state
+  on that sheet excludes every row: a `<groupfilter>` carrying
+  `user:ui-action-filter` with `user:ui-enumeration='inclusive'` over
+  `empty-level` members (Verified). Rewrite it to the `level-members` form.
+  Before and after, and the `on-empty` caveat that decides whether the fix
+  survives a deselect:
+  [references/failure-catalog.md](references/failure-catalog.md), "Data reads
+  wrong".
 
 Layout. Numbers, their measurement conditions, and the card idiom:
 [references/layout-and-zones.md](references/layout-and-zones.md).
@@ -223,14 +223,14 @@ Layout. Numbers, their measurement conditions, and the card idiom:
   `check_geometry.py --baseline`.
 - **Percent-of-total axis reads 200%.** A `<lod>` on Detail changed the mark
   grain (Verified). The shipped fix put the field on Tooltip (Inferred safe).
-- **Adding a floating panel, or removing a zone from a flow.** A floating
-  container is a top-level child of `<zones>`, a sibling of the `layout-basic`
-  root; a dynamic-zone-visibility subtree carries `hidden-by-user='true'` on
-  every zone. Removing a fixed-width sibling from a flow is a cascade across the
-  surviving column, written as a table and asserted row by row.
-- **Adding a filter card.** Three elements per filtered sheet plus one zone,
-  `filter-group` from the fresh base's max plus one, and a `distribute-evenly`
-  strip's stored `w`/`x` re-tiled by hand.
+- **Adding a floating panel on a parameter.** A top-level sibling of the
+  `layout-basic` root, and the visibility node's `dashboard-identifier` is the
+  `<dashboard>`'s `<simple-id>`, not the `<window>`'s. Recipe with the XML in
+  the reference.
+- **Removing a zone from a flow.** A cascade down the surviving column, asserted
+  row by row: recipe in the reference.
+- **Adding a filter card.** Three elements per filtered sheet plus one zone:
+  recipe in the reference.
 
 Formats and edits: [references/formatting.md](references/formatting.md).
 
@@ -239,9 +239,9 @@ Formats and edits: [references/formatting.md](references/formatting.md).
   Desktop.
 - **Parameter action fires, nothing changes.** A blanket replace rewrote the
   `<member>` domain. Every substitution asserts one match.
-- **Inserting a `<lod>` or a filter.** `<encodings>` children are in shelf
-  order, not alphabetical; `<filter>` and `<column-instance>` elements are
-  sorted by column string. Anchor on the neighbour, assert the position:
+- **Inserting a `<lod>` or a filter.** `<encodings>` children have no fixed
+  order; `<filter>` and `<column-instance>` elements are sorted by column
+  string. Anchor on the neighbour, assert the position:
   [references/content-models.md](references/content-models.md).
 
 Process: [references/build-workflow.md](references/build-workflow.md) and
@@ -252,8 +252,6 @@ Process: [references/build-workflow.md](references/build-workflow.md) and
 - **Whole-file diff, `.twbx.twbx`, tiny download, wrong exit code.** CRLF
   flattened by `read_text`; `filepath` gets an extension appended;
   `include_extract=False`; status read through a pipe.
-- **Restore point reported as revision 9 of 24.** `populate_revisions` returns
-  `revision_number` as strings; cast to `int` before `max()`.
 
 Everything observed, with exact error strings and numbers:
 [references/failure-catalog.md](references/failure-catalog.md). Risks a Tableau
@@ -277,7 +275,9 @@ All in `docs/tableau-xml/scripts/`; the README there has per-check tables.
   `uv run python docs/tableau-xml/scripts/check_geometry.py <twb> "<dashboard>" --baseline <base.twb>`.
   One dashboard per run. Catches visible sibling zones that overlap, a flow
   container whose parent-minus-children gap differs from the baseline's, and a
-  top-level `layout-basic` zone not spanning the 100000-unit canvas.
+  top-level `layout-basic` zone not spanning the 100000-unit canvas. Skips
+  `hidden-by-user` zones and everything under them, so a dynamic-zone-visibility
+  panel is never checked.
 - **`mutate.py`**:
   `uv run python docs/tableau-xml/scripts/mutate.py <src> <out> "<dashboard>" <op> [args]`.
   Builds a broken zone copy (`duplicate`, `reparent`, `move-after`, `swap`,

--- a/.claude/skills/tableau-workbook-xml/references/build-workflow.md
+++ b/.claude/skills/tableau-workbook-xml/references/build-workflow.md
@@ -57,7 +57,9 @@ Verified in #5230 across 13 publishes on REST API 3.25 with
   of the **overwrite target** (not a scratch copy); subtract the sheets this
   edit deliberately added. `<worksheets>` and `<dashboards>` list every sheet
   whether publishable or not and are the wrong source. Pass the result as
-  `hidden_views` on the `WorkbookItem`.
+  `hidden_views` on the `WorkbookItem`. Verified again on a second workbook: 15
+  publishable minus 5 live gave 10 to hide, and the copy came up with exactly
+  production's 5 live views.
 - **Embedded connection credentials.** A publish without a `connections=[...]`
   list drops them. The scratch copy hides this because the packaged extract
   still renders; the owner sees a failing refresh or a credential prompt later.
@@ -75,9 +77,11 @@ Verified in #5230 across 13 publishes on REST API 3.25 with
 - **Revision number.** Every Overwrite on this site created a revision (131 to
   132, 107 to 108, 45 to 46, 100 to 101). Call `populate_revisions` on the
   target before publishing and record the current number in the hand-over so the
-  owner has a restore point they apply themselves from the Server UI. That is
-  the owner's action, not yours: a restore on production is a production change
-  and needs the same two confirmations as a publish.
+  owner has a restore point they apply themselves from the Server UI.
+  `revision_number` comes back as a string, so `max()` picks `"9"` over `"24"`;
+  cast to `int` first (Verified). That is the owner's action, not yours: a
+  restore on production is a production change and needs the same two
+  confirmations as a publish.
 - **Refresh schedules and permissions.** Not established. A refresh was already
   queued after several Overwrites, which suggests the schedule survived, but
   nobody listed tasks before and after; the probe in
@@ -129,7 +133,16 @@ for label, pat in (("worksheets", r"<worksheet name='([^']*)'"),
 
 A pure extract refresh changes only `<datasources>`; worksheets and dashboards
 stay byte-identical. Anything else is a design change to understand before
-building on it.
+building on it. Between two pulls a day apart the base gained a sheet and a
+tooltip sheet, swapped a logo asset, renumbered `<devicelayouts>` ids, un-hid a
+window, and pointed `<repository-location>` at a `ZZ-REVIEW…` name: the owner
+had promoted a review copy. The target dashboard's `<zones>` were
+byte-identical, so the layout map survived; check that before reusing one.
+
+Pass the fresh base, not the older pull, as `--ref` to `check_twb.py`. Against
+an older pull, Tableau's own new elements (`preference`, `refresh`,
+`refresh-event`) are reported as absent from the reference, which is noise. The
+older pull as `--ref` answers one question only: what the owner changed.
 
 ## Write the assertion before the edit
 
@@ -218,6 +231,10 @@ cp docs/tableau-xml/scripts/tsc_session.py tests/test_zz_tableau.py
 uv run pytest tests/test_zz_tableau.py -s
 rm tests/test_zz_tableau.py
 ```
+
+Copy the template with `cp` or the Write tool. A Bash heredoc that writes the
+template's lines is denied by the PreToolUse hook: its credential lines match
+the hook's patterns (Verified, one denied call).
 
 ## Sessions and jobs
 

--- a/.claude/skills/tableau-workbook-xml/references/build-workflow.md
+++ b/.claude/skills/tableau-workbook-xml/references/build-workflow.md
@@ -57,9 +57,7 @@ Verified in #5230 across 13 publishes on REST API 3.25 with
   of the **overwrite target** (not a scratch copy); subtract the sheets this
   edit deliberately added. `<worksheets>` and `<dashboards>` list every sheet
   whether publishable or not and are the wrong source. Pass the result as
-  `hidden_views` on the `WorkbookItem`. Verified again on a second workbook: 15
-  publishable minus 5 live gave 10 to hide, and the copy came up with exactly
-  production's 5 live views.
+  `hidden_views` on the `WorkbookItem`.
 - **Embedded connection credentials.** A publish without a `connections=[...]`
   list drops them. The scratch copy hides this because the packaged extract
   still renders; the owner sees a failing refresh or a credential prompt later.
@@ -133,11 +131,11 @@ for label, pat in (("worksheets", r"<worksheet name='([^']*)'"),
 
 A pure extract refresh changes only `<datasources>`; worksheets and dashboards
 stay byte-identical. Anything else is a design change to understand before
-building on it. Between two pulls a day apart the base gained a sheet and a
-tooltip sheet, swapped a logo asset, renumbered `<devicelayouts>` ids, un-hid a
-window, and pointed `<repository-location>` at a `ZZ-REVIEW…` name: the owner
-had promoted a review copy. The target dashboard's `<zones>` were
-byte-identical, so the layout map survived; check that before reusing one.
+building on it. Before reusing a layout map from an earlier pull, diff the
+target dashboard's `<zones>` byte for byte: a promoted review copy changed
+sheets, a logo asset, `<devicelayouts>` ids, a window's `hidden` flag and
+`<repository-location>` between two pulls a day apart, and left `<zones>`
+intact.
 
 Pass the fresh base, not the older pull, as `--ref` to `check_twb.py`. Against
 an older pull, Tableau's own new elements (`preference`, `refresh`,
@@ -161,6 +159,11 @@ line endings enough to break a regex-based assertion on an _unmutated_ file.
 Resolve field references by caption at runtime rather than hard-coding instance
 strings, so a transcription slip fails loudly instead of rendering a literal
 token.
+
+For a worksheet edit, give the assertion the input file as a second argument and
+require every worksheet you did not name to be byte-identical, and the bytes
+before `<worksheets>` and after `</worksheets>` unchanged. It caught a mutant
+that touched a different sheet.
 
 ## Reading exit codes
 
@@ -285,6 +288,10 @@ direction:
   overwrote the other parameter's value.
 - **A worksheet used only as a viz-in-tooltip was deleted** while both
   references to it were kept, breaking the tooltips that depended on it.
+- **Deleted actions left their stored target states behind.** 24 of the 40
+  `user:ui-action-filter` states in the merged file name actions absent from
+  `<actions>`, and 10 of those are the `empty-level` form that excludes every
+  row ([failure-catalog.md](failure-catalog.md), "Data reads wrong").
 
 After any merge, diff the worksheet list **and** the parameter list against both
 sources before publishing. In this corpus Tableau renamed on some collisions and

--- a/.claude/skills/tableau-workbook-xml/references/content-models.md
+++ b/.claude/skills/tableau-workbook-xml/references/content-models.md
@@ -29,10 +29,10 @@ Adding an element means adding its manifest entry.
 
 The manifest is per workbook, so a refusal is too. "Desktop refuses dynamic zone
 visibility" was true of one lineage whose manifest lacked `DatagraphCoreV1`; the
-merged successor, saved by Desktop 2025.1.9, declared all four features and
-carried a Tableau-authored datagraph (Verified from the manifest). Before ruling
-a feature out, grep the target's manifest for it, and grep again whenever the
-base lineage changes: a merge or a promoted review copy is a lineage change.
+merged successor declared all four features and carried a Tableau-authored
+datagraph (observed in the file). Before ruling a feature out, grep the target's
+manifest for it, and grep again whenever the base lineage changes: a merge or a
+promoted review copy is a lineage change.
 
 ### Insert into the manifest. Never regenerate it
 
@@ -77,19 +77,15 @@ passes it. Check for an existing one before inserting.
 
 ### Encodings
 
-**Verified** on an untouched base. `<encodings>` children are in shelf order,
-not alphabetical: one sheet reads `color, lod, lod, tooltip ×7, text`. An
-assertion that required sorted children failed the unedited file. Insert a new
-`<lod>` right after the last existing `<lod>`, else right after `<color>`, and
-assert that position rather than a global order.
-
-A parameter action's source value sits on Detail: a constant calculated field
-(`Panel open` = TRUE) as a `<lod>` on the source sheet, declared in that sheet's
-`<datasource-dependencies>` as both `<column>` and `<column-instance>`. A
-one-value field cannot split the mark partition, so the percent-of-total trap in
-[layout-and-zones.md](layout-and-zones.md) does not apply; the closed render
-matched production. The owner's click on the review copy opened and closed the
-panel, which verifies the action, the datagraph binding and the zone together.
+Observed in the file: `<encodings>` children have no fixed order. One untouched
+base holds 31 distinct child sequences, among them
+`color, lod, tooltip ×7, text`, `text, color`, and
+`color, text, tooltip, tooltip, tooltip, lod, tooltip`; `text` alone is the
+commonest. An assertion that required sorted children failed the unedited file.
+Insert a new `<lod>` after the last existing `<lod>`, else after `<color>`, else
+as the first child, and assert that position rather than any global order. The
+parameter-action constant that goes on Detail this way is in
+[layout-and-zones.md](layout-and-zones.md).
 
 ### Worksheet
 

--- a/.claude/skills/tableau-workbook-xml/references/content-models.md
+++ b/.claude/skills/tableau-workbook-xml/references/content-models.md
@@ -27,6 +27,13 @@ in the same suite had complementary gaps:
 
 Adding an element means adding its manifest entry.
 
+The manifest is per workbook, so a refusal is too. "Desktop refuses dynamic zone
+visibility" was true of one lineage whose manifest lacked `DatagraphCoreV1`; the
+merged successor, saved by Desktop 2025.1.9, declared all four features and
+carried a Tableau-authored datagraph (Verified from the manifest). Before ruling
+a feature out, grep the target's manifest for it, and grep again whenever the
+base lineage changes: a merge or a promoted review copy is a lineage change.
+
 ### Insert into the manifest. Never regenerate it
 
 **Verified.** A regex that rebuilt the manifest silently dropped
@@ -68,6 +75,22 @@ cardinality is not established (see
 `check_twb.py` verifies order only: a second `<customized-tooltip>` in one pane
 passes it. Check for an existing one before inserting.
 
+### Encodings
+
+**Verified** on an untouched base. `<encodings>` children are in shelf order,
+not alphabetical: one sheet reads `color, lod, lod, tooltip ×7, text`. An
+assertion that required sorted children failed the unedited file. Insert a new
+`<lod>` right after the last existing `<lod>`, else right after `<color>`, and
+assert that position rather than a global order.
+
+A parameter action's source value sits on Detail: a constant calculated field
+(`Panel open` = TRUE) as a `<lod>` on the source sheet, declared in that sheet's
+`<datasource-dependencies>` as both `<column>` and `<column-instance>`. A
+one-value field cannot split the mark partition, so the percent-of-total trap in
+[layout-and-zones.md](layout-and-zones.md) does not apply; the closed render
+matched production. The owner's click on the review copy opened and closed the
+panel, which verifies the action, the datagraph binding and the zone together.
+
 ### Worksheet
 
 ```text
@@ -95,6 +118,17 @@ omits it is rejected with
 `missing elements in content model '(datasources?,...,slices?,aggregation)'`.
 The cheapest fix is to clone the filter/slices/aggregation skeleton from a
 working sheet rather than compose one.
+
+Read literally the model requires `filter`, `sort`, `perspectives` and
+`shelf-sorts`, yet a Tableau-authored title sheet in this corpus carries only
+`datasources`, `datasource-dependencies` and `aggregation`, and Desktop saved
+that file. A hand-built close-button sheet copied that minimal `<view>`; Server
+rendered it (Verified), and a Desktop open is pending (Inferred).
+
+Inside a `<view>`, `<filter>` elements and `<column-instance>` dependencies are
+sorted by column string in every sheet of this corpus (uppercase `Calculation_`
+before lowercase field names); `<slices>` columns are not. Insert before the
+neighbour that will follow, and assert that position.
 
 ### Zone (dashboard layout)
 

--- a/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
+++ b/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
@@ -82,12 +82,13 @@ was simply in the wrong units for a 0 to 1 axis, with its probe, is in
 
 ## Data reads wrong
 
-| Symptom                                                      | Cause                                                                 |
-| ------------------------------------------------------------ | --------------------------------------------------------------------- |
-| A parameter action fires and nothing changes                 | A blanket replace rewrote the parameter's `<member>` domain           |
-| A pop-out never opens; clicks corrupt an unrelated parameter | A merge deleted the boolean parameter and left every reference behind |
-| Viz-in-tooltip stops working                                 | A merge deleted the tooltip worksheet and kept both references        |
-| Bars move with a control but labels and colours do not       | Encodings on one sheet resolve through different calcs; see below     |
+| Symptom                                                       | Cause                                                                                                             |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| A parameter action fires and nothing changes                  | A blanket replace rewrote the parameter's `<member>` domain                                                       |
+| A pop-out never opens; clicks corrupt an unrelated parameter  | A merge deleted the boolean parameter and left every reference behind                                             |
+| Viz-in-tooltip stops working                                  | A merge deleted the tooltip worksheet and kept both references                                                    |
+| Bars move with a control but labels and colours do not        | Encodings on one sheet resolve through different calcs; see below                                                 |
+| A sheet inside a panel stays empty until another action fires | Its saved action-filter state is `ui-enumeration='inclusive'` over `empty-level` members: an empty set; see below |
 
 That last one is a reasoning failure, not a mechanical one. On one panel the bar
 length resolved through a parameter-aware calculation while the mark label and
@@ -97,35 +98,54 @@ labelled `+11.4pp` in green. The analysis that missed it traced only the bar.
 **Trace every encoding on a sheet (rows, columns, text, colour, size, tooltip),
 not just the one that looks like the measure.**
 
+The empty panel hid for months because its sheet was a 9px sliver. Production's
+saved state for one action's target filter on that sheet was
+`crossjoin … user:ui-enumeration='inclusive'` over two `empty-level` members,
+while the file's other 26 stored action states were `user:ui-enumeration='all'`
+over `level-members`. Rewriting the one block to the unrestricted form made the
+sheet render 40 rows with no selection; the closed render stayed byte-identical.
+**A sheet that has been invisible can carry a saved state nobody has seen.**
+Grep every sheet you wire an action to for `user:ui-action-filter`, read the
+stored state, and render the sheet alone or in the forced-open state and require
+rows before trusting its default.
+
 ## Tooling and process
 
-| Symptom                                             | Cause                                                                                    |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Workbook truncated to a fraction of its size        | Loop variable shadowed an outer regex match object                                       |
-| Whole file shows as changed in a diff               | `read_text(encoding="utf-8")` flattened CRLF to LF                                       |
-| Published workbook is a few hundred kilobytes       | `include_extract=False` on download                                                      |
-| Download lands at `name.twbx.twbx`                  | `tableauserverclient` appends the extension to `filepath`                                |
-| An exit code is reported as `0` or `120` wrongly    | Read through a pipeline; `$?` was `tail`'s status or a SIGPIPE artifact                  |
-| Extract refresh fails with `403180` after a publish | The workbook has no extract (live connection); not a credential failure. Verified, #5230 |
-| A commit lands on the wrong branch                  | A failed command short-circuited a chained `cd`; use `git -C` always                     |
+| Symptom                                                             | Cause                                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Workbook truncated to a fraction of its size                        | Loop variable shadowed an outer regex match object                                         |
+| Whole file shows as changed in a diff                               | `read_text(encoding="utf-8")` flattened CRLF to LF                                         |
+| Published workbook is a few hundred kilobytes                       | `include_extract=False` on download                                                        |
+| Download lands at `name.twbx.twbx`                                  | `tableauserverclient` appends the extension to `filepath`                                  |
+| An exit code is reported as `0` or `120` wrongly                    | Read through a pipeline; `$?` was `tail`'s status or a SIGPIPE artifact                    |
+| Extract refresh fails with `403180` after a publish                 | The workbook has no extract (live connection); not a credential failure. Verified, #5230   |
+| A commit lands on the wrong branch                                  | A failed command short-circuited a chained `cd`; use `git -C` always                       |
+| Restore point reported as revision `9` of `24`                      | `populate_revisions` returns `revision_number` as strings; cast to `int` before `max()`    |
+| `check_twb.py --ref` flags `preference`, `refresh`, `refresh-event` | `--ref` was an older pull; those are Tableau's own new elements. `--ref` the fresh base    |
+| A heredoc writing the `tsc_session.py` template is denied           | The PreToolUse hook matches the template's credential lines; `cp` it or use the Write tool |
 
 ## The tests themselves
 
 The most expensive category, because everything reports success.
 
-| Symptom                                                                             | Cause                                                                                   |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Geometry checker passes the exact bug it was written for                            | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect              |
-| Geometry checker false-positives on production                                      | An absolute tolerance tight enough for one container is wrong for another               |
-| Structure assertion passes a duplicated zone                                        | A parent map overwritten in document order hid the stale entry                          |
-| Structure assertion passes a re-parented zone                                       | It checked existence and type, never parentage                                          |
-| Structure assertion passes a reordered zone                                         | No sibling-order check                                                                  |
-| Structure assertion passes a card nested inside a card                              | Only leaf zones were pinned; the containers never were                                  |
-| Assertion checks presence, not position                                             | Searching a whole block for a token, rather than asserting the run sequence             |
-| `populate_csv` on a dashboard returned 0 rows and read as a working permission gate | The control also returned 0; a dashboard view yields no crosstab. Verified, #5230       |
-| Length guard passes an edit that changed nothing                                    | A same-length replacement moves the byte total by 0; count the strings. Verified, #5230 |
+| Symptom                                                                             | Cause                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Geometry checker passes the exact bug it was written for                            | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect                                             |
+| Geometry checker false-positives on production                                      | An absolute tolerance tight enough for one container is wrong for another                                              |
+| Structure assertion passes a duplicated zone                                        | A parent map overwritten in document order hid the stale entry                                                         |
+| Structure assertion passes a re-parented zone                                       | It checked existence and type, never parentage                                                                         |
+| Structure assertion passes a reordered zone                                         | No sibling-order check                                                                                                 |
+| Structure assertion passes a card nested inside a card                              | Only leaf zones were pinned; the containers never were                                                                 |
+| Assertion checks presence, not position                                             | Searching a whole block for a token, rather than asserting the run sequence                                            |
+| `populate_csv` on a dashboard returned 0 rows and read as a working permission gate | The control also returned 0; a dashboard view yields no crosstab. Verified, #5230                                      |
+| Length guard passes an edit that changed nothing                                    | A same-length replacement moves the byte total by 0; count the strings. Verified, #5230                                |
+| Assertion fails the untouched base: `<encodings>` children not alphabetical         | Tableau writes them in shelf order (`color, lod, lod, tooltip…, text`); assert the insert position, not a global order |
+| Assertion fails the untouched base: floating zone not under the `layout-basic` root | Floating containers are top-level siblings of the root                                                                 |
+| A mutant makes the assertion crash with `IndexError`                                | Non-zero exit, but no check is named; guard list indexing so every failure is a named FAIL line                        |
 
-Every one of those was found by building a mutant and running the assertion
+The last three fail in the other direction: a correct file, a wrong test. An
+assertion that fails on the untouched base is wrong, and the fix is to the test.
+Every one of the others was found by building a mutant and running the assertion
 against it. Make that a step, not an afterthought:
 `docs/tableau-xml/scripts/mutate.py` does the zone surgery; for anything outside
 a dashboard's zones, hand-write the broken variant.

--- a/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
+++ b/.claude/skills/tableau-workbook-xml/references/failure-catalog.md
@@ -82,32 +82,54 @@ was simply in the wrong units for a 0 to 1 axis, with its probe, is in
 
 ## Data reads wrong
 
-| Symptom                                                       | Cause                                                                                                             |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| A parameter action fires and nothing changes                  | A blanket replace rewrote the parameter's `<member>` domain                                                       |
-| A pop-out never opens; clicks corrupt an unrelated parameter  | A merge deleted the boolean parameter and left every reference behind                                             |
-| Viz-in-tooltip stops working                                  | A merge deleted the tooltip worksheet and kept both references                                                    |
-| Bars move with a control but labels and colours do not        | Encodings on one sheet resolve through different calcs; see below                                                 |
-| A sheet inside a panel stays empty until another action fires | Its saved action-filter state is `ui-enumeration='inclusive'` over `empty-level` members: an empty set; see below |
+| Symptom                                                      | Cause                                                                                                                  |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| A parameter action fires and nothing changes                 | A blanket replace rewrote the parameter's `<member>` domain                                                            |
+| A pop-out never opens; clicks corrupt an unrelated parameter | A merge deleted the boolean parameter and left every reference behind                                                  |
+| Viz-in-tooltip stops working                                 | A merge deleted the tooltip worksheet and kept both references                                                         |
+| Bars move with a control but labels and colours do not       | Encodings on one sheet resolve through different calcs; see below                                                      |
+| A panel sheet is empty with nothing selected                 | Its saved action-filter state is `user:ui-enumeration='inclusive'` over `empty-level` members: an empty set; see below |
 
-That last one is a reasoning failure, not a mechanical one. On one panel the bar
-length resolved through a parameter-aware calculation while the mark label and
-the colour resolved through projected-only calculations. Setting the control to
-the other basis moved the bars and left the labels, producing a near-zero bar
-labelled `+11.4pp` in green. The analysis that missed it traced only the bar.
-**Trace every encoding on a sheet (rows, columns, text, colour, size, tooltip),
-not just the one that looks like the measure.**
+The bars-and-labels row is a reasoning failure, not a mechanical one. On one
+panel the bar length resolved through a parameter-aware calculation while the
+mark label and the colour resolved through projected-only calculations. Setting
+the control to the other basis moved the bars and left the labels, producing a
+near-zero bar labelled `+11.4pp` in green. The analysis that missed it traced
+only the bar. **Trace every encoding on a sheet (rows, columns, text, colour,
+size, tooltip), not just the one that looks like the measure.**
 
-The empty panel hid for months because its sheet was a 9px sliver. Production's
-saved state for one action's target filter on that sheet was
-`crossjoin … user:ui-enumeration='inclusive'` over two `empty-level` members,
-while the file's other 26 stored action states were `user:ui-enumeration='all'`
-over `level-members`. Rewriting the one block to the unrestricted form made the
-sheet render 40 rows with no selection; the closed render stayed byte-identical.
-**A sheet that has been invisible can carry a saved state nobody has seen.**
-Grep every sheet you wire an action to for `user:ui-action-filter`, read the
-stored state, and render the sheet alone or in the forced-open state and require
-rows before trusting its default.
+The empty-panel row: nobody had seen the sheet's default because it was a 9px
+sliver. Its stored state for one action's target filter was the `empty-level`
+form. Rewriting that one `<groupfilter>` to the `level-members` form made the
+sheet render 40 rows with no selection, and the closed render stayed
+byte-identical. Before and after, from the file:
+
+```xml
+<filter class='categorical' column='[federated.…].[Action (Letter Band,Teacher Name)]'>
+  <groupfilter function='crossjoin' user:ui-action-filter='[Action1_…]' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate'>
+    <groupfilter function='empty-level' member='[Calculation_…]' />
+    <groupfilter function='empty-level' member='[teacher_name]' />
+  </groupfilter>
+</filter>
+```
+
+```xml
+<filter class='categorical' column='[federated.…].[Action (Letter Band,Teacher Name)]'>
+  <groupfilter function='crossjoin' user:ui-action-filter='[Action1_…]' user:ui-enumeration='all' user:ui-marker='enumerate'>
+    <groupfilter function='level-members' level='[Calculation_…]' />
+    <groupfilter function='level-members' level='[teacher_name]' />
+  </groupfilter>
+</filter>
+```
+
+The base holds 40 such states: 29 `level-members`, 11 `empty-level`, and 24 of
+the 40 name actions a merge had deleted. **A sheet that has been invisible can
+carry a saved state nobody has seen.** Before wiring an action to a sheet, grep
+it for `user:ui-action-filter` and read each state; then render the sheet alone
+or in the forced-open state and require rows. The rewrite fixes the default
+state only: if the action carries `on-empty` `none`, a deselect may blank the
+sheet again at runtime. Hypothesis and probe:
+[unverified-warnings.md](unverified-warnings.md), "Actions".
 
 ## Tooling and process
 
@@ -128,27 +150,26 @@ rows before trusting its default.
 
 The most expensive category, because everything reports success.
 
-| Symptom                                                                             | Cause                                                                                                                  |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Geometry checker passes the exact bug it was written for                            | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect                                             |
-| Geometry checker false-positives on production                                      | An absolute tolerance tight enough for one container is wrong for another                                              |
-| Structure assertion passes a duplicated zone                                        | A parent map overwritten in document order hid the stale entry                                                         |
-| Structure assertion passes a re-parented zone                                       | It checked existence and type, never parentage                                                                         |
-| Structure assertion passes a reordered zone                                         | No sibling-order check                                                                                                 |
-| Structure assertion passes a card nested inside a card                              | Only leaf zones were pinned; the containers never were                                                                 |
-| Assertion checks presence, not position                                             | Searching a whole block for a token, rather than asserting the run sequence                                            |
-| `populate_csv` on a dashboard returned 0 rows and read as a working permission gate | The control also returned 0; a dashboard view yields no crosstab. Verified, #5230                                      |
-| Length guard passes an edit that changed nothing                                    | A same-length replacement moves the byte total by 0; count the strings. Verified, #5230                                |
-| Assertion fails the untouched base: `<encodings>` children not alphabetical         | Tableau writes them in shelf order (`color, lod, lod, tooltip…, text`); assert the insert position, not a global order |
-| Assertion fails the untouched base: floating zone not under the `layout-basic` root | Floating containers are top-level siblings of the root                                                                 |
-| A mutant makes the assertion crash with `IndexError`                                | Non-zero exit, but no check is named; guard list indexing so every failure is a named FAIL line                        |
+| Symptom                                                                             | Cause                                                                                           |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Geometry checker passes the exact bug it was written for                            | Per-child tolerance; 900 units × 5 children exceeded the 4,445-unit defect                      |
+| Geometry checker false-positives on production                                      | An absolute tolerance tight enough for one container is wrong for another                       |
+| Structure assertion passes a duplicated zone                                        | A parent map overwritten in document order hid the stale entry                                  |
+| Structure assertion passes a re-parented zone                                       | It checked existence and type, never parentage                                                  |
+| Structure assertion passes a reordered zone                                         | No sibling-order check                                                                          |
+| Structure assertion passes a card nested inside a card                              | Only leaf zones were pinned; the containers never were                                          |
+| Assertion checks presence, not position                                             | Searching a whole block for a token, rather than asserting the run sequence                     |
+| `populate_csv` on a dashboard returned 0 rows and read as a working permission gate | The control also returned 0; a dashboard view yields no crosstab. Verified, #5230               |
+| Length guard passes an edit that changed nothing                                    | A same-length replacement moves the byte total by 0; count the strings. Verified, #5230         |
+| Assertion fails the untouched base: `<encodings>` children not alphabetical         | They have no fixed order; assert the insert position, not a global order                        |
+| Assertion fails the untouched base: floating zone not under the `layout-basic` root | Floating containers are top-level siblings of the root                                          |
+| A mutant makes the assertion crash with `IndexError`                                | Non-zero exit, but no check is named; guard list indexing so every failure is a named FAIL line |
 
-The last three fail in the other direction: a correct file, a wrong test. An
-assertion that fails on the untouched base is wrong, and the fix is to the test.
-Every one of the others was found by building a mutant and running the assertion
-against it. Make that a step, not an afterthought:
-`docs/tableau-xml/scripts/mutate.py` does the zone surgery; for anything outside
-a dashboard's zones, hand-write the broken variant.
+The two `untouched base` rows fail in the other direction: a correct file, a
+wrong test, and the fix is to the test. Every other row was found by building a
+mutant and running the assertion against it. Make that a step, not an
+afterthought: `docs/tableau-xml/scripts/mutate.py` does the zone surgery; for
+anything outside a dashboard's zones, hand-write the broken variant.
 
 ## The two reasoning failures worth naming
 

--- a/.claude/skills/tableau-workbook-xml/references/layout-and-zones.md
+++ b/.claude/skills/tableau-workbook-xml/references/layout-and-zones.md
@@ -118,8 +118,11 @@ one-string edit.
 doubled the axis to 200%. Percent-of-total is a table calculation over the mark
 partition, and Detail changes that partition. The source project put tooltip
 fields on the **Tooltip** shelf instead and reserved Detail for cases where the
-grain change is the intent. That Tooltip leaves the partition alone is
-**Inferred**; the probe is in [unverified-warnings.md](unverified-warnings.md).
+grain change is the intent. Tooltip-shelf fields (an `attr:` dimension and a
+plain count, on a percent-of-total sheet) left the render byte-identical
+(Verified), and a one-value constant on Detail also left the axis alone. The
+probe in [unverified-warnings.md](unverified-warnings.md) stays open for a
+many-valued dimension on Tooltip.
 
 ## Copying a card pattern
 
@@ -171,61 +174,126 @@ Two structural points:
   fixed text zone with a flexible sibling. A strip where every child is fixed
   was unprecedented and is worth avoiding.
 
-## Floating containers
+## A floating panel driven by a parameter action
 
-**Verified** by a depth trace and by render. A floating zone is a top-level
-child of `<zones>`, a sibling of the `layout-basic` root that follows it, not a
-descendant. An assertion that expected the Tableau-authored floating container
-under the root failed a correct file. A new floating panel goes after the last
-top-level zone, before `</zones>`.
+**Verified** by render (hidden at the parameter's `false`, shown at `true`) and
+by the owner's click (a band opened the panel, the × closed it), which together
+verify the zone, the datagraph binding and the two actions. Every fragment below
+is from the built file; the ids and GUIDs are the parts to swap.
 
-A container shown and hidden by dynamic zone visibility carries
-`hidden-by-user='true'` on the zone **and on every descendant** in the saved
-file. Copied that way, the panel rendered hidden at the parameter's `false` and
-shown at `true`. The binding is a node pair in the existing `<datagraph>`: its
-`dashboard-zone-visibility-node` names the zone id and a `dashboard-identifier`
-that is the `<dashboard>` element's `<simple-id>`, not the `<window>`'s. The two
-differ, and the render toggled only with the dashboard's.
+A floating zone is a top-level child of `<zones>`, a sibling of the
+`layout-basic` root that follows it, never a descendant. Nothing on the tag says
+"floating"; the position in the tree does. A new panel goes after the last
+top-level zone, before `</zones>`. A container shown and hidden by dynamic zone
+visibility carries `hidden-by-user='true'` on itself **and on every descendant**
+in the saved file:
 
-`check_geometry.py --baseline` passed a dashboard carrying two floating
-containers (one Tableau-authored, one added) and failed a one-zone mutant of the
-same file, so floating siblings did not false-positive it in this corpus.
+```xml
+<zone friendly-name='Band Roster' h='61555' hidden-by-user='true' id='800' param='vert' type-v2='layout-flow' w='98828' x='586' y='37556'>
+  <zone fixed-size='30' h='3333' hidden-by-user='true' id='801' is-fixed='true' param='horz' type-v2='layout-flow' w='98828' x='586' y='37556'>
+    <zone forceUpdate='true' h='3333' hidden-by-user='true' id='802' type-v2='text' w='94436' x='586' y='37556'>…</zone>
+    <zone fixed-size='60' h='3333' hidden-by-user='true' id='803' is-fixed='true' name='Y1 Schools - Roster Close' show-title='false' w='4392' x='95022' y='37556'>…</zone>
+  </zone>
+  <zone h='58222' hidden-by-user='true' id='804' name='Y1 Schools - Grades Roster' show-title='false' w='98828' x='586' y='40889'>…</zone>
+</zone>
+```
+
+The binding is a node pair added to the workbook's existing `<datagraph>`, plus
+one `<edge>` and two `<pair>` entries under `<node-execution-subgraphs>`, all
+with fresh GUIDs. `dashboard-identifier` is the `<dashboard>` element's
+`<simple-id>`, not the `<window>`'s; the two differ, and the build used the
+dashboard's:
+
+```xml
+<single-value-field-node fieldname='[Parameters].[Parameter 15]' fieldname-input-guid='…' node-guid='…' value-output-guid='OUT' />
+<dashboard-zone-visibility-node dashboard-identifier='{1FABAC57-…}' node-guid='…' visibility-input-guid='IN' zone-id='800' />
+<!-- under <edges> -->
+<edge from='OUT' to='IN' />
+```
+
+The open and close actions are `<edit-parameter-action>` elements, not
+`<action>`. The source value is a constant calculated field (`TRUE` to open,
+`FALSE` to close) on the source sheet's Detail shelf, declared in that sheet's
+`<datasource-dependencies>` as `<column>` and `<column-instance>`:
+
+```xml
+<edit-parameter-action caption='Open roster from band' name='[Action_Panel01]'>
+  <activation type='on-select' />
+  <source dashboard='Academic Health Schools' type='sheet' worksheet='Y1 Schools - GPA Distribution' />
+  <agg-type type='attr' />
+  <clear-option type='do-nothing' value='b:false' />
+  <params>
+    <param name='source-field' value='[federated.…].[none:Calculation_7600000000000000101:nk]' />
+    <param name='target-parameter' value='[Parameters].[Parameter 15]' />
+  </params>
+</edit-parameter-action>
+```
+
+Two consequences of that constant on Detail. It has one value, so it does not
+split the mark partition: the percent-of-total source sheet kept its axis and
+bars in the closed render, re-laid only by a 9px widening (Verified). It does
+show in the sheet's automatic tooltip as `Panel open: True` unless the sheet
+carries a `<customized-tooltip>` (Inferred; the hover is pending).
+
+The close button is a one-mark sheet: `<mark class='Shape' />`, a single `<lod>`
+of the `FALSE` constant, `<format attr='shape' value=':filled/times' />`, and a
+`<view>` of only `datasources`, `datasource-dependencies` and `aggregation`
+([content-models.md](content-models.md)).
+
+`check_geometry.py` skips every `hidden-by-user` zone, so nothing above is
+geometry-checked. The panel's rectangle against the zone map is your own
+assertion; the open-state render is the check.
 
 ## Removing a sibling from a flow
 
-**Verified.** Deleting a fixed-width child from a horizontal flow is a cascade,
-not a one-zone edit. Removing a 659-unit sliver from the right of one row meant
-widening 15 zones down the surviving column: 4 vertical containers, 5 rows and 3
-flexible leaves each `w +659`, and 3 fixed right-hand leaves `x +659`, so that
-every container's parent-minus-children gap kept its baseline value. Write the
-cascade as a table of `(zone id, attribute, old, new)`, apply each row as an
-exactly-once substitution, and assert each once. `check_geometry.py --baseline`
-reports a missed row as a gap pair (`zone 37 gap 659, zone 36 gap -659`).
+**Verified.** Deleting a fixed-width child from a flow is a cascade, not a
+one-zone edit. Every container and flexible leaf in the surviving column grows
+by the removed width; every fixed leaf to its right shifts by it; every
+container's parent-minus-children gap stays at its baseline value. Removing a
+659-unit sliver meant 15 zones: 12 `w +659` and 3 `x +659`. Write the cascade as
+a table of `(zone id, attribute, old, new)`, apply each row as an exactly-once
+substitution, and assert each once. A missed row shows in
+`check_geometry.py --baseline` as a gap pair
+(`zone 37 gap 659, zone 36 gap -659`).
 
 ## Adding a filter card
 
 **Verified by render**: the card appeared in the strip with the strip's gap
 unchanged, and every differing pixel between the two publishes lay inside the
 strip. That picking a value filters the sheets is **Inferred**; a render cannot
-click.
+click. Fragments are from the built file.
 
-A dashboard filter card is three elements per filtered sheet plus one zone:
+Three elements in each filtered sheet's `<view>`, each inserted before the
+neighbour that will follow it (filters and column-instances are sorted by column
+string, slices are not; [content-models.md](content-models.md)):
 
-- In each sheet's `<view>`: a
-  `<filter class='categorical' column='…' filter-group='N'>` holding a
-  `level-members` groupfilter, a `<column-instance>` in that sheet's
-  `<datasource-dependencies>`, and a `<column>` in `<slices>`. Filters and
-  column-instances are sorted, slices are not
-  ([content-models.md](content-models.md)); anchor each insert on the neighbour
-  that will follow it rather than computing a sort.
-- `filter-group` is a workbook-wide integer: the fresh base's max plus one.
-- One `type-v2='filter'` zone whose `name` is any one of the filtered sheets.
-- Guard "instance not yet referenced" per sheet, not per workbook: another sheet
-  may already use the same instance legitimately.
+```xml
+<filter class='categorical' column='[federated.…].[none:credit_type:nk]' filter-group='18'>
+  <groupfilter function='level-members' level='[none:credit_type:nk]' user:ui-enumeration='all' user:ui-marker='enumerate' />
+</filter>
+<!-- under <datasource-dependencies> -->
+<column-instance column='[credit_type]' derivation='None' name='[none:credit_type:nk]' pivot='key' type='nominal' />
+<!-- under <slices> -->
+<column>[federated.…].[none:credit_type:nk]</column>
+```
 
-A `distribute-evenly` strip does not re-solve its stored geometry on Server.
-Adding a ninth child means re-tiling every child's `w` and `x` by hand
-(`8 × 10981 + 10980 = 98828` across the strip) or the geometry check fails.
+`filter-group` is a workbook-wide integer: the fresh base's max plus one. Guard
+"instance not yet referenced" per sheet, not per workbook; another sheet may
+already use the same instance.
+
+One zone in the strip; `param` carries the column instance and `name` any one of
+the filtered sheets:
+
+```xml
+<zone h='6666' id='712' mode='checkdropdown' name='Y1 Schools - School Grade Distro' param='[federated.…].[none:credit_type:nk]' type-v2='filter' values='database' w='10980' x='88434' y='7556'>…</zone>
+```
+
+A strip with `layout-strategy-id='distribute-evenly'` does not re-solve its
+stored geometry on Server. Re-tile every child by hand: each `w` is
+`floor(inner / n)`, with one extra unit on `inner mod n` of the children, where
+`inner` is the strip's `w` minus its baseline gap; each `x` is cumulative from
+the strip's `x`. Nine children in a 98828-unit strip with gap 0 are eight at
+10981 and one at 10980. Anything else fails the geometry check.
 
 ## Editing the right copy of the tree
 

--- a/.claude/skills/tableau-workbook-xml/references/layout-and-zones.md
+++ b/.claude/skills/tableau-workbook-xml/references/layout-and-zones.md
@@ -24,6 +24,11 @@ pixels_wide = w / 100000 * 1366
 
 At 900px tall, 1 pixel is about 111 units.
 
+A recipe's pixel positions can contradict its own intent. "Directly under the
+band bars" at `y=280` would have covered the bottom 52px of a card that ends at
+338px. Convert every recipe coordinate to units, check it against the existing
+zone map, build to the intent, and report the deviation in the hand-over.
+
 ## Containers do not sum to their children
 
 **Verified, and it produced two arithmetic errors before it was understood.** A
@@ -165,6 +170,62 @@ Two structural points:
   so something can absorb slack. In the corpus, every working strip pairs a
   fixed text zone with a flexible sibling. A strip where every child is fixed
   was unprecedented and is worth avoiding.
+
+## Floating containers
+
+**Verified** by a depth trace and by render. A floating zone is a top-level
+child of `<zones>`, a sibling of the `layout-basic` root that follows it, not a
+descendant. An assertion that expected the Tableau-authored floating container
+under the root failed a correct file. A new floating panel goes after the last
+top-level zone, before `</zones>`.
+
+A container shown and hidden by dynamic zone visibility carries
+`hidden-by-user='true'` on the zone **and on every descendant** in the saved
+file. Copied that way, the panel rendered hidden at the parameter's `false` and
+shown at `true`. The binding is a node pair in the existing `<datagraph>`: its
+`dashboard-zone-visibility-node` names the zone id and a `dashboard-identifier`
+that is the `<dashboard>` element's `<simple-id>`, not the `<window>`'s. The two
+differ, and the render toggled only with the dashboard's.
+
+`check_geometry.py --baseline` passed a dashboard carrying two floating
+containers (one Tableau-authored, one added) and failed a one-zone mutant of the
+same file, so floating siblings did not false-positive it in this corpus.
+
+## Removing a sibling from a flow
+
+**Verified.** Deleting a fixed-width child from a horizontal flow is a cascade,
+not a one-zone edit. Removing a 659-unit sliver from the right of one row meant
+widening 15 zones down the surviving column: 4 vertical containers, 5 rows and 3
+flexible leaves each `w +659`, and 3 fixed right-hand leaves `x +659`, so that
+every container's parent-minus-children gap kept its baseline value. Write the
+cascade as a table of `(zone id, attribute, old, new)`, apply each row as an
+exactly-once substitution, and assert each once. `check_geometry.py --baseline`
+reports a missed row as a gap pair (`zone 37 gap 659, zone 36 gap -659`).
+
+## Adding a filter card
+
+**Verified by render**: the card appeared in the strip with the strip's gap
+unchanged, and every differing pixel between the two publishes lay inside the
+strip. That picking a value filters the sheets is **Inferred**; a render cannot
+click.
+
+A dashboard filter card is three elements per filtered sheet plus one zone:
+
+- In each sheet's `<view>`: a
+  `<filter class='categorical' column='…' filter-group='N'>` holding a
+  `level-members` groupfilter, a `<column-instance>` in that sheet's
+  `<datasource-dependencies>`, and a `<column>` in `<slices>`. Filters and
+  column-instances are sorted, slices are not
+  ([content-models.md](content-models.md)); anchor each insert on the neighbour
+  that will follow it rather than computing a sort.
+- `filter-group` is a workbook-wide integer: the fresh base's max plus one.
+- One `type-v2='filter'` zone whose `name` is any one of the filtered sheets.
+- Guard "instance not yet referenced" per sheet, not per workbook: another sheet
+  may already use the same instance legitimately.
+
+A `distribute-evenly` strip does not re-solve its stored geometry on Server.
+Adding a ninth child means re-tiling every child's `w` and `x` by hand
+(`8 × 10981 + 10980 = 98828` across the strip) or the geometry check fails.
 
 ## Editing the right copy of the tree
 

--- a/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
+++ b/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
@@ -94,11 +94,31 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
 - **A new image or shape reference publishes blank if the asset is not in the
   donor archive.** Probe: list the donor's entries before adding a
   `type-v2='bitmap'` zone.
+- **`<format attr='size'>` in a `Shape` mark's style-rule may set the shape
+  size.** The corpus carries values from 0.87 to 14.5. A copied close-button
+  sheet with no size format rendered a small, legible bold × in a 60px box
+  (Verified). That the attribute enlarges it is unprobed. Probe: set
+  `value='3'`, publish to scratch, render, count the shape's pixels.
 - **A stale `fixed-size` may look right in a render and wrong in Desktop.** The
   source verified only that Desktop may re-solve the layout on open. The margin
   to subtract is the container's own baseline gap from the geometry table, not a
   constant. Probe: hand the owner one resized zone with and without the updated
   `fixed-size` and ask which opens correctly.
+
+## Actions
+
+- **`on-empty='none'` on a filter action may mean "Show no values".** Only
+  `none` occurs in the local corpus (109 times). Two saved target states differ
+  by exactly that parameter: the action with `on-empty='none'` persists its
+  target filter as `crossjoin … ui-enumeration='inclusive'` over `empty-level`
+  members, an empty set, which blanked the target sheet until the action fired
+  (Verified, [failure-catalog.md](failure-catalog.md)); an action with no
+  `on-empty` persists `level-members` over the whole level, everything. That
+  reads as `none` = "Show no values" and absent = "Leave the filter", with the
+  third dropdown value, "Show all values", unobserved. Probe: on a scratch copy
+  in Desktop, set each of the three values on one action, save, and diff the
+  `on-empty` parameter. Until then, when a clear should show all rows, hand the
+  dropdown to the owner in web authoring.
 
 ## Process
 
@@ -108,9 +128,11 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
   `.twb`; diff it against the base. This is the one oracle that outranks every
   checker here. The skill cannot run Desktop; the owner can.
 - **`check_geometry.py` may false-positive on floating objects**, which
-  legitimately overlap tiled siblings. Running both checkers against the
-  untouched base before any edit (loop step 1) is what separates a checker bug
-  from a workbook bug.
+  legitimately overlap tiled siblings. Not seen yet: it passed a dashboard with
+  two top-level floating containers and failed a one-zone mutant of the same
+  file ([layout-and-zones.md](layout-and-zones.md)). Running both checkers
+  against the untouched base before any edit (loop step 1) is still what
+  separates a checker bug from a workbook bug.
 - **Cross-workbook parameter collisions may merge rather than delete.** The
   observed symptom (references pointing at an id now owned by an unrelated
   parameter) fits a merge on name and datatype as well as a deletion. The

--- a/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
+++ b/.claude/skills/tableau-workbook-xml/references/unverified-warnings.md
@@ -52,9 +52,11 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
 
 ## Layout and formatting
 
-- **A dimension on Tooltip may change the mark grain the same way Detail did.**
-  The source verified only that a `<lod>` on Detail doubled a percent-of-total
-  axis. Probe: move the identical field from `<lod>` to the Tooltip encoding on
+- **A many-valued dimension on Tooltip may change the mark grain the way Detail
+  did.** Narrowed: an `attr:` dimension and a plain count on the Tooltip shelf
+  of a percent-of-total sheet left the render byte-identical (Verified,
+  [layout-and-zones.md](layout-and-zones.md)). Probe for the remaining case:
+  move the identical many-valued field from `<lod>` to the Tooltip encoding on
   the same sheet, publish to scratch, render, read the axis maximum.
 - **The reference line that rendered at `2.0` may have resolved correctly.** A
   raw GPA goal plotted on a 0 to 1 percent axis lands at 200%. Probe: point
@@ -95,10 +97,11 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
   donor archive.** Probe: list the donor's entries before adding a
   `type-v2='bitmap'` zone.
 - **`<format attr='size'>` in a `Shape` mark's style-rule may set the shape
-  size.** The corpus carries values from 0.87 to 14.5. A copied close-button
-  sheet with no size format rendered a small, legible bold × in a 60px box
-  (Verified). That the attribute enlarges it is unprobed. Probe: set
-  `value='3'`, publish to scratch, render, count the shape's pixels.
+  size.** Shape marks in the base carry 0.87 and 2; the 14.5 values are on
+  Square and Text marks. A copied close-button sheet with no size format
+  rendered a small, legible bold × in a 60px box (Verified). That the attribute
+  enlarges it is unprobed. Probe: set `value='3'`, publish to scratch, render,
+  count the shape's pixels.
 - **A stale `fixed-size` may look right in a render and wrong in Desktop.** The
   source verified only that Desktop may re-solve the layout on open. The margin
   to subtract is the container's own baseline gap from the geometry table, not a
@@ -107,18 +110,19 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
 
 ## Actions
 
-- **`on-empty='none'` on a filter action may mean "Show no values".** Only
-  `none` occurs in the local corpus (109 times). Two saved target states differ
-  by exactly that parameter: the action with `on-empty='none'` persists its
-  target filter as `crossjoin … ui-enumeration='inclusive'` over `empty-level`
-  members, an empty set, which blanked the target sheet until the action fired
-  (Verified, [failure-catalog.md](failure-catalog.md)); an action with no
-  `on-empty` persists `level-members` over the whole level, everything. That
-  reads as `none` = "Show no values" and absent = "Leave the filter", with the
-  third dropdown value, "Show all values", unobserved. Probe: on a scratch copy
-  in Desktop, set each of the three values on one action, save, and diff the
-  `on-empty` parameter. Until then, when a clear should show all rows, hand the
-  dropdown to the owner in web authoring.
+- **`<param name='on-empty' value='none' />` on a filter action may mean "Show
+  no values".** `none` is the only value observed: twice in the base, and in
+  every other workbook on hand. The one action carrying it owns one stored
+  target state, the `empty-level` form that blanked its sheet
+  ([failure-catalog.md](failure-catalog.md), "Data reads wrong"); the one action
+  without it owns 15 states, all `level-members`; 24 further states name actions
+  a merge deleted and fit neither. Two actions is thin evidence for `none` =
+  "Show no values" and absent = "Leave the filter", and "Show all values" is
+  unobserved. If it holds, rewriting a stored `empty-level` state fixes the
+  default only until the next deselect. Probe: on a scratch copy in Desktop, set
+  each of the three values on one action, save, and diff the `on-empty` param.
+  Until then, when a clear should show all rows, hand the dropdown to the owner
+  in web authoring.
 
 ## Process
 
@@ -127,12 +131,11 @@ every line as a hypothesis. Do not cite this file as evidence; run the probe.
   the owner to make the change in Desktop on a scratch copy, save, and send the
   `.twb`; diff it against the base. This is the one oracle that outranks every
   checker here. The skill cannot run Desktop; the owner can.
-- **`check_geometry.py` may false-positive on floating objects**, which
-  legitimately overlap tiled siblings. Not seen yet: it passed a dashboard with
-  two top-level floating containers and failed a one-zone mutant of the same
-  file ([layout-and-zones.md](layout-and-zones.md)). Running both checkers
-  against the untouched base before any edit (loop step 1) is still what
-  separates a checker bug from a workbook bug.
+- **`check_geometry.py` may false-positive on visible floating objects**, which
+  legitimately overlap tiled siblings. Unexercised: the two floating containers
+  in this corpus are `hidden-by-user`, and the script skips those entirely.
+  Running both checkers against the untouched base before any edit (loop step 1)
+  is what separates a checker bug from a workbook bug.
 - **Cross-workbook parameter collisions may merge rather than delete.** The
   observed symptom (references pointing at an id now owned by an unrelated
   parameter) fits a merge on name and datatype as well as a deletion. The


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fold what the 2026-09-10 band roster panel and Credit Type filter build taught us into the `tableau-workbook-xml` skill. The build hit things the skill did not cover, and two of them cost a rebuild each. Nothing outside the skill folder changes.

What the skill now says that it did not before:

- A floating dashboard container sits beside the main layout root, not inside it, and a panel driven by dynamic zone visibility marks its whole subtree as hidden by user. The recipe shows the zone tree, the datagraph node pair and the parameter action from the built file.
- Encodings inside a sheet have no fixed order. Insert a new detail field next to a chosen neighbour and assert that position.
- A sheet inside a panel can be blank because a saved action filter excludes every row. The catalog shows the stored state before and after the fix, and links the caveat that a deselect may blank it again.
- The geometry checker skips every hidden zone, so a panel's geometry is covered only by your own assertion and the open-state render.
- A Desktop refusal is about one workbook's feature manifest. Check the target's manifest before ruling a feature out.
- Free parameter numbers, zone ids and filter-group values come from the fresh base, never from last week's script.
- Revision numbers come back as strings, so the largest one sorts wrong until cast.
- Two recipes with XML: adding a filter card, and the cascade of width changes when a zone leaves a flow container, each stated as a rule rather than one build's numbers.
- A merge that deletes actions leaves their stored target states behind.

## Reviewer Notes

- Second commit is the result of two adversarial reviews. One checked every claim against the workbook files and the geometry script and found five statements the files contradicted, all corrected. Details in the fold-out.
- The `on-empty` clear-behaviour mapping stays under unverified warnings with a Desktop probe. The evidence is two actions, and the file says so.
- The filter-card recipe is verified by render for the card itself. That picking a value filters the six sheets is marked Inferred.
- Three items come from a Stage 3 tooltip section the build session added to the notes after the first commit: Tooltip-shelf fields left a percent-of-total render byte-identical, the Detail constant shows in the automatic tooltip, and a sibling-sheets byte-identical assertion pattern.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR.

## CI checks

- [ ] **Trunk** passes. `trunk check --force` on the six files is clean locally after each commit.
- [ ] **dbt Cloud** and **Dagster Cloud** should not trigger; the change is markdown under `.claude/skills/`.

<details>
<summary>For Claude</summary>

Claude-authored from two hand-over notes in `.claude/scratch/band-roster/` (HANDOFF.md and SKILL-NOTES.md), human-directed. Edits were applied by anchored scripts with an exactly-once assertion per substitution: 27 in the first commit, 26 plus one whole-section replacement in the second.

Review round. Two adversarial subagents reviewed commit 9d3ad0a55. Evidence review (against base.twb, out.twb, out2.twb and check_geometry.py): 40 stored action states not 26 (29 level-members, 11 empty-level, 24 orphaned by the merge); check_geometry.py skips hidden-by-user zones so its pass on the panel was no evidence; source-build is 2025.1.18 not 2025.1.9; 31 distinct encodings orders so "shelf order" was invented and the quoted example came from the edited file; on-empty is a param element observed twice in the base, and the meaning rests on two actions; Shape marks carry sizes 0.87 and 2 while 14.5 is Square and Text; "for months", "only with the dashboard's", "last week's" were unsupported; two Verified marks were file observations and now read "observed in the file". Usability review: dangling "That last one" and a miscounted "last three" in the failure catalog; rule 3 contradicted step 2; the empty-panel fix lacked the on-empty caveat; three recipes described shapes without XML; re-tile and cascade were literals not rules; parameter-action material was shelved under Encodings; five-place duplication of the floating-container fact; description carried synonyms of "dashboard zones". All accepted and applied. One pushback: the usability review proposed dropping "parameter actions" from the description unless it had a home; the panel recipe now is that home, so it stays.

Retrieval tests (Sonnet subagent, files only). Before the first commit: NOT COVERED on six of nine questions, PARTIAL on three. After the first commit: all nine answered. After the second commit: ten questions targeting the fixes, all answered with quotes and no contradictions; one partial, where the text-only encodings case follows from the stated rule rather than being spelled out.

Frontmatter is 757 characters against the 1024 limit. No issue was opened; the request came directly as "create a pull request".

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
