### PR TITLE
fix(dbt): CSGF HSDC total graduates and cross-tab enrollment scoping

### DIFF
--- a/.claude/skills/csgf-data-collection/SKILL.md
+++ b/.claude/skills/csgf-data-collection/SKILL.md
@@ -933,7 +933,23 @@ after a deploy -- so this won't self-correct by waiting. **Don't treat this
 model as fixed for the actual submission until #5059 merges and kipptaf
 redeploys** (confirm via `mcp__dagster__get_location_load_history` showing a
 `LOADED` entry with the merge commit's hash, same check as any prod-deploy
-verification).
+verification). PR #5059 has since merged and deployed -- these fixes are live.
+
+**New this cycle (2026-09-11): CSGF added "Total Number of Graduates" to the HS
+Grad Data task** -- a real, distinct field from the existing "# Stud in Adj
+Cohort Grad w/i 4 Yrs" column (which is `total_4yr_grad`). Its tooltip reads
+"Include All Students Who Received a Diploma" -- i.e. every diploma recipient
+this year regardless of cohort, not just on-time 4-year grads. Added a new
+`all_graduates` CTE / `total_graduates` column to
+`rpt_gsheets__csgf_hs_grad_data` (no cohort filter, just
+`academic_year + 1 = current_academic_year and exitcode = 'G1'`, grouped by
+school) -- see `docs/models/csgf-data-model.md` for the full writeup. Real
+values entered for the 2026-2027 cycle: KIPP Cooper Norcross High School 94,
+KIPP Newark Collegiate Academy 168, KIPP Newark Lab High School 129. **When a
+Portal task adds a column mid-cycle like this, hover its tooltip for CSGF's own
+definition before assuming it maps to an existing model column -- two columns
+that sound similar (here, "graduates" vs. "4-year cohort grads") can be
+genuinely different metrics.**
 
 **`rpt_gsheets__csgf_enrollment` currently under-reports Miami** (as of this
 cycle -- owner is aware and fixing separately from this skill; check whether

--- a/.claude/skills/csgf-data-collection/SKILL.md
+++ b/.claude/skills/csgf-data-collection/SKILL.md
@@ -1252,6 +1252,19 @@ practice even though it's asked at the org level.
   accurate number (84/181 = 46.4%) than the real course-enrollment count (87/157
   = 55.4%). The two aren't identical: 3 of the 87 real Algebra 1 enrollees have
   no matched EOC score at all (absence, exemption, etc.).
+- **Forward risk, flagged by the collection owner: `kippmiami_powerschool` is a
+  one-time, frozen resource, not a repeatable source.** It's the archive of
+  Miami's retired PowerSchool SIS, frozen at the final ODBC pull (2026-07-01) --
+  it will never gain a 2026-2027 school year. Next cycle's version of this same
+  survey (or anything else needing Miami course enrollment/schedule data for
+  2026-2027 onward) can't reuse this approach -- Miami is fully on Focus by
+  then, and Focus course/schedule data has no dbt staging model yet (the same
+  gap already noted for AP/Honors course tags above). Expect to have to ask
+  where Focus actually stores schedule/course data (the raw
+  `dagster_kippmiami_dlt_focus` tables, almost certainly, per the Focus
+  custom-field/table conventions in `src/dbt/focus/CLAUDE.md`) and build the
+  join fresh, rather than looking for a `kippmiami_powerschool` equivalent that
+  won't exist.
 
 ## Open questions for this skill (not yet answered)
 

--- a/.claude/skills/csgf-data-collection/SKILL.md
+++ b/.claude/skills/csgf-data-collection/SKILL.md
@@ -1197,6 +1197,62 @@ to cycle -- don't assume last year's method still applies:**
   each cycle before relying on it -- it's a manual alignment step, not
   automatic.
 
+## Ad hoc CSGF surveys outside the Portal/HSDC
+
+Not everything CSGF asks for comes through the Portal or the HSDC sheet. CSGF's
+Analytics team (`datacollection@chartergrowthfund.org`) can also send a one-off
+email with a short Google Form survey, separate from the main collection, with
+its own deadline tied to the same cycle. Treat one of these the same way as any
+other CSGF item -- verify against real data, don't guess.
+
+**Worked example: Florida B.E.S.T. Algebra 1 Participation & EOC Performance
+Survey (2026-2027 cycle).** Org-level, one response per org (coordinate via Key
+Contacts so two people don't duplicate it), 4 questions: % of 8th graders and %
+of 9th graders enrolled in Algebra 1 (or equivalent) in 2025-2026, and among
+each group, % who scored Level 3+ on the 25-26 B.E.S.T. Algebra 1 EOC. Since
+KTAF's only Florida schools are in Miami, this is a Miami-only survey in
+practice even though it's asked at the org level.
+
+- **For Algebra 1 course enrollment, use the district-specific `kippmiami`
+  project's data, not kipptaf's cross-district extracts.** Charlie's guidance,
+  confirmed correct: `kipptaf`'s Focus-based models have no course- enrollment
+  staging built yet for Miami (the same gap already documented above for
+  AP/Honors course tags), so there's no way to get a real Algebra 1 enrollment
+  count from there. But Miami was still on PowerSchool through the end of the
+  2025-2026 school year (the archive `kippmiami_powerschool`, frozen at the
+  final ODBC pull 2026-07-01 -- see `src/dbt/kippmiami/CLAUDE.md`) -- for any
+  historical Miami question, check that project's own
+  `base_powerschool__course_enrollments` /
+  `base_powerschool__student_enrollments` / `stg_powerschool__courses` first,
+  not kipptaf's Focus-sourced tables.
+- **The 2025-2026 real numbers (Miami, confirmed 2026-09-11):** grade 8 -- 157
+  total 8th graders (all at Courage Academy; Royalty is K-4 only), 87 of them
+  actually enrolled in `Algebra I` or `Algebra I Honors`
+  (`stg_powerschool__courses.course_name`) per real course-enrollment records --
+  **55.4% enrolled**. Of those 87, 84 have a matched EOC record in
+  `kippmiami_fldoe.int_fldoe__all_assessments`
+  (`assessment_subject = 'Algebra I'`, `academic_year = 2025`) and 74 scored
+  `is_proficient` (Level 3+). **Decision: used test-takers as the denominator
+  (74/84 = 88.1%)**, not all enrollees (74/87 = 85.1%) -- both are defensible
+  reads of "among the 8th graders who took Algebra 1," but the collection owner
+  chose test-takers.
+- **Grade 9 is genuinely N/A for the 2025-2026 school year, not a data gap.**
+  Miami had **zero 9th graders enrolled anywhere in 2025-2026** -- confirmed via
+  `int_extracts__student_enrollments`: Legacy Elementary, Legacy Middle, and
+  Miami Technical High (Miami's only HS) all first appear at
+  `academic_year = 2026`, not `2025`. Miami Tech, the network's first Florida
+  high school, opened for the 2026-2027 school year, after the year this survey
+  asks about. The collection owner entered N/A for both grade-9 questions on
+  this basis.
+- **Don't proxy course enrollment from EOC test-taking counts if a real
+  enrollment source exists.** An earlier pass on this same question used EOC
+  test-taker counts as a stand-in for Algebra 1 enrollment (assuming Florida's
+  EOC-for-enrolled-students requirement made them equivalent) before the
+  `kippmiami_powerschool` archive was checked -- that produced a different, less
+  accurate number (84/181 = 46.4%) than the real course-enrollment count (87/157
+  = 55.4%). The two aren't identical: 3 of the 87 real Algebra 1 enrollees have
+  no matched EOC score at all (absence, exemption, etc.).
+
 ## Open questions for this skill (not yet answered)
 
 - Who is the current collection owner / project manager, for reference the next

--- a/.claude/skills/csgf-data-collection/SKILL.md
+++ b/.claude/skills/csgf-data-collection/SKILL.md
@@ -884,6 +884,15 @@ live CSGF sheet directly.
 
 ## Known data risks -- verify before submitting
 
+**Fixed 2026-09-11: SAT/ACT/AP Scores/AP Offerings must scope to the same
+population as HS Enrollment, or CSGF flags "ID not on Enrollment Tab."** HS
+Enrollment's own instructions say to only include students who completed the
+school year (`enroll_status in (0, 3)`); the other four HS-scoped models had no
+such filter and included mid-year transfers-out too. Full writeup in
+`docs/models/csgf-data-model.md`. If you see this exact error on a future
+cycle's HSDC tabs, check whether a newly-added HS-scoped model has the same gap
+before assuming it's a data problem.
+
 **Year anchoring across the eight `rpt_gsheets__csgf_*` models** (verified by
 reading each model's SQL directly, not just taken from prior notes -- see
 [issue #4897](https://github.com/TEAMSchools/teamster/issues/4897) for the

--- a/docs/models/csgf-data-model.md
+++ b/docs/models/csgf-data-model.md
@@ -207,6 +207,22 @@ this repo's own documented source (`stg_powerschool__students.yml`:
 in their field definitions. The SED field reuses this same `student_is_frl`
 value rather than a separate column.
 
+### `csgf_hs_grad_data.total_graduates` — new column, distinct from `total_4yr_grad`
+
+CSGF added a "Total Number of Graduates" column to the HS Grad Data task
+(2026-2027 cycle, confirmed via the task's own field tooltip: "Include All
+Students Who Received a Diploma"). This is genuinely different from
+`total_4yr_grad` -- the whole `grad_roster` CTE (and therefore every other
+column on this model) is scoped to `cohort = current_academic_year`, which
+excludes a student who received a diploma this year but belongs to an earlier
+cohort (held back a grade, graduating in year 5+) or a later one (graduated
+early). Added a separate `all_graduates` CTE with no cohort filter -- just
+`academic_year + 1 = current_academic_year and exitcode = 'G1'`, grouped by
+school -- and joined it in. Confirmed real, non-zero off-cohort graduates exist
+for all three current HS schools this cycle: KIPP Cooper Norcross High School
+has 87 on-time (cohort 2026) grads plus 3 cohort-2025 and 4 cohort-2027 grads
+for 94 total; Newark Collegiate 161 -> 168; Newark Lab 126 -> 129.
+
 ## Exit-code reference
 
 `enroll_status`/`exitcode` combinations that look similar can have very

--- a/docs/models/csgf-data-model.md
+++ b/docs/models/csgf-data-model.md
@@ -223,6 +223,24 @@ for all three current HS schools this cycle: KIPP Cooper Norcross High School
 has 87 on-time (cohort 2026) grads plus 3 cohort-2025 and 4 cohort-2027 grads
 for 94 total; Newark Collegiate 161 -> 168; Newark Lab 126 -> 129.
 
+### The four HS-scoped student-level models must match `csgf_hs_enrollment`'s population — resolved
+
+`csgf_hs_enrollment`'s own task instructions say "ONLY INCLUDE STUDENTS WHO
+COMPLETED THE 25-26 SCHOOL YEAR," which its `enroll_status in (0, 3)` filter
+(Currently Enrolled or Graduated) correctly implements. `csgf_hs_sat`,
+`csgf_hs_act`, `csgf_hs_ap_scores`, and `csgf_hs_ap_offerings` had no such
+filter, so a student who transferred out mid-year (`enroll_status = 2`) but had
+a test score or AP course on file still appeared in those four models while
+being correctly absent from Enrollment. CSGF cross-validates every HSDC tab's
+student ID against the Enrollment tab and flags "ID not on Enrollment Tab" for
+every one of these — confirmed live via a real error report during the 2026-2027
+submission. Root cause confirmed directly: every flagged student had
+`enroll_status = 2`. Network-wide impact: 170 students transferred out mid-year
+and were included in one or more of the four models before this fix. Fixed by
+adding `enroll_status in (0, 3)` to all four, matching `csgf_hs_enrollment`
+exactly. Verified after the fix: zero SAT or AP Scores student IDs are missing
+from the Enrollment tab's population.
+
 ## Exit-code reference
 
 `enroll_status`/`exitcode` combinations that look similar can have very

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_act.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_act.yml
@@ -1,5 +1,10 @@
 models:
   - name: rpt_gsheets__csgf_hs_act
+    description:
+      Scoped to enroll_status in (0, 3) -- Currently Enrolled or Graduated -- to
+      match rpt_gsheets__csgf_hs_enrollment's population; see
+      rpt_gsheets__csgf_hs_sat.yml for the full rationale (same fix, applied to
+      all four HS-scoped student-level models on 2026-09-11).
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_offerings.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_offerings.yml
@@ -32,7 +32,10 @@ models:
       `ap_course_name`), same as any course a given school simply doesn't offer.
       Confirmed none of the 11 real courses were taught network-wide as of the
       2026-2027 cycle (2025-2026 academic year); revisit this list if that
-      changes.
+      changes. Scoped to enroll_status in (0, 3) -- Currently Enrolled or
+      Graduated -- to match rpt_gsheets__csgf_hs_enrollment's population; see
+      rpt_gsheets__csgf_hs_sat.yml for the full rationale (same fix, applied to
+      all four HS-scoped student-level models on 2026-09-11).
     columns:
       - name: school_name
         data_type: string

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_scores.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_ap_scores.yml
@@ -1,5 +1,10 @@
 models:
   - name: rpt_gsheets__csgf_hs_ap_scores
+    description:
+      Scoped to enroll_status in (0, 3) -- Currently Enrolled or Graduated -- to
+      match rpt_gsheets__csgf_hs_enrollment's population; see
+      rpt_gsheets__csgf_hs_sat.yml for the full rationale (same fix, applied to
+      all four HS-scoped student-level models on 2026-09-11).
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_grad_data.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_grad_data.yml
@@ -34,5 +34,22 @@ models:
         data_type: int64
       - name: total_4yr_grad
         data_type: int64
+      - name: total_graduates
+        data_type: int64
+        description:
+          CSGF's own field tooltip reads "Include All Students Who Received a
+          Diploma." Distinct from total_4yr_grad -- not scoped to co.cohort =
+          var("current_academic_year") at all, since a student who received a
+          diploma this year can belong to an earlier cohort (5th-year/held-back
+          graduate) or a later one (early graduate), and both count here even
+          though grad_roster's cohort filter excludes them from every other
+          column on this model. Counts distinct students with exitcode = 'G1'
+          whose academic_year + 1 equals the current academic year, grouped by
+          school only. Added 2026-09-11 when CSGF's Portal task added this
+          column; confirmed real students exist in both the earlier- and
+          later-cohort direction for all three current HS schools (e.g. KIPP
+          Cooper Norcross High School has 87 on-time cohort-2026 grads per
+          total_4yr_grad, plus 3 cohort-2025 and 4 cohort-2027 grads this column
+          adds, for 94 total).
       - name: pct_grad
         data_type: float64

--- a/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_sat.yml
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/properties/rpt_gsheets__csgf_hs_sat.yml
@@ -1,5 +1,16 @@
 models:
   - name: rpt_gsheets__csgf_hs_sat
+    description:
+      Scoped to enroll_status in (0, 3) -- Currently Enrolled or Graduated -- to
+      match rpt_gsheets__csgf_hs_enrollment's population, per that task's own
+      instruction "ONLY INCLUDE STUDENTS WHO COMPLETED THE 25-26 SCHOOL YEAR."
+      CSGF cross-validates every HSDC tab's studentid against the HS Enrollment
+      tab and flags "ID not on Enrollment Tab" otherwise. Confirmed on
+      2026-09-11 -- 170 students network-wide transferred out mid-year
+      (enroll_status = 2) and were previously included here (and in csgf_hs_act,
+      csgf_hs_ap_scores, csgf_hs_ap_offerings) despite being excluded from
+      Enrollment -- all four models needed the same filter added, not just this
+      one.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_act.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_act.sql
@@ -16,3 +16,4 @@ where
     and e.school_level = 'HS'
     and e.rn_year = 1
     and e.is_enrolled_recent
+    and e.enroll_status in (0, 3)

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_offerings.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_offerings.sql
@@ -43,6 +43,7 @@ with
             and e.school_level = 'HS'
             and e.rn_year = 1
             and e.is_enrolled_recent
+            and e.enroll_status in (0, 3)
     ),
 
     grade_levels as (

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_scores.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_ap_scores.sql
@@ -41,3 +41,4 @@ where
     and e1.school_level = 'HS'
     and e1.rn_year = 1
     and e1.is_enrolled_recent
+    and e1.enroll_status in (0, 3)

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_grad_data.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_grad_data.sql
@@ -75,6 +75,19 @@ with
             and co.rn_year = 1
             and co.rn_undergrad = 1
             and co.cohort = {{ var("current_academic_year") }}
+    ),
+
+    all_graduates as (
+        select co.school_name, count(distinct co.student_number) as total_graduates,
+
+        from {{ ref("int_extracts__student_enrollments") }} as co
+        where
+            co.school_level = 'HS'
+            and co.rn_year = 1
+            and co.rn_undergrad = 1
+            and co.academic_year + 1 = {{ var("current_academic_year") }}
+            and co.exitcode = 'G1'
+        group by co.school_name
     )
 
 select
@@ -97,6 +110,8 @@ select
 
     sum(gr.is_4yr_grad) as total_4yr_grad,
 
+    coalesce(ag.total_graduates, 0) as total_graduates,
+
     round(
         sum(gr.is_4yr_grad) / (
             (sum(gr.is_entry_cohort) + sum(gr.is_transfer_in)) - sum(gr.is_transfer_out)
@@ -105,4 +120,5 @@ select
     ) as pct_grad,
 
 from grad_roster as gr
-group by gr.cohort, gr.school_name
+left join all_graduates as ag on gr.school_name = ag.school_name
+group by gr.cohort, gr.school_name, ag.total_graduates

--- a/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_sat.sql
+++ b/src/dbt/kipptaf/models/extracts/google/sheets/rpt_gsheets__csgf_hs_sat.sql
@@ -19,3 +19,4 @@ where
     and e.school_level = 'HS'
     and e.rn_year = 1
     and e.is_enrolled_recent
+    and e.enroll_status in (0, 3)


### PR DESCRIPTION
# Pull Request

## Summary & Motivation

When merged, this pull request will fix two problems found while working the 2026-2027 CSGF High School Data Collection submission.

First, CSGF added a new field to the HS Grad Data task, "Total Number of Graduates," meaning every student who received a diploma this year. We already had a similar-looking column, the count of on-time 4-year graduates, but that's a different number — it also counts students who graduated a year late or a year early, and real students exist in both groups this cycle.

Second, CSGF flagged real submission errors on the SAT tab: student IDs that don't appear on the HS Enrollment tab. The HS Enrollment tab only includes students who completed the school year, but our SAT, ACT, AP Scores, and AP Offerings models included everyone who tested or took a course, even students who transferred out mid-year. That mismatch is what CSGF's cross-tab check was catching.

## Reviewer Notes

- The new Grad Data column has no cohort filter, unlike every other column on that model — that's intentional, not an oversight. See "For Claude" for why.
- The enrollment-scoping fix touches four models at once (SAT, ACT, AP Scores, AP Offerings) because all four had the identical gap.
- Grad Data values are already entered on the CSGF Portal and under CSGF's review; this PR is catching the pipeline up to what was submitted by hand.

## Self-review

### dbt

- [x] Include a `[model_name].yml` properties file for all new models — no new models; added/updated descriptions on the five existing models this PR touches.
- [x] Include (or update) an exposure for all models consumed by a dashboard, analysis, or application — the `csgf_data` exposure already covers all of them; unchanged.
- [x] **Breaking change?** No. The Grad Data change adds a column; nothing renamed or removed. The enrollment-scoping change only removes rows for students who shouldn't have been included in the first place (a correctness fix, not a schema change).
- [x] If adding or modifying an external source, run `stage_external_sources` — no external source changes.

## CI checks

- [ ] **Trunk** — passes locally (`trunk check --force` on every changed file).
- [ ] **dbt Cloud** — pending.
- [ ] **Dagster Cloud** — not triggered; no schedule/sensor/integration changes.

<details>
<summary>For Claude</summary>

Claude-assisted, human-directed. Both fixes came out of live-working the actual 2026-2027 CSGF submission with the collection owner — she caught both problems in real Portal/error-report screenshots, and each was verified against real data before any code was written.

**Fix 1: `csgf_hs_grad_data.total_graduates`.** CSGF's Portal added a "Total Number of Graduates" column to the HS Grad Data task mid-cycle. Its field tooltip reads "Include All Students Who Received a Diploma." The collection owner initially wasn't sure this was a new metric versus a rename of the existing "# Stud in Adj Cohort Grad w/i 4 Yrs" column — confirmed it's genuinely distinct by checking real data before implementing.

`rpt_gsheets__csgf_hs_grad_data`'s `grad_roster` CTE (and therefore every existing column: `total_9_entry`, `total_transfer_in`, `total_transfer_out`, `adjusted_cohort`, `total_4yr_grad`, `pct_grad`) is scoped to `cohort = current_academic_year`. A student who received a diploma this year but belongs to a different cohort — held back a grade (earlier cohort) or graduated early (later cohort) — is entirely excluded from that CTE, not just miscounted.

Verified via BigQuery before implementing: querying `int_extracts__student_enrollments` for `school_level = 'HS' and rn_year = 1 and rn_undergrad = 1 and academic_year + 1 = 2026 and exitcode = 'G1'`, grouped by `(school_name, cohort)`, showed real off-cohort graduates at all three current HS schools this cycle — KIPP Cooper Norcross High School: 3 cohort-2025 + 87 cohort-2026 + 4 cohort-2027 = 94 total (vs. 87 for `total_4yr_grad` alone); KIPP Newark Collegiate Academy: 161 + 7 = 168; KIPP Newark Lab High School: 126 + 3 = 129.

Implementation: added an `all_graduates` CTE with no cohort filter — just `academic_year + 1 = current_academic_year and exitcode = 'G1'`, grouped by `school_name` — left-joined into the final `SELECT` on `school_name`, wrapped in `coalesce(ag.total_graduates, 0)`. Added `total_graduates` to the properties yml contract (required — this model has `contract: enforced: true`).

Rebuilt in dev: view compiles clean, `unique_combination_of_columns(cohort, school)` test still passes, and the three schools' `total_graduates` values (94/168/129) match exactly what the collection owner had already entered on the Portal by hand before this PR existed.

**Fix 2: enrollment-population scoping across four HS-scoped models.** The collection owner pasted CSGF's real error report for the SAT tab: every flagged student got "ID not on Enrollment Tab" plus "School Name Issue." Queried `int_extracts__student_enrollments` for the flagged student numbers and found every single one had `enroll_status = 2` ("Transferred Out"). Then pulled the HS Enrollment tab's own task instructions (via the collection owner's screenshot): "ONLY INCLUDE STUDENTS WHO COMPLETED THE 25-26 SCHOOL YEAR" — which is exactly what `csgf_hs_enrollment`'s existing `enroll_status in (0, 3)` filter (Currently Enrolled or Graduated) implements. The SAT tab's own instructions ("for every student who has tested that was enrolled in the 2025-2026 school year") sound broader, but the Enrollment tab's explicit instruction settles which side is correct: Enrollment's scoping is intentional, and the other four models needed to match it, not the reverse.

Checked all four HS-scoped student-level models' SQL directly (not assumed): `csgf_hs_sat`, `csgf_hs_act`, and `csgf_hs_ap_scores` filtered on `academic_year`/`school_level`/`rn_year`/`is_enrolled_recent` with no `enroll_status` condition at all; `csgf_hs_ap_offerings`'s `ap_courses` CTE had the identical gap. Quantified before fixing: `select countif(enroll_status = 2), count(*) from int_extracts__student_enrollments where academic_year = 2025 and school_level = 'HS' and rn_year = 1 and is_enrolled_recent` returned 170 transferred-out students out of 1,851 total — a real, network-wide population, not a couple of edge cases.

Added `enroll_status in (0, 3)` to all four models' `WHERE` clauses (aliased `e`/`e1` per model). Rebuilt all four in dev: all four compile clean, all pre-existing uniqueness tests still pass, SAT's distinct-student count dropped from 795 to 780 (the 15 transferred-out students who had SAT scores on file), and a direct check confirmed zero SAT or AP Scores student IDs are now missing from `csgf_hs_enrollment`'s population (was previously catching every transferred-out student with a score).

Also updated `docs/models/csgf-data-model.md` (a new "Grad Data total_graduates" subsection and a new "must match Enrollment's population" subsection under Known Risks) and the `csgf-data-collection` skill (short pointers in Known Data Risks / the HS Grad Data section) so both fixes are documented for next cycle, including the general lessons: check a new Portal column's tooltip before assuming it maps to an existing model column, and any future HS-scoped model needs to carry the same `enroll_status in (0, 3)` filter `csgf_hs_enrollment` uses or it will fail CSGF's cross-tab ID check.

</details>
