### PR TITLE
docs(claude): give the SQL-comment rule concrete cuts and a ceiling

### DIFF
--- a/.claude/rules/cube-authoring.md
+++ b/.claude/rules/cube-authoring.md
@@ -12,6 +12,19 @@ and diagnostics are in the `cube-ops` skill.
 
 ## Authoring conventions
 
+- **A dimension's `description:` is the BI surface, and nothing syncs it.**
+  Superset, Tableau on the SQL API, and the claude.ai Project all read the cube
+  text; a dbt mart `description:` reaches dbt docs and stops there. Writing the
+  explanation in the dbt properties file does NOT put it in front of a BI user —
+  `scripts/sync_cube_descriptions.py` skips any dimension that already has a
+  description, copies once into the file rather than linking, patches dimensions
+  only (never measures), and is run by no hook or CI job. Result: 113 of 172
+  comparable dimensions had drifted from their dbt columns as of 2026-09-10
+  (#5256). When a column's meaning matters to a BI reader, write it in BOTH
+  places in the same change until #5256 lands.
+- **`sync_cube_descriptions.py --check` is not read-only.** It writes every file
+  it would change and only alters the exit code afterward, so never run it to
+  inspect drift or on a dirty tree.
 - **Cubes private, views public.** Every cube YAML gets `public: false` at the
   cube level. Dimensions/measures use `public: true` only when meant to be
   exposed via a view. Never flip a cube to `public: true`.

--- a/.claude/rules/dbt-sql.md
+++ b/.claude/rules/dbt-sql.md
@@ -68,6 +68,31 @@ validation/profiling goes through BigQuery MCP, not `dbt show`.
   filter exists. Carve-out: TODOs, tracking-issue refs, and migration plumbing
   stay inline at the derivation site — a defect belongs in the code, not the
   metadata.
+- **Four cuts before committing any comment block.** The rule above is not
+  enough on its own — every one of these shipped in a single PR (#4710) written
+  by someone who had read it:
+  - **Cut what a test already enforces.** "response_type stays non-nullable"
+    beside a column carrying `not_null` is noise. The test fails loudly; the
+    comment cannot.
+  - **Cut counts and dated measurements.** "collapses 319,380 of 1,572,858 rows,
+    verified 2026-08-28" goes stale in silence, and a later reader cannot tell
+    whether a wrong number means the data moved or the logic broke. The census
+    belongs in the PR body. `dbt-yaml.md`'s no-stats rule for descriptions binds
+    comments too.
+  - **Cut pointers to other documentation.** "What the exclusions mean is on the
+    model description" states nothing. The fact either belongs at this line or
+    it does not.
+  - **Cut the second copy.** The same rationale pasted at two derivation sites
+    drifts apart and then disagrees with itself. State it once; reference it by
+    name from the other.
+- **A comment block over ~6 lines is almost always holding consumer content.**
+  Before pushing an edited model, list its blocks with
+  `awk '/^[[:space:]]*--/{if(!s)s=NR;n++;next}{if(n>=4)print n" at :"s;s=0;n=0}' <file>`
+  and find duplicated lines with
+  `grep -E '^\s*--' <file> | sed 's/^\s*--\s*//' | sort | uniq -d`. Judge the
+  block you are adding against its siblings, not against the file's total
+  comment ratio — a file can sit at 11% comments while the two blocks a reviewer
+  actually reads run 16 and 13 lines above a 5-line macro call.
 - **Max 1 level of function nesting.** `if(coalesce(x, y) > 0, 'a', 'b')` is at
   the limit; anything deeper gets split into a CTE. Aggregates as direct
   function arguments don't count toward depth —


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will give the inline-SQL-comment rule in `.claude/rules/dbt-sql.md` concrete cuts to make and a length ceiling, and will record in `.claude/rules/cube-authoring.md` that a Cube dimension description is the BI surface and that nothing syncs it from dbt.

The SQL-comment rule already existed and already said the right thing: keep inline comments to what a reader of that exact line cannot see. It was in place, and it was read. A single PR (#4710) then shipped all of this anyway:

- a 16-line comment above a 5-line macro call
- an 8-line paragraph copy-pasted verbatim at two derivation sites
- three dated row censuses, including "collapses 319,380 of 1,572,858 rows, verified 2026-08-28"
- a sentence asserting a column "stays non-nullable" directly above a column carrying a `not_null` test
- three lines whose only content was pointing at where something else is documented

The abstract test — "would this survive as a `description:` instead?" — caught none of them, because each one felt like code rationale in the moment. So the rule now names the four cuts and shows the example that shipped for each.

It also adds a ~6-line ceiling and two audit commands, plus the trap that made the ceiling necessary: the file sat at 11% comments overall while the two blocks a reviewer actually reads ran 16 and 13 lines. Judging a block against the file's total ratio hides the problem.

## Reviewer Notes

**The Cube half is a different finding and could be split out if you'd rather.** It records that `scripts/sync_cube_descriptions.py` cannot keep the two in step: it skips any dimension that already has a description, copies once into the file rather than linking, patches dimensions only (never measures), and no hook or CI job runs it. 113 of 172 comparable dimensions have drifted. That is tracked on #5256; this PR only writes down the current reality so nobody assumes a dbt description reaches BI.

**One footgun worth its own line:** `sync_cube_descriptions.py --check` is not read-only. It writes every file it would change and only alters the exit code afterward, so running it to inspect drift modifies the tree.

**This is instruction text, so the reviewable question is whether it changes behaviour, not whether it reads well.** Each bullet names a decision: cut this, keep that, run this command before pushing. Anything that does not is worth flagging — `.claude/CLAUDE.md`'s own editing rule says a line that cannot name the decision it changes should be cut.

## Self-review

### General

- [x] No Asana update needed
- [ ] Review the **Claude Code Review** comment posted on this PR.

### Dagster _(skip if no Dagster changes)_

Not applicable.

### dbt _(skip if no dbt changes)_

Not applicable — no models, tests, or properties files change. The rules files are agent instructions, not dbt project files.

### Docs _(skip if no schedule, sensor, or integration changes)_

Not applicable — no schedule, sensor, or integration changes. `.claude/rules/` is not part of the MkDocs site.

## CI checks

- [x] **Trunk** — passes; both files checked with `--force --no-fix`.
- [x] **dbt Cloud** — expected no-op; no models selected.
- [x] **Dagster Cloud** — not triggered; no Dagster paths changed.

<details>
<summary>For Claude</summary>

## AI assistance

Claude-authored, human-directed. The requester read the fact model on #4710, said the comments were too long and outside repo convention, and pushed back three separate times as each round of trimming stopped short. The four cuts are that conversation generalised.

Worth knowing for anyone editing these rules later: the first pushback was answered with a file-wide comment-to-code ratio, which was accurate and useless — it measured the wrong thing and dismissed a correct complaint. The ceiling bullet exists specifically so the next session does not repeat that.

One earlier response also claimed the repo has no precedent for row counts in comments. That was wrong on the facts — about twenty sites carry them, including null counts. The governing line is `dbt-yaml.md`'s "the repo's existing multi-paragraph SQL comments are not a precedent to extend", which is why the new text argues from staleness rather than from the practice being unheard of.

</details>
