### PR TITLE
perf(people): collapse the 5 self-joins in stg_people__student_logins into one pass

### DIFF
--- a/src/dbt/kipptaf/models/people/staging/stg_people__student_logins.sql
+++ b/src/dbt/kipptaf/models/people/staging/stg_people__student_logins.sql
@@ -3,6 +3,8 @@
     from {{ source("people", "src_people__student_logins") }}
 {% elif is_incremental() %}
     with
+        existing_logins as (select student_number, username, from {{ this }}),
+
         miami_candidates as (
             select
                 c.first_name,
@@ -20,11 +22,16 @@
         ),
 
         union_source as (
-            select student_number, dob, first_name, last_name,
+            select
+                student_number,
+                dob,
+                first_name,
+                last_name,
+
+                cast(null as int64) as student_number_bare,
             from {{ ref("stg_powerschool__students") }}
             where
-                student_number not in (select t.student_number, from {{ this }} as t)
-                and _dbt_source_project != 'kippmiami'
+                _dbt_source_project != 'kippmiami'
                 and dob is not null
                 and first_name is not null
                 and last_name is not null
@@ -32,15 +39,25 @@
 
             union all
 
-            select student_number, birth_date as dob, first_name, last_name,
+            select
+                student_number,
+                birth_date as dob,
+                first_name,
+                last_name,
+                student_number_bare,
             from miami_candidates
             where
-                student_number not in (select t.student_number, from {{ this }} as t)
-                and student_number_bare
-                not in (select t.student_number, from {{ this }} as t)
-                and birth_date is not null
+                birth_date is not null
                 and first_name is not null
                 and last_name is not null
+        ),
+
+        new_students as (
+            select u.student_number, u.dob, u.first_name, u.last_name,
+            from union_source as u
+            left join existing_logins as e1 on u.student_number = e1.student_number
+            left join existing_logins as e2 on u.student_number_bare = e2.student_number
+            where e1.student_number is null and e2.student_number is null
         ),
 
         components as (
@@ -62,129 +79,98 @@
                     r'[\pM\W]',
                     ''
                 ) as last_name_clean,
-            from union_source
+            from new_students
         ),
 
-        username_options as (
+        username_candidates as (
             /* powerschool usernames are capped @ 20 chars  */
             select
                 student_number,
+                last_name_clean,
+                dob_year,
 
-                concat(left(last_name_clean, 12), dob_month, dob_day) as username,
-
-                1 as priority_order,
-            from components
-
-            union all
-
-            select
-                student_number,
-
-                concat(left(first_name_clean, 12), dob_month, dob_day) as username,
-
-                2 as priority_order,
-            from components
-
-            union all
-
-            select
-                student_number,
+                concat(left(last_name_clean, 12), dob_month, dob_day) as username_1,
+                concat(left(first_name_clean, 12), dob_month, dob_day) as username_2,
 
                 concat(
                     left(concat(left(first_name_clean, 1), last_name_clean), 12),
                     dob_month,
                     dob_day
-                ) as username,
-
-                3 as priority_order,
-            from components
-
-            union all
-
-            select
-                student_number,
+                ) as username_3,
 
                 concat(
                     left(concat(first_name_clean, left(last_name_clean, 1)), 12),
                     dob_month,
                     dob_day
-                ) as username,
-
-                4 as priority_order,
-            from components
-
-            union all
-
-            select
-                student_number,
+                ) as username_4,
 
                 concat(
                     left(concat(first_name_clean, last_name_clean), 10),
                     dob_month,
                     dob_day,
                     dob_year
-                ) as username,
-
-                5 as priority_order,
+                ) as username_5,
             from components
+        ),
+
+        username_options as (
+            select c.student_number, o.priority_order, o.username,
+            from username_candidates as c
+            cross join
+                unnest(
+                    array<struct<priority_order int64, username string>>[
+                        (1, c.username_1),
+                        (2, c.username_2),
+                        (3, c.username_3),
+                        (4, c.username_4),
+                        (5, c.username_5)
+                    ]
+                ) as o
         ),
 
         username_filter as (
             select
-                student_number,
-                username,
+                o.student_number,
+                o.priority_order,
+                o.username,
 
                 row_number() over (
-                    partition by student_number order by priority_order asc
-                ) as priority_order,
-
-                row_number() over (
-                    partition by username
-                    order by priority_order asc, student_number asc
+                    partition by o.username
+                    order by o.priority_order asc, o.student_number asc
                 ) as rn_username,
-            from username_options
-            where username not in (select t.username, from {{ this }} as t)
+            from username_options as o
+            left join existing_logins as e on o.username = e.username
+            where e.username is null
+        ),
+
+        username_pick as (
+            select
+                student_number,
+
+                coalesce(
+                    max(if(priority_order = 1 and rn_username = 1, username, null)),
+                    max(if(priority_order = 2 and rn_username = 1, username, null)),
+                    max(if(priority_order = 3 and rn_username = 1, username, null)),
+                    max(if(priority_order = 4 and rn_username = 1, username, null)),
+                    max(if(priority_order = 5 and rn_username = 1, username, null))
+                ) as username,
+            from username_filter
+            group by student_number
         ),
 
         username_password as (
             select
                 c.student_number,
 
-                coalesce(
-                    u1.username, u2.username, u3.username, u4.username, u5.username
-                ) as username,
+                p.username,
 
                 if(
                     length(concat(c.last_name_clean, c.dob_year)) < 8,
                     left(concat(c.last_name_clean, c.dob_year, c.student_number), 8),
                     concat(left(c.last_name_clean, 18), c.dob_year)  /* 20 char limit */
                 ) as default_password,
-            from components as c
-            left join
-                username_filter as u1
-                on c.student_number = u1.student_number
-                and u1.priority_order = 1
-                and u1.rn_username = 1
-            left join
-                username_filter as u2
-                on c.student_number = u2.student_number
-                and u2.priority_order = 2
-                and u2.rn_username = 1
-            left join
-                username_filter as u3
-                on c.student_number = u3.student_number
-                and u3.priority_order = 3
-                and u3.rn_username = 1
-            left join
-                username_filter as u4
-                on c.student_number = u4.student_number
-                and u4.priority_order = 4
-                and u4.rn_username = 1
-            left join
-                username_filter as u5
-                on c.student_number = u5.student_number
-                and u5.priority_order = 5
-                and u5.rn_username = 1
+            from username_candidates as c
+            inner join username_pick as p on c.student_number = p.student_number
         )
 
     select *, username || '@teamstudents.org' as google_email,


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will make `stg_people__student_logins` build in one pass instead of re-reading its 3 upstream views 5 times.

The incremental branch left-joined the `username_filter` CTE 5 times, once per username priority, and ran 4 `not in (select ... from this)` subqueries. BigQuery inlines a CTE per reference, so it re-evaluated the PowerSchool union view, the Finalsite views, and both window functions for every join. Each run cost about 15 slot-minutes and 100 stages to add almost no rows. That is about 145 slot hours a week.

Now the model reads the target table as a 2-column projection through 3 plain anti-joins instead of 4 correlated subqueries, generates the 5 candidate usernames with one `unnest` over a single scan of the upstream views, and picks each student's username with one `group by`. Output is unchanged.

Closes #5214. Refs #5212.

## Reviewer Notes

- The dev and staging branch of the model reads the archived source, so dbt Cloud CI does not exercise the rewritten SQL. Verification ran against prod as a SELECT (details in the fold-out).
- `username_pick` uses `coalesce(max(if(priority_order = N ...)))` rather than a second `row_number`, per the repo's priority-pick convention. It is equivalent to the old `coalesce(u1..u5)`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [x] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models
- [x] Include (or update) an exposure — no consumer change
- [x] **Breaking change?** No. Column set and values are unchanged.
- [x] External sources — none touched

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes on retry. First run hit a transient BigQuery `Error encountered during execution. Retrying may solve the problem.` on 4 downstream Tableau views.
- [x] **Dagster Cloud** — not triggered (dbt-only change).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

Verification: compiled both versions with `--target prod` and ran them as one BigQuery SELECT against a simulated target (`stg_people__student_logins` minus students whose `student_number` ends in 0), so both sides saw the same snapshot and had real work to do. Result: 1,099 rows each, 1,099 distinct `student_number` and `username`, 0 rows only in old, 0 rows only in new, on a full join over all 4 output columns. Against the real target both versions return 0 rows today.

Cost: the new SQL alone ran in 14 stages at 0.5 slot-minutes (job `xsde2O27V9epxNriE6xaCBjXkz0`). Prod runs on the old SQL over the prior 7 days averaged 99 to 100 stages and 9.5 to 21 slot-minutes.

Equivalence notes: the old `username_filter` renumbered `priority_order` with `row_number` after the `not in` filter; the new one keeps the original priority. Both pick the lowest surviving priority with `rn_username = 1`, so the result is the same. `rn_username` in the old code ordered by the input `priority_order` (BigQuery resolves window `order by` against input columns, not select aliases), which is what the new code does too.

`existing_logins` is referenced 3 times (2 anti-joins on `student_number`, 1 on `username`). BigQuery may evaluate it per reference, but it is a 2-column projection of a 31k-row table and the whole query measured 0.5 slot-minutes, so collapsing further is not worth a non-equi `or` join.

Out of scope, noted for the parent: the model runs 76 to 109 times a day on prod. Its data changes daily at most. A cron automation condition like #5213 used would cut the remaining cost further.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
