### PR TITLE
perf(extracts): read the enrollment view once in int_extracts__student_enrollments

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -50,19 +50,19 @@ with
 
             first_value(ms_school_abbreviation ignore nulls) over (
                 partition by _dbt_source_project, student_number
-                order by exitdate desc
+                order by rn_all asc
                 rows between unbounded preceding and unbounded following
             ) as ms_attended,
 
             first_value(es_school_abbreviation ignore nulls) over (
                 partition by _dbt_source_project, student_number
-                order by exitdate desc
+                order by rn_all asc
                 rows between unbounded preceding and unbounded following
             ) as es_attended,
 
             first_value(es_grad_school_abbreviation ignore nulls) over (
                 partition by _dbt_source_project, student_number
-                order by exitdate desc
+                order by rn_all asc
                 rows between unbounded preceding and unbounded following
             ) as es_graduated,
 

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -61,7 +61,7 @@ with
             ) as es_attended,
 
             first_value(es_grad_school_abbreviation ignore nulls) over (
-                partition by student_number
+                partition by _dbt_source_project, student_number
                 order by exitdate desc
                 rows between unbounded preceding and unbounded following
             ) as es_graduated,

--- a/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_extracts__student_enrollments.sql
@@ -5,50 +5,79 @@ with
         from {{ ref("int_students__calendar_week") }}
     ),
 
-    esms_attend as (
+    enrollments as (
         select
-            _dbt_source_project,
-            student_number,
-            school_level,
-            school_abbreviation,
+            *,
 
-            row_number() over (
-                partition by student_number, school_level order by exitdate desc
-            ) as rn,
-        from {{ ref("base_powerschool__student_enrollments") }}
-    ),
+            if(
+                school_level = 'MS', school_abbreviation, null
+            ) as ms_school_abbreviation,
+            if(
+                school_level = 'ES', school_abbreviation, null
+            ) as es_school_abbreviation,
+            if(
+                grade_level != 99, date_diff(exitdate, entrydate, day), null
+            ) as days_enrolled,
 
-    es_grad as (
-        select
-            student_number,
-            school_abbreviation,
-
-            row_number() over (
-                partition by student_number order by exitdate desc
-            ) as rn,
-
-        from {{ ref("base_powerschool__student_enrollments") }}
-        where
-            grade_level = 4
-            and extract(month from exitdate) = 6
-            and exitdate < current_date('{{ var("local_timezone") }}')
-    ),
-
-    next_year_school as (
-        select
-            student_number,
-            academic_year,
+            if(
+                grade_level = 4
+                and extract(month from exitdate) = 6
+                and exitdate < current_date('{{ var("local_timezone") }}'),
+                school_abbreviation,
+                null
+            ) as es_grad_school_abbreviation,
 
             lead(school_abbreviation, 1) over (
-                partition by student_number order by academic_year asc
-            ) as next_year_school,
+                partition by student_number, rn_year order by academic_year asc
+            ) as next_year_school_lead,
 
             lead(schoolid, 1) over (
-                partition by student_number order by academic_year asc
+                partition by student_number, rn_year order by academic_year asc
+            ) as next_year_schoolid_lead,
+        from {{ ref("base_powerschool__student_enrollments") }}
+    ),
+
+    windowed as (
+        select
+            * except (
+                ms_school_abbreviation,
+                es_school_abbreviation,
+                es_grad_school_abbreviation,
+                days_enrolled,
+                next_year_school_lead,
+                next_year_schoolid_lead
+            ),
+
+            first_value(ms_school_abbreviation ignore nulls) over (
+                partition by _dbt_source_project, student_number
+                order by exitdate desc
+                rows between unbounded preceding and unbounded following
+            ) as ms_attended,
+
+            first_value(es_school_abbreviation ignore nulls) over (
+                partition by _dbt_source_project, student_number
+                order by exitdate desc
+                rows between unbounded preceding and unbounded following
+            ) as es_attended,
+
+            first_value(es_grad_school_abbreviation ignore nulls) over (
+                partition by student_number
+                order by exitdate desc
+                rows between unbounded preceding and unbounded following
+            ) as es_graduated,
+
+            max(if(rn_year = 1, next_year_school_lead, null)) over (
+                partition by student_number, academic_year
+            ) as next_year_school,
+
+            max(if(rn_year = 1, next_year_schoolid_lead, null)) over (
+                partition by student_number, academic_year
             ) as next_year_schoolid,
 
-        from {{ ref("base_powerschool__student_enrollments") }}
-        where rn_year = 1
+            sum(days_enrolled) over (
+                partition by _dbt_source_project, academic_year, student_number
+            ) as days_enrolled_year,
+        from enrollments
     ),
 
     mia_territory as (
@@ -81,23 +110,6 @@ with
 
         from {{ ref("stg_powerschool__s_nj_stu_x") }}
         where graduation_pathway_math = 'M' or graduation_pathway_ela = 'M'
-    ),
-
-    finalsite_enrollment_type_calc as (
-        select
-            _dbt_source_project,
-            academic_year,
-            student_number,
-
-            if(
-                sum(date_diff(exitdate, entrydate, day)) >= 7,
-                'Previously Enrolled',
-                'NTK'
-            ) as next_year_enrollment_history,
-
-        from {{ ref("base_powerschool__student_enrollments") }}
-        where grade_level != 99
-        group by _dbt_source_project, academic_year, student_number
     )
 
 select
@@ -117,7 +129,8 @@ select
         state_studentnumber,
         `state`,
         homeless_code,
-        homeless_primary_nighttime_residence_code
+        homeless_primary_nighttime_residence_code,
+        days_enrolled_year
     ),
 
     sc.contact_1_name,
@@ -218,12 +231,6 @@ select
     lc.location_region as region_official_name,
     lc.location_deanslist_school_id as deanslist_school_id,
 
-    m.school_abbreviation as ms_attended,
-
-    es.school_abbreviation as es_attended,
-
-    eg.school_abbreviation as es_graduated,
-
     mt.territory,
 
     hi.enter_date as home_instruction_enter_date,
@@ -258,9 +265,6 @@ select
     gc.earned_credits_cum_projected,
     gc.potential_credits_cum,
 
-    ny.next_year_school,
-    ny.next_year_schoolid,
-
     'KTAF' as district,
 
     concat(e.region, e.school_level) as region_school_level,
@@ -270,10 +274,6 @@ select
     cast(e.academic_year as string)
     || '-'
     || right(cast(e.academic_year + 1 as string), 2) as academic_year_display,
-
-    if(
-        e.grade_level = 99, null, fs.next_year_enrollment_history
-    ) as next_year_enrollment_history,
 
     if(ovg.fafsa_opt_out is not null, 'Yes', 'No') as overgrad_fafsa_opt_out,
 
@@ -354,6 +354,14 @@ select
     ) as is_ada_above_or_at_80_cum_gpa_less_2,
 
     if(e.exitdate < cal.first_day_school_year, true, false) as is_pre_year_withdrawal,
+
+    case
+        when e.grade_level = 99
+        then null
+        when e.days_enrolled_year >= 7
+        then 'Previously Enrolled'
+        else 'NTK'
+    end as next_year_enrollment_history,
 
     case
         e.gender when 'F' then 'Female' when 'M' then 'Male' when 'X' then 'Non-Binary'
@@ -454,7 +462,7 @@ select
         else 'No issues'
     end as fafsa_status_mismatch_category,
 
-from {{ ref("base_powerschool__student_enrollments") }} as e
+from windowed as e
 left join
     school_year_start as cal
     on e.schoolid = cal.schoolid
@@ -463,18 +471,6 @@ left join
 left join
     {{ ref("int_people__location_crosswalk") }} as lc
     on e.school_name = lc.location_name
-left join
-    esms_attend as m
-    on e.student_number = m.student_number
-    and e._dbt_source_project = m._dbt_source_project
-    and m.school_level = 'MS'
-    and m.rn = 1
-left join
-    esms_attend as es
-    on e.student_number = es.student_number
-    and e._dbt_source_project = es._dbt_source_project
-    and es.school_level = 'ES'
-    and es.rn = 1
 left join
     mia_territory as mt
     on e.student_number = mt.student_school_id
@@ -533,18 +529,9 @@ left join
     and e.schoolid = gc.schoolid
     and e._dbt_source_project = gc._dbt_source_project
 left join
-    next_year_school as ny
-    on e.student_number = ny.student_number
-    and e.academic_year = ny.academic_year
-left join
     graduation_pathway_m as mc
     on e.students_dcid = mc.studentsdcid
     and e._dbt_source_project = mc._dbt_source_project
-left join
-    finalsite_enrollment_type_calc as fs
-    on e.academic_year = fs.academic_year
-    and e.student_number = fs.student_number
-    and e._dbt_source_project = fs._dbt_source_project
 left join
     {{ ref("base_powerschool__course_enrollments") }} as sip
     on e.student_number = sip.students_student_number
@@ -553,7 +540,6 @@ left join
     and sip.courses_course_number = 'SEM01099G1'
     and sip.rn_course_number_year = 1
     and not sip.is_dropped_section
-left join es_grad as eg on e.student_number = eg.student_number and eg.rn = 1
 left join
     {{ ref("int_students__contacts_pivot") }} as sc
     on e.student_number = sc.student_number

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_extracts__student_enrollments.yml
@@ -9,6 +9,14 @@ models:
     config:
       schema: extracts
       materialized: table
+      meta:
+        dagster:
+          # Eager rebuilt this table ~145 times a day. Its fastest consumers are
+          # hourly: the Clever extract job (@hourly) and rpt_tableau__ops_dashboard
+          # (0 * * * *). Everything else reads it nightly or pulls on open
+          # (Connected Sheets). Refs #5215
+          automation_condition:
+            cron_schedule: 0 * * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will make `int_extracts__student_enrollments` read the enrollment view once per run instead of 6 times.

The model read `base_powerschool__student_enrollments` in its main select and in 5 CTEs. That ref is a passthrough view over `int_students__student_enrollments`, a 735-line view, so BigQuery inlined the whole enrollment SQL 6 times per run. Each run had 195 stages, and 45 `Coalesce` stages carried 14 of its 17 slot-minutes. At about 145 runs a day that was 153 slot hours a week, the second most expensive node in prod.

The 5 lookups are now window functions over one scan of the view. The dev build has 81 stages and takes 3.4 slot-minutes. Output is unchanged: same 134,501 rows, and all 6 affected columns match prod on every row.

The model also moves from the eager table condition to an hourly cron. Its fastest consumers, the Clever extract job and the ops dashboard, refresh hourly; everything else is nightly or a Connected Sheet that pulls on open. About 145 rebuilds a day become 24.

Refs #5215

## Reviewer Notes

- `es_graduated` and the two attended columns use `first_value(... ignore nulls)` with a full-partition frame, ordered by `rn_all asc`. The frame clause is what lets a row of any school level see the latest MS or ES stint. `rn_all` replaces the old `exitdate desc` because it carries a deterministic tiebreak (#5146); prod picks are identical on every row.
- `next_year_school` partitions the `lead()` by `rn_year` instead of filtering to `rn_year = 1`, then broadcasts the primary stint's value to the other rows of that student-year with `max()`.
- The Finalsite flag moved from a `group by` CTE to a `sum()` window plus a `case`. Grade 99 rows still get null, and a student-year with no `exitdate` still reads `NTK`.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — no consumer change
- [x] **Breaking change?** No. Column names and types are unchanged; the contract build passed.
- [x] External sources unchanged.

## CI checks

- [x] **Trunk** — passes.
- [x] **dbt Cloud** — passes.
- [x] **Dagster Cloud** — not triggered (dbt-only change).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The issue's stated cause (view fan-in on the 80M-row join stage) was wrong: that stage cost 2.4 of 17 slot-minutes. The cost was the 6-fold inlining of `int_students__student_enrollments`. Run alone, that view costs 1.4 slot-minutes and 41 stages; its Focus-branch `Coalesce` stages cost 0.03 slot-minutes each standalone and 0.7 each when inlined into the extract's 195-stage plan.

Probe evidence (prod SQL wrapped in `count(*)` plus a row fingerprint): baseline 19.3 slot-min, 194 stages, 44 `Coalesce`; the same query with the 5 side CTEs pointed at a table 5.6 slot-min, 82 stages. Dev build of this branch (job `c6ff4578-8d13-49da-9cc9-a40db05b84a0`): 3.4 slot-min, 81 stages, 21 `Coalesce` at 1.1 slot-min. The last 2 prod runs were 7.3 and 9.3 slot-min, 195 stages each.

Parity: `zz_cbini_kipptaf_extracts.int_extracts__student_enrollments` vs `kipptaf_extracts.int_extracts__student_enrollments`, keyed on (`_dbt_source_project`, `student_number`, `academic_year`, `entrydate`) for 112,938 rows and on a 9-column null-safe key for the 21,563 rows with null `entrydate`. Zero differences on `ms_attended`, `es_attended`, `es_graduated`, `next_year_school`, `next_year_schoolid`, `next_year_enrollment_history`. Zero students appear in more than one `_dbt_source_project` and no student has 2 `rn_year = 1` rows in a year, so partitioning the attended windows by project and broadcasting the lead with `max()` cannot change results. Ties on `exitdate` were arbitrary before (`row_number` with no tiebreaker); ordering by `rn_all asc` makes them deterministic, and prod has 0 such ties today so no value changes. All three windows partition by `_dbt_source_project, student_number`.

Cadence map behind the hourly cron, all 111 direct consumers: Clever extract job `@hourly`; `rpt_tableau__ops_dashboard` `0 * * * *`; attendance dashboards 06:00 and 15:00; assessment dashboard 01:00, 18:00 and Fri 16:00; ParentSquare (Newark job) 03:00 and 18:00; DeansList, Illuminate, autocomm and the remaining Tableau exposures nightly between 00:00 and 08:00; 69 Google Sheets exposures are Connected Sheets (pull); 2 Cube marts are staff surveys. The hourly consumers fire at :00 like the rebuild, so they may read the previous hour's table; `50 * * * *` is the alternative if that matters.

Not done here: `int_students__student_enrollments` stays a view. Materializing it (the config is commented out in its YAML) is a separate decision.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
