### PR TITLE
chore(devcontainer): hardlink the uv cache to stop per-worktree venv duplication

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "GOOGLE_CLOUD_PROJECT": "teamster-332318",
     "PYTHONDONTWRITEBYTECODE": "1",
     "TRUNK_TELEMETRY": "off",
-    "UV_LINK_MODE": "copy",
+    "UV_CACHE_DIR": "/workspaces/.uv-cache",
+    "UV_LINK_MODE": "hardlink",
     "UV_RESOLUTION": "highest"
   },
   "customizations": {


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will stop every git worktree from costing about 1.1GB of disk.

Right now `uv` copies each Python package into each worktree's `.venv`. It copies because the package cache sits on a different filesystem from `/workspaces`, and hardlinks cannot cross filesystems. With 40+ worktrees, this fills the 31GB Codespace volume over and over.

This change puts the cache on the same filesystem as the venvs and turns hardlinking on. Packages are then shared between venvs instead of copied.

Two settings change in `.devcontainer/devcontainer.json`:

- `UV_CACHE_DIR` is new. It points at `/workspaces/.uv-cache`.
- `UV_LINK_MODE` changes from `copy` to `hardlink`.

**You need to rebuild your container for this to take effect.** After you rebuild, the old cache at `~/.cache/uv` is no longer used and you can delete it. On my Codespace that cache had grown to 9.9GB.

## Reviewer Notes

- The cache lives outside the repo, at `/workspaces/.uv-cache`. That keeps a multi-gigabyte directory out of file scans and off `.gitignore`. It is still on the same filesystem, which is the part that matters.
- Hardlinking means venvs share package files on disk. Editing a file inside `site-packages` by hand would now change it for every venv and for the cache. Normal installs are safe. Hand-patching a package is not.
- I measured this instead of assuming it. Numbers are in the fold-out.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.

Dagster, dbt, and Docs sections are skipped. This change touches no Dagster code, no dbt models, and no schedules or sensors.

## CI checks

- [x] **Trunk** — passes. Ran `trunk check --force --no-fix` on the changed file in the worktree: no issues.
- [ ] **dbt Cloud** — expected to pass or not run. No dbt files changed.
- [ ] **Dagster Cloud** — expected not to trigger. No Dagster paths changed.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The change came out of repeated disk-exhaustion cleanups on a Codespace.

**Root cause.** `/home/vscode/.cache` reports `dev=45`. `/workspaces/teamster/.worktrees` reports `dev=1796`. They are the same 31GB storage pool but different devices, so `link()` fails across them and uv falls back to copying. `UV_LINK_MODE: "copy"` has been set since the original `chore: switch to uv` commit (2024-11-25); that commit records no rationale, and it reads as boilerplate added to silence uv's cross-filesystem warning rather than a deliberate choice.

**Measurement.** Built two identical `pandas` venvs against a shared cache at `/workspaces/.uvtest/cache` with hardlink mode, measuring `df` before and after the second build:

- first venv: package files show link count 2 (cache + venv)
- second venv: apparent size 93MB, actual new disk consumed **1MB**, link count 2 -> 3

Before the change, sampled `.so` files in worktree venvs all showed link count 1, confirming full physical copies. The test directory was removed afterward.

**Why the cache is outside the repo.** `/workspaces` and `/workspaces/teamster` are both `dev=1796`, so either location enables hardlinking. Outside the repo avoids adding a `.gitignore` entry and keeps ripgrep, trunk, and dbt file scans from walking a 9GB tree.

**Follow-up not in this PR.** After everyone rebuilds, `~/.cache/uv` is orphaned. Deleting it is a one-time reclaim (9.9GB on my Codespace). It could not be cleared in place beforehand: `uv cache clean` times out on `~/.cache/uv/.lock`, which is held by long-running `uv run` MCP server processes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)