### PR TITLE
fix(marts): carry a dropped ADP job function code forward for 30 days

### DIFF
--- a/src/dbt/kipptaf/dbt_project.yml
+++ b/src/dbt/kipptaf/dbt_project.yml
@@ -35,6 +35,10 @@ vars:
   # fresh-dashboard skill's "Update the Finalsite recruitment year" procedure
   # before bumping this.
   finalsite_recruitment_year: 2026
+  # dim_staff_cube_access carries a dropped ADP job function code forward for 30
+  # days, but only for gaps that open on or after this date. Staff whose code
+  # went missing earlier stay denied and remain a manual remediation list.
+  cube_access_carry_forward_floor_date: 2026-09-11
 
 models:
   kipptaf:

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_staff_cube_access.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_staff_cube_access.sql
@@ -38,6 +38,8 @@ with
             s.google_email,
 
             j.job_function_code,
+            j.job_code,
+            j.effective_start_date as job_effective_start_date,
 
             o.department_name,
             o.business_unit_name,
@@ -83,6 +85,59 @@ with
             {{ ref("dim_locations") }} as loc on wal.location_key = loc.location_key
     ),
 
+    prior_job_function_ranked as (
+        select
+            ca.staff_key,
+
+            j.job_function_code as prior_job_function_code,
+
+            row_number() over (
+                partition by ca.staff_key order by j.effective_start_date desc
+            ) as prior_rank,
+        from current_assignment as ca
+        inner join
+            {{ ref("dim_staff_work_assignments") }} as swa
+            on ca.staff_key = swa.staff_key
+        inner join
+            {{ ref("dim_work_assignment_jobs") }} as j
+            on swa.work_assignment_key = j.work_assignment_key
+            -- a different job_code means the role itself changed, so its code is
+            -- not this person's to replay
+            and ca.job_code = j.job_code
+        where ca.job_function_code is null and j.job_function_code is not null
+    ),
+
+    prior_job_function as (
+        select staff_key, prior_job_function_code,
+        from prior_job_function_ranked
+        where prior_rank = 1
+    ),
+
+    carry_forward as (
+        select
+            pjf.staff_key,
+            pjf.prior_job_function_code,
+
+            date_add(
+                ca.job_effective_start_date, interval 30 day
+            ) as carry_forward_expires_date,
+        from prior_job_function as pjf
+        inner join current_assignment as ca on pjf.staff_key = ca.staff_key
+        -- dim_work_assignment_jobs opens a new row only when job_code, job_title
+        -- or job_function_code changes, so the current row's start date is the
+        -- date the code went null. The floor keeps the pre-existing backlog
+        -- denied; only nulls opened on or after it are carried.
+        where
+            ca.job_effective_start_date
+            >= cast('{{ var("cube_access_carry_forward_floor_date") }}' as date)
+    ),
+
+    carry_forward_active as (
+        select staff_key, prior_job_function_code,
+        from carry_forward
+        where carry_forward_expires_date >= current_date('{{ var("local_timezone") }}')
+    ),
+
     enriched as (
         select
             ca.staff_key,
@@ -94,10 +149,23 @@ with
             ca.location_abbreviation,
 
             dr.department_group,
+
+            coalesce(
+                ca.job_function_code, cfa.prior_job_function_code
+            ) as job_function_code_resolved,
+
+            case
+                when ca.job_function_code is not null
+                then 'adp'
+                when cfa.prior_job_function_code is not null
+                then 'carried_forward'
+                else 'unresolved'
+            end as job_function_code_source,
         from current_assignment as ca
         left join
             {{ ref("stg_google_sheets__people__cube_access_department_rollup") }} as dr
             on ca.department_name = dr.department_name
+        left join carry_forward_active as cfa on ca.staff_key = cfa.staff_key
     ),
 
     -- Rank the crosswalk role rows so a specific-entity match beats the 'any'
@@ -124,7 +192,7 @@ with
         from enriched as e
         left join
             {{ ref("stg_google_sheets__people__cube_access_role") }} as rl
-            on e.job_function_code = rl.job_function_code
+            on e.job_function_code_resolved = rl.job_function_code
             and rl.entity in ('any', e.entity)
     ),
 
@@ -139,6 +207,8 @@ with
             e.department_group,
             e.entity,
             e.job_function_code,
+            e.job_function_code_resolved,
+            e.job_function_code_source,
 
             rp.job_function_level,
 
@@ -180,6 +250,8 @@ select
     department_group,
     entity,
     job_function_code,
+    job_function_code_resolved,
+    job_function_code_source,
     job_function_level,
 
     student_location_scope,

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_cube_access.yml
@@ -11,7 +11,11 @@ models:
       securityContext groups and location/department allow-lists that each
       view's access_policy reads; not exposed as a Cube. The staff directory and
       aggregate summary are open — these scopes only constrain sensitive fields.
-      Unresolved roles emit 'none' (deny), never NULL.
+      Unresolved roles emit 'none' (deny), never NULL. When ADP drops a person's
+      job function code, the code they last held under the same job_code carries
+      forward for 30 days so a data gap does not silently revoke access, bounded
+      by a floor date so the carry-forward applies only to gaps that open after
+      it shipped.
     data_tests:
       # A remit-scoped PII scope (all_in_scope / teaching_staff) with a none
       # location or department axis is a resolution bug: the remit resolves empty,
@@ -89,7 +93,39 @@ models:
 
       - name: job_function_code
         data_type: string
-        description: Current ADP job function code (CHIEF, SL, TEACH, ...).
+        description: >-
+          Current ADP job function code (CHIEF, SL, TEACH, ...). NULL when ADP
+          wrote the person's current work assignment row without one, which is
+          the condition the carry-forward covers.
+        data_tests:
+          # ADP leaves job_function_code empty on every new effective-dated work
+          # assignment row it writes, so a null here is an upstream data gap, not
+          # a modelling error — warn so People Operations gets the remediation
+          # list without blocking the build, and store the rows so the list is
+          # queryable rather than buried in run output.
+          - not_null:
+              config:
+                severity: warn
+                store_failures: true
+
+      - name: job_function_code_resolved
+        data_type: string
+        description: >-
+          Job function code the role crosswalk is joined on — the ADP value when
+          present, otherwise the code the person last held under the same
+          job_code, carried forward for 30 days after the ADP value went NULL.
+          NULL once nothing resolves, which denies every scope.
+
+      - name: job_function_code_source
+        data_type: string
+        description: >-
+          Which source supplied job_function_code_resolved — adp,
+          carried_forward, or unresolved.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [adp, carried_forward, unresolved]
 
       - name: job_function_level
         data_type: int64


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will stop a staff member losing all of their Cube access because ADP dropped their job function code.

ADP writes `job_function_code` empty on every new effective-dated work assignment row. A job change therefore revoked a person's whole access silently — the role crosswalk join missed, all 7 scopes coalesced to `none`, and `buildGroups` emitted only `staff-directory`. The person saw empty results on every other view and no error. 53 active staff sit in that state right now.

`dim_staff_cube_access` now joins the crosswalk on a new `job_function_code_resolved` column. That column falls back to the code the person last held under the same `job_code`, for 30 days after the ADP value went null. A new `job_function_code_source` column stamps each row `adp`, `carried_forward`, or `unresolved`.

A warn-severity `not_null` test on `job_function_code` stores the null rows, so People Operations gets a queryable remediation list rather than a silent outage. It warns rather than errors because the gap is an upstream ADP data problem, not something a build should block on.

This fixes the consequence, not the cause. The cause is that Job Function is not maintained on a job change in ADP, which People Operations owns. Refs #5265.

## Reviewer Notes

- **The carry-forward requires an unchanged `job_code`.** A different `job_code` means the role itself changed, so replaying the old code could hand someone a scope their new role should not have. 31 of the 53 have some prior code; only 21 held it under the same `job_code`, and only those 21 are eligible.
- **`cube_access_carry_forward_floor_date` is set to the day this was written, so the current 53 get nothing.** That is deliberate and was the explicit decision — the carry-forward protects gaps that open from here on, and today's backlog stays denied as a manual list. It also means merging this changes nobody's access on day one.
- **One inconsistency I did not change.** The `staff-pii-teaching_staff` policy filters subjects on the raw `job_function_code`, so a carried-forward teacher stays invisible to that policy. Pointing it at the resolved column would widen whose PII is visible, which is a separate access decision and out of scope here.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the
      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
      feedback; dismiss false positives with a brief reply explaining why.
      (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — see
      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an
      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
      for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No. This adds 2 columns and renames nothing. No dbt
      model `ref()`s this mart, and the `staff_cube_access` cube enumerates its
      dimensions rather than selecting everything, so the additions reach no
      consumer unasked.
- [x] If adding or modifying an external source, run `stage_external_sources`
      with **`--target staging`** so the dbt Cloud CI job can find the table.
      No external source changed.

## CI checks

- [ ] **Trunk** — passes. If it fails, run `trunk check` and `trunk fmt`
      locally, fix any issues, and push again.
- [ ] **dbt Cloud** — passes. If it fails: click **Details** on the check →
      expand **Invoke `dbt build ...`** → **Debug Logs**. Or tag **Claude** on
      the PR with the error details.
- [ ] **Dagster Cloud** — passes or not triggered (only runs when relevant paths
      change and the PR is not a draft).

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. The user scoped this deliberately to consequence-mitigation and declined the upstream fixes, so do not propose a People-Ops-editable `job_code` default tab or peer inference in review — both were considered and set aside.

Verification performed:

- `dbt compile --select dim_staff_cube_access --target prod` exits 0. Confirmed in the compiled SQL that the var rendered (`cast('2026-09-11' as date)`), the expiry rendered (`interval 30 day`), the timezone-aware today rendered (`current_date('America/New_York')`), and the crosswalk join moved to `job_function_code_resolved`.
- `trunk check --force --no-fix` clean on all 3 files.
- Behavioral check, read-only against prod, replicating the new CTE chain: with the shipped floor of 2026-09-11 the carry-forward fires for 0 people; with a backdated floor of 2026-01-01 it fires for 21. The second number is what proves the mechanism is live rather than inert, and 21 reconciles exactly with the same-`job_code` recoverable population.

Numbers behind the Reviewer Notes, all measured this session:

- 53 of 1,576 active staff have a null `job_function_code` and all 7 scopes at `none`.
- 31 of the 53 have any prior non-null code across their assignment history; 21 of those held it under the same `job_code`.
- Staleness of the 21: 10 sit on a still-open concurrent assignment, 1 at 73 days, 1 at 93, 1 at 94, 8 at 96. This is why a short staleness cap on the *prior code* was rejected in favor of a grace period measured from when the null opened — a 30-day cap on prior-code age would have caught only the 10 concurrent cases and excluded every person from the real June and July erosion.

The null-run start date needs no new state table. `dim_work_assignment_jobs` opens a new row only when `job_code`, `job_title`, or `job_function_code` changes, so the `is_current` row's `effective_start_date` is the date the code went null. That is load-bearing for the 30-day clock and is the one inference in the change worth re-checking if that model's change-detection CTEs are ever restructured.

ADP history, from the daily snapshots in `src_adp_workforce_now__workers` (2,093 partitions back to 2021): `jobFunctionCode` was null for every staff member until 2026-04-12, a pilot set 112, 106 of those were wiped on 2026-05-04, a backfill set 1,429 on 2026-06-04 leaving 1 gap, and the gap count then eroded back to 51 by 2026-09-24. 2026-06-30 to 07-01 alone lost 120 codes. Full daily series and the per-person remediation list are local and gitignored under `.claude/scratch/` — they carry names and employee numbers, so they are deliberately not in this PR or in #5265.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)