### PR TITLE
feat(powerschool): carry calendar week fields on the attendance fact and rebuild the Miami archive (PR 1)

### DIFF
--- a/src/dbt/kippmiami/CLAUDE.md
+++ b/src/dbt/kippmiami/CLAUDE.md
@@ -16,15 +16,16 @@ PowerSchool (pre-Focus SIS) is retired. `kippmiami_powerschool` is an archive
 built from the frozen `src_powerschool__*` externals (final ODBC pull
 2026-07-01). It was rebuilt on 2026-09-09 (#5012). It was rebuilt again after
 #5231 merged, adding identity and school columns to the GPA, final grades,
-calendar day, and student enrollment models. The recipe is the `dbt_project.yml`
-`powerschool:` block: re-include the package with the ODBC staging variant and
-16 post-hooks — the 8400 Focus prefix on `student_number`
-(`stg_powerschool__students`), 14 staging models with `yearid` dropping rows
-past AY2025 (`yearid > 35`), and `stg_powerschool__calendar_day` deleting
-`date_value >= '2026-07-01'`. The package is re-included for each rebuild and
-removed after. `int_fldoe__all_assessments` resolves `student_number` from
-`int_focus__students`, not the archive. kipptaf reads the dataset as a BQ-native
-source. Do not drop the dataset or the GCS files.
+calendar day, and student enrollment models, and a third time after #5250 to
+carry calendar-week fields on `int_powerschool__ps_adaadm_daily_ctod` (#5193).
+The recipe is the `dbt_project.yml` `powerschool:` block: re-include the package
+with the ODBC staging variant and 16 post-hooks — the 8400 Focus prefix on
+`student_number` (`stg_powerschool__students`), 14 staging models with `yearid`
+dropping rows past AY2025 (`yearid > 35`), and `stg_powerschool__calendar_day`
+deleting `date_value >= '2026-07-01'`. The package is re-included for each
+rebuild and removed after. `int_fldoe__all_assessments` resolves
+`student_number` from `int_focus__students`, not the archive. kipptaf reads the
+dataset as a BQ-native source. Do not drop the dataset or the GCS files.
 
 ## Source Packages
 

--- a/src/dbt/kippmiami/dbt_project.yml
+++ b/src/dbt/kippmiami/dbt_project.yml
@@ -56,6 +56,125 @@ models:
     staging:
       stg_iready__instructional_usage_data:
         +enabled: false
+  powerschool:
+    +materialized: table
+    sis:
+      staging:
+        dlt:
+          +enabled: false
+        odbc:
+          +enabled: true
+          # Miami's PowerSchool is retired. These hooks bake the network's
+          # Miami-only fixes into the frozen archive so kipptaf can stop
+          # applying them: the 8400 Focus student-number prefix, and an
+          # AY2025 (yearid 35) bound that drops the AY2026 scaffold rows.
+          # See docs/superpowers/specs/2026-09-08-miami-powerschool-retirement-design.md
+          stg_powerschool__students:
+            +post-hook: >-
+              update {{ this }} set student_number = student_number + 8400000000
+              where true
+          stg_powerschool__assignmentcategoryassoc:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__assignmentsection:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__attendance:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__attendance_code:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__cc:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__fte:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__gen:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__gradecalculationtype:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__gradeformulaset:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__gradeschoolconfig:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__prefs:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__storedgrades:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__termbins:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__terms:
+            +post-hook: delete from {{ this }} where yearid > 35
+          stg_powerschool__calendar_day:
+            +post-hook: delete from {{ this }} where date_value >= '2026-07-01'
+          # Miami's frozen archive has no NJ state-reporting files for these
+          # four ODBC tables (no files match the GCS pattern); nothing in the
+          # archive relations depends on any of them, so disable per Step 4.
+          stg_powerschool__s_nj_crs_x:
+            +enabled: false
+          stg_powerschool__s_nj_ren_x:
+            +enabled: false
+          stg_powerschool__s_nj_stu_x:
+            +enabled: false
+          stg_powerschool__s_nj_usr_x:
+            +enabled: false
+          stg_powerschool__studentrace:
+            +enabled: false
+          stg_powerschool__u_def_ext_students:
+            +enabled: false
+          stg_powerschool__u_expectations:
+            +enabled: false
+          stg_powerschool__gradplan:
+            +enabled: false
+          stg_powerschool__u_storedgrades_de:
+            +enabled: false
+          stg_powerschool__gpselectedcrs:
+            +enabled: false
+          stg_powerschool__gpselectedcrtype:
+            +enabled: false
+          stg_powerschool__gpselector:
+            +enabled: false
+          stg_powerschool__gpstudentwaiver:
+            +enabled: false
+          stg_powerschool__gptarget:
+            +enabled: false
+          stg_powerschool__gpversion:
+            +enabled: false
+          stg_powerschool__s_stu_x:
+            +enabled: false
+          # Miami's frozen archive has no gpnode/gpprogresssubject* files
+          # either (contrary to Task 1's expectation) — no files match the
+          # GCS pattern. int_powerschool__gpnode and
+          # int_powerschool__gpprogress_grades (their only consumers) are
+          # leaf models with no further downstream reader in the package, and
+          # nothing in the archive relations depends on them, so disable both
+          # per Step 4.
+          stg_powerschool__gpnode:
+            +enabled: false
+          stg_powerschool__gpprogresssubject:
+            +enabled: false
+          stg_powerschool__gpprogresssubjectearned:
+            +enabled: false
+          stg_powerschool__gpprogresssubjectenrolled:
+            +enabled: false
+          stg_powerschool__gpprogresssubjectrequested:
+            +enabled: false
+          stg_powerschool__gpprogresssubjectwaived:
+            +enabled: false
+          stg_powerschool__gpprogresssubjwaivedapplied:
+            +enabled: false
+          # Both models exist in the package with no properties.yml (no
+          # contract `columns:` spec), so the enforced contract fails
+          # "'columns' specification is missing" on build (package gap,
+          # unrelated to the frozen archive). Neither has a package
+          # consumer, so disable per Step 4.
+          stg_powerschool__period:
+            +enabled: false
+          stg_powerschool__sced_code_mapping:
+            +enabled: false
+      intermediate:
+        int_powerschool__s_nj_stu_x_unpivot:
+          +enabled: false
+        int_powerschool__gpnode:
+          +enabled: false
+        int_powerschool__gpprogress_grades:
+          +enabled: false
   renlearn:
     +materialized: table
     staging:
@@ -63,3 +182,57 @@ models:
         +enabled: false
       stg_renlearn__star_skill_area:
         +enabled: false
+
+sources:
+  powerschool:
+    sis:
+      staging:
+        odbc:
+          +enabled: true
+          powerschool_odbc:
+            src_powerschool__s_nj_crs_x:
+              +enabled: false
+            src_powerschool__s_nj_ren_x:
+              +enabled: false
+            src_powerschool__s_nj_stu_x:
+              +enabled: false
+            src_powerschool__s_nj_usr_x:
+              +enabled: false
+            src_powerschool__studentrace:
+              +enabled: false
+            src_powerschool__u_def_ext_students:
+              +enabled: false
+            src_powerschool__u_expectations:
+              +enabled: false
+            src_powerschool__gradplan:
+              +enabled: false
+            src_powerschool__u_storedgrades_de:
+              +enabled: false
+            src_powerschool__gpselectedcrs:
+              +enabled: false
+            src_powerschool__gpselectedcrtype:
+              +enabled: false
+            src_powerschool__gpselector:
+              +enabled: false
+            src_powerschool__gpstudentwaiver:
+              +enabled: false
+            src_powerschool__gptarget:
+              +enabled: false
+            src_powerschool__gpversion:
+              +enabled: false
+            src_powerschool__s_stu_x:
+              +enabled: false
+            src_powerschool__gpnode:
+              +enabled: false
+            src_powerschool__gpprogresssubject:
+              +enabled: false
+            src_powerschool__gpprogresssubjectearned:
+              +enabled: false
+            src_powerschool__gpprogresssubjectenrolled:
+              +enabled: false
+            src_powerschool__gpprogresssubjectrequested:
+              +enabled: false
+            src_powerschool__gpprogresssubjectwaived:
+              +enabled: false
+            src_powerschool__gpprogresssubjwaivedapplied:
+              +enabled: false

--- a/src/dbt/kippmiami/package-lock.yml
+++ b/src/dbt/kippmiami/package-lock.yml
@@ -7,12 +7,14 @@ packages:
     name: iready
   - local: ../focus
     name: focus
+  - local: ../powerschool
+    name: powerschool
   - local: ../renlearn
     name: renlearn
   - name: dbt_external_tables
     package: dbt-labs/dbt_external_tables
-    version: 0.12.3
+    version: 0.12.4
   - name: dbt_utils
     package: dbt-labs/dbt_utils
     version: 1.4.1
-sha1_hash: 68067fa253185d85be62fe500489028f2d15daf5
+sha1_hash: 27346872ea8ba9aecf67148b288f7c78a7429627

--- a/src/dbt/kippmiami/packages.yml
+++ b/src/dbt/kippmiami/packages.yml
@@ -4,6 +4,7 @@ packages:
   - local: ../finalsite
   - local: ../iready
   - local: ../focus
+  - local: ../powerschool
   - local: ../renlearn
   # https://github.com/dbt-labs/dbt-external-tables
   - package: dbt-labs/dbt_external_tables

--- a/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
+++ b/src/dbt/kipptaf/models/powerschool/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
@@ -121,6 +121,15 @@ models:
             source_system: PowerSchool
             source_model: stg_powerschool__calendar_day
             source_column: membershipvalue
+      - name: week_start_monday
+        data_type: date
+        description: Monday of the calendar week containing calendardate.
+      - name: week_end_sunday
+        data_type: date
+        description: Sunday of the calendar week containing calendardate.
+      - name: week_number_academic_year
+        data_type: int64
+        description: 1-based week index within the school's academic year.
       - name: _dbt_source_project
         data_type: string
         description: >-

--- a/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
+++ b/src/dbt/powerschool/models/sis/intermediate/int_powerschool__ps_adaadm_daily_ctod.sql
@@ -31,6 +31,10 @@ select
 
     tac.yearid,
 
+    cw.week_start_monday,
+    cw.week_end_sunday,
+    cw.week_number_academic_year,
+
     coalesce(ada_0.att_code, ada_1.att_code) as att_code,
 
     if(ada_0.id is not null, 0, aci_real.attendance_value)
@@ -77,3 +81,8 @@ left join
     on mv.fteid = aci_potential.fteid
     and mv.attendance_conversion_id = aci_potential.attendance_conversion_id
     and tac.id = aci_potential.input_value
+left join
+    {{ ref("int_powerschool__calendar_week") }} as cw
+    on mv.schoolid = cw.schoolid
+    and tac.yearid = cw.yearid
+    and mv.calendardate between cw.week_start_monday and cw.week_end_sunday

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
@@ -29,7 +29,10 @@ models:
         data_type: float64
       - name: week_start_monday
         data_type: date
+        description: Monday of the calendar week containing calendardate.
       - name: week_end_sunday
         data_type: date
+        description: Sunday of the calendar week containing calendardate.
       - name: week_number_academic_year
         data_type: int64
+        description: 1-based week index within the school's academic year.

--- a/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
+++ b/src/dbt/powerschool/models/sis/intermediate/properties/int_powerschool__ps_adaadm_daily_ctod.yml
@@ -27,3 +27,9 @@ models:
         data_type: float64
       - name: membershipvalue
         data_type: float64
+      - name: week_start_monday
+        data_type: date
+      - name: week_end_sunday
+        data_type: date
+      - name: week_number_academic_year
+        data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will add 3 calendar-week columns to the package attendance fact `int_powerschool__ps_adaadm_daily_ctod` (`week_start_monday`, `week_end_sunday`, `week_number_academic_year`) and re-include the `powerschool` package in `kippmiami` so the Miami archive can be rebuilt once with those columns.

This is PR 1 of 3 for #5193. Today kipptaf's `int_students__attendance_daily` inner-joins `int_students__calendar_week` to get these 3 fields. That join is the only thing that still needs the Miami calendar unions. Once every region's attendance fact carries the week fields, PR 2 drops the join and 9 Miami union relations with it.

The join is a left join on `schoolid`, `yearid`, and `calendardate between week_start_monday and week_end_sunday`. Rows with no matching calendar week keep null week fields instead of disappearing.

## Reviewer Notes

- Newark dev build: 13,915,561 rows, identical to prod. 2,908,468 of them (20.9%) have null week fields. Those are pre-2019 days with no `calendar_week` coverage (a `bell_schedule` and `cycle_day` gap). Today's kipptaf inner join drops exactly those rows, so PR 2 will keep a `week_start_monday is not null` guard to stay row-identical.
- The kippmiami re-include is byte-identical to #5231's (commit `ed848b22e9`): 16 archive hooks, same disables, same lockfile.

## After merge

Charlie: materialize the `powerschool` asset group of `kippmiami_dbt_assets` once from the Dagster UI, as for #5231. Pre-build baseline for `kippmiami_powerschool.int_powerschool__ps_adaadm_daily_ctod`: 1,285,741 rows, max `calendardate` 2026-06-04. After the build the row count must match and `countif(week_start_monday is null)` should be small. PR 1b then removes the package again.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — the 3 columns are declared in the package YAML and the kipptaf union YAML
- [ ] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — none affected
- [x] **Breaking change?** No. Columns are added, none renamed or removed.
- [ ] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** — not applicable

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Spec: `docs/superpowers/specs/2026-09-10-miami-history-unions-design.md`, plan: `docs/superpowers/plans/2026-09-10-miami-history-unions.md`, both on branch `cbini/chore/claude-miami-history-unions` (PR 2's branch).

Task 1 placed the 3 week columns before the calculated columns in the select list, not after `membershipvalue` as the plan text said, to satisfy sqlfluff ST06. The join keys on `tac.yearid` (from the LEFT-joined `terms_attendance_code` CTE) because that is the model's existing `yearid` output; `mv.yearid` would be the stricter key. No evidence the difference fires: the null-week rows are whole pre-coverage years, not scattered days.

Refs #5193
Refs #5012

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)