### PR TITLE
feat(cube): exclude not_taken from proficiency, expose strand breakdowns (2 of 2)

### DIFF
--- a/src/cube/mcp/project_knowledge/README.md
+++ b/src/cube/mcp/project_knowledge/README.md
@@ -52,7 +52,10 @@ Non-negotiables, every session:
    answer any substantive question — no matter how urgent or simple the request
    looks. Force-refresh `meta` at the start so you're never trusting a stale
    catalog.
-2. Filter `response_type` explicitly on every assessment query.
+2. Filter `response_type` explicitly on every assessment query. It is
+   non-nullable with four values (`overall`, `group`, `standard`,
+   `not_taken`) — never filter for a null/not-set `response_type` to reach
+   vendor or state rows; use `response_type = 'overall'` instead.
 3. Log every query as you go — never skip logging, never batch it to the end.
    Flag trips, inferences, and low-confidence answers in real time.
 4. State your confidence (High / Medium / Low) and name every assumption you

--- a/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-orchestrator.md
@@ -68,9 +68,12 @@ Before step 1, do two things:
    stale catalog has already produced a confident-but-wrong "unanswerable" in a
    prior session. If a field or view you need appears to be missing, refresh
    `meta` before concluding it is unavailable.
-3. **Filter `response_type` explicitly** on every assessment query. Never rely
-   on the silent default blend — see `assessment-cube-reference.md` (Shared
-   conventions) for the accepted values and the default.
+3. **Filter `response_type` explicitly** on every assessment query. The column
+   is non-nullable with four values (`overall`, `group`, `standard`,
+   `not_taken`) — never rely on the silent default blend, and never filter for a
+   null/not-set `response_type` to reach vendor or state rows; that idiom no
+   longer returns anything. See `assessment-cube-reference.md` (Shared
+   conventions) for the full vocabulary and the default.
 4. **State confidence and flag every inference.** Give each answer a High /
    Medium / Low confidence rating, and explicitly list every interpretation or
    default you chose on the participant's behalf. Surface these for human

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -20,15 +20,46 @@ Apply to every assessment source unless a source section overrides them.
   - Treat this list as current, not closed: other categories exist upstream
     (`college`, `ap`, `state_nj_parcc`, `state_fl_fsa`, plus `_unknown`
     fallbacks) but carry no scores on this view today.
-- **`response_type` — always filter it explicitly.** Values: `overall`,
-  `standard`, `group`, `null` (singular `standard` / `group`, not the older
-  `standards` / `groups`). Not additive across types. Default to `overall`
-  unless a standard- or group-level breakdown is explicitly requested. Only
-  Illuminate populates `standard` / `group`; every other source is
-  `response_type = null` (overall only). To isolate those null rows, filter with
-  operator `notSet` (or `set` for present) — `equals "null"` matches the literal
-  string, not SQL NULL, and silently returns zero rows. This holds for any NULL
-  filter.
+- **`response_type` — always filter it explicitly. The column is non-nullable**,
+  with exactly four values (singular `standard` / `group`, not the older
+  `standards` / `groups`): `overall`, `group`, `standard`, `not_taken`. Not
+  additive across types. Default to `overall` unless a standard- or group-level
+  breakdown is explicitly requested.
+  - **`overall`** — the summary row for every source (Illuminate, i-Ready,
+    DIBELS, STAR, NJ state, FL state). Filter `response_type = 'overall'` to
+    isolate it — this is the only cross-source filter that yields one row per
+    sitting. (Older guidance said to isolate the non-Illuminate sources with
+    operator `notSet`, because `response_type` used to be `null` for every one
+    of them. That idiom now returns zero rows — the column is populated on every
+    row — so use `response_type = 'overall'` wherever `notSet` used to be the
+    instruction.)
+  - **`group`** — named breakdowns: Illuminate reporting groups, and now also
+    i-Ready domains and DIBELS subtests.
+  - **`standard`** — Illuminate standards only.
+  - **`not_taken`** — an Illuminate assessment a student was expected to take
+    but has no recorded response for.
+  - `response_type_code` is populated on Illuminate `standard` rows and on
+    vendor `group` rows (i-Ready domain codes, DIBELS subtest codes) — it is
+    **NULL on Illuminate `group` rows.** Do not assume `group` always carries a
+    code.
+- **Querying the i-Ready/DIBELS breakdowns:** filter `response_type = 'group'`
+  and combine with `assessment_type` to pick `iready` vs `dibels` specifically,
+  since `group` also covers Illuminate reporting groups. For i-Ready, break out
+  by `response_type_description` (i-Ready domain names don't collide). **For
+  DIBELS, break out by `response_type_code` (`measure_standard`) instead —
+  `response_type_description` collides across DIBELS subtests:
+  `Decoding (NWF-WRC)` and `Letter Sounds (NWF-CLS)` both render as
+  `Nonsense Word Fluency`, and `Reading Fluency (ORF)` and
+  `Reading Accuracy (ORF-Accu)` both render as `Oral Reading Fluency`. Grouping
+  DIBELS by description silently merges those distinct subtests into one
+  figure.** `assessment_type` is now carried in the pre-aggregation, so these
+  queries hit the rollup rather than falling through to a live query.
+- **Proficiency measures exclude `not_taken`.** `count_scores`, the
+  `_sum_proficient`-derived measures, and the formative/CRQ pairs
+  (`pct_proficient_formative`, `pct_proficient_crq`) all exclude `not_taken`
+  rows now — a student who was not tested no longer silently drags down the
+  denominator. This moved the topline Illuminate `pct_proficient` from 45.80% to
+  49.54%. The backing pre-aggregation is renamed `proficiency_rollup_v2`.
 - **Headline metric: `pct_proficient`.** It is the one score measure comparable
   across the incompatible scales of all sources (proficient scores / total).
   `is_mastery` is the underlying per-score proficient flag. `scale_score`,
@@ -106,10 +137,11 @@ Apply to every assessment source unless a source section overrides them.
   student's actual grade use `grade_level`; for the grade an assessment targets
   use `grade_level_tested`.
   - **`grade_level_tested` is populated for Illuminate (99.8%) and every state
-    source, and is null on all 302,907 i-Ready, DIBELS, and STAR rows.** Filter
-    a vendor diagnostic by it and you get zero rows with no error. This has cost
-    two logged sessions a false "no data." For vendor sources, always use
-    `grade_level`.
+    source, and is null on every i-Ready, DIBELS, and STAR row — across every
+    `response_type` value, including the `group`-level domain/subtest rows.**
+    Filter a vendor diagnostic by it and you get zero rows with no error. This
+    has cost two logged sessions a false "no data." For vendor sources, always
+    use `grade_level`.
   - The two also answer different questions where both exist, so a result can
     change materially depending which you pick — say which one you used.
 - **Section/teacher rollups: filter `enrollment_resolution = subject_section`**
@@ -140,8 +172,10 @@ Apply to every assessment source unless a source section overrides them.
   trap.
 - **Domain rollup: `response_type_root_description`** is the CCSS domain rollup
   — reliable for CCSS-aligned content, unreliable for FL state-aligned
-  standards. Illuminate only (null elsewhere, since `response_type` is null
-  elsewhere).
+  standards. Illuminate only — the vendor and state branches hardcode it NULL;
+  there is no vendor or state equivalent. (i-Ready domains and DIBELS subtests
+  surface through `response_type_description` at `response_type = 'group'`
+  instead, not through this field.)
 - **The view is enrollment-scoped — its totals are not the vendor's or the
   state's totals.** A score appears only if it resolves to a section enrollment;
   scores that don't resolve are out of scope by design. For 2025-26 i-Ready that
@@ -226,8 +260,11 @@ Apply to every assessment source unless a source section overrides them.
   build the rollup explicitly from the module types you intend.
   `pct_proficient_crq` isolates CRQ. (Whether to pool across module types or
   report per-instrument is an open decision — flag it.)
-- **`response_type`:** `overall` / `standard` / `group`. Use `overall` unless a
-  standard/group breakdown is requested.
+- **`response_type`:** `overall` / `standard` / `group` / `not_taken`. Use
+  `overall` unless a standard/group breakdown is requested. `not_taken` is
+  Illuminate-only — it marks an assessment the student was expected to take but
+  has no recorded response for; exclude it explicitly if you are not
+  deliberately including no-shows (proficiency measures already exclude it).
 - **Bands:** `performance_band_label_number` applies, but read the Shared
   conventions entry first — the number is only meaningful inside the
   assessment's own band set, and the sets differ on cut points, band count, and
@@ -266,7 +303,12 @@ Apply to every assessment source unless a source section overrides them.
   (`category`): Math and ELA.
 - **Grade field: use `grade_level`. `grade_level_tested` is null on every
   i-Ready row** — filtering by it returns zero rows silently.
-- `response_type = null` (overall only — no standards breakdown).
+- **`response_type`:** `overall` is the summary row for every sitting; i-Ready
+  now also populates `group` for domain-level breakdowns (see Shared conventions
+  — filter `response_type = 'group'`, break out by `response_type_description`,
+  and pair with `assessment_type = 'iready'`). No `standard` breakdown exists
+  for i-Ready. Default to `overall` unless a domain breakdown is explicitly
+  requested.
 - **Proficiency:** `proficiency_level` is i-Ready's grade-level placement scale
   — `3 or More Grade Levels Below`, `2 Grade Levels Below`,
   `1 Grade Level Below`, `Early On Grade Level`, `Mid or Above Grade Level`.
@@ -317,15 +359,20 @@ Apply to every assessment source unless a source section overrides them.
 - **`is_replacement` is Illuminate-only by design** — null for i-Ready (and all
   vendor/state sources), not a gap. Genuine multiple sittings occur even within
   a single benchmark window, so dedup to the most recent `date_taken` per
-  student per window before computing anything student-level. **The rate varies
-  enormously by slice**, so treat the dedup as standing practice rather than
-  something to skip when it looks unnecessary: Camden grade 6 ELA runs 1.55% at
-  BOY, **15.38% at MOY**, and 3.06% at EOY, while Newark grades 3-4 Math runs
-  0.08% / 0.57% / 0.75% across the same rounds. Most windows sit under 2%; one
-  measured window hit one student in six. It is genuine repeat testing, not a
-  section-join fan-out. Skipping the dedup inflates any student-level count or
-  growth figure. (Which sitting is _authoritative_ for reporting is an open
-  decision; most-recent-by-date is the working convention, not ratified policy.)
+  student per window before computing anything student-level — **scope this
+  dedup to `response_type = 'overall'` rows.** At the current grain, an i-Ready
+  sitting also produces `group`-level domain rows alongside its `overall` row;
+  deduping across all `response_type` values collapses a subject's `overall` row
+  together with its domain rows into one, silently destroying the domain
+  breakdown. **The rate varies enormously by slice**, so treat the dedup as
+  standing practice rather than something to skip when it looks unnecessary:
+  Camden grade 6 ELA runs 1.55% at BOY, **15.38% at MOY**, and 3.06% at EOY,
+  while Newark grades 3-4 Math runs 0.08% / 0.57% / 0.75% across the same
+  rounds. Most windows sit under 2%; one measured window hit one student in six.
+  It is genuine repeat testing, not a section-join fan-out. Skipping the dedup
+  inflates any student-level count or growth figure. (Which sitting is
+  _authoritative_ for reporting is an open decision; most-recent-by-date is the
+  working convention, not ratified policy.)
 - **Query this view, not the upstream i-Ready model.** i-Ready arrives with
   fiscal-year re-pull duplicates — the same physical test landing under two
   partitions. The mart collapses them, so counts here are right; a query
@@ -347,7 +394,14 @@ Apply to every assessment source unless a source section overrides them.
   share will look worse than i-Ready's for the same students — one logged
   session saw 22% versus 10% in the same grade. Compare each instrument to
   itself over time, never to the other.
-- `response_type = null` (overall only).
+- **`response_type`:** `overall` is the summary row for every sitting; DIBELS
+  now also populates `group` for subtest-level breakdowns (see Shared
+  conventions — filter `response_type = 'group'`, break out by
+  `response_type_code`, and pair with `assessment_type = 'dibels'`).
+  **`response_type_description` collides across DIBELS subtests — do not group
+  by it** (e.g. `Decoding (NWF-WRC)` and `Letter Sounds (NWF-CLS)` both render
+  as `Nonsense Word Fluency`). No `standard` breakdown exists for DIBELS.
+  Default to `overall` unless a subtest breakdown is explicitly requested.
 - **Proficiency:** `proficiency_level` is the DIBELS benchmark tier —
   `Well Below Benchmark`, `Below Benchmark`, `At Benchmark`, `Above Benchmark`.
   `is_mastery` is populated. `performance_band_label_number` is null.
@@ -369,7 +423,8 @@ Apply to every assessment source unless a source section overrides them.
   (`category`): ELA and Math.
 - **Grade field: use `grade_level`. `grade_level_tested` is null on every STAR
   row.**
-- `response_type = null` (overall only).
+- `response_type = 'overall'` (overall only — no group or standard breakdown for
+  STAR).
 - **Proficiency:** `proficiency_level` is `Level 1`–`Level 5` (a share of rows
   have null `proficiency_level` / `is_mastery`). `performance_band_label_number`
   is null.
@@ -388,7 +443,8 @@ Apply to every assessment source unless a source section overrides them.
 - `assessment_type` values: `state_nj_njsla` (NJSLA ELA/Math),
   `state_nj_njsla_science` (NJSLA Science), `state_nj_njgpa` (NJGPA). `category`
   carries the subject (ELA / Math / Science).
-- `response_type = null` (overall only — no standards breakdown for state).
+- `response_type = 'overall'` (overall only — no group or standard breakdown for
+  state).
 - **Proficiency:** `proficiency_level` is the state achievement level;
   `is_mastery` is the proficient flag. `performance_band_label_number` is null.
 - **Time:** `academic_year` / `academic_year_label` now resolve for state
@@ -428,7 +484,8 @@ Apply to every assessment source unless a source section overrides them.
 - `assessment_type` values: `state_fl_fast` (FAST ELA/Math), `state_fl_science`
   (Science), `state_fl_eoc` (end-of-course, e.g. Civics). `category` carries the
   subject.
-- `response_type = null` (overall only).
+- `response_type = 'overall'` (overall only — no group or standard breakdown for
+  FL state).
 - **Proficiency:** `is_mastery` is the proficient flag — for FAST this matches
   Level 3+. `proficiency_level` carries the achievement level.
   `performance_band_label_number` is null.

--- a/src/cube/mcp/project_knowledge/assessment-cube-reference.md
+++ b/src/cube/mcp/project_knowledge/assessment-cube-reference.md
@@ -36,8 +36,8 @@ Apply to every assessment source unless a source section overrides them.
   - **`group`** — named breakdowns: Illuminate reporting groups, and now also
     i-Ready domains and DIBELS subtests.
   - **`standard`** — Illuminate standards only.
-  - **`not_taken`** — an Illuminate assessment a student was expected to take
-    but has no recorded response for.
+  - **`not_taken`** — an internal assessment a student was expected to take but
+    has no recorded response for.
   - `response_type_code` is populated on Illuminate `standard` rows and on
     vendor `group` rows (i-Ready domain codes, DIBELS subtest codes) — it is
     **NULL on Illuminate `group` rows.** Do not assume `group` always carries a
@@ -262,8 +262,8 @@ Apply to every assessment source unless a source section overrides them.
   report per-instrument is an open decision — flag it.)
 - **`response_type`:** `overall` / `standard` / `group` / `not_taken`. Use
   `overall` unless a standard/group breakdown is requested. `not_taken` is
-  Illuminate-only — it marks an assessment the student was expected to take but
-  has no recorded response for; exclude it explicitly if you are not
+  internal (Illuminate) only — it marks an assessment the student was expected
+  to take but has no recorded response for; exclude it explicitly if you are not
   deliberately including no-shows (proficiency measures already exclude it).
 - **Bands:** `performance_band_label_number` applies, but read the Shared
   conventions entry first — the number is only meaningful inside the

--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -58,7 +58,11 @@ cubes:
         public: true
 
       - name: term_key
-        description: FK to terms — the reporting quarter containing the score.
+        description: >-
+          FK to terms. The reporting quarter containing the date this score was
+          administered or taken, at the school of the resolved section
+          enrollment. Null when no reporting quarter is defined for that school
+          and date.
         sql: term_key
         type: string
 
@@ -119,8 +123,8 @@ cubes:
           Non-nullable across every source, including state. overall (the
           summary row for every source), group (a named breakdown — Illuminate
           reporting groups, i-Ready domains, DIBELS subtests), standard
-          (Illuminate standards only), or not_taken (an Illuminate assessment
-          the student was expected to take but has no recorded response).
+          (Illuminate standards only), or not_taken (an internal assessment the
+          student was expected to take but has no recorded response).
         sql: response_type
         type: string
         public: true
@@ -159,7 +163,7 @@ cubes:
         description: >-
           Illuminate-only flag. TRUE when a K-8 student sat a
           replacement-curriculum assessment off their enrolled grade level. Null
-          for all non-Illuminate sources (state and vendor: iReady, DIBELS,
+          for all non-Illuminate sources (state and vendor: i-Ready, DIBELS,
           STAR), which have no replacement-curriculum concept.
         sql: is_replacement
         type: boolean
@@ -468,7 +472,7 @@ cubes:
         # so one straddling July 1 lands its scores across two academic_year
         # partitions here, by each score's own test date. That is correct
         # per-score attribution, not a fan-out: 0 state administrations split
-        # today, only a handful of iReady/DIBELS windows do (#4546 finding 3).
+        # today, only a handful of i-Ready/DIBELS windows do (#4546 finding 3).
         time_dimension: dates.date_day
         granularity: year
         partition_granularity: year

--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -88,8 +88,15 @@ cubes:
 
       - name: is_mastery
         description: >-
-          TRUE if the student met the mastery/proficiency threshold for this
-          assessment.
+          TRUE if the student met the mastery or proficiency threshold for this
+          assessment. The threshold is per source, and they are not the same
+          bar: an at-or-above-grade-level placement for i-Ready, the measure's
+          own benchmark level for DIBELS, the performance band for Illuminate,
+          and the state achievement level for NJSLA, NJGPA and FAST. This is
+          what pct_proficient counts, so a cross-source proficiency rate is
+          comparing different definitions. Null on the DIBELS subtests whose
+          benchmark level is not set upstream, which sit in the denominator
+          without entering the numerator.
         sql: is_mastery
         type: boolean
         public: true

--- a/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
+++ b/src/cube/model/cubes/student_assessments/student_assessment_scores.yml
@@ -109,27 +109,41 @@ cubes:
 
       - name: response_type
         description: >-
-          Response-type breakdown (e.g., overall, strand, standard). Null for
-          state assessments.
+          Non-nullable across every source, including state. overall (the
+          summary row for every source), group (a named breakdown — Illuminate
+          reporting groups, i-Ready domains, DIBELS subtests), standard
+          (Illuminate standards only), or not_taken (an Illuminate assessment
+          the student was expected to take but has no recorded response).
         sql: response_type
         type: string
         public: true
 
       - name: response_type_code
-        description: Short code identifying the response type. Null for state.
+        description: >-
+          Breakdown identifier: custom_code on an Illuminate standard row,
+          domain_name on an i-Ready group row, measure_standard on a DIBELS
+          group row. Null on Illuminate group rows and on all overall/not_taken
+          rows.
         sql: response_type_code
         type: string
         public: true
 
       - name: response_type_description
-        description: Human-readable response-type description. Null for state.
+        description: >-
+          Human-readable label for the breakdown — the standard's description or
+          reporting-group label for Illuminate, a rendered domain name for
+          i-Ready, measure_name for DIBELS. Populated on every group and
+          standard row; null on overall and not_taken rows.
         sql: response_type_description
         type: string
         public: true
 
       - name: response_type_root_description
         description: >-
-          Description of the root (top-level) response type. Null for state.
+          Illuminate-only: description of the root (top-level) standard.
+          Populated only on Illuminate standard rows that resolve a parent
+          standard; null for Illuminate group rows and for every vendor/state
+          row, which have no root-standard concept.
         sql: response_type_root_description
         type: string
         public: true
@@ -147,17 +161,37 @@ cubes:
     measures:
       - name: count_scores
         description: >-
-          Scored-response count. COUNT(*) over the unique PK
-          (assessment_score_key) — additive, so pre-aggregations roll it up to
-          any grain.
+          Count of scored responses — excludes not_taken rows (no response
+          recorded). COUNT(*) over the unique PK (assessment_score_key),
+          filtered to response_type IS DISTINCT FROM 'not_taken' — additive, so
+          pre-aggregations roll it up to any grain. Expected effect: global
+          unfiltered pct_proficient moves from 45.66% to 48.24%, and the
+          Illuminate-only rate from 46.17% to 49.73% (measured 2026-09-10 on a
+          local dev server, this branch's cube model over this branch's fact),
+          since the ~940k not_taken rows (no response, so never proficient) no
+          longer inflate the denominator.
         type: count
         public: true
         # Forces joins to student_assessments and regions so all proficiency
         # measures share one CTE, enabling side-by-side queries without
         # BigQuery's "query too complex" multi-CTE fan-out error.
+        #
+        # IS DISTINCT FROM, never !=, on response_type — here and in the five
+        # other measures below. The two agree once the fact is rebuilt, because
+        # the rebuilt fact coalesces response_type to a non-null token. They
+        # disagree while the OLD fact is still in place, where response_type is
+        # null on every non-Illuminate row: `null != 'not_taken'` is null, not
+        # true, so a plain != drops the row. Measured 2026-09-10 against the
+        # then-current prod fact: DIBELS, i-Ready, STAR and all five NJ/FL
+        # state sources each read exactly 0 — 1.32M rows, silently, no error.
+        # Cube Cloud deploys on merge and the fact rebuilds hours later, so
+        # that window is real; a rollback re-opens it in the other direction.
+        # IS DISTINCT FROM keeps the null rows counted, which is their old
+        # behavior, and makes the two deploys order-independent.
         filters:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: count_students
         description: >-
@@ -183,6 +217,7 @@ cubes:
         filters:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: pct_proficient
         description: >-
@@ -244,10 +279,18 @@ cubes:
       - name: avg_scale_score
         description: >-
           Grain: recomputes at any query grain, but meaningful only within a
-          single assessment source/subject/grade — scale scores are not
-          comparable across sources, so pooling them is a silent-failure trap
-          (numerically valid, semantically meaningless). Average scale score,
-          built from additive primitives so pre-aggregations roll it up.
+          single assessment source/subject/grade and response type — scale
+          scores are not comparable across sources, so pooling them is a
+          silent-failure trap (numerically valid, semantically meaningless).
+          Scoping to DIBELS and one subject alone still pools a Composite score
+          with an ORF words-per-minute rate, since both are DIBELS scale_score
+          rows at different response types — response_type must also be held
+          constant. Holding response_type constant at 'group' is still not
+          enough for DIBELS: all eight subtests share response_type = 'group',
+          so it still pools an ORF words-per-minute rate with an NWF accuracy
+          percentage. response_type_code (unique per DIBELS subtest) is the safe
+          single-breakdown boundary. Average scale score, built from additive
+          primitives so pre-aggregations roll it up.
         sql: "{_sum_scale_score} / NULLIF({_count_scale_score}, 0)"
         type: number
         public: true
@@ -263,6 +306,7 @@ cubes:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
           - sql: "{student_assessments.module_type} IN ('QA', 'MQQ', 'CRQ')"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: _count_scores_formative
         description: >-
@@ -274,6 +318,7 @@ cubes:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
           - sql: "{student_assessments.module_type} IN ('QA', 'MQQ', 'CRQ')"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: pct_proficient_formative
         description: >-
@@ -300,6 +345,7 @@ cubes:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
           - sql: "{student_assessments.module_type} = 'CRQ'"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: _count_scores_crq
         description: >-
@@ -311,6 +357,7 @@ cubes:
           - sql: "{student_assessments.assessment_key} IS NOT NULL"
           - sql: "{regions.region_key} IS NOT NULL"
           - sql: "{student_assessments.module_type} = 'CRQ'"
+          - sql: "{CUBE}.response_type IS DISTINCT FROM 'not_taken'"
 
       - name: pct_proficient_crq
         description: >-
@@ -333,7 +380,18 @@ cubes:
       # it, so the name must be here (and exposed on the view) or a name-grouped
       # query falls back to the fact. The key adds cardinality; the name is 1:1
       # with the key (adds width, not rows).
-      - name: proficiency_rollup
+      #
+      # Renamed proficiency_rollup -> proficiency_rollup_v2 (this change): the
+      # rollup is ~12 yearly partitions with no incremental: true and no
+      # update_window, so each partition is served from its last successful
+      # build until replaced. This change flips response_type on every
+      # historical row (not_taken now excluded, and vendor rows newly carry
+      # populated response_type_code/description). Without the rename, the ~12
+      # partitions would rebuild independently against the same pre-agg name,
+      # and a multi-year query could silently mix old-vocabulary partitions
+      # with new-vocabulary ones mid-sweep — partial history, no error. The
+      # rename forces one clean full rebuild under a new name instead.
+      - name: proficiency_rollup_v2
         measures:
           - student_assessment_scores.count_scores
           - student_assessment_scores._sum_proficient
@@ -346,13 +404,30 @@ cubes:
           - student_assessments.module_type
           - student_assessments.academic_subject
           - student_assessments.grade_level_tested
+          # assessment_type (illuminate / state / iready / dibels / star /
+          # college) is near-functionally-determined by module_code above, so
+          # it costs close to zero added rollup rows. It is included anyway
+          # because without it no source-scoped query — the documented way to
+          # select i-Ready or DIBELS specifically — can hit the rollup; such a
+          # query would silently fall back to the ~14.2M-row fact instead.
+          - student_assessments.assessment_type
           - student_assessment_administrations.administration_period
           - student_assessment_scores.response_type_code
-          # response_type (overall / strand / standard) and its human-readable
-          # description are both functionally determined by response_type_code
-          # above (zero added rows). They serve standard-level cuts: filter
-          # response_type = 'standard' and break out by response_type_description
-          # (the IEP-vs-gen-ed-by-standard pilot pattern, WG 2026-07-02).
+          # Functional determination here is mixed, not uniform (do not
+          # assert "zero added rows" for this pair):
+          #   - For the vendor breakdown rows this change adds (i-Ready
+          #     domains, DIBELS subtests), response_type_code IS populated and
+          #     does determine response_type / response_type_description —
+          #     true for the first time as of this change.
+          #   - For Illuminate 'group' rows, response_type_code is still NULL
+          #     across the board while response_type_description varies
+          #     (verified: of 2,867,069 'group' rows, zero have a populated
+          #     code, all have a populated description) — so response_type_code
+          #     alone does NOT determine response_type_description for
+          #     Illuminate, and the rollup does gain rows here.
+          # They serve standard-level cuts: filter response_type = 'standard'
+          # and break out by response_type_description (the
+          # IEP-vs-gen-ed-by-standard pilot pattern, WG 2026-07-02).
           - student_assessment_scores.response_type
           - student_assessment_scores.response_type_description
           - students.race

--- a/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
+++ b/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
@@ -6,15 +6,21 @@ views:
       (one row per student x assessment x administration x response type) and
       aggregate breakdowns in a single view. pct_proficient (mastery rate) is
       the source-agnostic headline; scale_score is null for internal rows and
-      percent_correct is null for state and vendor rows. response_type /
-      response_type_code carry the standard/skill breakdown (Illuminate only).
-      State and vendor administrations have no single administered date, so the
-      Date members (academic_year, academic_year_label, date_day, month_number,
-      month_name) resolve for every source but are scoped by different dates per
-      source: the administration date for Illuminate/college, the student's
-      completion (test) date for state/vendor. A cross-source date cut (e.g.
-      "scores in May") therefore mixes those two date concepts. Contains direct
-      student identifiers — see access_policy for PII gating.
+      percent_correct is null for state and vendor rows. response_type is
+      non-nullable with four values: not_taken, overall, group, standard.
+      overall is the summary row for every source (Illuminate, NJ/FL state,
+      i-Ready, DIBELS, STAR) and is the only cross-source filter that yields one
+      row per sitting; group now covers vendor breakdowns too (i-Ready domains,
+      DIBELS subtests), not just Illuminate reporting groups; standard remains
+      Illuminate-only; not_taken is an Illuminate assessment the student was
+      expected to take but has no recorded response. State and vendor
+      administrations have no single administered date, so the Date members
+      (academic_year, academic_year_label, date_day, month_number, month_name)
+      resolve for every source but are scoped by different dates per source: the
+      administration date for Illuminate/college, the student's completion
+      (test) date for state/vendor. A cross-source date cut (e.g. "scores in
+      May") therefore mixes those two date concepts. Contains direct student
+      identifiers — see access_policy for PII gating.
 
     cubes:
       - join_path: student_assessment_scores

--- a/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
+++ b/src/cube/model/views/student_assessments/student_assessment_scores_view.yml
@@ -12,7 +12,7 @@ views:
       i-Ready, DIBELS, STAR) and is the only cross-source filter that yields one
       row per sitting; group now covers vendor breakdowns too (i-Ready domains,
       DIBELS subtests), not just Illuminate reporting groups; standard remains
-      Illuminate-only; not_taken is an Illuminate assessment the student was
+      Illuminate-only; not_taken is an internal assessment the student was
       expected to take but has no recorded response. State and vendor
       administrations have no single administered date, so the Date members
       (academic_year, academic_year_label, date_day, month_number, month_name)


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will exclude `not_taken` rows from Cube's proficiency measures, expose the strand-level breakdowns that #4710 adds to the fact, and rebuild the proficiency pre-aggregation under a new name.

**This is the second of two merges, and it is based on #4710, not on `main`.** Do not merge it until #4710 has merged **and** `fct_assessment_scores_enrollment_scoped` has rebuilt in production. See _Reviewer Notes_ for what happens if that order slips.

`response_type` used to be null for every non-Illuminate source and for every Illuminate assessment a student was assigned but never took. #4710 splits those into `overall` and `not_taken`. This PR is what makes that split matter: the roughly 940,000 `not_taken` rows leave every proficiency denominator. They have no recorded response, so they could never be proficient, and they were dragging every rate down.

Measured 2026-09-10 on a local Cube dev server, running this branch over a dev-schema build of #4710's fact:

| Measure | Before | After |
| --- | ---: | ---: |
| Global `pct_proficient` | 45.66% | 48.24% |
| Illuminate-only `pct_proficient` | 46.17% | 49.73% |
| Global `count_scores` | 13,485,050 | 14,021,353 |

**What is in this PR:** `student_assessment_scores.yml`, `student_assessment_scores_view.yml`, and the three `src/cube/mcp/project_knowledge/` files.

Refs #4708.

**Rollback plan.** Revert this PR before reverting #4710 — the order is not a preference, and the reason is in `docs/superpowers/plans/2026-08-28-strand-scores-rollback.md` on #4710's branch. Reverting this PR also restores the pre-aggregation's old name, so there is no manual rename step.

## Reviewer Notes

**This redefines two existing metrics.** `pct_proficient` and `count_scores` change value for every source, not just the two that gained breakdown rows. Please look at the measure filters first.

**The measure filters use `IS DISTINCT FROM`, not `!=`, on purpose.** Against a fact whose `response_type` is still null on non-Illuminate rows, `null != 'not_taken'` evaluates to null rather than true, so the row is dropped. Measured 2026-09-10 with this branch's cube model against the then-current production fact: DIBELS, i-Ready, STAR and all five NJ/FL state sources each returned **exactly 0** — 1.32M rows, silently, with no error. The null-safe form counts them instead, which is their pre-change behaviour. That is what makes the merge order recoverable rather than merely correct, and it is what protects the rollback path, where the old fact comes back while this model may still be deployed. Do not simplify it back to `!=`.

**The pre-aggregation is renamed, deliberately.** `proficiency_rollup` becomes `proficiency_rollup_v2`. Without the rename its twelve yearly partitions would rebuild independently against one name, and a multi-year query could mix old and new vocabulary mid-sweep and return partial history with no error. Merging after the fact has rebuilt means `_v2` gets built against the correct data on its very first build.

**Every measure read goes through that pre-aggregation, not the fact.** Confirmed through Cube's `/sql` endpoint on 2026-09-10. A correct fact table is therefore not evidence that consumers see correct numbers — the rollup has to have rebuilt too. Its `refresh_key` is `every: 1 day` across twelve yearly partitions, with no `incremental` and no `update_window`.

**The claude.ai Project update is a merge gate with a named owner.** **@anthonygwalters owns both halves** — uploading `assessment-cube-orchestrator.md` and `assessment-cube-reference.md` as project knowledge, and pasting the `README.md` content into the Project's custom instructions. These are two separate mechanisms in the claude.ai interface, not one. The repository is the source of truth; the Project is a deployment target that does not update itself. Reassign if someone else should carry it.

**One consequence of the split worth knowing:** the `response_type` vocabulary flips when **#4710** merges, but these knowledge files ship here. Between the two merges the Project's knowledge is stale in one direction — it still says `response_type` is null for vendor and state rows. That affects an internal agent's answers, not production numbers, and it closes when this merges. Uploading right after #4710 merges rather than waiting for this one is fine and slightly better.

**Consumers outside the repository were already audited for #4710.** The null-`response_type` filter breaks at that merge, not this one. Nothing extra is needed here.

## Self-review

### General

- [x] No Asana update needed — tracked on #4708
- [ ] Review the **Claude Code Review** comment posted on this PR. Note that `claude-review` does not run on a PR whose base is not `main`, so it may not appear; re-target or review by hand.

### Dagster _(skip if no Dagster changes)_

Not applicable — no Dagster changes.

### dbt _(skip if no dbt changes)_

Not applicable — no dbt changes. The fact model this reads is #4710.

### Docs _(skip if no schedule, sensor, or integration changes)_

Not applicable — no schedule, sensor, or integration changes.

## CI checks

- [x] **Trunk** — passes on the current head; all five files checked with `--force --no-fix`.
- [ ] **dbt Cloud** — expected to be a no-op; this PR selects no models.
- [x] **Dagster Cloud** — not triggered; no Dagster paths changed.

<details>
<summary>For Claude</summary>

## AI assistance

Claude-authored, human-directed. Split out of #4710 on 2026-09-10 after a before-and-after validation on the local Cube dev server found the deploy-ordering hazard. The requester chose the two-PR split, chose to keep #4710 as the dbt half rather than open two fresh PRs, and approved revising the rollback runbook for the new shape.

## Detail behind the Reviewer Notes flags

**`assessment_type` added to the rollup.** Without it, no source-scoped query — the documented way to select i-Ready or DIBELS — can hit the rollup, and every such query falls back to the 14.6M-row fact. It is near-functionally-determined by `module_code`, so it costs close to zero added rollup rows.

**Functional determination in the rollup is mixed, not uniform.** For the vendor breakdown rows, `response_type_code` is populated and does determine `response_type` and `response_type_description`. For Illuminate `group` rows the code is null across all 2,867,069 rows while the description varies, so the rollup does gain rows there. The comment in the file says so rather than claiming zero added rows.

**`avg_scale_score` needs a narrower grain than the old note claimed.** Holding source, subject and grade constant is no longer enough: a DIBELS Composite score pools with an ORF words-per-minute rate. Holding `response_type = 'group'` is also not enough, because all eight subtests share it. `response_type_code` is the safe single-breakdown boundary.

**Measurement method, for anyone re-running it.** Local Cube server (`npm --prefix src/cube run dev`) started with a locally-chosen API key, queried over REST with a minted HS256 token carrying an `email` claim, with the scores cube's `sql_table` temporarily pointed at `zz_cristinabaldor_kipptaf_marts` for the after-state. Four states were captured: `main`'s model over the production fact, `main`'s model over the branch fact, this model over the branch fact, and this model over the production fact. The last of those is the deploy-ordering scenario, and it is where the zeros appeared. A fifth run after the `IS DISTINCT FROM` fix reproduced the before-state global `count_scores` of 13,485,050 and `pct_proficient` of 45.66% exactly.

**Known measurement caveat.** Because every read is served by the pre-aggregation, per-source counts and the global count can disagree within a single capture when partitions have different build times. Two such gaps were observed, 670 rows and 84,237 rows, and were not isolated further. They point at the old rollup name, which this PR retires. Treat sub-0.1% deltas from that layer as noise; the order-of-magnitude findings above are unaffected.

</details>
