### PR TITLE
fix(dagster): give Directory API retries a 63s budget for 429s

### DIFF
--- a/src/teamster/libraries/google/CLAUDE.md
+++ b/src/teamster/libraries/google/CLAUDE.md
@@ -19,7 +19,9 @@ account with domain-wide delegation. Provides batch methods:
 
 **Retry pattern**: All `.execute()` calls (both `_list` and batch methods) are
 wrapped via the module-level `_retryable_execute(request)` factory +
-`backoff(fn=..., retry_on=(_TransientHttpError,))`. Never use bare
+`_backoff(fn)`, which retries `_TransientHttpError` 6 times with delays of 1, 2,
+4, 8, 16, 32s (63s total, enough to outlast a per-minute 429). Do not call
+`dagster.backoff` directly: its defaults give up after 1.5s. Never use bare
 `errors.HttpError` — 4xx client errors must not be retried. Transient codes:
 `{429, 500, 502, 503, 504}`.
 

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -37,6 +37,15 @@ def _backoff(fn: Callable[[], dict]) -> dict:
     ``dagster.backoff``'s defaults (4 retries, delays from 0.1s) give up after
     1.5s, inside the same rate-limit window that produced the 429. Delays of
     1, 2, 4, 8, 16, 32s total 63s, past a per-minute ``rateLimitExceeded``.
+
+    Args:
+        fn: Zero-arg callable from :func:`_retryable_execute`.
+
+    Returns:
+        The response dict from the first successful call.
+
+    Raises:
+        _TransientHttpError: If all 7 attempts fail.
     """
     return backoff(
         fn=fn,

--- a/src/teamster/libraries/google/directory/resources.py
+++ b/src/teamster/libraries/google/directory/resources.py
@@ -19,7 +19,7 @@ from teamster.core.utils.functions import chunk
 _TRANSIENT_HTTP_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 
 # Total attempts per batch (1 initial + retries) for sub-requests that fail with
-# a transient code. Matches dagster.backoff's default retry budget (1 + 4).
+# a transient code.
 _MAX_BATCH_ATTEMPTS: int = 5
 
 
@@ -29,6 +29,21 @@ class _TransientHttpError(errors.HttpError):
     Used as the ``retry_on`` target for :func:`backoff` so that client errors
     (4xx) propagate immediately instead of being retried.
     """
+
+
+def _backoff(fn: Callable[[], dict]) -> dict:
+    """Retry ``fn`` on ``_TransientHttpError`` with a budget that outlasts a 429.
+
+    ``dagster.backoff``'s defaults (4 retries, delays from 0.1s) give up after
+    1.5s, inside the same rate-limit window that produced the 429. Delays of
+    1, 2, 4, 8, 16, 32s total 63s, past a per-minute ``rateLimitExceeded``.
+    """
+    return backoff(
+        fn=fn,
+        retry_on=(_TransientHttpError,),
+        max_retries=6,
+        delay_generator=exponential_delay_generator(base_delay=1.0),
+    )
 
 
 def _retryable_execute(request) -> Callable[[], dict]:
@@ -214,13 +229,12 @@ class GoogleDirectoryResource(ConfigurableResource):
         max_results = kwargs.pop("max_results", self.max_results)
 
         while True:
-            response = backoff(
-                fn=_retryable_execute(
+            response = _backoff(
+                _retryable_execute(
                     getattr(self._resource, api_name)().list(
                         pageToken=next_page_token, maxResults=max_results, **kwargs
                     )
-                ),
-                retry_on=(_TransientHttpError,),
+                )
             )
 
             next_page_token = response.get("nextPageToken")
@@ -526,9 +540,7 @@ class GoogleDirectoryResource(ConfigurableResource):
 
             # Retries a transient failure of the whole batch envelope; individual
             # sub-request failures come back through self._exceptions below.
-            backoff(
-                fn=_retryable_execute(batch_request), retry_on=(_TransientHttpError,)
-            )
+            _backoff(_retryable_execute(batch_request))
 
             if not self._exceptions:
                 return failures

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -100,6 +100,21 @@ def test_list_retries_on_503_mid_pagination():
     assert mock_execute.call_count == 3
 
 
+def test_list_outlasts_a_sustained_429():
+    """A per-minute rateLimitExceeded needs a retry budget measured in tens of
+    seconds, not the dagster.backoff default of 1.5s across 5 attempts."""
+    resource, mock_api = _make_resource()
+    mock_execute = mock_api.users.return_value.list.return_value.execute
+    mock_execute.side_effect = [_http_error(429)] * 6 + [{"users": [{"id": "u1"}]}]
+
+    with patch("dagster._utils.backoff.time.sleep") as mock_sleep:
+        data = resource._list("users", customer="C123")
+
+    assert data == [{"id": "u1"}]
+    assert mock_execute.call_count == 7
+    assert sum(c.args[0] for c in mock_sleep.call_args_list) >= 60
+
+
 def test_list_returns_single_page():
     resource, mock_api = _make_resource()
     mock_api.users.return_value.list.return_value.execute.return_value = {

--- a/tests/resources/test_resource_google_directory.py
+++ b/tests/resources/test_resource_google_directory.py
@@ -115,6 +115,23 @@ def test_list_outlasts_a_sustained_429():
     assert sum(c.args[0] for c in mock_sleep.call_args_list) >= 60
 
 
+def test_batch_envelope_outlasts_a_sustained_429():
+    """The whole-batch ``execute()`` shares the 63s budget with ``_list``."""
+    resource, mock_api = _make_resource()
+    mock_batch = MagicMock()
+    mock_batch.execute.side_effect = [_http_error(429)] * 6 + [None]
+    mock_api.new_batch_http_request.return_value = mock_batch
+
+    with patch("dagster._utils.backoff.time.sleep") as mock_sleep:
+        failures = resource._execute_batch_with_retry(
+            [{"primaryEmail": "a@x.org"}], request_factory=MagicMock()
+        )
+
+    assert failures == []
+    assert mock_batch.execute.call_count == 7
+    assert sum(c.args[0] for c in mock_sleep.call_args_list) >= 60
+
+
 def test_list_returns_single_page():
     resource, mock_api = _make_resource()
     mock_api.users.return_value.list.return_value.execute.return_value = {


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will let the Google Directory API pulls ride out a rate-limit error instead of failing the run.

Run `76ab2239-6d3b-467e-9d6a-66af92ac9116` (the noon `google/directory/users` schedule) failed with `HttpError 429 rateLimitExceeded` on `users.list`. The retry layer already treats 429 as transient, but it used the dagster `backoff` defaults: 4 retries with delays of 0.1, 0.2, 0.4 and 0.8 seconds. That is 1.5 seconds total, all inside the same per-minute window that produced the 429. The Dagster auto-retry succeeded two minutes later, which is exactly what the in-step retry now covers.

The fix is one shared `_backoff` helper with delays of 1, 2, 4, 8, 16 and 32 seconds (63 seconds total). Both retry sites use it: each `_list` page request and the batch envelope in `_execute_batch_with_retry`.

## Reviewer Notes

- The batch sub-request retry loop already used `exponential_delay_generator()` from 0.1s. I left it alone; it is a different failure path and this PR fixes only the one that failed.
- Worst case a truly dead page request now takes 63 seconds longer to fail. The schedule has no `max_runtime` tag, so this does not collide with a runtime cap.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster

- [x] `uv run pytest tests/resources/test_resource_google_directory.py`: 47 passed. The 12 failures are the live-credential tests and fail identically on `main` in this Codespace.
- [ ] Run `uv run dagster definitions validate` for any modified code location (no definitions changed)

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — not applicable.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Root cause read from the run pod's `RUN_FAILURE` log line in GKE (`dagster-run-76ab2239-*`), because the Dagster event log for this run trips the repo's output-redaction hook and the step pod writes no stdout to k8s logs. Bottom of the error chain: `teamster.libraries.google.directory.resources._TransientHttpError: <HttpError 429 when requesting None returned "Resource has been exhausted (e.g. check quota).". Details: "[{'message': 'Resource has been exhausted (e.g. check quota).', 'domain': 'global', 'reason': 'rateLimitExceeded'}]">`. The same schedule has failed with an auto-retry recovering about every 1 to 3 weeks since February 2026, so this is chronic, not a one-off.

New test `test_list_outlasts_a_sustained_429` fails on `main` (retries exhausted after 5 calls) and passes here (7 calls, total sleep >= 60s).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)