### PR TITLE
docs(claude): make subagent model selection explicit and record the inline test

### DIFF
--- a/.claude/context/agent.md
+++ b/.claude/context/agent.md
@@ -23,9 +23,6 @@ Injected on the first `Agent` or `Workflow` call in a session.
   files (`reportMissingImports`, "not accessed", "not iterable") are expected
   false positives.
 - Subagents name specific files in `git add`, never `-u`, `-A`, or `.`.
-- Subagents cannot Write report files; the harness refuses with "Subagents
-  should return findings as text". Have them return the report as final text and
-  persist it to the scratchpad yourself.
 
 ## Price ratios
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,8 @@ Decide these two things before every `Agent` call, including the first:
   Otherwise do it inline: a small edit with the files already loaded is cheaper
   on the main model than a cold subagent on a cheaper one.
 - Which `model`. Pass the cheapest one you expect to finish on the first try.
-  Omit it (inherit) for judgment calls and reviews you will act on.
+  Name it explicitly on every dispatch; pick the capable model for judgment
+  calls and reviews you will act on.
 
 Price ratios, dispatch-prompt rules, and Workflow cleanup inject from
 `.claude/context/agent.md` on the first `Agent` or `Workflow` call. Do not
@@ -193,6 +194,10 @@ surrogate keys (`studentid`, `dcid`) and aggregates without small cells are not.
 - `finishing-a-development-branch` / `using-git-worktrees`: this repo uses `uv`,
   not `poetry`/`pip`. Run `uv run dbt build --select <model>+` alongside the
   skills' other tests.
+- `subagent-driven-development`: a plan step of roughly 10 lines or fewer whose
+  files are already in context is done inline, not dispatched. The skill assumes
+  every task is dispatched; the repo's dispatch-or-inline test in _Subagents_
+  governs.
 - Ponytail yields to superpowers process skills. It governs the size of what
   gets built inside them, not whether they run.
 


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will change three lines of subagent guidance.

Name the `model` on every `Agent` dispatch. The old rule said to omit it and
inherit. That produced the right model by accident and left the choice invisible
in the transcript. The superpowers `subagent-driven-development` skill already
requires an explicit model, so the two now agree.

Add one `subagent-driven-development` override: a plan step of roughly 10 lines
or fewer whose files are already in context is done inline, not dispatched. The
skill assumes every task is dispatched. On 2026-09-10 this rule saved four
dispatches, but only because the controller remembered it.

Drop the `.claude/context/agent.md` bullet saying subagents cannot Write report
files. That claim is false.

Refs #5193

## Reviewer Notes

The deleted bullet was verified false, not just assumed stale. A Haiku
general-purpose subagent was dispatched to Write a one-line file to the scratch
directory. The Write succeeded with no refusal, and the file was confirmed on
disk.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

Dagster, dbt, and Docs sections skipped: this change touches only CLAUDE.md and
`.claude/context/agent.md`.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft). If it fails: check the **Actions** tab
      for the workflow run logs. Re-run failed jobs if the failure looks
      transient; otherwise check the **Dagster Cloud** branch deployment for
      error details. Or tag **Claude** on the PR for help.

## Troubleshooting

- [SqlFluff Rules Reference](https://docs.sqlfluff.com/en/stable/rules.html)
- [Dagster "kinds" Reference](https://docs.dagster.io/guides/build/assets/metadata-and-tags/kind-tags#supported-icons)
- [Automated checks](https://teamschools.github.io/teamster/CONTRIBUTING/#automated-checks)
- [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/)

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed.

The probe behind the `agent.md` deletion: one `general-purpose` subagent on
Haiku, told to Write `probe ok` to a file under the scratch directory and report
whether the Write succeeded or was refused. It reported success; the file was
then confirmed on disk with `ls` and `cat` rather than accepted on the
subagent's self-report. The original bullet claimed the harness refuses with
"Subagents should return findings as text". No such refusal occurred. The
motivating counter-evidence was a 2026-09-10 session in which six Sonnet
`general-purpose` implementer subagents each wrote a report file under
`.superpowers/sdd/<plan>/` with no refusal, so the bullet was deleted outright
rather than narrowed.

The `subagent-driven-development` bullet went in _Superpowers skill overrides_
rather than _Subagents_ because it resolves a conflict with a specific skill,
which is what that section is for. The general dispatch-or-inline test stays in
_Subagents_ and the new bullet points back at it instead of restating it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)