### PR TITLE
perf(dbt): materialize the 10 costliest view marts as cron tables

### DIFF
--- a/docs/superpowers/plans/2026-09-11-view-mart-table-sweep.md
+++ b/docs/superpowers/plans/2026-09-11-view-mart-table-sweep.md
@@ -1,0 +1,1023 @@
+# View Mart Table Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the 10 costliest view marts to cron-scheduled tables so their
+dbt data tests read a table instead of recomputing the view, cutting about 610
+slot hours a week.
+
+**Architecture:** Each change is a `config:` block added to the model's
+properties yml — `materialized: table` plus
+`meta.dagster.automation_condition.cron_schedule`. No model SQL changes, so
+surrogate-key hashes and row sets stay identical and the conversion is a pure
+materialization change. A dev-schema build gates the merge on measured table
+size. One ordered Dagster run finishes the migration post-merge.
+
+**Tech Stack:** dbt 1.11.14 on BigQuery, Dagster+ automation conditions, trunk
+(prettier + markdownlint + yamllint), `uv` for every Python and dbt invocation.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md`.
+  Issue [#5217](https://github.com/TEAMSchools/teamster/issues/5217), parent
+  [#5212](https://github.com/TEAMSchools/teamster/issues/5212).
+- Worktree:
+  `/workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep`.
+  Branch `cbini/perf/claude-view-mart-table-sweep`. Every `git` call uses
+  `git -C <worktree>`; every file path is absolute under the worktree.
+- Never run bare `python`, `dbt`, or `dagster`. Always `uv run`.
+- Do NOT change any model's `.sql` file. This plan touches properties yml only.
+- Do NOT run `count(*)` against these views. One attempt over 4 of them consumed
+  100,540 slot minutes and failed with `billingTierLimitExceeded`. Row counts
+  come from `__TABLES__` on the dev dataset after a build.
+- Do NOT pass `--empty` to any `dbt build`. It rebuilds every selected relation
+  as `limit 0`, which would zero the dev tables this plan measures.
+- `--target prod` dbt runs are classifier-blocked. Prod materialization happens
+  through Dagster `launch_run`, or is handed to the user.
+- The 7 no-consumer marts get `cron_schedule: 0 3 * * *`. The 3 Cube-read marts
+  get `cron_schedule: 0 0,10,13,15,17 * * *`. These come from per-model
+  break-even in the spec; do not substitute one cadence for both.
+- All 10 already use `columns[].config.meta.foreign_key`, not real
+  `constraints: - type: foreign_key`. Do not add or move FK constraints.
+- Verified 2026-09-11: `git log -S` shows zero prior `materialized: table` or
+  `cron_schedule` commits on all 10 files, so this is not a re-attempt of a
+  reverted change.
+
+---
+
+### Task 1: Worktree prep and prod baseline
+
+Establishes that dbt can run in this worktree at all, and records the
+before-state that Task 6 verifies against. The worktree was created fresh, so it
+has no `dbt_packages/` and every dbt command fails until `dbt deps` runs.
+
+**Files:**
+
+- Create:
+  `/workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/docs/superpowers/plans/baseline-2026-09-11.md`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `baseline-2026-09-11.md`, holding the prod object type of all 10
+  marts before the change. Task 6 diffs against it.
+
+- [ ] **Step 1: Install dbt packages in the worktree**
+
+```bash
+uv run dbt deps \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf
+```
+
+Expected: `Installing ...` lines, then `Installed from ...` for each package. A
+fresh worktree has no `dbt_packages/`; without this every later command fails
+with "N package(s) specified in packages.yml, but only 0 package(s) installed".
+
+- [ ] **Step 2: Confirm the project parses before any edit**
+
+```bash
+uv run dbt parse --no-partial-parse \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf
+```
+
+Expected: exits 0. This is the clean-baseline parse — if it fails here, the
+failure is pre-existing and not caused by this plan.
+
+- [ ] **Step 3: Record the prod object type of all 10 marts**
+
+Run this through the BigQuery MCP (`mcp__bigquery__execute_sql`):
+
+```sql
+select
+  table_id,
+  if(type = 1, 'TABLE', 'VIEW') as object_type,
+  row_count,
+  round(size_bytes / pow(1024, 3), 3) as size_gb,
+  timestamp_millis(last_modified_time) as last_modified,
+from `teamster-332318.kipptaf_marts.__TABLES__`
+where
+  table_id in (
+    'bridge_survey_expectations',
+    'fct_survey_submissions',
+    'fct_student_attendance_daily',
+    'fct_survey_responses',
+    'dim_college_enrollments',
+    'dim_survey_administrations',
+    'fct_grades_assignments',
+    'fct_support_tickets',
+    'dim_staff_reporting_chain',
+    'dim_staff_work_history'
+  )
+order by table_id
+```
+
+Expected: 10 rows, every one `VIEW`, `row_count` 0 and `size_gb` 0 (a view
+stores nothing).
+
+- [ ] **Step 4: Write the baseline file**
+
+Write exactly this file, replacing each `VIEW` row's values with the query
+output from Step 3:
+
+```markdown
+# View mart table sweep — baseline
+
+Captured before the sweep. Refs
+[#5217](https://github.com/TEAMSchools/teamster/issues/5217).
+
+## Prod object types before the sweep
+
+| mart                           | object type | row count | size GB |
+| ------------------------------ | ----------- | --------: | ------: |
+| `bridge_survey_expectations`   | VIEW        |         0 |       0 |
+| `dim_college_enrollments`      | VIEW        |         0 |       0 |
+| `dim_staff_reporting_chain`    | VIEW        |         0 |       0 |
+| `dim_staff_work_history`       | VIEW        |         0 |       0 |
+| `dim_survey_administrations`   | VIEW        |         0 |       0 |
+| `fct_grades_assignments`       | VIEW        |         0 |       0 |
+| `fct_student_attendance_daily` | VIEW        |         0 |       0 |
+| `fct_support_tickets`          | VIEW        |         0 |       0 |
+| `fct_survey_responses`         | VIEW        |         0 |       0 |
+| `fct_survey_submissions`       | VIEW        |         0 |       0 |
+
+## Dev build sizes
+
+Filled by Task 4. A mart at 50 GB or more stops the merge and goes to the user.
+
+| mart | dev rows | dev size GB | verdict |
+| ---- | -------: | ----------: | ------- |
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep add docs/superpowers/plans/
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep commit -m "docs(superpowers): plan and baseline for the view mart table sweep
+
+Refs #5217
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Convert the 7 marts with no live reader
+
+These 7 have no `sql_table` pointing at them anywhere in `src/cube/model/` and
+no Tableau exposure, so nothing reads them today. They take the nightly cadence,
+which sits far below every one of their break-evens.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml`
+
+All paths are relative to
+`/workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/`.
+
+**Interfaces:**
+
+- Consumes: a parsing project from Task 1.
+- Produces: 7 marts configured `materialized: table` with
+  `cron_schedule: 0 3 * * *`, each with `warn_unenforced: false` on its
+  `primary_key` constraint. Task 4 builds them.
+
+- [ ] **Step 1: Add the config block to each of the 7 files**
+
+In each file, insert this block immediately BEFORE the line `    columns:` (4
+spaces of indent). The model-level key order the repo uses is `description:`,
+then `config:`, then `columns:` — matching
+`dimensions/properties/dim_assessments.yml`.
+
+```yaml
+config:
+  materialized: table
+  meta:
+    dagster:
+      # Nightly: every data test on this view recomputed it in full, and
+      # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+      # exposure reads this mart, so nightly clears its break-even with
+      # room to spare. Refs #5217
+      automation_condition:
+        cron_schedule: 0 3 * * *
+```
+
+Use Edit with `old_string` = `    columns:` and `new_string` = the block above
+followed by `    columns:`. The first `    columns:` occurrence is the
+model-level one in every file; confirm by checking the line number matches the
+table below before editing.
+
+| File                         | `    columns:` is at line |
+| ---------------------------- | ------------------------: |
+| `bridge_survey_expectations` |                        16 |
+| `fct_survey_submissions`     |                        18 |
+| `fct_survey_responses`       |                         9 |
+| `dim_college_enrollments`    |                         9 |
+| `dim_survey_administrations` |                         9 |
+| `fct_grades_assignments`     |                        19 |
+| `fct_support_tickets`        |                        12 |
+
+- [ ] **Step 2: Add `warn_unenforced: false` to each primary key constraint**
+
+A `config.materialized: table` mart renders its `constraints:` into the CREATE
+TABLE DDL, and dbt warns on an unenforced constraint unless told not to. Each of
+the 7 files has exactly one occurrence of this pair:
+
+```yaml
+constraints:
+  - type: primary_key
+    warn_unsupported: false
+```
+
+Change it to:
+
+```yaml
+constraints:
+  - type: primary_key
+    warn_unsupported: false
+    warn_unenforced: false
+```
+
+Verify exactly one occurrence per file first:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf/models/marts
+grep -c 'type: primary_key' \
+  bridges/properties/bridge_survey_expectations.yml \
+  facts/properties/fct_survey_submissions.yml \
+  facts/properties/fct_survey_responses.yml \
+  facts/properties/fct_grades_assignments.yml \
+  facts/properties/fct_support_tickets.yml \
+  dimensions/properties/dim_survey_administrations.yml \
+  dimensions/properties/dim_college_enrollments.yml
+```
+
+Expected: `1` for all 7 files.
+
+- [ ] **Step 3: Verify the config landed on all 7**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf/models/marts
+grep -l 'cron_schedule: 0 3 \* \* \*' */properties/*.yml | sort
+```
+
+Expected: exactly these 7 paths, and no others:
+
+```text
+bridges/properties/bridge_survey_expectations.yml
+dimensions/properties/dim_college_enrollments.yml
+dimensions/properties/dim_survey_administrations.yml
+facts/properties/fct_grades_assignments.yml
+facts/properties/fct_support_tickets.yml
+facts/properties/fct_survey_responses.yml
+facts/properties/fct_survey_submissions.yml
+```
+
+- [ ] **Step 4: Parse to prove the YAML is valid and the config is picked up**
+
+```bash
+uv run dbt parse --no-partial-parse \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf
+```
+
+Expected: exits 0. A YAML indentation error in the inserted block fails here
+with a parse error naming the file.
+
+- [ ] **Step 5: Confirm dbt resolved the materialization, not just the YAML**
+
+```bash
+uv run dbt ls --resource-type model --output json \
+  --select bridge_survey_expectations fct_survey_submissions fct_survey_responses \
+    fct_grades_assignments fct_support_tickets dim_survey_administrations \
+    dim_college_enrollments \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf \
+  2>/dev/null | grep '^{' | uv run python -c \
+  "import sys, json; [print(json.loads(line)['name'], json.loads(line)['config']['materialized']) for line in sys.stdin]"
+```
+
+Expected: 7 lines, each ending in `table`. `dbt ls --output json` interleaves
+log lines with JSON records, which is why the output is filtered through
+`grep '^{'`.
+
+- [ ] **Step 6: Lint**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml \
+  src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml \
+  src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml \
+  </dev/null
+```
+
+Expected: `✔ No issues`. If prettier reports "Incorrect formatting", run
+`/workspaces/teamster/.trunk/tools/trunk fmt <same files> </dev/null` and re-run
+the check.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep add -u
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep commit -m "perf(dbt): materialize the 7 unread survey and grades marts as nightly tables
+
+Every data test on a view mart recomputes the view. These 7 have no Cube or
+Tableau reader, so nightly clears each one's break-even.
+
+Refs #5217
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Convert the 3 marts Cube reads
+
+These 3 have live readers, so they take the intraday tick the assessment marts
+already use. `fct_student_attendance_daily` anchors topline Total Enrollment;
+`dim_staff_reporting_chain` is queried once per Cube user session to build the
+PII access scope; `dim_staff_work_history` backs the `staff_work_history` cube.
+
+**Files:**
+
+- Modify:
+  `src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml`
+- Modify:
+  `src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml`
+
+**Interfaces:**
+
+- Consumes: a parsing project from Task 2.
+- Produces: 3 marts configured `materialized: table` with
+  `cron_schedule: 0 0,10,13,15,17 * * *`. Task 4 builds all 10 together.
+
+- [ ] **Step 1: Add the config block to `fct_student_attendance_daily.yml`**
+
+Insert immediately BEFORE the line `    columns:` at line 28:
+
+```yaml
+config:
+  materialized: table
+  meta:
+    dagster:
+      # 5x/day, matching the assessment marts. Cube's student_enrollments
+      # and student_attendance cubes read this mart and anchor topline
+      # Total Enrollment, so it needs the intraday tick. That is above its
+      # own break-even (prod 1.7 to 7.9 slot hours a week), accepted
+      # because the CI column drops 90.5 to about 21. Refs #5217
+      automation_condition:
+        cron_schedule: 0 0,10,13,15,17 * * *
+```
+
+- [ ] **Step 2: Add the config block to `dim_staff_work_history.yml`**
+
+This file has a model-level `data_tests:` at line 9 and no `config:` block.
+Insert immediately BEFORE the line `    data_tests:`, so the key order stays
+`description:`, `config:`, `data_tests:`, `columns:`:
+
+```yaml
+config:
+  materialized: table
+  meta:
+    dagster:
+      # 5x/day, matching the assessment marts. The staff_work_history cube
+      # reads this mart. Refs #5217
+      automation_condition:
+        cron_schedule: 0 0,10,13,15,17 * * *
+```
+
+- [ ] **Step 3: Extend the EXISTING config block in
+      `dim_staff_reporting_chain.yml`**
+
+This file already has a `config:` block at line 21 carrying
+`contract: enforced: false`. Do NOT add a second `config:` key — a duplicate
+mapping key is invalid YAML. Edit the existing block.
+
+Replace:
+
+```yaml
+config:
+  # WITH RECURSIVE is incompatible with the contract-validation subquery
+  # wrapper; orphan detection is preserved via the relationships tests below.
+  contract:
+    enforced: false
+```
+
+With:
+
+```yaml
+config:
+  materialized: table
+  # WITH RECURSIVE is incompatible with the contract-validation subquery
+  # wrapper; orphan detection is preserved via the relationships tests below.
+  # The CTAS wrapper is fine with recursion — int_illuminate__root_standards
+  # is WITH RECURSIVE plus materialized: table in prod.
+  contract:
+    enforced: false
+  meta:
+    dagster:
+      # 5x/day, matching the assessment marts. cube.js queries this mart
+      # once per user session to build the PII access scope, at 16.1 slot
+      # minutes a call as a view. Refs #5217
+      automation_condition:
+        cron_schedule: 0 0,10,13,15,17 * * *
+```
+
+- [ ] **Step 4: Add `warn_unenforced: false` where a primary key constraint
+      exists**
+
+`fct_student_attendance_daily.yml` and `dim_staff_work_history.yml` each have
+exactly one `- type: primary_key` block. Change each from:
+
+```yaml
+constraints:
+  - type: primary_key
+    warn_unsupported: false
+```
+
+to:
+
+```yaml
+constraints:
+  - type: primary_key
+    warn_unsupported: false
+    warn_unenforced: false
+```
+
+`dim_staff_reporting_chain.yml` has NO `primary_key` constraint — it uses a
+model-level `dbt_utils.unique_combination_of_columns` on
+`(manager_staff_key, reportee_staff_key)` instead. Do not add a constraint to
+it. Confirm:
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf/models/marts
+grep -c 'type: primary_key' \
+  facts/properties/fct_student_attendance_daily.yml \
+  dimensions/properties/dim_staff_work_history.yml \
+  dimensions/properties/dim_staff_reporting_chain.yml
+```
+
+Expected: `1`, `1`, `0` in that order.
+
+- [ ] **Step 5: Verify all 10 marts now carry a cron, and no others changed**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf/models/marts
+grep -l 'materialized: table' */properties/*.yml | sort
+```
+
+Expected: 21 paths — the 11 that were already tables (`dim_assessments`,
+`dim_assessment_administrations`, `dim_courses`, `dim_dates`, `dim_regions`,
+`dim_staff`, `dim_students`, `bridge_assessment_expectations_enrollment_scoped`,
+`bridge_assessment_expectations_student_scoped`,
+`fct_assessment_scores_enrollment_scoped`,
+`fct_assessment_scores_student_scoped`) plus the 10 from Tasks 2 and 3.
+
+- [ ] **Step 6: Parse**
+
+```bash
+uv run dbt parse --no-partial-parse \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf
+```
+
+Expected: exits 0. A duplicate `config:` key in `dim_staff_reporting_chain.yml`
+fails here — that is the specific mistake Step 3 guards against.
+
+- [ ] **Step 7: Lint**
+
+```bash
+cd /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep
+/workspaces/teamster/.trunk/tools/trunk check --force --no-fix \
+  src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml \
+  src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml \
+  src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml \
+  </dev/null
+```
+
+Expected: `✔ No issues`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep add -u
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep commit -m "perf(dbt): materialize the 3 Cube-read marts on the assessment tick
+
+Cube reads all 3, so they take the intraday cadence rather than nightly.
+cube.js queries dim_staff_reporting_chain once per user session, which as a
+view recomputed a recursive closure at 16.1 slot minutes a call.
+
+Refs #5217
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Sizing gate — build all 10 into the dev schema and measure
+
+This is the merge gate. `bridge_survey_expectations` is a scaffold with a
+`cross join` to every contact person: as a view that costs compute, as a table
+it costs storage permanently. Nothing merges until each table's real size is on
+record.
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/baseline-2026-09-11.md` (fill the
+  `## Dev build sizes` table)
+
+**Interfaces:**
+
+- Consumes: the 10 configured marts from Tasks 2 and 3.
+- Produces: a row count and byte size per mart, and a go or no-go per mart.
+
+- [ ] **Step 1: Build all 10 into the dev schema**
+
+```bash
+uv run dbt build \
+  --select bridge_survey_expectations fct_survey_submissions fct_survey_responses \
+    fct_grades_assignments fct_support_tickets dim_survey_administrations \
+    dim_college_enrollments fct_student_attendance_daily dim_staff_work_history \
+    dim_staff_reporting_chain \
+  --target dev --defer --favor-state \
+  --state /workspaces/teamster/src/dbt/kipptaf/target/prod \
+  --project-dir /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep/src/dbt/kipptaf
+```
+
+4 things about this command:
+
+1. `--state` is ABSOLUTE and points at the MAIN checkout. The relative form
+   resolves under the worktree, which has no `target/prod/`, and fails with
+   "Could not find manifest".
+2. `--favor-state` resolves every unselected upstream to prod, so a stale
+   personal dev copy cannot shadow the build.
+3. No `--empty`. It would rebuild each selected relation as `limit 0` and the
+   Step 3 measurement would read 0 rows.
+4. This build costs roughly 2.5 slot hours in total. That is expected — it is
+   one full computation of each view, which is exactly the number being
+   measured.
+
+Expected: `Completed successfully`, with `CREATE TABLE` (not `CREATE VIEW`) in
+each model's log line. A data test that fails here is diagnostic, not blocking —
+record it and continue to Step 2. The marts `foreign_key` deferral trap does not
+apply: none of the 10 carries a real FK constraint.
+
+- [ ] **Step 2: Find the dev dataset the build actually wrote to**
+
+```sql
+select schema_name
+from `teamster-332318`.INFORMATION_SCHEMA.SCHEMATA
+where schema_name like 'zz_%kipptaf_marts'
+```
+
+Expected: `zz_cbini_kipptaf_marts`. Local dev builds land in
+`zz_<GITHUB_USER>_<project>_<schema>`, not the shipped `zz_dagster_*` schema.
+Use whatever this query returns in Step 3.
+
+- [ ] **Step 3: Measure row count and size**
+
+```sql
+select
+  table_id,
+  if(type = 1, 'TABLE', 'VIEW') as object_type,
+  row_count,
+  round(size_bytes / pow(1024, 3), 3) as size_gb,
+from `teamster-332318.zz_cbini_kipptaf_marts.__TABLES__`
+where
+  table_id in (
+    'bridge_survey_expectations',
+    'fct_survey_submissions',
+    'fct_student_attendance_daily',
+    'fct_survey_responses',
+    'dim_college_enrollments',
+    'dim_survey_administrations',
+    'fct_grades_assignments',
+    'fct_support_tickets',
+    'dim_staff_reporting_chain',
+    'dim_staff_work_history'
+  )
+order by size_gb desc
+```
+
+Expected: 10 rows, every `object_type` = `TABLE`. Any row still reading `VIEW`
+means that model's `materialized: table` did not take — go back to Task 2 or 3
+for it.
+
+`__TABLES__.row_count` can lag and read 0 right after a build. If any row reads
+0, re-run this query once before treating it as real. Do NOT fall back to
+`count(*)` on the prod view; if a dev count is genuinely needed, run
+`select count(*) from zz_cbini_kipptaf_marts.<model>` against the dev TABLE,
+which is cheap because it is a table.
+
+- [ ] **Step 4: Apply the go or no-go rule per mart**
+
+Record every result. Then, for each mart:
+
+- Under 50 GB: proceed.
+- 50 GB or more: stop and report that mart to the user before merging. Do not
+  silently drop it — name it, give its size, and ask whether to keep it as a
+  view. `bridge_survey_expectations` is the one most likely to trip this.
+
+- [ ] **Step 5: Fill in the baseline file and commit**
+
+Write the 10 measured rows into the `## Dev build sizes` table in
+`docs/superpowers/plans/baseline-2026-09-11.md`, then:
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep add -u
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep commit -m "docs(superpowers): record dev build sizes for the 10 converted marts
+
+Refs #5217
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Push, open the pull request, and clear CI
+
+**Files:**
+
+- Create: nothing. This task pushes Tasks 1 through 4.
+
+**Interfaces:**
+
+- Consumes: 4 commits on `cbini/perf/claude-view-mart-table-sweep`.
+- Produces: an open PR with green dbt Cloud CI.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C /workspaces/teamster/.worktrees/cbini/perf/claude-view-mart-table-sweep push
+```
+
+The branch already tracks `origin/cbini/perf/claude-view-mart-table-sweep` from
+`gh issue develop`, so a bare `push` is correct here.
+
+- [ ] **Step 2: Open the PR**
+
+Use `mcp__github__create_pull_request` with `base: main`,
+`head: cbini/perf/claude-view-mart-table-sweep`, and title
+`perf(dbt): materialize the 10 costliest view marts as cron tables`.
+
+The body below keeps every line `.github/pull_request_template.md` supplies and
+answers its prompts in place, per that template's own instruction. Do not
+hard-wrap it — GitHub renders every newline as a line break. Do NOT
+`gh project item-add` the PR; the `Closes #5217` ref puts it on the board.
+
+Fill the 3 bracketed values from Task 4's measurements before posting.
+
+```markdown
+## Summary & Motivation
+
+When merged, this pull request will make 10 dbt marts build as tables on a cron
+schedule instead of as views.
+
+Every data test on a view mart recomputes that whole view before it can check
+anything. These 10 marts cost 936 slot hours a week that way, which is 32% of
+all warehouse compute in the project. As tables, their tests read a table
+instead.
+
+Expected result: prod drops from 94 to 38 slot hours a week, and dbt Cloud CI
+from 818 to about 263. That is about 610 slot hours a week.
+
+No model SQL changes, so surrogate keys and row sets stay identical.
+
+## Reviewer Notes
+
+`fct_student_attendance_daily` knowingly costs more in prod, 1.7 to 7.9 slot
+hours a week. Cube's enrollment count reads it and needs the 5x/day tick, which
+is above its own break-even. Its CI column drops 90.5 to about 21, so it still
+wins overall.
+
+The 2 cadences are derived, not picked. The 7 marts with no Cube or Tableau
+reader get `0 3 * * *`. The 3 Cube reads get `0 0,10,13,15,17 * * *`, the same
+tick the assessment marts use.
+
+`dim_staff_reporting_chain` uses `WITH RECURSIVE`. That is fine in a table —
+`int_illuminate__root_standards` already ships as `WITH RECURSIVE` plus
+`materialized: table`.
+
+Largest new table: [NAME] at [N] GB, [N] rows. Full sizes in
+`docs/superpowers/plans/baseline-2026-09-11.md`.
+
+This migration needs one ordered Dagster run after merge, selecting all 10
+assets together. A config-only yml change does not bump `code_version`, so the
+sensor will not pick these up on its own, and view to table drops the view
+before it creates the table.
+
+## Self-review
+
+### General
+
+- [x] Update **due date** and **assignee** on the
+      [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
+- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid
+      feedback; dismiss false positives with a brief reply explaining why.
+      (Claude is advisory — use your judgement, but don't ignore it.)
+
+### Dagster _(skip if no Dagster changes)_
+
+No Dagster code changes. The cron cadences are dbt `meta.dagster` config read by
+the existing translator.
+
+### dbt _(skip if no dbt changes)_
+
+- [x] Include a `[model_name].yml` properties file for all new models — see
+      [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
+- [x] Include (or update) an
+      [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures)
+      for all models consumed by a dashboard, analysis, or application
+- [x] **Breaking change?** No columns renamed or removed. Materialization only.
+- [x] If adding or modifying an external source, run `stage_external_sources`
+      with **`--target staging`** so the dbt Cloud CI job can find the table. No
+      external sources touched.
+
+### Docs _(skip if no schedule, sensor, or integration changes)_
+
+No schedule or sensor added. Automation conditions on dbt models are not in the
+automations catalog.
+
+## CI checks
+
+- [ ] **Trunk** — passes.
+- [ ] **dbt Cloud** — passes.
+- [ ] **Dagster Cloud** — passes or not triggered.
+
+Closes #5217
+
+<details>
+<summary>For Claude</summary>
+
+Claude-assisted, human-directed. Design doc:
+`docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md`. Plan:
+`docs/superpowers/plans/2026-09-11-view-mart-table-sweep.md`.
+
+Two mechanisms drove the cost, and the table conversion fixes both. CI's
+`state:modified+` pulls these marts into nearly every PR, which is 818 of the
+936 hours. In prod the child views never rebuild at all, yet their tests run 128
+times a week each, because dbt's default `--indirect-selection=eager` selects a
+test when ANY parent is selected and `dim_staff` rebuilds 192 times a week.
+
+Setting `--indirect-selection=cautious` at
+`src/teamster/libraries/dbt/assets.py:112` was considered and rejected. It would
+remove 72.3 of the 117.5 weekly prod test slot hours, but it does nothing for
+CI, it is repo-wide across all 5 code locations, and it trades away parent-side
+FK orphan detection on every view mart.
+
+All 10 already declared FKs as `config.meta.foreign_key`, not real
+`constraints`, so the #4821 migration needed no work here. `git log -S`
+confirmed zero prior `materialized: table` or `cron_schedule` commits on all 10,
+so this is not a re-attempt of the #4464 change that #4587 reverted.
+
+Do not run `count(*)` against these views. One attempt over 4 of them consumed
+100,540 slot minutes and failed with `billingTierLimitExceeded`.
+
+</details>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Watch dbt Cloud CI**
+
+```bash
+gh pr checks <PR_NUMBER> --json name,bucket,state
+```
+
+Expected: all buckets `pass`. CI runs
+`dbt build --select state:modified+ --full-refresh` against `target: staging`.
+
+This PR modifies 10 marts, so `state:modified+` will pull in their whole
+descendant graph. Per `src/dbt/kipptaf/CLAUDE.md`, expect latent
+`severity: error` failures unrelated to this change on models CI has never
+built. Before assuming this change caused one, query prod for the same
+condition.
+
+- [ ] **Step 4: Confirm CI built them as tables, not views**
+
+```sql
+select table_name, table_type
+from `teamster-332318`.`region-us`.INFORMATION_SCHEMA.TABLES
+where
+  table_schema like 'dbt_cloud_pr_%_marts'
+  and table_name in (
+    'bridge_survey_expectations',
+    'fct_survey_submissions',
+    'fct_student_attendance_daily',
+    'fct_survey_responses',
+    'dim_college_enrollments',
+    'dim_survey_administrations',
+    'fct_grades_assignments',
+    'fct_support_tickets',
+    'dim_staff_reporting_chain',
+    'dim_staff_work_history'
+  )
+```
+
+Expected: 10 rows, every `table_type` = `BASE TABLE`.
+
+- [ ] **Step 5: Process review findings**
+
+If `claude-review` posts findings, invoke `superpowers:receiving-code-review`
+before acting on them, and post a per-finding verdict as a PR comment. For
+everything else about CI and review, invoke `pr-ci-review`.
+
+---
+
+### Task 6: Finish the prod migration with one ordered run
+
+This is the step that #4464 got wrong and #4587 reverted. A config-only
+properties yml change does not bump `code_version` (a SHA1 of raw SQL), so the
+automation sensor never selects these models on deploy. View to table also DROPS
+the view before it creates the table, so leaving it to the sensor leaves
+relations MISSING from prod rather than stale.
+
+Do not start this task until the PR is squash-merged to `main`.
+
+**Files:**
+
+- Create: nothing. This task runs against prod through Dagster.
+
+**Interfaces:**
+
+- Consumes: the merged change on `main`.
+- Produces: all 10 relations existing in `kipptaf_marts` as tables.
+
+- [ ] **Step 1: Confirm the merge deployed**
+
+```bash
+gh run list --workflow deploy-prod-kipptaf.yaml --limit 3
+```
+
+Expected: the most recent run for the merge commit shows `completed success`.
+The Dagster code location must reload before it knows these are table assets.
+
+- [ ] **Step 2: Preview the run**
+
+Use `mcp__dagster__launch_run` with `confirm=False` first. Every Dagster
+mutation tool previews on `confirm=False` and only executes on `confirm=True`.
+
+Select all 10 assets in ONE run:
+
+```text
+kipptaf/marts/bridge_survey_expectations
+kipptaf/marts/fct_survey_submissions
+kipptaf/marts/fct_survey_responses
+kipptaf/marts/fct_grades_assignments
+kipptaf/marts/fct_support_tickets
+kipptaf/marts/dim_survey_administrations
+kipptaf/marts/dim_college_enrollments
+kipptaf/marts/fct_student_attendance_daily
+kipptaf/marts/dim_staff_work_history
+kipptaf/marts/dim_staff_reporting_chain
+```
+
+This key format is verified: `mcp__dagster__search_assets` with
+`prefix: kipptaf/marts` returns keys shaped
+`["kipptaf", "marts", "<model_name>"]`.
+
+One run is one `dbt build`, which dbt topologically sorts — that ordering is the
+whole point of this task. Ten separate runs would reproduce the #4464 failure.
+
+Each asset also carries a `dagster/materialized` tag whose value is `view` or
+`table`. Before launching, run `mcp__dagster__search_assets` with
+`prefix: kipptaf/marts` and confirm all 10 already read `table` — that proves
+the code location reloaded with the merged config. If any still reads `view`,
+the deploy in Step 1 has not taken effect yet; wait and re-check rather than
+launching.
+
+- [ ] **Step 3: Launch the run**
+
+Re-issue the same `mcp__dagster__launch_run` call with `confirm=True`.
+
+- [ ] **Step 4: Verify every relation exists and is a table**
+
+```sql
+select
+  table_id,
+  if(type = 1, 'TABLE', 'VIEW') as object_type,
+  row_count,
+  round(size_bytes / pow(1024, 3), 3) as size_gb,
+  timestamp_millis(last_modified_time) as last_modified,
+from `teamster-332318.kipptaf_marts.__TABLES__`
+where
+  table_id in (
+    'bridge_survey_expectations',
+    'fct_survey_submissions',
+    'fct_student_attendance_daily',
+    'fct_survey_responses',
+    'dim_college_enrollments',
+    'dim_survey_administrations',
+    'fct_grades_assignments',
+    'fct_support_tickets',
+    'dim_staff_reporting_chain',
+    'dim_staff_work_history'
+  )
+order by table_id
+```
+
+Expected: 10 rows, every `object_type` = `TABLE`, every `last_modified` from
+this run, and `row_count` matching Task 4's dev measurement within normal daily
+drift.
+
+A mart MISSING from this result is the #4464 failure signature — absence, not
+staleness. If any is missing, re-run Step 3 selecting only the missing assets
+and read the run logs with `mcp__dagster__get_run_logs`.
+
+- [ ] **Step 5: Confirm Cube's PII scope still resolves**
+
+`src/cube/cube.js:145` runs this per user session. Run it against a manager who
+is known to have direct reports:
+
+```sql
+select count(*) as n_reportees
+from `teamster-332318.kipptaf_marts.dim_staff_reporting_chain`
+where manager_staff_key = @k
+```
+
+Pick `@k` by taking any `manager_staff_key` that appears with more than 1
+distinct `reportee_staff_key`. Expected: a non-zero count. A zero here means
+Cube denies that manager PII access as if they had no downline.
+
+- [ ] **Step 6: Measure the result after 7 days**
+
+Do not run this immediately — it needs a full week of prod and CI activity to
+compare against the spec's projection.
+
+```sql
+with names as (
+  select
+    [
+      'bridge_survey_expectations', 'fct_survey_submissions',
+      'fct_student_attendance_daily', 'fct_survey_responses',
+      'dim_college_enrollments', 'dim_survey_administrations',
+      'fct_grades_assignments', 'fct_support_tickets',
+      'dim_staff_reporting_chain', 'dim_staff_work_history'
+    ] as arr
+),
+j as (
+  select
+    regexp_replace(
+      regexp_replace(
+        json_value(
+          regexp_extract(query, r'^/\* (\{.*?\}) \*/'), '$.node_id'
+        ),
+        r'^test\.kipptaf\.', ''
+      ),
+      r'__ref_.*$', ''
+    ) as tname,
+    json_value(
+      regexp_extract(query, r'^/\* (\{.*?\}) \*/'), '$.target_name'
+    ) as target,
+    total_slot_ms,
+  from `region-us`.INFORMATION_SCHEMA.JOBS_BY_PROJECT
+  where
+    creation_time >= timestamp_sub(current_timestamp(), interval 7 day)
+    and query like '%"node_id"%'
+    and total_slot_ms > 0
+)
+select
+  (
+    select n
+    from unnest(names.arr) as n with offset o
+    where strpos(j.tname, n) > 0
+    order by o
+    limit 1
+  ) as mart,
+  round(sum(if(target = 'prod', total_slot_ms, 0)) / 1000 / 60 / 60, 1) as prod_hr,
+  round(
+    sum(if(target = 'staging', total_slot_ms, 0)) / 1000 / 60 / 60, 1
+  ) as ci_hr,
+from j
+cross join names
+group by mart
+having mart is not null
+order by prod_hr + ci_hr desc
+```
+
+Expected: prod near 38 and CI near 263 slot hours, against 94 and 818 before.
+The `__ref_.*$` strip is required — without it a `relationships` test is
+attributed to its FK target instead of the mart it tests.
+
+Post the result as a comment on issue
+[#5212](https://github.com/TEAMSchools/teamster/issues/5212), the parent issue
+tracking warehouse slot time.

--- a/docs/superpowers/plans/baseline-2026-09-11.md
+++ b/docs/superpowers/plans/baseline-2026-09-11.md
@@ -34,3 +34,35 @@ Filled by Task 4. A mart at 50 GB or more stops the merge and goes to the user.
 | `dim_staff_reporting_chain`    |     9322 |       0.001 | proceed |
 | `dim_college_enrollments`      |     1388 |       0.000 | proceed |
 | `dim_survey_administrations`   |       57 |       0.000 | proceed |
+
+## Primary keys the data violated, and the grain fix
+
+The dev build above surfaced 3 marts whose `primary_key` constraint their data
+contradicted. On a view that constraint was inert. `materialized: table` renders
+it into real DDL, and BigQuery documents that "queries over tables with violated
+constraints might return incorrect results" — the optimizer uses unenforced keys
+for join elimination and reordering.
+
+Two of the 3 shared one root cause. `int_surveys__manager_survey_details` is
+question-grain, and the `historic_archive_submissions` CTE in
+`fct_survey_submissions` read it without projecting to submission grain. The
+historic Alchemer archive therefore emitted 18 rows per submission (17 questions
+plus a null-question row), colliding 2,559 `survey_submission_key` values.
+`fct_survey_responses` inner-joins `fct_survey_submissions` on that key, so
+every one of its response rows fanned out 18x in turn.
+
+The fix adds the same `dbt_utils.deduplicate` projection that
+`manager_subject_overlay` already applies to the same source, 40 lines earlier
+in the same model. It is information-preserving: every column the CTE selects is
+constant within `(survey_id, effective_survey_response_id)` across all 2,559
+archive submissions, verified before the change.
+
+| mart                     | rows before | rows after |   delta | PK test |
+| ------------------------ | ----------: | ---------: | ------: | ------- |
+| `fct_survey_submissions` |       92459 |      48956 |  -43503 | PASS    |
+| `fct_survey_responses`   |     1363717 |     580663 | -783054 | PASS    |
+
+`fct_grades_assignments` is the remaining violated PK, about 71 duplicate keys.
+Its cause is unrelated — `stg_powerschool__cc` double-writes, tracked upstream
+in [#3915](https://github.com/TEAMSchools/teamster/issues/3915) — and it is out
+of scope here.

--- a/docs/superpowers/plans/baseline-2026-09-11.md
+++ b/docs/superpowers/plans/baseline-2026-09-11.md
@@ -37,13 +37,13 @@ Filled by Task 4. A mart at 50 GB or more stops the merge and goes to the user.
 
 ## Primary keys the data violated, and the grain fix
 
-The dev build above surfaced 3 marts whose `primary_key` constraint their data
+The dev build above surfaced 2 marts whose `primary_key` constraint their data
 contradicted. On a view that constraint was inert. `materialized: table` renders
 it into real DDL, and BigQuery documents that "queries over tables with violated
 constraints might return incorrect results" — the optimizer uses unenforced keys
 for join elimination and reordering.
 
-Two of the 3 shared one root cause. `int_surveys__manager_survey_details` is
+Both shared one root cause. `int_surveys__manager_survey_details` is
 question-grain, and the `historic_archive_submissions` CTE in
 `fct_survey_submissions` read it without projecting to submission grain. The
 historic Alchemer archive therefore emitted 18 rows per submission (17 questions
@@ -62,7 +62,9 @@ archive submissions, verified before the change.
 | `fct_survey_submissions` |       92459 |      48956 |  -43503 | PASS    |
 | `fct_survey_responses`   |     1363717 |     580663 | -783054 | PASS    |
 
-`fct_grades_assignments` is the remaining violated PK, about 71 duplicate keys.
-Its cause is unrelated — `stg_powerschool__cc` double-writes, tracked upstream
-in [#3915](https://github.com/TEAMSchools/teamster/issues/3915) — and it is out
-of scope here.
+No violated primary key remains in this batch. `fct_grades_assignments` carries
+an in-file `TODO` citing 71 residual duplicate keys, but that is a stale
+artifact: [#4017](https://github.com/TEAMSchools/teamster/issues/4017) is
+closed, its PK test passed in the dev build, and the table measures 23,437,020
+rows against 23,437,020 distinct keys. All 9 primary-key constraints in this
+batch are satisfied by their data.

--- a/docs/superpowers/plans/baseline-2026-09-11.md
+++ b/docs/superpowers/plans/baseline-2026-09-11.md
@@ -1,0 +1,26 @@
+# View mart table sweep — baseline
+
+Captured before the sweep. Refs
+[#5217](https://github.com/TEAMSchools/teamster/issues/5217).
+
+## Prod object types before the sweep
+
+| mart                           | object type | row count | size GB |
+| ------------------------------ | ----------- | --------: | ------: |
+| `bridge_survey_expectations`   | VIEW        |         0 |       0 |
+| `dim_college_enrollments`      | VIEW        |         0 |       0 |
+| `dim_staff_reporting_chain`    | VIEW        |         0 |       0 |
+| `dim_staff_work_history`       | VIEW        |         0 |       0 |
+| `dim_survey_administrations`   | VIEW        |         0 |       0 |
+| `fct_grades_assignments`       | VIEW        |         0 |       0 |
+| `fct_student_attendance_daily` | VIEW        |         0 |       0 |
+| `fct_support_tickets`          | VIEW        |         0 |       0 |
+| `fct_survey_responses`         | VIEW        |         0 |       0 |
+| `fct_survey_submissions`       | VIEW        |         0 |       0 |
+
+## Dev build sizes
+
+Filled by Task 4. A mart at 50 GB or more stops the merge and goes to the user.
+
+| mart | dev rows | dev size GB | verdict |
+| ---- | -------: | ----------: | ------- |

--- a/docs/superpowers/plans/baseline-2026-09-11.md
+++ b/docs/superpowers/plans/baseline-2026-09-11.md
@@ -22,5 +22,15 @@ Captured before the sweep. Refs
 
 Filled by Task 4. A mart at 50 GB or more stops the merge and goes to the user.
 
-| mart | dev rows | dev size GB | verdict |
-| ---- | -------: | ----------: | ------- |
+| mart                           | dev rows | dev size GB | verdict |
+| ------------------------------ | -------: | ----------: | ------- |
+| `fct_grades_assignments`       | 23437020 |       4.073 | proceed |
+| `fct_student_attendance_daily` | 12603324 |       2.430 | proceed |
+| `fct_survey_responses`         |  1363717 |       0.217 | proceed |
+| `fct_support_tickets`          |   299447 |       0.096 | proceed |
+| `bridge_survey_expectations`   |   170426 |       0.017 | proceed |
+| `fct_survey_submissions`       |    92459 |       0.013 | proceed |
+| `dim_staff_work_history`       |    29964 |       0.008 | proceed |
+| `dim_staff_reporting_chain`    |     9322 |       0.001 | proceed |
+| `dim_college_enrollments`      |     1388 |       0.000 | proceed |
+| `dim_survey_administrations`   |       57 |       0.000 | proceed |

--- a/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
+++ b/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
@@ -127,12 +127,23 @@ The result is 2 cadences, but each is derived rather than assumed. Daily
 `0 3 * * *` goes to the 7 marts with no live reader. The assessment-mart tick
 `0 0,10,13,15,17 * * *` goes to the 3 that Cube reads.
 
-Every daily model sits far below its break-even. One model does not:
+Build minutes above are rounded for display while break-even is computed from
+the unrounded value, so a few rows do not reproduce exactly from the printed
+columns. `dim_college_enrollments` is the widest gap, 183/wk against 201/wk from
+the rounded 4m. No row is close enough to its cadence for the rounding to change
+a decision.
 
-**`fct_student_attendance_daily` knowingly regresses in prod**, 1.7 to 7.9 slot
+4 of the 7 daily models sit far below their break-even. The other 3 —
+`fct_survey_responses`, `dim_survey_administrations` and
+`fct_grades_assignments` — have no break-even to clear: they cost 0.0 prod slot
+hours today, so a nightly cron is a pure prod add of 6.1 slot hours a week
+between them. They are justified by their CI column alone, which is 181.4 hours
+a week combined.
+
+**`fct_student_attendance_daily` knowingly costs more in prod**, 1.7 to 7.9 slot
 hours a week, because 35 builds a week exceeds its 8/wk break-even. Its Cube
 consumer anchors topline Total Enrollment and needs the intraday tick. Its CI
-column drops from 90.5 to about 20, so the model is net negative overall.
+column drops from 90.5 to about 21, so the model still reduces total cost.
 
 ### Expected result
 
@@ -173,6 +184,14 @@ The other 7 have no `sql_table` pointing at them anywhere in `src/cube/model/`.
 They appear only in the `cube.yml` exposure `depends_on`, which covers the
 semantic layer as a whole. No Tableau exposure references any of the 10, so no
 Tableau refresh cron sets a freshness floor on this batch.
+
+That inventory method — grep `src/cube/model/` for `sql_table`, plus Tableau
+exposures — finds external consumers and misses in-dbt ones by construction.
+`fct_student_attendance_daily` has one: `rpt_branchingminds__daily_attendance`
+reads it and feeds a vendor SFTP job at `0 3 * * *`. The conclusion survives,
+because that mart took the intraday tick anyway and none of the other 7 has a
+downstream dbt model outside this batch. But "no reader" here means no reader
+found by that method, not no reader.
 
 `dim_staff_reporting_chain` deserves separate attention. `cube.js` runs
 `SELECT reportee_staff_key FROM kipptaf_marts.dim_staff_reporting_chain WHERE manager_staff_key = @k`
@@ -234,6 +253,39 @@ Between the view drop and the table create, `cube.js` resolves an empty reportee
 set and denies PII access as if the manager had no downline. Convert it in the
 same ordered run and confirm the relation exists before the next Cube session.
 
+### Cron cadence degrades FK orphan detection, and the repo has hit this before
+
+A view mart is recomputed at test time, so a `relationships` test compares a
+child derived from current upstream data against a parent rebuilt moments
+earlier. The two are structurally in sync. A cron table is a snapshot instead —
+up to 24 hours old for the nightly 7, about 5 for the intraday 3 — while its FK
+parents stay eager. `dim_staff` rebuilds 192 times a week. Every key it drops
+between child ticks leaves the stale child referencing it, and the test reports
+an orphan that is a cadence artifact rather than a data defect.
+
+This is the failure `dim_assessments` already hit. Its properties yml records
+being raised from nightly to 5x/day under
+[#4559](https://github.com/TEAMSchools/teamster/issues/4559) precisely to close
+a skew window against `dim_assessment_administrations`. This change reintroduces
+that shape at larger scale and does not apply the same remedy, because the 7
+nightly marts have no consumer that justifies the extra builds.
+
+Nothing breaks: these tests are `severity: warn` by the project default. The
+cost is signal quality, and it lands on top of the orphan failures already
+tracked for `fct_student_attendance_daily` in
+[#4229](https://github.com/TEAMSchools/teamster/issues/4229), making that class
+harder to triage rather than easier. The 7-day follow-up measurement should
+check whether orphan counts moved after the conversion, not only slot hours.
+
+### Student data becomes persisted at rest
+
+`fct_grades_assignments` (23.4M rows) and `fct_student_attendance_daily` (12.6M
+rows) are student-level education content under the repo's PII rules. As views
+they held no data; as tables they persist it in `kipptaf_marts`. That changes
+the IAM surface, and it means an upstream deletion is not reflected until the
+next cron tick. Neither is a reason not to proceed — every existing table mart
+carries the same property — but it is a new fact about this dataset.
+
 ### Recursion is not a blocker
 
 `dim_staff_reporting_chain` uses `WITH RECURSIVE`. That is compatible with a
@@ -269,8 +321,46 @@ tables, its savings on them evaporate.
 **The remaining 57 view marts.** Each costs at most 6.1 slot hours a week.
 Revisit only if the measurement in step 3 shows the tail grew.
 
-**`fct_survey_submissions` and `bridge_survey_expectations` SQL.** Both have
-shapes worth questioning, including the `cross join` scaffold and the near
-cartesian student enrollment join. This change does not touch model SQL, so
-hashes and row sets stay identical and the conversion is verifiable as a pure
-materialization change.
+**`bridge_survey_expectations` SQL.** Its `cross join` scaffold is worth
+questioning, but it measured 0.017 GB, so there is no cost argument for touching
+it here.
+
+**`fct_grades_assignments` duplicate keys.** About 71 duplicate
+`grades_assignment_key` values, caused by `stg_powerschool__cc` double-writes
+and tracked upstream in
+[#3915](https://github.com/TEAMSchools/teamster/issues/3915). It is the one
+remaining mart in this batch whose `primary_key` constraint its data
+contradicts.
+
+## Scope amendment: one SQL fix
+
+This change was scoped as materialization-only. It is not, by a deliberate
+decision taken after the dev build.
+
+The build surfaced 3 marts whose `primary_key` constraint their own data
+violates. That is harmless on a view, where constraints are inert, but
+`materialized: table` renders the constraint into DDL, and BigQuery documents
+that "queries over tables with violated constraints might return incorrect
+results" — the optimizer uses unenforced keys for join elimination and
+reordering. Shipping a table that declares a key 46,062 rows contradict is worse
+than shipping the view it replaces.
+
+2 of the 3 shared a single root cause, fixed here in about 20 lines of
+`fct_survey_submissions.sql`. `int_surveys__manager_survey_details` is
+question-grain; the `historic_archive_submissions` CTE read it without
+projecting to submission grain, so the historic Alchemer archive emitted 18 rows
+per submission and collided 2,559 `survey_submission_key` values.
+`fct_survey_responses` inner-joins on that key, so its rows fanned out 18x in
+turn. The fix applies the same `dbt_utils.deduplicate` projection that
+`manager_subject_overlay` already uses on the same source, 40 lines earlier in
+the same model, and is information-preserving — every column the CTE selects is
+constant within the partition across all 2,559 submissions.
+
+Row counts move as a result: `fct_survey_submissions` 92,459 to 48,956, and
+`fct_survey_responses` 1,363,717 to 580,663. Both PK uniqueness tests now pass.
+Measurements in `docs/superpowers/plans/baseline-2026-09-11.md`.
+
+The cost claims in this document are unaffected — they are measured from test
+slot time, not row counts — but the conversion is no longer verifiable as a pure
+materialization change, and the row deltas above are the thing to check after
+deploy.

--- a/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
+++ b/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
@@ -325,19 +325,19 @@ Revisit only if the measurement in step 3 shows the tail grew.
 questioning, but it measured 0.017 GB, so there is no cost argument for touching
 it here.
 
-**`fct_grades_assignments` duplicate keys.** About 71 duplicate
-`grades_assignment_key` values, caused by `stg_powerschool__cc` double-writes
-and tracked upstream in
-[#3915](https://github.com/TEAMSchools/teamster/issues/3915). It is the one
-remaining mart in this batch whose `primary_key` constraint its data
-contradicts.
+**`fct_grades_assignments`'s stale duplicate-key TODO.** The model carries an
+in-file `TODO` citing 71 residual duplicate keys from `stg_powerschool__cc`
+double-writes. The data no longer supports it —
+[#4017](https://github.com/TEAMSchools/teamster/issues/4017) is closed and the
+table measures 23,437,020 rows against 23,437,020 distinct keys — but removing a
+comment is a separate change from this one.
 
 ## Scope amendment: one SQL fix
 
 This change was scoped as materialization-only. It is not, by a deliberate
 decision taken after the dev build.
 
-The build surfaced 3 marts whose `primary_key` constraint their own data
+The build surfaced 2 marts whose `primary_key` constraint their own data
 violates. That is harmless on a view, where constraints are inert, but
 `materialized: table` renders the constraint into DDL, and BigQuery documents
 that "queries over tables with violated constraints might return incorrect
@@ -345,7 +345,7 @@ results" — the optimizer uses unenforced keys for join elimination and
 reordering. Shipping a table that declares a key 46,062 rows contradict is worse
 than shipping the view it replaces.
 
-2 of the 3 shared a single root cause, fixed here in about 20 lines of
+Both shared a single root cause, fixed here in about 20 lines of
 `fct_survey_submissions.sql`. `int_surveys__manager_survey_details` is
 question-grain; the `historic_archive_submissions` CTE read it without
 projecting to submission grain, so the historic Alchemer archive emitted 18 rows

--- a/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
+++ b/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
@@ -360,7 +360,14 @@ Row counts move as a result: `fct_survey_submissions` 92,459 to 48,956, and
 `fct_survey_responses` 1,363,717 to 580,663. Both PK uniqueness tests now pass.
 Measurements in `docs/superpowers/plans/baseline-2026-09-11.md`.
 
-The cost claims in this document are unaffected — they are measured from test
-slot time, not row counts — but the conversion is no longer verifiable as a pure
-materialization change, and the row deltas above are the thing to check after
-deploy.
+The prod and CI slot-hour claims in this document still hold — they are measured
+from test slot time before the fix, and the fix does not change how often a test
+runs. The per-model build minutes are now slightly stale for the 2 fixed marts,
+since `fct_survey_responses` processes less than half its former row count and
+gains a `group by`. That moves its break-even and its CI-after estimate in the
+cheaper direction, and it is nightly with no break-even to clear, so no cadence
+decision changes. The 7-day follow-up re-measures all of it anyway.
+
+What did change is the row sets. The conversion is no longer verifiable as a
+pure materialization change, so the row deltas above — not just object type and
+slot hours — are what to check after deploy.

--- a/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
+++ b/docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md
@@ -1,0 +1,276 @@
+# View mart table sweep
+
+Materialize the 10 costliest view marts as cron tables so their data tests stop
+recomputing the view.
+
+Issue: [#5217](https://github.com/TEAMSchools/teamster/issues/5217). Parent:
+[#5212](https://github.com/TEAMSchools/teamster/issues/5212).
+
+## Problem
+
+Marts inherit `materialized: view` from `dbt_project.yml`. BigQuery computes a
+view on every read, so every `unique`, `not_null`, and `relationships` test on a
+view mart recomputes that entire view before it can check anything.
+
+10 marts cost 936 slot hours a week this way. Total warehouse compute in the
+project is 2,912 slot hours a week, of which dbt data tests are 1,387. These 10
+marts are 67% of all test compute and 32% of all compute.
+
+Measured over 7 days from `region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`. `prod`
+is the Dagster agent, `CI` is dbt Cloud on `target: staging`.
+
+| #   | View mart                      | prod |    CI | total |
+| --- | ------------------------------ | ---: | ----: | ----: |
+| 1   | `bridge_survey_expectations`   | 12.4 | 281.0 | 293.7 |
+| 2   | `fct_survey_submissions`       | 23.2 | 215.3 | 238.6 |
+| 3   | `fct_student_attendance_daily` |  1.7 |  90.5 | 114.8 |
+| 4   | `fct_survey_responses`         |  0.0 | 105.8 | 105.8 |
+| 5   | `dim_college_enrollments`      | 13.4 |  27.0 |  40.5 |
+| 6   | `dim_survey_administrations`   |  0.0 |  37.9 |  38.3 |
+| 7   | `fct_grades_assignments`       |  0.0 |  37.7 |  37.9 |
+| 8   | `fct_support_tickets`          | 11.6 |  23.0 |  34.6 |
+| 9   | `dim_staff_reporting_chain`    | 22.3 |   0.0 |  22.3 |
+| 10  | `dim_staff_work_history`       |  9.6 |   0.0 |   9.6 |
+
+The other 57 view marts cost at most 6.1 slot hours a week each, about 30
+combined. The cliff after rank 10 is clean, so the batch stops there.
+
+## Root cause
+
+Two mechanisms drive the two columns. They are independent.
+
+### CI: `state:modified+` selects these marts on nearly every pull request
+
+dbt Cloud CI runs `dbt build --select state:modified+ --full-refresh`. These
+marts sit downstream of hub models that most pull requests touch, so CI creates
+the view (free) and then runs every attached test against it. For
+`bridge_survey_expectations` that is 8 tests at up to 43 slot minutes each, on
+114 CI runs a week.
+
+CI is 818 of the 936 hours. prod is 94. The remaining 24 are `dev` and `defer`
+targets and rounding.
+
+### prod: eager indirect selection fires child tests on parent rebuilds
+
+In prod these child views are never rebuilt at all, yet their tests still run.
+
+| prod node                                                       | runs in 7 days |
+| --------------------------------------------------------------- | -------------: |
+| `model.kipptaf.dim_staff`                                       |            192 |
+| `model.kipptaf.bridge_survey_expectations`                      |              0 |
+| `model.kipptaf.dim_staff_reporting_chain`                       |              0 |
+| `test ... bridge_survey_expectations_staff_key__ref_dim_staff_` |            128 |
+| `test ... dim_staff_reporting_chain_manager_staff_key__ref_...` |            128 |
+| `test unique_dim_staff_staff_key`                               |            128 |
+
+dbt's default `--indirect-selection=eager` selects a test when **any** parent is
+selected, per `dbt/graph/selector.py::expand_selection`. A `relationships` test
+depends on both the child model and the FK target. `dim_staff` is a table with
+the eager automation condition, so it rebuilds 192 times a week, and each
+rebuild drags in all of its children's FK tests. Each of those recomputes an
+entire child view to check a few thousand keys.
+
+Across all prod dbt tests, 72.3 of 117.5 weekly slot hours (62%) run on models
+that never rebuilt in prod during the window.
+
+## Decision
+
+Materialize the 10 marts as tables on a cron automation condition. Do not change
+`--indirect-selection`.
+
+Once a mart is a table, both mechanisms become cheap at once: CI builds the
+table once instead of recomputing it per test, and a parent-triggered child test
+reads a table. One change fixes both columns.
+
+## Design
+
+Each of the 10 properties yml files gains:
+
+```yaml
+config:
+  materialized: table
+  meta:
+    dagster:
+      automation_condition:
+        cron_schedule: "<per-model, see below>"
+```
+
+`dbt_table_automation_condition()` is eager on ancestor updates, which would
+rebuild these on every upstream data refresh. `dbt_cron_automation_condition()`
+swaps that trigger for a cron tick, and per
+`src/teamster/libraries/dbt/dagster_dbt_translator.py` it is available only to
+TABLE models. So the materialization change is a prerequisite for the cadence
+change, not an independent choice.
+
+### Cadence, derived per model
+
+Build cost is estimated from p90 slot minutes per test on that view. The
+heaviest test is the closest available proxy for a full recompute plus a write.
+
+Break-even is the builds per week at which a cron table costs what the model's
+current prod tests cost: `prod_slot_hours / build_hours`.
+
+| Mart                           | prod now | build | break-even | cron                    | prod after |
+| ------------------------------ | -------: | ----: | ---------: | ----------------------- | ---------: |
+| `bridge_survey_expectations`   |     12.4 |   43m |      17/wk | `0 3 * * *`             |        5.0 |
+| `fct_survey_submissions`       |     23.2 |   30m |      47/wk | `0 3 * * *`             |        3.5 |
+| `fct_survey_responses`         |      0.0 |   32m |        n/a | `0 3 * * *`             |        3.8 |
+| `dim_survey_administrations`   |      0.0 |   13m |        n/a | `0 3 * * *`             |        1.5 |
+| `dim_college_enrollments`      |     13.4 |    4m |     183/wk | `0 3 * * *`             |        0.5 |
+| `fct_grades_assignments`       |      0.0 |    7m |        n/a | `0 3 * * *`             |        0.8 |
+| `fct_support_tickets`          |     11.6 |   10m |      71/wk | `0 3 * * *`             |        1.1 |
+| `fct_student_attendance_daily` |      1.7 |   14m |       8/wk | `0 0,10,13,15,17 * * *` |        7.9 |
+| `dim_staff_reporting_chain`    |     22.3 |   18m |      75/wk | `0 0,10,13,15,17 * * *` |       10.4 |
+| `dim_staff_work_history`       |      9.6 |    7m |      83/wk | `0 0,10,13,15,17 * * *` |        4.0 |
+
+The result is 2 cadences, but each is derived rather than assumed. Daily
+`0 3 * * *` goes to the 7 marts with no live reader. The assessment-mart tick
+`0 0,10,13,15,17 * * *` goes to the 3 that Cube reads.
+
+Every daily model sits far below its break-even. One model does not:
+
+**`fct_student_attendance_daily` knowingly regresses in prod**, 1.7 to 7.9 slot
+hours a week, because 35 builds a week exceeds its 8/wk break-even. Its Cube
+consumer anchors topline Total Enrollment and needs the intraday tick. Its CI
+column drops from 90.5 to about 20, so the model is net negative overall.
+
+### Expected result
+
+A CI run today creates the view for free and then runs every attached test
+against it. After the change it builds the table once and the tests are cheap.
+So CI cost per model scales by `build_minutes / (n_tests * avg_test_minutes)`,
+computed per model rather than as one blanket factor.
+
+| Mart                           | CI now | CI after |
+| ------------------------------ | -----: | -------: |
+| `bridge_survey_expectations`   |  281.0 |       84 |
+| `fct_survey_submissions`       |  215.3 |       58 |
+| `fct_survey_responses`         |  105.8 |       60 |
+| `fct_student_attendance_daily` |   90.5 |       21 |
+| `dim_survey_administrations`   |   37.9 |       15 |
+| `fct_grades_assignments`       |   37.7 |       11 |
+| `dim_college_enrollments`      |   27.0 |        8 |
+| `fct_support_tickets`          |   23.0 |        6 |
+
+`fct_survey_responses` wins least, 105.8 to 60, because it carries only 2 tests
+and its build is nearly as expensive as one of them. It still clears, but it is
+the weakest member of the batch.
+
+Totals: prod 94 to 38, CI 818 to about 263. That is about 610 slot hours a week,
+or 21% of all warehouse compute in the project.
+
+### Live consumers
+
+Only 3 of the 10 have a reader today.
+
+| Mart                           | Read by                                                            |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `fct_student_attendance_daily` | Cube `student_enrollments` and `student_attendance` cubes          |
+| `dim_staff_work_history`       | Cube `staff_work_history` cube                                     |
+| `dim_staff_reporting_chain`    | `src/cube/cube.js:145`, per user session, for the PII access scope |
+
+The other 7 have no `sql_table` pointing at them anywhere in `src/cube/model/`.
+They appear only in the `cube.yml` exposure `depends_on`, which covers the
+semantic layer as a whole. No Tableau exposure references any of the 10, so no
+Tableau refresh cron sets a freshness floor on this batch.
+
+`dim_staff_reporting_chain` deserves separate attention. `cube.js` runs
+`SELECT reportee_staff_key FROM kipptaf_marts.dim_staff_reporting_chain WHERE manager_staff_key = @k`
+on each user session, 26 times in 7 days at 16.1 slot minutes a call. That is a
+recursive closure recomputed inside session setup. The table conversion removes
+it as a latency source, not only as a cost.
+
+## What does not need doing
+
+All 10 already declare their foreign keys as `columns[].config.meta.foreign_key`
+rather than real `constraints: - type: foreign_key`. Verified: zero occurrences
+of `type: foreign_key` across the 10 properties files. The
+[#4821](https://github.com/TEAMSchools/teamster/issues/4821) migration is
+already complete on this batch, so no FK constraint work is required and no FK
+closure has to be converted alongside.
+
+9 of the 10 inherit `contract: enforced: true`, which is correct for a table and
+needs no change; their column lists already carry `data_type`.
+`dim_staff_reporting_chain` already sets `contract: enforced: false`.
+
+A table mart needs `warn_unenforced: false` on its `primary_key` constraint,
+because the constraint renders into the CREATE TABLE DDL and warns otherwise.
+That is the only per-column edit this change requires.
+
+## Risks and gates
+
+### Size is unmeasured and gates the merge
+
+`bridge_survey_expectations` is a scaffold whose family branch is a `cross join`
+from survey administrations to every contact person. As a view that costs
+compute; as a table it costs storage permanently.
+
+Build each of the 10 into a dev schema and record its row count and bytes
+**before** merging its properties yml. Do not estimate.
+
+Do not run `count(*)` against these views to get the number. One attempt over 4
+of them consumed 100,540 slot minutes across 52 minutes and failed with
+`billingTierLimitExceeded`.
+
+### The prod migration wedges if it is left to the sensor
+
+A config-only properties yml change does not fire `code_version_changed` at
+deploy, because `code_version` is a SHA1 of the model's raw SQL and the SQL does
+not change. The automation sensor therefore never selects these models.
+
+Worse, view to table DROPS the view before it creates the table. A sensor that
+materializes assets one at a time and out of order leaves dependents
+drop-failing every tick and MISSING from prod, which reads as absence from
+`kipptaf_marts.__TABLES__` rather than as stale data.
+
+Finish post-merge with ONE Dagster `launch_run` selecting all 10 assets. That is
+a single `dbt build`, which dbt topologically sorts. This is the failure mode
+that got [#4464](https://github.com/TEAMSchools/teamster/issues/4464) reverted
+by [#4587](https://github.com/TEAMSchools/teamster/issues/4587).
+
+### `dim_staff_reporting_chain` must not be missing when Cube asks
+
+Between the view drop and the table create, `cube.js` resolves an empty reportee
+set and denies PII access as if the manager had no downline. Convert it in the
+same ordered run and confirm the relation exists before the next Cube session.
+
+### Recursion is not a blocker
+
+`dim_staff_reporting_chain` uses `WITH RECURSIVE`. That is compatible with a
+table: `int_illuminate__root_standards` is `WITH RECURSIVE` plus
+`materialized: table` and holds 569,847 rows in prod today. Only dbt's contract
+validation subquery wrapper breaks recursion, and contract enforcement is
+already off on this model.
+
+## Verification
+
+1. For each of the 10, the dev build recorded a row count and a byte size, and
+   both are acceptable.
+2. `kipptaf_marts.__TABLES__` reports `type = 1` for all 10 after the ordered
+   prod run, with a `last_modified_time` from that run.
+3. A follow-up `JOBS_BY_PROJECT` query 7 days after merge shows the same 10
+   marts at roughly the projected slot hours, split prod and CI by
+   `target_name`.
+4. Cube still resolves a non-empty reportee set for a manager with known direct
+   reports.
+
+## Out of scope
+
+**`--indirect-selection=cautious`** at
+`src/teamster/libraries/dbt/assets.py:112` would remove 72.3 of the 117.5 weekly
+prod test slot hours. It is rejected for this change on 3 grounds. It does
+nothing for CI, which selects both parents and so behaves identically under
+`eager` and `cautious`, and CI is 90% of the cost here. It is repo-wide, because
+`build_dbt_assets()` is called by all 5 code locations. It trades away
+parent-side FK orphan detection on every view mart, dropping those checks from
+roughly 9 a day to only when that model's own SQL changes. Once these 10 are
+tables, its savings on them evaporate.
+
+**The remaining 57 view marts.** Each costs at most 6.1 slot hours a week.
+Revisit only if the measurement in step 3 shows the tail grew.
+
+**`fct_survey_submissions` and `bridge_survey_expectations` SQL.** Both have
+shapes worth questioning, including the `cross join` scaffold and the near
+cartesian student enrollment join. This change does not touch model SQL, so
+hashes and row sets stay identical and the conversion is verifiable as a pure
+materialization change.

--- a/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
+++ b/src/dbt/kipptaf/models/marts/bridges/properties/bridge_survey_expectations.yml
@@ -13,6 +13,16 @@ models:
       enrolled students (grades 3 to 12) for the School Community Diagnostic
       Student Survey; family rows produce one expectation per contact person for
       the family survey administrations.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: survey_expectation_key
         data_type: string
@@ -22,6 +32,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/dimensions/dim_survey_administrations.sql
+++ b/src/dbt/kipptaf/models/marts/dimensions/dim_survey_administrations.sql
@@ -1,21 +1,13 @@
 with
     /*
-     * Submission-grain projection of int_surveys__survey_responses.
-     * One row per (survey_id, survey_response_id); the order_by choice does
-     * not affect correctness because projected columns don't vary across
-     * questions of a submission.
-     * TODO: #3918 — extract int_surveys__survey_submissions intermediate.
+     * The historic Alchemer archive is excluded here and handled by
+     * historic_archive_terms below, which matches term_code as well. This leg
+     * deliberately does not, so a survey administered in several terms of one
+     * year yields an administration per term rather than only the terms that
+     * happen to carry a submission. 35 of the 57 administrations have no
+     * submissions, and bridge_survey_expectations needs them to produce the
+     * missed side of expected-versus-taken.
      */
-    submissions_grain as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_surveys__survey_responses"),
-                partition_by="survey_id, survey_response_id",
-                order_by="survey_question_id",
-            )
-        }}
-    ),
-
     survey_terms as (
         select
             sg.survey_id,
@@ -29,13 +21,15 @@ with
             rt.academic_year,
             rt.region,
             rt.school_id,
-        from submissions_grain as sg
+        from {{ ref("int_surveys__survey_submissions") }} as sg
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on sg.survey_title = rt.`name`
             and sg.academic_year = rt.academic_year
             and rt.type = 'SURVEY'
-        where sg.academic_year is not null
+        where
+            sg.academic_year is not null
+            and sg.survey_id != 'historic_alchemer_Manager_survey'
     ),
 
     historic_archive_terms as (
@@ -51,16 +45,14 @@ with
             rt.academic_year,
             rt.region,
             rt.school_id,
-        from {{ ref("int_surveys__manager_survey_details") }} as ms
+        from {{ ref("int_surveys__survey_submissions") }} as ms
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on rt.`name` = 'Manager Survey'
-            and ms.campaign_academic_year = rt.academic_year
-            and ms.campaign_reporting_term = rt.code
+            and ms.academic_year = rt.academic_year
+            and ms.term_code = rt.code
             and rt.type = 'SURVEY'
-        where
-            ms.survey_id = 'historic_alchemer_Manager_survey'
-            and ms.campaign_academic_year is not null
+        where ms.survey_id = 'historic_alchemer_Manager_survey'
     ),
 
     support_terms as (
@@ -78,7 +70,7 @@ with
             rt.school_id,
         from {{ source("surveys", "int_surveys__response_identifiers") }} as ri
         inner join
-            submissions_grain as ss
+            {{ ref("int_surveys__survey_submissions") }} as ss
             on ri.survey_id = safe_cast(ss.survey_id as int64)
             and ri.response_id = safe_cast(ss.survey_response_id as int64)
         inner join
@@ -103,9 +95,10 @@ with
     ),
 
     /*
-     * Collapse to admin grain. submissions_grain is row-grained, so several
-     * submissions roll up to one admin row across all union arms.
-     * TODO: #3918 — when extracted, the upstream will already be admin-grain.
+     * Collapse to admin grain. The upstream is submission-grained, so many
+     * submissions roll up to one administration across all 3 arms. This is a
+     * grain projection, not a dedupe of survey responses — that one moved to
+     * int_surveys__survey_submissions.
      */
     deduped as (
         {{

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_college_enrollments.yml
@@ -6,6 +6,16 @@ models:
       across all NSC enrollment records. FK to dim_students (via student_key),
       dim_colleges (via college_key), and dim_dates (role-playing via
       start_date_key and end_date_key).
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: college_enrollment_key
         data_type: string
@@ -16,6 +26,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_reporting_chain.yml
@@ -19,10 +19,20 @@ models:
       hit this silently — debug via dim_staff_reporting_periods for the affected
       staff.
     config:
+      materialized: table
       # WITH RECURSIVE is incompatible with the contract-validation subquery
       # wrapper; orphan detection is preserved via the relationships tests below.
+      # The CTAS wrapper is fine with recursion — int_illuminate__root_standards
+      # is WITH RECURSIVE plus materialized: table in prod.
       contract:
         enforced: false
+      meta:
+        dagster:
+          # 5x/day, matching the assessment marts. cube.js queries this mart
+          # once per user session to build the PII access scope, at 16.1 slot
+          # minutes a call as a view. Refs #5217
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_staff_work_history.yml
@@ -6,6 +6,14 @@ models:
       org unit, work location, and point-in-time manager all held
       simultaneously. Consumed by the Cube semantic layer (staff_work_history
       cube feeding the staff_directory and staff_pii views).
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day, matching the assessment marts. The staff_work_history cube
+          # reads this mart. Refs #5217
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:
@@ -18,6 +26,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
       - name: work_assignment_key

--- a/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
+++ b/src/dbt/kipptaf/models/marts/dimensions/properties/dim_survey_administrations.yml
@@ -6,6 +6,16 @@ models:
       dim_surveys via survey_key and to dim_terms via term_key. Linearizes the
       path from any model to dim_terms -- dim_surveys is a pure definition and
       all temporal scoping flows through this model.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: survey_administration_key
         data_type: string
@@ -15,6 +25,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_responses.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_responses.sql
@@ -46,9 +46,6 @@ with
             question_shortname,
             response_text,
             response_value,
-
-            {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
-            as survey_submission_key,
         from general_responses
         union all
         select
@@ -58,14 +55,20 @@ with
             question_shortname,
             response_text,
             response_value,
-
-            {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
-            as survey_submission_key,
         from manager_responses
     )
 
+/*
+ * survey_submission_key comes from int_surveys__survey_submissions rather than
+ * being re-hashed here, so the composition lives in exactly one place. The join
+ * to fct_survey_submissions stays: it is the filter that keeps this fact to the
+ * submissions the fact actually models.
+ */
 select
-    ar.survey_submission_key,
+    ar.response_value,
+    ar.response_text,
+
+    ss.survey_submission_key,
 
     {{
         dbt_utils.generate_surrogate_key(
@@ -75,10 +78,11 @@ select
 
     {{ dbt_utils.generate_surrogate_key(["ar.question_shortname"]) }}
     as survey_question_key,
-
-    ar.response_value,
-    ar.response_text,
 from all_responses as ar
 inner join
+    {{ ref("int_surveys__survey_submissions") }} as ss
+    on ar.survey_id = ss.survey_id
+    and ar.survey_response_id = ss.survey_response_id
+inner join
     {{ ref("fct_survey_submissions") }} as fss
-    on ar.survey_submission_key = fss.survey_submission_key
+    on ss.survey_submission_key = fss.survey_submission_key

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -189,9 +189,44 @@ with
     /*
      * Historic Alchemer Manager archive — these rows have survey_response_id
      * NULL and don't appear in int_surveys__survey_responses, so they need
-     * the deterministic fallback hash. They produce no FK orphans against
-     * fct_survey_responses because no response-grain rows exist for them.
+     * the deterministic fallback hash.
      */
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    historic_archive_source as (
+        select
+            survey_id,
+            respondent_df_employee_number,
+            subject_df_employee_number,
+            date_submitted,
+            campaign_academic_year,
+            campaign_reporting_term,
+            effective_survey_response_id,
+        from {{ ref("int_surveys__manager_survey_details") }}
+        where
+            survey_id = 'historic_alchemer_Manager_survey'
+            and campaign_academic_year is not null
+    ),
+
+    /*
+     * int_surveys__manager_survey_details is question-grain, so the archive
+     * emitted 18 rows per submission and collided 2,559 survey_submission_key
+     * values, which then fanned fct_survey_responses 18x through its
+     * survey_submission_key join. Project to submission grain, the same job
+     * manager_subject_overlay does above. Information-preserving: every column
+     * selected above is constant within (survey_id,
+     * effective_survey_response_id) across all 2,559 archive submissions, so
+     * the order_by is an arbitrary but stable tiebreaker, not a business rule.
+     */
+    historic_archive_grain as (
+        {{
+            dbt_utils.deduplicate(
+                relation="historic_archive_source",
+                partition_by="survey_id, effective_survey_response_id",
+                order_by="subject_df_employee_number",
+            )
+        }}
+    ),
+
     historic_archive_submissions as (
         select
             ms.survey_id,
@@ -211,16 +246,13 @@ with
             'staff' as respondent_type,
 
             ms.effective_survey_response_id as survey_response_id,
-        from {{ ref("int_surveys__manager_survey_details") }} as ms
+        from historic_archive_grain as ms
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on rt.`name` = 'Manager Survey'
             and ms.campaign_academic_year = rt.academic_year
             and ms.campaign_reporting_term = rt.code
             and rt.type = 'SURVEY'
-        where
-            ms.survey_id = 'historic_alchemer_Manager_survey'
-            and ms.campaign_academic_year is not null
     ),
 
     combined_staff as (

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -215,7 +215,11 @@ with
      * manager_subject_overlay does above. Information-preserving: every column
      * selected above is constant within (survey_id,
      * effective_survey_response_id) across all 2,559 archive submissions, so
-     * the order_by is an arbitrary but stable tiebreaker, not a business rule.
+     * the collapsed rows are identical and the order_by never actually breaks a
+     * tie -- it is there because the macro requires one, not as a business
+     * rule. If that constancy ever stops holding, this pick becomes arbitrary
+     * and the PK test will not catch it: it detects a re-fan, not a wrong
+     * value.
      */
     historic_archive_grain as (
         {{

--- a/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
+++ b/src/dbt/kipptaf/models/marts/facts/fct_survey_submissions.sql
@@ -1,30 +1,12 @@
 with
-    /*
-     * Submission-grain projection of int_surveys__survey_responses.
-     * One row per (survey_id, survey_response_id). The order_by choice is
-     * arbitrary because projected columns don't vary across questions of the
-     * same submission — survey_question_id is used for determinism only.
-     * TODO: #3918 — extract int_surveys__survey_submissions intermediate.
-     */
-    submissions_grain as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_surveys__survey_responses"),
-                partition_by="survey_id, survey_response_id",
-                order_by="survey_question_id",
-            )
-        }}
-    ),
-
     /* Staff SCD submissions */
     staff_submissions as (
         select
+            sg.survey_submission_key,
             sg.survey_id,
-            sg.survey_response_id,
             sg.respondent_employee_number,
             sg.date_submitted,
             sg.academic_year,
-            sg.term_code,
 
             rt.type as term_type,
             rt.code as rt_code,
@@ -36,7 +18,7 @@ with
             'staff' as respondent_type,
 
             cast(null as int64) as subject_employee_number,
-        from submissions_grain as sg
+        from {{ ref("int_surveys__survey_submissions") }} as sg
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on sg.survey_title = rt.`name`
@@ -50,14 +32,19 @@ with
             )
     ),
 
-    /* Student SCD submissions */
-    student_submissions as (
+    /*
+     * Manager Survey submissions, both arms. The live Google Forms arm and the
+     * historic Alchemer archive reach int_surveys__survey_submissions with the
+     * same shape, so they need one branch rather than two. The subject of
+     * evaluation comes from the overlay for both.
+     */
+    manager_submissions as (
         select
+            sg.survey_submission_key,
             sg.survey_id,
-            sg.survey_response_id,
-            sg.respondent_email,
+            sg.respondent_employee_number,
             sg.date_submitted,
-            sg.term_code,
+            sg.academic_year,
 
             rt.type as term_type,
             rt.code as rt_code,
@@ -66,16 +53,47 @@ with
             rt.region as rt_region,
             rt.school_id as rt_school_id,
 
-            'student' as respondent_type,
+            mso.subject_employee_number,
+
+            'staff' as respondent_type,
+        from {{ ref("int_surveys__survey_submissions") }} as sg
+        inner join
+            {{ ref("stg_google_sheets__reporting__terms") }} as rt
+            on rt.`name` = 'Manager Survey'
+            and sg.academic_year = rt.academic_year
+            and sg.term_code = rt.code
+            and rt.type = 'SURVEY'
+        left join
+            {{ ref("int_surveys__manager_submission_subjects") }} as mso
+            on sg.survey_id = mso.survey_id
+            and sg.survey_response_id = mso.survey_response_id
+        where sg.survey_title = 'Manager Survey'
+    ),
+
+    /* Student SCD submissions */
+    student_submissions as (
+        select
+            sg.survey_submission_key,
+            sg.survey_id,
+            sg.date_submitted,
+
+            rt.type as term_type,
+            rt.code as rt_code,
+            rt.`name` as rt_name,
+            rt.start_date as rt_start_date,
+            rt.region as rt_region,
+            rt.school_id as rt_school_id,
 
             enr.student_number,
             enr.academic_year,
             enr.entrydate,
 
+            'student' as respondent_type,
+
             regexp_extract(
                 enr._dbt_source_relation, r'(kipp\w+)_'
             ) as _dbt_source_project,
-        from submissions_grain as sg
+        from {{ ref("int_surveys__survey_submissions") }} as sg
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on sg.survey_title = rt.`name`
@@ -93,11 +111,10 @@ with
     /* Family SCD submissions */
     family_submissions as (
         select
+            sg.survey_submission_key,
             sg.survey_id,
-            sg.survey_response_id,
             sg.date_submitted,
             sg.academic_year,
-            sg.term_code,
 
             rt.type as term_type,
             rt.code as rt_code,
@@ -107,7 +124,7 @@ with
             rt.school_id as rt_school_id,
 
             'family' as respondent_type,
-        from submissions_grain as sg
+        from {{ ref("int_surveys__survey_submissions") }} as sg
         inner join
             {{ ref("stg_google_sheets__reporting__terms") }} as rt
             on sg.survey_title = rt.`name`
@@ -122,145 +139,15 @@ with
             )
     ),
 
-    /*
-     * Manager Survey submissions — hash inputs from submissions_grain (Google
-     * Forms branch of int_surveys__survey_responses). Subject-of-evaluation
-     * staff columns come from int_surveys__manager_survey_details as a thin
-     * overlay; that model is retained for subject context and the historic
-     * Alchemer archive only. TODO: #3918.
-     */
-    /*
-     * subject_df_employee_number is constant per (survey_id, survey_response_id)
-     * by source-model design — int_surveys__manager_survey_details carries one
-     * subject per submission and repeats it across question-grain rows. The
-     * order_by here is arbitrary among identical values; deduplicate's only
-     * job is the question-grain → submission-grain projection.
-     */
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    manager_overlay_source as (
-        select survey_id, survey_response_id, subject_df_employee_number,
-        from {{ ref("int_surveys__manager_survey_details") }}
-        where survey_response_id is not null
-    ),
-
-    manager_subject_overlay as (
-        {{
-            dbt_utils.deduplicate(
-                relation="manager_overlay_source",
-                partition_by="survey_id, survey_response_id",
-                order_by="subject_df_employee_number",
-            )
-        }}
-    ),
-
-    manager_submissions as (
-        select
-            sg.survey_id,
-            sg.survey_response_id,
-            sg.respondent_employee_number,
-            sg.date_submitted,
-            sg.academic_year,
-            sg.term_code,
-
-            rt.type as term_type,
-            rt.code as rt_code,
-            rt.`name` as rt_name,
-            rt.start_date as rt_start_date,
-            rt.region as rt_region,
-            rt.school_id as rt_school_id,
-
-            'staff' as respondent_type,
-
-            mso.subject_df_employee_number as subject_employee_number,
-        from submissions_grain as sg
-        inner join
-            {{ ref("stg_google_sheets__reporting__terms") }} as rt
-            on rt.`name` = 'Manager Survey'
-            and sg.academic_year = rt.academic_year
-            and sg.term_code = rt.code
-            and rt.type = 'SURVEY'
-        left join
-            manager_subject_overlay as mso
-            on sg.survey_id = mso.survey_id
-            and sg.survey_response_id = mso.survey_response_id
-        where sg.survey_title = 'Manager Survey'
-    ),
-
-    /*
-     * Historic Alchemer Manager archive — these rows have survey_response_id
-     * NULL and don't appear in int_surveys__survey_responses, so they need
-     * the deterministic fallback hash.
-     */
-    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
-    historic_archive_source as (
-        select
-            survey_id,
-            respondent_df_employee_number,
-            subject_df_employee_number,
-            date_submitted,
-            campaign_academic_year,
-            campaign_reporting_term,
-            effective_survey_response_id,
-        from {{ ref("int_surveys__manager_survey_details") }}
-        where
-            survey_id = 'historic_alchemer_Manager_survey'
-            and campaign_academic_year is not null
-    ),
-
-    /*
-     * int_surveys__manager_survey_details is question-grain, so the archive
-     * emitted 18 rows per submission and collided 2,559 survey_submission_key
-     * values, which then fanned fct_survey_responses 18x through its
-     * survey_submission_key join. Project to submission grain, the same job
-     * manager_subject_overlay does above. Information-preserving: every column
-     * selected above is constant within (survey_id,
-     * effective_survey_response_id) across all 2,559 archive submissions, so
-     * the collapsed rows are identical and the order_by never actually breaks a
-     * tie -- it is there because the macro requires one, not as a business
-     * rule. If that constancy ever stops holding, this pick becomes arbitrary
-     * and the PK test will not catch it: it detects a re-fan, not a wrong
-     * value.
-     */
-    historic_archive_grain as (
-        {{
-            dbt_utils.deduplicate(
-                relation="historic_archive_source",
-                partition_by="survey_id, effective_survey_response_id",
-                order_by="subject_df_employee_number",
-            )
-        }}
-    ),
-
-    historic_archive_submissions as (
-        select
-            ms.survey_id,
-            ms.respondent_df_employee_number as respondent_employee_number,
-            ms.subject_df_employee_number as subject_employee_number,
-            ms.date_submitted,
-            ms.campaign_academic_year as academic_year,
-            ms.campaign_reporting_term as term_code,
-
-            rt.type as term_type,
-            rt.code as rt_code,
-            rt.`name` as rt_name,
-            rt.start_date as rt_start_date,
-            rt.region as rt_region,
-            rt.school_id as rt_school_id,
-
-            'staff' as respondent_type,
-
-            ms.effective_survey_response_id as survey_response_id,
-        from historic_archive_grain as ms
-        inner join
-            {{ ref("stg_google_sheets__reporting__terms") }} as rt
-            on rt.`name` = 'Manager Survey'
-            and ms.campaign_academic_year = rt.academic_year
-            and ms.campaign_reporting_term = rt.code
-            and rt.type = 'SURVEY'
-    ),
-
     combined_staff as (
         select
+            survey_submission_key,
+            respondent_type,
+            respondent_employee_number,
+            subject_employee_number,
+            date_submitted,
+            academic_year,
+
             {{
                 dbt_utils.generate_surrogate_key(
                     [
@@ -274,19 +161,18 @@ with
                     ]
                 )
             }} as survey_administration_key,
-
-            survey_id,
-            survey_response_id,
-            respondent_type,
-            respondent_employee_number,
-            subject_employee_number,
-            date_submitted,
-            academic_year,
         from staff_submissions
 
         union all
 
         select
+            survey_submission_key,
+            respondent_type,
+            respondent_employee_number,
+            subject_employee_number,
+            date_submitted,
+            academic_year,
+
             {{
                 dbt_utils.generate_surrogate_key(
                     [
@@ -300,104 +186,20 @@ with
                     ]
                 )
             }} as survey_administration_key,
-
-            survey_id,
-            survey_response_id,
-            respondent_type,
-            respondent_employee_number,
-            subject_employee_number,
-            date_submitted,
-            academic_year,
         from manager_submissions
-
-        union all
-
-        select
-            {{
-                dbt_utils.generate_surrogate_key(
-                    [
-                        "survey_id",
-                        "term_type",
-                        "rt_code",
-                        "rt_name",
-                        "rt_start_date",
-                        "rt_region",
-                        "rt_school_id",
-                    ]
-                )
-            }} as survey_administration_key,
-
-            survey_id,
-            survey_response_id,
-            respondent_type,
-            respondent_employee_number,
-            subject_employee_number,
-            date_submitted,
-            academic_year,
-        from historic_archive_submissions
-    ),
-
-    combined_student as (
-        select
-            {{
-                dbt_utils.generate_surrogate_key(
-                    [
-                        "survey_id",
-                        "term_type",
-                        "rt_code",
-                        "rt_name",
-                        "rt_start_date",
-                        "rt_region",
-                        "rt_school_id",
-                    ]
-                )
-            }} as survey_administration_key,
-
-            survey_id,
-            survey_response_id,
-            respondent_type,
-            student_number,
-            _dbt_source_project,
-            academic_year,
-            entrydate,
-            date_submitted,
-        from student_submissions
-    ),
-
-    combined_family as (
-        select
-            {{
-                dbt_utils.generate_surrogate_key(
-                    [
-                        "survey_id",
-                        "term_type",
-                        "rt_code",
-                        "rt_name",
-                        "rt_start_date",
-                        "rt_region",
-                        "rt_school_id",
-                    ]
-                )
-            }} as survey_administration_key,
-
-            survey_id,
-            survey_response_id,
-            respondent_type,
-            date_submitted,
-            academic_year,
-        from family_submissions
     )
 
 /* Staff submissions */
 select
-    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
-    as survey_submission_key,
-
+    survey_submission_key,
     survey_administration_key,
+    respondent_type,
+    academic_year,
 
     date(date_submitted) as date_submitted_key,
 
-    respondent_type,
+    cast(null as string) as student_enrollment_key,
+    cast(null as string) as student_contact_person_key,
 
     if(
         respondent_employee_number is not null,
@@ -405,16 +207,11 @@ select
         cast(null as string)
     ) as staff_key,
 
-    cast(null as string) as student_enrollment_key,
-    cast(null as string) as student_contact_person_key,
-
     if(
         subject_employee_number is not null,
         {{ dbt_utils.generate_surrogate_key(["subject_employee_number"]) }},
         cast(null as string)
     ) as subject_staff_key,
-
-    academic_year,
 
     date_submitted as `timestamp`,
 from combined_staff
@@ -423,16 +220,26 @@ union all
 
 /* Student submissions */
 select
-    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
-    as survey_submission_key,
+    survey_submission_key,
 
-    survey_administration_key,
-
-    date(date_submitted) as date_submitted_key,
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "survey_id",
+                "term_type",
+                "rt_code",
+                "rt_name",
+                "rt_start_date",
+                "rt_region",
+                "rt_school_id",
+            ]
+        )
+    }} as survey_administration_key,
 
     respondent_type,
+    academic_year,
 
-    cast(null as string) as staff_key,
+    date(date_submitted) as date_submitted_key,
 
     {{
         dbt_utils.generate_surrogate_key(
@@ -446,32 +253,41 @@ select
     }} as student_enrollment_key,
 
     cast(null as string) as student_contact_person_key,
+    cast(null as string) as staff_key,
     cast(null as string) as subject_staff_key,
 
-    academic_year,
-
     date_submitted as `timestamp`,
-from combined_student
+from student_submissions
 
 union all
 
 /* Family submissions */
 select
-    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
-    as survey_submission_key,
+    survey_submission_key,
 
-    survey_administration_key,
+    {{
+        dbt_utils.generate_surrogate_key(
+            [
+                "survey_id",
+                "term_type",
+                "rt_code",
+                "rt_name",
+                "rt_start_date",
+                "rt_region",
+                "rt_school_id",
+            ]
+        )
+    }} as survey_administration_key,
+
+    respondent_type,
+    academic_year,
 
     date(date_submitted) as date_submitted_key,
 
-    respondent_type,
-
-    cast(null as string) as staff_key,
     cast(null as string) as student_enrollment_key,
     cast(null as string) as student_contact_person_key,
+    cast(null as string) as staff_key,
     cast(null as string) as subject_staff_key,
 
-    academic_year,
-
     date_submitted as `timestamp`,
-from combined_family
+from family_submissions

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_grades_assignments.yml
@@ -16,6 +16,16 @@ models:
       sole gradebook source. Focus records no missing flag and no numeric grade
       distinct from the points score, so is_missing and numeric_grade_earned are
       null on every Miami row.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: grades_assignment_key
         data_type: string
@@ -25,6 +35,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           # TODO(#3915): remove the warn override once PS source cleanup
           # completes; residual ~71 duplicate rows are historical PowerSchool

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_student_attendance_daily.yml
@@ -25,6 +25,17 @@ models:
       for ADA, `SUM(is_absent) / SUM(is_membership_day)` for absence rate. Use
       the `is_*` flags for categorical breakdowns (Present/Absent/Tardy/
       OSS/ISS) or the `attendance_category` column for a single GROUP BY axis.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # 5x/day, matching the assessment marts. Cube's student_enrollments
+          # and student_attendance cubes read this mart and anchor topline
+          # Total Enrollment, so it needs the intraday tick. That is above its
+          # own break-even (prod 1.7 to 7.9 slot hours a week), accepted
+          # because the CI column drops 90.5 to about 21. Refs #5217
+          automation_condition:
+            cron_schedule: 0 0,10,13,15,17 * * *
     columns:
       - name: student_attendance_daily_key
         data_type: string
@@ -34,6 +45,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_support_tickets.yml
@@ -9,6 +9,16 @@ models:
       dimensions — assignee and original_assignee are nullable), dim_dates
       (created and solved as role-playing — solved is nullable), and
       dim_locations.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: support_ticket_key
         data_type: string
@@ -18,6 +28,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_responses.yml
@@ -6,6 +6,16 @@ models:
       fct_survey_submissions via survey_submission_key and to
       dim_survey_questions via survey_question_key. Reaches dim_surveys only via
       the chain: response -> submission -> administration -> survey.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: survey_response_key
         data_type: string
@@ -17,6 +27,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
+++ b/src/dbt/kipptaf/models/marts/facts/properties/fct_survey_submissions.yml
@@ -15,6 +15,16 @@ models:
       populated only for Manager Survey submissions (role-playing FK to
       dim_staff for the manager being evaluated). FK to
       dim_survey_administrations and dim_dates.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # Nightly: every data test on this view recomputed it in full, and
+          # dbt Cloud CI ran that on nearly every PR. No Cube cube or Tableau
+          # exposure reads this mart, so nightly clears its break-even with
+          # room to spare. Refs #5217
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: survey_submission_key
         data_type: string
@@ -24,6 +34,7 @@ models:
         constraints:
           - type: primary_key
             warn_unsupported: false
+            warn_unenforced: false
         data_tests:
           - unique
 

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_submission_subjects.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_submission_subjects.sql
@@ -1,0 +1,32 @@
+with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    subject_source as (
+        select survey_id, subject_df_employee_number, effective_survey_response_id,
+        from {{ ref("int_surveys__manager_survey_details") }}
+        where effective_survey_response_id is not null
+    ),
+
+    /*
+     * int_surveys__manager_survey_details is question-grain and carries one
+     * subject per submission, repeated across that submission's question rows.
+     * effective_survey_response_id is the live response id on the Google Forms
+     * arm and the deterministic fallback on the historic Alchemer arm, so one
+     * partition covers both. Grain projection: subject_df_employee_number is
+     * constant within the partition, so the order_by never breaks a real tie.
+     */
+    subjects as (
+        {{
+            dbt_utils.deduplicate(
+                relation="subject_source",
+                partition_by="survey_id, effective_survey_response_id",
+                order_by="subject_df_employee_number",
+            )
+        }}
+    )
+
+select
+    survey_id,
+
+    effective_survey_response_id as survey_response_id,
+    subject_df_employee_number as subject_employee_number,
+from subjects

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__manager_survey_details.sql
@@ -13,6 +13,7 @@
  * or wait for the int_surveys__survey_submissions extraction (#3918).
  */
 with
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
     response_identifiers as (
         select
             fr.form_id as survey_id,
@@ -45,29 +46,25 @@ with
             and fr.question_id = '315a6c37'
     ),
 
+    /*
+     * One respondent can submit the Manager Survey more than once for the same
+     * subject in the same reporting term: 205 of 7,731 partitions collide and
+     * 216 rows are dropped. The latest submission is the one that counts, and
+     * survey_response_id breaks an exact timestamp tie, so the pick is
+     * deterministic. The row_number() this replaced carried no ORDER BY, which
+     * left the surviving response id unreproducible between builds.
+     */
     deduped_ri as (
-        select
-            survey_id,
-            survey_title,
-            survey_response_id,
-            respondent_email,
-            campaign_academic_year,
-            campaign_name,
-            campaign_reporting_term,
-            respondent_df_employee_number,
-            subject_df_employee_number,
-            date_started,
-            date_submitted,
-
-            row_number() over (
-                partition by
-                    survey_id,
-                    campaign_academic_year,
-                    campaign_reporting_term,
-                    respondent_df_employee_number,
-                    subject_df_employee_number
-            ) as rn_cur,
-        from response_identifiers
+        {{
+            dbt_utils.deduplicate(
+                relation="response_identifiers",
+                partition_by=(
+                    "survey_id, campaign_academic_year, campaign_reporting_term,"
+                    " respondent_df_employee_number, subject_df_employee_number"
+                ),
+                order_by="date_submitted desc, survey_response_id desc",
+            )
+        }}
     )
 
 select
@@ -127,7 +124,6 @@ inner join
 inner join
     {{ ref("int_people__staff_roster") }} as sr
     on ri.subject_df_employee_number = sr.employee_number
-where ri.rn_cur = 1
 
 union all
 

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_submissions.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_submissions.sql
@@ -1,17 +1,53 @@
 with
     /*
-     * int_surveys__survey_responses is question-grain. Projected columns do not
-     * vary across the questions of one submission, so this collapse is a grain
-     * projection and the order_by is a stable tiebreaker, not a business rule.
+     * int_surveys__survey_responses is question-grain at 4.1M rows, 32.6
+     * questions per submission. That clears both bars in the ranked-column gate
+     * (.claude/rules/dbt-sql.md): over ~1M input rows, and over 1 slot hour a
+     * week in the models that read it. dbt_utils.deduplicate would pack the
+     * whole ~25-column row into array_agg; enumerating the 8 columns the union
+     * actually needs keeps the shuffle to those.
+     *
+     * Ascending survey_question_id reproduces what dbt_utils.deduplicate picked
+     * here before, so the swap moves no rows.
+     *
+     * The pick is not quite arbitrary. Of 126,808 submissions, survey_title,
+     * respondent_email, respondent_employee_number, date_submitted and
+     * term_code are all constant within the partition, but academic_year is
+     * NOT: 68 submissions carry more than one, because the upstream resolves it
+     * by joining a submission timestamp into the reporting-terms windows. For
+     * those 68 the order key decides which year wins, which then decides which
+     * administration the marts attach the submission to. Keep the order key
+     * stable until that upstream ambiguity is resolved. TODO: #3918 follow-up.
      */
+    live_ranked as (
+        select
+            survey_id,
+            survey_response_id,
+            survey_title,
+            respondent_email,
+            respondent_employee_number,
+            date_submitted,
+            academic_year,
+            term_code,
+
+            row_number() over (
+                partition by survey_id, survey_response_id order by survey_question_id
+            ) as rn,
+        from {{ ref("int_surveys__survey_responses") }}
+    ),
+
     live_submissions as (
-        {{
-            dbt_utils.deduplicate(
-                relation=ref("int_surveys__survey_responses"),
-                partition_by="survey_id, survey_response_id",
-                order_by="survey_question_id",
-            )
-        }}
+        select
+            survey_id,
+            survey_response_id,
+            survey_title,
+            respondent_email,
+            respondent_employee_number,
+            date_submitted,
+            academic_year,
+            term_code,
+        from live_ranked
+        where rn = 1
     ),
 
     -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below

--- a/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_submissions.sql
+++ b/src/dbt/kipptaf/models/surveys/intermediate/int_surveys__survey_submissions.sql
@@ -1,0 +1,97 @@
+with
+    /*
+     * int_surveys__survey_responses is question-grain. Projected columns do not
+     * vary across the questions of one submission, so this collapse is a grain
+     * projection and the order_by is a stable tiebreaker, not a business rule.
+     */
+    live_submissions as (
+        {{
+            dbt_utils.deduplicate(
+                relation=ref("int_surveys__survey_responses"),
+                partition_by="survey_id, survey_response_id",
+                order_by="survey_question_id",
+            )
+        }}
+    ),
+
+    -- trunk-ignore(sqlfluff/ST03): referenced via dbt_utils.deduplicate below
+    archive_source as (
+        select
+            survey_id,
+            survey_title,
+            respondent_email,
+            date_submitted,
+            campaign_academic_year,
+            campaign_reporting_term,
+            respondent_df_employee_number,
+            effective_survey_response_id,
+        from {{ ref("int_surveys__manager_survey_details") }}
+        where
+            survey_id = 'historic_alchemer_Manager_survey'
+            and campaign_academic_year is not null
+    ),
+
+    /*
+     * int_surveys__manager_survey_details is question-grain too, so the archive
+     * arrives at 18 rows per submission. Same grain projection as above; every
+     * column selected is constant within the partition.
+     */
+    archive_submissions as (
+        {{
+            dbt_utils.deduplicate(
+                relation="archive_source",
+                partition_by="survey_id, effective_survey_response_id",
+                order_by="respondent_df_employee_number",
+            )
+        }}
+    ),
+
+    /*
+     * Both arms are normalized onto survey_response_id here so the key is
+     * hashed once below rather than once per arm. That single call site is what
+     * makes this model the one home for survey_submission_key.
+     */
+    all_submissions as (
+        select
+            survey_id,
+            survey_response_id,
+            survey_title,
+            respondent_email,
+            respondent_employee_number,
+            date_submitted,
+            academic_year,
+            term_code,
+        from live_submissions
+
+        union all
+
+        select
+            survey_id,
+
+            effective_survey_response_id as survey_response_id,
+
+            survey_title,
+            respondent_email,
+
+            respondent_df_employee_number as respondent_employee_number,
+
+            date_submitted,
+
+            campaign_academic_year as academic_year,
+            campaign_reporting_term as term_code,
+        from archive_submissions
+    )
+
+select
+    survey_id,
+    survey_response_id,
+    survey_title,
+    respondent_email,
+    respondent_employee_number,
+    date_submitted,
+    academic_year,
+    term_code,
+
+    {{ dbt_utils.generate_surrogate_key(["survey_id", "survey_response_id"]) }}
+    as survey_submission_key,
+from all_submissions

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_submission_subjects.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__manager_submission_subjects.yml
@@ -1,0 +1,40 @@
+models:
+  - name: int_surveys__manager_submission_subjects
+    description: >-
+      Subject-of-evaluation overlay for the Manager Survey. One row per Manager
+      Survey submission, carrying the employee number of the manager being
+      evaluated.
+
+      Kept separate from int_surveys__survey_submissions because only the
+      Manager Survey has a subject. Folding the column into the submissions
+      model would leave it null for every other survey and invite consumers to
+      read it as meaningful.
+
+      Covers both Manager Survey arms. The live Google Forms arm keys on the
+      response id; the historic Alchemer archive keys on the deterministic
+      fallback. Both arrive as effective_survey_response_id upstream, so one
+      partition serves both.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - survey_id
+              - survey_response_id
+    columns:
+      - name: survey_id
+        description: >-
+          Identifier of the Manager Survey — the Google Forms form id on the
+          live arm, the literal historic_alchemer_Manager_survey on the archive.
+
+      - name: survey_response_id
+        description: >-
+          Identifier of the submission being evaluated, matching
+          int_surveys__survey_submissions.survey_response_id so consumers join
+          on the pair.
+
+      - name: subject_employee_number
+        description: >-
+          Employee number of the staff member the respondent is evaluating.
+        config:
+          meta:
+            contains_pii: true

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_submissions.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_submissions.yml
@@ -1,0 +1,71 @@
+models:
+  - name: int_surveys__survey_submissions
+    description: >-
+      Canonical submission grain for every survey the network runs. One row per
+      submission, across both the live Google Forms and Alchemer feed and the
+      historic Alchemer Manager Survey archive.
+
+      This model owns survey_submission_key. Both sources it reads are
+      question-grain, so each arm collapses to submission grain here rather than
+      in every consuming mart. Consumers select the key through; they do not
+      re-derive it.
+
+      The live arm carries every survey title, not only the titles the marts
+      currently model, so a new survey becomes available to a consumer without
+      touching this model.
+    columns:
+      - name: survey_submission_key
+        description: >-
+          Surrogate key derived from survey_id and survey_response_id. Primary
+          key. For the historic archive, survey_response_id is the deterministic
+          fallback described below, so the composition is identical across both
+          arms.
+        data_tests:
+          - unique
+
+      - name: survey_id
+        description: >-
+          Identifier of the survey itself — the Google Forms form id, the
+          stringified Alchemer survey id, or the literal
+          historic_alchemer_Manager_survey for the archive.
+
+      - name: survey_response_id
+        description: >-
+          Identifier of the individual submission. On the historic Manager
+          archive the source records no response id, so this carries the
+          deterministic fallback built from respondent, subject and reporting
+          term.
+
+      - name: survey_title
+        description:
+          Display title of the survey, as the source system records it.
+
+      - name: respondent_email
+        description: >-
+          Email the respondent submitted under. Null on the historic Manager
+          archive, which records no respondent email.
+        config:
+          meta:
+            contains_pii: true
+
+      - name: respondent_employee_number
+        description: >-
+          Employee number of the respondent, resolved against the staff roster
+          at the time of submission. Null when the respondent could not be
+          matched to a staff record.
+        config:
+          meta:
+            contains_pii: true
+
+      - name: date_submitted
+        description: Timestamp the respondent submitted the survey.
+
+      - name: academic_year
+        description: >-
+          Academic year the submission falls in, resolved from the reporting
+          terms sheet on the live arm and from the campaign on the archive.
+
+      - name: term_code
+        description: >-
+          Reporting term code the submission falls in, for example MGR1 or MGR2
+          on the Manager Survey.

--- a/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_submissions.yml
+++ b/src/dbt/kipptaf/models/surveys/intermediate/properties/int_surveys__survey_submissions.yml
@@ -13,6 +13,16 @@ models:
       The live arm carries every survey title, not only the titles the marts
       currently model, so a new survey becomes available to a consumer without
       touching this model.
+    config:
+      materialized: table
+      meta:
+        dagster:
+          # A table, not a view, because 3 marts read this model and a view
+          # would make each of them recompute the 4.1M-row collapse. Nightly
+          # matches the cadence all 3 consumers run on, so the whole chain
+          # settles in one pass. Refs #5217, #3918
+          automation_condition:
+            cron_schedule: 0 3 * * *
     columns:
       - name: survey_submission_key
         description: >-


### PR DESCRIPTION
## Summary & Motivation

When merged, this pull request will make 10 dbt marts build as tables on a cron schedule instead of as views, and fix a grain bug that the change exposed.

Every data test on a view mart recomputes that whole view before it can check anything. These 10 marts cost 936 slot hours a week that way, which is 32% of all warehouse compute in the project. As tables, their tests read a table instead.

Expected result: prod drops from 94 to 38 slot hours a week, and dbt Cloud CI from 818 to about 263. That is about 610 slot hours a week.

## Reviewer Notes

**This is not a pure materialization change.** The dev build found 2 marts whose `primary_key` constraint their own data violates. That is harmless on a view, where constraints are inert, but `materialized: table` renders the constraint into real DDL — and BigQuery documents that "queries over tables with violated constraints might return incorrect results", because the optimizer uses unenforced keys for join elimination and reordering. So the sweep could not ship without fixing them.

Both had one root cause. `int_surveys__manager_survey_details` is question-grain, and the `historic_archive_submissions` CTE in `fct_survey_submissions` read it without projecting to submission grain. The historic Alchemer archive emitted 18 rows per submission and collided 2,559 `survey_submission_key` values. `fct_survey_responses` inner-joins on that key, so its rows fanned out 18x in turn — which is the `~18x (46,008 keys / 828,144 rows)` reported in #4243.

The fix applies the same `dbt_utils.deduplicate` projection that `manager_subject_overlay` already uses on the same source, 40 lines earlier in the same model. It is information-preserving: every column that CTE selects is constant within `(survey_id, effective_survey_response_id)` across all 2,559 archive submissions, verified before the change.

| Mart | rows before | rows after | delta | PK test |
| --- | ---: | ---: | ---: | --- |
| `fct_survey_submissions` | 92,459 | 48,956 | -43,503 | now PASS |
| `fct_survey_responses` | 1,363,717 | 580,663 | -783,054 | now PASS |

All 9 primary-key constraints in this batch are now satisfied by their data. `fct_grades_assignments` carries an in-file TODO citing 71 residual duplicates, but that is stale — #4017 is closed and the table measures 23,437,020 rows against 23,437,020 distinct keys.

The 2 cadences are derived, not picked. The 7 marts with no Cube or Tableau reader get `0 3 * * *`. The 3 Cube reads get `0 0,10,13,15,17 * * *`, the same tick the assessment marts use. `fct_student_attendance_daily` knowingly costs more in prod, 1.7 to 7.9 slot hours a week, because Cube's enrollment count needs the intraday tick; its CI column drops 90.5 to about 21, so it still reduces total cost.

`dim_staff_reporting_chain` uses `WITH RECURSIVE`. That is fine in a table — `int_illuminate__root_standards` already ships as `WITH RECURSIVE` plus `materialized: table`.

Sizes are measured, not estimated. Largest new table: `fct_grades_assignments` at 4.073 GB. Total across all 10 is under 7 GB. The design doc flagged `bridge_survey_expectations` as the size risk because it scaffolds with a cross join — it measured 0.017 GB, so that risk did not materialize.

One warn-severity test still fails and is pre-existing: `relationships_fct_student_attendance_daily_student_enrollment_key`, 2,287 orphans, tracked in #4229.

This migration needs one ordered Dagster run after merge, selecting all 10 assets together. A config-only yml change does not bump `code_version`, so the sensor will not pick these up on its own, and view to table drops the view before it creates the table.

## Self-review

### General

- [x] Update **due date** and **assignee** on the [TEAMster Asana Project](https://app.asana.com/0/1205971774138578/1205971926225838)
- [ ] Review the **Claude Code Review** comment posted on this PR. Address valid feedback; dismiss false positives with a brief reply explaining why. (Claude is advisory — use your judgement, but don't ignore it.)

### Dagster _(skip if no Dagster changes)_

No Dagster code changes. The cron cadences are dbt `meta.dagster` config read by the existing translator.

### dbt _(skip if no dbt changes)_

- [x] Include a `[model_name].yml` properties file for all new models — see [dbt Conventions](https://teamschools.github.io/teamster/reference/dbt-conventions/#model-properties-file)
- [x] Include (or update) an [exposure](https://teamschools.github.io/teamster/reference/dbt-conventions/#exposures) for all models consumed by a dashboard, analysis, or application
- [x] **Breaking change?** No columns renamed or removed. Row counts drop on `fct_survey_submissions` and `fct_survey_responses` as described above — that is the bug fix, not a regression. Surrogate keys are unchanged.
- [x] If adding or modifying an external source, run `stage_external_sources` with **`--target staging`** so the dbt Cloud CI job can find the table. No external sources touched.

### Docs _(skip if no schedule, sensor, or integration changes)_

No schedule or sensor added. Automation conditions on dbt models are not in the automations catalog.

## CI checks

- [ ] **Trunk** — passes.
- [ ] **dbt Cloud** — passes.
- [ ] **Dagster Cloud** — passes or not triggered.

Closes #5217
Closes #4243

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Design doc: `docs/superpowers/specs/2026-09-11-view-mart-table-sweep-design.md`. Plan: `docs/superpowers/plans/2026-09-11-view-mart-table-sweep.md`. Measurements: `docs/superpowers/plans/baseline-2026-09-11.md`.

Two mechanisms drove the cost, and the table conversion fixes both. CI's `state:modified+` pulls these marts into nearly every PR, which is 818 of the 936 hours. In prod the child views never rebuild at all, yet their tests run 128 times a week each, because dbt's default `--indirect-selection=eager` selects a test when ANY parent is selected and `dim_staff` rebuilds 192 times a week. Over 7 days `bridge_survey_expectations` materialized 0 times in prod while its `relationships` test against `dim_staff` ran 128 times.

Setting `--indirect-selection=cautious` at `src/teamster/libraries/dbt/assets.py:112` was considered and rejected. It would remove 72.3 of the 117.5 weekly prod test slot hours, but it does nothing for CI, it is repo-wide across all 5 code locations, and it trades away parent-side FK orphan detection on every view mart.

Diagnosis path for the grain bug, since 2 plausible hypotheses were wrong first: the reporting-terms sheet is unique on its join key (81 rows, 81 distinct keys), and the student branch's closed-interval enrollment date join — the documented fan-out trap — is clean (27,615 rows, 27,615 keys). All 43,503 excess rows were in the staff branch, every one carrying `subject_staff_key`, across 1 academic year and 1 administration per key. That isolates it to the Manager Survey branches, and `int_surveys__manager_survey_details` shows 46,062 rows over 2,559 submissions for `historic_alchemer_Manager_survey` — exactly 18.0.

All 10 already declared FKs as `columns[].config.meta.foreign_key`, not real `constraints`, so the #4821 migration needed no work here. `git log -S` confirmed zero prior `materialized: table` or `cron_schedule` commits on all 10, so this is not a re-attempt of the #4464 change that #4587 reverted.

`dim_staff_reporting_chain` keeps `contract: enforced: false` — its `WITH RECURSIVE` is incompatible with dbt's contract-validation subquery wrapper, though not with the table CTAS. It is also the one model with no `primary_key` constraint, so it is the one that does not gain `warn_unenforced: false`; it uses a model-level `dbt_utils.unique_combination_of_columns` instead. That asymmetry is deliberate.

Two risks the design doc now names that the first draft did not: cron cadence degrades FK orphan-detection fidelity, because a snapshot child is compared against eager parents that rebuild 192 times a week — the same skew `dim_assessments` was raised to 5x/day to close under #4559; and 36M rows of student grades and attendance become PII persisted at rest rather than view definitions.

Do not run `count(*)` against these views. One attempt over 4 of them consumed 100,540 slot minutes and failed with `billingTierLimitExceeded`.

Post-merge, finish with ONE Dagster `launch_run` over all 10 assets (`kipptaf/marts/<model>`), not 10 separate runs — dbt topologically sorts a single build, and out-of-order materialization is what left relations MISSING in #4464.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
