### PR TITLE
docs(students): move the calendar models' rationale into their properties yml

### DIFF
--- a/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_day.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_day.sql
@@ -1,10 +1,4 @@
 with
-    -- Focus's `school_id` is its internal id (14, 15, 58...), not the network
-    -- school number, and it differs from the `school_number` the focus package
-    -- exposes (a Florida code like 2332A). Resolve through both hops. The inner
-    -- join is also the filter that drops Focus's 3 non-instructional schools
-    -- (Applicants, Virtual Franchise, ZZ Course History), which have no
-    -- locations row.
     focus_schools as (
         select s.id as focus_school_id, loc.powerschool_school_id as schoolid,
         from {{ ref("int_focus__schools") }} as s
@@ -13,11 +7,6 @@ with
             on s.school_number = loc.focus_school_id
     ),
 
-    -- yearid comes from the package's int_powerschool__calendar_day, a left
-    -- join to the isyearrec = 1 term window. Some real calendar days fall
-    -- outside every window (August pre-service dates, a 15-day Paterson gap);
-    -- their yearid and academic_year are null, and nothing downstream requires
-    -- either to be non-null.
     powerschool_dated as (
         select
             cd._dbt_source_relation,
@@ -43,10 +32,6 @@ with
         where cd.date_value >= date '2000-01-01'
     ),
 
-    -- Dual-exposes the neutral names (`school_date`, `academic_year`,
-    -- `is_in_session`, `is_in_membership`) alongside the legacy names
-    -- (`date_value`, `yearid`, `insession`, `membershipvalue`) that
-    -- `dim_school_calendars` and the NJ-parity gate read.
     powerschool_conformed as (
         select
             _dbt_source_relation,
@@ -66,9 +51,6 @@ with
         from powerschool_dated
     ),
 
-    -- int_focus__calendar_day is Focus-native: it emits academic_year and
-    -- school_date, and no insession or membershipvalue at all. A row existing there
-    -- IS an in-session day, so both flags are constants supplied here.
     focus_conformed as (
         select
             cd._dbt_source_relation,
@@ -90,11 +72,8 @@ with
             cd.academic_year - 1990 as yearid,
         from {{ ref("int_focus__calendar_day") }} as cd
         inner join focus_schools as fs on cd.schoolid = fs.focus_school_id
-        -- One row. See int_students__sis_cutover for why the boundary is a
-        -- floor derived from recorded attendance rather than from Focus row
-        -- presence. Focus's calendar before the cutover year is a scaffold,
-        -- not the network's calendar of record, and the network keeps no
-        -- Miami calendar days before AY2026 (#5193).
+        -- One row. Floors on the cutover year, not on Focus row presence
+        -- (#5193).
         cross join {{ ref("int_students__sis_cutover") }} as c
         where cd.academic_year >= c.focus_start_academic_year
     )

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_rollup.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_rollup.sql
@@ -1,7 +1,4 @@
 with
-    -- Focus's school_id is its internal id (14, 15, 58...), not the network
-    -- school number. The inner join is also the filter that drops Focus's
-    -- non-instructional schools, which have no locations row.
     focus_schools as (
         select s.id as focus_school_id, loc.powerschool_school_id as schoolid,
         from {{ ref("int_focus__schools") }} as s
@@ -10,17 +7,12 @@ with
             on s.school_number = loc.focus_school_id
     ),
 
-    -- int_focus__calendar_rollup is Focus-native: academic_year, min_school_date
-    -- and max_school_date, and no track column at all. track is supplied here
-    -- as a typed NULL, which is what the consuming join is made null-safe for.
     focus_conformed as (
         -- trunk-ignore(sqlfluff/ST06): column order matches the PowerSchool arm's
         select
             cr.days_total,
             cr.days_remaining,
 
-            -- Carried through explicitly: the ops dashboard and csgf extract
-            -- both join on _dbt_source_project.
             cr._dbt_source_relation,
             cr._dbt_source_project,
 
@@ -33,11 +25,8 @@ with
             cast(null as string) as track,
         from {{ ref("int_focus__calendar_rollup") }} as cr
         inner join focus_schools as fs on cr.schoolid = fs.focus_school_id
-        -- One row. See int_students__sis_cutover for why the boundary is a
-        -- floor derived from recorded attendance rather than from Focus row
-        -- presence. Focus's calendar before the cutover year is a scaffold,
-        -- not the network's calendar of record, and the network keeps no
-        -- Miami calendar days before AY2026 (#5193).
+        -- One row. Floors on the cutover year, not on Focus row presence
+        -- (#5193).
         cross join {{ ref("int_students__sis_cutover") }} as c
         where cr.academic_year >= c.focus_start_academic_year
     )

--- a/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_week.sql
+++ b/src/dbt/kipptaf/models/students/intermediate/int_students__calendar_week.sql
@@ -1,7 +1,4 @@
 with
-    -- Focus's school_id is its internal id (14, 15, 58...), not the network
-    -- school number. The inner join is also the filter that drops Focus's
-    -- non-instructional schools, which have no locations row.
     focus_schools as (
         select s.id as focus_school_id, loc.powerschool_school_id as schoolid,
         from {{ ref("int_focus__schools") }} as s
@@ -10,9 +7,6 @@ with
             on s.school_number = loc.focus_school_id
     ),
 
-    -- int_focus__calendar_week is Focus-native: it emits academic_year but no
-    -- yearid or region, and schoolid is Focus's internal id rather than the
-    -- network school number.
     focus_conformed as (
         select
             cw.* except (schoolid, academic_year),
@@ -25,11 +19,8 @@ with
             {{ extract_region("cw") }} as region,
         from {{ ref("int_focus__calendar_week") }} as cw
         inner join focus_schools as fs on cw.schoolid = fs.focus_school_id
-        -- One row. See int_students__sis_cutover for why the boundary is a
-        -- floor derived from recorded attendance rather than from Focus row
-        -- presence. Focus's calendar before the cutover year is a scaffold,
-        -- not the network's calendar of record, and the network keeps no
-        -- Miami calendar days before AY2026 (#5193).
+        -- One row. Floors on the cutover year, not on Focus row presence
+        -- (#5193).
         cross join {{ ref("int_students__sis_cutover") }} as c
         where cw.academic_year >= c.focus_start_academic_year
     )

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_day.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_day.yml
@@ -3,10 +3,21 @@ models:
     description: >-
       SIS-neutral in-session school calendar days across the network. The
       PowerSchool branch is NJ-only; Miami rows come from Focus from the cutover
-      year forward, and no Miami calendar history before AY2026 is kept (#5193).
-      Focus's internal school id is crosswalked to the network school number
-      here, because the crosswalk sheet is a kipptaf model the focus package
-      cannot reach. Every measure is dual-exposed: a neutral column
+      year forward, and no Miami calendar history before AY2026 is kept. Focus's
+      internal school id (14, 15, 58...) is crosswalked to the network school
+      number here, because the crosswalk sheet is a kipptaf model the focus
+      package cannot reach. That id also differs from the school_number the
+      focus package exposes, a Florida code like 2332A, so the crosswalk
+      resolves both hops. It is an inner join, which doubles as the filter that
+      drops Focus's 3 non-instructional schools -- Applicants, Virtual
+      Franchise, ZZ Course History -- since those have no locations row.
+      int_focus__calendar_day is otherwise Focus-native. It emits academic_year
+      and school_date and no insession or membershipvalue at all, and a row
+      existing there IS an in-session day, so both flags are supplied as
+      constants on that branch. The Focus branch floors on the cutover year from
+      int_students__sis_cutover rather than on Focus row presence, because
+      Focus's calendar before that year is a scaffold rather than the network's
+      calendar of record. Every measure is dual-exposed: a neutral column
       (`school_date`, `academic_year`, `is_in_session`, `is_in_membership`) for
       new work, alongside the legacy PowerSchool-derived name (`date_value`,
       `yearid`, `insession`, `membershipvalue`) that dim_school_calendars and
@@ -39,7 +50,12 @@ models:
       - name: yearid
         description: >-
           Academic year minus 1990. Legacy alias, transitional -- read by
-          dim_school_calendars and the NJ-parity gate.
+          dim_school_calendars and the NJ-parity gate. On the PowerSchool branch
+          this arrives from int_powerschool__calendar_day, a left join to the
+          isyearrec = 1 term window, so real calendar days that fall outside
+          every window carry a null yearid and academic_year -- August
+          pre-service dates and a 15-day Paterson gap. Nothing downstream
+          requires either to be non-null.
       - name: academic_year
         description: Academic year. Neutral primary name; yearid + 1990.
       - name: insession

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_rollup.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_rollup.yml
@@ -8,7 +8,17 @@ models:
       The PowerSchool branch emits one row per calendar track; the Focus branch
       emits one row per school-year with a null track, because Focus has no
       track concept and Miami's track is already null on every network
-      enrollment row.
+      enrollment row. int_focus__calendar_rollup is Focus-native. It emits
+      academic_year, min_school_date and max_school_date, and no track at all,
+      so track arrives here as a typed NULL that the consuming join is made
+      null-safe for, and its schoolid is Focus's own internal id rather than the
+      network school number, so this model crosswalks that id through the people
+      locations sheet. The crosswalk is an inner join, which doubles as the
+      filter that drops Focus's non-instructional schools, since those have no
+      locations row. The Focus branch floors on the cutover year from
+      int_students__sis_cutover rather than on Focus row presence, because
+      Focus's calendar before that year is a scaffold rather than the network's
+      calendar of record.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -43,4 +53,6 @@ models:
       - name: _dbt_source_relation
         description: Source relation the row was unioned from.
       - name: _dbt_source_project
-        description: Originating district project.
+        description: >-
+          Originating district project. Carried on both branches because the ops
+          dashboard and the csgf extract join on it.

--- a/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_week.yml
+++ b/src/dbt/kipptaf/models/students/intermediate/properties/int_students__calendar_week.yml
@@ -6,9 +6,16 @@ models:
       SIS-neutral school weeks across the network -- the successor to
       int_powerschool__calendar_week, which stays a pure PowerSchool union. The
       PowerSchool branch is NJ-only; Miami rows come from Focus from the cutover
-      year forward, and no Miami calendar history before AY2026 is kept (#5193).
-      Focus's internal school id is crosswalked to the network school number
-      here.
+      year forward, and no Miami calendar history before AY2026 is kept.
+      int_focus__calendar_week is Focus-native. It emits academic_year but no
+      yearid or region, and its schoolid is Focus's own internal id (14, 15,
+      58...) rather than the network school number, so this model crosswalks
+      that id through the people locations sheet. The crosswalk is an inner
+      join, which doubles as the filter that drops Focus's non-instructional
+      schools, since those have no locations row. The Focus branch floors on the
+      cutover year from int_students__sis_cutover rather than on Focus row
+      presence, because Focus's calendar before that year is a scaffold rather
+      than the network's calendar of record.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will move the long explanatory comments in `int_students__calendar_day`, `int_students__calendar_week`, and `int_students__calendar_rollup` out of their SQL and into their properties yml descriptions.

An inline SQL comment marks a model `state:modified`, so correcting one on a heavily-consumed intermediate makes dbt Cloud CI rebuild that model's whole descendant graph. #5259 corrected these three and paid exactly that cost, surfacing 22 unrelated pre-existing warn-tests across the survey, assessment, KIPP Forward, Pearson, and AppSheet subgraphs. A properties `description` does not mark a model modified, so the next correction to this rationale will be free.

The change is comment-only. All three models are token-identical to `main` once comments are stripped, so no compiled SQL and no row anywhere changes.

## Reviewer Notes

- Relocated to descriptions: the Focus school-id crosswalk and the non-instructional schools its inner join drops, each upstream model's Focus-native shape, the cutover floor, the `yearid` nulls outside the term window, and why `_dbt_source_project` is carried on both branches of the rollup.
- Left inline, per `.claude/rules/dbt-sql.md`: the pre-2000 sentinel-row filter and the union-all positional note, since each explains its own line; the `#5193` ref, since `.claude/rules/dbt-yaml.md` keeps tracking-issue refs out of descriptions; and the sqlfluff suppression.
- Dropped the `(#5193)` ref from the two descriptions that carried it, for the same rule.
- This PR modifies the same three hub intermediates, so its own CI run will fan out and report that same set of pre-existing warnings one last time. The analysis is on #5259.

## Self-review

### General

- [ ] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — no lineage or column change
- [x] **Breaking change?** No. Comment-only, proven by token comparison.
- [x] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** — not applicable

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Follow-up to #5259, which corrected these comments in place and surfaced the fan-out cost.

Verification: for each of the 3 models, comments were stripped with `sed 's/--.*//'`, whitespace collapsed, and the result compared to `git show origin/main:<path>` — token-identical in all 3. `dbt parse --no-partial-parse` succeeds, and all 4 relocated passages appear in the compiled manifest, so dbt reads them rather than merely accepting the YAML. Trunk clean on all 6 files.

Left for a future pass: `int_students__calendar_day` still carries two inline notes (the sentinel-row filter, the union-all positional note) that are inline by the rules rather than by accident.

Refs #5193

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)